### PR TITLE
Persist audio volume across clip loads

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -446,6 +446,7 @@
   let favoriteDetectors = [];  // List of favorite detectors
   let loadedDetector = null; // Stores loaded detector model weights
   let datasetLoaded = false;
+  let audioVolume = 1.0; // Persisted volume across clip loads
   let progressTimer = null;
   const clipList = document.getElementById("clip-list");
   const center = document.getElementById("center");
@@ -1676,6 +1677,13 @@
     // Draw waveform only for audio clips
     if (mediaType === "audio") {
       drawWaveform(c.id);
+      const audioEl = document.getElementById("clip-audio");
+      if (audioEl) {
+        audioEl.volume = audioVolume;
+        audioEl.addEventListener("volumechange", () => {
+          audioVolume = audioEl.volume;
+        });
+      }
     }
 
     // Load paragraph text content


### PR DESCRIPTION
Save the user's volume adjustment in a module-level variable and restore
it whenever a new audio clip is rendered, so the setting is not lost when
switching between clips.

https://claude.ai/code/session_016Y3QaipzZuw6agKrzVMuMR