### PR TITLE
Add SessionStart hook to auto-install dependencies on web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Upgrade setuptools first — the system version (68.x) has a broken
+# install_layout attribute that prevents building wheels for some packages
+# (progressbar, wget) needed by laion_clap.
+pip install --upgrade setuptools -q
+
+# Install Python dependencies (CPU-only PyTorch).
+# --ignore-installed blinker: the system blinker (debian-managed) has no
+# RECORD file so pip cannot uninstall it; force-installing a fresh copy
+# lets Flask pick it up cleanly.
+pip install --extra-index-url https://download.pytorch.org/whl/cpu \
+  flask \
+  "numpy<2" \
+  "torch>=2.0.0" \
+  requests \
+  tqdm \
+  scikit-learn \
+  transformers \
+  laion_clap \
+  librosa \
+  "opencv-python-headless<4.10" \
+  Pillow \
+  ultralytics \
+  sentence-transformers \
+  --ignore-installed blinker \
+  -q
+
+# Install dev tools (linter + test runner)
+pip install pytest ruff -q

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,17 @@
       "Glob",
       "Grep"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Prevents sessions from hanging on permission prompts by pre-installing all Python dependencies (PyTorch CPU, Flask, ML libs, dev tools) when Claude Code starts in a remote environment.

https://claude.ai/code/session_01FJBjeJrjZipw3D3vM8cAvT