### PR TITLE
Add detector export/import and load-based sorting

### DIFF
--- a/app.py
+++ b/app.py
@@ -458,6 +458,86 @@ def import_labels():
     return jsonify({"applied": applied, "skipped": skipped})
 
 
+@app.route("/api/detector/export", methods=["POST"])
+def export_detector():
+    """Train MLP on current votes and export the model weights."""
+    if not good_votes or not bad_votes:
+        return jsonify({"error": "need at least one good and one bad vote"}), 400
+
+    # Train the model
+    X_list = []
+    y_list = []
+    for cid in good_votes:
+        X_list.append(clips[cid]["embedding"])
+        y_list.append(1.0)
+    for cid in bad_votes:
+        X_list.append(clips[cid]["embedding"])
+        y_list.append(0.0)
+
+    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+
+    input_dim = X.shape[1]
+
+    # Calculate threshold using cross-calibration
+    threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim)
+
+    # Train final model on all data
+    model = train_model(X, y, input_dim)
+
+    # Extract model weights
+    state_dict = model.state_dict()
+    weights = {}
+    for key, value in state_dict.items():
+        weights[key] = value.tolist()
+
+    return jsonify({"weights": weights, "threshold": round(threshold, 4)})
+
+
+@app.route("/api/detector-sort", methods=["POST"])
+def detector_sort():
+    """Score all clips using a loaded detector model."""
+    data = request.get_json(force=True)
+    detector = data.get("detector")
+    if not detector:
+        return jsonify({"error": "detector is required"}), 400
+
+    weights = detector.get("weights")
+    threshold = detector.get("threshold", 0.5)
+
+    if not weights:
+        return jsonify({"error": "detector weights are required"}), 400
+
+    # Reconstruct the model from weights
+    # Determine input_dim from the first layer weights
+    input_dim = len(weights["0.weight"][0])
+
+    model = nn.Sequential(
+        nn.Linear(input_dim, 64),
+        nn.ReLU(),
+        nn.Linear(64, 1),
+        nn.Sigmoid(),
+    )
+
+    # Load weights
+    state_dict = {}
+    for key, value in weights.items():
+        state_dict[key] = torch.tensor(value, dtype=torch.float32)
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    # Score every clip
+    all_ids = sorted(clips.keys())
+    all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
+    X_all = torch.tensor(all_embs, dtype=torch.float32)
+    with torch.no_grad():
+        scores = model(X_all).squeeze(1).tolist()
+
+    results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return jsonify({"results": results, "threshold": round(threshold, 4)})
+
+
 if __name__ == "__main__":
     # Initialize before server starts to avoid lazy-loading crashes
     initialize_app()

--- a/static/index.html
+++ b/static/index.html
@@ -84,12 +84,16 @@
     <div class="sort-bar">
       <span class="sort-label">Sort</span>
       <div class="sort-mode">
-        <label><input type="radio" name="sort-mode" value="none" checked> None</label>
-        <label><input type="radio" name="sort-mode" value="text"> Text</label>
-        <label><input type="radio" name="sort-mode" value="learned"> Learn</label>
+        <label><input type="radio" name="sort-mode" value="text" checked> Text</label>
+        <label><input type="radio" name="sort-mode" value="learned" id="learned-radio"> Learn</label>
+        <label><input type="radio" name="sort-mode" value="load" id="load-radio"> Load</label>
       </div>
-      <div id="text-sort-wrap" style="display:none">
+      <div id="text-sort-wrap">
         <input type="text" id="text-sort" placeholder='e.g. "high pitched beep"'>
+      </div>
+      <div id="load-sort-wrap" style="display:none">
+        <button id="load-detector-btn" style="width:100%; padding:6px; background:#7c8aff; color:#fff; border:none; border-radius:4px; cursor:pointer; font-size:0.85rem;">Load Detector</button>
+        <input type="file" id="load-detector-file" accept=".json" style="display:none">
       </div>
       <span class="sort-label" style="margin-top:8px">Select</span>
       <div class="sort-mode">
@@ -118,6 +122,10 @@
       <input type="file" id="import-file" accept=".json" style="display:none">
     </div>
     <div id="label-io-status" class="label-io-status"></div>
+    <div class="label-io">
+      <button id="export-detector-btn">Export Detector</button>
+    </div>
+    <div id="detector-io-status" class="label-io-status"></div>
     <div class="vote-section">
       <h3 class="good">Good</h3>
       <div id="good-list"></div>
