### PR TITLE
Add icon field to importers and support multiple archive formats

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,15 +84,11 @@ if __name__ == "__main__":
         print("🚀 Running in LOCAL mode (accessible from other devices)", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)
     else:
-        # Production mode - load models and synthetic clips on startup
+        # Production mode - load models on startup; dataset is chosen by the user
         print("🚀 Running in PRODUCTION mode", flush=True)
 
         # Use tqdm for loading feedback
-        with tqdm(total=2, desc="Initializing", unit="step") as pbar:
-            pbar.set_description("Initializing clips")
-            init_clips()
-            pbar.update(1)
-
+        with tqdm(total=1, desc="Initializing", unit="step") as pbar:
             pbar.set_description("Loading models")
             initialize_models()
             pbar.update(1)

--- a/static/index.html
+++ b/static/index.html
@@ -313,21 +313,10 @@
           <h3>📁 Load from File</h3>
           <p>Load a previously saved dataset file (.pkl)</p>
         </button>
-        <button class="dataset-option" id="load-folder-btn">
-          <h3>📂 Generate from Folder</h3>
-          <p>Process media files (sounds/videos/images/paragraphs) from a folder</p>
-        </button>
         <button class="dataset-option" id="load-demo-btn">
-          <h3>🎯 Load Demo Dataset</h3>
-          <p>Choose from pre-configured ESC-50 datasets</p>
+          <h3>🏆 Load Demo Dataset</h3>
+          <p>Choose from a selection of pre-configured demo datasets</p>
         </button>
-        <div style="margin-top: 16px; padding: 12px; background: #2a2d3a; border-radius: 4px;">
-          <label style="display: flex; align-items: center; color: #e0e0e0; cursor: pointer;">
-            <input type="checkbox" id="autodetect-mode-checkbox" style="margin-right: 8px;">
-            <span>Run auto-detect after loading (skip manual labeling)</span>
-          </label>
-          <p style="font-size: 0.85rem; color: #aaa; margin: 8px 0 0 0;">When checked, automatically runs all favorite detectors and shows positive hits.</p>
-        </div>
       </div>
       <div class="dataset-progress" id="dataset-progress" style="display:none">
         <div class="progress-bar">
@@ -342,7 +331,6 @@
     </div>
   </div>
   <input type="file" id="file-input" accept=".pkl" style="display:none">
-  <input type="file" id="folder-input" webkitdirectory directory multiple style="display:none">
 
   <!-- Right panel -->
   <div class="panel-right">
@@ -543,10 +531,8 @@
   const extendedImporterForm = document.getElementById("extended-importer-form");
   const backButton = document.getElementById("back-button");
   const loadFileBtn = document.getElementById("load-file-btn");
-  const loadFolderBtn = document.getElementById("load-folder-btn");
   const loadDemoBtn = document.getElementById("load-demo-btn");
   const fileInput = document.getElementById("file-input");
-  const folderInput = document.getElementById("folder-input");
   const datasetBar = document.getElementById("dataset-bar");
   const datasetInfo = document.getElementById("dataset-info");
   const leftPanel = document.getElementById("left-panel");
@@ -749,42 +735,6 @@
     fileInput.value = "";
   });
 
