### PR TITLE
Fix demo dataset progress bar showing 0% instead of meaningful feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,6 +171,7 @@ def clear_dataset():
 
 def load_dataset_from_pickle(file_path: Path):
     """Load a dataset from a pickle file."""
+    update_progress("loading", "Reading cached dataset...", 0, 0)
     with open(file_path, "rb") as f:
         data = pickle.load(f)
 
@@ -185,7 +186,15 @@ def load_dataset_from_pickle(file_path: Path):
 
     # Convert to the app's clip format
     missing_media = 0
-    for clip_id, clip_info in clips_data.items():
+    total_clips = len(clips_data)
+    for idx, (clip_id, clip_info) in enumerate(clips_data.items()):
+        if total_clips > 0:
+            update_progress(
+                "loading",
+                f"Loading clip {idx + 1}/{total_clips}...",
+                idx + 1,
+                total_clips,
+            )
         # Determine media type
         media_type = clip_info.get("type", "audio")
 
@@ -706,7 +715,6 @@ def load_demo_dataset(dataset_name: str):
     # Check if already embedded
     pkl_file = EMBEDDINGS_DIR / f"{dataset_name}.pkl"
     if pkl_file.exists():
-        update_progress("loading", f"Loading {dataset_name} dataset...", 0, 0)
         load_dataset_from_pickle(pkl_file)
 
         # Check if any clips were actually loaded

--- a/static/index.html
+++ b/static/index.html
@@ -127,6 +127,8 @@
   .dataset-progress { width: 100%; max-width: 500px; }
   .progress-bar { width: 100%; height: 24px; background: #1a1d27; border: 1px solid #2a2d3a; border-radius: 4px; overflow: hidden; position: relative; }
   .progress-fill { height: 100%; background: linear-gradient(90deg, #7c8aff, #a0aaff); transition: width 0.3s; }
+  .progress-fill.indeterminate { width: 30% !important; animation: indeterminate 1.5s ease-in-out infinite; }
+  @keyframes indeterminate { 0% { margin-left: 0%; } 50% { margin-left: 70%; } 100% { margin-left: 0%; } }
   .progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.75rem; color: #fff; font-weight: bold; }
   .progress-message { font-size: 0.85rem; color: #aaa; margin-top: 8px; text-align: center; }
   .demo-datasets { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; width: 100%; margin-top: 16px; }
@@ -391,6 +393,12 @@
     demoDatasetsDiv.style.display = "none";
     datasetProgress.style.display = "block";
     backButton.style.display = "none";
+    // Reset progress bar to indeterminate state
+    progressFill.style.width = "0%";
+    progressFill.classList.add("indeterminate");
+    progressText.textContent = "";
+    progressMessage.textContent = "Loading...";
+    progressMessage.style.color = "#aaa";
   }
 
   async function pollProgress() {
@@ -418,13 +426,16 @@
     }
 
     // Update progress bar
-    let percentage = 0;
     if (progress.total > 0) {
-      percentage = Math.round((progress.current / progress.total) * 100);
+      const percentage = Math.round((progress.current / progress.total) * 100);
+      progressFill.classList.remove("indeterminate");
+      progressFill.style.width = `${percentage}%`;
+      progressText.textContent = `${percentage}%`;
+    } else {
+      // Indeterminate state - no total known yet
+      progressFill.classList.add("indeterminate");
+      progressText.textContent = "";
     }
-
-    progressFill.style.width = `${percentage}%`;
-    progressText.textContent = `${percentage}%`;
     progressMessage.textContent = progress.message || "Loading...";
     progressMessage.style.color = "#aaa";
   }
@@ -440,6 +451,7 @@
       clearInterval(progressTimer);
       progressTimer = null;
     }
+    progressFill.classList.remove("indeterminate");
   }
 
   // Load from file


### PR DESCRIPTION
When loading a cached demo dataset, the progress bar would flash "0%"
because load_dataset_from_pickle never reported per-clip progress and
total was always 0. Now the pickle loader reports clip-by-clip progress,
and the frontend shows an animated indeterminate bar when total is unknown
instead of a static "0%".

https://claude.ai/code/session_01LP8zWajJNByFyiEfYnveZa