### PR TITLE
Add voting-iterations evaluation framework

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -40,6 +40,7 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu \
   Pillow \
   ultralytics \
   sentence-transformers \
+  pandas \
   --ignore-installed blinker \
   -q
 

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -8,6 +8,7 @@ requests
 tqdm
 scikit-learn
 transformers
+pandas
 
 # Per-media-type packages — listed inline here (instead of via -r includes)
 # because this file uses version pins for CPU compatibility.

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -2,6 +2,7 @@
 flask
 numpy
 torch
+pandas
 laion_clap
 librosa
 requests

--- a/tests/test_eval_voting_iterations.py
+++ b/tests/test_eval_voting_iterations.py
@@ -1,0 +1,306 @@
+"""Tests for the voting-iterations evaluation framework.
+
+All tests use small synthetic datasets with known, well-separated
+embeddings so no real model downloads are needed.
+"""
+
+import numpy as np
+import pandas as pd
+
+from vtsearch.eval.voting_iterations import (
+    _inclusion_weights,
+    _make_vote_sequence,
+    _split_clip_ids,
+    run_voting_iterations_eval,
+    simulate_voting_iterations,
+)
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_separable_clips(dim=16, n_per_cat=20, seed=0):
+    """Two categories with well-separated embeddings.
+
+    Category "alpha" clusters around [+1, 0, 0, ...],
+    category "beta"  clusters around [-1, 0, 0, ...].
+    """
+    rng = np.random.RandomState(seed)
+    clips = {}
+    clip_id = 1
+    for _ in range(n_per_cat):
+        emb = rng.normal(1.0, 0.2, dim).astype(np.float32)
+        clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "alpha"}
+        clip_id += 1
+    for _ in range(n_per_cat):
+        emb = rng.normal(-1.0, 0.2, dim).astype(np.float32)
+        clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "beta"}
+        clip_id += 1
+    return clips
+
+
+def _make_overlapping_clips(dim=16, n_per_cat=20, seed=0):
+    """Two categories with overlapping embeddings (harder to classify).
+
+    Category "alpha" centred at [+0.3, 0, 0, ...],
+    category "beta"  centred at [-0.3, 0, 0, ...], with large noise.
+    """
+    rng = np.random.RandomState(seed)
+    clips = {}
+    clip_id = 1
+    for _ in range(n_per_cat):
+        emb = rng.normal(0.3, 1.0, dim).astype(np.float32)
+        clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "alpha"}
+        clip_id += 1
+    for _ in range(n_per_cat):
+        emb = rng.normal(-0.3, 1.0, dim).astype(np.float32)
+        clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "beta"}
+        clip_id += 1
+    return clips
+
+
+def _make_three_category_clips(dim=16, n_per_cat=15, seed=0):
+    """Three categories: alpha, beta, gamma."""
+    rng = np.random.RandomState(seed)
+    clips = {}
+    clip_id = 1
+    centres = {"alpha": 1.0, "beta": -1.0, "gamma": 0.0}
+    for cat, centre in centres.items():
+        for _ in range(n_per_cat):
+            emb = rng.normal(centre, 0.2, dim).astype(np.float32)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": cat}
+            clip_id += 1
+    return clips
+
+
+# ------------------------------------------------------------------
+# Unit tests: helpers
+# ------------------------------------------------------------------
+
+
+class TestInclusionWeights:
+    def test_zero_inclusion(self):
+        fpr_w, fnr_w = _inclusion_weights(0)
+        assert fpr_w == 1.0
+        assert fnr_w == 1.0
+
+    def test_positive_inclusion(self):
+        fpr_w, fnr_w = _inclusion_weights(3)
+        assert fpr_w == 1.0
+        assert fnr_w == 8.0
+
+    def test_negative_inclusion(self):
+        fpr_w, fnr_w = _inclusion_weights(-2)
+        assert fpr_w == 4.0
+        assert fnr_w == 1.0
+
+
+class TestSplitClipIds:
+    def test_split_sizes(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rng = np.random.RandomState(42)
+        sim, test = _split_clip_ids(clips, 0.5, rng)
+        assert len(sim) + len(test) == len(clips)
+        assert len(sim) == 10
+        assert len(test) == 10
+
+    def test_no_overlap(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rng = np.random.RandomState(42)
+        sim, test = _split_clip_ids(clips, 0.5, rng)
+        assert set(sim).isdisjoint(set(test))
+
+    def test_deterministic(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rng1 = np.random.RandomState(42)
+        sim1, test1 = _split_clip_ids(clips, 0.5, rng1)
+        rng2 = np.random.RandomState(42)
+        sim2, test2 = _split_clip_ids(clips, 0.5, rng2)
+        assert sim1 == sim2
+        assert test1 == test2
+
+
+class TestMakeVoteSequence:
+    def test_all_clips_voted(self):
+        clips = _make_separable_clips(n_per_cat=5)
+        sim_ids = list(clips.keys())[:5]
+        rng = np.random.RandomState(42)
+        seq = _make_vote_sequence(sim_ids, clips, "alpha", rng)
+        assert len(seq) == 5
+        assert {cid for cid, _ in seq} == set(sim_ids)
+
+    def test_labels_match_category(self):
+        clips = _make_separable_clips(n_per_cat=5)
+        sim_ids = list(clips.keys())
+        rng = np.random.RandomState(42)
+        seq = _make_vote_sequence(sim_ids, clips, "alpha", rng)
+        for cid, label in seq:
+            expected = "good" if clips[cid]["category"] == "alpha" else "bad"
+            assert label == expected
+
+
+# ------------------------------------------------------------------
+# Unit tests: simulate_voting_iterations
+# ------------------------------------------------------------------
+
+
+class TestSimulateVotingIterations:
+    def test_returns_rows(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(
+            clips, target_category="alpha", seed=42,
+            dataset_name="test_ds", inclusion=0, sim_fraction=0.5,
+        )
+        assert len(rows) > 0
+
+    def test_row_schema(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(
+            clips, target_category="alpha", seed=42,
+            dataset_name="test_ds",
+        )
+        expected_keys = {"seed", "dataset", "category", "t", "cost", "fpr", "fnr"}
+        for row in rows:
+            assert set(row.keys()) == expected_keys
+
+    def test_seed_determinism(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rows1 = simulate_voting_iterations(clips, "alpha", seed=42)
+        rows2 = simulate_voting_iterations(clips, "alpha", seed=42)
+        assert len(rows1) == len(rows2)
+        for r1, r2 in zip(rows1, rows2):
+            assert r1 == r2
+
+    def test_different_seeds_differ(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rows1 = simulate_voting_iterations(clips, "alpha", seed=42)
+        rows2 = simulate_voting_iterations(clips, "alpha", seed=99)
+        # Different seeds should produce different vote orderings / splits,
+        # so the t-indexed costs should differ (not guaranteed for every row,
+        # but at least the full sequence should differ).
+        costs1 = [r["cost"] for r in rows1]
+        costs2 = [r["cost"] for r in rows2]
+        assert costs1 != costs2
+
+    def test_t_values_monotonically_increase(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(clips, "alpha", seed=42)
+        t_vals = [r["t"] for r in rows]
+        assert t_vals == sorted(t_vals)
+        # t starts >=2 because we need at least 1 good + 1 bad
+        assert all(t >= 2 for t in t_vals)
+
+    def test_cost_decreases_over_time_for_overlapping_data(self):
+        """With overlapping data, cost should generally decrease as more votes come in."""
+        clips = _make_overlapping_clips(n_per_cat=30, dim=16)
+        rows = simulate_voting_iterations(
+            clips, "alpha", seed=42, sim_fraction=0.5,
+        )
+        costs = [r["cost"] for r in rows]
+        # Compare average of first quarter vs last quarter
+        n = len(costs)
+        q = max(1, n // 4)
+        early_avg = sum(costs[:q]) / q
+        late_avg = sum(costs[-q:]) / q
+        assert late_avg <= early_avg
+
+    def test_empty_when_no_test_positives(self):
+        """If all clips of target category land in sim, test set has no positives -> empty."""
+        # Only 1 clip of target category — likely all end up in sim with 50% split
+        clips = {
+            1: {"id": 1, "embedding": np.ones(8, dtype=np.float32), "category": "rare"},
+            2: {"id": 2, "embedding": -np.ones(8, dtype=np.float32), "category": "common"},
+            3: {"id": 3, "embedding": -np.ones(8, dtype=np.float32) * 0.9, "category": "common"},
+            4: {"id": 4, "embedding": -np.ones(8, dtype=np.float32) * 0.8, "category": "common"},
+        }
+        rows = simulate_voting_iterations(clips, "rare", seed=42, sim_fraction=0.5)
+        # Might be empty or not depending on split — just shouldn't crash
+        assert isinstance(rows, list)
+
+    def test_inclusion_affects_cost(self):
+        """With overlapping data, different inclusion values produce different costs."""
+        clips = _make_overlapping_clips(n_per_cat=20)
+        rows_inc0 = simulate_voting_iterations(clips, "alpha", seed=42, inclusion=0)
+        rows_inc5 = simulate_voting_iterations(clips, "alpha", seed=42, inclusion=5)
+        # Same splits but different inclusion -> costs should differ
+        costs0 = [r["cost"] for r in rows_inc0]
+        costs5 = [r["cost"] for r in rows_inc5]
+        assert costs0 != costs5
+
+
+# ------------------------------------------------------------------
+# Integration test: run_voting_iterations_eval
+# ------------------------------------------------------------------
+
+
+class TestRunVotingIterationsEval:
+    def test_returns_dataframe(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips},
+            seeds=[42],
+            categories={"ds1": ["alpha"]},
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["seed", "dataset", "category", "t", "cost", "fpr", "fnr"]
+
+    def test_multiple_seeds(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips},
+            seeds=[1, 2, 3],
+            categories={"ds1": ["alpha"]},
+        )
+        assert set(df["seed"].unique()) == {1, 2, 3}
+
+    def test_multiple_categories(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips},
+            seeds=[42],
+            categories={"ds1": ["alpha", "beta"]},
+        )
+        assert set(df["category"].unique()) == {"alpha", "beta"}
+
+    def test_auto_categories(self):
+        """When categories=None, all unique categories are used."""
+        clips = _make_three_category_clips(n_per_cat=10)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips},
+            seeds=[42],
+        )
+        assert set(df["category"].unique()) == {"alpha", "beta", "gamma"}
+
+    def test_multiple_datasets(self):
+        clips1 = _make_separable_clips(n_per_cat=10, seed=0)
+        clips2 = _make_separable_clips(n_per_cat=10, seed=1)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips1, "ds2": clips2},
+            seeds=[42],
+            categories={"ds1": ["alpha"], "ds2": ["beta"]},
+        )
+        assert set(df["dataset"].unique()) == {"ds1", "ds2"}
+
+    def test_cost_column_numeric(self):
+        clips = _make_separable_clips(n_per_cat=10)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips},
+            seeds=[42],
+            categories={"ds1": ["alpha"]},
+        )
+        assert df["cost"].dtype == np.float64
+        assert df["fpr"].dtype == np.float64
+        assert df["fnr"].dtype == np.float64
+
+    def test_full_cross_product_shape(self):
+        """2 seeds x 1 dataset x 2 categories -> each combo produces rows."""
+        clips = _make_separable_clips(n_per_cat=10)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": clips},
+            seeds=[1, 2],
+            categories={"ds1": ["alpha", "beta"]},
+        )
+        combos = df.groupby(["seed", "dataset", "category"]).ngroups
+        assert combos == 4  # 2 seeds x 1 dataset x 2 categories

