### PR TITLE
Split requirements into GPU and CPU variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,25 @@ A Flask web application for audio clip evaluation with LAION-CLAP embeddings.
 
 ### 1. Install Dependencies
 
+Choose the requirements file based on your system:
+
+**For GPU systems** (with NVIDIA GPU):
 ```bash
 cd ~/vectorytones
 source venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements-gpu.txt
 ```
+
+**For CPU-only systems** (Chromebook, Mac, or systems without GPU):
+```bash
+cd ~/vectorytones
+source venv/bin/activate
+pip install -r requirements-cpu.txt
+```
+
+The main difference is the PyTorch version:
+- `requirements-gpu.txt` installs full PyTorch with CUDA support (~2GB)
+- `requirements-cpu.txt` installs PyTorch CPU-only (~500MB)
 
 ### 2. Download and Setup Datasets
 
@@ -61,14 +75,15 @@ Visit http://localhost:5000
 
 ```
 vectorytones/
-├── app.py                  # Flask application
-├── setup_datasets.py       # Dataset download & embedding script
-├── requirements.txt        # Python dependencies
-├── static/                 # Frontend assets
-├── templates/              # HTML templates
-└── data/                   # Downloaded datasets (not in git)
-    ├── ESC-50-master/      # ESC-50 audio files
-    └── embeddings/         # Precomputed CLAP embeddings
+├── app.py                      # Flask application
+├── setup_datasets.py           # Dataset download & embedding script
+├── requirements-gpu.txt        # Python dependencies (GPU systems)
+├── requirements-cpu.txt        # Python dependencies (CPU-only systems)
+├── static/                     # Frontend assets
+├── templates/                  # HTML templates
+└── data/                       # Downloaded datasets (not in git)
+    ├── ESC-50-master/          # ESC-50 audio files
+    └── embeddings/             # Precomputed CLAP embeddings
 ```
 
 ## Tech Stack

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,7 @@
+flask
+numpy
+torch==2.0.0 --index-url https://download.pytorch.org/whl/cpu
+laion_clap
+librosa
+requests
+tqdm

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,7 @@
+flask
+numpy
+torch
+laion_clap
+librosa
+requests
+tqdm


### PR DESCRIPTION
- Create requirements-gpu.txt with full PyTorch (CUDA support)
- Create requirements-cpu.txt with PyTorch CPU-only version
- Update README to explain which to use and the size difference
- CPU-only version is ~500MB vs ~2GB for GPU version

https://claude.ai/code/session_01UC4878N5eZN2FA6NCNHv35