### PR TITLE
Handle variable transformer model output formats in embeddings

### DIFF
--- a/vistatotes/media/video/media_type.py
+++ b/vistatotes/media/video/media_type.py
@@ -15,6 +15,23 @@ from transformers import XCLIPModel, XCLIPProcessor
 from config import MODELS_CACHE_DIR, XCLIP_MODEL_ID
 from vistatotes.media.base import DemoDataset, MediaType
 
+def _extract_tensor(output: object) -> torch.Tensor:
+    """Extract a plain tensor from model output.
+
+    Depending on the transformers version, get_video_features() / get_text_features()
+    may return either a raw tensor or a BaseModelOutputWithPooling dataclass.
+    This helper handles both cases.
+    """
+    if isinstance(output, torch.Tensor):
+        return output
+    for attr in ("video_embeds", "text_embeds", "pooler_output"):
+        val = getattr(output, attr, None)
+        if isinstance(val, torch.Tensor):
+            return val
+    # Final fallback: treat as tuple-like and return first element
+    return output[0]  # type: ignore[index]
+
+
 _VIDEO_MIME_TYPES: dict[str, str] = {
     ".webm": "video/webm",
     ".mov": "video/quicktime",
@@ -164,7 +181,7 @@ class VideoMediaType(MediaType):
             inputs = self._processor(videos=list(frames), return_tensors="pt")
             with torch.no_grad():
                 outputs = self._model.get_video_features(**inputs)
-                embedding = outputs.detach().cpu().numpy()
+                embedding = _extract_tensor(outputs).detach().cpu().numpy()
             return embedding[0]
         except Exception as e:
             print(f"Error embedding {file_path}: {e}")
@@ -179,7 +196,7 @@ class VideoMediaType(MediaType):
             inputs = self._processor(text=[text], return_tensors="pt")
             with torch.no_grad():
                 text_vec = (
-                    self._model.get_text_features(**inputs).detach().cpu().numpy()[0]
+                    _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
                 )
             return text_vec
         except Exception as e:


### PR DESCRIPTION
## Summary
This PR adds compatibility for different versions of the transformers library by introducing a helper function that handles variable output formats from model feature extraction methods. Different transformers versions return either raw tensors or dataclass objects, which was causing issues in the embedding pipeline.

## Key Changes
- Added `_extract_tensor()` helper function in both `vistatotes/media/image/media_type.py` and `vistatotes/media/video/media_type.py` that:
  - Returns raw tensors as-is
  - Extracts tensors from dataclass outputs by checking common attribute names (`image_embeds`, `text_embeds`, `video_embeds`, `pooler_output`)
  - Falls back to treating output as tuple-like and returning the first element
  
- Updated embedding methods to use the new helper:
  - `embed_pil_image()` in image media type
  - `embed_text()` in both image and video media types
  - `embed_media()` in video media type

## Implementation Details
The `_extract_tensor()` function is duplicated in both modules (rather than shared) to maintain module independence. The function gracefully handles multiple output formats that may occur across different transformers library versions, ensuring robust embedding extraction regardless of the installed version.

https://claude.ai/code/session_01UaVh3jAGBZj5boQpzwTcFp