### PR TITLE
Improve clip selection by breaking ties with threshold proximity

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1303,15 +1303,31 @@
       // Select highest scoring unlabeled clip
       nextClip = unlabeled[0];
     } else {
-      // Select clip closest to threshold
+      // Select clip closest to threshold, breaking ties by index
+      // proximity to the threshold position in sortOrder
       if (threshold === null) {
         return null;
       }
+      // Find threshold index: first position where score drops below threshold
+      let thresholdIdx = sortOrder.length;
+      for (let i = 0; i < sortOrder.length; i++) {
+        if (sortOrder[i].score < threshold) {
+          thresholdIdx = i;
+          break;
+        }
+      }
+      // Map clip id to its sortOrder index
+      const idToIdx = {};
+      sortOrder.forEach((item, idx) => { idToIdx[item.id] = idx; });
+
       let minDist = Infinity;
+      let minIdxDist = Infinity;
       for (const item of unlabeled) {
         const dist = Math.abs(item.score - threshold);
-        if (dist < minDist) {
+        const idxDist = Math.abs(idToIdx[item.id] - thresholdIdx);
+        if (dist < minDist || (dist === minDist && idxDist < minIdxDist)) {
           minDist = dist;
+          minIdxDist = idxDist;
           nextClip = item;
         }
       }


### PR DESCRIPTION
## Summary
Enhanced the clip selection algorithm to break ties when multiple unlabeled clips have the same distance to the threshold score. The selection now considers both score proximity and position proximity to the threshold in the sorted order.

## Key Changes
- Added logic to calculate the threshold index (first position where score drops below threshold)
- Created a mapping of clip IDs to their positions in the sort order
- Modified the tie-breaking condition to prefer clips whose position in the sort order is closest to the threshold index
- Updated selection criteria from `dist < minDist` to `dist < minDist || (dist === minDist && idxDist < minIdxDist)`

## Implementation Details
- The threshold index is determined by finding the first clip in `sortOrder` with a score below the threshold value
- When multiple clips have equal score distance to the threshold, the algorithm now selects the one whose index position in `sortOrder` is nearest to the threshold index
- This provides more consistent and predictable clip selection behavior when score distances are tied

https://claude.ai/code/session_01NNUU6Mbs3Hj6NMHBSiFGTn