### PR TITLE
Prevent auto-advance to same clip in clip selection

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1175,7 +1175,7 @@
 
     // Auto-advance to next clip
     const nextClip = findNextClip();
-    if (nextClip) {
+    if (nextClip && nextClip.id !== selected) {
       selectClip(nextClip.id);
     }
   }


### PR DESCRIPTION
## Summary
Fixed a logic issue in the clip auto-advance functionality that could cause the player to attempt to select the same clip that is already selected.

## Key Changes
- Added a check to verify that the next clip's ID differs from the currently selected clip before auto-advancing
- This prevents unnecessary clip selection operations and potential UI state inconsistencies

## Implementation Details
The fix adds an additional condition `nextClip.id !== selected` to the existing `if (nextClip)` check. This ensures that when auto-advancing to the next clip, the code only proceeds with the selection if the found next clip is actually different from the currently selected clip. This is a defensive measure that prevents edge cases where `findNextClip()` might return the same clip that is already active.

https://claude.ai/code/session_016kiSKYYFUJTqMTtT4P7jFK