### PR TITLE
Add evaluation framework for text-sort and learned-sort quality

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,431 @@
+"""Tests for the vtsearch.eval evaluation framework.
+
+These tests exercise the metrics, config, and runner modules using
+synthetic data — no real model downloads or embeddings required.
+"""
+
+import json
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vtsearch.eval.config import EVAL_DATASETS, EvalQuery
+from vtsearch.eval.metrics import (
+    DatasetResult,
+    LearnedSortMetrics,
+    QueryMetrics,
+    compute_average_precision,
+    compute_binary_classification_metrics,
+    compute_metrics,
+    compute_precision_recall_at_k,
+)
+from vtsearch.eval.runner import (
+    _cosine_similarity,
+    eval_learned_sort,
+    eval_text_sort,
+    format_results_json,
+)
+
+
+# =====================================================================
+# Metrics: compute_average_precision
+# =====================================================================
+
+
+class TestAveragePrecision:
+    def test_perfect_ranking(self):
+        """All relevant items at the top -> AP = 1.0."""
+        ranked = [1, 2, 3, 4, 5]
+        relevant = {1, 2, 3}
+        assert compute_average_precision(ranked, relevant) == pytest.approx(1.0)
+
+    def test_worst_ranking(self):
+        """All relevant items at the bottom -> AP < 1.0."""
+        ranked = [4, 5, 1, 2, 3]
+        relevant = {1, 2, 3}
+        ap = compute_average_precision(ranked, relevant)
+        assert ap < 1.0
+        assert ap > 0.0
+
+    def test_single_relevant(self):
+        """One relevant item at position k -> AP = 1/k."""
+        ranked = [10, 20, 30, 1, 40]
+        relevant = {1}
+        assert compute_average_precision(ranked, relevant) == pytest.approx(1 / 4)
+
+    def test_no_relevant(self):
+        ranked = [1, 2, 3]
+        relevant: set[int] = set()
+        assert compute_average_precision(ranked, relevant) == 0.0
+
+    def test_empty_ranking(self):
+        ranked: list[int] = []
+        relevant = {1, 2}
+        assert compute_average_precision(ranked, relevant) == 0.0
+
+    def test_interleaved(self):
+        """Relevant at positions 1, 3, 5 out of 6 items."""
+        ranked = [1, 10, 2, 20, 3, 30]
+        relevant = {1, 2, 3}
+        # P@1 = 1/1, P@3 = 2/3, P@5 = 3/5
+        expected = (1 / 1 + 2 / 3 + 3 / 5) / 3
+        assert compute_average_precision(ranked, relevant) == pytest.approx(expected)
+
+
+# =====================================================================
+# Metrics: precision / recall at k
+# =====================================================================
+
+
+class TestPrecisionRecallAtK:
+    def test_default_k_values(self):
+        ranked = list(range(1, 101))
+        relevant = set(range(1, 11))  # first 10
+        p, r = compute_precision_recall_at_k(ranked, relevant)
+        assert set(p.keys()) == {5, 10, 20}
+        assert p[5] == pytest.approx(1.0)
+        assert p[10] == pytest.approx(1.0)
+        assert p[20] == pytest.approx(0.5)
+        assert r[5] == pytest.approx(0.5)
+        assert r[10] == pytest.approx(1.0)
+        assert r[20] == pytest.approx(1.0)
+
+    def test_custom_k(self):
+        ranked = [1, 2, 3, 4, 5]
+        relevant = {1, 3, 5}
+        p, r = compute_precision_recall_at_k(ranked, relevant, k_values=[2, 4])
+        assert p[2] == pytest.approx(1 / 2)  # {1, 2} & {1, 3, 5} = {1}
+        assert p[4] == pytest.approx(2 / 4)  # {1, 2, 3, 4} & {1, 3, 5} = {1, 3}
+
+    def test_no_relevant(self):
+        ranked = [1, 2, 3]
+        relevant: set[int] = set()
+        p, r = compute_precision_recall_at_k(ranked, relevant, k_values=[2])
+        assert p[2] == 0.0
+        assert r[2] == 0.0
+
+
+# =====================================================================
+# Metrics: binary classification
+# =====================================================================
+
+
+class TestBinaryClassification:
+    def test_perfect(self):
+        preds = [1, 1, 0, 0]
+        labels = [1, 1, 0, 0]
+        acc, prec, rec, f1 = compute_binary_classification_metrics(preds, labels)
+        assert acc == 1.0
+        assert prec == 1.0
+        assert rec == 1.0
+        assert f1 == 1.0
+
+    def test_all_wrong(self):
+        preds = [0, 0, 1, 1]
+        labels = [1, 1, 0, 0]
+        acc, prec, rec, f1 = compute_binary_classification_metrics(preds, labels)
+        assert acc == 0.0
+        assert prec == 0.0
+        assert rec == 0.0
+        assert f1 == 0.0
+
+    def test_mixed(self):
+        preds = [1, 0, 1, 0]
+        labels = [1, 1, 0, 0]
+        acc, prec, rec, f1 = compute_binary_classification_metrics(preds, labels)
+        assert acc == pytest.approx(0.5)
+        # tp=1, fp=1, fn=1, tn=1
+        assert prec == pytest.approx(0.5)
+        assert rec == pytest.approx(0.5)
+        assert f1 == pytest.approx(0.5)
+
+    def test_empty(self):
+        acc, prec, rec, f1 = compute_binary_classification_metrics([], [])
+        assert acc == 0.0
+
+
+# =====================================================================
+# Metrics: compute_metrics (integration)
+# =====================================================================
+
+
+class TestComputeMetrics:
+    def test_returns_query_metrics(self):
+        ranked = [1, 2, 3, 4, 5]
+        relevant = {1, 2}
+        qm = compute_metrics(ranked, relevant, "test query", "test_cat", k_values=[2, 3])
+        assert isinstance(qm, QueryMetrics)
+        assert qm.query_text == "test query"
+        assert qm.target_category == "test_cat"
+        assert qm.average_precision == pytest.approx(1.0)
+        assert qm.num_relevant == 2
+        assert qm.num_total == 5
+        assert 2 in qm.precision_at_k
+        assert 3 in qm.recall_at_k
+
+
+# =====================================================================
+# Metrics: DatasetResult
+# =====================================================================
+
+
+class TestDatasetResult:
+    def test_mean_average_precision(self):
+        dr = DatasetResult(dataset_id="test", media_type="audio")
+        dr.text_sort = [
+            QueryMetrics("q1", "cat1", average_precision=0.8, num_relevant=5, num_total=20),
+            QueryMetrics("q2", "cat2", average_precision=0.6, num_relevant=5, num_total=20),
+        ]
+        assert dr.mean_average_precision == pytest.approx(0.7)
+
+    def test_mean_learned_f1(self):
+        dr = DatasetResult(dataset_id="test", media_type="image")
+        dr.learned_sort = [
+            LearnedSortMetrics(accuracy=0.9, precision=0.8, recall=0.7, f1=0.75, num_train=10, num_test=10),
+            LearnedSortMetrics(accuracy=0.85, precision=0.8, recall=0.9, f1=0.85, num_train=10, num_test=10),
+        ]
+        assert dr.mean_learned_f1 == pytest.approx(0.8)
+
+    def test_empty_results(self):
+        dr = DatasetResult(dataset_id="empty", media_type="audio")
+        assert dr.mean_average_precision == 0.0
+        assert dr.mean_learned_f1 == 0.0
+
+    def test_to_dict_has_expected_keys(self):
+        dr = DatasetResult(dataset_id="test", media_type="audio")
+        dr.text_sort = [
+            QueryMetrics(
+                "q1",
+                "cat1",
+                average_precision=0.8,
+                num_relevant=5,
+                num_total=20,
+                precision_at_k={5: 0.6},
+                recall_at_k={5: 0.3},
+            ),
+        ]
+        d = dr.to_dict()
+        assert d["dataset_id"] == "test"
+        assert d["media_type"] == "audio"
+        assert "text_sort" in d
+        assert d["text_sort"]["mAP"] == 0.8
+        assert len(d["text_sort"]["per_query"]) == 1
+
+    def test_to_dict_learned(self):
+        dr = DatasetResult(dataset_id="test", media_type="image")
+        dr.learned_sort = [
+            LearnedSortMetrics(
+                accuracy=0.9, precision=0.8, recall=0.7, f1=0.75, num_train=10, num_test=10, target_category="cat1"
+            ),
+        ]
+        d = dr.to_dict()
+        assert "learned_sort" in d
+        assert d["learned_sort"]["mean_f1"] == 0.75
+
+
+# =====================================================================
+# Config
+# =====================================================================
+
+
+class TestEvalConfig:
+    def test_all_eval_datasets_have_queries(self):
+        for ds_id, ds_cfg in EVAL_DATASETS.items():
+            assert "queries" in ds_cfg, f"{ds_id} missing queries"
+            assert len(ds_cfg["queries"]) > 0, f"{ds_id} has no queries"
+            for q in ds_cfg["queries"]:
+                assert isinstance(q, EvalQuery)
+                assert q.text.strip(), f"{ds_id}: empty query text"
+                assert q.target_category.strip(), f"{ds_id}: empty target_category"
+
+    def test_all_eval_datasets_reference_demo_datasets(self):
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        for ds_id, ds_cfg in EVAL_DATASETS.items():
+            demo_id = ds_cfg["demo_dataset"]
+            assert demo_id in DEMO_DATASETS, f"eval {ds_id} references missing demo dataset {demo_id}"
+
+    def test_query_categories_match_demo_categories(self):
+        """Every query's target_category must appear in the demo dataset's category list."""
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        for ds_id, ds_cfg in EVAL_DATASETS.items():
+            demo_id = ds_cfg["demo_dataset"]
+            demo_cats = set(DEMO_DATASETS[demo_id]["categories"])
+            for q in ds_cfg["queries"]:
+                assert q.target_category in demo_cats, (
+                    f"eval {ds_id}: query target {q.target_category!r} not in demo categories {demo_cats}"
+                )
+
+
+# =====================================================================
+# Runner: _cosine_similarity
+# =====================================================================
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self):
+        v = np.array([1.0, 0.0, 0.0])
+        assert _cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self):
+        a = np.array([1.0, 0.0])
+        b = np.array([0.0, 1.0])
+        assert _cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_opposite_vectors(self):
+        a = np.array([1.0, 0.0])
+        b = np.array([-1.0, 0.0])
+        assert _cosine_similarity(a, b) == pytest.approx(-1.0)
+
+    def test_zero_vector(self):
+        a = np.array([0.0, 0.0])
+        b = np.array([1.0, 0.0])
+        assert _cosine_similarity(a, b) == 0.0
+
+
+# =====================================================================
+# Runner: eval_text_sort with synthetic clips
+# =====================================================================
+
+
+class TestEvalTextSort:
+    """Test eval_text_sort using mocked embeddings."""
+
+    def _make_synthetic_clips(self):
+        """Create clips with known embeddings: cats point one way, dogs another."""
+        rng = np.random.RandomState(0)
+        clips = {}
+        clip_id = 1
+        # "cat" clips cluster around [1, 0, 0, ...]
+        cat_dir = np.zeros(16)
+        cat_dir[0] = 1.0
+        for _ in range(10):
+            emb = cat_dir + rng.normal(0, 0.05, 16)
+            emb /= np.linalg.norm(emb)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "cat", "type": "image"}
+            clip_id += 1
+        # "dog" clips cluster around [0, 1, 0, ...]
+        dog_dir = np.zeros(16)
+        dog_dir[1] = 1.0
+        for _ in range(10):
+            emb = dog_dir + rng.normal(0, 0.05, 16)
+            emb /= np.linalg.norm(emb)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "dog", "type": "image"}
+            clip_id += 1
+        return clips, cat_dir, dog_dir
+
+    def test_text_sort_separates_categories(self):
+        clips, cat_dir, dog_dir = self._make_synthetic_clips()
+
+        queries = [
+            EvalQuery("a cat", "cat"),
+            EvalQuery("a dog", "dog"),
+        ]
+
+        # Mock embed_text_query to return the cluster centre
+        def mock_embed(text, media_type):
+            if "cat" in text:
+                return cat_dir.copy()
+            return dog_dir.copy()
+
+        with patch("vtsearch.models.embeddings.embed_text_query", side_effect=mock_embed):
+            results = eval_text_sort(clips, queries, "image", k_values=[5, 10])
+
+        assert len(results) == 2
+        # With clean clusters, AP should be very high
+        for qm in results:
+            assert qm.average_precision > 0.9
+            assert qm.num_relevant == 10
+
+    def test_text_sort_returns_correct_fields(self):
+        clips, cat_dir, _ = self._make_synthetic_clips()
+        queries = [EvalQuery("a cat", "cat")]
+
+        with patch("vtsearch.models.embeddings.embed_text_query", return_value=cat_dir.copy()):
+            results = eval_text_sort(clips, queries, "image", k_values=[5])
+
+        qm = results[0]
+        assert qm.query_text == "a cat"
+        assert qm.target_category == "cat"
+        assert 5 in qm.precision_at_k
+        assert 5 in qm.recall_at_k
+        assert qm.num_total == 20
+
+
+# =====================================================================
+# Runner: eval_learned_sort with synthetic clips
+# =====================================================================
+
+
+class TestEvalLearnedSort:
+    def _make_synthetic_clips(self, dim=16, n_per_cat=20):
+        """Two categories with separable embeddings."""
+        rng = np.random.RandomState(42)
+        clips = {}
+        clip_id = 1
+        for _ in range(n_per_cat):
+            emb = rng.normal(1.0, 0.3, dim).astype(np.float32)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "cat_a", "type": "image"}
+            clip_id += 1
+        for _ in range(n_per_cat):
+            emb = rng.normal(-1.0, 0.3, dim).astype(np.float32)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "cat_b", "type": "image"}
+            clip_id += 1
+        return clips
+
+    def test_learned_sort_returns_metrics(self):
+        clips = self._make_synthetic_clips()
+        queries = [EvalQuery("category a stuff", "cat_a")]
+        results = eval_learned_sort(clips, queries, train_fraction=0.5, seed=42)
+        assert len(results) == 1
+        lm = results[0]
+        assert lm.target_category == "cat_a"
+        assert 0.0 <= lm.accuracy <= 1.0
+        assert 0.0 <= lm.f1 <= 1.0
+        assert lm.num_train > 0
+        assert lm.num_test > 0
+
+    def test_learned_sort_well_separated_categories(self):
+        """With well-separated embeddings, learned sort should get high F1."""
+        clips = self._make_synthetic_clips(n_per_cat=30)
+        queries = [EvalQuery("a", "cat_a")]
+        results = eval_learned_sort(clips, queries, train_fraction=0.5, seed=42)
+        assert results[0].f1 > 0.7  # generous threshold for small synthetic data
+
+    def test_learned_sort_skips_tiny_categories(self):
+        """Categories with < 2 clips should be skipped."""
+        clips = {
+            1: {"id": 1, "embedding": np.ones(8, dtype=np.float32), "category": "rare", "type": "image"},
+            2: {"id": 2, "embedding": -np.ones(8, dtype=np.float32), "category": "common", "type": "image"},
+        }
+        queries = [EvalQuery("rare stuff", "rare")]
+        results = eval_learned_sort(clips, queries, train_fraction=0.5)
+        assert len(results) == 0  # skipped due to too few clips
+
+
+# =====================================================================
+# Runner: format_results_json
+# =====================================================================
+
+
+class TestFormatResults:
+    def test_valid_json(self):
+        dr = DatasetResult(dataset_id="test", media_type="audio")
+        dr.text_sort = [
+            QueryMetrics(
+                "q1",
+                "cat1",
+                average_precision=0.9,
+                num_relevant=5,
+                num_total=20,
+                precision_at_k={5: 0.8},
+                recall_at_k={5: 0.4},
+            ),
+        ]
+        result = format_results_json([dr])
+        parsed = json.loads(result)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["dataset_id"] == "test"

