### PR TITLE
Remove large media fields from auto-detect response

### DIFF
--- a/vistatotes/datasets/loader.py
+++ b/vistatotes/datasets/loader.py
@@ -597,6 +597,7 @@ def load_demo_dataset(
                     "wav_bytes": None,
                     "video_bytes": None,
                     "image_bytes": image_bytes,
+                    "text_content": None,
                     "filename": f"{category}_{clip_id}.png",
                     "category": category,
                     "width": img.width,

--- a/vistatotes/routes/sorting.py
+++ b/vistatotes/routes/sorting.py
@@ -812,10 +812,12 @@ def auto_detect():
         for cid, score in zip(all_ids, scores):
             if score >= threshold:
                 clip_info = clips[cid].copy()
-                # Don't include embedding in response (too large)
+                # Don't include embedding or raw media in response
                 clip_info.pop("embedding", None)
                 clip_info.pop("wav_bytes", None)
                 clip_info.pop("video_bytes", None)
+                clip_info.pop("image_bytes", None)
+                clip_info.pop("text_content", None)
                 clip_info["score"] = round(score, 4)
                 positive_hits.append(clip_info)
 


### PR DESCRIPTION
## Summary
This PR removes large media content fields from the auto-detect API response to reduce payload size and improve performance.

## Key Changes
- Updated `auto_detect()` in `sorting.py` to exclude `image_bytes` and `text_content` fields from clip info responses, in addition to existing exclusions for `embedding`, `wav_bytes`, and `video_bytes`
- Updated `load_demo_dataset()` in `loader.py` to initialize `text_content` field to `None` for consistency with other media fields

## Implementation Details
- The comment in `sorting.py` was updated to reflect that both embeddings and raw media are excluded from responses
- These large binary/text fields are unnecessary in the API response since they're already stored in the clip data and can be retrieved separately if needed
- Initializing `text_content` to `None` in the dataset loader ensures the field exists in all clip objects for uniform handling

https://claude.ai/code/session_01AWZFnuwFQF6yb3XVhkqvE1