### PR TITLE
Move media type icon from per-clip to header

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -532,7 +532,16 @@
 
     if (datasetLoaded) {
       showMainUI();
-      datasetInfo.textContent = `${status.num_clips} clips loaded`;
+      const mediaHeaderConfig = {
+        "audio":     { icon: "🔊", label: "audio" },
+        "video":     { icon: "🎬", label: "video" },
+        "image":     { icon: "🖼️", label: "image" },
+        "paragraph": { icon: "📄", label: "text" },
+      };
+      const mhc = mediaHeaderConfig[status.media_type];
+      datasetInfo.textContent = mhc
+        ? `${mhc.icon} ${status.num_clips} ${mhc.label} clips loaded`
+        : `${status.num_clips} clips loaded`;
     } else {
       showWelcomeScreen();
     }
@@ -1535,15 +1544,7 @@
       if (isGood) className += " labeled-good";
       if (isBad) className += " labeled-bad";
       div.className = className;
-      // Icon based on media type
-      const mediaIcons = {
-        "video": "🎬 ",
-        "image": "🖼️ ",
-        "paragraph": "📄 ",
-        "audio": "🔊 "
-      };
-      const mediaIcon = mediaIcons[c.type] || "";
-      let html = `<div style="font-weight: 500;">${mediaIcon}${c.filename || 'Clip #' + c.id}</div>`;
+      let html = `<div style="font-weight: 500;">${c.filename || 'Clip #' + c.id}</div>`;
       if (scoreMap[c.id] !== undefined) {
         html += `<span class="sim">${(scoreMap[c.id] * 100).toFixed(1)}%</span>`;
       }

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -31,11 +31,15 @@ def clear_dataset():
 @datasets_bp.route("/api/dataset/status")
 def dataset_status():
     """Return the current dataset status."""
+    media_type = None
+    if clips:
+        media_type = next(iter(clips.values())).get("type", "audio")
     return jsonify(
         {
             "loaded": len(clips) > 0,
             "num_clips": len(clips),
             "has_votes": len(good_votes) + len(bad_votes) > 0,
+            "media_type": media_type,
         }
     )
 


### PR DESCRIPTION
Show the medium icon once in the "N clips loaded" header (e.g. "🔊 400
audio clips loaded") instead of repeating it next to every clip in the
list. The status API now returns the dataset's media_type so the
frontend can build the label.

https://claude.ai/code/session_01KJr8hKibY3GGsKsCCVZTU7