### PR TITLE
Serve favicon and logo from project root instead of static

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>VTSearch</title>
+<link rel="icon" href="/favicon.ico" type="image/x-icon">
 <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
@@ -41,7 +42,7 @@
     </div>
   </div>
   <h1>VTSearch</h1>
-  <span>Media explorer</span>
+  <img src="/logo.svg" alt="VTSearch logo" class="header-logo">
 </header>
 <div class="layout">
   <!-- Left panel -->

--- a/static/styles.css
+++ b/static/styles.css
@@ -2,7 +2,7 @@
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #0f1117; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
 header { background: #1a1d27; padding: 12px 24px; border-bottom: 1px solid #2a2d3a; display: flex; align-items: center; gap: 12px; position: relative; }
 header h1 { font-size: 1.3rem; color: #7c8aff; }
-header span { font-size: 0.85rem; color: #888; }
+.header-logo { height: 28px; width: auto; }
 .layout { display: flex; flex: 1; overflow: hidden; }
 
 /* Burger menu */

--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from flask import Blueprint, Response, current_app
+from flask import Blueprint, Response, current_app, send_from_directory
 
 main_bp = Blueprint("main", __name__)
 
@@ -17,18 +17,34 @@ def index() -> Response:
     return current_app.send_static_file("index.html")
 
 
+def _project_root() -> Path:
+    """Return the project root directory (parent of the ``vtsearch`` package)."""
+    return Path(current_app.root_path).parent
+
+
 @main_bp.route("/favicon.ico")
 def favicon() -> tuple[str, int] | Response:
-    """Serve the site favicon, or return a 204 No Content if it does not exist.
-
-    Returning 204 instead of 404 suppresses repetitive browser error logs when
-    no favicon has been configured.
+    """Serve the site favicon from the project root.
 
     Returns:
-        The ``static/favicon.ico`` file as a response if it exists on disk,
+        The ``favicon.ico`` file from the project root if it exists,
         otherwise an empty ``(str, int)`` tuple with HTTP status 204.
     """
-    # Return empty response if file doesn't exist to stop 404 logs
-    if not (Path(current_app.root_path) / "static" / "favicon.ico").exists():
+    root = _project_root()
+    if not (root / "favicon.ico").exists():
         return "", 204
-    return current_app.send_static_file("favicon.ico")
+    return send_from_directory(str(root), "favicon.ico", mimetype="image/x-icon")
+
+
+@main_bp.route("/logo.svg")
+def logo() -> tuple[str, int] | Response:
+    """Serve the site logo from the project root.
+
+    Returns:
+        The ``logo.svg`` file from the project root if it exists,
+        otherwise an empty ``(str, int)`` tuple with HTTP status 204.
+    """
+    root = _project_root()
+    if not (root / "logo.svg").exists():
+        return "", 204
+    return send_from_directory(str(root), "logo.svg", mimetype="image/svg+xml")


### PR DESCRIPTION
## Summary
This PR refactors the favicon and logo serving mechanism to load these assets from the project root directory instead of the static folder, and updates the UI to display the logo as an image rather than text.

## Key Changes
- **New route handler**: Added `/logo.svg` endpoint to serve the site logo from the project root
- **Refactored favicon handling**: Modified `/favicon.ico` endpoint to serve from project root instead of static directory
- **Helper function**: Introduced `_project_root()` utility function to consistently resolve the project root directory
- **Updated imports**: Added `send_from_directory` to Flask imports for proper file serving
- **UI improvements**: 
  - Replaced "Media explorer" text subtitle with an SVG logo image in the header
  - Added favicon link declaration to HTML head
  - Updated CSS to style the logo image instead of the subtitle span
- **Better error handling**: Both endpoints return HTTP 204 (No Content) when files don't exist, preventing unnecessary error logs

## Implementation Details
- Both favicon and logo endpoints use `send_from_directory()` with appropriate MIME types (`image/x-icon` and `image/svg+xml`)
- File existence checks prevent 404 errors by returning empty 204 responses
- The `_project_root()` function uses `Path(current_app.root_path).parent` to navigate from the vtsearch package directory to the project root

https://claude.ai/code/session_01AHiUSxUc9KHb33RTZz437Z