### PR TITLE
Fix clip selection logic to prioritize threshold proximity

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1363,8 +1363,8 @@
       // Select highest scoring unlabeled clip (or first in order for null sort)
       nextClip = unlabeled[0];
     } else {
-      // Select clip closest to threshold, breaking ties by index
-      // proximity to the threshold position in ordered list
+      // Select unlabeled clip closest to threshold by list position,
+      // breaking ties by score distance
       if (effectiveThreshold === null) {
         return null;
       }
@@ -1380,14 +1380,14 @@
       const idToIdx = {};
       ordered.forEach((item, idx) => { idToIdx[item.id] = idx; });
 
-      let minDist = Infinity;
       let minIdxDist = Infinity;
+      let minDist = Infinity;
       for (const item of unlabeled) {
-        const dist = Math.abs(item.score - effectiveThreshold);
         const idxDist = Math.abs(idToIdx[item.id] - thresholdIdx);
-        if (dist < minDist || (dist === minDist && idxDist < minIdxDist)) {
-          minDist = dist;
+        const dist = Math.abs(item.score - effectiveThreshold);
+        if (idxDist < minIdxDist || (idxDist === minIdxDist && dist < minDist)) {
           minIdxDist = idxDist;
+          minDist = dist;
           nextClip = item;
         }
       }


### PR DESCRIPTION
## Summary
Updated the clip selection algorithm to correctly prioritize unlabeled clips by their proximity to the threshold position in the ordered list, with score distance as a secondary tiebreaker.

## Key Changes
- **Reordered comparison logic**: Changed the selection criteria from primarily comparing score distance to primarily comparing index distance (position in the ordered list relative to the threshold)
- **Updated variable initialization order**: Moved `minIdxDist` declaration before `minDist` to reflect the new priority order
- **Fixed conditional logic**: Changed the comparison from `dist < minDist || (dist === minDist && idxDist < minIdxDist)` to `idxDist < minIdxDist || (idxDist === minIdxDist && dist < minDist)` to properly implement the intended selection strategy
- **Improved code comments**: Clarified that the algorithm selects clips closest to threshold by list position first, then breaks ties by score distance

## Implementation Details
The change inverts the selection priority: instead of finding clips with scores closest to the threshold and using list position as a tiebreaker, the algorithm now finds clips closest to the threshold's position in the ordered list and uses score distance as a tiebreaker. This better reflects the intended behavior for selecting the next clip to label.

https://claude.ai/code/session_013HGbTsh5gBqP33y8xSurUi