### PR TITLE
Add modular Results Exporter abstraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 from config import DATA_DIR, NUM_CLIPS
 from vistatotes.audio import generate_wav
 from vistatotes.models import embed_audio_file, initialize_models
-from vistatotes.routes import clips_bp, datasets_bp, main_bp, sorting_bp
+from vistatotes.routes import clips_bp, datasets_bp, exporters_bp, main_bp, sorting_bp
 from vistatotes.utils import clips
 
 app = Flask(__name__)
@@ -69,6 +69,7 @@ app.register_blueprint(main_bp)
 app.register_blueprint(clips_bp)
 app.register_blueprint(sorting_bp)
 app.register_blueprint(datasets_bp)
+app.register_blueprint(exporters_bp)
 
 
 # ---------------------------------------------------------------------------

--- a/requirements-exporters.txt
+++ b/requirements-exporters.txt
@@ -1,0 +1,12 @@
+# Aggregated requirements for all results exporters.
+#
+# Each exporter lives in vistatotes/exporters/<name>/ and has its own
+# requirements.txt listing any packages it needs beyond the core deps.
+#
+# To add a new exporter's dependencies, append a line here:
+#   -r vistatotes/exporters/<name>/requirements.txt
+#
+# ── Built-in exporters ──────────────────────────────────────────────────────
+-r vistatotes/exporters/gui/requirements.txt
+-r vistatotes/exporters/file/requirements.txt
+-r vistatotes/exporters/email_smtp/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,9 @@ tqdm
 # To add a new importer, create vistatotes/datasets/importers/<name>/requirements.txt,
 # then add a -r line to requirements-importers.txt.
 -r requirements-importers.txt
+
+# Per-exporter dependencies.
+# Each exporter declares its own requirements in its subdirectory.
+# To add a new exporter, create vistatotes/exporters/<name>/requirements.txt,
+# then add a -r line to requirements-exporters.txt.
+-r requirements-exporters.txt

--- a/static/index.html
+++ b/static/index.html
@@ -440,6 +440,23 @@
       <div style="margin-top: 16px;">
         <button id="copy-results-btn" style="padding: 8px 16px; background: #7c8aff; color: #fff; border: none; border-radius: 4px; cursor: pointer;">Copy Results to Clipboard</button>
       </div>
+
+      <!-- ── Export Results ─────────────────────────────────────── -->
+      <hr style="border-color: #3a3d4a; margin: 20px 0;">
+      <div id="exporter-section">
+        <h3 style="color: #e0e0e0; margin: 0 0 12px 0; font-size: 1rem;">Export Results</h3>
+        <div style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px;">
+          <label style="color: #aaa; white-space: nowrap;">Export via:</label>
+          <select id="exporter-select" style="background: #2a2d3a; color: #e0e0e0; border: 1px solid #555; border-radius: 4px; padding: 6px 10px; min-width: 180px;">
+            <option value="">Loading exporters…</option>
+          </select>
+        </div>
+        <div id="exporter-fields" style="margin-bottom: 12px;"></div>
+        <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+          <button id="export-btn" style="padding: 8px 20px; background: #4caf50; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9rem;">Export</button>
+          <span id="export-status" style="color: #aaa; font-size: 0.85rem;"></span>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -571,6 +588,10 @@
   const autodetectProgressModal = document.getElementById("autodetect-progress-modal");
   const autodetectProgressText = document.getElementById("autodetect-progress-text");
   const autodetectProgressBar = document.getElementById("autodetect-progress-bar");
+  const exporterSelect = document.getElementById("exporter-select");
+  const exporterFields = document.getElementById("exporter-fields");
+  const exportBtn = document.getElementById("export-btn");
+  const exportStatus = document.getElementById("export-status");
 
   // ---- Dataset Management ----
 
