### PR TITLE
Update VistaTotes tagline to generic "Media explorer"

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -216,7 +216,7 @@
     </div>
   </div>
   <h1>VistaTotes</h1>
-  <span>Sound clip explorer with vector embeddings</span>
+  <span>Media explorer</span>
 </header>
 <div class="layout">
   <!-- Left panel -->


### PR DESCRIPTION
## Summary
Updated the VistaTotes header tagline to be more generic and inclusive of the application's broader purpose.

## Changes
- Changed tagline from "Sound clip explorer with vector embeddings" to "Media explorer"

## Details
This change simplifies the subtitle to reflect a more general media exploration capability rather than being specifically tied to sound clips and the technical implementation detail of vector embeddings. This makes the application description more accessible to users while remaining accurate about its core functionality.

https://claude.ai/code/session_01FwkkiaHKJ9thusFxCwB533