### PR TITLE
Improve right panel layout and labeling indicator UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1918,7 +1918,7 @@
     if (data.status === "red") {
       subtext.textContent = `${data.good_count}g / ${data.bad_count}b`;
     } else if (data.status === "yellow") {
-      subtext.textContent = "keep labeling";
+      subtext.textContent = "Continue";
     } else if (data.status === "green") {
       subtext.textContent = "ready to stop";
     } else {

--- a/static/styles.css
+++ b/static/styles.css
@@ -103,7 +103,7 @@ video { max-width: 600px; max-height: 400px; }
 .btn-bad:hover, .btn-bad.voted { background: #f44336; color: #fff; }
 
 /* Right panel – votes */
-.panel-right { width: 160px; border-left: 1px solid #2a2d3a; overflow-y: auto; background: #14161e; display: flex; flex-direction: column; }
+.panel-right { width: 160px; border-left: 1px solid #2a2d3a; overflow-y: auto; overflow-x: hidden; background: #14161e; display: flex; flex-direction: column; }
 .vote-section { flex: 1; overflow-y: auto; padding: 12px 16px; }
 .vote-section + .vote-section { border-top: 1px solid #2a2d3a; }
 .vote-section h3 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px; }
@@ -152,11 +152,11 @@ video { max-width: 600px; max-height: 400px; }
 .dataset-bar button:hover { background: #252940; color: #e0e0e0; }
 
 /* Progress indicator button */
-.progress-check-bar { padding: 10px 16px; border-bottom: 1px solid #2a2d3a; }
+.progress-check-bar { padding: 10px 8px; border-bottom: 1px solid #2a2d3a; }
 .labeling-indicator {
   width: 100%; padding: 7px 10px; border-radius: 4px; background: transparent;
   font-size: 0.8rem; cursor: pointer; transition: border-color 0.4s, opacity 0.2s;
-  display: flex; align-items: center; gap: 8px; border: 1px solid #444; text-align: left;
+  display: flex; align-items: center; gap: 6px; border: 1px solid #444; text-align: left;
 }
 .labeling-indicator:hover { opacity: 0.82; }
 .labeling-indicator:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -165,7 +165,7 @@ video { max-width: 600px; max-height: 400px; }
   background: #555; transition: background 0.4s, box-shadow 0.4s;
 }
 .indicator-label { flex: 1; color: #aaa; font-size: 0.8rem; transition: color 0.4s; }
-.indicator-subtext { font-size: 0.68rem; color: #666; white-space: nowrap; transition: color 0.4s; }
+.indicator-subtext { font-size: 0.68rem; color: #666; transition: color 0.4s; text-align: right; }
 
 /* Red – too few labels */
 .labeling-indicator[data-status="red"] { border-color: #c0392b; }


### PR DESCRIPTION
## Summary
This PR refines the styling and messaging of the right panel and labeling progress indicator to improve layout consistency and user experience.

## Key Changes
- **Right panel overflow**: Added `overflow-x: hidden` to `.panel-right` to prevent horizontal scrolling
- **Progress indicator padding**: Reduced horizontal padding in `.progress-check-bar` from 16px to 8px for better spacing
- **Labeling indicator gap**: Decreased gap between elements from 8px to 6px for tighter layout
- **Indicator subtext alignment**: Removed `white-space: nowrap` and added `text-align: right` to `.indicator-subtext` for better text wrapping and right alignment
- **Status message**: Updated yellow status message from "keep labeling" to "Continue" for clearer user guidance

## Implementation Details
These changes work together to create a more compact and visually balanced right panel while maintaining readability. The removal of `white-space: nowrap` allows the subtext to wrap naturally, which is now properly aligned to the right side of the indicator.

https://claude.ai/code/session_01Km4M2G1QxU4SQSzSkubrB8