### PR TITLE
Lazy-load test dependencies instead of installing on every session start

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Lazy dependency installer — only runs pip install the first time.
+# Called before test/app commands that actually need the full stack.
+# Skips entirely outside remote (Claude Code on the web) environments.
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+MARKER="/tmp/.vistatotes-deps-installed"
+
+if [ -f "$MARKER" ]; then
+  exit 0
+fi
+
+echo "Installing project dependencies (first test run this session)..."
+
+# Upgrade setuptools first — the system version (68.x) has a broken
+# install_layout attribute that prevents building wheels for some packages
+# (progressbar, wget) needed by laion_clap.
+pip install --upgrade setuptools -q
+
+# Install Python dependencies (CPU-only PyTorch).
+# --ignore-installed blinker: the system blinker (debian-managed) has no
+# RECORD file so pip cannot uninstall it; force-installing a fresh copy
+# lets Flask pick it up cleanly.
+pip install --extra-index-url https://download.pytorch.org/whl/cpu \
+  flask \
+  "numpy<2" \
+  "torch>=2.0.0" \
+  requests \
+  tqdm \
+  scikit-learn \
+  transformers \
+  laion_clap \
+  librosa \
+  "opencv-python-headless<4.10" \
+  Pillow \
+  ultralytics \
+  sentence-transformers \
+  --ignore-installed blinker \
+  -q
+
+# Install dev tools (linter + test runner)
+pip install pytest ruff -q
+
+touch "$MARKER"
+echo "Dependencies installed."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,31 +6,7 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Upgrade setuptools first — the system version (68.x) has a broken
-# install_layout attribute that prevents building wheels for some packages
-# (progressbar, wget) needed by laion_clap.
-pip install --upgrade setuptools -q
-
-# Install Python dependencies (CPU-only PyTorch).
-# --ignore-installed blinker: the system blinker (debian-managed) has no
-# RECORD file so pip cannot uninstall it; force-installing a fresh copy
-# lets Flask pick it up cleanly.
-pip install --extra-index-url https://download.pytorch.org/whl/cpu \
-  flask \
-  "numpy<2" \
-  "torch>=2.0.0" \
-  requests \
-  tqdm \
-  scikit-learn \
-  transformers \
-  laion_clap \
-  librosa \
-  "opencv-python-headless<4.10" \
-  Pillow \
-  ultralytics \
-  sentence-transformers \
-  --ignore-installed blinker \
-  -q
-
-# Install dev tools (linter + test runner)
-pip install pytest ruff -q
+# Install lightweight dev tools only — linter and formatter.
+# Heavy dependencies (PyTorch, transformers, etc.) are installed lazily
+# by ensure-test-deps.sh the first time tests or the app are run.
+pip install ruff -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 Media explorer web app for browsing/voting on audio, images, or text. Semantic sorting (LAION-CLAP, CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + vanilla JS + PyTorch.
 
 ## Commands
-- **Run tests**: `python -m pytest tests/ -v`
-- **Start app**: `python app.py` (or `python app.py --local` for dev)
-- **CLI autodetect**: `python app.py --autodetect --dataset <file.pkl> --detector <file.json>`
-- **CLI autodetect + exporter**: `python app.py --autodetect --dataset <file.pkl> --detector <file.json> --exporter file --filepath results.json`
+- **Run tests**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -v`
+- **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
+- **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --detector <file.json>`
+- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --detector <file.json> --exporter file --filepath results.json`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`


### PR DESCRIPTION
session-start.sh now only installs ruff (lightweight linter). Heavy
dependencies (PyTorch, transformers, etc.) are deferred to
ensure-test-deps.sh, which runs on-demand before tests or app commands
and uses a marker file to skip redundant installs within a session.

https://claude.ai/code/session_01CYtttPt97YLbfq7ZFc4pEk