-  // Load from folder (Note: folder selection requires server-side path input)
-  loadFolderBtn.addEventListener("click", () => {
-    const path = prompt("Enter the full path to the folder containing media files:");
-    if (!path) return;
-
-    // Ask user to select media type via radio buttons in a modal-like prompt
-    const mediaType = prompt(
-      "Enter media type (sounds/videos/images/paragraphs):",
-      "sounds"
-    );
-    if (!mediaType || !["sounds", "videos", "images", "paragraphs"].includes(mediaType.toLowerCase())) {
-      alert("Invalid media type. Please choose: sounds, videos, images, or paragraphs");
-      return;
-    }
-
-    startProgressPolling();
-
-    fetch("/api/dataset/load-folder", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path, media_type: mediaType.toLowerCase() }),
-    }).then(res => {
-      if (!res.ok) {
-        res.json().then(error => {
-          progressMessage.textContent = `Error: ${error.error}`;
-          progressMessage.style.color = "#f44336";
-          stopProgressPolling();
-        });
-      }
-    }).catch(e => {
-      progressMessage.textContent = `Error: ${e.message}`;
-      progressMessage.style.color = "#f44336";
-      stopProgressPolling();
-    });
-  });
-
   // Load demo dataset
   loadDemoBtn.addEventListener("click", async () => {
     datasetOptions.style.display = "none";
@@ -883,13 +833,25 @@
       for (const importer of data.importers) {
         const btn = document.createElement("button");
         btn.className = "dataset-option";
-        btn.innerHTML = `<h3>🔌 ${importer.display_name}</h3><p>${importer.description}</p>`;
+        btn.innerHTML = `<h3>${importer.icon || "🔌"} ${importer.display_name}</h3><p>${importer.description}</p>`;
         btn.addEventListener("click", () => showExtendedImporterForm(importer));
         datasetOptions.appendChild(btn);
       }
     } catch (_) {
       // Extended importers are optional – silently ignore failures.
     }
+    // Always render the autodetect toggle last, after all import options
+    const autodetectDiv = document.createElement("div");
+    autodetectDiv.id = "autodetect-toggle";
+    autodetectDiv.style = "margin-top: 16px; padding: 12px; background: #2a2d3a; border-radius: 4px;";
+    autodetectDiv.innerHTML = `
+      <label style="display: flex; align-items: center; color: #e0e0e0; cursor: pointer;">
+        <input type="checkbox" id="autodetect-mode-checkbox" style="margin-right: 8px;">
+        <span>Run auto-detect after loading (skip manual labeling)</span>
+      </label>
+      <p style="font-size: 0.85rem; color: #aaa; margin: 8px 0 0 0;">When checked, automatically runs all favorite detectors and shows positive hits.</p>
+    `;
+    datasetOptions.appendChild(autodetectDiv);
   }
 
   function showExtendedImporterForm(importer) {
@@ -911,6 +873,12 @@
           html += `<option value="${opt}"${opt === field.default ? " selected" : ""}>${opt}</option>`;
         }
         html += `</select>`;
+      } else if (field.field_type === "folder") {
+        html += `<div style="display:flex;gap:8px;align-items:center;">`;
+        html += `<input type="text" name="${field.key}" placeholder="${field.description}" style="${inputStyle}flex:1;" data-folder-input="true" ${field.required ? "required" : ""}>`;
+        html += `<button type="button" data-browse-btn="true" style="padding:8px 14px;background:#252940;border:1px solid #2a2d3a;border-radius:4px;color:#aaa;cursor:pointer;white-space:nowrap;">Browse…</button>`;
+        html += `</div>`;
+        html += `<input type="file" data-folder-picker="true" webkitdirectory style="display:none;">`;
       } else {
         const itype = field.field_type === "url" ? "url" : "text";
         html += `<input type="${itype}" name="${field.key}" value="${field.default}" placeholder="${field.description}" style="${inputStyle}" ${field.required ? "required" : ""}>`;
@@ -920,11 +888,28 @@
       }
       html += `</div>`;
     }
-    html += `<button type="submit" style="width:100%;padding:10px;background:#7c8aff;border:none;border-radius:4px;color:#fff;cursor:pointer;font-size:0.9rem;">Start Import</button>`;
+    html += `<button type="submit" style="width:100%;padding:10px;background:#7c8aff;border:none;border-radius:4px;color:#fff;cursor:pointer;font-size:0.9rem;">Import</button>`;
     html += `</form></div>`;
 
     extendedImporterForm.innerHTML = html;
     extendedImporterForm.style.display = "block";
