### PR TITLE
Enhance demo dataset metadata and UI with descriptions and file counts

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,81 +61,97 @@ progress_data = {
 }
 
 # Demo dataset definitions (from setup_datasets.py)
+# ESC-50 has 40 clips per category
+CLIPS_PER_CATEGORY = 40
+ESC50_DOWNLOAD_SIZE_MB = 600  # Approximate download size of full ESC-50 dataset
+
 DEMO_DATASETS = {
-    "animals": [
-        "dog",
-        "rooster",
-        "pig",
-        "cow",
-        "frog",
-        "cat",
-        "hen",
-        "insects",
-        "sheep",
-        "crow",
-        "rain",
-        "sea_waves",
-        "crackling_fire",
-        "crickets",
-        "chirping_birds",
-        "water_drops",
-        "wind",
-        "pouring_water",
-        "toilet_flush",
-        "thunderstorm",
-    ],
-    "natural": [
-        "rain",
-        "sea_waves",
-        "crackling_fire",
-        "crickets",
-        "chirping_birds",
-        "water_drops",
-        "wind",
-        "pouring_water",
-        "thunderstorm",
-        "frog",
-    ],
-    "urban": [
-        "clock_alarm",
-        "clock_tick",
-        "door_wood_knock",
-        "mouse_click",
-        "keyboard_typing",
-        "door_wood_creaks",
-        "can_opening",
-        "washing_machine",
-        "vacuum_cleaner",
-        "helicopter",
-        "chainsaw",
-        "siren",
-        "car_horn",
-        "engine",
-        "train",
-        "church_bells",
-        "airplane",
-        "fireworks",
-        "hand_saw",
-    ],
-    "household": [
-        "clock_alarm",
-        "clock_tick",
-        "door_wood_knock",
-        "mouse_click",
-        "keyboard_typing",
-        "door_wood_creaks",
-        "can_opening",
-        "washing_machine",
-        "vacuum_cleaner",
-        "sneezing",
-        "coughing",
-        "breathing",
-        "laughing",
-        "brushing_teeth",
-        "snoring",
-        "drinking_sipping",
-        "footsteps",
-    ],
+    "animals": {
+        "categories": [
+            "dog",
+            "rooster",
+            "pig",
+            "cow",
+            "frog",
+            "cat",
+            "hen",
+            "insects",
+            "sheep",
+            "crow",
+            "rain",
+            "sea_waves",
+            "crackling_fire",
+            "crickets",
+            "chirping_birds",
+            "water_drops",
+            "wind",
+            "pouring_water",
+            "toilet_flush",
+            "thunderstorm",
+        ],
+        "description": "Animal and nature sounds"
+    },
+    "natural": {
+        "categories": [
+            "rain",
+            "sea_waves",
+            "crackling_fire",
+            "crickets",
+            "chirping_birds",
+            "water_drops",
+            "wind",
+            "pouring_water",
+            "thunderstorm",
+            "frog",
+        ],
+        "description": "Natural environmental sounds"
+    },
+    "urban": {
+        "categories": [
+            "clock_alarm",
+            "clock_tick",
+            "door_wood_knock",
+            "mouse_click",
+            "keyboard_typing",
+            "door_wood_creaks",
+            "can_opening",
+            "washing_machine",
+            "vacuum_cleaner",
+            "helicopter",
+            "chainsaw",
+            "siren",
+            "car_horn",
+            "engine",
+            "train",
+            "church_bells",
+            "airplane",
+            "fireworks",
+            "hand_saw",
+        ],
+        "description": "Urban and mechanical sounds"
+    },
+    "household": {
+        "categories": [
+            "clock_alarm",
+            "clock_tick",
+            "door_wood_knock",
+            "mouse_click",
+            "keyboard_typing",
+            "door_wood_creaks",
+            "can_opening",
+            "washing_machine",
+            "vacuum_cleaner",
+            "sneezing",
+            "coughing",
+            "breathing",
+            "laughing",
+            "brushing_teeth",
+            "snoring",
+            "drinking_sipping",
+            "footsteps",
+        ],
+        "description": "Household and human sounds"
+    },
 }
 
 
@@ -455,7 +471,7 @@ def load_demo_dataset(dataset_name: str):
     metadata = load_esc50_metadata(audio_dir.parent)
 
     # Filter files for this dataset