@@ -1470,8 +1491,11 @@
       </div>
     `).join('');
 
-    // Store results for copying
+    // Store results for copying / exporting
     window.autodetectResultsData = data;
+
+    // Reset exporter status
+    if (exportStatus) { exportStatus.textContent = ""; }
 
     // Show modal
     autodetectModal.classList.add("show");
@@ -1512,6 +1536,119 @@
       });
     });
   }
+
+  // ---- Results Exporters ----
+
+  let availableExporters = [];
+
+  async function loadExporters() {
+    try {
+      const res = await fetch("/api/exporters");
+      if (!res.ok) return;
+      availableExporters = await res.json();
+      if (exporterSelect) {
+        exporterSelect.innerHTML = availableExporters.map(exp =>
+          `<option value="${exp.name}">${exp.icon} ${exp.display_name}</option>`
+        ).join('');
+        renderExporterFields();
+      }
+    } catch (_) { /* silently ignore – exporters are optional */ }
+  }
+
+  function renderExporterFields() {
+    if (!exporterSelect || !exporterFields) return;
+    const selected = availableExporters.find(e => e.name === exporterSelect.value);
+    if (!selected || selected.fields.length === 0) {
+      exporterFields.innerHTML = "";
+      return;
+    }
+    exporterFields.innerHTML = selected.fields.map(f => {
+      const inputType = f.field_type === "password" ? "password"
+                      : f.field_type === "email"    ? "email"
+                      : "text";
+      if (f.field_type === "select") {
+        return `
+          <div style="margin-bottom: 10px;">
+            <label style="display:block; color:#aaa; font-size:0.85rem; margin-bottom:4px;">${f.label}${f.required ? ' *' : ''}</label>
+            <select data-key="${f.key}" style="background:#1a1d27; color:#e0e0e0; border:1px solid #555; border-radius:4px; padding:6px 10px; width:100%;">
+              ${f.options.map(o => `<option value="${o}"${o === f.default ? ' selected' : ''}>${o}</option>`).join('')}
+            </select>
+            ${f.description ? `<div style="color:#777; font-size:0.78rem; margin-top:3px;">${f.description}</div>` : ''}
+          </div>`;
+      }
+      return `
+        <div style="margin-bottom: 10px;">
+          <label style="display:block; color:#aaa; font-size:0.85rem; margin-bottom:4px;">${f.label}${f.required ? ' *' : ''}</label>
+          <input type="${inputType}" data-key="${f.key}"
+            value="${f.default || ''}"
+            placeholder="${f.placeholder || ''}"
+            style="background:#1a1d27; color:#e0e0e0; border:1px solid #555; border-radius:4px; padding:6px 10px; width:100%; box-sizing:border-box;">
+          ${f.description ? `<div style="color:#777; font-size:0.78rem; margin-top:3px;">${f.description}</div>` : ''}
+        </div>`;
+    }).join('');
+  }
+
+  if (exporterSelect) {
+    exporterSelect.addEventListener("change", renderExporterFields);
+  }
+
+  if (exportBtn) {
+    exportBtn.addEventListener("click", async () => {
+      if (!window.autodetectResultsData) {
+        exportStatus.textContent = "No results to export yet.";
+        exportStatus.style.color = "#f44336";
+        return;
+      }
+      const exporterName = exporterSelect ? exporterSelect.value : "";
+      if (!exporterName) {
+        exportStatus.textContent = "Select an exporter first.";
+        exportStatus.style.color = "#f44336";
+        return;
+      }
+
+      // Collect field values from rendered inputs/selects
+      const fieldValues = {};
+      exporterFields.querySelectorAll("[data-key]").forEach(el => {
+        fieldValues[el.dataset.key] = el.value;
+      });
+
+      exportBtn.disabled = true;
+      exportStatus.textContent = "Exporting…";
+      exportStatus.style.color = "#aaa";
+
+      try {
+        const res = await fetch("/api/exporters/export", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            exporter_name: exporterName,
+            field_values: fieldValues,
+            results: window.autodetectResultsData,
+          }),
+        });
+        const data = await res.json();
+        if (res.ok && data.success) {
+          exportStatus.textContent = data.message || "Export complete.";
+          exportStatus.style.color = "#4caf50";
+          // If the GUI exporter returned display_results, re-show results
+          if (data.display_results) {
+            window.autodetectResultsData = data.display_results;
+          }
+        } else {
+          exportStatus.textContent = `Error: ${data.error || "Export failed."}`;
+          exportStatus.style.color = "#f44336";
+        }
+      } catch (err) {
+        exportStatus.textContent = `Network error: ${err.message}`;
+        exportStatus.style.color = "#f44336";
+      } finally {
+        exportBtn.disabled = false;
+      }
+    });
+  }
+
+  // Load exporters immediately so the dropdown is ready when the modal opens
+  loadExporters();
 
   // ---- Sort mode switching ----
 

--- a/test_exporters.py
+++ b/test_exporters.py
@@ -1,0 +1,586 @@
+"""Tests for the Results Exporter abstraction.
+
+Covers:
+- ExporterField and ResultsExporter base classes
+- Auto-discovery registry
+- Built-in exporters: gui, file, email_smtp
+- Flask API routes: GET /api/exporters, POST /api/exporters/export
+"""
+
+from __future__ import annotations
+
+import json
+import smtplib
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app as app_module
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    app_module.app.config["TESTING"] = True
+    with app_module.app.test_client() as c:
+        yield c
+
+
+SAMPLE_RESULTS = {
+    "media_type": "audio",
+    "detectors_run": 2,
+    "results": {
+        "dog_bark": {
+            "detector_name": "dog_bark",
+            "threshold": 0.5,
+            "total_hits": 3,
+            "hits": [
+                {"id": 1, "filename": "bark1.wav", "score": 0.9},
+                {"id": 2, "filename": "bark2.wav", "score": 0.7},
+                {"id": 3, "filename": "bark3.wav", "score": 0.6},
+            ],
+        },
+        "cat_meow": {
+            "detector_name": "cat_meow",
+            "threshold": 0.6,
+            "total_hits": 1,
+            "hits": [
+                {"id": 5, "filename": "meow.wav", "score": 0.8},
+            ],
+        },
+    },
+}
+
+EMPTY_RESULTS = {
+    "media_type": "audio",
+    "detectors_run": 0,
+    "results": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# ExporterField
+# ---------------------------------------------------------------------------
+
+
+class TestExporterField:
+    def test_to_dict_contains_required_keys(self):
+        from vistatotes.exporters.base import ExporterField
+
+        f = ExporterField(key="fp", label="File Path", field_type="text")
+        d = f.to_dict()
+        assert d["key"] == "fp"
+        assert d["label"] == "File Path"
+        assert d["field_type"] == "text"
+        assert "description" in d
+        assert "options" in d
+        assert "default" in d
+        assert "required" in d
+        assert "placeholder" in d
+
+    def test_defaults(self):
+        from vistatotes.exporters.base import ExporterField
+
+        f = ExporterField(key="x", label="X", field_type="text")
+        assert f.required is True
+        assert f.default == ""
+        assert f.placeholder == ""
+        assert f.options == []
+        assert f.description == ""
+
+    def test_custom_values(self):
+        from vistatotes.exporters.base import ExporterField
+
+        f = ExporterField(
+            key="mode",
+            label="Mode",
+            field_type="select",
+            options=["a", "b"],
+            default="a",
+            required=False,
+            description="Choose mode",
+            placeholder="Pick one",
+        )
+        d = f.to_dict()
+        assert d["options"] == ["a", "b"]
+        assert d["default"] == "a"
+        assert d["required"] is False
+
+
+# ---------------------------------------------------------------------------
+# ResultsExporter base class
+# ---------------------------------------------------------------------------
+
+
+class TestResultsExporterBase:
+    def test_export_raises_not_implemented(self):
+        from vistatotes.exporters.base import ResultsExporter
+
+        exp = ResultsExporter()
+        with pytest.raises(NotImplementedError):
+            exp.export({}, {})
+
+    def test_to_dict_contains_standard_keys(self):
+        from vistatotes.exporters.base import ExporterField, ResultsExporter
+
+        class Dummy(ResultsExporter):
+            name = "dummy"
+            display_name = "Dummy"
+            description = "A test exporter."
+            icon = "🧪"
+            fields = [ExporterField(key="k", label="K", field_type="text")]
+
+            def export(self, results, field_values):
+                return {"message": "ok"}
+
+        d = Dummy().to_dict()
+        assert d["name"] == "dummy"
+        assert d["display_name"] == "Dummy"
+        assert d["description"] == "A test exporter."
+        assert d["icon"] == "🧪"
+        assert len(d["fields"]) == 1
+        assert d["fields"][0]["key"] == "k"
+
+
+# ---------------------------------------------------------------------------
+# Registry (auto-discovery)
+# ---------------------------------------------------------------------------
+
+
+class TestExporterRegistry:
+    def test_list_exporters_returns_all_builtins(self):
+        from vistatotes.exporters import list_exporters
+
+        names = {e.name for e in list_exporters()}
+        assert "gui" in names
+        assert "file" in names
+        assert "email_smtp" in names
+
+    def test_get_exporter_known(self):
+        from vistatotes.exporters import get_exporter
+
+        for name in ("gui", "file", "email_smtp"):
+            exp = get_exporter(name)
+            assert exp is not None, f"Exporter '{name}' not found"
+            assert exp.name == name
+
+    def test_get_exporter_unknown_returns_none(self):
+        from vistatotes.exporters import get_exporter
+
+        assert get_exporter("no_such_exporter") is None
+
+    def test_each_exporter_has_display_name_and_icon(self):
+        from vistatotes.exporters import list_exporters
+
+        for exp in list_exporters():
+            assert exp.display_name, f"{exp.name} missing display_name"
+            assert exp.icon, f"{exp.name} missing icon"
+            assert exp.description, f"{exp.name} missing description"
+
+    def test_each_exporter_fields_are_valid(self):
+        from vistatotes.exporters import list_exporters
+
+        for exp in list_exporters():
+            for f in exp.fields:
+                assert f.key, f"{exp.name} has a field without a key"
+                assert f.label, f"{exp.name} field '{f.key}' has no label"
+                assert f.field_type in (
+                    "text", "password", "email", "file", "folder", "select"
+                ), f"{exp.name} field '{f.key}' has unknown type '{f.field_type}'"
+
+
+# ---------------------------------------------------------------------------
+# GUI exporter
+# ---------------------------------------------------------------------------
+
+
+class TestGuiExporter:
+    def test_has_no_fields(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("gui")
+        assert exp.fields == []
+
+    def test_export_returns_message_and_display_results(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("gui")
+        result = exp.export(SAMPLE_RESULTS, {})
+        assert "message" in result
+        assert "display_results" in result
+        assert result["display_results"] is SAMPLE_RESULTS
+
+    def test_export_counts_hits_in_message(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("gui")
+        result = exp.export(SAMPLE_RESULTS, {})
+        # 3 + 1 = 4 total hits
+        assert "4" in result["message"]
+        assert "2" in result["message"]  # 2 detectors
+
+    def test_export_empty_results(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("gui")
+        result = exp.export(EMPTY_RESULTS, {})
+        assert "message" in result
+        assert result["display_results"] is EMPTY_RESULTS
+
+
+# ---------------------------------------------------------------------------
+# File exporter
+# ---------------------------------------------------------------------------
+
+
+class TestFileExporter:
+    def test_has_filepath_field(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("file")
+        keys = [f.key for f in exp.fields]
+        assert "filepath" in keys
+
+    def test_export_writes_json(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("file")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "results.json"
+            result = exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            assert "message" in result
+            assert fpath.exists()
+            written = json.loads(fpath.read_text())
+            assert written["media_type"] == "audio"
+            assert written["detectors_run"] == 2
+
+    def test_export_creates_parent_dirs(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("file")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "sub" / "dir" / "results.json"
+            exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            assert fpath.exists()
+
+    def test_export_raises_on_empty_filepath(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("file")
+        with pytest.raises(ValueError, match="file path"):
+            exp.export(SAMPLE_RESULTS, {"filepath": ""})
+
+    def test_export_message_contains_hit_count(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("file")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "out.json"
+            result = exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            assert "4" in result["message"]  # 3 + 1 hits
+
+    def test_to_dict_has_all_keys(self):
+        from vistatotes.exporters import get_exporter
+
+        d = get_exporter("file").to_dict()
+        assert d["name"] == "file"
+        assert "fields" in d
+        assert len(d["fields"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Email SMTP exporter
+# ---------------------------------------------------------------------------
+
+
+class TestEmailSmtpExporter:
+    def test_has_required_fields(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        keys = {f.key for f in exp.fields}
+        assert "to" in keys
+        assert "from_email" in keys
+        assert "smtp_password" in keys
+        assert "smtp_host" in keys
+        assert "smtp_port" in keys
+
+    def test_password_field_type_is_password(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        pwd_field = next(f for f in exp.fields if f.key == "smtp_password")
+        assert pwd_field.field_type == "password"
+
+    def test_export_raises_on_missing_to(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        with pytest.raises(ValueError, match="Recipient"):
+            exp.export(SAMPLE_RESULTS, {
+                "to": "",
+                "from_email": "me@example.com",
+                "smtp_password": "secret",
+                "smtp_host": "smtp.example.com",
+                "smtp_port": "587",
+            })
+
+    def test_export_raises_on_missing_from(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        with pytest.raises(ValueError, match="Sender"):
+            exp.export(SAMPLE_RESULTS, {
+                "to": "you@example.com",
+                "from_email": "",
+                "smtp_password": "secret",
+                "smtp_host": "smtp.example.com",
+                "smtp_port": "587",
+            })
+
+    def test_export_raises_on_missing_password(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        with pytest.raises(ValueError, match="password"):
+            exp.export(SAMPLE_RESULTS, {
+                "to": "you@example.com",
+                "from_email": "me@example.com",
+                "smtp_password": "",
+                "smtp_host": "smtp.example.com",
+                "smtp_port": "587",
+            })
+
+    def test_export_calls_smtp(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+
+        mock_server = MagicMock()
+        mock_smtp_cls = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("vistatotes.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls):
+            result = exp.export(SAMPLE_RESULTS, {
+                "to": "you@example.com",
+                "from_email": "me@example.com",
+                "smtp_password": "secret",
+                "smtp_host": "smtp.example.com",
+                "smtp_port": "587",
+            })
+
+        mock_smtp_cls.assert_called_once_with("smtp.example.com", 587)
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("me@example.com", "secret")
+        mock_server.sendmail.assert_called_once()
+        assert "message" in result
+        assert "you@example.com" in result["message"]
+
+    def test_plain_text_builder(self):
+        from vistatotes.exporters.email_smtp import _build_plain_text
+
+        text = _build_plain_text(SAMPLE_RESULTS)
+        assert "Auto-Detect Results" in text
+        assert "dog_bark" in text
+        assert "cat_meow" in text
+        assert "bark1.wav" in text
+
+    def test_html_builder(self):
+        from vistatotes.exporters.email_smtp import _build_html
+
+        html = _build_html(SAMPLE_RESULTS)
+        assert "<html>" in html
+        assert "dog_bark" in html
+        assert "cat_meow" in html
+        assert "bark1.wav" in html
+
+    def test_default_smtp_host_in_field(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        host_field = next(f for f in exp.fields if f.key == "smtp_host")
+        assert host_field.default == "smtp.gmail.com"
+
+    def test_default_smtp_port_in_field(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        port_field = next(f for f in exp.fields if f.key == "smtp_port")
+        assert port_field.default == "587"
+
+
+# ---------------------------------------------------------------------------
+# API – GET /api/exporters
+# ---------------------------------------------------------------------------
+
+
+class TestGetExportersEndpoint:
+    def test_returns_200(self, client):
+        res = client.get("/api/exporters")
+        assert res.status_code == 200
+
+    def test_returns_list(self, client):
+        res = client.get("/api/exporters")
+        data = res.get_json()
+        assert isinstance(data, list)
+
+    def test_contains_builtin_exporters(self, client):
+        res = client.get("/api/exporters")
+        names = {e["name"] for e in res.get_json()}
+        assert "gui" in names
+        assert "file" in names
+        assert "email_smtp" in names
+
+    def test_each_entry_has_required_keys(self, client):
+        res = client.get("/api/exporters")
+        for entry in res.get_json():
+            assert "name" in entry
+            assert "display_name" in entry
+            assert "description" in entry
+            assert "icon" in entry
+            assert "fields" in entry
+
+
+# ---------------------------------------------------------------------------
+# API – POST /api/exporters/export
+# ---------------------------------------------------------------------------
+
+
+class TestExportEndpoint:
+    def test_missing_exporter_name_returns_400(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={"results": SAMPLE_RESULTS},
+        )
+        assert res.status_code == 400
+        assert "exporter_name" in res.get_json()["error"]
+
+    def test_unknown_exporter_returns_404(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={"exporter_name": "unicorn", "results": SAMPLE_RESULTS},
+        )
+        assert res.status_code == 404
+        assert "unicorn" in res.get_json()["error"]
+
+    def test_gui_exporter_returns_success(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "gui",
+                "field_values": {},
+                "results": SAMPLE_RESULTS,
+            },
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert "message" in data
+        assert "display_results" in data
+
+    def test_file_exporter_creates_file(self, client):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "export.json"
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": SAMPLE_RESULTS,
+                },
+            )
+            assert res.status_code == 200
+            data = res.get_json()
+            assert data["success"] is True
+            assert fpath.exists()
+            written = json.loads(fpath.read_text())
+            assert written["detectors_run"] == 2
+
+    def test_file_exporter_missing_filepath_returns_400(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "file",
+                "field_values": {"filepath": ""},
+                "results": SAMPLE_RESULTS,
+            },
+        )
+        assert res.status_code == 400
+
+    def test_file_exporter_missing_field_returns_400(self, client):
+        """The route should reject the request before calling export()."""
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "file",
+                "field_values": {},  # 'filepath' is required but absent
+                "results": SAMPLE_RESULTS,
+            },
+        )
+        assert res.status_code == 400
+        data = res.get_json()
+        assert "missing_fields" in data
+        assert "filepath" in data["missing_fields"]
+
+    def test_email_exporter_sends_via_smtp(self, client):
+        mock_server = MagicMock()
+        mock_smtp_cls = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("vistatotes.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls):
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "email_smtp",
+                    "field_values": {
+                        "to": "you@example.com",
+                        "from_email": "me@example.com",
+                        "smtp_password": "secret",
+                        "smtp_host": "smtp.example.com",
+                        "smtp_port": "587",
+                    },
+                    "results": SAMPLE_RESULTS,
+                },
+            )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert "you@example.com" in data["message"]
+        mock_server.sendmail.assert_called_once()
+
+    def test_export_with_empty_results_dict(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "gui",
+                "field_values": {},
+                "results": {},
+            },
+        )
+        assert res.status_code == 200
+        assert res.get_json()["success"] is True
+
+    def test_export_with_no_results_key(self, client):
+        """results defaults to {} when omitted."""
+        res = client.post(
+            "/api/exporters/export",
+            json={"exporter_name": "gui"},
+        )
+        assert res.status_code == 200
+
+    def test_non_json_body_treated_as_empty(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            data="not json",
+            content_type="text/plain",
+        )
+        # exporter_name will be empty → 400
+        assert res.status_code == 400

--- a/vistatotes/exporters/__init__.py
+++ b/vistatotes/exporters/__init__.py
@@ -1,0 +1,64 @@
+"""Results-exporter registry with auto-discovery.
+
+Any package placed directly under this directory is automatically registered
+if it exposes a module-level ``EXPORTER`` attribute that is a
+:class:`~vistatotes.exporters.base.ResultsExporter` instance.
+
+Usage::
+
+    from vistatotes.exporters import get_exporter, list_exporters
+
+    exporter = get_exporter("file")
+    for exp in list_exporters():
+        print(exp.name, exp.display_name)
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vistatotes.exporters.base import ResultsExporter
+
+_registry: dict[str, ResultsExporter] = {}
+
+
+def _discover() -> None:
+    """Scan sub-packages for ``EXPORTER`` objects and register them."""
+    package_dir = Path(__file__).parent
+    for _, module_name, is_pkg in pkgutil.iter_modules([str(package_dir)]):
+        if not is_pkg:
+            continue
+        try:
+            mod = importlib.import_module(
+                f"vistatotes.exporters.{module_name}"
+            )
+            exporter = getattr(mod, "EXPORTER", None)
+            if exporter is not None:
+                _registry[exporter.name] = exporter
+        except Exception as exc:  # pragma: no cover
+            warnings.warn(
+                f"Failed to load results exporter '{module_name}': {exc}",
+                stacklevel=2,
+            )
+
+
+def _ensure_discovered() -> None:
+    if not _registry:
+        _discover()
+
+
+def get_exporter(name: str) -> ResultsExporter | None:
+    """Return the registered exporter with *name*, or ``None`` if not found."""
+    _ensure_discovered()
+    return _registry.get(name)
+
+
+def list_exporters() -> list[ResultsExporter]:
+    """Return all registered exporters in discovery order."""
+    _ensure_discovered()
+    return list(_registry.values())

--- a/vistatotes/exporters/base.py
+++ b/vistatotes/exporters/base.py
@@ -1,0 +1,157 @@
+"""Base classes for Results Exporters.
+
+To add a new exporter, subclass :class:`ResultsExporter`, define its class
+attributes and :meth:`~ResultsExporter.export`, then expose a module-level
+``EXPORTER`` instance from a package under this directory.  The registry will
+discover it automatically.
+
+Example – a minimal SFTP exporter skeleton::
+
+    # vistatotes/exporters/sftp/__init__.py
+    from vistatotes.exporters.base import ResultsExporter, ExporterField
+
+    class SftpExporter(ResultsExporter):
+        name         = "sftp"
+        display_name = "SFTP Upload"
+        description  = "Upload results JSON to a remote SFTP server."
+        icon         = "📡"
+        fields = [
+            ExporterField("host",     "Hostname",    "text"),
+            ExporterField("user",     "Username",    "text"),
+            ExporterField("password", "Password",    "password"),
+            ExporterField("path",     "Remote Path", "text",
+                          default="/results/autodetect.json"),
+        ]
+
+        def export(self, results: dict, field_values: dict) -> dict:
+            import paramiko
+            ...  # connect, write JSON, disconnect
+            return {"message": f"Uploaded to {field_values['host']}:{field_values['path']}"}
+
+    EXPORTER = SftpExporter()
+
+Then create ``vistatotes/exporters/sftp/requirements.txt`` containing
+``paramiko>=2.0.0`` and add::
+
+    -r vistatotes/exporters/sftp/requirements.txt
+
+to ``requirements-exporters.txt``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+FieldType = Literal["text", "password", "email", "file", "folder", "select"]
+
+
+@dataclass
+class ExporterField:
+    """Describes a single configurable input for an exporter.
+
+    The ``field_type`` value drives how the frontend renders it:
+
+    - ``"text"``     – Generic single-line text input.
+    - ``"password"`` – Text input whose characters are masked.
+    - ``"email"``    – Text input pre-validated as an e-mail address.
+    - ``"file"``     – OS file-picker; value arrives as a path string from the
+      browser (save-as path).
+    - ``"folder"``   – Path text-input for a local directory.
+    - ``"select"``   – Drop-down; ``options`` must be populated.
+    """
+
+    key: str
+    label: str
+    field_type: FieldType
+    description: str = ""
+    #: For ``"select"`` fields: the list of allowed values.
+    options: list[str] = field(default_factory=list)
+    #: Pre-filled default value shown in the UI.
+    default: str = ""
+    required: bool = True
+    #: Hint shown as placeholder text inside the input widget.
+    placeholder: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "field_type": self.field_type,
+            "description": self.description,
+            "options": self.options,
+            "default": self.default,
+            "required": self.required,
+            "placeholder": self.placeholder,
+        }
+
+
+class ResultsExporter:
+    """Abstract base class for results exporters.
+
+    Subclass this, set the class-level attributes, implement :meth:`export`,
+    and expose a module-level ``EXPORTER = YourExporter()`` – the registry
+    picks it up automatically.
+
+    The :meth:`export` method receives the full results dict returned by
+    ``/api/auto-detect`` and a flat mapping of field values supplied by the
+    user via the UI.  It should return a dict with at minimum a ``"message"``
+    key describing what happened (shown to the user as confirmation).
+    """
+
+    #: Internal snake_case identifier used in API routes, e.g. ``"sftp"``.
+    name: str
+    #: Human-readable label shown in the UI, e.g. ``"SFTP Upload"``.
+    display_name: str
+    #: One-sentence description shown as a subtitle in the UI.
+    description: str
+    #: Emoji or icon string shown next to the display name in the UI.
+    icon: str = "📤"
+    #: Ordered list of fields the user must fill before exporting.
+    #: Leave empty if the exporter needs no configuration.
+    fields: list[ExporterField]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Perform the export and return a status dict.
+
+        Args:
+            results: The full auto-detect results dict from ``/api/auto-detect``.
+                     Shape::
+
+                         {
+                           "media_type": "audio",
+                           "detectors_run": 2,
+                           "results": {
+                             "detector_name": {
+                               "detector_name": "...",
+                               "threshold": 0.5,
+                               "total_hits": 15,
+                               "hits": [{...}, ...]
+                             }
+                           }
+                         }
+
+            field_values: Mapping of :attr:`ExporterField.key` → value string
+                supplied by the user.
+
+        Returns:
+            A dict that **must** contain a ``"message"`` key with a short
+            human-readable confirmation string.  It may also carry arbitrary
+            extra keys (e.g. ``"filepath"`` for file-based exporters).
+
+        Raises:
+            NotImplementedError: If the subclass has not implemented this.
+            Exception: Any exception propagates to the route handler, which
+                returns it as a 500 JSON error.
+        """
+        raise NotImplementedError(f"{type(self).__name__}.export() is not implemented")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise exporter metadata for the ``/api/exporters`` endpoint."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "description": self.description,
+            "icon": self.icon,
+            "fields": [f.to_dict() for f in self.fields],
+        }

--- a/vistatotes/exporters/email_smtp/__init__.py
+++ b/vistatotes/exporters/email_smtp/__init__.py
@@ -1,0 +1,181 @@
+"""Email (SMTP) exporter – sends auto-detect results via e-mail.
+
+Uses only Python's built-in ``smtplib`` and ``email`` stdlib modules.
+No additional pip packages are required.
+
+Tested against Gmail (smtp.gmail.com:587 with an App Password) and generic
+STARTTLS-capable SMTP servers.  For Gmail, enable 2-step verification and
+generate an App Password at https://myaccount.google.com/apppasswords.
+"""
+
+from __future__ import annotations
+
+import json
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any
+
+from vistatotes.exporters.base import ExporterField, ResultsExporter
+
+
+def _build_plain_text(results: dict[str, Any]) -> str:
+    """Render results as a human-readable plain-text summary."""
+    lines: list[str] = [
+        "Auto-Detect Results",
+        "===================",
+        f"Media Type:    {results.get('media_type', 'unknown')}",
+        f"Detectors Run: {results.get('detectors_run', 0)}",
+        "",
+    ]
+    for det_result in results.get("results", {}).values():
+        lines.append(f"--- {det_result['detector_name']} ---")
+        lines.append(
+            f"Threshold: {det_result['threshold']}  |  "
+            f"Total Hits: {det_result['total_hits']}"
+        )
+        if det_result["hits"]:
+            for hit in det_result["hits"]:
+                lines.append(
+                    f"  Clip #{hit['id']}: {hit.get('filename', 'N/A')} "
+                    f"(score: {hit['score']})"
+                )
+        else:
+            lines.append("  No positive hits found.")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _build_html(results: dict[str, Any]) -> str:
+    """Render results as a minimal HTML e-mail body."""
+    rows = ""
+    for det_result in results.get("results", {}).values():
+        hits_html = ""
+        for hit in det_result["hits"]:
+            hits_html += (
+                f"<tr><td>Clip #{hit['id']}</td>"
+                f"<td>{hit.get('filename', 'N/A')}</td>"
+                f"<td>{hit['score']}</td></tr>"
+            )
+        if not hits_html:
+            hits_html = '<tr><td colspan="3"><em>No positive hits found.</em></td></tr>'
+        rows += (
+            f"<h3>{det_result['detector_name']}</h3>"
+            f"<p>Threshold: {det_result['threshold']} &mdash; "
+            f"Total Hits: {det_result['total_hits']}</p>"
+            f"<table border='1' cellpadding='4' cellspacing='0'>"
+            f"<tr><th>Clip</th><th>Filename</th><th>Score</th></tr>"
+            f"{hits_html}</table>"
+        )
+    return (
+        f"<html><body>"
+        f"<h2>Auto-Detect Results</h2>"
+        f"<p><strong>Media Type:</strong> {results.get('media_type', 'unknown')}<br>"
+        f"<strong>Detectors Run:</strong> {results.get('detectors_run', 0)}</p>"
+        f"{rows}"
+        f"</body></html>"
+    )
+
+
+class EmailSmtpExporter(ResultsExporter):
+    """Send auto-detect results by e-mail via an SMTP server.
+
+    Supports any STARTTLS-capable SMTP server (Gmail, Outlook, custom, etc.).
+    The message is sent as multipart/alternative with both plain-text and HTML
+    parts; the raw JSON is also attached inline.
+    """
+
+    name = "email_smtp"
+    display_name = "Send by Email"
+    description = "Email the results summary to any address via SMTP."
+    icon = "📧"
+    fields = [
+        ExporterField(
+            key="to",
+            label="Recipient Email",
+            field_type="email",
+            description="The email address to send the results to.",
+            placeholder="recipient@example.com",
+        ),
+        ExporterField(
+            key="from_email",
+            label="Sender Email",
+            field_type="email",
+            description="The email address used as the sender (must match your SMTP account).",
+            placeholder="you@example.com",
+        ),
+        ExporterField(
+            key="smtp_password",
+            label="SMTP Password / App Password",
+            field_type="password",
+            description=(
+                "Your SMTP password. For Gmail, use an App Password "
+                "(see https://myaccount.google.com/apppasswords)."
+            ),
+        ),
+        ExporterField(
+            key="smtp_host",
+            label="SMTP Host",
+            field_type="text",
+            description="The outgoing mail server hostname.",
+            placeholder="smtp.gmail.com",
+            default="smtp.gmail.com",
+        ),
+        ExporterField(
+            key="smtp_port",
+            label="SMTP Port",
+            field_type="text",
+            description="Port for STARTTLS connections (usually 587).",
+            placeholder="587",
+            default="587",
+        ),
+    ]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        to_addr = field_values.get("to", "").strip()
+        from_addr = field_values.get("from_email", "").strip()
+        password = field_values.get("smtp_password", "")
+        smtp_host = field_values.get("smtp_host", "smtp.gmail.com").strip()
+        smtp_port = int(field_values.get("smtp_port", "587").strip() or "587")
+
+        if not to_addr:
+            raise ValueError("Recipient email address is required.")
+        if not from_addr:
+            raise ValueError("Sender email address is required.")
+        if not password:
+            raise ValueError("SMTP password is required.")
+
+        media_type = results.get("media_type", "unknown")
+        total_hits = sum(
+            r.get("total_hits", 0) for r in results.get("results", {}).values()
+        )
+        subject = (
+            f"VistaTotes Auto-Detect: {total_hits} hit(s) on {media_type} dataset"
+        )
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = from_addr
+        msg["To"] = to_addr
+
+        plain = _build_plain_text(results)
+        html = _build_html(results)
+        msg.attach(MIMEText(plain, "plain", "utf-8"))
+        msg.attach(MIMEText(html, "html", "utf-8"))
+
+        with smtplib.SMTP(smtp_host, smtp_port) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(from_addr, password)
+            server.sendmail(from_addr, [to_addr], msg.as_string())
+
+        return {
+            "message": (
+                f"Email with {total_hits} hit(s) sent to {to_addr} "
+                f"via {smtp_host}:{smtp_port}."
+            ),
+            "to": to_addr,
+        }
+
+
+EXPORTER = EmailSmtpExporter()

--- a/vistatotes/exporters/email_smtp/requirements.txt
+++ b/vistatotes/exporters/email_smtp/requirements.txt
@@ -1,0 +1,1 @@
+# No additional packages required – uses only Python stdlib (smtplib, email).

--- a/vistatotes/exporters/file/__init__.py
+++ b/vistatotes/exporters/file/__init__.py
@@ -1,0 +1,63 @@
+"""File exporter – saves auto-detect results to a JSON file on disk.
+
+No additional pip packages are required; uses only Python's ``json`` and
+``pathlib`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vistatotes.exporters.base import ExporterField, ResultsExporter
+
+
+class FileExporter(ResultsExporter):
+    """Save auto-detect results as a JSON file at a path chosen by the user.
+
+    The user supplies the destination path (absolute or relative to the
+    current working directory).  Parent directories are created automatically.
+    """
+
+    name = "file"
+    display_name = "Save to File"
+    description = "Write the results to a JSON file on the local filesystem."
+    icon = "💾"
+    fields = [
+        ExporterField(
+            key="filepath",
+            label="File Path",
+            field_type="text",
+            description=(
+                "Absolute or relative path where the JSON results file will be "
+                "written.  Parent directories are created automatically."
+            ),
+            placeholder="/home/user/autodetect_results.json",
+            default="autodetect_results.json",
+        ),
+    ]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        filepath_str = field_values.get("filepath", "").strip()
+        if not filepath_str:
+            raise ValueError("A file path is required.")
+
+        filepath = Path(filepath_str)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+        total_hits = sum(
+            r.get("total_hits", 0) for r in results.get("results", {}).values()
+        )
+        return {
+            "message": (
+                f"Saved {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) "
+                f"to {filepath.resolve()}."
+            ),
+            "filepath": str(filepath.resolve()),
+        }
+
+
+EXPORTER = FileExporter()

