### PR TITLE
Add --importer CLI support for autodetect across all Data Importers

### DIFF
--- a/vistatotes/datasets/importers/base.py
+++ b/vistatotes/datasets/importers/base.py
@@ -5,7 +5,15 @@ attributes and :meth:`~DatasetImporter.run`, then expose a module-level
 ``IMPORTER`` instance from a package under this directory.  The registry will
 discover it automatically.
 
-Example – a minimal SFTP importer skeleton::
+Each importer also supports CLI usage via :meth:`~DatasetImporter.add_cli_arguments`
+and :meth:`~DatasetImporter.run_cli`.  The base class provides default
+implementations that derive CLI arguments from the :attr:`fields` list, so most
+importers work on the command line without any extra code.  Importers whose
+:meth:`run` expects non-string values (e.g. Werkzeug ``FileStorage`` objects)
+should override :meth:`run_cli` to handle the CLI-appropriate types (file paths
+as strings).
+
+Example \u2013 a minimal SFTP importer skeleton::
 
     # vistatotes/datasets/importers/sftp/__init__.py
     from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
@@ -38,6 +46,7 @@ Then add ``-r vistatotes/datasets/importers/sftp/requirements.txt`` to
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -50,12 +59,12 @@ class ImporterField:
 
     The ``field_type`` value drives how the frontend renders it:
 
-    - ``"file"``   – OS file-picker; value arrives as a Werkzeug
+    - ``"file"``   \u2013 OS file-picker; value arrives as a Werkzeug
       :class:`~werkzeug.datastructures.FileStorage` object.
-    - ``"folder"`` – Path text-input or OS folder-picker.
-    - ``"url"``    – Text input pre-validated as a URL.
-    - ``"text"``   – Generic single-line text input.
-    - ``"select"`` – Drop-down; ``options`` must be populated.
+    - ``"folder"`` \u2013 Path text-input or OS folder-picker.
+    - ``"url"``    \u2013 Text input pre-validated as a URL.
+    - ``"text"``   \u2013 Generic single-line text input.
+    - ``"select"`` \u2013 Drop-down; ``options`` must be populated.
     """
 
     key: str
@@ -87,8 +96,18 @@ class DatasetImporter:
     """Abstract base class for dataset importers.
 
     Subclass this, set the class-level attributes, implement :meth:`run`,
-    and expose a module-level ``IMPORTER = YourImporter()`` – the registry
+    and expose a module-level ``IMPORTER = YourImporter()`` \u2013 the registry
     picks it up automatically.
+
+    CLI support
+    -----------
+    Every importer is automatically usable from the command line via
+    ``python app.py --autodetect --importer <name> [importer args] --detector <file>``.
+
+    The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
+    :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override
+    either method when the defaults are not sufficient (e.g. when :meth:`run`
+    expects a Werkzeug ``FileStorage`` rather than a plain file path).
     """
 
     #: Internal snake_case identifier used in API routes, e.g. ``"sftp"``.
@@ -98,7 +117,7 @@ class DatasetImporter:
     #: One-sentence description shown as a subtitle in the UI.
     description: str
     #: Emoji or icon string shown next to the display name in the UI.
-    icon: str = "🔌"
+    icon: str = "\U0001f50c"
     #: Ordered list of fields the user must fill before importing.
     fields: list[ImporterField]
 
@@ -106,7 +125,7 @@ class DatasetImporter:
         """Perform the import, populating *clips* in-place.
 
         Args:
-            field_values: Mapping of :attr:`ImporterField.key` → value.
+            field_values: Mapping of :attr:`ImporterField.key` \u2192 value.
                 Fields with ``field_type="file"`` receive a Werkzeug
                 :class:`~werkzeug.datastructures.FileStorage` object; all
                 other fields receive plain strings.
