### PR TITLE
Remove debug print statements and configure logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,12 @@
+import logging
 import os
 
 # Limit threads to reduce memory overhead in constrained environments
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
+
+# Suppress Werkzeug request logging (GET/POST lines) — only show errors
+logging.getLogger("werkzeug").setLevel(logging.ERROR)
 
 # Visual feedback for startup
 print("⏳ Initializing VTSearch...", flush=True)
@@ -28,7 +32,6 @@ app = Flask(__name__)
 
 
 def init_clips():
-    print("DEBUG: Generating synthetic waveforms...", flush=True)
     DATA_DIR.mkdir(exist_ok=True)
     temp_path = DATA_DIR / "temp_embed.wav"
 

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -130,10 +130,8 @@ class AudioMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         update_progress("loading", "Loading audio embedder (CLAP model)...", 0, 0)
-        print("DEBUG: Loading CLAP model for Audio...", flush=True)
         self._model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
         self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir)
-        print("DEBUG: CLAP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -132,10 +132,8 @@ class ImageMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         update_progress("loading", "Loading image embedder (CLIP model)...", 0, 0)
-        print("DEBUG: Loading CLIP model for Image...", flush=True)
         self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
         self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir)
-        print("DEBUG: CLIP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -104,9 +104,7 @@ class TextMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         update_progress("loading", "Loading text embedder (E5 model)...", 0, 0)
-        print("DEBUG: Loading E5-base-v2 model for Text...", flush=True)
         self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir)
-        print("DEBUG: E5-base-v2 model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -146,10 +146,8 @@ class VideoMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         update_progress("loading", "Loading video embedder (X-CLIP model)...", 0, 0)
-        print("DEBUG: Loading X-CLIP model for Video...", flush=True)
         self._model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
         self._processor = XCLIPProcessor.from_pretrained(XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False)
-        print("DEBUG: X-CLIP model loaded.", flush=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/routes/clips.py
+++ b/vtsearch/routes/clips.py
@@ -230,13 +230,11 @@ def vote_clip(clip_id: int) -> tuple[Response, int] | Response:
           ``"good"`` or ``"bad"``.
     """
     if clip_id not in clips:
-        print(f"DEBUG: Vote failed - Clip {clip_id} not found", flush=True)
         return jsonify({"error": "not found"}), 404
 
     try:
         data = request.get_json(force=True)
-    except Exception as e:
-        print(f"DEBUG: Vote failed - JSON error: {e}", flush=True)
+    except Exception:
         return jsonify({"error": "Invalid request body"}), 400
 
     if data is None:
@@ -244,7 +242,6 @@ def vote_clip(clip_id: int) -> tuple[Response, int] | Response:
 
     vote = data.get("vote")
     if vote not in ("good", "bad"):
-        print(f"DEBUG: Vote failed - Invalid vote '{vote}'", flush=True)
         return jsonify({"error": "vote must be 'good' or 'bad'"}), 400
 
     if vote == "good":
@@ -264,5 +261,4 @@ def vote_clip(clip_id: int) -> tuple[Response, int] | Response:
             bad_votes[clip_id] = None
             add_label_to_history(clip_id, "bad")
 
-    print(f"DEBUG: Vote '{vote}' recorded for clip {clip_id}", flush=True)
     return jsonify({"ok": True})

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -45,8 +45,7 @@ def sort_clips():
     """Return clips sorted by cosine similarity to a text query."""
     try:
         data = request.get_json(force=True)
-    except Exception as e:
-        print(f"DEBUG: Sort failed - JSON error: {e}", flush=True)
+    except Exception:
         update_sort_progress("idle")
         return jsonify({"error": "Invalid request body"}), 400
 
@@ -55,7 +54,6 @@ def sort_clips():
         return jsonify({"error": "Invalid request body"}), 400
 
     text = data.get("text", "").strip()
-    print(f"DEBUG: Sort request for '{text}'", flush=True)
 
     if not text:
         update_sort_progress("idle")
@@ -63,7 +61,6 @@ def sort_clips():
 
     # Determine media type from current clips
     if not clips:
-        print("DEBUG: Sort failed - No clips loaded", flush=True)
         update_sort_progress("idle")
         return jsonify({"error": "No clips loaded"}), 400
 
@@ -88,10 +85,6 @@ def sort_clips():
     # Embed text query using refactored module
     text_vec = embed_text_query(text, media_type)
     if text_vec is None:
-        print(
-            f"DEBUG: Sort failed - Could not embed text for media type {media_type}",
-            flush=True,
-        )
         update_sort_progress("idle")
         return (
             jsonify({"error": f"Could not embed text for media type {media_type}"}),


### PR DESCRIPTION
## Summary
This PR removes scattered debug print statements throughout the codebase and replaces them with proper logging configuration. This improves code cleanliness and reduces unnecessary console output in production.

## Key Changes
- **Removed debug print statements** from:
  - `vtsearch/routes/sorting.py`: Removed 4 debug prints related to sort requests and failures
  - `vtsearch/routes/clips.py`: Removed 4 debug prints related to vote operations
  - `app.py`: Removed 1 debug print from clip initialization
  - `vtsearch/media/audio/media_type.py`: Removed 2 debug prints for CLAP model loading
  - `vtsearch/media/image/media_type.py`: Removed 2 debug prints for CLIP model loading
  - `vtsearch/media/text/media_type.py`: Removed 2 debug prints for E5 model loading
  - `vtsearch/media/video/media_type.py`: Removed 2 debug prints for X-CLIP model loading

- **Improved exception handling** in `vtsearch/routes/sorting.py` and `vtsearch/routes/clips.py`:
  - Changed bare exception handlers to not capture unused exception variables
  - Maintains error handling behavior while improving code style

- **Added logging configuration** in `app.py`:
  - Imported `logging` module
  - Suppressed Werkzeug request logging (GET/POST lines) to reduce noise, keeping only error-level logs

## Implementation Details
The removal of debug prints reduces console clutter while maintaining the application's functionality. The Werkzeug logging suppression specifically targets the verbose HTTP request logging that Werkzeug outputs by default, allowing the application to remain quiet during normal operation while still reporting errors.

https://claude.ai/code/session_01P8g7nXTDx7GDkwg8gnUrWK