### PR TITLE
Add caching for labeling progress model/flips/predictions

### DIFF
--- a/vistatotes/utils/__init__.py
+++ b/vistatotes/utils/__init__.py
@@ -7,7 +7,10 @@ from vistatotes.utils.state import (add_favorite_detector,
                                     favorite_detectors, get_favorite_detectors,
                                     get_favorite_detectors_by_media,
                                     get_inclusion, good_votes, inclusion,
-                                    label_history, remove_favorite_detector,
+                                    label_history, progress_flips_cache,
+                                    progress_model_cache,
+                                    progress_predictions_cache,
+                                    remove_favorite_detector,
                                     rename_favorite_detector, set_inclusion)
 
 __all__ = [
@@ -32,4 +35,8 @@ __all__ = [
     "rename_favorite_detector",
     "get_favorite_detectors",
     "get_favorite_detectors_by_media",
+    # Labeling-progress caches
+    "progress_model_cache",
+    "progress_flips_cache",
+    "progress_predictions_cache",
 ]


### PR DESCRIPTION
## Summary
This PR introduces a three-level caching system for the labeling progress analysis pipeline to avoid redundant model training and prediction computation when analyzing the same historical steps multiple times.

## Key Changes

- **Added three new module-level caches** in `vistatotes/utils/state.py`:
  - `progress_model_cache`: Caches trained models, thresholds, and label lists keyed by `(time_index, inclusion_value)`
  - `progress_flips_cache`: Caches flip counts (label prediction changes between steps)
  - `progress_predictions_cache`: Caches per-clip binary predictions for unlabeled clips at each step

- **Modified `recreate_model_at_time()`** in `vistatotes/models/progress.py`:
  - Added cache lookup at function entry to return cached results immediately
  - Stores results in `progress_model_cache` before returning (including `None` models for steps with insufficient training data)
  - Eliminates redundant model training on subsequent calls for the same step

- **Modified `calculate_prediction_stability_over_time()`** in `vistatotes/models/progress.py`:
  - Added cache lookup for flip counts to skip computation if already cached
  - Stores predictions in `progress_predictions_cache` for use by subsequent steps
  - Changed flip detection logic to search backward through cached predictions rather than maintaining a single `previous_predictions` variable
  - Only computes flips for uncached steps; all historical steps are read directly from cache

- **Updated `clear_votes()`** in `vistatotes/utils/state.py`:
  - Now clears all three progress caches alongside vote/history data to prevent stale entries after session resets

- **Exported cache objects** in `vistatotes/utils/__init__.py` for test access

- **Added comprehensive test suite** in `test_app.py`:
  - 14 new tests covering cache population, cache hits, cache invalidation, and end-to-end behavior
  - Tests verify that second calls reuse cached data without retraining models
  - Tests confirm that adding new labels only trains models for new steps, not historical ones

## Implementation Details

- Cache keys use `(time_index, inclusion_value)` tuples so different inclusion values maintain separate cache entries
- The caching is transparent to callers—no API changes required
- Backward search through `progress_predictions_cache` allows flip detection to work correctly even when some intermediate steps lack unlabeled clips
- All caches are cleared together to maintain consistency and prevent stale data after votes are reset

https://claude.ai/code/session_01XrtqjE6mXRAciwFR2iXaGV