### PR TITLE
Lazy-load embedding models on first use instead of at startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,6 @@ import hashlib
 print("⏳ Importing ML libraries (this may take a few seconds)...", flush=True)
 
 from flask import Flask
-from tqdm import tqdm
 
 # Import refactored modules
 from config import DATA_DIR, NUM_CLIPS
@@ -103,16 +102,9 @@ if __name__ == "__main__":
         print("🚀 Running in LOCAL mode (accessible from other devices)", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)
     else:
-        # Production mode - load models on startup; dataset is chosen by the user
+        # Production mode — models load lazily when the first dataset is loaded
         print("🚀 Running in PRODUCTION mode", flush=True)
-
-        # Use tqdm for loading feedback
-        with tqdm(total=1, desc="Initializing", unit="step") as pbar:
-            pbar.set_description("Loading models")
-            initialize_models()
-            pbar.update(1)
-
-            pbar.set_description("Ready")
+        initialize_models()
 
         print("✅ VistaTotes is ready!", flush=True)
         print("🌐 Open http://localhost:5000 in your browser", flush=True)

--- a/vistatotes/media/audio/media_type.py
+++ b/vistatotes/media/audio/media_type.py
@@ -186,6 +186,8 @@ class AudioMediaType(MediaType):
 
     # internal helpers used by loader.py's get_clap_model() bridge
     def _get_model_and_processor(self):
+        if self._model is None:
+            self.load_models()
         return self._model, self._processor
 
     # ------------------------------------------------------------------

--- a/vistatotes/media/base.py
+++ b/vistatotes/media/base.py
@@ -142,7 +142,8 @@ class MediaType(ABC):
     def load_models(self) -> None:
         """Load (and cache) the embedding models for this media type.
 
-        Called once at application startup for every registered media type.
+        Called lazily the first time this media type needs to embed something
+        (i.e. on the first ``embed_media``, ``embed_text``, or getter call).
         Implementations must be idempotent — a second call should be a no-op.
         """
 

--- a/vistatotes/media/image/media_type.py
+++ b/vistatotes/media/image/media_type.py
@@ -186,6 +186,8 @@ class ImageMediaType(MediaType):
 
     # internal helper used by loader.py's get_clip_model() bridge
     def _get_model_and_processor(self):
+        if self._model is None:
+            self.load_models()
         return self._model, self._processor
 
     # ------------------------------------------------------------------

--- a/vistatotes/media/text/media_type.py
+++ b/vistatotes/media/text/media_type.py
@@ -150,6 +150,8 @@ class TextMediaType(MediaType):
 
     # internal helper used by loader.py's get_e5_model() bridge
     def _get_model(self) -> Optional[SentenceTransformer]:
+        if self._model is None:
+            self.load_models()
         return self._model
 
     # ------------------------------------------------------------------

--- a/vistatotes/media/video/media_type.py
+++ b/vistatotes/media/video/media_type.py
@@ -207,6 +207,8 @@ class VideoMediaType(MediaType):
 
     # internal helper used by loader.py's get_xclip_model() bridge
     def _get_model_and_processor(self):
+        if self._model is None:
+            self.load_models()
         return self._model, self._processor
 
     # ------------------------------------------------------------------

--- a/vistatotes/routes/datasets.py
+++ b/vistatotes/routes/datasets.py
@@ -13,7 +13,6 @@ from config import (CIFAR10_DOWNLOAD_SIZE_MB, CLIPS_PER_CATEGORY,
 from vistatotes.datasets import (DEMO_DATASETS, export_dataset_to_file,
                                  get_importer, list_importers,
                                  load_demo_dataset)
-from vistatotes.models import get_e5_model
 from vistatotes.models.progress import clear_progress_cache
 from vistatotes.utils import (bad_votes, clips, get_progress, good_votes,
                               label_history, update_progress)
@@ -249,8 +248,7 @@ def load_demo_dataset_route():
     def load_task():
         try:
             clear_dataset()
-            e5_model = get_e5_model()
-            load_demo_dataset(dataset_name, clips, e5_model)
+            load_demo_dataset(dataset_name, clips)
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
 


### PR DESCRIPTION
Each media type's embedder (CLAP, CLIP, X-CLIP, E5) now loads only
when first needed — either via embed_media/embed_text or through
the getter functions. This eliminates the startup delay and avoids
loading models that are never used, which is especially important
for CLI mode where only one media type is relevant.

https://claude.ai/code/session_0117whCWBCgpjKaPR8gqDXtD