### PR TITLE
Auto-select first clip on initialization

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -221,6 +221,11 @@
         await fetchClips();
         await fetchVotes();
 
+        // Auto-select first clip if none selected
+        if (clips.length > 0 && !selected) {
+          selectClip(clips[0].id);
+        }
+
         // Check if auto-detect mode is enabled
         const autodetectCheckbox = document.getElementById("autodetect-mode-checkbox");
         if (autodetectCheckbox && autodetectCheckbox.checked) {
@@ -2245,7 +2250,15 @@
   };
 
   // Initialize
-  checkDatasetStatus();
+  checkDatasetStatus().then(async () => {
+    if (datasetLoaded) {
+      await fetchClips();
+      await fetchVotes();
+      if (clips.length > 0 && !selected) {
+        selectClip(clips[0].id);
+      }
+    }
+  });
   fetchInclusion();
   updateLabelCounts();
   loadFavoriteDetectors();


### PR DESCRIPTION
## Summary
This PR adds automatic selection of the first clip when the application initializes, improving the user experience by ensuring a clip is always selected when clips are available.

## Key Changes
- Added logic to auto-select the first clip after fetching clips and votes during initialization if no clip is currently selected
- Refactored the initialization sequence to properly await `checkDatasetStatus()` before attempting to fetch clips
- Ensured the auto-selection logic runs both during the main initialization flow and after dataset status check completes

## Implementation Details
- The auto-selection only occurs when clips are available (`clips.length > 0`) and no clip is currently selected (`!selected`)
- The initialization now uses a promise chain to ensure proper sequencing: dataset status check → fetch clips/votes → auto-select first clip
- This prevents potential race conditions where clips might not be available when the initialization logic runs

https://claude.ai/code/session_01AUyVwqtg7X5MwWXFcVjVPX