### PR TITLE
Handle null sort order in clip selection logic

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1325,12 +1325,22 @@
   // ---- Next Clip Selection ----
 
   function findNextClip() {
-    if (!sortOrder || sortOrder.length === 0) {
+    // Determine the ordered list to walk and effective threshold
+    let ordered = sortOrder;
+    let effectiveThreshold = threshold;
+    if (!ordered || ordered.length === 0) {
+      // Null sort: use clips in their current (arbitrary) order
+      ordered = clips.map(c => ({ id: c.id, score: 0 }));
+      // Treat threshold as the bottom for Hard mode
+      effectiveThreshold = -Infinity;
+    }
+
+    if (ordered.length === 0) {
       return null;
     }
 
     // Get unlabeled clips (not voted on)
-    const unlabeled = sortOrder.filter(item => {
+    const unlabeled = ordered.filter(item => {
       return !votes.good.includes(item.id) && !votes.bad.includes(item.id);
     });
 
@@ -1340,30 +1350,30 @@
 
     let nextClip;
     if (selectMode === "top") {
-      // Select highest scoring unlabeled clip
+      // Select highest scoring unlabeled clip (or first in order for null sort)
       nextClip = unlabeled[0];
     } else {
       // Select clip closest to threshold, breaking ties by index
-      // proximity to the threshold position in sortOrder
-      if (threshold === null) {
+      // proximity to the threshold position in ordered list
+      if (effectiveThreshold === null) {
         return null;
       }
       // Find threshold index: first position where score drops below threshold
-      let thresholdIdx = sortOrder.length;
-      for (let i = 0; i < sortOrder.length; i++) {
-        if (sortOrder[i].score < threshold) {
+      let thresholdIdx = ordered.length;
+      for (let i = 0; i < ordered.length; i++) {
+        if (ordered[i].score < effectiveThreshold) {
           thresholdIdx = i;
           break;
         }
       }
-      // Map clip id to its sortOrder index
+      // Map clip id to its ordered index
       const idToIdx = {};
-      sortOrder.forEach((item, idx) => { idToIdx[item.id] = idx; });
+      ordered.forEach((item, idx) => { idToIdx[item.id] = idx; });
 
       let minDist = Infinity;
       let minIdxDist = Infinity;
       for (const item of unlabeled) {
-        const dist = Math.abs(item.score - threshold);
+        const dist = Math.abs(item.score - effectiveThreshold);
         const idxDist = Math.abs(idToIdx[item.id] - thresholdIdx);
         if (dist < minDist || (dist === minDist && idxDist < minIdxDist)) {
           minDist = dist;


### PR DESCRIPTION
## Summary
This change improves the robustness of the `findNextClip()` function by properly handling cases where `sortOrder` is null or empty, ensuring the clip selection process can continue even without a pre-sorted list.

## Key Changes
- **Null sort order handling**: When `sortOrder` is null or empty, the function now creates an ordered list from all available clips with a score of 0, allowing selection to proceed
- **Effective threshold logic**: Introduced `effectiveThreshold` variable that defaults to `-Infinity` when no sort order exists, ensuring all clips are considered valid candidates in Hard mode
- **Improved variable naming**: Replaced direct `sortOrder` references with `ordered` variable for clarity and consistency throughout the function
- **Updated comments**: Clarified that "top" mode selects the first clip in order when sort order is null, and updated threshold-related comments to reference the new `ordered` list

## Implementation Details
- When `sortOrder` is null/empty, clips are presented in their current arbitrary order rather than failing
- The threshold comparison logic now uses `effectiveThreshold` consistently, preventing null reference issues
- The function maintains backward compatibility with existing behavior when `sortOrder` is properly populated
- Index-based proximity calculations now work correctly with the `ordered` list regardless of its origin

https://claude.ai/code/session_012nu5dBQTFTQk7vUAZMmhZR