### PR TITLE
Implement Favorite Detectors manage workflow and autodetect

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -406,18 +406,37 @@
 
 <!-- Favorite Detectors Management Modal -->
 <div id="favorites-modal" class="modal">
-  <div class="modal-content">
+  <div class="modal-content" style="max-width: 700px;">
     <div class="modal-header">
       <h2>Manage Favorite Detectors</h2>
       <button class="modal-close" id="favorites-modal-close">&times;</button>
     </div>
     <div class="modal-body">
-      <div id="favorites-list" style="margin-top: 16px;">
+      <!-- Add Detector Section -->
+      <div style="background: #14161e; border: 1px solid #2a2d3a; border-radius: 6px; padding: 16px; margin-bottom: 20px;">
+        <div style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; color: #666; margin-bottom: 10px;">Add Detector</div>
+        <div style="margin-bottom: 10px;">
+          <label style="font-size: 0.78rem; color: #888; display: block; margin-bottom: 4px;">Name (optional — defaults to filename)</label>
+          <input type="text" id="fav-add-name" placeholder="e.g. Dog Barks" style="width: 100%; padding: 6px 8px; border: 1px solid #2a2d3a; border-radius: 4px; background: #1a1d27; color: #e0e0e0; font-size: 0.85rem; outline: none;">
+        </div>
+        <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+          <button id="fav-add-from-votes-btn" style="flex: 1; padding: 8px 12px; background: #7c8aff; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">From Current Labels</button>
+          <button id="fav-add-from-detector-btn" style="flex: 1; padding: 8px 12px; background: #3a3d50; color: #ccc; border: 1px solid #4a4d60; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">From Detector File (.json)</button>
+          <button id="fav-add-from-labels-btn" style="flex: 1; padding: 8px 12px; background: #3a3d50; color: #ccc; border: 1px solid #4a4d60; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">From Label File (.json)</button>
+        </div>
+        <div id="fav-add-status" style="font-size: 0.78rem; color: #888; margin-top: 8px; min-height: 1.2em;"></div>
+      </div>
+      <!-- Saved Detectors List -->
+      <div style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; color: #666; margin-bottom: 8px;">Saved Detectors</div>
+      <div id="favorites-list">
         <p style="color: #888;">No favorite detectors saved yet.</p>
       </div>
     </div>
   </div>
 </div>
+<!-- Hidden file inputs for favorites modal -->
+<input type="file" id="fav-detector-file-input" accept=".json" style="display:none">
+<input type="file" id="fav-labels-file-input" accept=".json" style="display:none">
 
 <!-- Auto-Detect Results Modal -->
 <div id="autodetect-modal" class="modal">
@@ -549,6 +568,13 @@
   const favoritesModal = document.getElementById("favorites-modal");
   const favoritesModalClose = document.getElementById("favorites-modal-close");
   const favoritesList = document.getElementById("favorites-list");
+  const favAddName = document.getElementById("fav-add-name");
+  const favAddStatus = document.getElementById("fav-add-status");
+  const favAddFromVotesBtn = document.getElementById("fav-add-from-votes-btn");
+  const favAddFromDetectorBtn = document.getElementById("fav-add-from-detector-btn");
+  const favAddFromLabelsBtn = document.getElementById("fav-add-from-labels-btn");
+  const favDetectorFileInput = document.getElementById("fav-detector-file-input");
+  const favLabelsFileInput = document.getElementById("fav-labels-file-input");
   const autodetectModal = document.getElementById("autodetect-modal");
   const autodetectModalClose = document.getElementById("autodetect-modal-close");
   const autodetectSummary = document.getElementById("autodetect-summary");
@@ -1000,18 +1026,28 @@
       return;
     }
 
