### PR TITLE
Add test markers for slow subprocess tests and improve reproducibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,9 @@
 Media explorer web app for browsing/voting on audio, images, or text. Semantic sorting (LAION-CLAP, CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + vanilla JS + PyTorch.
 
 ## Commands
-- **Run tests (CPU)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -v`
+- **Run tests (CPU, fast)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -v`
+- **Run tests (CPU, full)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -v -m 'not gpu'`
+- **Run slow CLI subprocess tests only**: `python -m pytest tests/ -v -m slow`
 - **Run GPU tests**: `python -m pytest tests/test_gpu.py -v -m gpu` (requires CUDA GPU; downloads models on first run)
 - **Run all tests (CPU + GPU)**: `python -m pytest tests/ -v -m ''`
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
@@ -39,7 +41,7 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_label_importers.py` — Label importer base class, registry, json_file/csv_file importers, API routes
   - `test_inclusion.py` — Inclusion GET/POST
   - `test_detectors.py` — Detector export, detector sort, favorites, auto-detect
-  - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag
+  - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag. Subprocess tests marked `slow` (~16s each, excluded from default run)
   - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
   - `test_rss_youtube_importers.py` — RSS feed and YouTube playlist importer metadata, CLI args, run logic
   - `test_csv_webhook_exporters.py` — CSV and Webhook exporter metadata, CLI args, export logic
@@ -48,6 +50,12 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_extractors.py` — Image class extractor
   - `test_processors.py` — Media processor tests
   - `test_gpu.py` — GPU tests: training, cross-calibration, detectors, embedding models (CLAP/CLIP/X-CLIP/E5), CPU↔GPU equivalence, memory cleanup (skipped without CUDA)
+
+## Test Markers
+- **Default** (`pytest tests/ -v`): Runs fast CPU tests only (~35s). Excludes `gpu` and `slow` markers.
+- **`slow`**: CLI subprocess tests that spawn `python app.py --autodetect` (each ~16s, total ~290s). Run with `-m slow` or include with `-m 'not gpu'`.
+- **`gpu`**: CUDA-only tests. Run with `-m gpu`.
+- **All tests**: Use `-m ''` to run everything.
 
 ## Test Workflow (IMPORTANT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,6 @@ indent-style = "space"
 testpaths = ["tests"]
 markers = [
     "gpu: tests that require a CUDA GPU (deselected by default, run with: -m gpu)",
+    "slow: CLI subprocess tests that spawn a fresh Python process (~16s each)",
 ]
-addopts = "-m 'not gpu'"
+addopts = "-m 'not gpu and not slow'"

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -352,6 +352,7 @@ class TestImporterCLIArguments:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestAutodetectCLI:
     """Tests for the command-line --autodetect flag via subprocess."""
 
@@ -466,6 +467,7 @@ class TestAutodetectCLI:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestAutodetectImporterCLI:
     """Tests for the --autodetect --importer path via subprocess."""
 
@@ -903,6 +905,7 @@ class TestAutodetectImporterMainWithExporter:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestAutodetectExporterCLI:
     """Tests for the --autodetect --exporter path via subprocess."""
 

--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -176,7 +176,7 @@ def simulate_voting_iterations(
         input_dim = X.shape[1]
 
         # Train and find threshold (mirrors train_and_score)
-        threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim, inclusion)
+        threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim, inclusion, rng=rng)
         model = train_model(X, y, input_dim, inclusion)
 
         # Evaluate on held-out test set

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -208,6 +208,7 @@ def calculate_cross_calibration_threshold(
     y_list: list[float],
     input_dim: int,
     inclusion_value: int = 0,
+    rng: np.random.RandomState | None = None,
 ) -> float:
     """Estimate a decision threshold using cross-calibration.
 
@@ -229,6 +230,8 @@ def calculate_cross_calibration_threshold(
         input_dim: Dimensionality of the embeddings.
         inclusion_value: Integer in ``[-10, 10]`` passed to :func:`train_model`
             and :func:`find_optimal_threshold` to control the FPR/FNR trade-off.
+        rng: Optional seeded RandomState for reproducible splits. Falls back
+            to the global ``np.random`` state when ``None``.
 
     Returns:
         A float threshold. Returns 0.5 if fewer than 4 examples are provided
@@ -241,7 +244,8 @@ def calculate_cross_calibration_threshold(
 
     # Split data in half
     mid = n // 2
-    indices = np.random.permutation(n)
+    _rng = rng if rng is not None else np.random
+    indices = _rng.permutation(n)
     idx1 = indices[:mid]
     idx2 = indices[mid:]
 


### PR DESCRIPTION
## Summary
This PR improves test organization and reproducibility by introducing pytest markers for slow tests and adding optional seeding support to cross-calibration calculations.

## Key Changes

- **Test Organization**: Added `slow` pytest marker to CLI subprocess tests (`TestAutodetectCLI`, `TestAutodetectImporterCLI`, `TestAutodetectExporterCLI`) that spawn fresh Python processes and take ~16s each. Updated `pyproject.toml` to exclude these by default (`-m 'not gpu and not slow'`), reducing default test runtime from ~325s to ~35s.

- **Documentation**: Updated `CLAUDE.md` with:
  - Clarified test command descriptions (fast vs. full CPU tests)
  - Added new "Test Markers" section explaining default, slow, and gpu markers
  - Documented that slow subprocess tests are excluded from default runs but can be included with `-m 'not gpu'`

- **Reproducibility**: Enhanced `calculate_cross_calibration_threshold()` in `vtsearch/models/training.py` with optional `rng` parameter for seeded random splits, enabling deterministic cross-validation. Updated `simulate_voting_iterations()` to pass the seeded RNG through to this function.

## Implementation Details

- The `rng` parameter in `calculate_cross_calibration_threshold()` defaults to `None` and falls back to global `np.random` state for backward compatibility
- Slow tests are now easily runnable with `pytest tests/ -v -m slow` or included in full CPU test suite with `-m 'not gpu'`
- Default pytest behavior now runs only fast tests, improving developer iteration speed

https://claude.ai/code/session_01JUhFcdE3euaJ4yzRotvh8K