### PR TITLE
Improve dataset welcome screen layout responsiveness

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -123,6 +123,7 @@
 
   /* Dataset management */
   .dataset-welcome { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px; padding: 48px; max-width: 600px; margin: 0 auto; text-align: center; }
+  .dataset-welcome.wide { max-width: min(1040px, 95vw); }
   .dataset-welcome h2 { font-size: 1.8rem; color: #7c8aff; margin-bottom: 8px; }
   .dataset-welcome p { font-size: 1rem; color: #aaa; margin-bottom: 16px; }
   .dataset-options { display: flex; flex-direction: column; gap: 12px; width: 100%; }
@@ -137,7 +138,7 @@
   @keyframes indeterminate { 0% { margin-left: 0%; } 50% { margin-left: 70%; } 100% { margin-left: 0%; } }
   .progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.75rem; color: #fff; font-weight: bold; }
   .progress-message { font-size: 0.85rem; color: #aaa; margin-top: 8px; text-align: center; }
-  .demo-datasets { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; width: 100%; margin-top: 16px; }
+  .demo-datasets { display: grid; grid-template-columns: repeat(4, minmax(180px, 1fr)); gap: 16px; width: 100%; margin-top: 16px; }
   .demo-column { display: flex; flex-direction: column; gap: 8px; }
   .demo-column-header { font-size: 0.7rem; font-weight: 700; color: #7c8aff; text-transform: uppercase; letter-spacing: 0.08em; padding-bottom: 6px; border-bottom: 1px solid #2a2d3a; margin-bottom: 2px; }
   .demo-dataset { padding: 14px; border: 2px solid #2a2d3a; border-radius: 8px; background: #1a1d27; cursor: pointer; transition: all 0.2s; text-align: left; }
@@ -542,6 +543,7 @@
   function showWelcomeScreen() {
     center.innerHTML = "";
     center.appendChild(datasetWelcome);
+    datasetWelcome.classList.remove("wide");
     datasetWelcome.style.display = "flex";
     center.className = "panel-center";
     datasetOptions.style.display = "flex";
@@ -714,6 +716,7 @@
     datasetOptions.style.display = "none";
     demoDatasetsDiv.style.display = "grid";
     backButton.style.display = "block";
+    datasetWelcome.classList.add("wide");
 
     // Fetch demo datasets
     try {


### PR DESCRIPTION
## Summary
Enhanced the dataset welcome screen layout to better accommodate wider content, particularly when displaying demo datasets in a grid format.

## Key Changes
- Added a `.dataset-welcome.wide` CSS class modifier that expands the max-width to 1040px (or 95vw) for wider layouts
- Updated `.demo-datasets` grid to use `minmax(180px, 1fr)` for columns instead of fixed `1fr`, ensuring better responsiveness and preventing columns from becoming too narrow
- Modified `showWelcomeScreen()` to remove the "wide" class when displaying the initial welcome screen
- Modified the demo datasets display logic to add the "wide" class when showing the grid of demo datasets

## Implementation Details
The changes allow the welcome screen to adapt between two layouts:
- **Normal mode**: Narrower 600px max-width for the initial welcome message
- **Wide mode**: Expanded 1040px max-width when displaying the demo datasets grid

The grid column adjustment ensures that demo dataset cards maintain a minimum width of 180px while still being responsive on smaller viewports, improving the visual presentation of the dataset selection interface.

https://claude.ai/code/session_01AkdeivZD4MbCuj4NmDck1S