### PR TITLE
Update demo dataset labels with descriptive names

### DIFF
--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -74,7 +74,7 @@ class AudioMediaType(MediaType):
         return [
             DemoDataset(
                 id="sounds_s",
-                label="Sounds (S)",
+                label="ESC-50 Animals & Fireside (S)",
                 description=(
                     "200 clips of dogs, cats, roosters, church bells, and crackling"
                     " fire from the ESC-50 collection."
@@ -90,7 +90,7 @@ class AudioMediaType(MediaType):
             ),
             DemoDataset(
                 id="sounds_m",
-                label="Sounds (M)",
+                label="ESC-50 Everyday Sounds (M)",
                 description=(
                     "400 clips of babies, laughter, clapping, footsteps, chainsaws,"
                     " airplanes, and more from the ESC-50 collection."
@@ -111,7 +111,7 @@ class AudioMediaType(MediaType):
             ),
             DemoDataset(
                 id="sounds_l",
-                label="Sounds (L)",
+                label="ESC-50 Environmental Mix (L)",
                 description=(
                     "800 clips spanning nature, animals, weather, traffic, and"
                     " household sounds from the ESC-50 collection."

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -100,7 +100,7 @@ class ImageMediaType(MediaType):
         return [
             DemoDataset(
                 id="images_s",
-                label="Images (S)",
+                label="Caltech-101 Nature & Flight (S)",
                 description=(
                     "Photographs of butterflies, sunflowers, starfish, and"
                     " helicopters from the Caltech-101 dataset."
@@ -111,7 +111,7 @@ class ImageMediaType(MediaType):
             ),
             DemoDataset(
                 id="images_m",
-                label="Images (M)",
+                label="Caltech-101 Animals & Objects (M)",
                 description=(
                     "Photographs of dolphins, grand pianos, elephants, kangaroos,"
                     " laptops, lobsters, watches, and flamingos from Caltech-101."
@@ -131,7 +131,7 @@ class ImageMediaType(MediaType):
             ),
             DemoDataset(
                 id="images_l",
-                label="Images (L)",
+                label="Caltech-101 Diverse Objects (L)",
                 description=(
                     "Photographs across 15 diverse categories including animals,"
                     " instruments, vehicles, and objects from Caltech-101."

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -72,7 +72,7 @@ class TextMediaType(MediaType):
         return [
             DemoDataset(
                 id="paragraphs_s",
-                label="Paragraphs (S)",
+                label="Newsgroup Sports & Science (S)",
                 description=(
                     "Short articles about sports and space science from the"
                     " 20 Newsgroups collection."
@@ -82,7 +82,7 @@ class TextMediaType(MediaType):
             ),
             DemoDataset(
                 id="paragraphs_m",
-                label="Paragraphs (M)",
+                label="Newsgroup World News & Tech (M)",
                 description=(
                     "Articles spanning world affairs, business, computer graphics,"
                     " and medicine from the 20 Newsgroups collection."
@@ -92,7 +92,7 @@ class TextMediaType(MediaType):
             ),
             DemoDataset(
                 id="paragraphs_l",
-                label="Paragraphs (L)",
+                label="Newsgroup 8-Topic Mix (L)",
                 description=(
                     "Articles across eight topics including cars, hockey,"
                     " electronics, cryptography, and religion from 20 Newsgroups."


### PR DESCRIPTION
## Summary
Updated demo dataset labels across audio, image, and text media types to be more descriptive and informative, replacing generic size-based labels with dataset-specific names that indicate the content categories included in each dataset.

## Changes
- **Audio datasets**: Replaced generic "Sounds (S/M/L)" labels with descriptive names indicating content:
  - "Sounds (S)" → "ESC-50 Animals & Fireside (S)"
  - "Sounds (M)" → "ESC-50 Everyday Sounds (M)"
  - "Sounds (L)" → "ESC-50 Environmental Mix (L)"

- **Image datasets**: Replaced generic "Images (S/M/L)" labels with descriptive names:
  - "Images (S)" → "Caltech-101 Nature & Flight (S)"
  - "Images (M)" → "Caltech-101 Animals & Objects (M)"
  - "Images (L)" → "Caltech-101 Diverse Objects (L)"

- **Text datasets**: Replaced generic "Paragraphs (S/M/L)" labels with descriptive names:
  - "Paragraphs (S)" → "Newsgroup Sports & Science (S)"
  - "Paragraphs (M)" → "Newsgroup World News & Tech (M)"
  - "Paragraphs (L)" → "Newsgroup 8-Topic Mix (L)"

## Details
The dataset descriptions already contained detailed information about the content, but the labels were generic. These changes make the labels more informative and user-friendly by including the dataset source (ESC-50, Caltech-101, 20 Newsgroups) and key content categories, helping users better understand what each demo dataset contains at a glance.

https://claude.ai/code/session_011FyHa8djGxbGCtYgAf1cj1