### PR TITLE
Fix test collection failure: lazy-import cv2 in VideoMediaType and update stale test string

### DIFF
--- a/test_app.py
+++ b/test_app.py
@@ -142,7 +142,7 @@ class TestIndex:
     def test_serves_index_html(self, client):
         resp = client.get("/")
         assert resp.status_code == 200
-        assert b"VectoryTones" in resp.data
+        assert b"VistaTotes" in resp.data
 
 
 # ---------------------------------------------------------------------------

--- a/vistatotes/media/video/media_type.py
+++ b/vistatotes/media/video/media_type.py
@@ -6,7 +6,6 @@ import io
 from pathlib import Path
 from typing import Optional
 
-import cv2
 import numpy as np
 import torch
 from flask import Response, send_file
@@ -139,6 +138,7 @@ class VideoMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            import cv2  # noqa: PLC0415  (lazy import — cv2 is optional)
             cap = cv2.VideoCapture(str(file_path))
             if not cap.isOpened():
                 print(f"Error opening video {file_path}")
@@ -198,6 +198,7 @@ class VideoMediaType(MediaType):
         with open(file_path, "rb") as f:
             video_bytes = f.read()
         try:
+            import cv2  # noqa: PLC0415
             cap = cv2.VideoCapture(str(file_path))
             fps = cap.get(cv2.CAP_PROP_FPS)
             frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)


### PR DESCRIPTION
- Move `import cv2` from module-level to inside the two methods that use
  it (embed_media, load_clip_data), so the module loads cleanly even
  when OpenCV is not installed.
- Update TestIndex assertion from old name "VectoryTones" to current
  app name "VistaTotes" (the HTML title was already updated but the
  test wasn't).

All 149 tests now pass.

https://claude.ai/code/session_016K3SKc9Abvd9tHmR5uwEGS