--- a/vtsearch/eval/__init__.py
+++ b/vtsearch/eval/__init__.py
@@ -3,10 +3,18 @@
 from vtsearch.eval.config import EVAL_DATASETS, EvalQuery
 from vtsearch.eval.metrics import compute_metrics
 from vtsearch.eval.runner import run_eval
+from vtsearch.eval.voting_iterations import (
+    run_voting_iterations_eval,
+    run_voting_iterations_eval_from_pickles,
+    simulate_voting_iterations,
+)
 
 __all__ = [
     "EVAL_DATASETS",
     "EvalQuery",
     "compute_metrics",
     "run_eval",
+    "run_voting_iterations_eval",
+    "run_voting_iterations_eval_from_pickles",
+    "simulate_voting_iterations",
 ]

--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -1,0 +1,294 @@
+"""Evaluate learned-sort cost over simulated voting iterations.
+
+For each combination of seed *s*, dataset *d*, and target category *c*:
+
+1. Load the dataset and split clips into **D_sim** (simulation) and
+   **D_test** (held-out) using *s* to control the random split.
+2. Assign ground-truth labels based on *c*: clips whose ``"category"``
+   matches *c* are positive (``good``), others are negative (``bad``).
+3. Create a shuffled voting sequence from D_sim (order controlled by *s*).
+4. Iterate through the voting sequence.  At each step *t* (once at least
+   one good **and** one bad vote exist), train a model on votes so far,
+   find a threshold, score D_test, and record the inclusion-weighted cost
+   (``fpr_weight * FPR + fnr_weight * FNR``).
+
+The result is a :class:`pandas.DataFrame` with columns
+``seed, dataset, category, t, cost, fpr, fnr``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import torch
+
+from vtsearch.models.training import (
+    calculate_cross_calibration_threshold,
+    train_model,
+)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _inclusion_weights(inclusion: int) -> tuple[float, float]:
+    """Return ``(fpr_weight, fnr_weight)`` for a given inclusion value."""
+    if inclusion >= 0:
+        return 1.0, 2.0**inclusion
+    return 2.0 ** (-inclusion), 1.0
+
+
+def _split_clip_ids(
+    clips_dict: dict[int, dict[str, Any]],
+    sim_fraction: float,
+    rng: np.random.RandomState,
+) -> tuple[list[int], list[int]]:
+    """Randomly partition clip IDs into simulation and test sets."""
+    all_ids = sorted(clips_dict.keys())
+    shuffled = rng.permutation(all_ids).tolist()
+    n_sim = max(1, int(len(shuffled) * sim_fraction))
+    return shuffled[:n_sim], shuffled[n_sim:]
+
+
+def _make_vote_sequence(
+    sim_ids: list[int],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    rng: np.random.RandomState,
+) -> list[tuple[int, str]]:
+    """Build a shuffled list of ``(clip_id, label)`` pairs from simulation IDs."""
+    votes = [
+        (cid, "good" if clips_dict[cid]["category"] == target_category else "bad")
+        for cid in sim_ids
+    ]
+    order = rng.permutation(len(votes))
+    return [votes[i] for i in order]
+
+
+def _evaluate_on_test(
+    model: torch.nn.Sequential,
+    threshold: float,
+    clips_dict: dict[int, dict[str, Any]],
+    test_ids: list[int],
+    target_category: str,
+    inclusion: int,
+) -> dict[str, float]:
+    """Score *test_ids* with *model* and return inclusion-weighted cost, FPR, FNR."""
+    if not test_ids:
+        return {"cost": float("nan"), "fpr": float("nan"), "fnr": float("nan")}
+
+    embs = np.array([clips_dict[cid]["embedding"] for cid in test_ids])
+    X = torch.tensor(embs, dtype=torch.float32)
+
+    with torch.no_grad():
+        scores = model(X).squeeze(1).tolist()
+
+    true_labels = [
+        1.0 if clips_dict[cid]["category"] == target_category else 0.0
+        for cid in test_ids
+    ]
+
+    total_pos = sum(1 for lbl in true_labels if lbl == 1.0)
+    total_neg = len(true_labels) - total_pos
+
+    fp = fn = 0
+    for score, label in zip(scores, true_labels):
+        predicted = 1 if score >= threshold else 0
+        if predicted == 1 and label == 0.0:
+            fp += 1
+        elif predicted == 0 and label == 1.0:
+            fn += 1
+
+    fpr = fp / total_neg if total_neg > 0 else 0.0
+    fnr = fn / total_pos if total_pos > 0 else 0.0
+
+    fpr_weight, fnr_weight = _inclusion_weights(inclusion)
+    cost = fpr_weight * fpr + fnr_weight * fnr
+
+    return {"cost": round(cost, 6), "fpr": round(fpr, 6), "fnr": round(fnr, 6)}
+
+
+# ------------------------------------------------------------------
+# Single (seed, dataset, category) evaluation
+# ------------------------------------------------------------------
+
+
+def simulate_voting_iterations(
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    seed: int,
+    dataset_name: str = "",
+    inclusion: int = 0,
+    sim_fraction: float = 0.5,
+) -> list[dict[str, Any]]:
+    """Simulate voting on *clips_dict* and evaluate at every step.
+
+    Args:
+        clips_dict: Pre-loaded clip dict (``{id: clip_data}``).
+        target_category: Category treated as the positive class.
+        seed: Random seed for splitting and vote ordering.
+        dataset_name: Label included in result rows.
+        inclusion: Inclusion setting in ``[-10, 10]``.
+        sim_fraction: Fraction of clips used for simulated voting.
+
+    Returns:
+        List of row dicts with keys
+        ``seed, dataset, category, t, cost, fpr, fnr``.
+    """
+    rng = np.random.RandomState(seed)
+    torch.manual_seed(seed)
+
+    sim_ids, test_ids = _split_clip_ids(clips_dict, sim_fraction, rng)
+
+    # Ensure the test set has both positive and negative clips
+    test_pos = [cid for cid in test_ids if clips_dict[cid]["category"] == target_category]
+    test_neg = [cid for cid in test_ids if clips_dict[cid]["category"] != target_category]
+    if not test_pos or not test_neg:
+        return []
+
+    vote_seq = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
+
+    good_votes: dict[int, None] = {}
+    bad_votes: dict[int, None] = {}
+    rows: list[dict[str, Any]] = []
+
+    for t, (cid, label) in enumerate(vote_seq, start=1):
+        if label == "good":
+            good_votes[cid] = None
+        else:
+            bad_votes[cid] = None
+
+        # Need at least 1 good and 1 bad to train
+        if not good_votes or not bad_votes:
+            continue
+
+        # Build training data
+        X_list: list[np.ndarray] = []
+        y_list: list[float] = []
+        for vid in good_votes:
+            X_list.append(clips_dict[vid]["embedding"])
+            y_list.append(1.0)
+        for vid in bad_votes:
+            X_list.append(clips_dict[vid]["embedding"])
+            y_list.append(0.0)
+
+        X = torch.tensor(np.array(X_list), dtype=torch.float32)
+        y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+        input_dim = X.shape[1]
+
+        # Train and find threshold (mirrors train_and_score)
+        threshold = calculate_cross_calibration_threshold(
+            X_list, y_list, input_dim, inclusion
+        )
+        model = train_model(X, y, input_dim, inclusion)
+
+        # Evaluate on held-out test set
+        metrics = _evaluate_on_test(
+            model, threshold, clips_dict, test_ids, target_category, inclusion
+        )
+
+        rows.append(
+            {
+                "seed": seed,
+                "dataset": dataset_name,
+                "category": target_category,
+                "t": t,
+                **metrics,
+            }
+        )
+
+    return rows
+
+
+# ------------------------------------------------------------------
+# Full evaluation across seeds x datasets x categories
+# ------------------------------------------------------------------
+
+
+def run_voting_iterations_eval(
+    dataset_clips: dict[str, dict[int, dict[str, Any]]],
+    seeds: list[int],
+    categories: Optional[dict[str, list[str]]] = None,
+    inclusion: int = 0,
+    sim_fraction: float = 0.5,
+) -> pd.DataFrame:
+    """Run the voting-iterations evaluation over multiple seeds/datasets/categories.
+
+    Args:
+        dataset_clips: Mapping of dataset name to a pre-loaded clips dict.
+            Each clips dict maps ``int`` clip IDs to clip data dicts
+            (must include ``"embedding"`` and ``"category"`` keys).
+        seeds: List of random seeds to iterate over.
+        categories: Optional mapping of dataset name to list of target
+            categories.  If ``None`` or a dataset is missing from the dict,
+            all unique categories in that dataset are used.
+        inclusion: Inclusion setting in ``[-10, 10]``.
+        sim_fraction: Fraction of clips reserved for simulated voting.
+
+    Returns:
+        A :class:`~pandas.DataFrame` with columns
+        ``seed, dataset, category, t, cost, fpr, fnr``.
+    """
+    all_rows: list[dict[str, Any]] = []
+
+    for ds_name, clips_dict in dataset_clips.items():
+        # Determine target categories
+        if categories and ds_name in categories:
+            target_cats = categories[ds_name]
+        else:
+            target_cats = sorted({clips_dict[cid]["category"] for cid in clips_dict})
+
+        for seed in seeds:
+            for cat in target_cats:
+                rows = simulate_voting_iterations(
+                    clips_dict,
+                    target_category=cat,
+                    seed=seed,
+                    dataset_name=ds_name,
+                    inclusion=inclusion,
+                    sim_fraction=sim_fraction,
+                )
+                all_rows.extend(rows)
+
+    return pd.DataFrame(all_rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr"])
+
+
+def run_voting_iterations_eval_from_pickles(
+    dataset_paths: dict[str, str],
+    seeds: list[int],
+    categories: Optional[dict[str, list[str]]] = None,
+    inclusion: int = 0,
+    sim_fraction: float = 0.5,
+) -> pd.DataFrame:
+    """Convenience wrapper that loads datasets from pickle files.
+
+    Args:
+        dataset_paths: Mapping of dataset name to pickle file path.
+        seeds: List of random seeds.
+        categories: Optional category filter (see :func:`run_voting_iterations_eval`).
+        inclusion: Inclusion setting in ``[-10, 10]``.
+        sim_fraction: Fraction of clips for simulation.
+
+    Returns:
+        A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`.
+    """
+    from vtsearch.datasets.loader import load_dataset_from_pickle
+
+    dataset_clips: dict[str, dict[int, dict[str, Any]]] = {}
+    for name, path in dataset_paths.items():
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(Path(path), clips)
+        dataset_clips[name] = clips
+
+    return run_voting_iterations_eval(
+        dataset_clips,
+        seeds=seeds,
+        categories=categories,
+        inclusion=inclusion,
+        sim_fraction=sim_fraction,
+    )


### PR DESCRIPTION
## Summary
This PR introduces a new evaluation framework for assessing learned-sort cost over simulated voting iterations. The framework simulates an interactive labeling process where clips are voted on sequentially, and at each step a model is trained and evaluated on a held-out test set.

## Key Changes

- **New module `vtsearch/eval/voting_iterations.py`**: Implements the core evaluation logic
  - `simulate_voting_iterations()`: Runs a single evaluation for a given seed, dataset, and target category
  - `run_voting_iterations_eval()`: Orchestrates evaluation across multiple seeds, datasets, and categories
  - `run_voting_iterations_eval_from_pickles()`: Convenience wrapper for loading datasets from pickle files
  - Helper functions for inclusion weighting, clip splitting, and vote sequence generation

- **Comprehensive test suite `tests/test_eval_voting_iterations.py`**: 
  - Unit tests for helper functions (`_inclusion_weights`, `_split_clip_ids`, `_make_vote_sequence`)
  - Integration tests for `simulate_voting_iterations()` covering determinism, cost trends, and edge cases
  - End-to-end tests for `run_voting_iterations_eval()` with multiple seeds, datasets, and categories
  - Synthetic test fixtures with well-separated and overlapping embeddings

- **Updated `vtsearch/eval/__init__.py`**: Exports the new public API functions

- **Dependency updates**: Added `pandas` to requirements files and test dependencies

## Implementation Details

The evaluation workflow for each (seed, dataset, category) combination:
1. Splits clips into simulation and test sets using the seed for reproducibility
2. Creates a shuffled voting sequence from the simulation set
3. Iterates through votes, training a model at each step (once at least one good and one bad vote exist)
4. Evaluates on the held-out test set and records inclusion-weighted cost metrics
5. Returns a DataFrame with columns: `seed, dataset, category, t, cost, fpr, fnr`

The framework integrates with existing training utilities (`train_model`, `calculate_cross_calibration_threshold`) and supports configurable inclusion settings to weight false positive and false negative rates.

https://claude.ai/code/session_01KkBzhL6PuoFffG7xnNpeTZ