### PR TITLE
Fix four bugs found during logic review

### DIFF
--- a/vistatotes/datasets/loader.py
+++ b/vistatotes/datasets/loader.py
@@ -543,7 +543,7 @@ def load_demo_dataset(dataset_name: str, clips: dict, e5_model):
                             cid: {
                                 k: v.tolist() if isinstance(v, np.ndarray) else v
                                 for k, v in clip.items()
-                                if k not in ["wav_bytes", "video_bytes", "image_bytes"]
+                                if k not in ["wav_bytes", "video_bytes"]
                             }
                             for cid, clip in clips.items()
                         },
@@ -650,13 +650,7 @@ def load_demo_dataset(dataset_name: str, clips: dict, e5_model):
                             cid: {
                                 k: v.tolist() if isinstance(v, np.ndarray) else v
                                 for k, v in clip.items()
-                                if k
-                                not in [
-                                    "wav_bytes",
-                                    "video_bytes",
-                                    "image_bytes",
-                                    "text_content",
-                                ]
+                                if k not in ["wav_bytes", "video_bytes", "image_bytes"]
                             }
                             for cid, clip in clips.items()
                         },
@@ -854,6 +848,12 @@ def export_dataset_to_file(clips: dict) -> bytes:
                 "category": clip.get("category", "unknown"),
                 "wav_bytes": clip.get("wav_bytes"),
                 "video_bytes": clip.get("video_bytes"),
+                "image_bytes": clip.get("image_bytes"),
+                "text_content": clip.get("text_content"),
+                "word_count": clip.get("word_count"),
+                "character_count": clip.get("character_count"),
+                "width": clip.get("width"),
+                "height": clip.get("height"),
             }
             for cid, clip in clips.items()
         }

--- a/vistatotes/models/training.py
+++ b/vistatotes/models/training.py
@@ -119,7 +119,7 @@ def find_optimal_threshold(scores, labels, inclusion_value=0):
         fpr_weight = 1.0
         fnr_weight = 2.0**inclusion_value
     else:
-        fpr_weight = 2.0**inclusion_value
+        fpr_weight = 2.0 ** (-inclusion_value)
         fnr_weight = 1.0
 
     for i in range(len(sorted_pairs)):

--- a/vistatotes/routes/clips.py
+++ b/vistatotes/routes/clips.py
@@ -1,6 +1,7 @@
 """Blueprint for clip-related routes."""
 
 import io
+from pathlib import Path
 
 from flask import Blueprint, jsonify, request, send_file
 
@@ -60,10 +61,11 @@ def clip_video(clip_id):
     else:
         mimetype = "video/mp4"
 
+    ext = Path(filename).suffix if filename else ".mp4"
     return send_file(
         io.BytesIO(c["video_bytes"]),
         mimetype=mimetype,
-        download_name=f"clip_{clip_id}.mp4",
+        download_name=f"clip_{clip_id}{ext}",
     )
 
 

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -24,7 +24,7 @@ from vistatotes.datasets import (
     load_demo_dataset,
 )
 from vistatotes.models import get_e5_model
-from vistatotes.utils import bad_votes, clips, good_votes, get_progress, update_progress
+from vistatotes.utils import bad_votes, clips, good_votes, label_history, get_progress, update_progress
 
 datasets_bp = Blueprint("datasets", __name__)
 
@@ -34,6 +34,7 @@ def clear_dataset():
     clips.clear()
     good_votes.clear()
     bad_votes.clear()
+    label_history.clear()
 
 
 @datasets_bp.route("/api/dataset/status")

--- a/vistatotes/utils/__init__.py
+++ b/vistatotes/utils/__init__.py
@@ -2,14 +2,22 @@
 
 from vistatotes.utils.progress import get_progress, update_progress
 from vistatotes.utils.state import (
+    add_favorite_detector,
+    add_label_to_history,
     bad_votes,
     clear_all,
     clear_clips,
     clear_votes,
     clips,
+    favorite_detectors,
+    get_favorite_detectors,
+    get_favorite_detectors_by_media,
     get_inclusion,
     good_votes,
     inclusion,
+    label_history,
+    remove_favorite_detector,
+    rename_favorite_detector,
     set_inclusion,
 )
 
@@ -21,10 +29,18 @@ __all__ = [
     "clips",
     "good_votes",
     "bad_votes",
+    "label_history",
     "inclusion",
+    "favorite_detectors",
     "clear_votes",
     "clear_clips",
     "clear_all",
     "get_inclusion",
     "set_inclusion",
+    "add_label_to_history",
+    "add_favorite_detector",
+    "remove_favorite_detector",
+    "rename_favorite_detector",
+    "get_favorite_detectors",
+    "get_favorite_detectors_by_media",
 ]


### PR DESCRIPTION
1. training.py find_optimal_threshold: negative inclusion_value produced a
   fractional fpr_weight (2^negative) instead of the intended amplified weight
   (2^|inclusion|), inverting the exclusion bias. Changed to 2.0**(-inclusion_value)
   to match train_model() and calculate_error_cost_over_time().

2. datasets/loader.py: export_dataset_to_file omitted image_bytes and
   text_content, making image/paragraph datasets unrestorable after export.
   Also fixed the image and paragraph demo-dataset pkl saves, which excluded
   those same fields with no file-path fallback stored, so cached pkl files
   could never be reloaded.

3. routes/datasets.py clear_dataset(): did not clear label_history, leaving
   stale historical labels after loading a new dataset. Also added the missing
   symbols (label_history, add_label_to_history, add_favorite_detector, etc.)
   to vistatotes/utils/__init__.py, which were imported by sorting.py but not
   exported, causing an ImportError at startup.

4. routes/clips.py clip_video: download_name was hardcoded to .mp4 regardless
   of the actual file format (.webm, .avi, .mov). Now derives the extension
   from the stored filename.

https://claude.ai/code/session_014wkjQd3mZGWvrDB6SWvwgH