### PR TITLE
Remove save detector functionality and reorder menu items

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -112,7 +112,6 @@
   const menuDetectorStatus = document.getElementById("menu-detector-status");
   const importFile = document.getElementById("import-file");
   const menuFavoritesManage = document.getElementById("menu-favorites-manage");
-  const menuFavoritesSave = document.getElementById("menu-favorites-save");
   const menuFavoritesAutodetect = document.getElementById("menu-favorites-autodetect");
   const favoritesModal = document.getElementById("favorites-modal");
   const favoritesModalClose = document.getElementById("favorites-modal-close");
@@ -746,55 +745,6 @@
   if (favoritesModalClose) {
     favoritesModalClose.addEventListener("click", () => {
       favoritesModal.classList.remove("show");
-    });
-  }
-
-  if (menuFavoritesSave) {
-    menuFavoritesSave.addEventListener("click", async () => {
-      if (votes.good.length === 0 || votes.bad.length === 0) {
-        alert("You need to vote on at least one good and one bad clip before saving a detector.");
-        return;
-      }
-
-      const name = prompt("Enter a name for this detector:");
-      if (!name) return;
-
-      // Export the detector first
-      const res = await fetch("/api/detector/export", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      if (!res.ok) {
-        alert("Failed to export detector.");
-        return;
-      }
-
-      const detectorData = await res.json();
-
-      // Determine media type from current clips
-      const mediaType = clips.length > 0 ? clips[0].type : "audio";
-
-      // Save as favorite
-      const saveRes = await fetch("/api/favorite-detectors", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: name,
-          media_type: mediaType,
-          weights: detectorData.weights,
-          threshold: detectorData.threshold,
-        }),
-      });
-
-      if (saveRes.ok) {
-        alert(`Detector "${name}" saved successfully!`);
-        await loadFavoriteDetectors();
-      } else {
-        alert("Failed to save detector.");
-      }
-
-      burgerDropdown.classList.remove("show");
     });
   }
 

--- a/static/index.html
+++ b/static/index.html
@@ -18,25 +18,24 @@
     <div class="burger-dropdown" id="burger-dropdown">
       <div class="burger-section">
         <div class="burger-section-title">Dataset</div>
-        <div class="burger-item" id="menu-dataset-export">Export Dataset</div>
         <div class="burger-item" id="menu-dataset-change">Change Dataset</div>
+        <div class="burger-item" id="menu-dataset-export">Export Dataset</div>
       </div>
       <div class="burger-section">
         <div class="burger-section-title">Labels</div>
-        <div class="burger-item" id="menu-labels-export">Export Labels</div>
         <div class="burger-item" id="menu-labels-import">Import Labels</div>
+        <div class="burger-item" id="menu-labels-export">Export Labels</div>
         <div class="burger-status" id="menu-labels-status"></div>
       </div>
       <div class="burger-section">
         <div class="burger-section-title">Detector</div>
-        <div class="burger-item" id="menu-detector-import">Import Detector</div>
+        <div class="burger-item" id="menu-detector-import">Load Sort</div>
         <div class="burger-item" id="menu-detector-export">Export Detector</div>
         <div class="burger-status" id="menu-detector-status"></div>
       </div>
       <div class="burger-section">
         <div class="burger-section-title">Favorite Detectors</div>
         <div class="burger-item" id="menu-favorites-manage">Manage Favorites</div>
-        <div class="burger-item" id="menu-favorites-save">Save Current Detector</div>
         <div class="burger-item" id="menu-favorites-autodetect">Run Auto-Detect</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
This PR removes the "Save Current Detector" menu option and its associated event handler, while also reordering several menu items in the burger dropdown for better UX organization.

## Key Changes
- **Removed "Save Current Detector" feature**: Deleted the `menuFavoritesSave` element reference and its 50-line click event handler that allowed users to save the current detector state as a favorite
- **Reordered menu items** for improved logical grouping:
  - Dataset section: Moved "Change Dataset" before "Export Dataset"
  - Labels section: Moved "Import Labels" before "Export Labels"
  - Detector section: Renamed "Import Detector" to "Load Sort"
- The removed functionality included detector export, media type detection, and API calls to persist favorite detectors

## Implementation Details
The removed event handler performed the following workflow:
1. Validated that at least one good and one bad clip had been voted on
2. Prompted user for a detector name
3. Exported the current detector via `/api/detector/export`
4. Saved it as a favorite via `/api/favorite-detectors` POST endpoint
5. Refreshed the favorites list on success

This functionality is no longer available through the UI, though the backend API endpoints may still exist.

https://claude.ai/code/session_01TtWdATMd6RrhgYEjhb3Spt