+
+    // Wire up folder browse buttons
+    const browseBtn = extendedImporterForm.querySelector("[data-browse-btn]");
+    const folderPicker = extendedImporterForm.querySelector("[data-folder-picker]");
+    const folderTextInput = extendedImporterForm.querySelector("[data-folder-input]");
+    if (browseBtn && folderPicker && folderTextInput) {
+      browseBtn.addEventListener("click", () => folderPicker.click());
+      folderPicker.addEventListener("change", () => {
+        if (folderPicker.files.length > 0) {
+          // webkitRelativePath is "folderName/sub/file" — top segment is the folder name
+          const topFolder = folderPicker.files[0].webkitRelativePath.split("/")[0];
+          if (!folderTextInput.value) {
+            folderTextInput.placeholder = `Selected: ${topFolder} — enter full path below`;
+          }
+        }
+      });
+    }
 
     document.getElementById("ext-imp-form").addEventListener("submit", async (e) => {
       e.preventDefault();

--- a/test_importers.py
+++ b/test_importers.py
@@ -1,0 +1,283 @@
+"""Tests for the importer subsystem that don't require ML/torch dependencies.
+
+These tests verify:
+- HTTP Archive importer metadata (name, icon, description)
+- Folder importer metadata (icon, description, field ordering)
+- _extract_archive helper (zip and tar)
+- DatasetImporter base class icon field
+- Folder importer is not in _BUILTIN_IMPORTER_NAMES
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import tarfile
+import wave
+import zipfile
+
+import pytest
+
+
+def _make_wav_bytes() -> bytes:
+    """Create a minimal valid WAV file in memory."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(44100)
+        samples = struct.pack("<" + "h" * 100, *([0] * 100))
+        wf.writeframes(samples)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# DatasetImporter base class – icon field
+# ---------------------------------------------------------------------------
+
+
+class TestImporterBaseIcon:
+    def test_base_class_has_icon_attribute(self):
+        from vistatotes.datasets.importers.base import DatasetImporter
+
+        assert hasattr(DatasetImporter, "icon")
+        assert DatasetImporter.icon == "🔌"
+
+    def test_to_dict_includes_icon(self):
+        from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
+
+        class DummyImporter(DatasetImporter):
+            name = "dummy"
+            display_name = "Dummy"
+            description = "A dummy importer."
+            icon = "🧪"
+            fields = []
+
+            def run(self, field_values, clips):
+                pass
+
+        d = DummyImporter().to_dict()
+        assert "icon" in d
+        assert d["icon"] == "🧪"
+
+    def test_to_dict_uses_default_icon_when_not_overridden(self):
+        from vistatotes.datasets.importers.base import DatasetImporter
+
+        class MinimalImporter(DatasetImporter):
+            name = "minimal"
+            display_name = "Minimal"
+            description = "No icon override."
+            fields = []
+
+            def run(self, field_values, clips):
+                pass
+
+        d = MinimalImporter().to_dict()
+        assert d["icon"] == "🔌"
+
+
+# ---------------------------------------------------------------------------
+# HTTP Archive importer metadata
+# ---------------------------------------------------------------------------
+
+
+class TestHttpArchiveImporterMetadata:
+    def _get_importer(self):
+        from vistatotes.datasets.importers.http_zip import IMPORTER
+
+        return IMPORTER
+
+    def test_name_is_http_archive(self):
+        assert self._get_importer().name == "http_archive"
+
+    def test_display_name(self):
+        assert self._get_importer().display_name == "Generate from HTTP Archive"
+
+    def test_icon_is_globe(self):
+        assert self._get_importer().icon == "🌐"
+
+    def test_description_mentions_zip_tar_rar(self):
+        desc = self._get_importer().description.lower()
+        assert "zip" in desc
+        assert "tar" in desc
+        assert "rar" in desc
+
+    def test_to_dict_includes_icon(self):
+        d = self._get_importer().to_dict()
+        assert d["icon"] == "🌐"
+        assert d["name"] == "http_archive"
+        assert d["display_name"] == "Generate from HTTP Archive"
+
+    def test_fields_include_url_and_media_type(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "url" in fields
+        assert "media_type" in fields
+
+    def test_url_field_type(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert fields["url"].field_type == "url"
+
+    def test_media_type_options(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        opts = fields["media_type"].options
+        assert "sounds" in opts
+        assert "videos" in opts
+        assert "images" in opts
+        assert "paragraphs" in opts
+
+
+# ---------------------------------------------------------------------------
+# Folder importer metadata
+# ---------------------------------------------------------------------------
+
+
+class TestFolderImporterMetadata:
+    def _get_importer(self):
+        from vistatotes.datasets.importers.folder import IMPORTER
+
+        return IMPORTER
+
+    def test_name_is_folder(self):
+        assert self._get_importer().name == "folder"
+
+    def test_icon_is_folder_emoji(self):
+        assert self._get_importer().icon == "📂"
+
+    def test_description_says_media_files_from_a_folder(self):
+        desc = self._get_importer().description.lower()
+        assert "media files from a folder" in desc
+
+    def test_description_does_not_list_specific_media_types(self):
+        desc = self._get_importer().description
+        assert "sounds/videos" not in desc
+        assert "(sounds" not in desc
+
+    def test_media_type_field_before_path_field(self):
+        keys = [f.key for f in self._get_importer().fields]
+        assert keys.index("media_type") < keys.index("path")
+
+    def test_path_field_type_is_folder(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert fields["path"].field_type == "folder"
+
+    def test_to_dict_includes_icon(self):
+        d = self._get_importer().to_dict()
+        assert d["icon"] == "📂"
+
+
+# ---------------------------------------------------------------------------
+# Folder importer not in builtin names
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinImporterNames:
+    def test_folder_not_in_builtin_names(self):
+        from vistatotes.routes.datasets import _BUILTIN_IMPORTER_NAMES
+
+        assert "folder" not in _BUILTIN_IMPORTER_NAMES
+
+    def test_pickle_still_in_builtin_names(self):
+        from vistatotes.routes.datasets import _BUILTIN_IMPORTER_NAMES
+
+        assert "pickle" in _BUILTIN_IMPORTER_NAMES
+
+
+# ---------------------------------------------------------------------------
+# _extract_archive helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractArchive:
+    def test_extract_zip(self, tmp_path):
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        wav_data = _make_wav_bytes()
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("sounds/tone.wav", wav_data)
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _extract_archive(zip_path, extract_dir)
+        assert (extract_dir / "sounds" / "tone.wav").exists()
+
+    def test_extract_tar_uncompressed(self, tmp_path):
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        wav_data = _make_wav_bytes()
+        tar_path = tmp_path / "test.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            info = tarfile.TarInfo(name="tone.wav")
+            info.size = len(wav_data)
+            tf.addfile(info, io.BytesIO(wav_data))
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _extract_archive(tar_path, extract_dir)
+        assert (extract_dir / "tone.wav").exists()
+
+    def test_extract_tar_gz(self, tmp_path):
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        wav_data = _make_wav_bytes()
+        tar_path = tmp_path / "test.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tf:
+            info = tarfile.TarInfo(name="sounds/tone.wav")
+            info.size = len(wav_data)
+            tf.addfile(info, io.BytesIO(wav_data))
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _extract_archive(tar_path, extract_dir)
+        assert (extract_dir / "sounds" / "tone.wav").exists()
+
+    def test_extract_tar_bz2(self, tmp_path):
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        wav_data = _make_wav_bytes()
+        tar_path = tmp_path / "test.tar.bz2"
+        with tarfile.open(tar_path, "w:bz2") as tf:
+            info = tarfile.TarInfo(name="tone.wav")
+            info.size = len(wav_data)
+            tf.addfile(info, io.BytesIO(wav_data))
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _extract_archive(tar_path, extract_dir)
+        assert (extract_dir / "tone.wav").exists()
+
+    def test_unsupported_extension_raises_value_error(self, tmp_path):
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        # A file that is not a zip or tar and doesn't end in .rar
+        bad_archive = tmp_path / "test.7z"
+        bad_archive.write_bytes(b"not a valid archive format at all")
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        with pytest.raises((ValueError, Exception)):
+            _extract_archive(bad_archive, extract_dir)
+
+    def test_rar_without_rarfile_raises_runtime_error(self, tmp_path):
+        """Attempting RAR extraction without rarfile installed should fail gracefully."""
+        import sys
+        import unittest.mock as mock
+
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        rar_path = tmp_path / "test.rar"
+        # Write RAR v4 magic bytes so it's identified as .rar by extension
+        rar_path.write_bytes(b"Rar!\x1a\x07\x00" + b"\x00" * 20)
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+
+        with mock.patch.dict(sys.modules, {"rarfile": None}):
+            with pytest.raises((RuntimeError, ImportError, Exception)):
+                _extract_archive(rar_path, extract_dir)
+
+    def test_zip_preserves_multiple_files(self, tmp_path):
+        from vistatotes.datasets.importers.http_zip import _extract_archive
+
+        zip_path = tmp_path / "multi.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for i in range(3):
+                zf.writestr(f"file{i}.wav", _make_wav_bytes())
+        extract_dir = tmp_path / "out"
+        extract_dir.mkdir()
+        _extract_archive(zip_path, extract_dir)
+        assert len(list(extract_dir.glob("*.wav"))) == 3

--- a/vistatotes/datasets/importers/base.py
+++ b/vistatotes/datasets/importers/base.py
@@ -97,6 +97,8 @@ class DatasetImporter:
     display_name: str
     #: One-sentence description shown as a subtitle in the UI.
     description: str
+    #: Emoji or icon string shown next to the display name in the UI.
+    icon: str = "🔌"
     #: Ordered list of fields the user must fill before importing.
     fields: list[ImporterField]
 
@@ -124,5 +126,6 @@ class DatasetImporter:
             "name": self.name,
             "display_name": self.display_name,
             "description": self.description,
+            "icon": self.icon,
             "fields": [f.to_dict() for f in self.fields],
         }

--- a/vistatotes/datasets/importers/folder/__init__.py
+++ b/vistatotes/datasets/importers/folder/__init__.py
@@ -20,15 +20,10 @@ class FolderImporter(DatasetImporter):
     """
 
     name = "folder"
-    display_name = "Local Folder"
-    description = "Scan a local directory of media files and embed them."
+    display_name = "Generate from Folder"
+    description = "Import media files from a folder."
+    icon = "📂"
     fields = [
-        ImporterField(
-            key="path",
-            label="Folder Path",
-            field_type="folder",
-            description="Absolute path to the directory containing media files.",
-        ),
         ImporterField(
             key="media_type",
             label="Media Type",
@@ -36,6 +31,12 @@ class FolderImporter(DatasetImporter):
             description="Type of media files to scan for in the folder.",
             options=["sounds", "videos", "images", "paragraphs"],
             default="sounds",
+        ),
+        ImporterField(
+            key="path",
+            label="Folder",
+            field_type="folder",
+            description="Absolute path to the directory containing media files.",
         ),
     ]
 

--- a/vistatotes/datasets/importers/http_zip/__init__.py
+++ b/vistatotes/datasets/importers/http_zip/__init__.py
@@ -1,11 +1,16 @@
-"""HTTP-ZIP importer – downloads a public ZIP of media files and loads them.
+"""HTTP-Archive importer – downloads a public archive of media files and loads them.
+
+Supports .zip, .tar, .tar.gz, .tar.bz2, .tar.xz archives.
+RAR support requires the optional ``rarfile`` package.
 
 Requires only ``requests``, which is already a core dependency.
 """
 
 from __future__ import annotations
 
+import tarfile
 import zipfile
+from pathlib import Path
 
 from config import DATA_DIR
 from vistatotes.datasets.downloader import download_file_with_progress
@@ -14,49 +19,12 @@ from vistatotes.datasets.loader import load_dataset_from_folder
 from vistatotes.utils import update_progress
 
 
-class HttpZipImporter(DatasetImporter):
-    """Download a publicly-accessible ZIP archive and load its media files.
+def _extract_archive(archive_path: Path, extract_dir: Path) -> None:
+    """Extract *archive_path* into *extract_dir*, supporting zip/tar/rar."""
+    name = archive_path.name.lower()
 
-    The archive is streamed to ``DATA_DIR/http_zip_download.zip``, extracted
-    to ``DATA_DIR/http_zip_extract/``, then scanned with the standard
-    :func:`~vistatotes.datasets.loader.load_dataset_from_folder` pipeline.
-    Both temporary paths are cleaned up after a successful run.
-    """
-
-    name = "http_zip"
-    display_name = "HTTP ZIP Download"
-    description = "Download a .zip archive from a URL and load the media files inside."
-    fields = [
-        ImporterField(
-            key="url",
-            label="ZIP URL",
-            field_type="url",
-            description="URL to a publicly accessible .zip file of media files.",
-        ),
-        ImporterField(
-            key="media_type",
-            label="Media Type",
-            field_type="select",
-            description="Type of media files contained in the ZIP.",
-            options=["sounds", "videos", "images", "paragraphs"],
-            default="sounds",
-        ),
-    ]
-
-    def run(self, field_values: dict, clips: dict) -> None:
-        url = field_values["url"]
-        media_type = field_values.get("media_type", "sounds")
-
-        DATA_DIR.mkdir(exist_ok=True)
-        zip_path = DATA_DIR / "http_zip_download.zip"
-        extract_dir = DATA_DIR / "http_zip_extract"
-
-        update_progress("downloading", "Downloading ZIP...", 0, 0)
-        download_file_with_progress(url, zip_path)
-
-        update_progress("loading", "Extracting ZIP...", 0, 0)
-        extract_dir.mkdir(exist_ok=True)
-        with zipfile.ZipFile(zip_path, "r") as zf:
+    if name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path, "r") as zf:
             members = zf.namelist()
             total = len(members)
             for i, member in enumerate(members, 1):
@@ -67,9 +35,101 @@ class HttpZipImporter(DatasetImporter):
                     total,
                 )
                 zf.extract(member, extract_dir)
-        zip_path.unlink(missing_ok=True)
+
+    elif tarfile.is_tarfile(archive_path):
+        with tarfile.open(archive_path, "r:*") as tf:
+            members = tf.getmembers()
+            total = len(members)
+            for i, member in enumerate(members, 1):
+                update_progress(
+                    "loading",
+                    f"Extracting {member.name.split('/')[-1]}...",
+                    i,
+                    total,
+                )
+                tf.extract(member, extract_dir, filter="data")
+
+    elif name.endswith(".rar"):
+        try:
+            import rarfile  # optional dependency
+        except ImportError as exc:
+            raise RuntimeError(
+                "RAR extraction requires the 'rarfile' package. "
+                "Install it with: pip install rarfile"
+            ) from exc
+        with rarfile.RarFile(archive_path, "r") as rf:
+            members = rf.namelist()
+            total = len(members)
+            for i, member in enumerate(members, 1):
+                update_progress(
+                    "loading",
+                    f"Extracting {member.split('/')[-1]}...",
+                    i,
+                    total,
+                )
+                rf.extract(member, extract_dir)
+
+    else:
+        raise ValueError(
+            f"Unsupported archive format: {archive_path.name}. "
+            "Supported formats: .zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .rar"
+        )
+
+
+class HttpArchiveImporter(DatasetImporter):
+    """Download a publicly-accessible archive and load its media files.
+
+    The archive is streamed to a temporary file in ``DATA_DIR``, extracted
+    to ``DATA_DIR/http_archive_extract/``, then scanned with the standard
+    :func:`~vistatotes.datasets.loader.load_dataset_from_folder` pipeline.
+    Both temporary paths are cleaned up after a successful run.
+
+    Supported archive formats: ``.zip``, ``.tar``, ``.tar.gz``,
+    ``.tar.bz2``, ``.tar.xz``, ``.rar`` (requires ``rarfile`` package).
+    """
+
+    name = "http_archive"
+    display_name = "Generate from HTTP Archive"
+    description = "Download a .zip, .tar, or .rar archive from a URL and load the media files inside."
+    icon = "🌐"
+    fields = [
+        ImporterField(
+            key="url",
+            label="Archive URL",
+            field_type="url",
+            description="URL to a publicly accessible archive (.zip, .tar.gz, .rar, …) of media files.",
+        ),
+        ImporterField(
+            key="media_type",
+            label="Media Type",
+            field_type="select",
+            description="Type of media files contained in the archive.",
+            options=["sounds", "videos", "images", "paragraphs"],
+            default="sounds",
+        ),
+    ]
+
+    def run(self, field_values: dict, clips: dict) -> None:
+        url = field_values["url"]
+        media_type = field_values.get("media_type", "sounds")
+
+        DATA_DIR.mkdir(exist_ok=True)
+
+        # Derive a local filename from the URL so we preserve the extension
+        url_path = url.split("?")[0].rstrip("/")
+        url_filename = url_path.split("/")[-1] or "archive"
+        archive_path = DATA_DIR / f"http_archive_download_{url_filename}"
+        extract_dir = DATA_DIR / "http_archive_extract"
+
+        update_progress("downloading", "Downloading archive...", 0, 0)
+        download_file_with_progress(url, archive_path)
+
+        update_progress("loading", "Extracting archive...", 0, 0)
+        extract_dir.mkdir(exist_ok=True)
+        _extract_archive(archive_path, extract_dir)
+        archive_path.unlink(missing_ok=True)
 
         load_dataset_from_folder(extract_dir, media_type, clips)
 
 
-IMPORTER = HttpZipImporter()
+IMPORTER = HttpArchiveImporter()

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -22,7 +22,7 @@ datasets_bp = Blueprint("datasets", __name__)
 # Names of importers that have dedicated, hand-crafted UI sections in the
 # frontend.  They are excluded from the generic /api/dataset/importers list
 # so the frontend doesn't render a duplicate panel for them.
-_BUILTIN_IMPORTER_NAMES = {"pickle", "folder"}
+_BUILTIN_IMPORTER_NAMES = {"pickle"}
 
 
 def clear_dataset():


### PR DESCRIPTION
## Summary
This PR enhances the importer system by adding an `icon` field to all importers and extends the HTTP archive importer to support multiple archive formats (zip, tar, tar.gz, tar.bz2, tar.xz, and rar). It also reorganizes the UI to use a generic importer list instead of hardcoded buttons, and updates the startup behavior to require explicit dataset selection.

## Key Changes

### Importer System Enhancements
- **Added `icon` field to `DatasetImporter` base class** with default value `"🔌"` that can be overridden by subclasses
- **Updated `to_dict()` method** to include the icon field in serialized importer metadata
- **HTTP Archive importer** now uses icon `"🌐"` and display name "Generate from HTTP Archive"
- **Folder importer** now uses icon `"📂"` and is moved to the extended importers list (no longer a builtin)
- **Reordered folder importer fields** to show media_type before path for better UX

### Archive Format Support
- **Extracted `_extract_archive()` helper function** that handles multiple archive formats:
  - ZIP files via `zipfile` module
  - TAR archives (uncompressed, gzip, bzip2, xz) via `tarfile` module with `filter="data"` for security
  - RAR files via optional `rarfile` package with graceful error handling
- **Updated HTTP Archive importer** to preserve file extensions from URLs and support all archive formats
- **Added progress reporting** during extraction for better UX

### UI and Routing Changes
- **Removed hardcoded "Load from Folder" button** from the dataset selection screen
- **Folder importer removed from `_BUILTIN_IMPORTER_NAMES`** so it appears in the generic `/api/dataset/importers` list
- **Extended importer form** now dynamically renders all non-builtin importers with their icons
- **Autodetect checkbox moved** to render after all import options
- **Removed folder input element** from HTML (no longer needed with generic form)

### Startup Behavior
- **Production mode no longer auto-generates clips** on startup; users must explicitly select a dataset
- **`init_clips()` is only called in LOCAL mode** for testing convenience
- **Status endpoint returns `loaded=False`** when clips are empty to trigger dataset selection UI

### Testing
- **New comprehensive test file `test_importers.py`** covering:
  - Importer metadata (names, icons, descriptions, field ordering)
  - Archive extraction for all supported formats
  - Error handling for unsupported formats and missing dependencies
- **Extended `test_app.py`** with tests for startup state, importer registry, and archive extraction

## Implementation Details
- Archive extraction uses `tarfile.open(..., "r:*")` to auto-detect compression format
- TAR extraction uses `filter="data"` parameter to prevent path traversal attacks
- RAR support is optional; missing `rarfile` raises `RuntimeError` with installation instructions
- Progress updates during extraction show individual file names being extracted
- Temporary archive files are cleaned up after successful extraction

https://claude.ai/code/session_01GsfnCLGnYSDukSNNbptRdi