### PR TITLE
Add RSS feed, YouTube playlist importers and CSV, webhook exporters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 - `config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
 - `vistatotes/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `datasets.py`
 - `vistatotes/models/` — Embeddings, training, model loading, progress tracking
-- `vistatotes/datasets/` — Dataset loading, downloading, importers (folder/pickle/http_zip)
+- `vistatotes/datasets/` — Dataset loading, downloading, importers (folder/pickle/http_zip/rss_feed/youtube_playlist)
+- `vistatotes/exporters/` — Results exporters (file/gui/email_smtp/csv_file/webhook)
 - `vistatotes/media/` — Media type plugins: audio, image, text, video
 - `vistatotes/utils/` — Global state (`clips` dict, votes), progress utilities
 - `static/index.html` — HTML structure (270 lines)
@@ -34,6 +35,8 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_detectors.py` — Detector export, detector sort, favorites, auto-detect
   - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag
   - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
+  - `test_rss_youtube_importers.py` — RSS feed and YouTube playlist importer metadata, CLI args, run logic
+  - `test_csv_webhook_exporters.py` — CSV and Webhook exporter metadata, CLI args, export logic
 
 ## Key Details
 - Global state lives in `vistatotes/utils/state.py`: `clips`, `good_votes`, `bad_votes` are module-level dicts

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -1,0 +1,528 @@
+"""Tests for CSV and Webhook exporters."""
+
+import argparse
+import csv
+import json
+from unittest import mock
+
+import pytest
+
+import app as app_module
+from vistatotes.cli import (
+    _build_results_dict,
+    _run_exporter,
+    run_autodetect,
+)
+from vistatotes.datasets.loader import export_dataset_to_file
+
+
+# ---------------------------------------------------------------------------
+# Helpers (same pattern as test_cli_autodetect.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset_file(tmp_path, clips_dict):
+    """Export a clips dict to a pickle file and return the path."""
+    pkl_bytes = export_dataset_to_file(clips_dict)
+    dataset_path = tmp_path / "dataset.pkl"
+    dataset_path.write_bytes(pkl_bytes)
+    return dataset_path
+
+
+def _make_detector_file(tmp_path, client, good_ids, bad_ids, name="detector.json"):
+    """Train a detector via the API and write its JSON to a file."""
+    app_module.good_votes.update({k: None for k in good_ids})
+    app_module.bad_votes.update({k: None for k in bad_ids})
+    resp = client.post("/api/detector/export")
+    assert resp.status_code == 200
+    detector = resp.get_json()
+    app_module.good_votes.clear()
+    app_module.bad_votes.clear()
+
+    detector_path = tmp_path / name
+    detector_path.write_text(json.dumps(detector))
+    return detector_path, detector
+
+
+def _make_sample_results():
+    """Create a sample results dict for testing exporters directly."""
+    return {
+        "media_type": "audio",
+        "detectors_run": 1,
+        "results": {
+            "test_detector": {
+                "detector_name": "test_detector",
+                "threshold": 0.5,
+                "total_hits": 3,
+                "hits": [
+                    {"id": 1, "filename": "clip_1.wav", "category": "birds", "score": 0.95},
+                    {"id": 2, "filename": "clip_2.wav", "category": "rain", "score": 0.82},
+                    {"id": 3, "filename": "clip_3.wav", "category": "birds", "score": 0.71},
+                ],
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# CSV Exporter — metadata
+# ---------------------------------------------------------------------------
+
+
+class TestCsvExporterMetadata:
+    """CSV exporter metadata and registration."""
+
+    def test_csv_exporter_registered(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("csv")
+        assert exp is not None
+
+    def test_csv_exporter_display_name(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("csv")
+        assert exp.display_name == "Save to CSV"
+
+    def test_csv_exporter_icon(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("csv")
+        assert exp.icon == "\U0001f4ca"
+
+    def test_csv_exporter_has_filepath_field(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("csv")
+        keys = [f.key for f in exp.fields]
+        assert "filepath" in keys
+
+    def test_csv_exporter_to_dict(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("csv")
+        d = exp.to_dict()
+        assert d["name"] == "csv"
+        assert "fields" in d
+        assert len(d["fields"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# CSV Exporter — CLI arguments
+# ---------------------------------------------------------------------------
+
+
+class TestCsvExporterCLI:
+    """CLI argument parsing for the CSV exporter."""
+
+    def test_adds_filepath_arg(self):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        parser = argparse.ArgumentParser()
+        exp.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--filepath", "/tmp/results.csv"])
+        assert args.filepath == "/tmp/results.csv"
+
+    def test_filepath_default(self):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        parser = argparse.ArgumentParser()
+        exp.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+        assert args.filepath == "autodetect_results.csv"
+
+    def test_validate_passes(self):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        exp.validate_cli_field_values({"filepath": "/tmp/out.csv"})
+
+    def test_validate_missing_filepath(self):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        with pytest.raises(ValueError, match="Missing required argument: --filepath"):
+            exp.validate_cli_field_values({})
+
+
+# ---------------------------------------------------------------------------
+# CSV Exporter — export functionality
+# ---------------------------------------------------------------------------
+
+
+class TestCsvExporterExport:
+    """Tests for the CSV export() method."""
+
+    def test_creates_csv_file(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = _make_sample_results()
+        filepath = tmp_path / "output.csv"
+
+        result = exp.export(results, {"filepath": str(filepath)})
+        assert filepath.exists()
+        assert "message" in result
+        assert "Saved" in result["message"]
+
+    def test_csv_has_correct_header(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = _make_sample_results()
+        filepath = tmp_path / "output.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+        assert header == ["detector", "threshold", "filename", "category", "score"]
+
+    def test_csv_has_correct_row_count(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = _make_sample_results()
+        filepath = tmp_path / "output.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        # 1 header + 3 data rows
+        assert len(rows) == 4
+
+    def test_csv_row_values(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = _make_sample_results()
+        filepath = tmp_path / "output.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            next(reader)  # skip header
+            first_row = next(reader)
+        assert first_row[0] == "test_detector"
+        assert first_row[2] == "clip_1.wav"
+        assert first_row[3] == "birds"
+        assert first_row[4] == "0.95"
+
+    def test_csv_empty_results(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = {"media_type": "audio", "detectors_run": 0, "results": {}}
+        filepath = tmp_path / "empty.csv"
+
+        result = exp.export(results, {"filepath": str(filepath)})
+        assert filepath.exists()
+        assert "0 hit(s)" in result["message"]
+
+    def test_csv_creates_parent_dirs(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = _make_sample_results()
+        filepath = tmp_path / "sub" / "dir" / "output.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        assert filepath.exists()
+
+    def test_csv_empty_filepath_raises(self):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        with pytest.raises(ValueError, match="file path is required"):
+            exp.export({}, {"filepath": ""})
+
+    def test_csv_multiple_detectors(self, tmp_path):
+        from vistatotes.exporters.csv_file import CsvExporter
+
+        exp = CsvExporter()
+        results = {
+            "media_type": "audio",
+            "detectors_run": 2,
+            "results": {
+                "det_a": {
+                    "detector_name": "det_a",
+                    "threshold": 0.4,
+                    "total_hits": 1,
+                    "hits": [{"id": 1, "filename": "a.wav", "category": "x", "score": 0.9}],
+                },
+                "det_b": {
+                    "detector_name": "det_b",
+                    "threshold": 0.6,
+                    "total_hits": 2,
+                    "hits": [
+                        {"id": 2, "filename": "b.wav", "category": "y", "score": 0.8},
+                        {"id": 3, "filename": "c.wav", "category": "z", "score": 0.7},
+                    ],
+                },
+            },
+        }
+        filepath = tmp_path / "multi.csv"
+
+        result = exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        # 1 header + 3 data rows
+        assert len(rows) == 4
+        assert "3 hit(s)" in result["message"]
+        assert "2 detector(s)" in result["message"]
+
+
+class TestCsvExporterIntegration:
+    """Integration: CSV exporter via _run_exporter and with real detector results."""
+
+    def test_csv_via_run_exporter(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        results = _build_results_dict(hits, str(detector_path), "audio")
+
+        output_file = tmp_path / "integrated.csv"
+        _run_exporter("csv", {"filepath": str(output_file)}, results)
+
+        assert output_file.exists()
+        with open(output_file, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+        assert header[0] == "detector"
+
+
+# ---------------------------------------------------------------------------
+# Webhook Exporter — metadata
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookExporterMetadata:
+    """Webhook exporter metadata and registration."""
+
+    def test_webhook_exporter_registered(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        assert exp is not None
+
+    def test_webhook_exporter_display_name(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        assert exp.display_name == "Webhook (HTTP POST)"
+
+    def test_webhook_exporter_icon(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        assert exp.icon == "\U0001f310"
+
+    def test_webhook_exporter_has_url_field(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        keys = [f.key for f in exp.fields]
+        assert "url" in keys
+
+    def test_webhook_exporter_has_auth_header_field(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        keys = [f.key for f in exp.fields]
+        assert "auth_header" in keys
+
+    def test_webhook_auth_header_not_required(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        auth_field = next(f for f in exp.fields if f.key == "auth_header")
+        assert auth_field.required is False
+
+    def test_webhook_exporter_to_dict(self):
+        from vistatotes.exporters import get_exporter
+
+        exp = get_exporter("webhook")
+        d = exp.to_dict()
+        assert d["name"] == "webhook"
+        assert "fields" in d
+
+
+# ---------------------------------------------------------------------------
+# Webhook Exporter — CLI arguments
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookExporterCLI:
+    """CLI argument parsing for the Webhook exporter."""
+
+    def test_adds_url_arg(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        parser = argparse.ArgumentParser()
+        exp.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--url", "https://example.com/hook"])
+        assert args.url == "https://example.com/hook"
+
+    def test_validate_passes_with_url(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        # auth_header is optional, so only url is needed
+        exp.validate_cli_field_values({"url": "https://example.com/hook"})
+
+    def test_validate_missing_url(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        with pytest.raises(ValueError, match="Missing required argument: --url"):
+            exp.validate_cli_field_values({})
+
+    def test_validate_passes_without_auth_header(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        # Should not raise
+        exp.validate_cli_field_values({"url": "https://example.com/hook"})
+
+
+# ---------------------------------------------------------------------------
+# Webhook Exporter — export functionality
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookExporterExport:
+    """Tests for the Webhook export() method using mocked HTTP."""
+
+    def test_posts_json_to_url(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        results = _make_sample_results()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp) as mock_post:
+            result = exp.export(results, {"url": "https://example.com/hook"})
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["json"] == results
+        assert "message" in result
+        assert "200" in result["message"]
+
+    def test_sends_auth_header_when_provided(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        results = _make_sample_results()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp) as mock_post:
+            exp.export(results, {"url": "https://example.com/hook", "auth_header": "Bearer my-token"})
+
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer my-token"
+
+    def test_no_auth_header_when_empty(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        results = _make_sample_results()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp) as mock_post:
+            exp.export(results, {"url": "https://example.com/hook", "auth_header": ""})
+
+        call_kwargs = mock_post.call_args
+        assert "Authorization" not in call_kwargs.kwargs["headers"]
+
+    def test_empty_url_raises(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        with pytest.raises(ValueError, match="webhook URL is required"):
+            exp.export({}, {"url": ""})
+
+    def test_http_error_propagates(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        results = _make_sample_results()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("500 Server Error")
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp):
+            with pytest.raises(Exception, match="500 Server Error"):
+                exp.export(results, {"url": "https://example.com/hook"})
+
+    def test_message_contains_hit_count(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        results = _make_sample_results()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp):
+            result = exp.export(results, {"url": "https://example.com/hook"})
+
+        assert "3 hit(s)" in result["message"]
+        assert "1 detector(s)" in result["message"]
+
+    def test_result_includes_status_code_and_url(self):
+        from vistatotes.exporters.webhook import WebhookExporter
+
+        exp = WebhookExporter()
+        results = _make_sample_results()
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp):
+            result = exp.export(results, {"url": "https://example.com/hook"})
+
+        assert result["status_code"] == 201
+        assert result["url"] == "https://example.com/hook"
+
+
+class TestWebhookExporterIntegration:
+    """Integration: Webhook exporter via _run_exporter."""
+
+    def test_webhook_via_run_exporter(self, client, tmp_path):
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+
+        hits = run_autodetect(str(dataset_path), str(detector_path))
+        results = _build_results_dict(hits, str(detector_path), "audio")
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch("vistatotes.exporters.webhook.requests.post", return_value=mock_resp):
+            _run_exporter("webhook", {"url": "https://example.com/hook"}, results)
+
+    def test_unknown_exporter_still_raises(self):
+        with pytest.raises(ValueError, match="Unknown exporter"):
+            _run_exporter("nonexistent_exporter", {}, {})

--- a/tests/test_rss_youtube_importers.py
+++ b/tests/test_rss_youtube_importers.py
@@ -1,0 +1,294 @@
+"""Tests for RSS feed and YouTube playlist importers."""
+
+import argparse
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# RSS Feed Importer — metadata & CLI
+# ---------------------------------------------------------------------------
+
+
+class TestRssFeedImporterMetadata:
+    """RSS feed importer metadata appears in /api/dataset/importers."""
+
+    def test_rss_feed_in_importer_list(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        names = [imp["name"] for imp in data["importers"]]
+        assert "rss_feed" in names
+
+    def test_rss_feed_display_name(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "rss_feed"), None)
+        assert imp is not None
+        assert imp["display_name"] == "RSS / Podcast Feed"
+
+    def test_rss_feed_icon(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "rss_feed"), None)
+        assert imp is not None
+        assert imp["icon"] == "\U0001f4e1"
+
+    def test_rss_feed_has_url_field(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "rss_feed"), None)
+        keys = [f["key"] for f in imp["fields"]]
+        assert "url" in keys
+
+    def test_rss_feed_has_media_type_field(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "rss_feed"), None)
+        keys = [f["key"] for f in imp["fields"]]
+        assert "media_type" in keys
+
+    def test_rss_feed_has_max_episodes_field(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "rss_feed"), None)
+        keys = [f["key"] for f in imp["fields"]]
+        assert "max_episodes" in keys
+
+
+class TestRssFeedImporterCLI:
+    """CLI argument parsing for the RSS feed importer."""
+
+    def test_adds_expected_args(self):
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        parser = argparse.ArgumentParser()
+        imp.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--url", "https://example.com/feed.xml"])
+        assert args.url == "https://example.com/feed.xml"
+        assert args.media_type == "sounds"
+
+    def test_media_type_choices(self):
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        parser = argparse.ArgumentParser()
+        imp.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--url", "https://example.com/feed.xml", "--media-type", "images"])
+        assert args.media_type == "images"
+
+    def test_rejects_invalid_media_type(self):
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        parser = argparse.ArgumentParser()
+        imp.add_cli_arguments(parser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--url", "https://example.com/feed.xml", "--media-type", "invalid"])
+
+    def test_validate_missing_url(self):
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        with pytest.raises(ValueError, match="Missing required argument: --url"):
+            imp.validate_cli_field_values({"media_type": "sounds"})
+
+    def test_validate_passes_with_url(self):
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        # Should not raise — max_episodes is not required
+        imp.validate_cli_field_values({"url": "https://example.com/feed.xml", "media_type": "sounds"})
+
+    def test_run_cli_rejects_invalid_url(self):
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        with pytest.raises(ValueError, match="Invalid URL"):
+            imp.run_cli({"url": "not-a-url", "media_type": "sounds"}, {})
+
+
+class TestRssFeedImporterRun:
+    """Unit tests for the RSS feed importer's run() method using mocks."""
+
+    def test_missing_feedparser_raises_runtime_error(self):
+        """Attempting import without feedparser installed raises RuntimeError."""
+        import sys
+
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+        with mock.patch.dict(sys.modules, {"feedparser": None}):
+            with pytest.raises((RuntimeError, ImportError)):
+                imp.run({"url": "https://example.com/feed.xml", "media_type": "sounds"}, {})
+
+    def test_empty_feed_raises_value_error(self):
+        """A feed with no enclosures raises ValueError."""
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+
+        fake_feed = mock.MagicMock()
+        fake_feed.bozo = False
+        fake_feed.entries = [mock.MagicMock(enclosures=[], title="Ep 1")]
+
+        with mock.patch("vistatotes.datasets.importers.rss_feed.feedparser", create=True) as mock_fp:
+            mock_fp.parse.return_value = fake_feed
+            # Patch sys.modules so the import inside run() succeeds
+            import sys
+
+            with mock.patch.dict(sys.modules, {"feedparser": mock_fp}):
+                with pytest.raises(ValueError, match="No media enclosures"):
+                    imp.run({"url": "https://example.com/feed.xml", "media_type": "sounds"}, {})
+
+    def test_bozo_feed_with_no_entries_raises(self):
+        """A bozo (malformed) feed with no entries raises ValueError."""
+        from vistatotes.datasets.importers.rss_feed import RssFeedImporter
+
+        imp = RssFeedImporter()
+
+        fake_feed = mock.MagicMock()
+        fake_feed.bozo = True
+        fake_feed.entries = []
+        fake_feed.bozo_exception = Exception("malformed XML")
+
+        import sys
+
+        with mock.patch("vistatotes.datasets.importers.rss_feed.feedparser", create=True) as mock_fp:
+            mock_fp.parse.return_value = fake_feed
+            with mock.patch.dict(sys.modules, {"feedparser": mock_fp}):
+                with pytest.raises(ValueError, match="Failed to parse feed"):
+                    imp.run({"url": "https://example.com/feed.xml", "media_type": "sounds"}, {})
+
+
+# ---------------------------------------------------------------------------
+# YouTube Playlist Importer — metadata & CLI
+# ---------------------------------------------------------------------------
+
+
+class TestYouTubePlaylistImporterMetadata:
+    """YouTube playlist importer metadata appears in /api/dataset/importers."""
+
+    def test_youtube_in_importer_list(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        names = [imp["name"] for imp in data["importers"]]
+        assert "youtube_playlist" in names
+
+    def test_youtube_display_name(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "youtube_playlist"), None)
+        assert imp is not None
+        assert imp["display_name"] == "YouTube Playlist"
+
+    def test_youtube_icon(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "youtube_playlist"), None)
+        assert imp is not None
+        assert imp["icon"] == "\U0001f3ac"
+
+    def test_youtube_has_url_field(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "youtube_playlist"), None)
+        keys = [f["key"] for f in imp["fields"]]
+        assert "url" in keys
+
+    def test_youtube_has_media_type_field(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "youtube_playlist"), None)
+        keys = [f["key"] for f in imp["fields"]]
+        assert "media_type" in keys
+
+    def test_youtube_media_type_options(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "youtube_playlist"), None)
+        mt_field = next(f for f in imp["fields"] if f["key"] == "media_type")
+        assert "videos" in mt_field["options"]
+        assert "sounds" in mt_field["options"]
+
+    def test_youtube_has_max_videos_field(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        imp = next((i for i in data["importers"] if i["name"] == "youtube_playlist"), None)
+        keys = [f["key"] for f in imp["fields"]]
+        assert "max_videos" in keys
+
+
+class TestYouTubePlaylistImporterCLI:
+    """CLI argument parsing for the YouTube playlist importer."""
+
+    def test_adds_expected_args(self):
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        parser = argparse.ArgumentParser()
+        imp.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--url", "https://www.youtube.com/playlist?list=PLtest"])
+        assert args.url == "https://www.youtube.com/playlist?list=PLtest"
+        assert args.media_type == "videos"
+
+    def test_media_type_choices(self):
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        parser = argparse.ArgumentParser()
+        imp.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--url", "https://www.youtube.com/watch?v=test", "--media-type", "sounds"])
+        assert args.media_type == "sounds"
+
+    def test_rejects_invalid_media_type(self):
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        parser = argparse.ArgumentParser()
+        imp.add_cli_arguments(parser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--url", "https://youtube.com", "--media-type", "invalid"])
+
+    def test_validate_missing_url(self):
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        with pytest.raises(ValueError, match="Missing required argument: --url"):
+            imp.validate_cli_field_values({"media_type": "videos"})
+
+    def test_validate_passes_with_url(self):
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        # Should not raise — max_videos is not required
+        imp.validate_cli_field_values({"url": "https://www.youtube.com/playlist?list=PLtest", "media_type": "videos"})
+
+    def test_run_cli_rejects_invalid_url(self):
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        with pytest.raises(ValueError, match="Invalid URL"):
+            imp.run_cli({"url": "not-a-url", "media_type": "videos"}, {})
+
+
+class TestYouTubePlaylistImporterRun:
+    """Unit tests for the YouTube playlist importer's run() method using mocks."""
+
+    def test_missing_yt_dlp_raises_runtime_error(self):
+        """Attempting import without yt-dlp installed raises RuntimeError."""
+        import sys
+
+        from vistatotes.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+
+        imp = YouTubePlaylistImporter()
+        with mock.patch.dict(sys.modules, {"yt_dlp": None}):
+            with pytest.raises((RuntimeError, ImportError)):
+                imp.run({"url": "https://www.youtube.com/watch?v=test", "media_type": "videos"}, {})

--- a/vistatotes/datasets/importers/rss_feed/__init__.py
+++ b/vistatotes/datasets/importers/rss_feed/__init__.py
@@ -1,0 +1,156 @@
+"""RSS/Podcast feed importer – downloads audio enclosures from an RSS feed.
+
+Requires the ``feedparser`` package.  Add ``feedparser`` to
+``requirements-cpu.txt`` / ``requirements-gpu.txt`` if not already present.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from config import DATA_DIR
+from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
+from vistatotes.utils import update_progress
+
+
+def _download_enclosure(url: str, dest: Path, timeout: int = 120) -> None:
+    """Stream an enclosure URL to *dest*."""
+    resp = requests.get(url, stream=True, timeout=timeout)
+    resp.raise_for_status()
+    with open(dest, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+
+class RssFeedImporter(DatasetImporter):
+    """Download audio episodes from an RSS or podcast feed and embed them.
+
+    The importer parses the feed, downloads each audio enclosure, then
+    embeds the files using the selected media-type model.  Non-audio feeds
+    work too — just pick the right media type.
+    """
+
+    name = "rss_feed"
+    display_name = "RSS / Podcast Feed"
+    description = "Import media files from an RSS or podcast feed URL."
+    icon = "\U0001f4e1"
+    fields = [
+        ImporterField(
+            key="url",
+            label="Feed URL",
+            field_type="url",
+            description="URL of an RSS or Atom feed with media enclosures.",
+        ),
+        ImporterField(
+            key="media_type",
+            label="Media Type",
+            field_type="select",
+            description="Type of media to extract from the feed.",
+            options=["sounds", "videos", "images", "paragraphs"],
+            default="sounds",
+        ),
+        ImporterField(
+            key="max_episodes",
+            label="Max Episodes",
+            field_type="text",
+            description="Maximum number of episodes to download (0 = all).",
+            default="50",
+            required=False,
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any], clips: dict) -> None:
+        try:
+            import feedparser
+        except ImportError as exc:
+            raise RuntimeError(
+                "RSS feed import requires the 'feedparser' package. "
+                "Install it with: pip install feedparser"
+            ) from exc
+
+        from vistatotes.datasets.loader import load_dataset_from_folder
+        from vistatotes.media import get_by_folder_name
+
+        url = field_values["url"]
+        media_type = field_values.get("media_type", "sounds")
+        max_episodes = int(field_values.get("max_episodes", "0") or "0")
+
+        update_progress("downloading", "Parsing feed...", 0, 0)
+        feed = feedparser.parse(url)
+
+        if feed.bozo and not feed.entries:
+            raise ValueError(f"Failed to parse feed: {feed.bozo_exception}")
+
+        # Resolve valid file extensions for the chosen media type
+        mt = get_by_folder_name(media_type)
+        valid_exts = {ext.lstrip("*.").lower() for ext in mt.file_extensions}
+
+        # Collect enclosure URLs
+        enclosures: list[tuple[str, str]] = []
+        for entry in feed.entries:
+            for link in getattr(entry, "enclosures", []):
+                href = link.get("href", "")
+                if not href:
+                    continue
+                enclosures.append((entry.get("title", ""), href))
+            if max_episodes and len(enclosures) >= max_episodes:
+                enclosures = enclosures[:max_episodes]
+                break
+
+        if not enclosures:
+            raise ValueError("No media enclosures found in the feed.")
+
+        # Download enclosures to a temp folder
+        download_dir = DATA_DIR / "rss_feed_download"
+        download_dir.mkdir(parents=True, exist_ok=True)
+
+        total = len(enclosures)
+        for i, (title, href) in enumerate(enclosures, 1):
+            # Derive a filename from the URL
+            url_path = href.split("?")[0].rstrip("/")
+            url_filename = url_path.split("/")[-1] or f"episode_{i}"
+
+            # If the filename has no recognised extension, try to guess from
+            # the first valid extension for this media type.
+            suffix = Path(url_filename).suffix.lstrip(".").lower()
+            if suffix not in valid_exts:
+                default_ext = sorted(valid_exts)[0]
+                url_filename = f"{Path(url_filename).stem}.{default_ext}"
+
+            # Avoid filename collisions by prefixing with a short hash
+            short_hash = hashlib.md5(href.encode()).hexdigest()[:8]
+            dest_name = f"{short_hash}_{url_filename}"
+            dest = download_dir / dest_name
+
+            update_progress(
+                "downloading",
+                f"Downloading {url_filename} ({i}/{total})...",
+                i,
+                total,
+            )
+            try:
+                _download_enclosure(href, dest)
+            except Exception as exc:
+                # Skip episodes that fail to download
+                update_progress(
+                    "downloading",
+                    f"Skipped {url_filename}: {exc}",
+                    i,
+                    total,
+                )
+                continue
+
+        load_dataset_from_folder(download_dir, media_type, clips)
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+        url = field_values.get("url", "")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        self.run(field_values, clips)
+
+
+IMPORTER = RssFeedImporter()

--- a/vistatotes/datasets/importers/youtube_playlist/__init__.py
+++ b/vistatotes/datasets/importers/youtube_playlist/__init__.py
@@ -1,0 +1,133 @@
+"""YouTube playlist importer – downloads videos via yt-dlp and embeds them.
+
+Requires the ``yt-dlp`` package.  Install with: ``pip install yt-dlp``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from config import DATA_DIR
+from vistatotes.datasets.importers.base import DatasetImporter, ImporterField
+from vistatotes.utils import update_progress
+
+
+class YouTubePlaylistImporter(DatasetImporter):
+    """Download videos from a YouTube playlist or channel and embed them.
+
+    Uses ``yt-dlp`` to download videos in mp4 format, then embeds them using
+    the selected media-type model.  Works with playlists, channels, and
+    individual video URLs.
+    """
+
+    name = "youtube_playlist"
+    display_name = "YouTube Playlist"
+    description = "Download videos from a YouTube playlist or channel URL via yt-dlp."
+    icon = "\U0001f3ac"
+    fields = [
+        ImporterField(
+            key="url",
+            label="Playlist / Channel URL",
+            field_type="url",
+            description="URL of a YouTube playlist, channel, or single video.",
+        ),
+        ImporterField(
+            key="media_type",
+            label="Media Type",
+            field_type="select",
+            description="How to treat the downloaded files.",
+            options=["videos", "sounds"],
+            default="videos",
+        ),
+        ImporterField(
+            key="max_videos",
+            label="Max Videos",
+            field_type="text",
+            description="Maximum number of videos to download (0 = all).",
+            default="20",
+            required=False,
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any], clips: dict) -> None:
+        try:
+            import yt_dlp  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError(
+                "YouTube import requires the 'yt-dlp' package. "
+                "Install it with: pip install yt-dlp"
+            ) from exc
+
+        from vistatotes.datasets.loader import load_dataset_from_folder
+
+        url = field_values["url"]
+        media_type = field_values.get("media_type", "videos")
+        max_videos = int(field_values.get("max_videos", "0") or "0")
+
+        download_dir = DATA_DIR / "youtube_playlist_download"
+        download_dir.mkdir(parents=True, exist_ok=True)
+
+        update_progress("downloading", "Fetching playlist info...", 0, 0)
+
+        # Build yt-dlp options
+        ydl_opts: dict[str, Any] = {
+            "format": "mp4[height<=720]/best[height<=720]/mp4/best",
+            "outtmpl": str(download_dir / "%(id)s.%(ext)s"),
+            "quiet": True,
+            "no_warnings": True,
+            "ignoreerrors": True,
+        }
+
+        if max_videos:
+            ydl_opts["playlistend"] = max_videos
+
+        if media_type == "sounds":
+            # Extract audio only
+            ydl_opts["format"] = "bestaudio/best"
+            ydl_opts["postprocessors"] = [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "wav",
+                    "preferredquality": "192",
+                }
+            ]
+            ydl_opts["outtmpl"] = str(download_dir / "%(id)s.%(ext)s")
+
+        # Progress hook
+        downloaded_count = 0
+
+        def _progress_hook(d: dict) -> None:
+            nonlocal downloaded_count
+            if d["status"] == "finished":
+                downloaded_count += 1
+                filename = Path(d.get("filename", "")).name
+                update_progress(
+                    "downloading",
+                    f"Downloaded {filename} ({downloaded_count})...",
+                    downloaded_count,
+                    max_videos or 0,
+                )
+
+        ydl_opts["progress_hooks"] = [_progress_hook]
+
+        import yt_dlp
+
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([url])
+
+        # Check that something was downloaded
+        any_files = list(download_dir.iterdir())
+        if not any_files:
+            raise ValueError("No videos were downloaded. Check the URL and try again.")
+
+        load_dataset_from_folder(download_dir, media_type, clips)
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+        url = field_values.get("url", "")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        self.run(field_values, clips)
+
+
+IMPORTER = YouTubePlaylistImporter()

--- a/vistatotes/exporters/csv_file/__init__.py
+++ b/vistatotes/exporters/csv_file/__init__.py
@@ -1,0 +1,78 @@
+"""CSV exporter – saves auto-detect results to a CSV file on disk.
+
+No additional pip packages are required; uses only Python's ``csv`` and
+``pathlib`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from vistatotes.exporters.base import ExporterField, ResultsExporter
+
+
+class CsvExporter(ResultsExporter):
+    """Save auto-detect results as a CSV file.
+
+    Produces one row per hit across all detectors, with columns for the
+    detector name, filename, category, and score.  Opens directly in
+    Excel, Google Sheets, or any spreadsheet application.
+    """
+
+    name = "csv"
+    display_name = "Save to CSV"
+    description = "Write the results to a CSV file for spreadsheet analysis."
+    icon = "\U0001f4ca"
+    fields = [
+        ExporterField(
+            key="filepath",
+            label="File Path",
+            field_type="text",
+            description=(
+                "Absolute or relative path where the CSV results file will be "
+                "written.  Parent directories are created automatically."
+            ),
+            placeholder="/home/user/autodetect_results.csv",
+            default="autodetect_results.csv",
+        ),
+    ]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        filepath_str = field_values.get("filepath", "").strip()
+        if not filepath_str:
+            raise ValueError("A file path is required.")
+
+        filepath = Path(filepath_str)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        total_hits = 0
+        with open(filepath, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["detector", "threshold", "filename", "category", "score"])
+
+            for det_result in results.get("results", {}).values():
+                detector_name = det_result.get("detector_name", "unknown")
+                threshold = det_result.get("threshold", "")
+                for hit in det_result.get("hits", []):
+                    writer.writerow([
+                        detector_name,
+                        threshold,
+                        hit.get("filename", ""),
+                        hit.get("category", ""),
+                        hit.get("score", ""),
+                    ])
+                    total_hits += 1
+
+        return {
+            "message": (
+                f"Saved {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) "
+                f"to {filepath.resolve()}."
+            ),
+            "filepath": str(filepath.resolve()),
+        }
+
+
+EXPORTER = CsvExporter()

