### PR TITLE
Speed up test suite with embedding cache and reduced training epochs

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,18 +31,56 @@ app = Flask(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _embedding_cache_path():
+    """Path to the cached test-clip embeddings file."""
+    return DATA_DIR / "clip_embedding_cache.npz"
+
+
+def _embedding_cache_key():
+    """Deterministic key derived from clip-generation parameters so the cache
+    auto-invalidates when NUM_CLIPS, frequencies, or durations change."""
+    parts = []
+    for i in range(1, NUM_CLIPS + 1):
+        freq = 200 + (i - 1) * 50
+        dur = round(1.0 + (i % 5) * 0.5, 1)
+        parts.append(f"{i}:{freq}:{dur}")
+    return hashlib.md5("|".join(parts).encode()).hexdigest()
+
+
 def init_clips():
+    import numpy as np
+
     DATA_DIR.mkdir(exist_ok=True)
     temp_path = DATA_DIR / "temp_embed.wav"
+    cache_path = _embedding_cache_path()
+    cache_key = _embedding_cache_key()
 
+    # Try to load cached embeddings
+    cached_embeddings = {}
+    if cache_path.exists():
+        try:
+            data = np.load(cache_path, allow_pickle=False)
+            if "cache_key" in data and str(data["cache_key"]) == cache_key:
+                for i in range(1, NUM_CLIPS + 1):
+                    k = f"emb_{i}"
+                    if k in data:
+                        cached_embeddings[i] = data[k]
+        except Exception:
+            pass
+
+    new_embeddings = {}
     for i in range(1, NUM_CLIPS + 1):
         freq = 200 + (i - 1) * 50  # 200 Hz .. 1150 Hz
         duration = round(1.0 + (i % 5) * 0.5, 1)  # 1.0 – 3.0 s
         wav_bytes = generate_wav(freq, duration)
 
-        # Generate embedding by saving to temp file
-        temp_path.write_bytes(wav_bytes)
-        embedding = embed_audio_file(temp_path)
+        if i in cached_embeddings:
+            embedding = cached_embeddings[i]
+        else:
+            # Generate embedding by saving to temp file
+            temp_path.write_bytes(wav_bytes)
+            embedding = embed_audio_file(temp_path)
+            new_embeddings[i] = embedding
 
         clips[i] = {
             "id": i,
@@ -58,6 +96,13 @@ def init_clips():
     # Clean up temp file
     if temp_path.exists():
         temp_path.unlink()
+
+    # Save cache if we computed any new embeddings (or cache didn't exist)
+    if new_embeddings or not cached_embeddings:
+        save_data = {"cache_key": np.array(cache_key)}
+        for i in range(1, NUM_CLIPS + 1):
+            save_data[f"emb_{i}"] = clips[i]["embedding"]
+        np.savez(cache_path, **save_data)
 
 
 # Model initialization is now handled by vtsearch.models.initialize_models()

--- a/config.py
+++ b/config.py
@@ -28,6 +28,9 @@ CLIPS_PER_CATEGORY = 40
 CLIPS_PER_VIDEO_CATEGORY = 10
 IMAGES_PER_CIFAR10_CATEGORY = 100
 
+# Training
+TRAIN_EPOCHS = 200
+
 # Model IDs
 CLAP_MODEL_ID = "laion/clap-htsat-unfused"
 XCLIP_MODEL_ID = "microsoft/xclip-base-patch32"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 import pytest
 
+import config
+
+# Reduce training epochs for faster tests (default is 200; 30 is sufficient
+# for the tiny MLP to converge on the small test dataset).
+config.TRAIN_EPOCHS = 30
+
 import app as app_module
 
 # Import refactored modules and make them accessible through app_module

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -7,6 +7,8 @@ import torch
 import torch.nn as nn
 from sklearn.mixture import GaussianMixture
 
+from config import TRAIN_EPOCHS
+
 
 def calculate_gmm_threshold(scores: list[float]) -> float:
     """Use a Gaussian Mixture Model to find a threshold between two score distributions.
@@ -113,7 +115,7 @@ def train_model(
     loss_fn = nn.BCELoss(reduction="none")
 
     model.train()
-    for _ in range(200):
+    for _ in range(TRAIN_EPOCHS):
         optimizer.zero_grad()
         predictions = model(X_train)
         losses = loss_fn(predictions, y_train)


### PR DESCRIPTION
- Cache CLAP embeddings to disk (clip_embedding_cache.npz) so init_clips()
  only computes them on the first run; subsequent test sessions load from cache
- Extract TRAIN_EPOCHS constant (default 200) and override to 30 in conftest.py,
  sufficient for the tiny MLP to converge on the small test dataset
- Rewrite test_deterministic_embeddings and test_md5_deterministic to verify
  properties without calling init_clips() a second time (avoids re-embedding
  all 20 clips)

https://claude.ai/code/session_01UFnrzn9oR9tiTWbew5yiAd