### PR TITLE
Sort labeled clips by click time instead of clip number

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2116,9 +2116,7 @@
     goodList.innerHTML = "";
     badList.innerHTML = "";
 
-    const sortedGood = [...votes.good].sort((a, b) => a - b);
-
-    sortedGood.forEach(id => {
+    votes.good.forEach(id => {
       const div = document.createElement("div");
       div.className = "vote-entry";
       div.textContent = `Clip #${id}`;
@@ -2126,9 +2124,7 @@
       goodList.appendChild(div);
     });
 
-    const sortedBad = [...votes.bad].sort((a, b) => a - b);
-
-    sortedBad.forEach(id => {
+    votes.bad.forEach(id => {
       const div = document.createElement("div");
       div.className = "vote-entry";
       div.textContent = `Clip #${id}`;


### PR DESCRIPTION
The renderVotes() function was sorting good and bad vote lists by clip ID
(numerically), obscuring the order in which users labeled clips. Since the
backend returns votes in insertion order (Python dict insertion order = click
time), simply iterating votes.good and votes.bad directly gives click-time
order without any explicit sort.

https://claude.ai/code/session_01KVPUsaV16XGzTBXQn9JMkU