--- a/vistatotes/exporters/webhook/__init__.py
+++ b/vistatotes/exporters/webhook/__init__.py
@@ -1,0 +1,71 @@
+"""Webhook exporter – POSTs auto-detect results to an arbitrary URL.
+
+Requires only ``requests``, which is already a core dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from vistatotes.exporters.base import ExporterField, ResultsExporter
+
+
+class WebhookExporter(ResultsExporter):
+    """POST the results JSON to a user-specified URL.
+
+    Enables integration with automation platforms (Zapier, n8n, Make,
+    custom services) without writing a dedicated exporter.  The full
+    results dict is sent as the JSON request body.
+    """
+
+    name = "webhook"
+    display_name = "Webhook (HTTP POST)"
+    description = "POST the results as JSON to a URL."
+    icon = "\U0001f310"
+    fields = [
+        ExporterField(
+            key="url",
+            label="Webhook URL",
+            field_type="text",
+            description="The URL to POST the results JSON to.",
+            placeholder="https://example.com/webhook",
+        ),
+        ExporterField(
+            key="auth_header",
+            label="Authorization Header",
+            field_type="password",
+            description="Optional Bearer token or API key sent as the Authorization header.",
+            required=False,
+        ),
+    ]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        url = field_values.get("url", "").strip()
+        if not url:
+            raise ValueError("A webhook URL is required.")
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        auth_header = field_values.get("auth_header", "").strip()
+        if auth_header:
+            headers["Authorization"] = auth_header
+
+        resp = requests.post(url, json=results, headers=headers, timeout=30)
+        resp.raise_for_status()
+
+        total_hits = sum(
+            r.get("total_hits", 0) for r in results.get("results", {}).values()
+        )
+        return {
+            "message": (
+                f"Posted {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) "
+                f"to {url} (HTTP {resp.status_code})."
+            ),
+            "status_code": resp.status_code,
+            "url": url,
+        }
+
+
+EXPORTER = WebhookExporter()


### PR DESCRIPTION
New data importers:
- rss_feed: Parse RSS/podcast feeds, download audio enclosures, embed them
- youtube_playlist: Download videos via yt-dlp from playlists/channels

New results exporters:
- csv: Write hits to CSV (detector, threshold, filename, category, score)
- webhook: POST results JSON to an arbitrary URL with optional auth header

All four plugins use the auto-discovery registry pattern and work in both GUI and CLI modes. 67 new tests covering metadata, CLI args, validation, export logic, and integration with _run_exporter.

https://claude.ai/code/session_01VygHMmu7vWBYEqDLrdx8n5