### PR TITLE
Add label importer abstraction with JSON/CSV file importers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,18 +9,21 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --detector <file.json>`
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --detector <file.json> --exporter file --filepath results.json`
+- **CLI label import**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-labels --dataset <file.pkl> --label-importer json_file --file labels.json`
+- **CLI label import (CSV)**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-labels --dataset <file.pkl> --label-importer csv_file --file labels.csv`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`
 
 ## Architecture
 - `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing
-- `vtsearch/cli.py` — CLI autodetect: load dataset + detector, run inference, export results
+- `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detector, run inference, export results), import_labels_main (load dataset + label importer)
 - `config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
-- `vtsearch/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`
+- `vtsearch/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking
 - `vtsearch/datasets/` — Dataset loading, downloading, importers (folder/pickle/http_zip/rss_feed/youtube_playlist)
 - `vtsearch/exporters/` — Results exporters (file/gui/email_smtp/csv_file/webhook)
+- `vtsearch/labels/importers/` — Label importers (json_file/csv_file); auto-discovered via `LABEL_IMPORTER` sentinel
 - `vtsearch/media/` — Media type plugins: audio, image, text, video
 - `vtsearch/utils/` — Global state (`clips` dict, votes), progress utilities
 - `static/index.html` — HTML structure (270 lines)
@@ -32,7 +35,8 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_clips.py` — Clip init, listing, audio endpoint, MD5
   - `test_votes.py` — Voting and vote retrieval
   - `test_sorting.py` — Text sort, learned sort, example sort, train_and_score
-  - `test_labels.py` — Label export/import
+  - `test_labels.py` — Label export/import (via /api/labels/export and /api/labels/import)
+  - `test_label_importers.py` — Label importer base class, registry, json_file/csv_file importers, API routes
   - `test_inclusion.py` — Inclusion GET/POST
   - `test_detectors.py` — Detector export, detector sort, favorites, auto-detect
   - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from flask import Flask
 from config import DATA_DIR, NUM_CLIPS
 from vtsearch.audio import generate_wav
 from vtsearch.models import embed_audio_file, initialize_models
-from vtsearch.routes import clips_bp, datasets_bp, detectors_bp, exporters_bp, main_bp, sorting_bp
+from vtsearch.routes import clips_bp, datasets_bp, detectors_bp, exporters_bp, label_importers_bp, main_bp, sorting_bp
 from vtsearch.utils import clips
 
 app = Flask(__name__)
@@ -124,6 +124,7 @@ app.register_blueprint(sorting_bp)
 app.register_blueprint(detectors_bp)
 app.register_blueprint(datasets_bp)
 app.register_blueprint(exporters_bp)
+app.register_blueprint(label_importers_bp)
 
 
 # ---------------------------------------------------------------------------
@@ -152,13 +153,24 @@ if __name__ == "__main__":
         type=str,
         help="Name of the results exporter to use (e.g. file, email_smtp, gui). Used with --autodetect.",
     )
+    parser.add_argument(
+        "--import-labels",
+        action="store_true",
+        help="Import labels into a loaded dataset from the command line.",
+    )
+    parser.add_argument(
+        "--label-importer",
+        type=str,
+        help="Name of the label importer to use (e.g. json_file, csv_file). Used with --import-labels.",
+    )
 
-    # Two-pass parsing: first pass gets --importer and --exporter names,
-    # second pass adds their arguments and re-parses.
+    # Two-pass parsing: first pass gets --importer, --exporter, and
+    # --label-importer names; second pass adds their arguments and re-parses.
     args, remaining = parser.parse_known_args()
 
     importer = None
     exporter = None
+    label_importer = None
 
     if args.autodetect and args.importer:
         from vtsearch.datasets.importers import get_importer, list_importers
@@ -180,14 +192,35 @@ if __name__ == "__main__":
 
         exporter.add_cli_arguments(parser)
 
-    if importer or exporter:
+    if getattr(args, "import_labels", False) and getattr(args, "label_importer", None):
+        from vtsearch.labels.importers import get_label_importer, list_label_importers
+
+        label_importer = get_label_importer(args.label_importer)
+        if label_importer is None:
+            available = ", ".join(imp.name for imp in list_label_importers())
+            parser.error(f"Unknown label importer: {args.label_importer}. Available: {available}")
+
+        label_importer.add_cli_arguments(parser)
+
+    if importer or exporter or label_importer:
         args = parser.parse_args()
     elif remaining:
         # No importer/exporter specified but there are unknown args; let
         # argparse report the error.
         parser.parse_args()
 
-    if args.autodetect:
+    if getattr(args, "import_labels", False):
+        if not getattr(args, "label_importer", None):
+            parser.error("--import-labels requires --label-importer <name>")
+        if not args.dataset:
+            parser.error("--import-labels requires --dataset <file.pkl>")
+
+        from vtsearch.cli import import_labels_main
+
+        field_values = {f.key: getattr(args, f.key, f.default or None) for f in label_importer.fields}
+        import_labels_main(args.dataset, args.label_importer, field_values)
+
+    elif args.autodetect:
         # Collect exporter field values if an exporter was specified
         exporter_field_values = None
         if exporter:

--- a/static/index.html
+++ b/static/index.html
@@ -122,7 +122,7 @@
 
   <!-- Right panel -->
   <div class="panel-right">
-    <input type="file" id="import-file" accept=".json" style="display:none">
+    <!-- import-file removed: label import now uses the label importer modal -->
     <div class="progress-check-bar">
       <button id="check-progress-btn" class="labeling-indicator" data-status="">
         <span class="indicator-dot"></span>
@@ -243,6 +243,21 @@
       <div style="background: #2a2d3a; border-radius: 8px; overflow: hidden; height: 24px;">
         <div id="autodetect-progress-bar" style="background: #7c8aff; height: 100%; width: 0%; transition: width 0.3s;"></div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Label Importer Picker Modal -->
