### PR TITLE
Report embedder loading progress in the GUI

### DIFF
--- a/vistatotes/media/image/media_type.py
+++ b/vistatotes/media/image/media_type.py
@@ -15,6 +15,7 @@ from transformers import CLIPModel, CLIPProcessor
 from config import CLIP_MODEL_ID, MODELS_CACHE_DIR
 from vistatotes.media.base import DemoDataset, MediaType
 
+
 def _extract_tensor(output: object) -> torch.Tensor:
     """Extract a plain tensor from model output.
 
@@ -101,8 +102,7 @@ class ImageMediaType(MediaType):
                 id="animals_images",
                 label="Animals & Wildlife",
                 description=(
-                    "400 photographs of birds, cats, dogs, horses, deer, and frogs"
-                    " sourced from the CIFAR-10 dataset."
+                    "400 photographs of birds, cats, dogs, horses, deer, and frogs sourced from the CIFAR-10 dataset."
                 ),
                 categories=["bird", "cat", "deer", "dog", "frog", "horse"],
                 source="cifar10_sample",
@@ -111,8 +111,7 @@ class ImageMediaType(MediaType):
                 id="vehicles_images",
                 label="Vehicles & Transport",
                 description=(
-                    "400 photographs of airplanes, cars, ships, and trucks sourced"
-                    " from the CIFAR-10 dataset."
+                    "400 photographs of airplanes, cars, ships, and trucks sourced from the CIFAR-10 dataset."
                 ),
                 categories=["airplane", "automobile", "ship", "truck"],
                 source="cifar10_sample",
@@ -128,15 +127,14 @@ class ImageMediaType(MediaType):
             return
         import gc
 
+        from vistatotes.utils import update_progress
+
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
+        update_progress("loading", "Loading image embedder (CLIP model)...", 0, 0)
         print("DEBUG: Loading CLIP model for Image...", flush=True)
-        self._model = CLIPModel.from_pretrained(
-            CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir
-        )
-        self._processor = CLIPProcessor.from_pretrained(
-            CLIP_MODEL_ID, cache_dir=cache_dir
-        )
+        self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
+        self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir)
         print("DEBUG: CLIP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
@@ -176,9 +174,7 @@ class ImageMediaType(MediaType):
         try:
             inputs = self._processor(text=[text], return_tensors="pt")
             with torch.no_grad():
-                text_vec = (
-                    _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
-                )
+                text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
             return text_vec
         except Exception as e:
             print(f"Error embedding text query for image: {e}")

--- a/vistatotes/media/text/media_type.py
+++ b/vistatotes/media/text/media_type.py
@@ -74,8 +74,7 @@ class TextMediaType(MediaType):
                 id="world_news",
                 label="World & Business News",
                 description=(
-                    "Paragraphs drawn from international news and business articles"
-                    " in the 20 Newsgroups collection."
+                    "Paragraphs drawn from international news and business articles in the 20 Newsgroups collection."
                 ),
                 categories=["world", "business"],
                 source="ag_news_sample",
@@ -84,8 +83,7 @@ class TextMediaType(MediaType):
                 id="sports_science_news",
                 label="Sports & Science News",
                 description=(
-                    "Paragraphs drawn from sports coverage and science journalism"
-                    " in the 20 Newsgroups collection."
+                    "Paragraphs drawn from sports coverage and science journalism in the 20 Newsgroups collection."
                 ),
                 categories=["sports", "science"],
                 source="ag_news_sample",
@@ -101,8 +99,11 @@ class TextMediaType(MediaType):
             return
         import gc
 
+        from vistatotes.utils import update_progress
+
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
+        update_progress("loading", "Loading text embedder (E5 model)...", 0, 0)
         print("DEBUG: Loading E5-base-v2 model for Text...", flush=True)
         self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir)
         print("DEBUG: E5-base-v2 model loaded.", flush=True)
@@ -118,9 +119,7 @@ class TextMediaType(MediaType):
             if not text_content:
                 print(f"Warning: empty text file {file_path}")
                 return None
-            return self._model.encode(
-                f"passage: {text_content}", normalize_embeddings=True
-            )
+            return self._model.encode(f"passage: {text_content}", normalize_embeddings=True)
         except Exception as e:
             print(f"Error embedding {file_path}: {e}")
             return None

--- a/vistatotes/routes/sorting.py
+++ b/vistatotes/routes/sorting.py
@@ -85,7 +85,19 @@ def sort_clips():
 
     # Total steps: 1 (embed) + len(clips) (similarities) + 1 (threshold)
     total_steps = 1 + len(clips) + 1
-    update_sort_progress("sorting", "Embedding text query…", 0, total_steps)
+
+    # Check if the embedder needs loading (first use of this media type)
+    from vistatotes.media import get as media_get
+
+    try:
+        mt = media_get(media_type)
+        needs_loading = getattr(mt, "_model", None) is None
+    except KeyError:
+        needs_loading = False
+    if needs_loading:
+        update_sort_progress("sorting", "Loading embedder…", 0, total_steps)
+    else:
+        update_sort_progress("sorting", "Embedding text query…", 0, total_steps)
 
     # Embed text query using refactored module
     text_vec = embed_text_query(text, media_type)


### PR DESCRIPTION
When a dataset triggers lazy-loading of an embedder for the first time
in a session, the progress bar now shows "Loading X embedder (MODEL)..."
instead of misleadingly saying "Embedding clip 1/N..." while the model
downloads or initializes. Also updates the sort progress to show
"Loading embedder..." when a text sort triggers first-time model loading.

https://claude.ai/code/session_01ECcoThTz877qYoQDg97L1V