@@ -135,10 +143,11 @@
   let votes = { good: [], bad: [] };
   let selected = null;
   let sortOrder = null;   // null = default, or [{id, score}, ...]
-  let sortMode = "none";  // "none" | "text" | "learned"
+  let sortMode = "text";  // "text" | "learned" | "load"
   let selectMode = "good"; // "good" | "hard"
   let threshold = null;    // threshold for Good/Bad boundary
   let sortTimer = null;
+  let loadedDetector = null; // Stores loaded detector model weights
 
   const clipList = document.getElementById("clip-list");
   const center = document.getElementById("center");
@@ -146,6 +155,11 @@
   const badList = document.getElementById("bad-list");
   const textSortInput = document.getElementById("text-sort");
   const textSortWrap = document.getElementById("text-sort-wrap");
+  const loadSortWrap = document.getElementById("load-sort-wrap");
+  const loadDetectorBtn = document.getElementById("load-detector-btn");
+  const loadDetectorFile = document.getElementById("load-detector-file");
+  const learnedRadio = document.getElementById("learned-radio");
+  const loadRadio = document.getElementById("load-radio");
   const sortStatus = document.getElementById("sort-status");
   const nextClipBtn = document.getElementById("next-clip-btn");
   const stripeOverview = document.getElementById("stripe-overview");
@@ -153,19 +167,45 @@
 
   // ---- Sort mode switching ----
 
+  function updateSortModeAvailability() {
+    const hasGoodAndBad = votes.good.length > 0 && votes.bad.length > 0;
+    learnedRadio.disabled = !hasGoodAndBad;
+    learnedRadio.parentElement.style.opacity = hasGoodAndBad ? "1" : "0.5";
+    learnedRadio.parentElement.style.cursor = hasGoodAndBad ? "pointer" : "not-allowed";
+
+    const hasLoadedDetector = loadedDetector !== null;
+    loadRadio.disabled = !hasLoadedDetector;
+    loadRadio.parentElement.style.opacity = hasLoadedDetector ? "1" : "0.5";
+    loadRadio.parentElement.style.cursor = hasLoadedDetector ? "pointer" : "not-allowed";
+  }
+
   document.querySelectorAll('input[name="sort-mode"]').forEach(radio => {
     radio.addEventListener("change", () => {
+      // Validate selection
+      if (radio.value === "learned" && (votes.good.length === 0 || votes.bad.length === 0)) {
+        sortStatus.textContent = "Vote good & bad clips first";
+        // Revert to text mode
+        document.querySelector('input[name="sort-mode"][value="text"]').checked = true;
+        return;
+      }
+      if (radio.value === "load" && loadedDetector === null) {
+        sortStatus.textContent = "Load a detector first";
+        // Revert to text mode
+        document.querySelector('input[name="sort-mode"][value="text"]').checked = true;
+        return;
+      }
+
       sortMode = radio.value;
       textSortWrap.style.display = sortMode === "text" ? "" : "none";
+      loadSortWrap.style.display = sortMode === "load" ? "" : "none";
       sortStatus.textContent = "";
-      if (sortMode === "none") {
-        sortOrder = null;
-        threshold = null;
-        renderClipList();
-      } else if (sortMode === "text") {
+
+      if (sortMode === "text") {
         onTextSortInput();
       } else if (sortMode === "learned") {
         fetchLearnedSort();
+      } else if (sortMode === "load") {
+        fetchLoadedSort();
       }
     });
   });
@@ -228,6 +268,62 @@
     renderClipList();
   }
 
