### PR TITLE
Add CLI autodetect: run detector on dataset from command line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,14 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 ## Commands
 - **Run tests**: `python -m pytest tests/ -v`
 - **Start app**: `python app.py` (or `python app.py --local` for dev)
+- **CLI autodetect**: `python app.py --autodetect --dataset <file.pkl> --detector <file.json>`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`
 
 ## Architecture
-- `app.py` — Flask entry point, registers blueprints, startup logic
+- `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing
+- `vistatotes/cli.py` — CLI autodetect: load dataset + detector, run inference, print results
 - `config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
 - `vistatotes/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `datasets.py`
 - `vistatotes/models/` — Embeddings, training, model loading, progress tracking
@@ -29,6 +31,7 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_labels.py` — Label export/import
   - `test_inclusion.py` — Inclusion GET/POST
   - `test_detectors.py` — Detector export, detector sort, favorites, auto-detect
+  - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function and --autodetect flag
   - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
 
 ## Key Details

--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ Open that URL in your browser. The app starts with no clips loaded — use the m
 
 Press **Ctrl+C** in the terminal to stop the server.
 
+## Running a detector from the command line
+
+If you have a dataset file (`.pkl`) and a detector file (`.json`), you can run the detector against the dataset without starting the web server. This prints which items the detector predicts as "Good."
+
+```bash
+python app.py --autodetect --dataset path/to/dataset.pkl --detector path/to/detector.json
+```
+
+**How to get the files:**
+
+- **Dataset file** — Export from the web UI via the dataset menu ("Export dataset"), or use a cached `.pkl` file from the `data/embeddings/` directory after loading a demo dataset.
+- **Detector file** — In the web UI, vote on some items, then export a detector from the sorting panel. Save the returned JSON to a file. You can also use a favorite detector exported via the API (`POST /api/detector/export`).
+
+**Example output:**
+
+```
+Predicted Good (5 items):
+
+  1-34094-A-6.wav  (score: 0.9832, category: cat)
+  1-30226-A-0.wav  (score: 0.9541, category: dog)
+  1-17150-B-2.wav  (score: 0.8923, category: cat)
+  1-22694-A-4.wav  (score: 0.7612, category: dog)
+  1-77445-A-1.wav  (score: 0.6204, category: cat)
+```
+
+Both `--dataset` and `--detector` are required when using `--autodetect`.
+
 ## Loading a demo dataset
 
 When the app is running, click the hamburger menu in the top-left corner to open the dataset panel. From there you can browse the available demo datasets and load one. Each demo is downloaded and embedded on first use, then cached for instant loading afterward.

--- a/app.py
+++ b/app.py
@@ -77,10 +77,28 @@ app.register_blueprint(exporters_bp)
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    # Check if we're running in local mode or deployment mode
-    if len(sys.argv) > 1 and sys.argv[1] == "--local":
+    parser = argparse.ArgumentParser(description="VistaTotes — media explorer web app")
+    parser.add_argument("--local", action="store_true", help="Run in local development mode")
+    parser.add_argument(
+        "--autodetect",
+        action="store_true",
+        help="Run a detector on a dataset from the command line and print predicted-Good items",
+    )
+    parser.add_argument("--dataset", type=str, help="Path to a dataset pickle file (used with --autodetect)")
+    parser.add_argument("--detector", type=str, help="Path to a detector JSON file (used with --autodetect)")
+    args = parser.parse_args()
+
+    if args.autodetect:
+        if not args.dataset or not args.detector:
+            parser.error("--autodetect requires both --dataset and --detector")
+
+        from vistatotes.cli import autodetect_main
+
+        autodetect_main(args.dataset, args.detector)
+
+    elif args.local:
         # Local development mode
         print("🚀 Running in LOCAL mode (accessible from other devices)", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -1,0 +1,293 @@
+"""Tests for the CLI autodetect feature (vistatotes/cli.py)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import app as app_module
+from vistatotes.cli import run_autodetect
+from vistatotes.datasets.loader import export_dataset_to_file
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset_file(tmp_path, clips_dict):
+    """Export a clips dict to a pickle file and return the path."""
+    pkl_bytes = export_dataset_to_file(clips_dict)
+    dataset_path = tmp_path / "dataset.pkl"
+    dataset_path.write_bytes(pkl_bytes)
+    return dataset_path
+
+
+def _make_detector_file(tmp_path, client, good_ids, bad_ids, name="detector.json"):
+    """Train a detector via the API and write its JSON to a file."""
+    app_module.good_votes.update({k: None for k in good_ids})
+    app_module.bad_votes.update({k: None for k in bad_ids})
+    resp = client.post("/api/detector/export")
+    assert resp.status_code == 200
+    detector = resp.get_json()
+    app_module.good_votes.clear()
+    app_module.bad_votes.clear()
+
+    detector_path = tmp_path / name
+    detector_path.write_text(json.dumps(detector))
+    return detector_path, detector
+
+
+# ---------------------------------------------------------------------------
+# Tests for run_autodetect()
+# ---------------------------------------------------------------------------
+
+
+class TestRunAutodetect:
+    """Tests for the core run_autodetect function."""
+
+    def test_returns_list(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        assert isinstance(hits, list)
+
+    def test_hits_have_required_fields(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        for hit in hits:
+            assert "id" in hit
+            assert "filename" in hit
+            assert "category" in hit
+            assert "score" in hit
+
+    def test_scores_in_valid_range(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        for hit in hits:
+            assert 0.0 <= hit["score"] <= 1.0
+
+    def test_hits_sorted_descending_by_score(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        scores = [h["score"] for h in hits]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_all_hits_at_or_above_threshold(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        threshold = detector["threshold"]
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        for hit in hits:
+            assert hit["score"] >= threshold - 1e-6  # float tolerance
+
+    def test_good_clips_score_higher_than_bad(self, client, tmp_path):
+        """Clips that were voted good should tend to score higher."""
+        good_ids = [1, 2, 3]
+        bad_ids = [18, 19, 20]
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, good_ids, bad_ids)
+
+        # Score all clips by re-running with a threshold of 0 so every clip is included
+        detector_data = json.loads(detector_path.read_text())
+        detector_data["threshold"] = 0.0
+        low_threshold_path = tmp_path / "detector_low.json"
+        low_threshold_path.write_text(json.dumps(detector_data))
+
+        all_hits = run_autodetect(str(dataset_path), str(low_threshold_path))
+        all_score_map = {h["id"]: h["score"] for h in all_hits}
+
+        avg_good = np.mean([all_score_map.get(i, 0) for i in good_ids])
+        avg_bad = np.mean([all_score_map.get(i, 0) for i in bad_ids])
+        assert avg_good > avg_bad
+
+    def test_dataset_file_not_found(self, client, tmp_path):
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        with pytest.raises(FileNotFoundError, match="Dataset file not found"):
+            run_autodetect("/nonexistent/dataset.pkl", str(detector_path))
+
+    def test_detector_file_not_found(self, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        with pytest.raises(FileNotFoundError, match="Detector file not found"):
+            run_autodetect(str(dataset_path), "/nonexistent/detector.json")
+
+    def test_empty_dataset_raises_error(self, client, tmp_path):
+        empty_clips: dict = {}
+        dataset_path = _make_dataset_file(tmp_path, empty_clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+
+        with pytest.raises(ValueError, match="No clips loaded"):
+            run_autodetect(str(dataset_path), str(detector_path))
+
+    def test_detector_missing_weights_raises_error(self, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        bad_detector = tmp_path / "bad_detector.json"
+        bad_detector.write_text(json.dumps({"threshold": 0.5}))
+
+        with pytest.raises(ValueError, match="missing 'weights'"):
+            run_autodetect(str(dataset_path), str(bad_detector))
+
+    def test_detector_missing_threshold_raises_error(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, detector = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+
+        # Write detector with threshold removed
+        del detector["threshold"]
+        no_threshold_path = tmp_path / "no_threshold.json"
+        no_threshold_path.write_text(json.dumps(detector))
+
+        with pytest.raises(ValueError, match="missing 'threshold'"):
+            run_autodetect(str(dataset_path), str(no_threshold_path))
+
+    def test_hits_do_not_contain_embedding(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        for hit in hits:
+            assert "embedding" not in hit
+
+    def test_hits_do_not_contain_raw_media(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        for hit in hits:
+            assert "wav_bytes" not in hit
+            assert "image_bytes" not in hit
+            assert "video_bytes" not in hit
+            assert "text_content" not in hit
+
+    def test_with_threshold_zero_returns_all_clips(self, client, tmp_path):
+        """A threshold of 0 should return all clips since sigmoid output >= 0."""
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        detector["threshold"] = 0.0
+        zero_path = tmp_path / "zero_threshold.json"
+        zero_path.write_text(json.dumps(detector))
+
+        hits = run_autodetect(str(dataset_path), str(zero_path))
+        assert len(hits) == len(app_module.clips)
+
+    def test_with_threshold_one_returns_few_or_none(self, client, tmp_path):
+        """A threshold of 1.0 should return very few or no clips."""
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        detector["threshold"] = 1.0
+        high_path = tmp_path / "high_threshold.json"
+        high_path.write_text(json.dumps(detector))
+
+        hits = run_autodetect(str(dataset_path), str(high_path))
+        # With threshold=1.0 most clips should be excluded (sigmoid rarely reaches 1.0)
+        assert len(hits) < len(app_module.clips)
+
+
+# ---------------------------------------------------------------------------
+# Tests for CLI entry point (app.py --autodetect)
+# ---------------------------------------------------------------------------
+
+
+class TestAutodetectCLI:
+    """Tests for the command-line --autodetect flag via subprocess."""
+
+    def test_autodetect_prints_output(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        result = subprocess.run(
+            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path), "--detector", str(detector_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+            timeout=120,
+        )
+        assert result.returncode == 0
+        assert "Predicted Good" in result.stdout or "No items predicted as Good" in result.stdout
+
+    def test_autodetect_missing_dataset_flag(self, client, tmp_path):
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+
+        result = subprocess.run(
+            [sys.executable, "app.py", "--autodetect", "--detector", str(detector_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+            timeout=120,
+        )
+        assert result.returncode != 0
+
+    def test_autodetect_missing_detector_flag(self, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+
+        result = subprocess.run(
+            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+            timeout=120,
+        )
+        assert result.returncode != 0
+
+    def test_autodetect_nonexistent_dataset(self, client, tmp_path):
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+
+        result = subprocess.run(
+            [sys.executable, "app.py", "--autodetect", "--dataset", "/tmp/nonexistent.pkl", "--detector", str(detector_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+            timeout=120,
+        )
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+    def test_autodetect_output_contains_filenames(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        # Use threshold 0 to ensure all clips appear
+        detector["threshold"] = 0.0
+        zero_path = tmp_path / "zero_threshold.json"
+        zero_path.write_text(json.dumps(detector))
+
+        result = subprocess.run(
+            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path), "--detector", str(zero_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+            timeout=120,
+        )
+        assert result.returncode == 0
+        assert "score:" in result.stdout
+
+    def test_autodetect_no_hits_message(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        # Use threshold 1.0 to ensure no hits
+        detector["threshold"] = 1.0
+        high_path = tmp_path / "high_threshold.json"
+        high_path.write_text(json.dumps(detector))
+
+        result = subprocess.run(
+            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path), "--detector", str(high_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+            timeout=120,
+        )
+        assert result.returncode == 0
+        assert "No items predicted as Good" in result.stdout

--- a/vistatotes/cli.py
+++ b/vistatotes/cli.py
@@ -1,0 +1,123 @@
+"""Command-line interface utilities for VistaTotes."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+
+from vistatotes.datasets.loader import load_dataset_from_pickle
+
+
+def run_autodetect(dataset_path: str, detector_path: str) -> list[dict[str, Any]]:
+    """Load a dataset and detector, run the detector, and return positive hits.
+
+    Args:
+        dataset_path: Path to a pickle file containing the dataset.
+        detector_path: Path to a JSON file containing detector weights and threshold.
+
+    Returns:
+        A list of dicts for clips predicted as "Good", each containing
+        the clip's ``id``, ``filename``, ``category``, and ``score``.
+
+    Raises:
+        FileNotFoundError: If the dataset or detector file does not exist.
+        ValueError: If the dataset is empty or the detector file is invalid.
+    """
+    dataset_file = Path(dataset_path)
+    detector_file = Path(detector_path)
+
+    if not dataset_file.exists():
+        raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
+    if not detector_file.exists():
+        raise FileNotFoundError(f"Detector file not found: {detector_path}")
+
+    # Load dataset
+    clips: dict[int, dict[str, Any]] = {}
+    load_dataset_from_pickle(dataset_file, clips)
+
+    if not clips:
+        raise ValueError(f"No clips loaded from dataset: {dataset_path}")
+
+    # Load detector
+    with open(detector_file, "r") as f:
+        detector_data = json.load(f)
+
+    if "weights" not in detector_data:
+        raise ValueError("Detector file missing 'weights' field")
+    if "threshold" not in detector_data:
+        raise ValueError("Detector file missing 'threshold' field")
+
+    weights = detector_data["weights"]
+    threshold = detector_data["threshold"]
+
+    # Reconstruct the MLP model from weights
+    input_dim = len(weights["0.weight"][0])
+
+    model = nn.Sequential(
+        nn.Linear(input_dim, 64),
+        nn.ReLU(),
+        nn.Linear(64, 1),
+        nn.Sigmoid(),
+    )
+
+    state_dict = {}
+    for key, value in weights.items():
+        state_dict[key] = torch.tensor(value, dtype=torch.float32)
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    # Score all clips
+    all_ids = sorted(clips.keys())
+    all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
+    X_all = torch.tensor(all_embs, dtype=torch.float32)
+
+    with torch.no_grad():
+        scores = model(X_all).squeeze(1).tolist()
+
+    # Collect positive hits (score >= threshold)
+    positive_hits = []
+    for cid, score in zip(all_ids, scores):
+        if score >= threshold:
+            clip = clips[cid]
+            positive_hits.append(
+                {
+                    "id": cid,
+                    "filename": clip.get("filename", f"clip_{cid}"),
+                    "category": clip.get("category", "unknown"),
+                    "score": round(score, 4),
+                }
+            )
+
+    # Sort by score descending
+    positive_hits.sort(key=lambda x: x["score"], reverse=True)
+
+    return positive_hits
+
+
+def autodetect_main(dataset_path: str, detector_path: str) -> None:
+    """CLI entry point: run autodetect and print results to stdout.
+
+    Prints each predicted-Good clip as a line with its filename and score.
+    Exits with code 0 on success, 1 on error.
+
+    Args:
+        dataset_path: Path to the dataset pickle file.
+        detector_path: Path to the detector JSON file.
+    """
+    try:
+        hits = run_autodetect(dataset_path, detector_path)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not hits:
+        print("No items predicted as Good.")
+        return
+
+    print(f"Predicted Good ({len(hits)} items):\n")
+    for hit in hits:
+        print(f"  {hit['filename']}  (score: {hit['score']}, category: {hit['category']})")


### PR DESCRIPTION
New --autodetect flag lets users run a saved detector against a dataset
pickle file without starting the web server, printing which items are
predicted as Good along with their scores.

Usage: python app.py --autodetect --dataset data.pkl --detector det.json

- vistatotes/cli.py: core run_autodetect() and CLI entry point
- app.py: switched to argparse, added --autodetect/--dataset/--detector
- tests/test_cli_autodetect.py: 21 tests (function + subprocess)
- Updated CLAUDE.md and README.md with usage documentation

https://claude.ai/code/session_015GUaM1pj76P3RFRRjhqwC8