-    categories = DEMO_DATASETS[dataset_name]
+    categories = DEMO_DATASETS[dataset_name]["categories"]
     audio_files = []
     for audio_path in sorted(audio_dir.glob("*.wav")):
         if audio_path.name in metadata:
@@ -1087,13 +1103,30 @@ def dataset_progress():
 def demo_dataset_list():
     """List available demo datasets."""
     demos = []
-    for name in DEMO_DATASETS.keys():
+    for name, dataset_info in DEMO_DATASETS.items():
         pkl_file = EMBEDDINGS_DIR / f"{name}.pkl"
+        is_ready = pkl_file.exists()
+
+        # Calculate number of files (40 clips per ESC-50 category)
+        num_categories = len(dataset_info["categories"])
+        num_files = num_categories * CLIPS_PER_CATEGORY
+
+        # Calculate download size
+        if is_ready:
+            # If ready, show the actual .pkl file size
+            download_size_mb = pkl_file.stat().st_size / (1024 * 1024)
+        else:
+            # If not ready, user needs to download full ESC-50
+            download_size_mb = ESC50_DOWNLOAD_SIZE_MB
+
         demos.append(
             {
                 "name": name,
-                "ready": pkl_file.exists(),
-                "num_categories": len(DEMO_DATASETS[name]),
+                "ready": is_ready,
+                "num_categories": num_categories,
+                "num_files": num_files,
+                "download_size_mb": round(download_size_mb, 1),
+                "description": dataset_info.get("description", "")
             }
         )
     return jsonify({"datasets": demos})

--- a/static/index.html
+++ b/static/index.html
@@ -456,9 +456,20 @@
     data.datasets.forEach(dataset => {
       const div = document.createElement("div");
       div.className = "demo-dataset" + (dataset.ready ? " ready" : "");
+
+      // Format file count
+      const fileCountText = `${dataset.num_files} sound files`;
+
+      // Format download size
+      const sizeText = dataset.ready
+        ? `${dataset.download_size_mb} MB (cached)`
+        : `${dataset.download_size_mb} MB download`;
+
       div.innerHTML = `
         <h4>${dataset.name}</h4>
-        <p>${dataset.num_categories} categories</p>
+        <p style="margin: 4px 0; font-size: 0.85rem;">${fileCountText}</p>
+        <p style="margin: 4px 0; font-size: 0.8rem; color: #888;">${dataset.num_categories} categories</p>
+        <p style="margin: 4px 0; font-size: 0.8rem; color: #666;">${sizeText}</p>
         ${dataset.ready ? '<span class="ready-badge">Ready</span>' : '<span style="font-size:0.7rem;color:#888;">Needs download</span>'}
       `;
       div.onclick = () => loadDemo(dataset.name);


### PR DESCRIPTION
## Summary
This PR improves the demo dataset feature by adding richer metadata to dataset definitions and enhancing the UI to display more useful information to users about available datasets.

## Key Changes

- **Dataset Structure Refactoring**: Converted `DEMO_DATASETS` from simple lists to dictionaries containing both `categories` and `description` fields, providing better organization and extensibility
- **Metadata Constants**: Added `CLIPS_PER_CATEGORY` and `ESC50_DOWNLOAD_SIZE_MB` constants to centralize dataset size information
- **Enhanced Dataset Information**: The `/demo_dataset_list` endpoint now returns:
  - `num_files`: Calculated total number of sound files (categories × clips per category)
  - `download_size_mb`: Shows cached .pkl file size if ready, otherwise shows full ESC-50 download size
  - `description`: Human-readable description of each dataset
- **Improved UI Display**: Updated the demo dataset cards to show:
  - Total number of sound files
  - Number of categories (secondary information)
  - Download/cache size with status indicator
  - Better visual hierarchy with adjusted font sizes and spacing

## Implementation Details

- The `load_demo_dataset()` function was updated to access categories from the new nested structure
- Download size calculation is smart: it shows actual cached file size when available, otherwise estimates based on the full ESC-50 dataset size
- UI styling uses inline styles for better readability of dataset information with appropriate font sizing and color coding

https://claude.ai/code/session_01GAsb9RHoecNxe3FspH4hTt