+  // ---- Load detector sort ----
+
+  async function fetchLoadedSort() {
+    if (!loadedDetector) {
+      sortStatus.textContent = "Load a detector first";
+      return;
+    }
+    sortStatus.textContent = "Scoring with loaded detector\u2026";
+    const res = await fetch("/api/detector-sort", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ detector: loadedDetector }),
+    });
+    if (!res.ok) {
+      sortOrder = null;
+      threshold = null;
+      sortStatus.textContent = "Failed to score with detector";
+      renderClipList();
+      return;
+    }
+    const data = await res.json();
+    sortOrder = data.results;  // [{id, score}, ...]
+    threshold = data.threshold;
+    sortStatus.textContent = `Threshold: ${(threshold * 100).toFixed(1)}%`;
+    renderClipList();
+  }
+
+  // ---- Load detector file ----
+
+  loadDetectorBtn.addEventListener("click", () => {
+    loadDetectorFile.click();
+  });
+
+  loadDetectorFile.addEventListener("change", async () => {
+    const file = loadDetectorFile.files[0];
+    if (!file) return;
+    sortStatus.textContent = "Loading detector\u2026";
+    const text = await file.text();
+    try {
+      loadedDetector = JSON.parse(text);
+      sortStatus.textContent = "Detector loaded";
+      updateSortModeAvailability();
+      // Auto-switch to load mode
+      document.querySelector('input[name="sort-mode"][value="load"]').checked = true;
+      sortMode = "load";
+      loadSortWrap.style.display = "";
+      textSortWrap.style.display = "none";
+      fetchLoadedSort();
+    } catch (e) {
+      sortStatus.textContent = "Invalid detector file";
+      loadedDetector = null;
+      updateSortModeAvailability();
+    }
+    loadDetectorFile.value = "";
+  });
+
   // ---- Next Clip Selection ----
 
   nextClipBtn.addEventListener("click", () => {
@@ -284,6 +380,7 @@
     votes = await res.json();
     renderVotes();
     renderStripe();
+    updateSortModeAvailability();
     if (selected) renderCenter();
   }
 
@@ -446,6 +543,8 @@
   const importBtn = document.getElementById("import-btn");
   const importFile = document.getElementById("import-file");
   const labelIoStatus = document.getElementById("label-io-status");
+  const exportDetectorBtn = document.getElementById("export-detector-btn");
+  const detectorIoStatus = document.getElementById("detector-io-status");
 
   exportBtn.addEventListener("click", async () => {
     labelIoStatus.textContent = "";
@@ -493,8 +592,37 @@
     importFile.value = "";
   });
 
+  // ---- Detector export ----
+
+  exportDetectorBtn.addEventListener("click", async () => {
+    detectorIoStatus.textContent = "";
+    if (votes.good.length === 0 || votes.bad.length === 0) {
+      detectorIoStatus.textContent = "Vote good & bad clips first";
+      return;
+    }
+    detectorIoStatus.textContent = "Exporting detector\u2026";
+    const res = await fetch("/api/detector/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) {
+      detectorIoStatus.textContent = "Export failed";
+      return;
+    }
+    const data = await res.json();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "detector.json";
+    a.click();
+    URL.revokeObjectURL(url);
+    detectorIoStatus.textContent = "Detector exported";
+  });
+
   fetchClips();
   fetchVotes();
+  updateSortModeAvailability();
 })();
 </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,12 +84,16 @@
     <div class="sort-bar">
       <span class="sort-label">Sort</span>
       <div class="sort-mode">
-        <label><input type="radio" name="sort-mode" value="none" checked> None</label>
-        <label><input type="radio" name="sort-mode" value="text"> Text</label>
-        <label><input type="radio" name="sort-mode" value="learned"> Learn</label>
+        <label><input type="radio" name="sort-mode" value="text" checked> Text</label>
+        <label><input type="radio" name="sort-mode" value="learned" id="learned-radio"> Learn</label>
+        <label><input type="radio" name="sort-mode" value="load" id="load-radio"> Load</label>
       </div>
-      <div id="text-sort-wrap" style="display:none">
+      <div id="text-sort-wrap">
         <input type="text" id="text-sort" placeholder='e.g. "high pitched beep"'>
+      </div>
+      <div id="load-sort-wrap" style="display:none">
+        <button id="load-detector-btn" style="width:100%; padding:6px; background:#7c8aff; color:#fff; border:none; border-radius:4px; cursor:pointer; font-size:0.85rem;">Load Detector</button>
+        <input type="file" id="load-detector-file" accept=".json" style="display:none">
       </div>
       <span class="sort-label" style="margin-top:8px">Select</span>
       <div class="sort-mode">
@@ -118,6 +122,10 @@
       <input type="file" id="import-file" accept=".json" style="display:none">
     </div>
     <div id="label-io-status" class="label-io-status"></div>
+    <div class="label-io">
+      <button id="export-detector-btn">Export Detector</button>
+    </div>
+    <div id="detector-io-status" class="label-io-status"></div>
     <div class="vote-section">
       <h3 class="good">Good</h3>
       <div id="good-list"></div>