@@ -119,6 +138,50 @@ class DatasetImporter:
                 stores it in the progress tracker as an error message.
         """
         raise NotImplementedError(f"{type(self).__name__}.run() is not implemented")
+
+    # ------------------------------------------------------------------
+    # CLI support
+    # ------------------------------------------------------------------
+
+    def add_cli_arguments(self, parser: argparse.ArgumentParser) -> None:
+        """Register this importer's fields as ``argparse`` arguments.
+
+        The default implementation converts each :class:`ImporterField` into a
+        CLI flag (e.g. a field with ``key="media_type"`` becomes
+        ``--media-type``).  ``"select"`` fields gain a ``choices`` constraint.
+
+        Override this method if you need custom argument handling.
+        """
+        for f in self.fields:
+            # file fields are not usable via browser upload on CLI;
+            # they become simple path arguments instead
+            arg_name = f"--{f.key.replace('_', '-')}"
+            kwargs: dict[str, Any] = {
+                "dest": f.key,
+                "help": f.description or f.label,
+            }
+            if f.default:
+                kwargs["default"] = f.default
+            if f.field_type == "select" and f.options:
+                kwargs["choices"] = f.options
+            parser.add_argument(arg_name, **kwargs)
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+        """Load a dataset from CLI-provided *field_values* into *clips*.
+
+        The default implementation simply delegates to :meth:`run`, which
+        works for importers whose ``run()`` only expects plain string values.
+        Importers that expect non-string objects (e.g. ``FileStorage``) must
+        override this method to handle file-path strings appropriately.
+        """
+        self.run(field_values, clips)
+
+    def validate_cli_field_values(self, field_values: dict[str, Any]) -> None:
+        """Raise ``ValueError`` if any required field is missing or empty."""
+        for f in self.fields:
+            if f.required and not field_values.get(f.key):
+                cli_flag = f"--{f.key.replace('_', '-')}"
+                raise ValueError(f"Missing required argument: {cli_flag}")
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise importer metadata for the ``/api/dataset/importers`` endpoint."""

--- a/vistatotes/datasets/importers/folder/__init__.py
+++ b/vistatotes/datasets/importers/folder/__init__.py
@@ -1,4 +1,4 @@
-"""Local-folder importer – scans a directory of media files and embeds them.
+"""Local-folder importer \u2013 scans a directory of media files and embeds them.
 
 No additional pip packages are required; librosa, opencv, and Pillow are
 already in the core requirements.
@@ -7,6 +7,7 @@ already in the core requirements.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
 from vistatotes.datasets.loader import load_dataset_from_folder
@@ -22,7 +23,7 @@ class FolderImporter(DatasetImporter):
     name = "folder"
     display_name = "Generate from Folder"
     description = "Import media files from a folder."
