### PR TITLE
Fix burger menu click handler

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -578,7 +578,7 @@
 
   // Close burger menu when clicking outside
   document.addEventListener("click", (e) => {
-    if (!burgerDropdown.contains(e.target) && e.target !== burgerBtn) {
+    if (!burgerDropdown.contains(e.target) && !burgerBtn.contains(e.target)) {
       burgerDropdown.classList.remove("show");
     }
   });


### PR DESCRIPTION
Changed click-outside detection from checking e.target !== burgerBtn to !burgerBtn.contains(e.target) to properly handle clicks on the span elements inside the burger button.

https://claude.ai/code/session_012kLBFzdGA78LnLvPTTjkxc