### PR TITLE
Fix sorting precision loss by using raw scores before rounding

### DIFF
--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -85,6 +85,26 @@ class TestTrainAndScore:
         avg_bad = np.mean([score_map[i] for i in app_module.bad_votes])
         assert avg_good > avg_bad
 
+    def test_order_changes_after_new_vote(self):
+        """After adding a vote and retraining, the sort order should change."""
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [19, 20]})
+        results_before, _ = app_module.train_and_score(
+            app_module.clips, app_module.good_votes, app_module.bad_votes
+        )
+        order_before = [e["id"] for e in results_before]
+
+        # Add a new good vote on a clip that was in the middle
+        app_module.good_votes[10] = None
+        results_after, _ = app_module.train_and_score(
+            app_module.clips, app_module.good_votes, app_module.bad_votes
+        )
+        order_after = [e["id"] for e in results_after]
+
+        assert order_before != order_after, (
+            "Sort order did not change after adding a new vote"
+        )
+
 
 class TestLearnedSort:
     def test_returns_all_clips(self, client):

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -326,6 +326,8 @@ def train_and_score(
     with torch.no_grad():
         scores = model(X_all).squeeze(1).tolist()
 
-    results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
-    results.sort(key=lambda x: x["score"], reverse=True)
+    # Sort by raw scores (full precision) so that tiny differences still
+    # affect ordering.  Round only for the JSON response values.
+    paired = sorted(zip(all_ids, scores), key=lambda x: x[1], reverse=True)
+    results = [{"id": cid, "score": round(s, 4)} for cid, s in paired]
     return results, threshold

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -364,8 +364,9 @@ def label_file_sort():
         with torch.no_grad():
             scores = model(X_all).squeeze(1).tolist()
 
-        results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
-        results.sort(key=lambda x: x["score"], reverse=True)
+        # Sort by raw scores (full precision) before rounding for display.
+        paired = sorted(zip(all_ids, scores), key=lambda x: x[1], reverse=True)
+        results = [{"id": cid, "score": round(s, 4)} for cid, s in paired]
 
         return jsonify(
             {


### PR DESCRIPTION
## Summary
Fixed a precision loss bug in the sorting logic where scores were rounded to 4 decimal places before sorting, causing clips with very similar rounded scores to have unstable ordering. Now scores are sorted at full precision and only rounded for display in the JSON response.

## Changes
- **vtsearch/models/training.py**: Modified `train_and_score()` to sort by raw score values before rounding, ensuring that small differences in model scores still affect the final ordering
- **vtsearch/routes/sorting.py**: Applied the same fix to `label_file_sort()` for consistency across the codebase
- **tests/test_sorting.py**: Added `test_order_changes_after_new_vote()` to verify that adding a new vote causes the sort order to change, catching regressions in sorting stability

## Implementation Details
The fix changes the sorting approach from:
1. Create results with rounded scores
2. Sort by rounded scores

To:
1. Sort by raw (full precision) scores
2. Create results with rounded scores for display

This ensures that the ordering is determined by the actual model output precision rather than the display precision, making the sort order more stable and responsive to model changes.

https://claude.ai/code/session_01Y1KrK8GmSY9QjqNJiBd9Uo