--- a/vistatotes/exporters/file/requirements.txt
+++ b/vistatotes/exporters/file/requirements.txt
@@ -1,0 +1,1 @@
+# No additional packages required – uses only Python stdlib (json, pathlib).

--- a/vistatotes/exporters/gui/__init__.py
+++ b/vistatotes/exporters/gui/__init__.py
@@ -1,0 +1,41 @@
+"""GUI exporter – returns results to the browser for display in a modal.
+
+No additional pip packages are required; this exporter is handled entirely
+by the frontend JavaScript.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vistatotes.exporters.base import ResultsExporter
+
+
+class GuiExporter(ResultsExporter):
+    """Display auto-detect results in the browser's built-in results modal.
+
+    This is the default exporter: it performs no server-side work and simply
+    passes the results back to the frontend, which renders them in the
+    Auto-Detect Results modal.  No configuration fields are needed.
+    """
+
+    name = "gui"
+    display_name = "Show in Browser"
+    description = "Display the results in a popup window in the browser."
+    icon = "🖥️"
+    fields = []  # no questions to ask
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        total_hits = sum(
+            r.get("total_hits", 0) for r in results.get("results", {}).values()
+        )
+        return {
+            "message": (
+                f"Showing {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s)."
+            ),
+            "display_results": results,
+        }
+
+
+EXPORTER = GuiExporter()

--- a/vistatotes/exporters/gui/requirements.txt
+++ b/vistatotes/exporters/gui/requirements.txt
@@ -1,0 +1,1 @@
+# No additional packages required – uses only Python stdlib and the browser.

--- a/vistatotes/routes/__init__.py
+++ b/vistatotes/routes/__init__.py
@@ -2,6 +2,7 @@
 
 from vistatotes.routes.clips import clips_bp
 from vistatotes.routes.datasets import datasets_bp
+from vistatotes.routes.exporters import exporters_bp
 from vistatotes.routes.main import main_bp
 from vistatotes.routes.sorting import sorting_bp
 
@@ -10,4 +11,5 @@ __all__ = [
     "clips_bp",
     "sorting_bp",
     "datasets_bp",
+    "exporters_bp",
 ]

--- a/vistatotes/routes/exporters.py
+++ b/vistatotes/routes/exporters.py
@@ -1,0 +1,111 @@
+"""Flask routes for the Results Exporter API.
+
+Endpoints
+---------
+GET  /api/exporters
+    List all registered exporters with their metadata and field definitions.
+
+POST /api/exporters/export
+    Run a specific exporter on auto-detect results supplied in the request
+    body.  Body (JSON)::
+
+        {
+            "exporter_name": "file",
+            "field_values":  {"filepath": "/home/user/results.json"},
+            "results":       { ...auto-detect results dict... }
+        }
+
+    Returns::
+
+        {"success": true, "message": "...", ...exporter-specific keys...}
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from vistatotes.exporters import get_exporter, list_exporters
+
+exporters_bp = Blueprint("exporters", __name__)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/exporters
+# ---------------------------------------------------------------------------
+
+
+@exporters_bp.route("/api/exporters", methods=["GET"])
+def get_exporters():
+    """Return a list of all registered results exporters."""
+    return jsonify([exp.to_dict() for exp in list_exporters()])
+
+
+# ---------------------------------------------------------------------------
+# POST /api/exporters/export
+# ---------------------------------------------------------------------------
+
+
+@exporters_bp.route("/api/exporters/export", methods=["POST"])
+def run_export():
+    """Run the named exporter on the supplied auto-detect results.
+
+    Request body (JSON):
+
+    .. code-block:: json
+
+        {
+            "exporter_name": "file",
+            "field_values":  {"filepath": "/home/user/results.json"},
+            "results":       {}
+        }
+
+    ``field_values`` and ``results`` are both optional – they default to
+    empty dicts – but a valid ``exporter_name`` is required.
+    """
+    data = request.get_json(force=True, silent=True) or {}
+
+    exporter_name = data.get("exporter_name", "").strip()
+    if not exporter_name:
+        return jsonify({"error": "exporter_name is required"}), 400
+
+    exporter = get_exporter(exporter_name)
+    if exporter is None:
+        known = [exp.name for exp in list_exporters()]
+        return (
+            jsonify(
+                {
+                    "error": f"Unknown exporter '{exporter_name}'. "
+                    f"Available: {known}"
+                }
+            ),
+            404,
+        )
+
+    field_values: dict = data.get("field_values", {}) or {}
+    results: dict = data.get("results", {}) or {}
+
+    # Validate required fields
+    missing = [
+        f.key
+        for f in exporter.fields
+        if f.required and not field_values.get(f.key, "").strip()
+    ]
+    if missing:
+        return (
+            jsonify(
+                {
+                    "error": f"Missing required field(s): {missing}",
+                    "missing_fields": missing,
+                }
+            ),
+            400,
+        )
+
+    try:
+        outcome = exporter.export(results, field_values)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:  # pragma: no cover
+        return jsonify({"error": f"Export failed: {exc}"}), 500
+
+    return jsonify({"success": True, **outcome})


