### PR TITLE
Fix CLIP model load warnings by ignoring unexpected position_ids keys

### DIFF
--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -132,6 +132,9 @@ class ImageMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         update_progress("loading", "Loading image embedder (CLIP model)...", 0, 0)
+        # Older CLIP checkpoints include position_ids buffers that newer transformers
+        # versions compute on-the-fly.  Tell the loader to silently ignore them.
+        CLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
         self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir)
 


### PR DESCRIPTION
Older CLIP checkpoints include position_ids buffers that newer
transformers versions compute on-the-fly, causing unexpected key
warnings during model loading. Set _keys_to_ignore_on_load_unexpected
on CLIPModel to silently skip these keys.

https://claude.ai/code/session_013hSSAQgo46wVbNrcntdnfx