### PR TITLE
Update labeling indicator green status text from "ready to stop" to "Done"

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1980,7 +1980,7 @@
     } else if (data.status === "yellow") {
       subtext.textContent = "Continue";
     } else if (data.status === "green") {
-      subtext.textContent = "ready to stop";
+      subtext.textContent = "Done";
     } else {
       subtext.textContent = "";
     }

--- a/static/styles.css
+++ b/static/styles.css
@@ -179,7 +179,7 @@ video { max-width: 600px; max-height: 400px; }
 .labeling-indicator[data-status="yellow"] .indicator-label { color: #f0d070; }
 .labeling-indicator[data-status="yellow"] .indicator-subtext { color: #a08830; }
 
-/* Green – ready to stop */
+/* Green – done */
 .labeling-indicator[data-status="green"] { border-color: #27ae60; }
 .labeling-indicator[data-status="green"] .indicator-dot { background: #2ecc71; box-shadow: 0 0 5px #2ecc7188; }
 .labeling-indicator[data-status="green"] .indicator-label { color: #7deba0; }


### PR DESCRIPTION
## Summary
Updated the user-facing text and internal comments for the green status state of the labeling indicator to use clearer, more concise language.

## Changes
- Changed the green status subtext from "ready to stop" to "Done" in `static/app.js`
- Updated the corresponding CSS comment from "Green – ready to stop" to "Green – done" in `static/styles.css` for consistency

## Details
This change improves the user experience by using simpler, more intuitive language. "Done" is more direct and immediately communicates that the labeling task is complete, whereas "ready to stop" is more ambiguous and verbose.

https://claude.ai/code/session_01HMHPzFWq38nxmGEyoc5g7v