### PR TITLE
Remove unused imports across codebase

### DIFF
--- a/test_exporters.py
+++ b/test_exporters.py
@@ -10,10 +10,8 @@ Covers:
 from __future__ import annotations
 
 import json
-import smtplib
 import tempfile
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/test_importers.py
+++ b/test_importers.py
@@ -44,7 +44,7 @@ class TestImporterBaseIcon:
         assert DatasetImporter.icon == "🔌"
 
     def test_to_dict_includes_icon(self):
-        from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
+        from vistatotes.datasets.importers.base import DatasetImporter
 
         class DummyImporter(DatasetImporter):
             name = "dummy"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -76,7 +76,7 @@ class TestStartupState:
                 for child in ast.walk(node):
                     if isinstance(child, ast.Call):
                         func = child.func
-                        name = (
+                        _ = (
                             func.id
                             if isinstance(func, ast.Name)
                             else getattr(func, "attr", "")

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -66,7 +66,7 @@ class TestImportLabels:
     def test_import_overrides_existing_label(self, client):
         app_module.good_votes[1] = None
         labels = [{"md5": app_module.clips[1]["md5"], "label": "bad"}]
-        resp = client.post("/api/labels/import", json={"labels": labels})
+        client.post("/api/labels/import", json={"labels": labels})
         assert 1 not in app_module.good_votes
         assert 1 in app_module.bad_votes
 

--- a/vistatotes/exporters/email_smtp/__init__.py
+++ b/vistatotes/exporters/email_smtp/__init__.py
@@ -10,7 +10,6 @@ generate an App Password at https://myaccount.google.com/apppasswords.
 
 from __future__ import annotations
 
-import json
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText

--- a/vistatotes/media/base.py
+++ b/vistatotes/media/base.py
@@ -18,9 +18,9 @@ the registry.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
 from flask import Response

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from flask import Blueprint, jsonify, request, send_file
 
 from config import (CIFAR10_DOWNLOAD_SIZE_MB, CLIPS_PER_CATEGORY,
-                    CLIPS_PER_VIDEO_CATEGORY, DATA_DIR, EMBEDDINGS_DIR,
+                    CLIPS_PER_VIDEO_CATEGORY, EMBEDDINGS_DIR,
                     ESC50_DOWNLOAD_SIZE_MB, IMAGES_PER_CIFAR10_CATEGORY,
                     SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB, VIDEO_DIR)
 from vistatotes.datasets import (DEMO_DATASETS, export_dataset_to_file,


### PR DESCRIPTION
## Summary
This PR removes unused imports that were identified through code analysis, improving code cleanliness and reducing unnecessary dependencies.

## Key Changes
- **vistatotes/media/base.py**: Removed unused `field` from dataclasses import and `Any` from typing import
- **test_exporters.py**: Removed unused `smtplib` and `Any` imports
- **test_importers.py**: Removed unused `ImporterField` from the base importer import
- **tests/test_datasets.py**: Changed unused variable `name` to `_` to follow Python conventions for intentionally unused variables
- **tests/test_labels.py**: Removed unused `resp` variable assignment from client.post() call
- **vistatotes/routes/datasets.py**: Removed unused `DATA_DIR` import from config
- **vistatotes/exporters/email_smtp/__init__.py**: Removed unused `json` import

## Notes
These changes improve code quality by eliminating dead code and making it clearer which imports are actually utilized in each module.

https://claude.ai/code/session_01ApQ2fQNEdH9zkQDwUsmiDa