### PR TITLE
Use fast CLIP processor by default for image embedding

### DIFF
--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -133,7 +133,7 @@ class ImageMediaType(MediaType):
         cache_dir = str(MODELS_CACHE_DIR)
         update_progress("loading", "Loading image embedder (CLIP model)...", 0, 0)
         self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
-        self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir)
+        self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:


### PR DESCRIPTION
Pass use_fast=True to CLIPProcessor.from_pretrained to use the fast
tokenizer, improving processing speed for image embeddings.

https://claude.ai/code/session_018Ldd6bUgt4SrUrLPDpADUi