### PR TITLE
Auto-select next clip after sorting operations

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1570,7 +1570,7 @@
       if (sortMode === "text") {
         onTextSortInput();
       } else if (sortMode === "learned") {
-        fetchLearnedSort();
+        fetchLearnedSort(true);
       }
     });
   });
@@ -1582,7 +1582,7 @@
       if (!radio.checked) return;
       selectMode = radio.value;
       const nextClip = findNextClip();
-      if (nextClip && nextClip.id !== selected) {
+      if (nextClip) {
         selectClip(nextClip.id);
       }
     });
@@ -1630,6 +1630,8 @@
       hideSortProgress();
       sortStatus.textContent = `Threshold: ${(threshold * 100).toFixed(1)}%`;
       renderClipList();
+      const nextClip = findNextClip();
+      if (nextClip) selectClip(nextClip.id);
     } catch (error) {
       hideSortProgress();
       sortStatus.textContent = `Error: ${error.message}`;
@@ -1653,7 +1655,7 @@
 
   // ---- Learned sort ----
 
-  async function fetchLearnedSort() {
+  async function fetchLearnedSort(autoSelect = false) {
     showSortProgress("Training\u2026");
     try {
       const res = await fetch("/api/learned-sort", {
@@ -1674,6 +1676,10 @@
       hideSortProgress();
       sortStatus.textContent = `Threshold: ${(threshold * 100).toFixed(1)}%`;
       renderClipList();
+      if (autoSelect) {
+        const nextClip = findNextClip();
+        if (nextClip) selectClip(nextClip.id);
+      }
     } catch (error) {
       hideSortProgress();
       sortStatus.textContent = `Error: ${error.message}`;
@@ -1683,7 +1689,7 @@
 
   // ---- Load detector sort ----
 
-  async function fetchLoadedSort() {
+  async function fetchLoadedSort(autoSelect = false) {
     if (!loadedDetector) {
       sortStatus.textContent = "Load a detector first";
       return;
@@ -1709,6 +1715,10 @@
       hideSortProgress();
       sortStatus.textContent = `Threshold: ${(threshold * 100).toFixed(1)}%`;
       renderClipList();
+      if (autoSelect) {
+        const nextClip = findNextClip();
+        if (nextClip) selectClip(nextClip.id);
+      }
     } catch (error) {
       hideSortProgress();
       sortStatus.textContent = `Error: ${error.message}`;
@@ -1749,7 +1759,7 @@
       sortMode = "load";
       loadSortWrap.style.display = "";
       textSortWrap.style.display = "none";
-      fetchLoadedSort();
+      fetchLoadedSort(true);
     } catch (e) {
       sortStatus.textContent = "Invalid detector file";
       menuDetectorStatus.textContent = "Invalid detector file";


### PR DESCRIPTION
## Summary
This PR improves the user experience by automatically selecting the next clip after sorting operations complete, eliminating the need for manual selection.

## Key Changes
- Added `autoSelect` parameter to `fetchLearnedSort()` and `fetchLoadedSort()` functions to control automatic clip selection behavior
- Modified sort mode radio button change handler to remove the redundant `nextClip.id !== selected` check, allowing selection even when the next clip is the same
- Added automatic clip selection after threshold adjustment in manual sort mode
- Updated all sort operation callers to pass `autoSelect=true` when initiated from UI interactions (sort mode changes, detector file loading)

## Implementation Details
- When `autoSelect=true`, the sort functions now call `findNextClip()` and automatically select it via `selectClip()` after rendering the updated clip list
- The threshold adjustment in manual sort mode now also triggers automatic selection of the next clip
- The radio button handler simplification removes an unnecessary condition that prevented re-selection of the same clip

https://claude.ai/code/session_01DATDkWQBw9tFKhhCTBAwwP