### PR TITLE
Improve dataset change confirmation and menu handling

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -596,7 +596,7 @@
   // Dataset change
   if (menuDatasetChange && burgerDropdown) {
     menuDatasetChange.addEventListener("click", () => {
-      if (confirm("Clear current dataset and load a new one?")) {
+      if (confirm("Changing the dataset will erase your current dataset. Continue?")) {
         fetch("/api/dataset/clear", { method: "POST" })
           .then(() => {
             showWelcomeScreen();
@@ -604,9 +604,11 @@
             votes = { good: [], bad: [] };
             selected = null;
             datasetLoaded = false;
+            burgerDropdown.classList.remove("show");
           });
+      } else {
+        burgerDropdown.classList.remove("show");
       }
-      burgerDropdown.classList.remove("show");
     });
   }
 


### PR DESCRIPTION
## Summary
Updated the dataset change confirmation flow to provide clearer user messaging and ensure the burger menu dropdown is properly closed regardless of the user's confirmation choice.

## Key Changes
- Updated confirmation dialog message from "Clear current dataset and load a new one?" to "Changing the dataset will erase your current dataset. Continue?" for better clarity
- Moved burger dropdown menu closing logic inside the confirmation handler to ensure it only closes after the user confirms the action
- Added explicit dropdown closing in the cancellation path (else block) so the menu closes whether the user confirms or cancels the action

## Implementation Details
The burger dropdown menu now closes in both scenarios:
1. When the user confirms the dataset change and the clear operation completes
2. When the user cancels the operation by clicking "Cancel" on the confirmation dialog

This prevents the menu from remaining open when the user dismisses the confirmation dialog.

https://claude.ai/code/session_01CdVCusDko1R6f58eoqid1b