### PR TITLE
Add model caching to progress tracking to avoid retraining

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ import app as app_module
 from config import NUM_CLIPS, SAMPLE_RATE
 from vistatotes.audio import generate_wav
 from vistatotes.models import initialize_models, train_and_score
-from vistatotes.utils import bad_votes, clips, good_votes
+from vistatotes.models.progress import clear_progress_cache
+from vistatotes.utils import bad_votes, clips, good_votes, label_history
 
 # Attach to app_module for backward compatibility with existing tests
 app_module.NUM_CLIPS = NUM_CLIPS
@@ -24,9 +25,11 @@ app_module.init_clips()
 
 @pytest.fixture(autouse=True)
 def reset_votes():
-    """Reset vote state before each test."""
+    """Reset vote state and progress cache before each test."""
     good_votes.clear()
     bad_votes.clear()
+    label_history.clear()
+    clear_progress_cache()
 
 
 @pytest.fixture

--- a/vistatotes/models/__init__.py
+++ b/vistatotes/models/__init__.py
@@ -1,17 +1,21 @@
 """Model loading, embeddings, and training utilities."""
 
-from vistatotes.models.embeddings import (embed_audio_file, embed_image_file,
-                                          embed_paragraph_file,
-                                          embed_text_query, embed_video_file)
-from vistatotes.models.loader import (get_clap_model, get_clip_model,
-                                      get_e5_model, get_xclip_model,
-                                      initialize_models)
-from vistatotes.models.progress import (analyze_labeling_progress,
-                                        compute_labeling_status)
-from vistatotes.models.training import (calculate_cross_calibration_threshold,
-                                        calculate_gmm_threshold,
-                                        find_optimal_threshold,
-                                        train_and_score, train_model)
+from vistatotes.models.embeddings import (
+    embed_audio_file,
+    embed_image_file,
+    embed_paragraph_file,
+    embed_text_query,
+    embed_video_file,
+)
+from vistatotes.models.loader import get_clap_model, get_clip_model, get_e5_model, get_xclip_model, initialize_models
+from vistatotes.models.progress import analyze_labeling_progress, clear_progress_cache, compute_labeling_status
+from vistatotes.models.training import (
+    calculate_cross_calibration_threshold,
+    calculate_gmm_threshold,
+    find_optimal_threshold,
+    train_and_score,
+    train_model,
+)
 
 __all__ = [
     # Embeddings
@@ -34,5 +38,6 @@ __all__ = [
     "calculate_cross_calibration_threshold",
     # Progress
     "analyze_labeling_progress",
+    "clear_progress_cache",
     "compute_labeling_status",
 ]

--- a/vistatotes/models/progress.py
+++ b/vistatotes/models/progress.py
@@ -1,4 +1,9 @@
-"""Progress tracking and stopping condition analysis."""
+"""Progress tracking and stopping condition analysis.
+
+Caches trained models and stability metrics per labelling step so that
+repeated queries (the progress button, the auto-indicator) never retrain
+models that have already been computed.
+"""
 
 from typing import Any, Optional
 
@@ -8,137 +13,169 @@ import torch.nn as nn
 
 from vistatotes.models.training import find_optimal_threshold, train_model
 
+# ---------------------------------------------------------------------------
+# Module-level cache
+# ---------------------------------------------------------------------------
+# Each entry in ``_cached_steps`` corresponds to one index in ``label_history``
+# and stores the model, threshold, label sets, and stability result for that
+# step.  ``_cache_good_ids`` / ``_cache_bad_ids`` track the running label sets
+# so the next step only needs to apply a single delta.
 
-def recreate_model_at_time(
-    clips_dict: dict[int, dict[str, Any]],
-    label_history: list[tuple[int, str, float]],
-    time_index: int,
-    inclusion_value: int = 0,
-) -> tuple[Optional[nn.Sequential], Optional[float], list[int], list[int]]:
-    """Recreate the classifier that would have been trained after a given labelling step.
+_cache_inclusion: Optional[int] = None
+_cached_steps: list[dict[str, Any]] = []
+_cache_good_ids: set[int] = set()
+_cache_bad_ids: set[int] = set()
+_cache_prev_predictions: Optional[dict[int, int]] = None
 
-    Builds training data from all labels in ``label_history`` up to and including
-    ``time_index``, then trains an MLP and computes a threshold using those labels.
-    Later labels for the same clip override earlier ones (last label wins).
 
-    Args:
-        clips_dict: Mapping of clip ID to clip data dict. Each value must contain
-            an ``"embedding"`` key with a ``numpy.ndarray`` embedding vector.
-        label_history: Ordered list of ``(clip_id, label, timestamp)`` tuples
-            representing all labelling events, where ``label`` is ``"good"`` or
-            ``"bad"``.
-        time_index: Index into ``label_history``. Labels from index 0 through
-            ``time_index`` (inclusive) are used. Must be in
-            ``[0, len(label_history) - 1]``.
-        inclusion_value: Integer in ``[-10, 10]`` controlling the FPR/FNR trade-off
-            passed to :func:`~vistatotes.models.training.train_model` and
-            :func:`~vistatotes.models.training.find_optimal_threshold`.
+def clear_progress_cache() -> None:
+    """Clear all cached progress data.
 
-    Returns:
-        A 4-tuple ``(model, threshold, good_ids, bad_ids)`` where:
-
-        - ``model`` is the trained ``nn.Sequential`` model, or ``None`` if there
-          is insufficient labelled data (fewer than 2 examples, or all labels are
-          the same class).
-        - ``threshold`` is the float decision boundary, or ``None`` when ``model``
-          is ``None``.
-        - ``good_ids`` is a list of clip IDs currently labelled good (may be
-          non-empty even when ``model`` is ``None``).
-        - ``bad_ids`` is a list of clip IDs currently labelled bad (may be
-          non-empty even when ``model`` is ``None``).
+    Must be called whenever votes are cleared, clips change, or inclusion
+    is altered so that stale models are not reused.
     """
-    if time_index < 0 or time_index >= len(label_history):
-        return None, None, [], []
-
-    # Collect labels up to time_index
-    good_ids: set[int] = set()
-    bad_ids: set[int] = set()
-
-    for i in range(time_index + 1):
-        clip_id, label, _ = label_history[i]
-        if label == "good":
-            bad_ids.discard(clip_id)
-            good_ids.add(clip_id)
-        else:
-            good_ids.discard(clip_id)
-            bad_ids.add(clip_id)
-
-    # Need at least one of each to train
-    if not good_ids or not bad_ids:
-        return None, None, list(good_ids), list(bad_ids)
-
-    # Build training data
-    X_list: list[np.ndarray] = []
-    y_list: list[float] = []
-    for cid in good_ids:
-        if cid in clips_dict:
-            X_list.append(clips_dict[cid]["embedding"])
-            y_list.append(1.0)
-    for cid in bad_ids:
-        if cid in clips_dict:
-            X_list.append(clips_dict[cid]["embedding"])
-            y_list.append(0.0)
-
-    if len(X_list) < 2:
-        return None, None, list(good_ids), list(bad_ids)
-
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
-    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-    input_dim = X.shape[1]
-
-    # Train model
-    model = train_model(X, y, input_dim, inclusion_value)
-
-    # Calculate threshold on training data (not ideal, but matches current approach)
-    with torch.no_grad():
-        scores = model(X).squeeze(1).tolist()
-    threshold = find_optimal_threshold(scores, y_list, inclusion_value)
-
-    return model, threshold, list(good_ids), list(bad_ids)
+    global _cache_inclusion, _cache_prev_predictions
+    _cached_steps.clear()
+    _cache_good_ids.clear()
+    _cache_bad_ids.clear()
+    _cache_prev_predictions = None
+    _cache_inclusion = None
 
 
-def calculate_error_cost_over_time(
+def _ensure_cache(
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
+    inclusion_value: int,
+) -> None:
+    """Bring the cache up to date with *label_history*.
+
+    Only computes steps that are not yet cached.  If *inclusion_value*
+    differs from the value used for existing cache entries the entire cache
+    is rebuilt.
+    """
+    global _cache_inclusion, _cache_prev_predictions
+
+    if _cache_inclusion is not None and _cache_inclusion != inclusion_value:
+        clear_progress_cache()
+
+    if _cache_inclusion is None:
+        _cache_inclusion = inclusion_value
+
+    start = len(_cached_steps)
+    if start >= len(label_history):
+        return  # already up to date
+
+    all_clip_ids = sorted(clips_dict.keys())
+
+    for t in range(start, len(label_history)):
+        clip_id, label, _ = label_history[t]
+
+        # Incrementally update running label sets
+        if label == "good":
+            _cache_bad_ids.discard(clip_id)
+            _cache_good_ids.add(clip_id)
+        else:
+            _cache_good_ids.discard(clip_id)
+            _cache_bad_ids.add(clip_id)
+
+        good_ids = list(_cache_good_ids)
+        bad_ids = list(_cache_bad_ids)
+
+        model: Optional[nn.Sequential] = None
+        threshold: Optional[float] = None
+        stability: Optional[dict[str, Any]] = None
+
+        if _cache_good_ids and _cache_bad_ids:
+            # Build training data
+            X_list: list[np.ndarray] = []
+            y_list: list[float] = []
+            for cid in _cache_good_ids:
+                if cid in clips_dict:
+                    X_list.append(clips_dict[cid]["embedding"])
+                    y_list.append(1.0)
+            for cid in _cache_bad_ids:
+                if cid in clips_dict:
+                    X_list.append(clips_dict[cid]["embedding"])
+                    y_list.append(0.0)
+
+            if len(X_list) >= 2:
+                X = torch.tensor(np.array(X_list), dtype=torch.float32)
+                y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+                input_dim = X.shape[1]
+
+                model = train_model(X, y, input_dim, inclusion_value)
+
+                with torch.no_grad():
+                    scores = model(X).squeeze(1).tolist()
+                threshold = find_optimal_threshold(scores, y_list, inclusion_value)
+
+                # --- Stability ---
+                labeled_ids = _cache_good_ids | _cache_bad_ids
+                unlabeled_ids = [cid for cid in all_clip_ids if cid not in labeled_ids]
+
+                if not unlabeled_ids:
+                    stability = {
+                        "time_index": t,
+                        "num_labels": len(good_ids) + len(bad_ids),
+                        "num_flips": 0,
+                        "num_unlabeled": 0,
+                    }
+                else:
+                    unlabeled_embs = np.array([clips_dict[cid]["embedding"] for cid in unlabeled_ids])
+                    X_unlabeled = torch.tensor(unlabeled_embs, dtype=torch.float32)
+
+                    with torch.no_grad():
+                        scores_unl = model(X_unlabeled).squeeze(1).tolist()
+
+                    predictions: dict[int, int] = {
+                        cid: 1 if score >= threshold else 0 for cid, score in zip(unlabeled_ids, scores_unl)
+                    }
+
+                    num_flips = 0
+                    if _cache_prev_predictions is not None:
+                        common = predictions.keys() & _cache_prev_predictions.keys()
+                        for cid in common:
+                            if predictions[cid] != _cache_prev_predictions[cid]:
+                                num_flips += 1
+
+                    stability = {
+                        "time_index": t,
+                        "num_labels": len(good_ids) + len(bad_ids),
+                        "num_flips": num_flips,
+                        "num_unlabeled": len(unlabeled_ids),
+                    }
+
+                    _cache_prev_predictions = predictions
+
+        _cached_steps.append(
+            {
+                "model": model,
+                "threshold": threshold,
+                "good_ids": good_ids,
+                "bad_ids": bad_ids,
+                "stability": stability,
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper: evaluate cached models against a label set
+# ---------------------------------------------------------------------------
+
+
+def _eval_cached_models(
+    clips_dict: dict[int, dict[str, Any]],
     current_good_votes: dict[int, None],
     current_bad_votes: dict[int, None],
-    inclusion_value: int = 0,
+    inclusion_value: int,
+    start: int = 0,
+    end: Optional[int] = None,
 ) -> list[dict[str, Any]]:
-    """Calculate classification error cost at each labelling step against the current labelset.
+    """Score cached models against the current labelset (forward passes only).
 
-    For each time step ``t`` in ``label_history``, recreates the model trained on
-    labels up to ``t`` and evaluates it against the *current* full labelset. This
-    shows how the model's quality improved as more labels were added.
-
-    Args:
-        clips_dict: Mapping of clip ID to clip data dict. Each value must contain
-            an ``"embedding"`` key with a ``numpy.ndarray`` embedding vector.
-        label_history: Ordered list of ``(clip_id, label, timestamp)`` tuples
-            representing all labelling events.
-        current_good_votes: Dict whose keys are clip IDs currently labelled good.
-        current_bad_votes: Dict whose keys are clip IDs currently labelled bad.
-        inclusion_value: Integer in ``[-10, 10]`` controlling the FPR/FNR trade-off.
-            - 0: cost = ``fpr + fnr``.
-            - Positive: cost = ``fpr + 2^inclusion_value * fnr`` (penalise misses more).
-            - Negative: cost = ``2^(-inclusion_value) * fpr + fnr`` (penalise false
-              alarms more).
-
-    Returns:
-        A list of dicts, one per time step where a model could be trained (i.e.
-        where both classes were present). Each dict has the keys:
-
-        - ``"time_index"`` (``int``): Index into ``label_history``.
-        - ``"num_labels"`` (``int``): Total number of labelled clips at this step.
-        - ``"error_cost"`` (``float``): Weighted ``fpr + fnr``, rounded to 4 dp.
-        - ``"fpr"`` (``float``): False-positive rate, rounded to 4 dp.
-        - ``"fnr"`` (``float``): False-negative rate, rounded to 4 dp.
-
-        Returns an empty list if ``current_good_votes`` and ``current_bad_votes``
-        are both empty.
+    Returns a list of error-cost dicts for every cached step in
+    ``[start, end)`` that has a trained model.
     """
-    results: list[dict[str, Any]] = []
-
-    # Determine weights based on inclusion
     if inclusion_value >= 0:
         fpr_weight = 1.0
         fnr_weight = 2.0**inclusion_value
@@ -146,7 +183,7 @@ def calculate_error_cost_over_time(
         fpr_weight = 2.0 ** (-inclusion_value)
         fnr_weight = 1.0
 
-    # Build current truth labels
+    # Build evaluation set from current votes
     current_labels: dict[int, float] = {}
     for cid in current_good_votes:
         current_labels[cid] = 1.0
@@ -156,63 +193,48 @@ def calculate_error_cost_over_time(
     if not current_labels:
         return []
 
-    # Only evaluate on currently labeled clips
-    eval_ids = list(current_labels.keys())
     eval_embs: list[np.ndarray] = []
     eval_labels: list[float] = []
-    for cid in eval_ids:
+    for cid, lbl in current_labels.items():
         if cid in clips_dict:
             eval_embs.append(clips_dict[cid]["embedding"])
-            eval_labels.append(current_labels[cid])
+            eval_labels.append(lbl)
 
     if not eval_embs:
         return []
 
     X_eval = torch.tensor(np.array(eval_embs), dtype=torch.float32)
+    total_positives = sum(1 for lbl in eval_labels if lbl == 1)
+    total_negatives = len(eval_labels) - total_positives
 
-    # Iterate through time, training models and evaluating
-    for t in range(len(label_history)):
-        model, threshold, good_ids, bad_ids = recreate_model_at_time(
-            clips_dict, label_history, t, inclusion_value
-        )
+    if end is None:
+        end = len(_cached_steps)
 
-        if model is None:
-            # Not enough data yet
+    results: list[dict[str, Any]] = []
+    for t in range(start, end):
+        step = _cached_steps[t]
+        if step["model"] is None:
             continue
 
-        # Score the current labelset
         with torch.no_grad():
-            scores = model(X_eval).squeeze(1).tolist()
+            scores = step["model"](X_eval).squeeze(1).tolist()
 
-        # Calculate FPR and FNR
-        fp = 0
-        fn = 0
-        tp = 0
-        tn = 0
-
+        fp = fn = 0
         for score, true_label in zip(scores, eval_labels):
-            predicted = 1 if score >= threshold else 0
+            predicted = 1 if score >= step["threshold"] else 0
             if predicted == 1 and true_label == 0:
                 fp += 1
             elif predicted == 0 and true_label == 1:
                 fn += 1
-            elif predicted == 1 and true_label == 1:
-                tp += 1
-            else:
-                tn += 1
 
-        total_positives = sum(1 for lbl in eval_labels if lbl == 1)
-        total_negatives = len(eval_labels) - total_positives
-
-        fpr = fp / total_negatives if total_negatives > 0 else 0
-        fnr = fn / total_positives if total_positives > 0 else 0
-
+        fpr = fp / total_negatives if total_negatives > 0 else 0.0
+        fnr = fn / total_positives if total_positives > 0 else 0.0
         error_cost = fpr_weight * fpr + fnr_weight * fnr
 
         results.append(
             {
                 "time_index": t,
-                "num_labels": len(good_ids) + len(bad_ids),
+                "num_labels": len(step["good_ids"]) + len(step["bad_ids"]),
                 "error_cost": round(error_cost, 4),
                 "fpr": round(fpr, 4),
                 "fnr": round(fnr, 4),
@@ -222,102 +244,60 @@ def calculate_error_cost_over_time(
     return results
 
 
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def recreate_model_at_time(
+    clips_dict: dict[int, dict[str, Any]],
+    label_history: list[tuple[int, str, float]],
+    time_index: int,
+    inclusion_value: int = 0,
+) -> tuple[Optional[nn.Sequential], Optional[float], list[int], list[int]]:
+    """Return the cached model for a given labelling step, training it if needed.
+
+    Args:
+        clips_dict: Mapping of clip ID to clip data dict with ``"embedding"``.
+        label_history: Ordered labelling events.
+        time_index: Index into *label_history*.
+        inclusion_value: FPR/FNR trade-off in ``[-10, 10]``.
+
+    Returns:
+        ``(model, threshold, good_ids, bad_ids)`` — same contract as before.
+    """
+    if time_index < 0 or time_index >= len(label_history):
+        return None, None, [], []
+
+    _ensure_cache(clips_dict, label_history, inclusion_value)
+
+    step = _cached_steps[time_index]
+    return step["model"], step["threshold"], step["good_ids"], step["bad_ids"]
+
+
+def calculate_error_cost_over_time(
+    clips_dict: dict[int, dict[str, Any]],
+    label_history: list[tuple[int, str, float]],
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+    inclusion_value: int = 0,
+) -> list[dict[str, Any]]:
+    """Calculate classification error cost at each labelling step.
+
+    Uses cached models — no retraining.
+    """
+    _ensure_cache(clips_dict, label_history, inclusion_value)
+    return _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
+
+
 def calculate_prediction_stability_over_time(
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
     inclusion_value: int = 0,
 ) -> list[dict[str, Any]]:
-    """Count how many unlabelled clips change their predicted label at each step.
-
-    At each time step ``t``, recreates the model trained on labels up to ``t``,
-    scores all *unlabelled* clips, and counts how many changed their predicted
-    label (flipped) compared to the previous time step. A decreasing flip count
-    is a sign that the model's predictions are stabilising.
-
-    Args:
-        clips_dict: Mapping of clip ID to clip data dict. Each value must contain
-            an ``"embedding"`` key with a ``numpy.ndarray`` embedding vector.
-        label_history: Ordered list of ``(clip_id, label, timestamp)`` tuples
-            representing all labelling events.
-        inclusion_value: Integer in ``[-10, 10]`` controlling the decision
-            threshold used to binarise model scores. Passed to
-            :func:`recreate_model_at_time`.
-
-    Returns:
-        A list of dicts, one per time step where a model could be trained. Each
-        dict has the keys:
-
-        - ``"time_index"`` (``int``): Index into ``label_history``.
-        - ``"num_labels"`` (``int``): Total number of labelled clips at this step.
-        - ``"num_flips"`` (``int``): Number of unlabelled clips whose predicted
-          label changed since the previous time step (0 for the first valid step).
-        - ``"num_unlabeled"`` (``int``): Number of unlabelled clips at this step.
-    """
-    results: list[dict[str, Any]] = []
-    previous_predictions: Optional[dict[int, int]] = None
-
-    # Get all clip IDs
-    all_clip_ids = sorted(clips_dict.keys())
-
-    for t in range(len(label_history)):
-        model, threshold, good_ids, bad_ids = recreate_model_at_time(
-            clips_dict, label_history, t, inclusion_value
-        )
-
-        if model is None:
-            continue
-
-        # Get IDs of currently labeled clips
-        labeled_ids = set(good_ids) | set(bad_ids)
-
-        # Get unlabeled clips
-        unlabeled_ids = [cid for cid in all_clip_ids if cid not in labeled_ids]
-
-        if not unlabeled_ids:
-            results.append(
-                {
-                    "time_index": t,
-                    "num_labels": len(good_ids) + len(bad_ids),
-                    "num_flips": 0,
-                    "num_unlabeled": 0,
-                }
-            )
-            continue
-
-        # Score unlabeled clips
-        unlabeled_embs = np.array([clips_dict[cid]["embedding"] for cid in unlabeled_ids])
-        X_unlabeled = torch.tensor(unlabeled_embs, dtype=torch.float32)
-
-        with torch.no_grad():
-            scores = model(X_unlabeled).squeeze(1).tolist()
-
-        # Convert scores to binary predictions
-        predictions: dict[int, int] = {
-            cid: 1 if score >= threshold else 0
-            for cid, score in zip(unlabeled_ids, scores)
-        }
-
-        # Count flips from previous time step
-        num_flips = 0
-        if previous_predictions is not None:
-            # Only count flips for clips that were unlabeled in both time steps
-            common_unlabeled = set(predictions.keys()) & set(previous_predictions.keys())
-            for cid in common_unlabeled:
-                if predictions[cid] != previous_predictions[cid]:
-                    num_flips += 1
-
-        results.append(
-            {
-                "time_index": t,
-                "num_labels": len(good_ids) + len(bad_ids),
-                "num_flips": num_flips,
-                "num_unlabeled": len(unlabeled_ids),
-            }
-        )
-
-        previous_predictions = predictions
-
-    return results
+    """Return cached prediction-stability metrics for every step."""
+    _ensure_cache(clips_dict, label_history, inclusion_value)
+    return [step["stability"] for step in _cached_steps if step["stability"] is not None]
 
 
 def compute_labeling_status(
@@ -327,32 +307,9 @@ def compute_labeling_status(
     current_bad_votes: dict[int, None],
     inclusion_value: int = 0,
 ) -> dict[str, Any]:
-    """Compute a lightweight red/yellow/green labeling status from the last 10 steps.
+    """Compute a lightweight red/yellow/green labeling status.
 
-    Evaluates only the most recent 10 labeling steps (instead of the full history)
-    to quickly determine whether continuing to label is worthwhile.
-
-    Status meanings:
-
-    - ``"red"``: Fewer than 20 total labels, or fewer than 5 good or 5 bad labels.
-      The metric is not yet reliable.
-    - ``"yellow"``: Minimum counts met, but error cost over the last 10 steps is
-      still sloping downward, meaning labeling is still improving the model.
-    - ``"green"``: Minimum counts met and error cost is flat over the last 10 steps.
-      You can likely stop labeling.
-
-    Args:
-        clips_dict: Mapping of clip ID to clip data dict (must include ``"embedding"``).
-        label_history: Ordered list of ``(clip_id, label, timestamp)`` tuples.
-        current_good_votes: Dict whose keys are clip IDs labelled good.
-        current_bad_votes: Dict whose keys are clip IDs labelled bad.
-        inclusion_value: Integer in ``[-10, 10]`` controlling the FPR/FNR trade-off.
-
-    Returns:
-        A dict with keys ``"status"`` (``"red"``, ``"yellow"``, or ``"green"``),
-        ``"reason"`` (human-readable explanation), ``"good_count"``, ``"bad_count"``,
-        and ``"total_count"``. Yellow/green results also include a ``"slope"`` value
-        (relative slope of error cost over the last 10 steps).
+    Uses cached models for the last 10 steps — only forward passes, no training.
     """
     good = len(current_good_votes)
     bad = len(current_bad_votes)
@@ -360,18 +317,18 @@ def compute_labeling_status(
 
     base = {"good_count": good, "bad_count": bad, "total_count": total}
 
-    # Red: not enough data for a reliable metric
     if total < 20 or good < 5 or bad < 5:
         return {
             **base,
             "status": "red",
             "reason": (
-                f"Need at least 20 labels with 5 good and 5 bad. "
-                f"Currently {total} total ({good} good, {bad} bad)."
+                f"Need at least 20 labels with 5 good and 5 bad. Currently {total} total ({good} good, {bad} bad)."
             ),
         }
 
-    n = len(label_history)
+    _ensure_cache(clips_dict, label_history, inclusion_value)
+
+    n = len(_cached_steps)
     if n < 3:
         return {
             **base,
@@ -379,57 +336,12 @@ def compute_labeling_status(
             "reason": "Not enough label history steps to assess trend.",
         }
 
-    # Determine FPR/FNR weights from inclusion
-    if inclusion_value >= 0:
-        fpr_weight = 1.0
-        fnr_weight = 2.0**inclusion_value
-    else:
-        fpr_weight = 2.0 ** (-inclusion_value)
-        fnr_weight = 1.0
-
-    # Build the current evaluation set (all labeled clips)
-    current_labels: dict[int, float] = {}
-    for cid in current_good_votes:
-        current_labels[cid] = 1.0
-    for cid in current_bad_votes:
-        current_labels[cid] = 0.0
-
-    eval_pairs = [(cid, lbl) for cid, lbl in current_labels.items() if cid in clips_dict]
-    if not eval_pairs:
-        return {**base, "status": "red", "reason": "No clip embeddings available."}
-
-    eval_ids, eval_labels_list = zip(*eval_pairs)
-    eval_embs = [clips_dict[cid]["embedding"] for cid in eval_ids]
-    X_eval = torch.tensor(np.array(eval_embs), dtype=torch.float32)
-
-    total_positives = sum(1 for lbl in eval_labels_list if lbl == 1.0)
-    total_negatives = len(eval_labels_list) - total_positives
-
-    # Evaluate only the last 10 time steps
     start_idx = max(0, n - 10)
-    recent_error_costs: list[float] = []
+    recent_entries = _eval_cached_models(
+        clips_dict, current_good_votes, current_bad_votes, inclusion_value, start_idx, n
+    )
 
-    for t in range(start_idx, n):
-        model, threshold, _, _ = recreate_model_at_time(
-            clips_dict, label_history, t, inclusion_value
-        )
-        if model is None:
-            continue
-
-        with torch.no_grad():
-            scores = model(X_eval).squeeze(1).tolist()
-
-        fp = fn = 0
-        for score, true_label in zip(scores, eval_labels_list):
-            predicted = 1 if score >= threshold else 0
-            if predicted == 1 and true_label == 0.0:
-                fp += 1
-            elif predicted == 0 and true_label == 1.0:
-                fn += 1
-
-        fpr = fp / total_negatives if total_negatives > 0 else 0.0
-        fnr = fn / total_positives if total_positives > 0 else 0.0
-        recent_error_costs.append(fpr_weight * fpr + fnr_weight * fnr)
+    recent_error_costs = [e["error_cost"] for e in recent_entries]
 
     if len(recent_error_costs) < 3:
         return {
@@ -438,7 +350,7 @@ def compute_labeling_status(
             "reason": "Not enough valid model steps in recent history to assess trend.",
         }
 
-    # Linear regression slope over the last 10 error-cost values
+    # Linear regression slope over the recent error-cost values
     n_pts = len(recent_error_costs)
     x_vals = list(range(n_pts))
     x_mean = sum(x_vals) / n_pts
@@ -448,30 +360,22 @@ def compute_labeling_status(
     denom = sum((x_vals[i] - x_mean) ** 2 for i in range(n_pts))
     slope = numer / denom if denom != 0 else 0.0
 
-    # Relative slope: normalise by mean error cost so the threshold is scale-independent
     relative_slope = slope / y_mean if y_mean > 0 else slope
 
-    # If still dropping by more than 1.5 % of mean per step, labeling is still helping
     FLAT_THRESHOLD = -0.015
 
     if relative_slope < FLAT_THRESHOLD:
         return {
             **base,
             "status": "yellow",
-            "reason": (
-                "Error cost is still declining over the last 10 labels. "
-                "Keep labeling to improve the model."
-            ),
+            "reason": ("Error cost is still declining over the last 10 labels. Keep labeling to improve the model."),
             "slope": round(relative_slope, 4),
         }
     else:
         return {
             **base,
             "status": "green",
-            "reason": (
-                "Error cost has leveled off over the last 10 labels. "
-                "You can likely stop labeling."
-            ),
+            "reason": ("Error cost has leveled off over the last 10 labels. You can likely stop labeling."),
             "slope": round(relative_slope, 4),
         }
 
@@ -485,38 +389,14 @@ def analyze_labeling_progress(
 ) -> dict[str, Any]:
     """Run a comprehensive analysis of labelling progress.
 
-    Combines error-cost tracking (how well the model fits the current labelset over
-    time) with prediction-stability tracking (how often unlabelled clips change
-    their predicted label over time). Together these metrics can help determine
-    when enough labels have been collected.
-
-    Args:
-        clips_dict: Mapping of clip ID to clip data dict. Each value must contain
-            an ``"embedding"`` key with a ``numpy.ndarray`` embedding vector.
-        label_history: Ordered list of ``(clip_id, label, timestamp)`` tuples
-            representing all labelling events.
-        current_good_votes: Dict whose keys are clip IDs currently labelled good.
-        current_bad_votes: Dict whose keys are clip IDs currently labelled bad.
-        inclusion_value: Integer in ``[-10, 10]`` controlling the FPR/FNR trade-off
-            passed to both sub-analyses.
-
-    Returns:
-        A dict with the following keys:
-
-        - ``"error_cost_over_time"`` (``list[dict]``): Output of
-          :func:`calculate_error_cost_over_time`.
-        - ``"stability_over_time"`` (``list[dict]``): Output of
-          :func:`calculate_prediction_stability_over_time`.
-        - ``"total_labels"`` (``int``): Combined count of good and bad votes.
-        - ``"total_clips"`` (``int``): Total number of clips in ``clips_dict``.
+    Models and stability metrics are read from the per-step cache.  Error
+    cost is recomputed cheaply using cached models (forward passes only).
     """
-    error_cost = calculate_error_cost_over_time(
-        clips_dict, label_history, current_good_votes, current_bad_votes, inclusion_value
-    )
+    _ensure_cache(clips_dict, label_history, inclusion_value)
 
-    stability = calculate_prediction_stability_over_time(
-        clips_dict, label_history, inclusion_value
-    )
+    error_cost = _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
+
+    stability = [step["stability"] for step in _cached_steps if step["stability"] is not None]
 
     return {
         "error_cost_over_time": error_cost,

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -14,6 +14,7 @@ from vistatotes.datasets import (DEMO_DATASETS, export_dataset_to_file,
                                  get_importer, list_importers,
                                  load_demo_dataset)
 from vistatotes.models import get_e5_model
+from vistatotes.models.progress import clear_progress_cache
 from vistatotes.utils import (bad_votes, clips, get_progress, good_votes,
                               label_history, update_progress)
 
@@ -31,6 +32,7 @@ def clear_dataset():
     good_votes.clear()
     bad_votes.clear()
     label_history.clear()
+    clear_progress_cache()
 
 
 def _run_importer_in_background(importer, field_values: dict) -> None:

--- a/vistatotes/utils/state.py
+++ b/vistatotes/utils/state.py
@@ -25,19 +25,27 @@ def clear_votes() -> None:
 
     Removes all entries from ``good_votes``, ``bad_votes``, and
     ``label_history`` in place. Does not affect the ``clips`` dict.
+    Also clears the progress model cache.
     """
+    from vistatotes.models.progress import clear_progress_cache
+
     good_votes.clear()
     bad_votes.clear()
     label_history.clear()
+    clear_progress_cache()
 
 
 def clear_clips() -> None:
     """Clear all loaded clips from memory.
 
     Removes all entries from the ``clips`` dict in place. Does not affect
-    votes or label history.
+    votes or label history. Also clears the progress model cache since
+    cached models reference clip embeddings.
     """
+    from vistatotes.models.progress import clear_progress_cache
+
     clips.clear()
+    clear_progress_cache()
 
 
 def clear_all() -> None:
@@ -64,12 +72,19 @@ def get_inclusion() -> int:
 def set_inclusion(value: int) -> None:
     """Set the global inclusion value.
 
+    Also clears the progress model cache since cached models were trained
+    with the old inclusion value.
+
     Args:
         value: New inclusion setting. Should be an integer in ``[-10, 10]``.
             Values outside this range are accepted but may produce unexpected
             results in model training weight calculations.
     """
     global inclusion
+    if value != inclusion:
+        from vistatotes.models.progress import clear_progress_cache
+
+        clear_progress_cache()
     inclusion = value
 
 
@@ -85,9 +100,7 @@ def add_label_to_history(clip_id: int, label: str) -> None:
     label_history.append((clip_id, label, time.time()))
 
 
-def add_favorite_detector(
-    name: str, media_type: str, weights: dict[str, Any], threshold: float
-) -> None:
+def add_favorite_detector(name: str, media_type: str, weights: dict[str, Any], threshold: float) -> None:
     """Add or overwrite a named favorite detector in the global store.
 
     If a detector with the same ``name`` already exists it is replaced.


### PR DESCRIPTION
## Summary
Refactored the progress tracking module to cache trained models and stability metrics at each labelling step, eliminating redundant model retraining when the progress button or auto-indicator queries the same historical steps multiple times.

## Key Changes

- **Introduced module-level cache**: Added `_cached_steps`, `_cache_good_ids`, `_cache_bad_ids`, and `_cache_prev_predictions` to store trained models, thresholds, label sets, and stability metrics for each labelling step.

- **Refactored model training logic**: 
  - Extracted incremental model training into `_ensure_cache()` which only computes steps not yet cached
  - Replaced `recreate_model_at_time()` to use cached results instead of retraining from scratch
  - Moved stability metric computation into the cache building process

- **Extracted evaluation helper**: Created `_eval_cached_models()` to score cached models against a labelset using only forward passes (no retraining).

- **Added cache invalidation**: 
  - New `clear_progress_cache()` function to clear stale cache entries
  - Integrated cache clearing into `clear_votes()`, `clear_clips()`, and `set_inclusion()` in `state.py`
  - Updated dataset loading routes to clear cache when clips change

- **Simplified public API**:
  - `calculate_error_cost_over_time()` now calls `_ensure_cache()` then `_eval_cached_models()`
  - `calculate_prediction_stability_over_time()` returns cached stability metrics directly
  - `compute_labeling_status()` uses cached models for the last 10 steps
  - `analyze_labeling_progress()` leverages the cache for both error cost and stability

- **Updated exports**: Added `clear_progress_cache` to the public API in `__init__.py`

## Implementation Details

- Cache is invalidated whenever `inclusion_value` changes, ensuring models are retrained with correct FPR/FNR weights
- Incremental label set tracking (`_cache_good_ids`/`_cache_bad_ids`) means each new step only applies a single label delta
- Stability metrics (prediction flips on unlabelled clips) are computed once during cache building rather than on-demand
- Forward passes on cached models are still performed for error cost evaluation since the evaluation set (current votes) can change between queries

https://claude.ai/code/session_012E7gkhFr4sPJJQjyS3XXVk