-    favoritesList.innerHTML = favoriteDetectors.map(detector => `
-      <div style="background: #2a2d3a; padding: 12px; margin-bottom: 8px; border-radius: 4px; display: flex; justify-content: space-between; align-items: center;">
-        <div>
-          <div style="font-weight: bold; color: #7c8aff;">${escapeHtml(detector.name)}</div>
-          <div style="font-size: 0.85rem; color: #aaa;">Media: ${detector.media_type} | Threshold: ${detector.threshold.toFixed(2)}</div>
+    const mediaIcons = { audio: "🔊", image: "🖼️", video: "🎬", paragraph: "📄" };
+    favoritesList.innerHTML = favoriteDetectors.map(detector => {
+      const icon = mediaIcons[detector.media_type] || "🔍";
+      const created = detector.created_at
+        ? new Date(detector.created_at * 1000).toLocaleDateString()
+        : "";
+      return `
+      <div style="background: #2a2d3a; padding: 12px; margin-bottom: 8px; border-radius: 4px; display: flex; justify-content: space-between; align-items: center; gap: 12px;">
+        <div style="flex: 1; min-width: 0;">
+          <div style="font-weight: bold; color: #7c8aff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${escapeHtml(detector.name)}</div>
+          <div style="font-size: 0.8rem; color: #888; margin-top: 3px; display: flex; align-items: center; gap: 10px;">
+            <span style="background: #1a1d27; border: 1px solid #3a3d50; border-radius: 3px; padding: 1px 6px; white-space: nowrap;">${icon} ${detector.media_type}</span>
+            <span>threshold&nbsp;${detector.threshold.toFixed(2)}</span>
+            ${created ? `<span>${created}</span>` : ""}
+          </div>
         </div>
-        <div>
-          <button onclick="renameDetector('${escapeHtml(detector.name)}')" style="padding: 4px 8px; margin-right: 4px; background: #555; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">Rename</button>
-          <button onclick="deleteDetector('${escapeHtml(detector.name)}')" style="padding: 4px 8px; background: #f44336; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">Delete</button>
+        <div style="display: flex; gap: 6px; flex-shrink: 0;">
+          <button onclick="renameDetector('${escapeHtml(detector.name)}')" style="padding: 4px 10px; background: #3a3d50; color: #ccc; border: 1px solid #4a4d60; border-radius: 4px; cursor: pointer; font-size: 0.78rem;">Rename</button>
+          <button onclick="deleteDetector('${escapeHtml(detector.name)}')" style="padding: 4px 10px; background: #c0392b; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.78rem;">Delete</button>
         </div>
-      </div>
-    `).join('');
+      </div>`;
+    }).join('');
   }
 
   function escapeHtml(text) {
@@ -1111,6 +1147,137 @@
       }
 
       burgerDropdown.classList.remove("show");
+    });
+  }
+
+  // ---- Add Detector panel inside Manage Favorites modal ----
+
+  function setFavAddStatus(msg, color) {
+    if (favAddStatus) {
+      favAddStatus.textContent = msg;
+      favAddStatus.style.color = color || "#aaa";
+    }
+  }
+
+  // Add from current votes (train a new detector from labelled clips)
+  if (favAddFromVotesBtn) {
+    favAddFromVotesBtn.addEventListener("click", async () => {
+      if (votes.good.length === 0 || votes.bad.length === 0) {
+        setFavAddStatus("Need at least one good and one bad vote first.", "#f44336");
+        return;
+      }
+      const name = favAddName ? favAddName.value.trim() : "";
+      if (!name) {
+        setFavAddStatus("Enter a name first.", "#f44336");
+        return;
+      }
+      setFavAddStatus("Training detector\u2026", "#aaa");
+
+      const exportRes = await fetch("/api/detector/export", { method: "POST" });
+      if (!exportRes.ok) {
+        setFavAddStatus("Failed to train detector.", "#f44336");
+        return;
+      }
+      const detectorData = await exportRes.json();
+      const mediaType = clips.length > 0 ? clips[0].type : "audio";
+
+      const saveRes = await fetch("/api/favorite-detectors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          media_type: mediaType,
+          weights: detectorData.weights,
+          threshold: detectorData.threshold,
+        }),
+      });
+
+      if (saveRes.ok) {
+        setFavAddStatus(`Detector \u201c${name}\u201d saved (${mediaType}).`, "#4caf50");
+        if (favAddName) favAddName.value = "";
+        await loadFavoriteDetectors();
+      } else {
+        setFavAddStatus("Failed to save detector.", "#f44336");
+      }
+    });
+  }
+
+  // Add from a detector JSON file (same format as Load Sort / detector export)
+  if (favAddFromDetectorBtn) {
+    favAddFromDetectorBtn.addEventListener("click", () => {
+      if (favDetectorFileInput) favDetectorFileInput.click();
+    });
+  }
+
+  if (favDetectorFileInput) {
+    favDetectorFileInput.addEventListener("change", async () => {
+      const file = favDetectorFileInput.files[0];
+      if (!file) return;
+      const defaultName = file.name.replace(/\.[^/.]+$/, "");
+      const detectorName = (favAddName && favAddName.value.trim()) || defaultName;
+
+      setFavAddStatus("Importing detector\u2026", "#aaa");
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("name", detectorName);
+
+      const res = await fetch("/api/favorite-detectors/import-pkl", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setFavAddStatus(`Imported \u201c${data.name}\u201d (${data.media_type}).`, "#4caf50");
+        if (favAddName) favAddName.value = "";
+        await loadFavoriteDetectors();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setFavAddStatus(`Error: ${err.error || "Import failed"}`, "#f44336");
+      }
+      favDetectorFileInput.value = "";
+    });
+  }
+
+  // Add from a label file (JSON with paths + labels; trains a new detector)
+  if (favAddFromLabelsBtn) {
+    favAddFromLabelsBtn.addEventListener("click", () => {
+      if (favLabelsFileInput) favLabelsFileInput.click();
+    });
+  }
+
+  if (favLabelsFileInput) {
+    favLabelsFileInput.addEventListener("change", async () => {
+      const file = favLabelsFileInput.files[0];
+      if (!file) return;
+      const defaultName = file.name.replace(/\.[^/.]+$/, "");
+      const detectorName = (favAddName && favAddName.value.trim()) || defaultName;
+
+      setFavAddStatus("Training from label file\u2026", "#aaa");
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("name", detectorName);
+
+      const res = await fetch("/api/favorite-detectors/import-labels", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setFavAddStatus(
+          `Trained \u201c${data.name}\u201d (${data.media_type}, ${data.loaded} files).`,
+          "#4caf50"
+        );
+        if (favAddName) favAddName.value = "";
+        await loadFavoriteDetectors();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setFavAddStatus(`Error: ${err.error || "Training failed"}`, "#f44336");
+      }
+      favLabelsFileInput.value = "";
     });
   }
 

