### PR TITLE
Add CLI --exporter support to route autodetect results to any Results Exporter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,14 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 - **Run tests**: `python -m pytest tests/ -v`
 - **Start app**: `python app.py` (or `python app.py --local` for dev)
 - **CLI autodetect**: `python app.py --autodetect --dataset <file.pkl> --detector <file.json>`
+- **CLI autodetect + exporter**: `python app.py --autodetect --dataset <file.pkl> --detector <file.json> --exporter file --filepath results.json`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`
 
 ## Architecture
 - `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing
-- `vistatotes/cli.py` — CLI autodetect: load dataset + detector, run inference, print results
+- `vistatotes/cli.py` — CLI autodetect: load dataset + detector, run inference, export results
 - `config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
 - `vistatotes/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `datasets.py`
 - `vistatotes/models/` — Embeddings, training, model loading, progress tracking
@@ -31,7 +32,7 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_labels.py` — Label export/import
   - `test_inclusion.py` — Inclusion GET/POST
   - `test_detectors.py` — Detector export, detector sort, favorites, auto-detect
-  - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function and --autodetect flag
+  - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag
   - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
 
 ## Key Details

--- a/vistatotes/cli.py
+++ b/vistatotes/cli.py
@@ -170,6 +170,13 @@ def _list_importer_names() -> list[str]:
     return [imp.name for imp in list_importers()]
 
 
+def _list_exporter_names() -> list[str]:
+    """Return the names of all registered exporters."""
+    from vistatotes.exporters import list_exporters
+
+    return [exp.name for exp in list_exporters()]
+
+
 def _print_hits(hits: list[dict[str, Any]]) -> None:
     """Print autodetect results to stdout."""
     if not hits:
@@ -181,31 +188,122 @@ def _print_hits(hits: list[dict[str, Any]]) -> None:
         print(f"  {hit['filename']}  (score: {hit['score']}, category: {hit['category']})")
 
 
-def autodetect_main(dataset_path: str, detector_path: str) -> None:
-    """CLI entry point: run autodetect and print results to stdout.
+def _build_results_dict(
+    hits: list[dict[str, Any]],
+    detector_path: str,
+    media_type: str = "unknown",
+) -> dict[str, Any]:
+    """Build the full results dict expected by exporters.
 
-    Prints each predicted-Good clip as a line with its filename and score.
+    Args:
+        hits: List of hit dicts from :func:`_score_clips_with_detector`.
+        detector_path: Path to the detector JSON (re-read for metadata).
+        media_type: The media type string for the dataset.
+
+    Returns:
+        A dict matching the shape expected by
+        :meth:`~vistatotes.exporters.base.ResultsExporter.export`.
+    """
+    detector_data = json.loads(Path(detector_path).read_text())
+    detector_name = detector_data.get("name", Path(detector_path).stem)
+    threshold = detector_data.get("threshold", 0.5)
+
+    return {
+        "media_type": media_type,
+        "detectors_run": 1,
+        "results": {
+            detector_name: {
+                "detector_name": detector_name,
+                "threshold": threshold,
+                "total_hits": len(hits),
+                "hits": hits,
+            }
+        },
+    }
+
+
+def _detect_media_type(clips: dict[int, dict[str, Any]]) -> str:
+    """Return the media type from the first clip, or ``"unknown"``."""
+    for clip in clips.values():
+        return clip.get("type", "unknown")
+    return "unknown"
+
+
+def _run_exporter(
+    exporter_name: str,
+    field_values: dict[str, Any],
+    results: dict[str, Any],
+) -> None:
+    """Validate and run a named exporter, printing its confirmation message.
+
+    Raises:
+        ValueError: If the exporter is unknown or required fields are missing.
+    """
+    from vistatotes.exporters import get_exporter
+
+    exporter = get_exporter(exporter_name)
+    if exporter is None:
+        available = _list_exporter_names()
+        raise ValueError(f"Unknown exporter: {exporter_name}. Available: {', '.join(available)}")
+
+    exporter.validate_cli_field_values(field_values)
+    result = exporter.export_cli(results, field_values)
+    print(result.get("message", "Export complete."))
+
+
+def autodetect_main(
+    dataset_path: str,
+    detector_path: str,
+    exporter_name: str | None = None,
+    exporter_field_values: dict[str, Any] | None = None,
+) -> None:
+    """CLI entry point: run autodetect and output results.
+
+    When *exporter_name* is ``None`` the hits are printed to stdout.
+    Otherwise the named exporter is used to deliver the results.
+
     Exits with code 0 on success, 1 on error.
 
     Args:
         dataset_path: Path to the dataset pickle file.
         detector_path: Path to the detector JSON file.
+        exporter_name: Optional registered exporter name.
+        exporter_field_values: Optional exporter field values.
     """
     try:
-        hits = run_autodetect(dataset_path, detector_path)
+        dataset_file = Path(dataset_path)
+        if not dataset_file.exists():
+            raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
+
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(dataset_file, clips)
+        if not clips:
+            raise ValueError(f"No clips loaded from dataset: {dataset_path}")
+
+        hits = _score_clips_with_detector(clips, detector_path)
+
+        if exporter_name:
+            media_type = _detect_media_type(clips)
+            results = _build_results_dict(hits, detector_path, media_type)
+            _run_exporter(exporter_name, exporter_field_values or {}, results)
+        else:
+            _print_hits(hits)
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-
-    _print_hits(hits)
 
 
 def autodetect_importer_main(
     importer_name: str,
     field_values: dict[str, Any],
     detector_path: str,
+    exporter_name: str | None = None,
+    exporter_field_values: dict[str, Any] | None = None,
 ) -> None:
-    """CLI entry point: run autodetect with a named importer and print results.
+    """CLI entry point: run autodetect with a named importer and output results.
+
+    When *exporter_name* is ``None`` the hits are printed to stdout.
+    Otherwise the named exporter is used to deliver the results.
 
     Exits with code 0 on success, 1 on error.
 
@@ -213,11 +311,32 @@ def autodetect_importer_main(
         importer_name: Registered name of the importer.
         field_values: Mapping of importer field keys to their CLI values.
         detector_path: Path to the detector JSON file.
+        exporter_name: Optional registered exporter name.
+        exporter_field_values: Optional exporter field values.
     """
     try:
-        hits = run_autodetect_with_importer(importer_name, field_values, detector_path)
+        from vistatotes.datasets.importers import get_importer
+
+        importer = get_importer(importer_name)
+        if importer is None:
+            available = _list_importer_names()
+            raise ValueError(f"Unknown importer: {importer_name}. Available: {', '.join(available)}")
+
+        importer.validate_cli_field_values(field_values)
+
+        clips: dict[int, dict[str, Any]] = {}
+        importer.run_cli(field_values, clips)
+        if not clips:
+            raise ValueError(f"No clips loaded by importer '{importer_name}'")
+
+        hits = _score_clips_with_detector(clips, detector_path)
+
+        if exporter_name:
+            media_type = _detect_media_type(clips)
+            results = _build_results_dict(hits, detector_path, media_type)
+            _run_exporter(exporter_name, exporter_field_values or {}, results)
+        else:
+            _print_hits(hits)
     except (FileNotFoundError, ValueError, NotADirectoryError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-
-    _print_hits(hits)

--- a/vistatotes/exporters/gui/__init__.py
+++ b/vistatotes/exporters/gui/__init__.py
@@ -26,15 +26,30 @@ class GuiExporter(ResultsExporter):
     fields = []  # no questions to ask
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        total_hits = sum(
-            r.get("total_hits", 0) for r in results.get("results", {}).values()
-        )
+        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
         return {
-            "message": (
-                f"Showing {total_hits} hit(s) across "
-                f"{results.get('detectors_run', 0)} detector(s)."
-            ),
+            "message": (f"Showing {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s)."),
             "display_results": results,
+        }
+
+    def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Print results to stdout (there is no browser in CLI mode)."""
+        lines: list[str] = []
+        for det_result in results.get("results", {}).values():
+            hits = det_result.get("hits", [])
+            if not hits:
+                lines.append("No items predicted as Good.")
+                continue
+            lines.append(f"Predicted Good ({len(hits)} items):\n")
+            for hit in hits:
+                lines.append(
+                    f"  {hit['filename']}  (score: {hit['score']}, category: {hit.get('category', 'unknown')})"
+                )
+        output = "\n".join(lines) if lines else "No results."
+        print(output)
+        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
+        return {
+            "message": (f"Printed {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s) to stdout."),
         }
 
 


### PR DESCRIPTION
Mirrors the pattern established by Data Importers: each ResultsExporter now
has add_cli_arguments(), export_cli(), and validate_cli_field_values() methods
in the base class, with sensible defaults derived from the fields list.

Users can now specify --exporter <name> along with exporter-specific flags:
  python app.py --autodetect --dataset data.pkl --detector det.json --exporter file --filepath results.json
  python app.py --autodetect --importer pickle --file data.pkl --detector det.json --exporter email_smtp --to user@example.com ...

The GUI exporter overrides export_cli() to print formatted results to stdout
(since there is no browser in CLI mode). File and email_smtp exporters work
with the base class defaults. The two-pass argparse approach now handles both
--importer and --exporter dynamic arguments.

https://claude.ai/code/session_01NuA3LqWBEqaPjHRW55nPbt