### PR TITLE
Disable fast tokenizer for X-CLIP processor initialization

### DIFF
--- a/vistatotes/media/video/media_type.py
+++ b/vistatotes/media/video/media_type.py
@@ -128,7 +128,7 @@ class VideoMediaType(MediaType):
             XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir
         )
         self._processor = XCLIPProcessor.from_pretrained(
-            XCLIP_MODEL_ID, cache_dir=cache_dir
+            XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False
         )
         print("DEBUG: X-CLIP model loaded.", flush=True)
 


### PR DESCRIPTION
## Summary
Updated the X-CLIP processor initialization to explicitly disable the fast tokenizer by setting `use_fast=False`.

## Key Changes
- Added `use_fast=False` parameter to `XCLIPProcessor.from_pretrained()` call in the `load_models()` method

## Implementation Details
This change ensures the X-CLIP processor uses the standard (non-fast) tokenizer implementation. This may be necessary for compatibility or consistency reasons, particularly if the fast tokenizer variant has known issues or behavioral differences that affect the model's performance in this context.

https://claude.ai/code/session_01DVpyYF3bBDeojvVMYmLgXL