--- a/test_app.py
+++ b/test_app.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import json
 import wave
 
 import numpy as np
@@ -887,3 +888,405 @@ class TestDatasetEndpoints:
 
         # Re-initialize for other tests
         app_module.init_clips()
+
+
+# ---------------------------------------------------------------------------
+# Favorite Detectors CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestFavoriteDetectors:
+    """Tests for the favorite-detectors management endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def clear_favorites(self):
+        from vistatotes.utils.state import favorite_detectors
+
+        favorite_detectors.clear()
+        yield
+        favorite_detectors.clear()
+
+    def _export_detector(self, client):
+        """Helper: vote on some clips and export a valid detector payload."""
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        resp = client.post("/api/detector/export")
+        assert resp.status_code == 200
+        return resp.get_json()
+
+    def _post_favorite(self, client, name, detector):
+        return client.post(
+            "/api/favorite-detectors",
+            json={
+                "name": name,
+                "media_type": "audio",
+                "weights": detector["weights"],
+                "threshold": detector["threshold"],
+            },
+        )
+
+    # -- GET list --
+
+    def test_get_empty_list(self, client):
+        resp = client.get("/api/favorite-detectors")
+        assert resp.status_code == 200
+        assert resp.get_json()["detectors"] == []
+
+    def test_get_list_after_add(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "my-detector", det)
+
+        resp = client.get("/api/favorite-detectors")
+        data = resp.get_json()
+        assert len(data["detectors"]) == 1
+        d = data["detectors"][0]
+        assert d["name"] == "my-detector"
+        assert d["media_type"] == "audio"
+        assert "threshold" in d
+
+    # -- POST add --
+
+    def test_add_detector_returns_success(self, client):
+        det = self._export_detector(client)
+        resp = self._post_favorite(client, "test-det", det)
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+    def test_add_missing_name_returns_400(self, client):
+        det = self._export_detector(client)
+        resp = client.post(
+            "/api/favorite-detectors",
+            json={"media_type": "audio", "weights": det["weights"]},
+        )
+        assert resp.status_code == 400
+
+    def test_add_missing_media_type_returns_400(self, client):
+        det = self._export_detector(client)
+        resp = client.post(
+            "/api/favorite-detectors",
+            json={"name": "test", "weights": det["weights"]},
+        )
+        assert resp.status_code == 400
+
+    def test_add_missing_weights_returns_400(self, client):
+        resp = client.post(
+            "/api/favorite-detectors",
+            json={"name": "test", "media_type": "audio"},
+        )
+        assert resp.status_code == 400
+
+    def test_add_multiple_detectors(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "det-a", det)
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        self._post_favorite(client, "det-b", det)
+
+        resp = client.get("/api/favorite-detectors")
+        names = {d["name"] for d in resp.get_json()["detectors"]}
+        assert names == {"det-a", "det-b"}
+
+    def test_add_overwrites_existing_name(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "dup", det)
+        self._post_favorite(client, "dup", det)
+
+        resp = client.get("/api/favorite-detectors")
+        assert len(resp.get_json()["detectors"]) == 1
+
+    # -- DELETE --
+
+    def test_delete_detector(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "to-delete", det)
+
+        resp = client.delete("/api/favorite-detectors/to-delete")
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+        resp = client.get("/api/favorite-detectors")
+        assert resp.get_json()["detectors"] == []
+
+    def test_delete_nonexistent_returns_404(self, client):
+        resp = client.delete("/api/favorite-detectors/does-not-exist")
+        assert resp.status_code == 404
+
+    # -- RENAME --
+
+    def test_rename_detector(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "old-name", det)
+
+        resp = client.put(
+            "/api/favorite-detectors/old-name/rename",
+            json={"new_name": "new-name"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["new_name"] == "new-name"
+
+        names = [d["name"] for d in client.get("/api/favorite-detectors").get_json()["detectors"]]
+        assert "new-name" in names
+        assert "old-name" not in names
+
+    def test_rename_nonexistent_returns_400(self, client):
+        resp = client.put(
+            "/api/favorite-detectors/ghost/rename",
+            json={"new_name": "anything"},
+        )
+        assert resp.status_code == 400
+
+    def test_rename_to_existing_name_returns_400(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "det-a", det)
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        self._post_favorite(client, "det-b", det)
+
+        resp = client.put(
+            "/api/favorite-detectors/det-a/rename",
+            json={"new_name": "det-b"},
+        )
+        assert resp.status_code == 400
+
+    def test_rename_missing_new_name_returns_400(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "some-det", det)
+
+        resp = client.put(
+            "/api/favorite-detectors/some-det/rename",
+            json={},
+        )
+        assert resp.status_code == 400
+
+    # -- import-pkl (detector JSON file) --
+
+    def test_import_pkl_from_detector_json(self, client):
+        det = self._export_detector(client)
+        json_bytes = json.dumps(det).encode("utf-8")
+        data = {
+            "file": (io.BytesIO(json_bytes), "detector.json"),
+            "name": "imported",
+        }
+        resp = client.post(
+            "/api/favorite-detectors/import-pkl",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result["success"] is True
+        assert result["name"] == "imported"
+
+    def test_import_pkl_uses_filename_stem_as_default_name(self, client):
+        det = self._export_detector(client)
+        json_bytes = json.dumps(det).encode("utf-8")
+        data = {"file": (io.BytesIO(json_bytes), "my_detector.json")}
+        resp = client.post(
+            "/api/favorite-detectors/import-pkl",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["name"] == "my_detector"
+
+    def test_import_pkl_preserves_media_type_from_file(self, client):
+        det = self._export_detector(client)
+        # Embed explicit media_type in the "file" payload
+        det["media_type"] = "image"
+        json_bytes = json.dumps(det).encode("utf-8")
+        data = {
+            "file": (io.BytesIO(json_bytes), "image_detector.json"),
+            "name": "img-det",
+        }
+        resp = client.post(
+            "/api/favorite-detectors/import-pkl",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["media_type"] == "image"
+
+    def test_import_pkl_no_file_returns_400(self, client):
+        resp = client.post("/api/favorite-detectors/import-pkl", data={})
+        assert resp.status_code == 400
+
+    def test_import_pkl_invalid_format_returns_400(self, client):
+        data = {"file": (io.BytesIO(b'{"not_a_detector": true}'), "bad.json")}
+        resp = client.post(
+            "/api/favorite-detectors/import-pkl",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+
+    # -- Detector data is stored correctly --
+
+    def test_stored_detector_has_correct_fields(self, client):
+        det = self._export_detector(client)
+        self._post_favorite(client, "field-check", det)
+
+        from vistatotes.utils.state import favorite_detectors
+
+        assert "field-check" in favorite_detectors
+        stored = favorite_detectors["field-check"]
+        assert stored["name"] == "field-check"
+        assert stored["media_type"] == "audio"
+        assert "weights" in stored
+        assert "threshold" in stored
+        assert "created_at" in stored
+
+
+# ---------------------------------------------------------------------------
+# Auto-Detect
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDetect:
+    """Tests for POST /api/auto-detect."""
+
+    @pytest.fixture(autouse=True)
+    def clear_favorites(self):
+        from vistatotes.utils.state import favorite_detectors
+
+        favorite_detectors.clear()
+        yield
+        favorite_detectors.clear()
+
+    def _add_audio_detector(self, client, name="test-detector"):
+        """Helper: create and save an audio detector."""
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        export_resp = client.post("/api/detector/export")
+        assert export_resp.status_code == 200
+        detector = export_resp.get_json()
+
+        save_resp = client.post(
+            "/api/favorite-detectors",
+            json={
+                "name": name,
+                "media_type": "audio",
+                "weights": detector["weights"],
+                "threshold": detector["threshold"],
+            },
+        )
+        assert save_resp.status_code == 200
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+
+    # -- no matching detectors --
+
+    def test_no_favorites_returns_400(self, client):
+        resp = client.post("/api/auto-detect")
+        assert resp.status_code == 400
+        assert "No favorite detectors" in resp.get_json()["error"]
+
+    def test_no_matching_media_type_returns_400(self, client):
+        """A detector for a different media type should not match audio clips."""
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        export_resp = client.post("/api/detector/export")
+        detector = export_resp.get_json()
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+
+        # Save as "image" type — clips are audio, so it won't match
+        client.post(
+            "/api/favorite-detectors",
+            json={
+                "name": "image-detector",
+                "media_type": "image",
+                "weights": detector["weights"],
+                "threshold": detector["threshold"],
+            },
+        )
+        resp = client.post("/api/auto-detect")
+        assert resp.status_code == 400
+
+    # -- basic success --
+
+    def test_returns_200_with_matching_detector(self, client):
+        self._add_audio_detector(client)
+        resp = client.post("/api/auto-detect")
+        assert resp.status_code == 200
+
+    def test_response_has_required_top_level_fields(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        assert "media_type" in data
+        assert "detectors_run" in data
+        assert "results" in data
+
+    def test_media_type_matches_clips(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        assert data["media_type"] == "audio"
+
+    def test_detectors_run_count(self, client):
+        self._add_audio_detector(client, name="det-1")
+        self._add_audio_detector(client, name="det-2")
+        data = client.post("/api/auto-detect").get_json()
+        assert data["detectors_run"] == 2
+
+    # -- per-detector result structure --
+
+    def test_each_result_has_required_fields(self, client):
+        self._add_audio_detector(client, name="struct-check")
+        data = client.post("/api/auto-detect").get_json()
+        result = data["results"]["struct-check"]
+        assert "detector_name" in result
+        assert "threshold" in result
+        assert "total_hits" in result
+        assert "hits" in result
+
+    def test_detector_name_matches_key(self, client):
+        self._add_audio_detector(client, name="named-detector")
+        data = client.post("/api/auto-detect").get_json()
+        result = data["results"]["named-detector"]
+        assert result["detector_name"] == "named-detector"
+
+    def test_total_hits_matches_hits_length(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            assert result["total_hits"] == len(result["hits"])
+
+    # -- hit data safety --
+
+    def test_hits_do_not_contain_embeddings(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            for hit in result["hits"]:
+                assert "embedding" not in hit
+
+    def test_hits_do_not_contain_wav_bytes(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            for hit in result["hits"]:
+                assert "wav_bytes" not in hit
+
+    def test_hits_contain_score(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            for hit in result["hits"]:
+                assert "score" in hit
+                assert 0.0 <= hit["score"] <= 1.0
+
+    def test_hits_sorted_descending_by_score(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            scores = [h["score"] for h in result["hits"]]
+            assert scores == sorted(scores, reverse=True)
+
+    # -- threshold correctness --
+
+    def test_all_hits_score_at_or_above_threshold(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            threshold = result["threshold"]
+            for hit in result["hits"]:
+                assert hit["score"] >= threshold - 1e-6  # float tolerance


### PR DESCRIPTION
- Add detector UI panel to Manage Favorites modal with three import
  paths: from current labels, from a detector JSON file, and from a
  label file—matching all the same ways Load Sort accepts input
- Each saved detector now displays its media type as a badge (with
  icon), threshold, and creation date in the list view
- Fix import-labels endpoint to support all four media types (audio,
  image, video, paragraph) by auto-detecting media type from file
  extensions and using the matching embed function; accepts an optional
  media_type form field to force a specific type
- Fix import-pkl endpoint to read media_type from the detector file
  when present, falling back to the current dataset type then "audio"
- Add TestFavoriteDetectors test class covering CRUD (list, add,
  delete, rename), import-pkl, field validation, and stored-state checks
- Add TestAutoDetect test class covering no-matching-detector errors,
  response structure, hit safety (no embeddings/bytes), score ordering,
  and threshold correctness

https://claude.ai/code/session_01EHJAtCHsUjxjvgN5cPqvEN