-    icon = "📂"
+    icon = "\U0001f4c2"
     fields = [
         ImporterField(
             key="media_type",
@@ -44,6 +45,14 @@ class FolderImporter(DatasetImporter):
         folder = Path(field_values["path"])
         media_type = field_values.get("media_type", "sounds")
         load_dataset_from_folder(folder, media_type, clips)
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+        folder = Path(field_values["path"])
+        if not folder.exists():
+            raise FileNotFoundError(f"Folder not found: {folder}")
+        if not folder.is_dir():
+            raise NotADirectoryError(f"Not a directory: {folder}")
+        self.run(field_values, clips)
 
 
 IMPORTER = FolderImporter()

--- a/vistatotes/datasets/importers/http_zip/__init__.py
+++ b/vistatotes/datasets/importers/http_zip/__init__.py
@@ -1,4 +1,4 @@
-"""HTTP-Archive importer – downloads a public archive of media files and loads them.
+"""HTTP-Archive importer \u2013 downloads a public archive of media files and loads them.
 
 Supports .zip, .tar, .tar.gz, .tar.bz2, .tar.xz archives.
 RAR support requires the optional ``rarfile`` package.
@@ -11,6 +11,7 @@ from __future__ import annotations
 import tarfile
 import zipfile
 from pathlib import Path
+from typing import Any
 
 from config import DATA_DIR
 from vistatotes.datasets.downloader import download_file_with_progress
@@ -54,8 +55,7 @@ def _extract_archive(archive_path: Path, extract_dir: Path) -> None:
             import rarfile  # optional dependency
         except ImportError as exc:
             raise RuntimeError(
-                "RAR extraction requires the 'rarfile' package. "
-                "Install it with: pip install rarfile"
+                "RAR extraction requires the 'rarfile' package. Install it with: pip install rarfile"
             ) from exc
         with rarfile.RarFile(archive_path, "r") as rf:
             members = rf.namelist()
@@ -91,13 +91,13 @@ class HttpArchiveImporter(DatasetImporter):
     name = "http_archive"
     display_name = "Generate from HTTP Archive"
     description = "Download a .zip, .tar, or .rar archive from a URL and load the media files inside."
-    icon = "🌐"
+    icon = "\U0001f310"
     fields = [
         ImporterField(
             key="url",
             label="Archive URL",
             field_type="url",
-            description="URL to a publicly accessible archive (.zip, .tar.gz, .rar, …) of media files.",
+            description="URL to a publicly accessible archive (.zip, .tar.gz, .rar, \u2026) of media files.",
         ),
         ImporterField(
             key="media_type",
@@ -130,6 +130,12 @@ class HttpArchiveImporter(DatasetImporter):
         archive_path.unlink(missing_ok=True)
 
         load_dataset_from_folder(extract_dir, media_type, clips)
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+        url = field_values.get("url", "")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        self.run(field_values, clips)
 
 
 IMPORTER = HttpArchiveImporter()

--- a/vistatotes/datasets/importers/pickle/__init__.py
+++ b/vistatotes/datasets/importers/pickle/__init__.py
@@ -1,10 +1,13 @@
-"""Pickle-file importer – loads a previously exported ``.pkl`` dataset.
+"""Pickle-file importer \u2013 loads a previously exported ``.pkl`` dataset.
 
 No additional pip packages are required; everything needed is already in
 the core requirements.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
 
 from config import DATA_DIR
 from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
@@ -44,6 +47,13 @@ class PickleImporter(DatasetImporter):
         finally:
             temp_path.unlink(missing_ok=True)
         update_progress("idle", f"Loaded {len(clips)} clips from file")
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+        """Load from a pickle file path (string) instead of FileStorage."""
+        file_path = Path(field_values["file"])
+        if not file_path.exists():
+            raise FileNotFoundError(f"Dataset file not found: {file_path}")
+        load_dataset_from_pickle(file_path, clips)
 
 
 IMPORTER = PickleImporter()


### PR DESCRIPTION
Previously, `--autodetect` only accepted pickle files via `--dataset`.
Now users can specify any registered Data Importer via `--importer`:

  python app.py --autodetect --importer folder --path /data --media-type sounds --detector det.json
  python app.py --autodetect --importer pickle --file dataset.pkl --detector det.json
  python app.py --autodetect --importer http_archive --url https://example.com/a.zip --media-type images --detector det.json

Changes:
- DatasetImporter base class: add add_cli_arguments(), run_cli(), and
  validate_cli_field_values() with default implementations derived from
  the existing fields list
- Each importer: add run_cli() overrides where needed (pickle handles
  file paths instead of FileStorage; folder validates path; http_archive
  validates URL)
- cli.py: extract shared _score_clips_with_detector() helper; add
  run_autodetect_with_importer() and autodetect_importer_main()
- app.py: add --importer flag with two-pass argparse (dynamically adds
  the selected importer's arguments)
- Tests: 25 new tests covering run_autodetect_with_importer, CLI arg
  generation, field validation, and subprocess --importer invocations

https://claude.ai/code/session_01QoaqviF7o2rLH2dCiznqqD