+<div id="label-importer-modal" class="modal">
+  <div class="modal-content" style="max-width: 600px;">
+    <div class="modal-header">
+      <h2>Import Labels</h2>
+      <button class="modal-close" id="label-importer-modal-close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div id="label-importer-list"></div>
+      <div id="label-importer-form" style="display:none"></div>
+      <button id="label-importer-back" style="display:none; margin-top:12px; padding:6px 14px; background:#3a3d50; color:#ccc; border:1px solid #4a4d60; border-radius:4px; cursor:pointer;">&#8592; Back</button>
     </div>
   </div>
 </div>

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -1,0 +1,684 @@
+"""Tests for the Label Importer abstraction.
+
+Covers:
+- LabelImporterField and LabelImporter base classes
+- Auto-discovery registry (list_label_importers, get_label_importer)
+- Built-in importers: json_file, csv_file
+- Flask API routes: GET /api/label-importers, POST /api/label-importers/import/<name>
+- CLI import_labels_main function
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import app as app_module
+
+
+# ---------------------------------------------------------------------------
+# LabelImporterField
+# ---------------------------------------------------------------------------
+
+
+class TestLabelImporterField:
+    def test_to_dict_contains_required_keys(self):
+        from vtsearch.labels.importers.base import LabelImporterField
+
+        f = LabelImporterField(key="file", label="My File", field_type="file")
+        d = f.to_dict()
+        assert d["key"] == "file"
+        assert d["label"] == "My File"
+        assert d["field_type"] == "file"
+        assert "description" in d
+        assert "accept" in d
+        assert "options" in d
+        assert "default" in d
+        assert "required" in d
+        assert "placeholder" in d
+
+    def test_defaults(self):
+        from vtsearch.labels.importers.base import LabelImporterField
+
+        f = LabelImporterField(key="x", label="X", field_type="text")
+        assert f.required is True
+        assert f.default == ""
+        assert f.placeholder == ""
+        assert f.options == []
+        assert f.description == ""
+        assert f.accept == ""
+
+    def test_custom_values(self):
+        from vtsearch.labels.importers.base import LabelImporterField
+
+        f = LabelImporterField(
+            key="mode",
+            label="Mode",
+            field_type="select",
+            options=["a", "b"],
+            default="a",
+            required=False,
+            description="Pick one",
+            placeholder="Choose…",
+        )
+        d = f.to_dict()
+        assert d["options"] == ["a", "b"]
+        assert d["default"] == "a"
+        assert d["required"] is False
+
+
+# ---------------------------------------------------------------------------
+# LabelImporter base class
+# ---------------------------------------------------------------------------
+
+
+class TestLabelImporterBase:
+    def _make_minimal(self):
+        from vtsearch.labels.importers.base import LabelImporter
+
+        class Minimal(LabelImporter):
+            name = "minimal"
+            display_name = "Minimal"
+            description = "A minimal label importer."
+            fields = []
+
+            def run(self, field_values):
+                return []
+
+        return Minimal()
+
+    def test_run_raises_not_implemented_when_not_overridden(self):
+        from vtsearch.labels.importers.base import LabelImporter
+
+        imp = LabelImporter()
+        with pytest.raises(NotImplementedError):
+            imp.run({})
+
+    def test_to_dict_contains_standard_keys(self):
+        imp = self._make_minimal()
+        d = imp.to_dict()
+        assert d["name"] == "minimal"
+        assert d["display_name"] == "Minimal"
+        assert d["description"] == "A minimal label importer."
+        assert "icon" in d
+        assert "fields" in d
+
+    def test_default_icon(self):
+        from vtsearch.labels.importers.base import LabelImporter
+
+        assert LabelImporter.icon == "🏷️"
+
+    def test_custom_icon_in_to_dict(self):
+        from vtsearch.labels.importers.base import LabelImporter
+
+        class Custom(LabelImporter):
+            name = "c"
+            display_name = "C"
+            description = "C"
+            icon = "🔖"
+            fields = []
+
+            def run(self, field_values):
+                return []
+
+        assert Custom().to_dict()["icon"] == "🔖"
+
+    def test_validate_cli_field_values_raises_on_missing_required(self):
+        from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+        class Imp(LabelImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = [LabelImporterField("filepath", "File", "text", required=True)]
+
+            def run(self, field_values):
+                return []
+
+        imp = Imp()
+        with pytest.raises(ValueError, match="--filepath"):
+            imp.validate_cli_field_values({})
+
+    def test_validate_cli_field_values_passes_when_provided(self):
+        from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+        class Imp(LabelImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = [LabelImporterField("filepath", "File", "text", required=True)]
+
+            def run(self, field_values):
+                return []
+
+        imp = Imp()
+        imp.validate_cli_field_values({"filepath": "/some/path"})  # no raise
+
+    def test_run_cli_delegates_to_run(self):
+        from vtsearch.labels.importers.base import LabelImporter
+
+        class Imp(LabelImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = []
+
+            def run(self, field_values):
+                return [{"md5": "abc", "label": "good"}]
+
+        imp = Imp()
+        result = imp.run_cli({})
+        assert result == [{"md5": "abc", "label": "good"}]
+
+    def test_add_cli_arguments_adds_text_field(self):
+        import argparse
+
+        from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+        class Imp(LabelImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = [LabelImporterField("server", "Server", "text", description="DB host")]
+
+            def run(self, field_values):
+                return []
+
+        parser = argparse.ArgumentParser()
+        Imp().add_cli_arguments(parser)
+        args = parser.parse_args(["--server", "localhost"])
+        assert args.server == "localhost"
+
+    def test_add_cli_arguments_select_adds_choices(self):
+        import argparse
+
+        from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+        class Imp(LabelImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = [LabelImporterField("mode", "Mode", "select", options=["a", "b"], default="a")]
+
+            def run(self, field_values):
+                return []
+
+        parser = argparse.ArgumentParser()
+        Imp().add_cli_arguments(parser)
+        args = parser.parse_args([])  # uses default
+        assert args.mode == "a"
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--mode", "invalid"])
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestLabelImporterRegistry:
+    def test_list_label_importers_returns_builtins(self):
+        from vtsearch.labels.importers import list_label_importers
+
+        names = {imp.name for imp in list_label_importers()}
+        assert "json_file" in names
+        assert "csv_file" in names
+
+    def test_get_label_importer_known(self):
+        from vtsearch.labels.importers import get_label_importer
+
+        for name in ("json_file", "csv_file"):
+            imp = get_label_importer(name)
+            assert imp is not None, f"Label importer '{name}' not found"
+            assert imp.name == name
+
+    def test_get_label_importer_unknown_returns_none(self):
+        from vtsearch.labels.importers import get_label_importer
+
+        assert get_label_importer("no_such_importer") is None
+
+    def test_each_importer_has_display_name_and_icon(self):
+        from vtsearch.labels.importers import list_label_importers
+
+        for imp in list_label_importers():
+            assert imp.display_name, f"{imp.name} missing display_name"
+            assert imp.icon, f"{imp.name} missing icon"
+            assert imp.description, f"{imp.name} missing description"
+
+    def test_each_importer_fields_are_valid(self):
+        from vtsearch.labels.importers import list_label_importers
+
+        valid_types = ("file", "text", "password", "select")
+        for imp in list_label_importers():
+            for f in imp.fields:
+                assert f.key, f"{imp.name} has a field without a key"
+                assert f.label, f"{imp.name} field '{f.key}' has no label"
+                assert f.field_type in valid_types, (
+                    f"{imp.name} field '{f.key}' has unknown type '{f.field_type}'"
+                )
+
+
+# ---------------------------------------------------------------------------
+# JSON file importer
+# ---------------------------------------------------------------------------
+
+
+class TestJsonLabelImporter:
+    def _get_importer(self):
+        from vtsearch.labels.importers.json_file import LABEL_IMPORTER
+
+        return LABEL_IMPORTER
+
+    def test_name(self):
+        assert self._get_importer().name == "json_file"
+
+    def test_display_name(self):
+        assert "json" in self._get_importer().display_name.lower()
+
+    def test_icon(self):
+        assert self._get_importer().icon
+
+    def test_has_file_field(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "file" in fields
+        assert fields["file"].field_type == "file"
+
+    def test_run_with_file_storage(self):
+        from werkzeug.datastructures import FileStorage
+
+        payload = {"labels": [{"md5": "abc", "label": "good"}]}
+        raw = json.dumps(payload).encode()
+        fs = FileStorage(stream=io.BytesIO(raw), filename="labels.json", content_type="application/json")
+        result = self._get_importer().run({"file": fs})
+        assert len(result) == 1
+        assert result[0]["md5"] == "abc"
+        assert result[0]["label"] == "good"
+
+    def test_run_returns_both_good_and_bad(self):
+        from werkzeug.datastructures import FileStorage
+
+        payload = {
+            "labels": [
+                {"md5": "aaa", "label": "good"},
+                {"md5": "bbb", "label": "bad"},
+            ]
+        }
+        raw = json.dumps(payload).encode()
+        fs = FileStorage(stream=io.BytesIO(raw), filename="labels.json")
+        result = self._get_importer().run({"file": fs})
+        labels = {r["md5"]: r["label"] for r in result}
+        assert labels["aaa"] == "good"
+        assert labels["bbb"] == "bad"
+
+    def test_run_raises_on_invalid_json(self):
+        from werkzeug.datastructures import FileStorage
+
+        fs = FileStorage(stream=io.BytesIO(b"not json at all"), filename="labels.json")
+        with pytest.raises(ValueError, match="JSON"):
+            self._get_importer().run({"file": fs})
+
+    def test_run_raises_on_missing_labels_key(self):
+        from werkzeug.datastructures import FileStorage
+
+        fs = FileStorage(stream=io.BytesIO(b'{"data": []}'), filename="labels.json")
+        with pytest.raises(ValueError, match="labels"):
+            self._get_importer().run({"file": fs})
+
+    def test_run_raises_when_no_file(self):
+        with pytest.raises(ValueError):
+            self._get_importer().run({"file": None})
+
+    def test_run_cli_reads_file_path(self, tmp_path):
+        payload = {"labels": [{"md5": "xyz", "label": "bad"}]}
+        p = tmp_path / "labels.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run_cli({"file": str(p)})
+        assert len(result) == 1
+        assert result[0]["md5"] == "xyz"
+
+    def test_run_cli_raises_on_empty_path(self):
+        with pytest.raises(ValueError, match="--file"):
+            self._get_importer().run_cli({"file": ""})
+
+
+# ---------------------------------------------------------------------------
+# CSV file importer
+# ---------------------------------------------------------------------------
+
+
+class TestCsvLabelImporter:
+    def _get_importer(self):
+        from vtsearch.labels.importers.csv_file import LABEL_IMPORTER
+
+        return LABEL_IMPORTER
+
+    def test_name(self):
+        assert self._get_importer().name == "csv_file"
+
+    def test_display_name(self):
+        assert "csv" in self._get_importer().display_name.lower()
+
+    def test_icon(self):
+        assert self._get_importer().icon
+
+    def test_has_file_field(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "file" in fields
+        assert fields["file"].field_type == "file"
+
+    def test_run_with_file_storage(self):
+        from werkzeug.datastructures import FileStorage
+
+        csv_bytes = b"md5,label\nabc123,good\ndef456,bad\n"
+        fs = FileStorage(stream=io.BytesIO(csv_bytes), filename="labels.csv", content_type="text/csv")
+        result = self._get_importer().run({"file": fs})
+        assert len(result) == 2
+        labels = {r["md5"]: r["label"] for r in result}
+        assert labels["abc123"] == "good"
+        assert labels["def456"] == "bad"
+
+    def test_run_strips_bom(self):
+        from werkzeug.datastructures import FileStorage
+
+        csv_bytes = b"\xef\xbb\xbfmd5,label\nabc,good\n"
+        fs = FileStorage(stream=io.BytesIO(csv_bytes), filename="labels.csv")
+        result = self._get_importer().run({"file": fs})
+        assert len(result) == 1
+        assert result[0]["md5"] == "abc"
+
+    def test_run_normalises_label_to_lowercase(self):
+        from werkzeug.datastructures import FileStorage
+
+        csv_bytes = b"md5,label\nabc,GOOD\n"
+        fs = FileStorage(stream=io.BytesIO(csv_bytes), filename="labels.csv")
+        result = self._get_importer().run({"file": fs})
+        assert result[0]["label"] == "good"
+
+    def test_run_raises_on_missing_columns(self):
+        from werkzeug.datastructures import FileStorage
+
+        csv_bytes = b"hash,category\nabc,good\n"
+        fs = FileStorage(stream=io.BytesIO(csv_bytes), filename="labels.csv")
+        with pytest.raises(ValueError, match="md5"):
+            self._get_importer().run({"file": fs})
+
+    def test_run_raises_on_empty_file(self):
+        from werkzeug.datastructures import FileStorage
+
+        fs = FileStorage(stream=io.BytesIO(b""), filename="labels.csv")
+        with pytest.raises(ValueError):
+            self._get_importer().run({"file": fs})
+
+    def test_run_raises_when_no_file(self):
+        with pytest.raises(ValueError):
+            self._get_importer().run({"file": None})
+
+    def test_run_cli_reads_file_path(self, tmp_path):
+        p = tmp_path / "labels.csv"
+        p.write_text("md5,label\nxyz789,bad\n")
+        result = self._get_importer().run_cli({"file": str(p)})
+        assert len(result) == 1
+        assert result[0]["md5"] == "xyz789"
+
+    def test_run_cli_raises_on_empty_path(self):
+        with pytest.raises(ValueError, match="--file"):
+            self._get_importer().run_cli({"file": ""})
+
+    def test_run_ignores_extra_columns(self):
+        from werkzeug.datastructures import FileStorage
+
+        csv_bytes = b"md5,label,score,extra\nabc,good,0.9,whatever\n"
+        fs = FileStorage(stream=io.BytesIO(csv_bytes), filename="labels.csv")
+        result = self._get_importer().run({"file": fs})
+        assert len(result) == 1
+        assert result[0] == {"md5": "abc", "label": "good"}
+
+
+# ---------------------------------------------------------------------------
+# parse helpers (_parse_json_bytes, _parse_csv_bytes)
+# ---------------------------------------------------------------------------
+
+
+class TestParseHelpers:
+    def test_parse_json_bytes_valid(self):
+        from vtsearch.labels.importers.json_file import _parse_json_bytes
+
+        raw = json.dumps({"labels": [{"md5": "a", "label": "good"}]}).encode()
+        result = _parse_json_bytes(raw)
+        assert result == [{"md5": "a", "label": "good"}]
+
+    def test_parse_json_bytes_empty_labels(self):
+        from vtsearch.labels.importers.json_file import _parse_json_bytes
+
+        raw = json.dumps({"labels": []}).encode()
+        result = _parse_json_bytes(raw)
+        assert result == []
+
+    def test_parse_json_bytes_non_dict_entries_filtered(self):
+        from vtsearch.labels.importers.json_file import _parse_json_bytes
+
+        raw = json.dumps({"labels": [{"md5": "a", "label": "good"}, "bad_entry", 42]}).encode()
+        result = _parse_json_bytes(raw)
+        assert len(result) == 1
+
+    def test_parse_csv_bytes_valid(self):
+        from vtsearch.labels.importers.csv_file import _parse_csv_bytes
+
+        raw = b"md5,label\nabc,good\ndef,bad\n"
+        result = _parse_csv_bytes(raw)
+        assert len(result) == 2
+
+    def test_parse_csv_bytes_case_insensitive_headers(self):
+        from vtsearch.labels.importers.csv_file import _parse_csv_bytes
+
+        raw = b"MD5,LABEL\nabc,good\n"
+        result = _parse_csv_bytes(raw)
+        assert len(result) == 1
+        assert result[0]["md5"] == "abc"
+
+    def test_parse_csv_bytes_skips_empty_md5(self):
+        from vtsearch.labels.importers.csv_file import _parse_csv_bytes
+
+        raw = b"md5,label\n,good\nabc,bad\n"
+        result = _parse_csv_bytes(raw)
+        # Empty md5 row is skipped
+        assert len(result) == 1
+        assert result[0]["md5"] == "abc"
+
+
+# ---------------------------------------------------------------------------
+# API – GET /api/label-importers
+# ---------------------------------------------------------------------------
+
+
+class TestGetLabelImportersEndpoint:
+    def test_returns_200(self, client):
+        res = client.get("/api/label-importers")
+        assert res.status_code == 200
+
+    def test_returns_list(self, client):
+        res = client.get("/api/label-importers")
+        data = res.get_json()
+        assert isinstance(data, list)
+
+    def test_contains_builtin_importers(self, client):
+        res = client.get("/api/label-importers")
+        names = {entry["name"] for entry in res.get_json()}
+        assert "json_file" in names
+        assert "csv_file" in names
+
+    def test_each_entry_has_required_keys(self, client):
+        res = client.get("/api/label-importers")
+        for entry in res.get_json():
+            assert "name" in entry
+            assert "display_name" in entry
+            assert "description" in entry
+            assert "icon" in entry
+            assert "fields" in entry
+
+
+# ---------------------------------------------------------------------------
+# API – POST /api/label-importers/import/<name>
+# ---------------------------------------------------------------------------
+
+
+class TestLabelImportEndpoint:
+    def test_unknown_importer_returns_404(self, client):
+        res = client.post("/api/label-importers/import/no_such_importer")
+        assert res.status_code == 404
+        assert "no_such_importer" in res.get_json()["error"]
+
+    def test_json_importer_applies_good_label(self, client):
+        md5 = app_module.clips[1]["md5"]
+        payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]}).encode()
+        data = {"file": (io.BytesIO(payload), "labels.json")}
+        res = client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 1
+        assert result["skipped"] == 0
+        assert 1 in app_module.good_votes
+
+    def test_json_importer_applies_bad_label(self, client):
+        md5 = app_module.clips[2]["md5"]
+        payload = json.dumps({"labels": [{"md5": md5, "label": "bad"}]}).encode()
+        data = {"file": (io.BytesIO(payload), "labels.json")}
+        res = client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        assert 2 in app_module.bad_votes
+
+    def test_json_importer_skips_unknown_md5(self, client):
+        payload = json.dumps({"labels": [{"md5": "no_such_md5", "label": "good"}]}).encode()
+        data = {"file": (io.BytesIO(payload), "labels.json")}
+        res = client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 0
+        assert result["skipped"] == 1
+
+    def test_json_importer_skips_invalid_label_value(self, client):
+        md5 = app_module.clips[1]["md5"]
+        payload = json.dumps({"labels": [{"md5": md5, "label": "meh"}]}).encode()
+        data = {"file": (io.BytesIO(payload), "labels.json")}
+        res = client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 0
+        assert result["skipped"] == 1
+
+    def test_csv_importer_applies_labels(self, client):
+        md5_1 = app_module.clips[1]["md5"]
+        md5_2 = app_module.clips[2]["md5"]
+        csv_bytes = f"md5,label\n{md5_1},good\n{md5_2},bad\n".encode()
+        data = {"file": (io.BytesIO(csv_bytes), "labels.csv")}
+        res = client.post(
+            "/api/label-importers/import/csv_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 2
+        assert 1 in app_module.good_votes
+        assert 2 in app_module.bad_votes
+
+    def test_csv_importer_skips_unknown_md5(self, client):
+        csv_bytes = b"md5,label\nunknown_hash,good\n"
+        data = {"file": (io.BytesIO(csv_bytes), "labels.csv")}
+        res = client.post(
+            "/api/label-importers/import/csv_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 0
+        assert result["skipped"] == 1
+
+    def test_import_overrides_existing_label(self, client):
+        app_module.good_votes[1] = None
+        md5 = app_module.clips[1]["md5"]
+        payload = json.dumps({"labels": [{"md5": md5, "label": "bad"}]}).encode()
+        data = {"file": (io.BytesIO(payload), "labels.json")}
+        client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert 1 not in app_module.good_votes
+        assert 1 in app_module.bad_votes
+
+    def test_import_response_has_message(self, client):
+        payload = json.dumps({"labels": []}).encode()
+        data = {"file": (io.BytesIO(payload), "labels.json")}
+        res = client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        assert "message" in res.get_json()
+
+    def test_json_roundtrip_via_importer(self, client):
+        """Export labels via the old route and re-import via label importer endpoint."""
+        app_module.good_votes.update({k: None for k in [1, 3, 5]})
+        app_module.bad_votes.update({k: None for k in [2, 4]})
+
+        export_res = client.get("/api/labels/export")
+        exported = export_res.get_json()
+
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+
+        raw = json.dumps(exported).encode()
+        data = {"file": (io.BytesIO(raw), "labels.json")}
+        res = client.post(
+            "/api/label-importers/import/json_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        result = res.get_json()
+        assert result["applied"] == 5
+        assert set(app_module.good_votes) == {1, 3, 5}
+        assert set(app_module.bad_votes) == {2, 4}
+
+    def test_multiple_clips_via_csv(self, client):
+        lines = ["md5,label"]
+        good_ids = [1, 2, 3]
+        bad_ids = [4, 5]
+        for cid in good_ids:
+            lines.append(f"{app_module.clips[cid]['md5']},good")
+        for cid in bad_ids:
+            lines.append(f"{app_module.clips[cid]['md5']},bad")
+        csv_bytes = "\n".join(lines).encode()
+        data = {"file": (io.BytesIO(csv_bytes), "labels.csv")}
+        res = client.post(
+            "/api/label-importers/import/csv_file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        result = res.get_json()
+        assert result["applied"] == 5
+        assert set(app_module.good_votes) == {1, 2, 3}
+        assert set(app_module.bad_votes) == {4, 5}

--- a/vtsearch/labels/importers/__init__.py
+++ b/vtsearch/labels/importers/__init__.py
@@ -1,0 +1,62 @@
+"""Label importer registry with auto-discovery.
+
+Any package placed directly under this directory is automatically registered
+if it exposes a module-level ``LABEL_IMPORTER`` attribute that is a
+:class:`~vtsearch.labels.importers.base.LabelImporter` instance.
+
+Usage::
+
+    from vtsearch.labels.importers import get_label_importer, list_label_importers
+
+    importer = get_label_importer("csv")
+    for imp in list_label_importers():
+        print(imp.name, imp.display_name)
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vtsearch.labels.importers.base import LabelImporter
+
+_registry: dict[str, LabelImporter] = {}
+
+
+def _discover() -> None:
+    """Scan sub-packages for ``LABEL_IMPORTER`` objects and register them."""
+    package_dir = Path(__file__).parent
+    for _, module_name, is_pkg in pkgutil.iter_modules([str(package_dir)]):
+        if not is_pkg:
+            continue
+        try:
+            mod = importlib.import_module(f"vtsearch.labels.importers.{module_name}")
+            importer = getattr(mod, "LABEL_IMPORTER", None)
+            if importer is not None:
+                _registry[importer.name] = importer
+        except Exception as exc:  # pragma: no cover
+            warnings.warn(
+                f"Failed to load label importer '{module_name}': {exc}",
+                stacklevel=2,
+            )
+
+
+def _ensure_discovered() -> None:
+    if not _registry:
+        _discover()
+
+
+def get_label_importer(name: str) -> LabelImporter | None:
+    """Return the registered label importer with *name*, or ``None`` if not found."""
+    _ensure_discovered()
+    return _registry.get(name)
+
+
+def list_label_importers() -> list[LabelImporter]:
+    """Return all registered label importers in discovery order."""
+    _ensure_discovered()
+    return list(_registry.values())