### PR DESCRIPTION
Introduces a pluggable ResultsExporter system mirroring the existing
DatasetImporter pattern so that future developers can add new export
targets with minimal code.

New files & modules
─────────────────────────────────────────────────────────────────
vistatotes/exporters/base.py
  – ExporterField dataclass (key, label, field_type, options,
    default, placeholder, required, description) with to_dict()
  – ResultsExporter base class: name, display_name, description,
    icon, fields, export(results, field_values) → dict, to_dict()

vistatotes/exporters/__init__.py
  – Auto-discovery registry (same pattern as dataset importers):
    scans sub-packages for a module-level EXPORTER attribute.
  – list_exporters() / get_exporter(name) public API.

Three built-in exporters (each in its own sub-package with a
requirements.txt for future pip-install extensions):

  exporters/gui/          – Show in Browser (no fields; returns
                            display_results for the frontend modal)
  exporters/file/         – Save to File (filepath field; writes JSON)
  exporters/email_smtp/   – Send by Email (STARTTLS SMTP; multipart
                            plain-text + HTML email; 5 config fields)

vistatotes/routes/exporters.py
  – GET  /api/exporters          → list all registered exporters
  – POST /api/exporters/export   → run chosen exporter on results
    Body: {exporter_name, field_values, results}
    Validates required fields before calling export(); returns
    {success, message, ...exporter-specific keys}.

