### PR TITLE
Add lazy model loading to embedding methods across media types

### DIFF
--- a/vistatotes/media/audio/media_type.py
+++ b/vistatotes/media/audio/media_type.py
@@ -135,6 +135,8 @@ class AudioMediaType(MediaType):
         print("DEBUG: CLAP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:
@@ -161,6 +163,8 @@ class AudioMediaType(MediaType):
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:

--- a/vistatotes/media/image/media_type.py
+++ b/vistatotes/media/image/media_type.py
@@ -123,6 +123,8 @@ class ImageMediaType(MediaType):
         print("DEBUG: CLIP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:
@@ -134,6 +136,8 @@ class ImageMediaType(MediaType):
 
     def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
         """Embed a PIL Image that is already in memory (e.g. from CIFAR-10)."""
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:
@@ -148,6 +152,8 @@ class ImageMediaType(MediaType):
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:

--- a/vistatotes/media/text/media_type.py
+++ b/vistatotes/media/text/media_type.py
@@ -109,6 +109,8 @@ class TextMediaType(MediaType):
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
+            self.load_models()
+        if self._model is None:
             return None
         try:
             with open(file_path, "r", encoding="utf-8") as f:
@@ -126,6 +128,8 @@ class TextMediaType(MediaType):
     def embed_text_passage(self, text: str) -> Optional[np.ndarray]:
         """Embed *text* as a passage (used when loading demo datasets in-memory)."""
         if self._model is None:
+            self.load_models()
+        if self._model is None:
             return None
         try:
             return self._model.encode(f"passage: {text}", normalize_embeddings=True)
@@ -134,6 +138,8 @@ class TextMediaType(MediaType):
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None:
             return None
         try:

--- a/vistatotes/media/video/media_type.py
+++ b/vistatotes/media/video/media_type.py
@@ -134,6 +134,8 @@ class VideoMediaType(MediaType):
         print("DEBUG: X-CLIP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:
@@ -169,6 +171,8 @@ class VideoMediaType(MediaType):
             return None
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
         if self._model is None or self._processor is None:
             return None
         try:


### PR DESCRIPTION
## Summary
This PR adds automatic lazy loading of models in embedding methods across all media type modules (image, text, audio, and video). If a model hasn't been loaded when an embedding method is called, it will now automatically trigger model loading instead of silently returning `None`.

## Key Changes
- **Image media type** (`vistatotes/media/image/media_type.py`): Added lazy loading checks to `embed_media()`, `embed_pil_image()`, and `embed_text()` methods
- **Text media type** (`vistatotes/media/text/media_type.py`): Added lazy loading checks to `embed_media()`, `embed_text_passage()`, and `embed_text()` methods
- **Audio media type** (`vistatotes/media/audio/media_type.py`): Added lazy loading checks to `embed_media()` and `embed_text()` methods
- **Video media type** (`vistatotes/media/video/media_type.py`): Added lazy loading checks to `embed_media()` and `embed_text()` methods

## Implementation Details
Each embedding method now includes an early check: if `self._model is None`, it calls `self.load_models()` before proceeding with the embedding logic. This ensures models are loaded on-demand when needed, improving the robustness of the embedding pipeline and preventing silent failures when models haven't been explicitly initialized.

https://claude.ai/code/session_01WzgLaMG5Mg7u3M3Mdbct6L