--- a/vtsearch/labels/importers/base.py
+++ b/vtsearch/labels/importers/base.py
@@ -1,0 +1,216 @@
+"""Base classes for Label Importers.
+
+To add a new label importer, subclass :class:`LabelImporter`, define its class
+attributes and :meth:`~LabelImporter.run`, then expose a module-level
+``LABEL_IMPORTER`` instance from a package under this directory.  The registry
+will discover it automatically.
+
+Each importer also supports CLI usage via :meth:`~LabelImporter.add_cli_arguments`
+and :meth:`~LabelImporter.run_cli`.  The base class provides default
+implementations that derive CLI arguments from the :attr:`fields` list, so most
+importers work on the command line without any extra code.  Importers whose
+:meth:`run` expects non-string values (e.g. Werkzeug ``FileStorage`` objects)
+should override :meth:`run_cli` to handle the CLI-appropriate types (file paths
+as strings).
+
+The label format used throughout is a list of dicts::
+
+    [{"md5": "<clip-md5>", "label": "good"}, ...]
+
+where ``label`` is ``"good"`` or ``"bad"``.
+
+Example – a minimal database label importer skeleton::
+
+    # vtsearch/labels/importers/postgres/__init__.py
+    from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+    class PostgresLabelImporter(LabelImporter):
+        name         = "postgres"
+        display_name = "PostgreSQL Query"
+        description  = "Import labels from a PostgreSQL database query."
+        icon         = "🐘"
+        fields = [
+            LabelImporterField("host",     "Hostname", "text"),
+            LabelImporterField("database", "Database", "text"),
+            LabelImporterField("query",    "SQL Query", "text",
+                               description="Must return md5 and label columns."),
+        ]
+
+        def run(self, field_values: dict) -> list[dict]:
+            import psycopg2
+            conn = psycopg2.connect(host=field_values["host"],
+                                    database=field_values["database"])
+            cur = conn.cursor()
+            cur.execute(field_values["query"])
+            return [{"md5": row[0], "label": row[1]} for row in cur.fetchall()]
+
+    LABEL_IMPORTER = PostgresLabelImporter()
+
+Then create ``vtsearch/labels/importers/postgres/requirements.txt`` containing
+``psycopg2-binary`` and add::
+
+    -r vtsearch/labels/importers/postgres/requirements.txt
+
+to ``requirements-label-importers.txt``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+FieldType = Literal["file", "text", "password", "select"]
+
+
+@dataclass
+class LabelImporterField:
+    """Describes a single configurable input for a label importer.
+
+    The ``field_type`` value drives how the frontend renders it:
+
+    - ``"file"``     – OS file-picker; value arrives as a Werkzeug
+      :class:`~werkzeug.datastructures.FileStorage` object.
+    - ``"text"``     – Generic single-line text input.
+    - ``"password"`` – Text input whose characters are masked.
+    - ``"select"``   – Drop-down; ``options`` must be populated.
+    """
+
+    key: str
+    label: str
+    field_type: FieldType
+    description: str = ""
+    #: For ``"file"`` fields: comma-separated extensions, e.g. ``".csv"``.
+    accept: str = ""
+    #: For ``"select"`` fields: the list of allowed values.
+    options: list[str] = field(default_factory=list)
+    #: Pre-filled default value shown in the UI.
+    default: str = ""
+    required: bool = True
+    #: Hint shown as placeholder text inside the input widget.
+    placeholder: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "field_type": self.field_type,
+            "description": self.description,
+            "accept": self.accept,
+            "options": self.options,
+            "default": self.default,
+            "required": self.required,
+            "placeholder": self.placeholder,
+        }
+
+
+class LabelImporter:
+    """Abstract base class for label importers.
+
+    Subclass this, set the class-level attributes, implement :meth:`run`,
+    and expose a module-level ``LABEL_IMPORTER = YourImporter()`` – the
+    registry picks it up automatically.
+
+    The :meth:`run` method must return a list of label dicts in the form::
+
+        [{"md5": "<clip-md5>", "label": "good"}, ...]
+
+    where ``label`` is ``"good"`` or ``"bad"``.  The route handler applies
+    these to the global vote state (``good_votes`` / ``bad_votes``) by
+    matching clip MD5 hashes.
+
+    CLI support
+    -----------
+    Every importer is automatically usable from the command line via::
+
+        python app.py --label-importer <name> [importer args]
+
+    The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
+    :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override
+    either when the defaults are insufficient (e.g. when :meth:`run` expects a
+    Werkzeug ``FileStorage`` rather than a plain file path).
+    """
+
+    #: Internal snake_case identifier used in API routes, e.g. ``"csv"``.
+    name: str
+    #: Human-readable label shown in the UI, e.g. ``"CSV File"``.
+    display_name: str
+    #: One-sentence description shown as a subtitle in the UI.
+    description: str
+    #: Emoji or icon string shown next to the display name in the UI.
+    icon: str = "🏷️"
+    #: Ordered list of fields the user must fill before importing.
+    fields: list[LabelImporterField]
+
+    def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Perform the import and return a list of label dicts.
+
+        Args:
+            field_values: Mapping of :attr:`LabelImporterField.key` → value.
+                Fields with ``field_type="file"`` receive a Werkzeug
+                :class:`~werkzeug.datastructures.FileStorage` object; all
+                other fields receive plain strings.
+
+        Returns:
+            A list of dicts, each with ``"md5"`` and ``"label"`` keys.
+            ``label`` must be ``"good"`` or ``"bad"``; any other value will
+            be skipped by the route handler.
+
+        Raises:
+            NotImplementedError: If the subclass has not implemented this.
+            Exception: Any exception propagates to the route handler, which
+                returns it as a 500 JSON error.
+        """
+        raise NotImplementedError(f"{type(self).__name__}.run() is not implemented")
+
+    # ------------------------------------------------------------------
+    # CLI support
+    # ------------------------------------------------------------------
+
+    def add_cli_arguments(self, parser: argparse.ArgumentParser) -> None:
+        """Register this importer's fields as ``argparse`` arguments.
+
+        The default implementation converts each :class:`LabelImporterField`
+        into a CLI flag (e.g. a field with ``key="filepath"`` becomes
+        ``--filepath``).  ``"select"`` fields gain a ``choices`` constraint.
+
+        Override this method if you need custom argument handling.
+        """
+        for f in self.fields:
+            arg_name = f"--{f.key.replace('_', '-')}"
+            kwargs: dict[str, Any] = {
+                "dest": f.key,
+                "help": f.description or f.label,
+            }
+            if f.default:
+                kwargs["default"] = f.default
+            if f.field_type == "select" and f.options:
+                kwargs["choices"] = f.options
+            parser.add_argument(arg_name, **kwargs)
+
+    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Import labels from CLI-provided *field_values*.
+
+        The default implementation simply delegates to :meth:`run`, which
+        works for importers whose ``run()`` only expects plain string values.
+        Importers that expect non-string objects (e.g. ``FileStorage``) must
+        override this method to handle file-path strings appropriately.
+        """
+        return self.run(field_values)
+
+    def validate_cli_field_values(self, field_values: dict[str, Any]) -> None:
+        """Raise ``ValueError`` if any required field is missing or empty."""
+        for f in self.fields:
+            if f.required and not field_values.get(f.key):
+                cli_flag = f"--{f.key.replace('_', '-')}"
+                raise ValueError(f"Missing required argument: {cli_flag}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise importer metadata for the ``/api/label-importers`` endpoint."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "description": self.description,
+            "icon": self.icon,
+            "fields": [f.to_dict() for f in self.fields],
+        }

--- a/vtsearch/labels/importers/csv_file/__init__.py
+++ b/vtsearch/labels/importers/csv_file/__init__.py
@@ -1,0 +1,105 @@
+"""CSV label importer – loads labels from a ``.csv`` file on disk.
+
+The CSV file must have at least two columns: ``md5`` and ``label``.  A header
+row is required.  Any additional columns are silently ignored.
+
+Example CSV::
+
+    md5,label
+    d41d8cd98f00b204e9800998ecf8427e,good
+    098f6bcd4621d373cade4e832627b4f6,bad
+
+No additional pip packages are required; uses only Python's ``csv`` and
+``io`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+from typing import Any
+
+from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+
+class CsvLabelImporter(LabelImporter):
+    """Import labels from a CSV file with ``md5`` and ``label`` columns.
+
+    The file must have a header row.  Any row missing the ``md5`` or
+    ``label`` column, or with a label that is not ``"good"`` or ``"bad"``,
+    is silently skipped by the route handler.
+    """
+
+    name = "csv_file"
+    display_name = "CSV File"
+    description = "Import labels from a CSV file with md5 and label columns."
+    icon = "📊"
+    fields = [
+        LabelImporterField(
+            key="file",
+            label="Labels CSV File",
+            field_type="file",
+            accept=".csv",
+            description="A CSV file with header row containing 'md5' and 'label' columns.",
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Parse the uploaded CSV file and return label dicts.
+
+        In the GUI path ``field_values["file"]`` is a Werkzeug
+        ``FileStorage`` object.  Use :meth:`run_cli` for the CLI path.
+        """
+        file_storage = field_values.get("file")
+        if file_storage is None:
+            raise ValueError("No file provided.")
+        try:
+            raw = file_storage.read()
+        except AttributeError:
+            raise ValueError("Expected a file upload, not a string. Use run_cli for CLI usage.")
+        return _parse_csv_bytes(raw)
+
+    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Load labels from a file-path string (CLI usage)."""
+        filepath = field_values.get("file", "").strip()
+        if not filepath:
+            raise ValueError("--file is required.")
+        raw = Path(filepath).read_bytes()
+        return _parse_csv_bytes(raw)
+
+    def add_cli_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--file",
+            dest="file",
+            help="Path to a CSV file with md5 and label columns.",
+            required=False,
+        )
+
+
+def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
+    """Decode *raw* bytes as CSV and extract ``md5``/``label`` pairs."""
+    try:
+        text = raw.decode("utf-8-sig")  # strip BOM if present
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1")
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise ValueError("CSV file appears to be empty.")
+
+    # Normalise header names to lower-case and strip whitespace
+    normalised = {k.strip().lower(): k for k in reader.fieldnames if k}
+    if "md5" not in normalised or "label" not in normalised:
+        raise ValueError("CSV must have 'md5' and 'label' column headers.")
+
+    results = []
+    for row in reader:
+        md5 = row.get(normalised["md5"], "").strip()
+        label = row.get(normalised["label"], "").strip().lower()
+        if md5 and label:
+            results.append({"md5": md5, "label": label})
+    return results
+
+
+LABEL_IMPORTER = CsvLabelImporter()

--- a/vtsearch/labels/importers/json_file/__init__.py
+++ b/vtsearch/labels/importers/json_file/__init__.py
@@ -1,0 +1,87 @@
+"""JSON label importer – loads labels from a ``.json`` file on disk.
+
+This importer reads the standard VTSearch label format::
+
+    {"labels": [{"md5": "...", "label": "good"}, ...]}
+
+No additional pip packages are required; uses only Python's ``json`` and
+``pathlib`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+
+class JsonLabelImporter(LabelImporter):
+    """Import labels from a JSON file in the standard VTSearch label format.
+
+    The file must be a JSON object with a top-level ``"labels"`` key whose
+    value is a list of ``{"md5": "...", "label": "good"|"bad"}`` dicts.
+    This is the same format produced by ``GET /api/labels/export``.
+    """
+
+    name = "json_file"
+    display_name = "JSON File"
+    description = "Import labels from a VTSearch-format JSON file (.json)."
+    icon = "📄"
+    fields = [
+        LabelImporterField(
+            key="file",
+            label="Labels JSON File",
+            field_type="file",
+            accept=".json",
+            description="A JSON file with a 'labels' list of {md5, label} objects.",
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Parse the uploaded JSON file and return label dicts.
+
+        In the GUI path ``field_values["file"]`` is a Werkzeug
+        ``FileStorage`` object; in the CLI path it is a plain file-path string.
+        Use :meth:`run_cli` for the CLI path.
+        """
+        file_storage = field_values.get("file")
+        if file_storage is None:
+            raise ValueError("No file provided.")
+        try:
+            raw = file_storage.read()
+        except AttributeError:
+            raise ValueError("Expected a file upload, not a string. Use run_cli for CLI usage.")
+        return _parse_json_bytes(raw)
+
+    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Load labels from a file-path string (CLI usage)."""
+        filepath = field_values.get("file", "").strip()
+        if not filepath:
+            raise ValueError("--file is required.")
+        raw = Path(filepath).read_bytes()
+        return _parse_json_bytes(raw)
+
+    def add_cli_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--file",
+            dest="file",
+            help="Path to a VTSearch labels JSON file.",
+            required=False,
+        )
+
+
+def _parse_json_bytes(raw: bytes) -> list[dict[str, str]]:
+    """Decode *raw* bytes as JSON and extract the labels list."""
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+    labels = data.get("labels")
+    if not isinstance(labels, list):
+        raise ValueError("JSON must contain a top-level 'labels' list.")
+    return [entry for entry in labels if isinstance(entry, dict)]
+
+
+LABEL_IMPORTER = JsonLabelImporter()

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -4,6 +4,7 @@ from vtsearch.routes.clips import clips_bp
 from vtsearch.routes.datasets import datasets_bp
 from vtsearch.routes.detectors import detectors_bp
 from vtsearch.routes.exporters import exporters_bp
+from vtsearch.routes.label_importers import label_importers_bp
 from vtsearch.routes.main import main_bp
 from vtsearch.routes.sorting import sorting_bp
 
@@ -14,4 +15,5 @@ __all__ = [
     "detectors_bp",
     "datasets_bp",
     "exporters_bp",
+    "label_importers_bp",
 ]

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -1,0 +1,131 @@
+"""Flask routes for the Label Importer API.
+
+Endpoints
+---------
+GET  /api/label-importers
+    List all registered label importers with their metadata and field definitions.
+
+POST /api/label-importers/import/<importer_name>
+    Run the named label importer.  Accepts ``multipart/form-data`` (when the
+    importer has a ``"file"`` field) or JSON (for text-only importers).
+
+    Returns::
+
+        {"applied": <int>, "skipped": <int>, "message": "<str>"}
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from vtsearch.labels.importers import get_label_importer, list_label_importers
+from vtsearch.utils import add_label_to_history, bad_votes, clips, good_votes
+
+label_importers_bp = Blueprint("label_importers", __name__)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/label-importers
+# ---------------------------------------------------------------------------
+
+
+@label_importers_bp.route("/api/label-importers", methods=["GET"])
+def get_label_importers():
+    """Return a list of all registered label importers."""
+    return jsonify([imp.to_dict() for imp in list_label_importers()])
+
+
+# ---------------------------------------------------------------------------
+# POST /api/label-importers/import/<importer_name>
+# ---------------------------------------------------------------------------
+
+
+@label_importers_bp.route("/api/label-importers/import/<importer_name>", methods=["POST"])
+def run_label_import(importer_name: str):
+    """Run the named label importer and apply the resulting labels.
+
+    Accepts ``multipart/form-data`` when the importer has a ``"file"`` field,
+    or ``application/json`` for text-only importers.  In both cases the route
+    builds a ``field_values`` dict and passes it to
+    :meth:`~vtsearch.labels.importers.base.LabelImporter.run`.
+
+    Returns JSON with ``applied``, ``skipped``, and ``message`` keys.
+    """
+    importer = get_label_importer(importer_name)
+    if importer is None:
+        known = [imp.name for imp in list_label_importers()]
+        return (
+            jsonify({"error": f"Unknown label importer '{importer_name}'. Available: {known}"}),
+            404,
+        )
+
+    # Build field_values from either multipart or JSON body
+    has_file_fields = any(f.field_type == "file" for f in importer.fields)
+    field_values: dict = {}
+
+    if has_file_fields:
+        for f in importer.fields:
+            if f.field_type == "file":
+                field_values[f.key] = request.files.get(f.key)
+            else:
+                field_values[f.key] = request.form.get(f.key, f.default or "")
+    else:
+        body = request.get_json(force=True, silent=True) or {}
+        for f in importer.fields:
+            field_values[f.key] = body.get(f.key, f.default or "")
+
+    # Validate required fields (skip file fields — presence checked by importer)
+    missing = [
+        f.key
+        for f in importer.fields
+        if f.required and f.field_type != "file" and not field_values.get(f.key, "").strip()
+    ]
+    if missing:
+        return (
+            jsonify({"error": f"Missing required field(s): {missing}", "missing_fields": missing}),
+            400,
+        )
+
+    try:
+        label_entries = importer.run(field_values)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:  # pragma: no cover
+        return jsonify({"error": f"Import failed: {exc}"}), 500
+
+    if not isinstance(label_entries, list):
+        return jsonify({"error": "Importer did not return a list of label dicts."}), 500
+
+    # Apply labels to global vote state
+    md5_to_id = {clip["md5"]: clip["id"] for clip in clips.values()}
+    applied = 0
+    skipped = 0
+
+    for entry in label_entries:
+        md5 = entry.get("md5", "")
+        label = entry.get("label", "")
+        if label not in ("good", "bad"):
+            skipped += 1
+            continue
+        cid = md5_to_id.get(md5)
+        if cid is None:
+            skipped += 1
+            continue
+
+        if label == "good":
+            bad_votes.pop(cid, None)
+            good_votes[cid] = None
+            add_label_to_history(cid, "good")
+        else:
+            good_votes.pop(cid, None)
+            bad_votes[cid] = None
+            add_label_to_history(cid, "bad")
+        applied += 1
+
+    return jsonify(
+        {
+            "applied": applied,
+            "skipped": skipped,
+            "message": f"Applied {applied} label(s), skipped {skipped}.",
+        }
+    )


### PR DESCRIPTION
## Summary
Introduces a pluggable label importer system that allows importing clip labels from multiple sources (JSON files, CSV files, and extensible to databases, APIs, etc.). Replaces the previous hardcoded JSON-only import with a flexible registry-based architecture supporting both GUI and CLI workflows.

## Key Changes

### Core Abstraction
- **`vtsearch/labels/importers/base.py`**: New base classes for the importer system
  - `LabelImporterField`: Describes configurable inputs (file, text, password, select fields)
  - `LabelImporter`: Abstract base class with `run()` method for importers to implement
  - Built-in CLI support via `add_cli_arguments()` and `run_cli()` methods
  - Validation and serialization via `to_dict()` and `validate_cli_field_values()`

### Auto-Discovery Registry
- **`vtsearch/labels/importers/__init__.py`**: Registry system that auto-discovers importers
  - `list_label_importers()`: Returns all registered importers
  - `get_label_importer(name)`: Retrieves a specific importer by name
  - Automatic discovery of sub-packages exposing `LABEL_IMPORTER` module attribute

### Built-in Importers
- **`vtsearch/labels/importers/json_file/__init__.py`**: JSON file importer
  - Reads VTSearch standard format: `{"labels": [{"md5": "...", "label": "good|bad"}]}`
  - Supports both GUI (FileStorage) and CLI (file path) workflows
  - Helper function `_parse_json_bytes()` for parsing

- **`vtsearch/labels/importers/csv_file/__init__.py`**: CSV file importer
  - Reads CSV with `md5` and `label` columns
  - Handles BOM stripping, case-insensitive headers, extra columns
  - Normalizes labels to lowercase
  - Helper function `_parse_csv_bytes()` for parsing

### API Routes
- **`vtsearch/routes/label_importers.py`**: New Flask blueprint with two endpoints
  - `GET /api/label-importers`: Lists all registered importers with metadata and field definitions
  - `POST /api/label-importers/import/<name>`: Runs a named importer, applies labels to clips, returns `{applied, skipped, message}`
  - Handles both multipart/form-data (for file fields) and JSON request bodies
  - Validates required fields and applies labels by MD5 matching

### CLI Integration
- **`vtsearch/cli.py`**: New `import_labels_main()` function
  - Entry point for CLI label importing: `python app.py --import-labels --label-importer <name> [args]`
  - Loads dataset, validates importer fields, applies labels, prints summary
  - Delegates to importer's `run_cli()` method

### Frontend Updates
- **`static/app.js`**: Replaced hardcoded JSON import with modal-based importer picker
  - `openLabelImporterModal()`: Fetches available importers and displays picker UI
  - `showLabelImporterForm()`: Dynamically generates form based on importer's field definitions
  - Supports file uploads, text inputs, password fields, and select dropdowns
  - Submits to new `/api/label-importers/import/<name>` endpoint

- **`static/index.html`**: Added label importer modal UI
  - Removed hardcoded `#import-file` input element
  - Added modal with importer list and dynamic form container

### App Integration
- **`app.py`**: Registers new `label_importers_bp` blueprint and adds CLI arguments
  - `--import-labels`: Flag to enable label importing mode
  - `--label-importer`: Specifies which importer to use

### Testing
- **`tests/test_label_importers.py`**: Comprehensive test suite (684 lines)
  - Tests for `LabelImporterField` and `LabelImporter` base classes
  - Registry tests

https://claude.ai/code/session_01LpzQ3dBybPZ74LUjETeHtk