requirements-exporters.txt
  – Aggregates per-exporter requirements.txt files (currently all
    stdlib-only; future SFTP/cloud exporters add entries here).

requirements.txt
  – Added -r requirements-exporters.txt (parallel to importers).

static/index.html
  – Auto-detect results modal now has an "Export Results" section:
    exporter drop-down (populated from /api/exporters), dynamic
    field form (text/password/email/select inputs rendered from
    field metadata), Export button, and status message.
  – Exporters are fetched once at page load via loadExporters().
  – Export status resets each time new auto-detect results arrive.

app.py / vistatotes/routes/__init__.py
  – Register exporters_bp blueprint.

test_exporters.py
  – 45 tests covering: ExporterField, ResultsExporter base class,
    registry discovery, GUI/File/Email exporters (unit + SMTP mock),
    and all route behaviours (200/400/404, missing fields, etc.).

How to add a new exporter (e.g. SFTP)
──────────────────────────────────────
1. Create vistatotes/exporters/sftp/__init__.py with an EXPORTER
   instance subclassing ResultsExporter; implement export().
2. Add vistatotes/exporters/sftp/requirements.txt with e.g. paramiko.
3. Append -r vistatotes/exporters/sftp/requirements.txt to
   requirements-exporters.txt.
That's it – the registry and UI discover it automatically.

https://claude.ai/code/session_01YYND1nsnVhUu4cRwczHkXi