### PR TITLE
Narrow right column, remove sort dropdown, shorten button label

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -106,7 +106,7 @@
   .btn-bad:hover, .btn-bad.voted { background: #f44336; color: #fff; }
 
   /* Right panel – votes */
-  .panel-right { width: 240px; border-left: 1px solid #2a2d3a; overflow-y: auto; background: #14161e; display: flex; flex-direction: column; }
+  .panel-right { width: 160px; border-left: 1px solid #2a2d3a; overflow-y: auto; background: #14161e; display: flex; flex-direction: column; }
   .vote-section { flex: 1; overflow-y: auto; padding: 12px 16px; }
   .vote-section + .vote-section { border-top: 1px solid #2a2d3a; }
   .vote-section h3 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px; }
@@ -316,26 +316,14 @@
   <div class="panel-right">
     <input type="file" id="import-file" accept=".json" style="display:none">
     <div class="progress-check-bar">
-      <button id="check-progress-btn">Check Labeling Progress</button>
+      <button id="check-progress-btn">Labeling Progress</button>
     </div>
     <div class="vote-section">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-        <h3 class="good" style="margin: 0;">Good <span class="label-count" id="good-count">(0)</span></h3>
-        <select id="good-sort-mode" style="font-size: 0.75rem; padding: 2px 4px; background: #2a2a2a; color: #aaa; border: 1px solid #444; border-radius: 3px;">
-          <option value="clip">By Clip#</option>
-          <option value="order">By Click</option>
-        </select>
-      </div>
+      <h3 class="good">Good <span class="label-count" id="good-count">(0)</span></h3>
       <div id="good-list"></div>
     </div>
     <div class="vote-section">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-        <h3 class="bad" style="margin: 0;">Bad <span class="label-count" id="bad-count">(0)</span></h3>
-        <select id="bad-sort-mode" style="font-size: 0.75rem; padding: 2px 4px; background: #2a2a2a; color: #aaa; border: 1px solid #444; border-radius: 3px;">
-          <option value="clip">By Clip#</option>
-          <option value="order">By Click</option>
-        </select>
-      </div>
+      <h3 class="bad">Bad <span class="label-count" id="bad-count">(0)</span></h3>
       <div id="bad-list"></div>
     </div>
   </div>
@@ -443,15 +431,10 @@
   let loadedDetector = null; // Stores loaded detector model weights
   let datasetLoaded = false;
   let progressTimer = null;
-  let goodSortMode = "clip"; // "clip" | "order"
-  let badSortMode = "clip";  // "clip" | "order"
-
   const clipList = document.getElementById("clip-list");
   const center = document.getElementById("center");
   const goodList = document.getElementById("good-list");
   const badList = document.getElementById("bad-list");
-  const goodSortSelect = document.getElementById("good-sort-mode");
-  const badSortSelect = document.getElementById("bad-sort-mode");
   const textSortInput = document.getElementById("text-sort");
   const textSortWrap = document.getElementById("text-sort-wrap");
   const loadSortWrap = document.getElementById("load-sort-wrap");
@@ -1283,18 +1266,6 @@
     updateInclusion(parseInt(inclusionSlider.value));
   });
 
-  // ---- Good/Bad vote list sorting ----
-
-  goodSortSelect.addEventListener("change", () => {
-    goodSortMode = goodSortSelect.value;
-    renderVotes();
-  });
-
-  badSortSelect.addEventListener("change", () => {
-    badSortMode = badSortSelect.value;
-    renderVotes();
-  });
-
   // ---- Text sort ----
 
   async function fetchTextSort(text) {
@@ -1797,10 +1768,7 @@
     goodList.innerHTML = "";
     badList.innerHTML = "";
 
-    // Sort good votes based on selected mode
-    const sortedGood = goodSortMode === "clip"
-      ? [...votes.good].sort((a, b) => a - b)  // By clip# (numerical)
-      : [...votes.good];  // By click order (insertion order)
+    const sortedGood = [...votes.good].sort((a, b) => a - b);
 
     sortedGood.forEach(id => {
       const div = document.createElement("div");
@@ -1810,10 +1778,7 @@
       goodList.appendChild(div);
     });
 
-    // Sort bad votes based on selected mode
-    const sortedBad = badSortMode === "clip"
-      ? [...votes.bad].sort((a, b) => a - b)  // By clip# (numerical)
-      : [...votes.bad];  // By click order (insertion order)
+    const sortedBad = [...votes.bad].sort((a, b) => a - b);
 
     sortedBad.forEach(id => {
       const div = document.createElement("div");


### PR DESCRIPTION
- Reduce panel-right width from 240px to 160px
- Remove Good/Bad sort-mode dropdowns; always sort by clip# (numerical)
- Shorten button text from "Check Labeling Progress" to "Labeling Progress"
- Clean up associated JS variables and event listeners

https://claude.ai/code/session_01JsKWB5CqBgmAjMgCFJhc4V