### PR TITLE
Fix demo dataset ready status for audio/video with missing source directories

### DIFF
--- a/vistatotes/media/__init__.py
+++ b/vistatotes/media/__init__.py
@@ -57,8 +57,8 @@ def all_demo_datasets() -> dict:
     registered media type's :attr:`~MediaType.demo_datasets` list.
 
     Each value is a dict with the keys expected by the datasets route:
-    ``label``, ``description``, ``categories``, ``media_type``, and
-    optionally ``source``.
+    ``label``, ``description``, ``categories``, ``media_type``,
+    optionally ``source``, and optionally ``required_folder``.
     """
     result: dict = {}
     for mt in _registry.values():
@@ -71,6 +71,8 @@ def all_demo_datasets() -> dict:
             }
             if ds.source:
                 entry["source"] = ds.source
+            if ds.required_folder is not None:
+                entry["required_folder"] = ds.required_folder
             result[ds.id] = entry
     return result
 

--- a/vistatotes/media/audio/media_type.py
+++ b/vistatotes/media/audio/media_type.py
@@ -12,7 +12,7 @@ import torch
 from flask import Response, send_file
 from transformers import ClapModel, ClapProcessor
 
-from config import CLAP_MODEL_ID, MODELS_CACHE_DIR, SAMPLE_RATE
+from config import CLAP_MODEL_ID, DATA_DIR, MODELS_CACHE_DIR, SAMPLE_RATE
 from vistatotes.media.base import DemoDataset, MediaType
 
 
@@ -91,6 +91,7 @@ class AudioMediaType(MediaType):
                     "water_drops",
                     "crickets",
                 ],
+                required_folder=DATA_DIR / "ESC-50-master" / "audio",
             ),
             DemoDataset(
                 id="city_sounds",
@@ -111,6 +112,7 @@ class AudioMediaType(MediaType):
                     "keyboard_typing",
                     "door_wood_knock",
                 ],
+                required_folder=DATA_DIR / "ESC-50-master" / "audio",
             ),
         ]
 

--- a/vistatotes/media/base.py
+++ b/vistatotes/media/base.py
@@ -46,6 +46,16 @@ class DemoDataset:
     """Identifier for the raw data source (e.g. ``"cifar10_sample"``, ``"ucf101"``).
     Leave empty for sources that don't require an explicit identifier."""
 
+    required_folder: Optional[Path] = None
+    """Local directory that must exist for a cached ``.pkl`` to be usable.
+
+    Audio and video datasets store references to external media files rather
+    than inlining the bytes, so a stale ``.pkl`` left behind after the source
+    directory was removed would incorrectly appear ready.  Set this to the
+    directory that the importer places the source files into (e.g.
+    ``DATA_DIR / "ESC-50-master" / "audio"``).  Leave ``None`` for datasets
+    whose ``.pkl`` is entirely self-contained (images, text)."""
+
 
 class MediaType(ABC):
     """Abstract base class that every media type must implement.

--- a/vistatotes/media/video/media_type.py
+++ b/vistatotes/media/video/media_type.py
@@ -12,7 +12,7 @@ from flask import Response, send_file
 from PIL import Image
 from transformers import XCLIPModel, XCLIPProcessor
 
-from config import MODELS_CACHE_DIR, XCLIP_MODEL_ID
+from config import MODELS_CACHE_DIR, VIDEO_DIR, XCLIP_MODEL_ID
 from vistatotes.media.base import DemoDataset, MediaType
 
 def _extract_tensor(output: object) -> torch.Tensor:
@@ -110,6 +110,7 @@ class VideoMediaType(MediaType):
                     "YoYo",
                 ],
                 source="ucf101",
+                required_folder=VIDEO_DIR / "ucf101",
             ),
             DemoDataset(
                 id="sports_video",
@@ -126,6 +127,7 @@ class VideoMediaType(MediaType):
                     "TaiChi",
                 ],
                 source="ucf101",
+                required_folder=VIDEO_DIR / "ucf101",
             ),
         ]
 

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from flask import Blueprint, jsonify, request, send_file
 
 from config import (CIFAR10_DOWNLOAD_SIZE_MB, CLIPS_PER_CATEGORY,
-                    CLIPS_PER_VIDEO_CATEGORY, DATA_DIR, EMBEDDINGS_DIR,
+                    CLIPS_PER_VIDEO_CATEGORY, EMBEDDINGS_DIR,
                     ESC50_DOWNLOAD_SIZE_MB, IMAGES_PER_CIFAR10_CATEGORY,
                     SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB, VIDEO_DIR)
 from vistatotes.datasets import (DEMO_DATASETS, export_dataset_to_file,
@@ -167,18 +167,15 @@ def demo_dataset_list():
 
         media_type = dataset_info.get("media_type", "audio")
 
-        # Audio and video pkl files store references to external media
-        # directories rather than inline bytes.  If the source directory
-        # has been removed since the pkl was created, the dataset cannot
-        # actually be loaded — don't show it as ready.
+        # Some pkl files reference external media directories rather than
+        # inlining bytes.  If that directory has been removed since the pkl
+        # was created, the dataset can't actually be loaded — don't show it
+        # as ready.  Each demo dataset declares its own required_folder so
+        # this check stays generic as new demo datasets are added.
         if is_ready:
-            if media_type == "audio":
-                if not (DATA_DIR / "ESC-50-master" / "audio").exists():
-                    is_ready = False
-            elif media_type == "video":
-                video_source = dataset_info.get("source", "ucf101")
-                if video_source == "ucf101" and not (VIDEO_DIR / "ucf101").exists():
-                    is_ready = False
+            required_folder = dataset_info.get("required_folder")
+            if required_folder is not None and not required_folder.exists():
+                is_ready = False
 
         # Calculate number of files
         num_categories = len(dataset_info["categories"])


### PR DESCRIPTION
Audio and video pkl files store references to external media directories
(audio_dir / video_dir) rather than inlining the media bytes. If the
source directory is removed after initial embedding, the pkl still
exists so the dataset falsely showed a green "Ready" border on the demo
loading screen.

Add source-directory checks in demo_dataset_list: an audio dataset now
requires DATA_DIR/ESC-50-master/audio to exist alongside its pkl, and a
UCF-101 video dataset requires VIDEO_DIR/ucf101. Image and text datasets
are unaffected because their pkl files are fully self-contained (bytes
and content stored inline).

Adds two regression tests covering both stale-pkl scenarios.

https://claude.ai/code/session_01JKok5g8cG79nR1mcj61w3w