### PR TITLE
Fix welcome screen display by clearing and re-appending DOM element

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -538,6 +538,8 @@
   }
 
   function showWelcomeScreen() {
+    center.innerHTML = "";
+    center.appendChild(datasetWelcome);
     datasetWelcome.style.display = "flex";
     center.className = "panel-center";
     datasetOptions.style.display = "flex";


### PR DESCRIPTION
## Summary
Fixed the welcome screen initialization to properly clear the container and re-append the welcome element before displaying it.

## Key Changes
- Clear the `center` container's innerHTML before showing the welcome screen
- Re-append the `datasetWelcome` element to ensure it's properly attached to the DOM
- Maintain existing display style and className assignments

## Implementation Details
The changes ensure that when `showWelcomeScreen()` is called, the DOM is in a clean state before displaying the welcome screen. This prevents potential issues where the welcome element might not be properly rendered if it was previously removed or detached from the DOM. The innerHTML clearing and element re-appending happen before the display styles are applied, ensuring proper DOM hierarchy.

https://claude.ai/code/session_01AnDpVq9ygvqhHfwhsQ9UnS