--- a/vtsearch/eval/__init__.py
+++ b/vtsearch/eval/__init__.py
@@ -1,0 +1,12 @@
+"""Evaluation framework for VTSearch sorting quality."""
+
+from vtsearch.eval.config import EVAL_DATASETS, EvalQuery
+from vtsearch.eval.metrics import compute_metrics
+from vtsearch.eval.runner import run_eval
+
+__all__ = [
+    "EVAL_DATASETS",
+    "EvalQuery",
+    "compute_metrics",
+    "run_eval",
+]

--- a/vtsearch/eval/__main__.py
+++ b/vtsearch/eval/__main__.py
@@ -1,0 +1,133 @@
+"""CLI entry point for the VTSearch evaluation framework.
+
+Usage::
+
+    # Run all evaluations (text-sort + learned-sort) on all datasets
+    python -m vtsearch.eval
+
+    # Only text-sort evaluation
+    python -m vtsearch.eval --mode text
+
+    # Only learned-sort evaluation
+    python -m vtsearch.eval --mode learned
+
+    # Evaluate specific datasets
+    python -m vtsearch.eval --datasets animals_images vehicles_images
+
+    # Custom train/test split for learned-sort
+    python -m vtsearch.eval --mode learned --train-fraction 0.6
+
+    # Save results as JSON
+    python -m vtsearch.eval --output results.json
+
+    # List available eval datasets
+    python -m vtsearch.eval --list
+"""
+
+import argparse
+import sys
+
+# Ensure models are initialised (creates cache dirs, sets thread counts)
+from vtsearch.models import initialize_models
+
+initialize_models()
+
+from vtsearch.eval.config import EVAL_DATASETS
+from vtsearch.eval.runner import format_results_json, run_eval
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m vtsearch.eval",
+        description="Evaluate VTSearch text-sort and learned-sort quality on demo datasets.",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=None,
+        metavar="ID",
+        help="Eval dataset IDs to run (default: all).  Use --list to see available IDs.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["text", "learned", "both"],
+        default="both",
+        help="Which evaluation to run (default: both).",
+    )
+    parser.add_argument(
+        "--k",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="K",
+        help="k values for P@k / R@k (default: 5 10 20).",
+    )
+    parser.add_argument(
+        "--train-fraction",
+        type=float,
+        default=0.5,
+        help="Fraction of clips used for training in learned-sort eval (default: 0.5).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducible splits (default: 42).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        metavar="FILE",
+        help="Write JSON results to FILE.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available eval datasets and exit.",
+    )
+
+    args = parser.parse_args()
+
+    if args.list:
+        print("Available eval datasets:\n")
+        for ds_id, ds_cfg in sorted(EVAL_DATASETS.items()):
+            queries = ds_cfg["queries"]
+            cats = ", ".join(q.target_category for q in queries)
+            print(f"  {ds_id}")
+            print(f"    demo dataset: {ds_cfg['demo_dataset']}")
+            print(f"    categories:   {cats}")
+            print(f"    queries:      {len(queries)}")
+            print()
+        sys.exit(0)
+
+    results = run_eval(
+        dataset_ids=args.datasets,
+        mode=args.mode,
+        k_values=args.k,
+        train_fraction=args.train_fraction,
+        seed=args.seed,
+    )
+
+    # Print summary
+    print(f"\n{'=' * 60}")
+    print("SUMMARY")
+    print(f"{'=' * 60}")
+    for r in results:
+        line = f"  {r.dataset_id:25s}"
+        if r.text_sort:
+            line += f"  mAP={r.mean_average_precision:.4f}"
+        if r.learned_sort:
+            line += f"  mean_F1={r.mean_learned_f1:.4f}"
+        print(line)
+
+    # Optionally write JSON
+    if args.output:
+        json_str = format_results_json(results)
+        with open(args.output, "w") as f:
+            f.write(json_str)
+        print(f"\nResults written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vtsearch/eval/config.py
+++ b/vtsearch/eval/config.py
@@ -1,0 +1,154 @@
+"""Eval dataset configurations built from demo datasets.
+
+Each eval dataset wraps a demo dataset and adds per-category text
+descriptions — the queries a user would type in the Text Sort box.
+
+The ``EVAL_DATASETS`` dict is keyed by demo dataset ID.  Each value is
+a dict with:
+
+- ``"demo_dataset"``: the demo dataset ID to load
+- ``"queries"``: list of :class:`EvalQuery`, one per category
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EvalQuery:
+    """One evaluation query: a text description targeting a single category."""
+
+    text: str
+    """The natural-language query to embed (what a user would type)."""
+
+    target_category: str
+    """The ground-truth category name that should rank highest."""
+
+
+# ------------------------------------------------------------------
+# Audio eval datasets  (ESC-50)
+# ------------------------------------------------------------------
+
+_NATURE_SOUNDS_QUERIES = [
+    EvalQuery("birds singing and chirping", "chirping_birds"),
+    EvalQuery("a crow cawing", "crow"),
+    EvalQuery("frogs croaking near a pond", "frog"),
+    EvalQuery("buzzing insects", "insects"),
+    EvalQuery("rain falling", "rain"),
+    EvalQuery("ocean waves crashing on shore", "sea_waves"),
+    EvalQuery("thunderstorm with loud thunder", "thunderstorm"),
+    EvalQuery("strong wind blowing", "wind"),
+    EvalQuery("dripping water drops", "water_drops"),
+    EvalQuery("crickets chirping at night", "crickets"),
+]
+
+_CITY_SOUNDS_QUERIES = [
+    EvalQuery("a car horn honking", "car_horn"),
+    EvalQuery("emergency siren wailing", "siren"),
+    EvalQuery("engine running and revving", "engine"),
+    EvalQuery("a train passing by on rails", "train"),
+    EvalQuery("helicopter flying overhead", "helicopter"),
+    EvalQuery("vacuum cleaner running", "vacuum_cleaner"),
+    EvalQuery("washing machine spinning", "washing_machine"),
+    EvalQuery("an alarm clock ringing", "clock_alarm"),
+    EvalQuery("someone typing on a keyboard", "keyboard_typing"),
+    EvalQuery("knocking on a wooden door", "door_wood_knock"),
+]
+
+# ------------------------------------------------------------------
+# Image eval datasets  (CIFAR-10)
+# ------------------------------------------------------------------
+
+_ANIMALS_IMAGES_QUERIES = [
+    EvalQuery("a photograph of a bird", "bird"),
+    EvalQuery("a photograph of a cat", "cat"),
+    EvalQuery("a photograph of a deer", "deer"),
+    EvalQuery("a photograph of a dog", "dog"),
+    EvalQuery("a photograph of a frog", "frog"),
+    EvalQuery("a photograph of a horse", "horse"),
+]
+
+_VEHICLES_IMAGES_QUERIES = [
+    EvalQuery("a photograph of an airplane", "airplane"),
+    EvalQuery("a photograph of a car", "automobile"),
+    EvalQuery("a photograph of a ship", "ship"),
+    EvalQuery("a photograph of a truck", "truck"),
+]
+
+# ------------------------------------------------------------------
+# Text / paragraph eval datasets  (20 Newsgroups)
+# ------------------------------------------------------------------
+
+_WORLD_NEWS_QUERIES = [
+    EvalQuery("international politics and world affairs", "world"),
+    EvalQuery("buying and selling goods and products", "business"),
+]
+
+_SPORTS_SCIENCE_QUERIES = [
+    EvalQuery("baseball games and athletic competition", "sports"),
+    EvalQuery("outer space exploration and astronomy", "science"),
+]
+
+# ------------------------------------------------------------------
+# Video eval datasets  (UCF-101)
+# ------------------------------------------------------------------
+
+_ACTIVITIES_VIDEO_QUERIES = [
+    EvalQuery("someone applying eye makeup", "ApplyEyeMakeup"),
+    EvalQuery("someone applying lipstick", "ApplyLipstick"),
+    EvalQuery("someone brushing their teeth", "BrushingTeeth"),
+    EvalQuery("a person playing drums", "Drumming"),
+    EvalQuery("a person doing yo-yo tricks", "YoYo"),
+]
+
+_SPORTS_VIDEO_QUERIES = [
+    EvalQuery("a person diving off a cliff", "CliffDiving"),
+    EvalQuery("someone walking on their hands", "HandstandWalking"),
+    EvalQuery("a person jumping rope", "JumpRope"),
+    EvalQuery("someone doing push-ups", "PushUps"),
+    EvalQuery("a person practicing tai chi", "TaiChi"),
+]
+
+# ------------------------------------------------------------------
+# Registry — keyed by demo dataset ID
+# ------------------------------------------------------------------
+
+EVAL_DATASETS: dict[str, dict] = {
+    # Audio
+    "nature_sounds": {
+        "demo_dataset": "nature_sounds",
+        "queries": _NATURE_SOUNDS_QUERIES,
+    },
+    "city_sounds": {
+        "demo_dataset": "city_sounds",
+        "queries": _CITY_SOUNDS_QUERIES,
+    },
+    # Image
+    "animals_images": {
+        "demo_dataset": "animals_images",
+        "queries": _ANIMALS_IMAGES_QUERIES,
+    },
+    "vehicles_images": {
+        "demo_dataset": "vehicles_images",
+        "queries": _VEHICLES_IMAGES_QUERIES,
+    },
+    # Text
+    "world_news": {
+        "demo_dataset": "world_news",
+        "queries": _WORLD_NEWS_QUERIES,
+    },
+    "sports_science_news": {
+        "demo_dataset": "sports_science_news",
+        "queries": _SPORTS_SCIENCE_QUERIES,
+    },
+    # Video
+    "activities_video": {
+        "demo_dataset": "activities_video",
+        "queries": _ACTIVITIES_VIDEO_QUERIES,
+    },
+    "sports_video": {
+        "demo_dataset": "sports_video",
+        "queries": _SPORTS_VIDEO_QUERIES,
+    },
+}

--- a/vtsearch/eval/metrics.py
+++ b/vtsearch/eval/metrics.py
@@ -1,0 +1,216 @@
+"""Ranking and classification metrics for evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class QueryMetrics:
+    """Metrics for a single text-sort query against one target category."""
+
+    query_text: str
+    target_category: str
+    average_precision: float
+    precision_at_k: dict[int, float] = field(default_factory=dict)
+    recall_at_k: dict[int, float] = field(default_factory=dict)
+    num_relevant: int = 0
+    num_total: int = 0
+
+
+@dataclass
+class LearnedSortMetrics:
+    """Metrics for a single learned-sort evaluation fold."""
+
+    accuracy: float
+    precision: float
+    recall: float
+    f1: float
+    num_train: int
+    num_test: int
+    target_category: str = ""
+
+
+@dataclass
+class DatasetResult:
+    """Aggregated results for one eval dataset."""
+
+    dataset_id: str
+    media_type: str
+    text_sort: list[QueryMetrics] = field(default_factory=list)
+    learned_sort: list[LearnedSortMetrics] = field(default_factory=list)
+
+    @property
+    def mean_average_precision(self) -> float:
+        """Mean AP across all text-sort queries (mAP)."""
+        if not self.text_sort:
+            return 0.0
+        return float(np.mean([q.average_precision for q in self.text_sort]))
+
+    @property
+    def mean_learned_f1(self) -> float:
+        """Mean F1 across all learned-sort folds."""
+        if not self.learned_sort:
+            return 0.0
+        return float(np.mean([f.f1 for f in self.learned_sort]))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict for JSON output."""
+        result: dict[str, Any] = {
+            "dataset_id": self.dataset_id,
+            "media_type": self.media_type,
+        }
+
+        if self.text_sort:
+            result["text_sort"] = {
+                "mAP": round(self.mean_average_precision, 4),
+                "per_query": [
+                    {
+                        "query": q.query_text,
+                        "target_category": q.target_category,
+                        "AP": round(q.average_precision, 4),
+                        "num_relevant": q.num_relevant,
+                        "precision_at_k": {str(k): round(v, 4) for k, v in sorted(q.precision_at_k.items())},
+                        "recall_at_k": {str(k): round(v, 4) for k, v in sorted(q.recall_at_k.items())},
+                    }
+                    for q in self.text_sort
+                ],
+            }
+
+        if self.learned_sort:
+            result["learned_sort"] = {
+                "mean_f1": round(self.mean_learned_f1, 4),
+                "per_category": [
+                    {
+                        "target_category": f.target_category,
+                        "accuracy": round(f.accuracy, 4),
+                        "precision": round(f.precision, 4),
+                        "recall": round(f.recall, 4),
+                        "f1": round(f.f1, 4),
+                        "num_train": f.num_train,
+                        "num_test": f.num_test,
+                    }
+                    for f in self.learned_sort
+                ],
+            }
+
+        return result
+
+
+def compute_average_precision(ranked_ids: list[int], relevant_ids: set[int]) -> float:
+    """Compute Average Precision for a ranked list of clip IDs.
+
+    AP = sum over relevant positions of (precision@k) / num_relevant.
+
+    Args:
+        ranked_ids: Clip IDs in descending order of predicted relevance.
+        relevant_ids: Set of clip IDs that are actually relevant (match target category).
+
+    Returns:
+        Average Precision score in [0, 1].  Returns 0 if no relevant items exist.
+    """
+    if not relevant_ids:
+        return 0.0
+
+    hits = 0
+    sum_precisions = 0.0
+    for i, cid in enumerate(ranked_ids):
+        if cid in relevant_ids:
+            hits += 1
+            sum_precisions += hits / (i + 1)
+
+    return sum_precisions / len(relevant_ids)
+
+
+def compute_precision_recall_at_k(
+    ranked_ids: list[int],
+    relevant_ids: set[int],
+    k_values: list[int] | None = None,
+) -> tuple[dict[int, float], dict[int, float]]:
+    """Compute precision@k and recall@k for several values of k.
+
+    Args:
+        ranked_ids: Clip IDs in descending order of predicted relevance.
+        relevant_ids: Set of clip IDs that are actually relevant.
+        k_values: List of k values to evaluate.  Defaults to [5, 10, 20].
+
+    Returns:
+        Tuple of (precision_at_k, recall_at_k) dicts keyed by k.
+    """
+    if k_values is None:
+        k_values = [5, 10, 20]
+
+    num_relevant = len(relevant_ids)
+    precision_at_k: dict[int, float] = {}
+    recall_at_k: dict[int, float] = {}
+
+    for k in k_values:
+        top_k = set(ranked_ids[:k])
+        hits = len(top_k & relevant_ids)
+        precision_at_k[k] = hits / k if k > 0 else 0.0
+        recall_at_k[k] = hits / num_relevant if num_relevant > 0 else 0.0
+
+    return precision_at_k, recall_at_k
+
+
+def compute_metrics(
+    ranked_ids: list[int],
+    relevant_ids: set[int],
+    query_text: str,
+    target_category: str,
+    k_values: list[int] | None = None,
+) -> QueryMetrics:
+    """Compute all text-sort metrics for a single query.
+
+    Args:
+        ranked_ids: Clip IDs sorted by descending similarity.
+        relevant_ids: Clip IDs belonging to the target category.
+        query_text: The text query used.
+        target_category: The category name targeted.
+        k_values: Optional list of k values for P@k / R@k.
+
+    Returns:
+        A :class:`QueryMetrics` with AP, P@k, and R@k populated.
+    """
+    ap = compute_average_precision(ranked_ids, relevant_ids)
+    p_at_k, r_at_k = compute_precision_recall_at_k(ranked_ids, relevant_ids, k_values)
+
+    return QueryMetrics(
+        query_text=query_text,
+        target_category=target_category,
+        average_precision=ap,
+        precision_at_k=p_at_k,
+        recall_at_k=r_at_k,
+        num_relevant=len(relevant_ids),
+        num_total=len(ranked_ids),
+    )
+
+
+def compute_binary_classification_metrics(
+    predictions: list[int],
+    labels: list[int],
+) -> tuple[float, float, float, float]:
+    """Compute accuracy, precision, recall, F1 for binary predictions.
+
+    Args:
+        predictions: List of 0/1 predicted labels.
+        labels: List of 0/1 ground-truth labels.
+
+    Returns:
+        Tuple of (accuracy, precision, recall, f1).
+    """
+    tp = sum(p == 1 and gt == 1 for p, gt in zip(predictions, labels))
+    fp = sum(p == 1 and gt == 0 for p, gt in zip(predictions, labels))
+    fn = sum(p == 0 and gt == 1 for p, gt in zip(predictions, labels))
+    tn = sum(p == 0 and gt == 0 for p, gt in zip(predictions, labels))
+
+    total = tp + fp + fn + tn
+    accuracy = (tp + tn) / total if total > 0 else 0.0
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+
+    return accuracy, precision, recall, f1

--- a/vtsearch/eval/runner.py
+++ b/vtsearch/eval/runner.py
@@ -1,0 +1,284 @@
+"""Eval runner — loads datasets and measures sorting quality.
+
+Two evaluation modes:
+
+1. **Text sort**: For each query, embed the text, rank all clips by cosine
+   similarity to the query embedding, and measure how well clips of the
+   target category float to the top (AP, P@k, R@k).
+
+2. **Learned sort**: For each category, randomly split its clips into
+   train/test.  Simulate votes (target = good, rest = bad) on the
+   train set, run ``train_and_score``, and measure classification
+   quality on the held-out test set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import numpy as np
+
+from vtsearch.eval.config import EVAL_DATASETS, EvalQuery
+from vtsearch.eval.metrics import (
+    DatasetResult,
+    LearnedSortMetrics,
+    compute_binary_classification_metrics,
+    compute_metrics,
+)
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    norm = np.linalg.norm(a) * np.linalg.norm(b)
+    if norm == 0:
+        return 0.0
+    return float(np.dot(a, b) / norm)
+
+
+def _run_text_sort_query(
+    query: EvalQuery,
+    clips: dict[int, dict[str, Any]],
+    media_type: str,
+) -> list[dict[str, Any]]:
+    """Embed the query text and rank clips by cosine similarity.
+
+    Returns a list of ``{"id": int, "similarity": float}`` sorted descending.
+    """
+    from vtsearch.models.embeddings import embed_text_query
+
+    text_vec = embed_text_query(query.text, media_type)
+    if text_vec is None:
+        raise RuntimeError(f"Could not embed query {query.text!r} for media type {media_type}")
+
+    results = []
+    for clip_id, clip in clips.items():
+        sim = _cosine_similarity(clip["embedding"], text_vec)
+        results.append({"id": clip_id, "similarity": sim})
+
+    results.sort(key=lambda x: x["similarity"], reverse=True)
+    return results
+
+
+def eval_text_sort(
+    clips: dict[int, dict[str, Any]],
+    queries: list[EvalQuery],
+    media_type: str,
+    k_values: list[int] | None = None,
+) -> list:
+    """Run text-sort evaluation for a list of queries.
+
+    For each query, computes AP, P@k, and R@k treating clips whose
+    ``"category"`` matches ``query.target_category`` as relevant.
+
+    Args:
+        clips: Loaded clip dict (``{id: clip_data}``).
+        queries: List of :class:`EvalQuery` to evaluate.
+        media_type: The media type string for embedding dispatch.
+        k_values: Optional k values for P@k/R@k.
+
+    Returns:
+        List of :class:`~vtsearch.eval.metrics.QueryMetrics`.
+    """
+    from vtsearch.eval.metrics import QueryMetrics
+
+    results: list[QueryMetrics] = []
+    for query in queries:
+        ranked = _run_text_sort_query(query, clips, media_type)
+        ranked_ids = [r["id"] for r in ranked]
+        relevant_ids = {cid for cid, c in clips.items() if c.get("category") == query.target_category}
+
+        qm = compute_metrics(ranked_ids, relevant_ids, query.text, query.target_category, k_values)
+        results.append(qm)
+
+    return results
+
+
+def eval_learned_sort(
+    clips: dict[int, dict[str, Any]],
+    queries: list[EvalQuery],
+    train_fraction: float = 0.5,
+    seed: int = 42,
+) -> list[LearnedSortMetrics]:
+    """Run learned-sort evaluation via simulated voting.
+
+    For each query/category:
+      1. Partition clips into target-category (positive) and others (negative).
+      2. Randomly split both pools into train and test by ``train_fraction``.
+      3. Build ``good_votes`` from train positives, ``bad_votes`` from train
+         negatives.
+      4. Call ``train_and_score`` on the full clip set.
+      5. Measure accuracy/precision/recall/F1 on the test set using the
+         cross-calibrated threshold.
+
+    Args:
+        clips: Loaded clip dict.
+        queries: List of :class:`EvalQuery` (one per category to test).
+        train_fraction: Fraction of clips to use for training (rest for test).
+        seed: Random seed for reproducible splits.
+
+    Returns:
+        List of :class:`LearnedSortMetrics`, one per query.
+    """
+    from vtsearch.models.training import train_and_score
+
+    rng = np.random.RandomState(seed)
+    results: list[LearnedSortMetrics] = []
+
+    for query in queries:
+        # Split clips into target vs. other
+        target_ids = [cid for cid, c in clips.items() if c.get("category") == query.target_category]
+        other_ids = [cid for cid, c in clips.items() if c.get("category") != query.target_category]
+
+        if len(target_ids) < 2 or len(other_ids) < 2:
+            continue  # not enough data
+
+        # Shuffle and split
+        rng.shuffle(target_ids)
+        rng.shuffle(other_ids)
+
+        n_target_train = max(1, int(len(target_ids) * train_fraction))
+        n_other_train = max(1, int(len(other_ids) * train_fraction))
+
+        train_good = target_ids[:n_target_train]
+        test_good = target_ids[n_target_train:]
+        train_bad = other_ids[:n_other_train]
+        test_bad = other_ids[n_other_train:]
+
+        if not test_good or not test_bad:
+            continue  # empty test set
+
+        # Build vote dicts
+        good_votes: dict[int, None] = {cid: None for cid in train_good}
+        bad_votes: dict[int, None] = {cid: None for cid in train_bad}
+
+        # Run train_and_score
+        scored, threshold = train_and_score(clips, good_votes, bad_votes)
+
+        # Evaluate on test set
+        score_map = {r["id"]: r["score"] for r in scored}
+        test_ids = test_good + test_bad
+        predictions = [1 if score_map.get(cid, 0) >= threshold else 0 for cid in test_ids]
+        labels = [1] * len(test_good) + [0] * len(test_bad)
+
+        acc, prec, rec, f1 = compute_binary_classification_metrics(predictions, labels)
+
+        results.append(
+            LearnedSortMetrics(
+                accuracy=acc,
+                precision=prec,
+                recall=rec,
+                f1=f1,
+                num_train=len(train_good) + len(train_bad),
+                num_test=len(test_ids),
+                target_category=query.target_category,
+            )
+        )
+
+    return results
+
+
+def run_eval(
+    dataset_ids: list[str] | None = None,
+    mode: str = "both",
+    k_values: list[int] | None = None,
+    train_fraction: float = 0.5,
+    seed: int = 42,
+) -> list[DatasetResult]:
+    """Run evaluation on one or more eval datasets.
+
+    This is the main entry point.  It loads the demo dataset (downloading
+    and embedding if needed), then runs text-sort and/or learned-sort
+    evaluation.
+
+    Args:
+        dataset_ids: Which eval datasets to run.  ``None`` means all.
+        mode: ``"text"`` for text-sort only, ``"learned"`` for learned-sort
+            only, ``"both"`` for both.
+        k_values: k values for P@k/R@k.
+        train_fraction: Train/test split ratio for learned-sort.
+        seed: Random seed.
+
+    Returns:
+        List of :class:`DatasetResult`, one per evaluated dataset.
+    """
+    from vtsearch.datasets.config import DEMO_DATASETS
+    from vtsearch.datasets.loader import load_demo_dataset
+
+    if dataset_ids is None:
+        dataset_ids = list(EVAL_DATASETS.keys())
+
+    all_results: list[DatasetResult] = []
+
+    for ds_id in dataset_ids:
+        if ds_id not in EVAL_DATASETS:
+            print(f"WARNING: unknown eval dataset {ds_id!r}, skipping", file=sys.stderr)
+            continue
+
+        eval_cfg = EVAL_DATASETS[ds_id]
+        demo_id = eval_cfg["demo_dataset"]
+
+        if demo_id not in DEMO_DATASETS:
+            print(f"WARNING: demo dataset {demo_id!r} not found, skipping {ds_id!r}", file=sys.stderr)
+            continue
+
+        demo_info = DEMO_DATASETS[demo_id]
+        media_type = demo_info.get("media_type", "audio")
+
+        print(f"\n{'=' * 60}")
+        print(f"Evaluating: {ds_id}  (media_type={media_type})")
+        print(f"{'=' * 60}")
+
+        # Load the demo dataset into a fresh clips dict
+        clips: dict[int, dict] = {}
+        try:
+            load_demo_dataset(demo_id, clips)
+        except Exception as e:
+            print(f"ERROR loading dataset {demo_id}: {e}", file=sys.stderr)
+            continue
+
+        print(f"Loaded {len(clips)} clips across categories: ", end="")
+        categories = sorted({c.get("category", "?") for c in clips.values()})
+        print(", ".join(categories))
+
+        queries = eval_cfg["queries"]
+        ds_result = DatasetResult(dataset_id=ds_id, media_type=media_type)
+
+        # --- Text sort ---
+        if mode in ("text", "both"):
+            print(f"\n--- Text Sort Evaluation ({len(queries)} queries) ---")
+            text_results = eval_text_sort(clips, queries, media_type, k_values)
+            ds_result.text_sort = text_results
+
+            for qm in text_results:
+                p5 = qm.precision_at_k.get(5, 0)
+                p10 = qm.precision_at_k.get(10, 0)
+                print(
+                    f"  [{qm.target_category:20s}] AP={qm.average_precision:.3f}  "
+                    f"P@5={p5:.2f}  P@10={p10:.2f}  "
+                    f"({qm.num_relevant} relevant / {qm.num_total} total)"
+                )
+            print(f"  mAP = {ds_result.mean_average_precision:.4f}")
+
+        # --- Learned sort ---
+        if mode in ("learned", "both"):
+            print(f"\n--- Learned Sort Evaluation ({len(queries)} categories) ---")
+            learned_results = eval_learned_sort(clips, queries, train_fraction, seed)
+            ds_result.learned_sort = learned_results
+
+            for lm in learned_results:
+                print(
+                    f"  [{lm.target_category:20s}] Acc={lm.accuracy:.3f}  "
+                    f"P={lm.precision:.3f}  R={lm.recall:.3f}  F1={lm.f1:.3f}  "
+                    f"(train={lm.num_train}, test={lm.num_test})"
+                )
+            print(f"  Mean F1 = {ds_result.mean_learned_f1:.4f}")
+
+        all_results.append(ds_result)
+
+    return all_results
+
+
+def format_results_json(results: list[DatasetResult]) -> str:
+    """Serialise a list of :class:`DatasetResult` to a JSON string."""
+    return json.dumps([r.to_dict() for r in results], indent=2)


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive evaluation framework for VTSearch that measures the quality of both text-sort (embedding-based ranking) and learned-sort (voting-based classification) features. The framework includes metrics computation, dataset configurations, a runner for executing evaluations, and a CLI interface.

## Key Changes

- **Metrics module** (`vtsearch/eval/metrics.py`): Implements core ranking and classification metrics
  - Average Precision (AP) for ranking quality
  - Precision@k and Recall@k for top-k evaluation
  - Binary classification metrics (accuracy, precision, recall, F1)
  - Data classes for organizing results (`QueryMetrics`, `LearnedSortMetrics`, `DatasetResult`)

- **Config module** (`vtsearch/eval/config.py`): Defines evaluation datasets and queries
  - `EvalQuery` dataclass for text descriptions targeting specific categories
  - `EVAL_DATASETS` registry mapping demo datasets to evaluation queries
  - Pre-configured queries for 8 evaluation datasets across audio, image, text, and video modalities

- **Runner module** (`vtsearch/eval/runner.py`): Orchestrates evaluation execution
  - `eval_text_sort()`: Embeds queries and ranks clips by cosine similarity, measuring AP/P@k/R@k
  - `eval_learned_sort()`: Simulates voting on train/test splits and measures classification quality
  - `run_eval()`: Main entry point that loads demo datasets and runs evaluations
  - `format_results_json()`: Serializes results to JSON

- **CLI module** (`vtsearch/eval/__main__.py`): Command-line interface
  - `--mode` flag to select text-sort, learned-sort, or both
  - `--datasets` flag to evaluate specific datasets
  - `--k` flag for custom P@k/R@k values
  - `--train-fraction` and `--seed` for learned-sort configuration
  - `--output` flag to save results as JSON
  - `--list` flag to display available datasets

- **Comprehensive test suite** (`tests/test_eval.py`): 431 lines of tests covering
  - All metric computation functions with edge cases
  - Config validation (dataset references, category matching)
  - Text-sort evaluation with synthetic embeddings
  - Learned-sort evaluation with separable synthetic data
  - JSON serialization

## Notable Implementation Details

- Evaluation uses synthetic data in tests (no real model downloads required)
- Text-sort evaluation treats clips matching the target category as relevant items
- Learned-sort evaluation simulates voting by splitting clips into train/test sets and using `train_and_score()`
- Cosine similarity is computed with zero-vector handling
- Results are aggregated with mean metrics (mAP, mean F1) for dataset-level summaries
- JSON output includes per-query/per-category breakdowns alongside aggregate metrics

https://claude.ai/code/session_013iwkAJQLQQC7Dzrq3BunHh