### PR TITLE
Fix dataset readiness check to detect empty required folders

### DIFF
--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -176,7 +176,9 @@ def demo_dataset_list():
         # this check stays generic as new demo datasets are added.
         if is_ready:
             required_folder = dataset_info.get("required_folder")
-            if required_folder is not None and not required_folder.exists():
+            if required_folder is not None and (
+                not required_folder.exists() or not any(required_folder.iterdir())
+            ):
                 is_ready = False
 
         # Calculate number of files


### PR DESCRIPTION
## Summary
Updated the dataset readiness validation logic to properly detect when required folders exist but are empty, marking such datasets as not ready.

## Key Changes
- **vtsearch/routes/datasets.py**: Modified the `demo_dataset_list()` function to check not only if a required folder exists, but also if it contains any files. A dataset is now marked as not ready if its required folder is empty.
- **tests/test_datasets.py**: Added `test_audio_pkl_with_empty_esc50_shows_not_ready()` test case to verify that datasets with empty required folders are correctly identified as not ready.

## Implementation Details
The fix changes the readiness check from:
```python
if required_folder is not None and not required_folder.exists():
    is_ready = False
```

To:
```python
if required_folder is not None and (
    not required_folder.exists() or not any(required_folder.iterdir())
):
    is_ready = False
```

This ensures that both missing folders and empty folders are treated as invalid states for dataset readiness. The test validates this behavior for the ESC-50 audio dataset scenario.

https://claude.ai/code/session_011U1ZtAVvYQSop7CTs4o3hQ