@@ -135,10 +143,11 @@
   let votes = { good: [], bad: [] };
   let selected = null;
   let sortOrder = null;   // null = default, or [{id, score}, ...]
-  let sortMode = "none";  // "none" | "text" | "learned"
+  let sortMode = "text";  // "text" | "learned" | "load"
   let selectMode = "good"; // "good" | "hard"
   let threshold = null;    // threshold for Good/Bad boundary
   let sortTimer = null;
+  let loadedDetector = null; // Stores loaded detector model weights
 
   const clipList = document.getElementById("clip-list");
   const center = document.getElementById("center");
@@ -146,6 +155,11 @@
   const badList = document.getElementById("bad-list");
   const textSortInput = document.getElementById("text-sort");
   const textSortWrap = document.getElementById("text-sort-wrap");
+  const loadSortWrap = document.getElementById("load-sort-wrap");
+  const loadDetectorBtn = document.getElementById("load-detector-btn");
+  const loadDetectorFile = document.getElementById("load-detector-file");
+  const learnedRadio = document.getElementById("learned-radio");
+  const loadRadio = document.getElementById("load-radio");
   const sortStatus = document.getElementById("sort-status");
   const nextClipBtn = document.getElementById("next-clip-btn");
   const stripeOverview = document.getElementById("stripe-overview");
@@ -153,19 +167,45 @@
 
   // ---- Sort mode switching ----
 
+  function updateSortModeAvailability() {
+    const hasGoodAndBad = votes.good.length > 0 && votes.bad.length > 0;
+    learnedRadio.disabled = !hasGoodAndBad;
+    learnedRadio.parentElement.style.opacity = hasGoodAndBad ? "1" : "0.5";
+    learnedRadio.parentElement.style.cursor = hasGoodAndBad ? "pointer" : "not-allowed";
+
+    const hasLoadedDetector = loadedDetector !== null;
+    loadRadio.disabled = !hasLoadedDetector;
+    loadRadio.parentElement.style.opacity = hasLoadedDetector ? "1" : "0.5";
+    loadRadio.parentElement.style.cursor = hasLoadedDetector ? "pointer" : "not-allowed";
+  }
+
   document.querySelectorAll('input[name="sort-mode"]').forEach(radio => {
     radio.addEventListener("change", () => {
+      // Validate selection
+      if (radio.value === "learned" && (votes.good.length === 0 || votes.bad.length === 0)) {
+        sortStatus.textContent = "Vote good & bad clips first";
+        // Revert to text mode
+        document.querySelector('input[name="sort-mode"][value="text"]').checked = true;
+        return;
+      }
+      if (radio.value === "load" && loadedDetector === null) {
+        sortStatus.textContent = "Load a detector first";
+        // Revert to text mode
+        document.querySelector('input[name="sort-mode"][value="text"]').checked = true;
+        return;
+      }
+
       sortMode = radio.value;
       textSortWrap.style.display = sortMode === "text" ? "" : "none";
+      loadSortWrap.style.display = sortMode === "load" ? "" : "none";
       sortStatus.textContent = "";
-      if (sortMode === "none") {
-        sortOrder = null;
-        threshold = null;
-        renderClipList();
-      } else if (sortMode === "text") {
+
+      if (sortMode === "text") {
         onTextSortInput();
       } else if (sortMode === "learned") {
         fetchLearnedSort();
+      } else if (sortMode === "load") {
+        fetchLoadedSort();
       }
     });
   });
@@ -228,6 +268,62 @@
     renderClipList();
   }
 
