### PR TITLE
Add stripe overview visualization for clip sorting

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,7 @@
   .layout { display: flex; flex: 1; overflow: hidden; }
 
   /* Left panel – clip list */
-  .panel-left { width: 240px; border-right: 1px solid #2a2d3a; overflow-y: auto; background: #14161e; display: flex; flex-direction: column; }
+  .panel-left { width: 240px; border-right: 1px solid #2a2d3a; overflow-y: auto; background: #14161e; display: flex; flex-direction: column; position: relative; }
   .panel-left h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: #888; padding: 12px 16px 8px; }
   .sort-bar { padding: 8px 16px 12px; border-bottom: 1px solid #2a2d3a; }
   .sort-mode { display: flex; gap: 10px; margin-bottom: 6px; }
@@ -30,6 +30,16 @@
   .clip-item.active { background: #252940; color: #7c8aff; }
   .clip-item .sub { font-size: 0.75rem; color: #666; margin-top: 2px; }
   .clip-item .sim { font-size: 0.7rem; color: #7c8aff; float: right; margin-top: 2px; }
+
+  /* Stripe overview */
+  .stripe-overview { position: absolute; right: 0; top: 0; bottom: 0; width: 20px; background: #1a1d27; border-left: 1px solid #2a2d3a; cursor: pointer; }
+  .stripe-container { position: relative; height: 100%; }
+  .stripe-dot { position: absolute; left: 50%; width: 6px; height: 6px; border-radius: 50%; transform: translateX(-50%); }
+  .stripe-dot.good { background: #4caf50; }
+  .stripe-dot.bad { background: #f44336; }
+  .stripe-threshold { position: absolute; left: 0; right: 0; height: 2px; background: #7c8aff; }
+  .stripe-threshold::before { content: ''; position: absolute; left: 0; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent; border-left: 6px solid #7c8aff; }
+  .stripe-threshold::after { content: ''; position: absolute; right: 0; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent; border-right: 6px solid #7c8aff; }
 
   /* Center panel – player */
   .panel-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; padding: 32px; }
@@ -84,6 +94,9 @@
       <div id="sort-status" class="sort-status"></div>
     </div>
     <div id="clip-list"></div>
+    <div class="stripe-overview" id="stripe-overview">
+      <div class="stripe-container" id="stripe-container"></div>
+    </div>
   </div>
 
   <!-- Center panel -->
@@ -123,6 +136,8 @@
   const textSortWrap = document.getElementById("text-sort-wrap");
   const sortStatus = document.getElementById("sort-status");
   const nextClipBtn = document.getElementById("next-clip-btn");
+  const stripeOverview = document.getElementById("stripe-overview");
+  const stripeContainer = document.getElementById("stripe-container");
 
   // ---- Sort mode switching ----
 
@@ -256,6 +271,7 @@
     const res = await fetch("/api/votes");
     votes = await res.json();
     renderVotes();
+    renderStripe();
     if (selected) renderCenter();
   }
 
@@ -285,6 +301,8 @@
       div.onclick = () => selectClip(c.id);
       clipList.appendChild(div);
     });
+
+    renderStripe();
   }
 
   function selectClip(id) {
@@ -341,6 +359,74 @@
       badList.appendChild(div);
     });
   }
+
+  function renderStripe() {
+    stripeContainer.innerHTML = "";
+
+    // Only show stripe when sorted
+    if (!sortOrder || sortOrder.length === 0) {
+      stripeOverview.style.display = "none";
+      return;
+    }
+
+    stripeOverview.style.display = "block";
+    const totalClips = sortOrder.length;
+
+    // Render dots for each labeled clip
+    sortOrder.forEach((item, index) => {
+      const isGood = votes.good.includes(item.id);
+      const isBad = votes.bad.includes(item.id);
+
+      if (isGood || isBad) {
+        const dot = document.createElement("div");
+        dot.className = `stripe-dot ${isGood ? "good" : "bad"}`;
+        dot.style.top = `${(index / totalClips) * 100}%`;
+        dot.setAttribute("data-clip-id", item.id);
+        dot.setAttribute("data-index", index);
+        stripeContainer.appendChild(dot);
+      }
+    });
+
+    // Render threshold line if available
+    if (threshold !== null) {
+      // Find the index where score crosses threshold
+      let thresholdIndex = 0;
+      for (let i = 0; i < sortOrder.length; i++) {
+        if (sortOrder[i].score < threshold) {
+          thresholdIndex = i;
+          break;
+        }
+      }
+
+      const thresholdLine = document.createElement("div");
+      thresholdLine.className = "stripe-threshold";
+      thresholdLine.style.top = `${(thresholdIndex / totalClips) * 100}%`;
+      stripeContainer.appendChild(thresholdLine);
+    }
+  }
+
+  // ---- Stripe click handler ----
+
+  stripeOverview.addEventListener("click", (e) => {
+    if (!sortOrder || sortOrder.length === 0) return;
+
+    const rect = stripeOverview.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const percentage = y / rect.height;
+    const index = Math.floor(percentage * sortOrder.length);
+    const clampedIndex = Math.max(0, Math.min(index, sortOrder.length - 1));
+
+    if (sortOrder[clampedIndex]) {
+      const clipId = sortOrder[clampedIndex].id;
+      selectClip(clipId);
+
+      // Scroll the clip into view
+      const clipItems = clipList.querySelectorAll(".clip-item");
+      if (clipItems[clampedIndex]) {
+        clipItems[clampedIndex].scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+  });
 
   fetchClips();
   fetchVotes();


### PR DESCRIPTION
## Summary
This PR adds a visual stripe overview panel to the left sidebar that provides a minimap-like representation of all clips in the current sort order, with color-coded indicators for labeled clips and a threshold line.

## Key Changes
- **Stripe Overview Panel**: Added a 20px-wide vertical stripe on the right edge of the left panel that displays the entire clip list at a glance
- **Visual Indicators**: 
  - Green dots represent clips labeled as "good"
  - Red dots represent clips labeled as "bad"
  - Blue threshold line shows where the quality threshold is set
- **Interactive Navigation**: Clicking on the stripe jumps to that position in the clip list and smoothly scrolls it into view
- **Dynamic Rendering**: The stripe updates whenever clips are fetched, votes are updated, or the sort order changes
- **Conditional Display**: The stripe only appears when clips are sorted; it hides when no sort order is active

## Implementation Details
- Added `position: relative` to `.panel-left` to establish positioning context for the absolute-positioned stripe
- Created new CSS classes for stripe styling (`.stripe-overview`, `.stripe-container`, `.stripe-dot`, `.stripe-threshold`)
- Implemented `renderStripe()` function that:
  - Maps clip positions proportionally to the stripe height
  - Calculates threshold line position based on score values
  - Handles edge cases (empty sort order, null threshold)
- Added click handler to stripe that converts click position to clip index and triggers selection with smooth scrolling
- Integrated stripe rendering into existing data flow (after fetching clips/votes and when rendering clip list)

https://claude.ai/code/session_017tnMNtKFH2ePcyiMicu9L5