### PR TITLE
Add multi-modality support for Videos, Images, Sounds, and Paragraphs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ scikit-learn
 librosa
 requests
 opencv-python
+sentence-transformers
+pillow

--- a/static/index.html
+++ b/static/index.html
@@ -229,8 +229,8 @@
           <p>Load a previously saved dataset file (.pkl)</p>
         </button>
         <button class="dataset-option" id="load-folder-btn">
-          <h3>🎵 Generate from Folder</h3>
-          <p>Process audio files from a folder on your computer</p>
+          <h3>📂 Generate from Folder</h3>
+          <p>Process media files (sounds/videos/images/paragraphs) from a folder</p>
         </button>
         <button class="dataset-option" id="load-demo-btn">
           <h3>🎯 Load Demo Dataset</h3>
@@ -476,15 +476,25 @@
 
   // Load from folder (Note: folder selection requires server-side path input)
   loadFolderBtn.addEventListener("click", () => {
-    const path = prompt("Enter the full path to the folder containing audio files:");
+    const path = prompt("Enter the full path to the folder containing media files:");
     if (!path) return;
+
+    // Ask user to select media type via radio buttons in a modal-like prompt
+    const mediaType = prompt(
+      "Enter media type (sounds/videos/images/paragraphs):",
+      "sounds"
+    );
+    if (!mediaType || !["sounds", "videos", "images", "paragraphs"].includes(mediaType.toLowerCase())) {
+      alert("Invalid media type. Please choose: sounds, videos, images, or paragraphs");
+      return;
+    }
 
     startProgressPolling();
 
     fetch("/api/dataset/load-folder", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path }),
+      body: JSON.stringify({ path, media_type: mediaType.toLowerCase() }),
     }).then(res => {
       if (!res.ok) {
         res.json().then(error => {
@@ -988,7 +998,14 @@
       if (isGood) className += " labeled-good";
       if (isBad) className += " labeled-bad";
       div.className = className;
-      const mediaIcon = (c.type === "video") ? "🎬 " : "";
+      // Icon based on media type
+      const mediaIcons = {
+        "video": "🎬 ",
+        "image": "🖼️ ",
+        "paragraph": "📄 ",
+        "audio": "🔊 "
+      };
+      const mediaIcon = mediaIcons[c.type] || "";
       let html = `<div style="font-weight: 500;">${mediaIcon}${c.filename || 'Clip #' + c.id}</div>`;
       if (scoreMap[c.id] !== undefined) {
         html += `<span class="sim">${(scoreMap[c.id] * 100).toFixed(1)}%</span>`;
@@ -1000,7 +1017,13 @@
       if (c.category && c.category !== "unknown") {
         subInfo.push(c.category);
       }
-      subInfo.push(`${c.duration.toFixed(1)}s`);
+      if (c.type === "audio" || c.type === "video") {
+        subInfo.push(`${c.duration.toFixed(1)}s`);
+      } else if (c.type === "image" && c.width && c.height) {
+        subInfo.push(`${c.width}×${c.height}`);
+      } else if (c.type === "paragraph" && c.word_count) {
+        subInfo.push(`${c.word_count} words`);
+      }
       html += `<div class="sub">${subInfo.join(' &middot; ')}</div>`;
       div.innerHTML = html;
       div.onclick = () => selectClip(c.id);
@@ -1031,14 +1054,30 @@
     if (c.category && c.category !== "unknown") {
       metaInfo.push(c.category);
     }
-    metaInfo.push(`${c.duration.toFixed(1)}s`);
+    if (mediaType === "audio" || mediaType === "video") {
+      metaInfo.push(`${c.duration.toFixed(1)}s`);
+    }
+    if (mediaType === "image" && c.width && c.height) {
+      metaInfo.push(`${c.width}×${c.height}`);
+    }
+    if (mediaType === "paragraph" && c.word_count) {
+      metaInfo.push(`${c.word_count} words`);
+    }
     metaInfo.push(`${(c.file_size / 1024).toFixed(1)} KB`);
 
-    // Render audio or video player based on media type
+    // Render media player based on media type
     let playerHTML = '';
     if (mediaType === "video") {
       playerHTML = `<video controls loop autoplay src="/api/clips/${c.id}/video" id="clip-video" style="width: 600px; max-height: 400px; border: 1px solid #2a2d3a; border-radius: 8px; background: #1a1d27;"></video>`;
+    } else if (mediaType === "image") {
+      playerHTML = `<img src="/api/clips/${c.id}/image" id="clip-image" style="max-width: 600px; max-height: 400px; border: 1px solid #2a2d3a; border-radius: 8px; background: #1a1d27;">`;
+    } else if (mediaType === "paragraph") {
+      playerHTML = `
+        <div id="clip-paragraph" style="max-width: 600px; max-height: 400px; overflow-y: auto; padding: 16px; border: 1px solid #2a2d3a; border-radius: 8px; background: #1a1d27; white-space: pre-wrap; line-height: 1.6; text-align: left;">
+          Loading...
+        </div>`;
     } else {
+      // Audio/Sound
       playerHTML = `
         <canvas id="waveform-canvas" width="600" height="120"></canvas>
         <audio controls loop autoplay src="/api/clips/${c.id}/audio" id="clip-audio"></audio>`;
@@ -1065,10 +1104,25 @@
           <span class="metadata-label">Media Type</span>
           <span class="metadata-value">${mediaType}</span>
         </div>
+        ${(mediaType === 'audio' || mediaType === 'video') ? `
         <div class="metadata-item">
           <span class="metadata-label">Duration</span>
           <span class="metadata-value">${c.duration.toFixed(1)}s</span>
+        </div>` : ''}
+        ${(mediaType === 'image' && c.width && c.height) ? `
+        <div class="metadata-item">
+          <span class="metadata-label">Dimensions</span>
+          <span class="metadata-value">${c.width}×${c.height}</span>
+        </div>` : ''}
+        ${(mediaType === 'paragraph' && c.word_count) ? `
+        <div class="metadata-item">
+          <span class="metadata-label">Word Count</span>
+          <span class="metadata-value">${c.word_count}</span>
         </div>
+        <div class="metadata-item">
+          <span class="metadata-label">Characters</span>
+          <span class="metadata-value">${c.character_count}</span>
+        </div>` : ''}
         <div class="metadata-item">
           <span class="metadata-label">File Size</span>
           <span class="metadata-value">${(c.file_size / 1024).toFixed(1)} KB</span>
@@ -1092,6 +1146,21 @@
     // Draw waveform only for audio clips
     if (mediaType === "audio") {
       drawWaveform(c.id);
+    }
+
+    // Load paragraph text content
+    if (mediaType === "paragraph") {
+      fetch(`/api/clips/${c.id}/paragraph`)
+        .then(res => res.json())
+        .then(data => {
+          const paragraphDiv = document.getElementById("clip-paragraph");
+          if (paragraphDiv) {
+            paragraphDiv.textContent = data.content;
+          }
+        })
+        .catch(err => {
+          console.error("Error loading paragraph:", err);
+        });
     }
   }
 


### PR DESCRIPTION
This comprehensive update expands vectorytones from audio-only to supporting
four distinct modalities: Videos, Images, Sounds (audio), and Paragraphs (text).

Backend Changes:
- Added CLIP model (openai/clip-vit-base-patch32) for Images embedding
- Replaced VideoMAE with X-CLIP (microsoft/xclip-base-patch32) for Videos
- Added E5-LARGE-V2 (intfloat/e5-large-v2) for Paragraphs embedding
- Kept CLAP (laion/clap-htsat-unfused) for Sounds/audio

New Embedding Functions:
- embed_image_file(): Uses CLIP vision encoder for images
- embed_video_file(): Updated to use X-CLIP instead of VideoMAE
- embed_paragraph_file(): Uses E5-LARGE-V2 with "passage:" prefix

Dataset Loading:
- Updated load_dataset_from_folder() to accept media_type parameter
- Added support for image extensions (.jpg, .jpeg, .png, .gif, .bmp, .webp)
- Added support for paragraph extensions (.txt, .md)
- Updated load_dataset_from_pickle() to handle all four media types
- Added proper metadata tracking (dimensions for images, word count for paragraphs)

API Endpoints:
- Added /api/clips/<id>/image for serving image data
- Added /api/clips/<id>/paragraph for serving paragraph text
- Updated /api/dataset/load-folder to accept media_type parameter
- Updated /api/sort to use appropriate text encoder based on media type:
  * Sounds: CLAP text encoder
  * Videos: X-CLIP text encoder
  * Images: CLIP text encoder
  * Paragraphs: E5-LARGE-V2 with "query:" prefix

UI Enhancements:
- Added media type selector when loading from folder
- Updated renderCenter() to display all media types appropriately:
  * Videos: HTML5 video player with loop and autoplay
  * Images: Image display in center panel
  * Sounds: Waveform visualization + audio player with loop
  * Paragraphs: Text content display with scrolling
- Added media-specific icons in clip list (🎬 🖼️ 🔊 📄)
- Updated metadata display to show relevant info per media type
- Added dimensions for images, word/character count for paragraphs

Demo Datasets:
- Added placeholder structures for objects_images and news_paragraphs datasets
- Retained existing ESC-50 audio datasets (animals, natural, urban, household)
- Retained actions_video dataset from UCF-101

Dependencies:
- Added sentence-transformers for E5-LARGE-V2 model
- Added pillow for image loading and processing

Special Handling:
- Paragraphs use "passage:" prefix for dataset embedding
- Paragraphs use "query:" prefix for sort text embedding
- All media types support the same ML workflow (voting, detectors, labels)
- Detector and label files remain cross-compatible within the same media type

https://claude.ai/code/session_01PJYQDpPHPnEUcobyYfxC93