### PR TITLE
Add data directory to gitignore for demo datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .venv/
+
+# Demo dataset files
+data/


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude the `data/` directory, preventing demo dataset files from being committed to the repository.

## Changes
- Added `data/` directory to `.gitignore` with a descriptive comment indicating it contains demo dataset files

## Details
This change ensures that large or temporary demo datasets are not tracked by git, keeping the repository clean and reducing unnecessary commits. The comment clarifies the purpose of the ignored directory for future developers.

https://claude.ai/code/session_01BSfHxoLZ8avZJvEDNgZ8RT