+  // ---- Load detector sort ----
+
+  async function fetchLoadedSort() {
+    if (!loadedDetector) {
+      sortStatus.textContent = "Load a detector first";
+      return;
+    }
+    sortStatus.textContent = "Scoring with loaded detector\u2026";
+    const res = await fetch("/api/detector-sort", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ detector: loadedDetector }),
+    });
+    if (!res.ok) {
+      sortOrder = null;
+      threshold = null;
+      sortStatus.textContent = "Failed to score with detector";
+      renderClipList();
+      return;
+    }
+    const data = await res.json();
+    sortOrder = data.results;  // [{id, score}, ...]
+    threshold = data.threshold;
+    sortStatus.textContent = `Threshold: ${(threshold * 100).toFixed(1)}%`;
+    renderClipList();
+  }
+
+  // ---- Load detector file ----
+
+  loadDetectorBtn.addEventListener("click", () => {
+    loadDetectorFile.click();
+  });
+
+  loadDetectorFile.addEventListener("change", async () => {
+    const file = loadDetectorFile.files[0];
+    if (!file) return;
+    sortStatus.textContent = "Loading detector\u2026";
+    const text = await file.text();
+    try {
+      loadedDetector = JSON.parse(text);
+      sortStatus.textContent = "Detector loaded";
+      updateSortModeAvailability();
+      // Auto-switch to load mode
+      document.querySelector('input[name="sort-mode"][value="load"]').checked = true;
+      sortMode = "load";
+      loadSortWrap.style.display = "";
+      textSortWrap.style.display = "none";
+      fetchLoadedSort();
+    } catch (e) {
+      sortStatus.textContent = "Invalid detector file";
+      loadedDetector = null;
+      updateSortModeAvailability();
+    }
+    loadDetectorFile.value = "";
+  });
+
   // ---- Next Clip Selection ----
 
   nextClipBtn.addEventListener("click", () => {
@@ -284,6 +380,7 @@
     votes = await res.json();
     renderVotes();
     renderStripe();
+    updateSortModeAvailability();
     if (selected) renderCenter();
   }
 
@@ -446,6 +543,8 @@
   const importBtn = document.getElementById("import-btn");
   const importFile = document.getElementById("import-file");
   const labelIoStatus = document.getElementById("label-io-status");
+  const exportDetectorBtn = document.getElementById("export-detector-btn");
+  const detectorIoStatus = document.getElementById("detector-io-status");
 
   exportBtn.addEventListener("click", async () => {
     labelIoStatus.textContent = "";
@@ -493,8 +592,37 @@
     importFile.value = "";
   });
 
+  // ---- Detector export ----
+
+  exportDetectorBtn.addEventListener("click", async () => {
+    detectorIoStatus.textContent = "";
+    if (votes.good.length === 0 || votes.bad.length === 0) {
+      detectorIoStatus.textContent = "Vote good & bad clips first";
+      return;
+    }
+    detectorIoStatus.textContent = "Exporting detector\u2026";
+    const res = await fetch("/api/detector/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) {
+      detectorIoStatus.textContent = "Export failed";
+      return;
+    }
+    const data = await res.json();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "detector.json";
+    a.click();
+    URL.revokeObjectURL(url);
+    detectorIoStatus.textContent = "Detector exported";
+  });
+
   fetchClips();
   fetchVotes();
+  updateSortModeAvailability();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
This PR adds the ability to export trained detectors as JSON files and load them back to sort clips, enabling model persistence and reuse across sessions.

## Key Changes

**Frontend (HTML/JavaScript):**
- Replaced "None" sort mode with "Load" mode for loading pre-trained detectors
- Changed default sort mode from "none" to "text"
- Added "Load Detector" button and file input for importing detector JSON files
- Added "Export Detector" button to save trained models
- Implemented `updateSortModeAvailability()` to disable sort modes when prerequisites aren't met (e.g., "Learn" requires both good and bad votes, "Load" requires a loaded detector)
- Added validation to prevent selecting unavailable sort modes with user-friendly error messages
- Added `fetchLoadedSort()` function to score clips using a loaded detector model
- Added detector file loading logic that parses JSON and auto-switches to load mode
- Added detector export UI with status feedback

**Backend (Python/Flask):**
- Added `/api/detector/export` endpoint that trains an MLP on current votes and exports model weights as JSON
- Added `/api/detector-sort` endpoint that reconstructs a model from exported weights and scores all clips
- Both endpoints return results with threshold information for clip sorting

## Implementation Details

- Detector export includes model weights (as nested lists) and a threshold value calculated via cross-calibration
- Detector import reconstructs the same MLP architecture (input → 64 hidden units → output with sigmoid) from the exported weights
- Sort mode availability is dynamically updated after votes are loaded, enabling/disabling radio buttons with visual feedback (opacity and cursor changes)
- Auto-switching to load mode occurs after successful detector file import
- Error handling for invalid detector files with appropriate user messaging

https://claude.ai/code/session_015eDieiKdnCFuA9MDxLWUn6