### PR TITLE
Add element-level origin tracking with LabelSet and Origin classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 - `config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
 - `vtsearch/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking
-- `vtsearch/datasets/` — Dataset loading, downloading, importers (folder/pickle/http_zip/rss_feed/youtube_playlist)
+- `vtsearch/datasets/` — Dataset loading, downloading, origin tracking, labelsets, importers (folder/pickle/http_zip/rss_feed/youtube_playlist)
 - `vtsearch/exporters/` — Results exporters (file/gui/email_smtp/csv_file/webhook)
 - `vtsearch/labels/importers/` — Label importers (json_file/csv_file); auto-discovered via `LABEL_IMPORTER` sentinel
 - `vtsearch/processors/importers/` — Processor importers (detector_file/label_file); auto-discovered via `PROCESSOR_IMPORTER` sentinel
@@ -52,6 +52,7 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_extractors.py` — Image class extractor
   - `test_processors.py` — Media processor tests
   - `test_processor_importers.py` — Processor importer base class, registry, detector_file/label_file importers, API routes, CLI
+  - `test_origin_labelset.py` — Origin class, LabeledElement, LabelSet, build_origin(), label export/import with origins, integration
   - `test_gpu.py` — GPU tests: training, cross-calibration, detectors, embedding models (CLAP/CLIP/X-CLIP/E5), CPU↔GPU equivalence, memory cleanup (skipped without CUDA)
 
 ## Test Markers
@@ -74,6 +75,9 @@ This ensures work is recoverable if the session crashes during a test run.
 ## Key Details
 - Global state lives in `vtsearch/utils/state.py`: `clips`, `good_votes`, `bad_votes` are module-level dicts
 - Votes are `dict[int, None]` (not sets) — use `votes[id] = None` syntax
+- Each clip has `origin` (dict or None) and `origin_name` (str) for per-element provenance tracking
+- `Origin` class in `vtsearch/datasets/origin.py`; `LabelSet`/`LabeledElement` in `vtsearch/datasets/labelset.py`
+- Label export (`/api/labels/export`) returns a `LabelSet` with per-element origin info (superset of legacy format)
 - `data/` dir created at runtime for embeddings, model cache, media files
 - OMP_NUM_THREADS and MKL_NUM_THREADS set to 1 for memory optimization
 - Linter/formatter: ruff (E402 ignored, line-length 120, see pyproject.toml)

--- a/app.py
+++ b/app.py
@@ -103,6 +103,7 @@ def init_clips():
             embedding = embed_audio_file(temp_path)
             new_embeddings[i] = embedding
 
+        fname = f"test_clip_{i}.wav"
         clips[i] = {
             "id": i,
             "type": "audio",
@@ -112,6 +113,10 @@ def init_clips():
             "md5": hashlib.md5(wav_bytes).hexdigest(),
             "embedding": embedding,
             "wav_bytes": wav_bytes,
+            "filename": fname,
+            "category": "test",
+            "origin": {"importer": "test", "params": {}},
+            "origin_name": fname,
         }
 
     # Clean up temp file

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -180,7 +180,7 @@ class TestCsvExporterExport:
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             header = next(reader)
-        assert header == ["detector", "threshold", "filename", "category", "score"]
+        assert header == ["detector", "threshold", "filename", "category", "score", "origin", "origin_name"]
 
     def test_csv_has_correct_row_count(self, tmp_path):
         from vtsearch.exporters.csv_file import CsvExporter

--- a/tests/test_origin_labelset.py
+++ b/tests/test_origin_labelset.py
@@ -11,10 +11,6 @@ Covers:
 
 from __future__ import annotations
 
-import json
-
-import pytest
-
 import app as app_module
 from vtsearch.datasets.labelset import LabelSet, LabeledElement
 from vtsearch.datasets.origin import Origin

--- a/tests/test_origin_labelset.py
+++ b/tests/test_origin_labelset.py
@@ -1,0 +1,436 @@
+"""Tests for Origin and LabelSet classes.
+
+Covers:
+- Origin serialisation, display, equality, hashing
+- LabeledElement serialisation
+- LabelSet construction from clips+votes, from results, from dict
+- LabelSet roundtrip serialisation
+- DatasetImporter.build_origin()
+- Integration with label export/import routes
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import app as app_module
+from vtsearch.datasets.labelset import LabelSet, LabeledElement
+from vtsearch.datasets.origin import Origin
+
+
+# ---------------------------------------------------------------------------
+# Origin
+# ---------------------------------------------------------------------------
+
+
+class TestOrigin:
+    def test_to_dict(self):
+        o = Origin("folder", {"path": "/data", "media_type": "sounds"})
+        d = o.to_dict()
+        assert d == {"importer": "folder", "params": {"path": "/data", "media_type": "sounds"}}
+
+    def test_from_dict(self):
+        d = {"importer": "http_archive", "params": {"url": "https://example.com/data.zip"}}
+        o = Origin.from_dict(d)
+        assert o.importer == "http_archive"
+        assert o.params == {"url": "https://example.com/data.zip"}
+
+    def test_from_dict_missing_params(self):
+        d = {"importer": "test"}
+        o = Origin.from_dict(d)
+        assert o.params == {}
+
+    def test_display_with_params(self):
+        o = Origin("folder", {"path": "/data/audio"})
+        assert o.display() == "folder(/data/audio)"
+
+    def test_display_without_params(self):
+        o = Origin("unknown", {})
+        assert o.display() == "unknown"
+
+    def test_equality(self):
+        a = Origin("folder", {"path": "/data"})
+        b = Origin("folder", {"path": "/data"})
+        assert a == b
+
+    def test_inequality(self):
+        a = Origin("folder", {"path": "/data"})
+        b = Origin("folder", {"path": "/other"})
+        assert a != b
+
+    def test_hash_consistency(self):
+        a = Origin("folder", {"path": "/data"})
+        b = Origin("folder", {"path": "/data"})
+        assert hash(a) == hash(b)
+
+    def test_roundtrip(self):
+        o = Origin("demo", {"name": "esc50_animals"})
+        assert Origin.from_dict(o.to_dict()) == o
+
+    def test_default_params(self):
+        o = Origin("test")
+        assert o.params == {}
+        assert o.display() == "test"
+
+
+# ---------------------------------------------------------------------------
+# LabeledElement
+# ---------------------------------------------------------------------------
+
+
+class TestLabeledElement:
+    def test_to_dict_minimal(self):
+        e = LabeledElement(md5="abc", label="good")
+        d = e.to_dict()
+        assert d == {"md5": "abc", "label": "good"}
+        # No optional keys when empty
+        assert "origin" not in d
+        assert "origin_name" not in d
+        assert "filename" not in d
+        assert "category" not in d
+
+    def test_to_dict_full(self):
+        origin = {"importer": "folder", "params": {"path": "/data"}}
+        e = LabeledElement(
+            md5="abc",
+            label="bad",
+            origin=origin,
+            origin_name="clip.wav",
+            filename="clip.wav",
+            category="dogs",
+        )
+        d = e.to_dict()
+        assert d["md5"] == "abc"
+        assert d["label"] == "bad"
+        assert d["origin"] == origin
+        assert d["origin_name"] == "clip.wav"
+        assert d["filename"] == "clip.wav"
+        assert d["category"] == "dogs"
+
+    def test_from_dict(self):
+        d = {
+            "md5": "xyz",
+            "label": "good",
+            "origin": {"importer": "demo", "params": {"name": "test"}},
+            "origin_name": "test_1.wav",
+            "filename": "test_1.wav",
+            "category": "birds",
+        }
+        e = LabeledElement.from_dict(d)
+        assert e.md5 == "xyz"
+        assert e.label == "good"
+        assert e.origin == d["origin"]
+        assert e.origin_name == "test_1.wav"
+
+    def test_from_dict_legacy(self):
+        """Legacy label format with only md5 and label."""
+        d = {"md5": "abc", "label": "bad"}
+        e = LabeledElement.from_dict(d)
+        assert e.md5 == "abc"
+        assert e.label == "bad"
+        assert e.origin is None
+        assert e.origin_name == ""
+
+
+# ---------------------------------------------------------------------------
+# LabelSet
+# ---------------------------------------------------------------------------
+
+
+class TestLabelSet:
+    def test_empty(self):
+        ls = LabelSet()
+        assert len(ls) == 0
+        assert ls.to_dict() == {"labels": []}
+
+    def test_from_elements(self):
+        elements = [
+            LabeledElement(md5="a", label="good"),
+            LabeledElement(md5="b", label="bad"),
+        ]
+        ls = LabelSet(elements)
+        assert len(ls) == 2
+
+    def test_iter(self):
+        elements = [LabeledElement(md5="a", label="good")]
+        ls = LabelSet(elements)
+        items = list(ls)
+        assert len(items) == 1
+        assert items[0].md5 == "a"
+
+    def test_to_dict(self):
+        origin = {"importer": "test", "params": {}}
+        elements = [
+            LabeledElement(md5="a", label="good", origin=origin, origin_name="a.wav"),
+            LabeledElement(md5="b", label="bad"),
+        ]
+        ls = LabelSet(elements)
+        d = ls.to_dict()
+        assert len(d["labels"]) == 2
+        assert d["labels"][0]["origin"] == origin
+        assert d["labels"][0]["origin_name"] == "a.wav"
+        # Second element has no origin
+        assert "origin" not in d["labels"][1]
+
+    def test_from_dict(self):
+        d = {
+            "labels": [
+                {"md5": "a", "label": "good", "origin": {"importer": "test", "params": {}}},
+                {"md5": "b", "label": "bad"},
+            ]
+        }
+        ls = LabelSet.from_dict(d)
+        assert len(ls) == 2
+        assert ls.elements[0].origin == {"importer": "test", "params": {}}
+        assert ls.elements[1].origin is None
+
+    def test_from_dict_skips_non_dicts(self):
+        d = {"labels": [{"md5": "a", "label": "good"}, "not a dict", 42]}
+        ls = LabelSet.from_dict(d)
+        assert len(ls) == 1
+
+    def test_roundtrip(self):
+        origin = {"importer": "folder", "params": {"path": "/data"}}
+        elements = [
+            LabeledElement(
+                md5="abc",
+                label="good",
+                origin=origin,
+                origin_name="clip.wav",
+                filename="clip.wav",
+                category="dogs",
+            ),
+        ]
+        ls = LabelSet(elements)
+        d = ls.to_dict()
+        ls2 = LabelSet.from_dict(d)
+        assert len(ls2) == 1
+        assert ls2.elements[0].md5 == "abc"
+        assert ls2.elements[0].origin == origin
+
+    def test_from_clips_and_votes(self):
+        clips = {
+            1: {
+                "md5": "hash1",
+                "filename": "a.wav",
+                "category": "dogs",
+                "origin": {"importer": "folder", "params": {"path": "/data"}},
+                "origin_name": "a.wav",
+            },
+            2: {
+                "md5": "hash2",
+                "filename": "b.wav",
+                "category": "cats",
+                "origin": {"importer": "folder", "params": {"path": "/data"}},
+                "origin_name": "b.wav",
+            },
+            3: {"md5": "hash3", "filename": "c.wav", "category": "birds"},
+        }
+        good_votes = {1: None}
+        bad_votes = {2: None, 3: None}
+
+        ls = LabelSet.from_clips_and_votes(clips, good_votes, bad_votes)
+        assert len(ls) == 3
+        assert ls.elements[0].label == "good"
+        assert ls.elements[0].origin == {"importer": "folder", "params": {"path": "/data"}}
+        assert ls.elements[1].label == "bad"
+        # Clip 3 has no origin set
+        assert ls.elements[2].origin is None
+        # But origin_name falls back to filename
+        assert ls.elements[2].origin_name == "c.wav"
+
+    def test_from_clips_and_votes_skips_missing_clips(self):
+        clips = {1: {"md5": "hash1", "filename": "a.wav", "category": "x"}}
+        good_votes = {1: None, 999: None}
+        bad_votes = {}
+        ls = LabelSet.from_clips_and_votes(clips, good_votes, bad_votes)
+        assert len(ls) == 1
+
+    def test_from_results(self):
+        results = {
+            "media_type": "audio",
+            "detectors_run": 1,
+            "results": {
+                "detector1": {
+                    "detector_name": "detector1",
+                    "threshold": 0.5,
+                    "total_hits": 2,
+                    "hits": [
+                        {
+                            "id": 1,
+                            "filename": "a.wav",
+                            "category": "dogs",
+                            "score": 0.9,
+                            "md5": "hash1",
+                            "origin": {"importer": "folder", "params": {"path": "/data"}},
+                            "origin_name": "a.wav",
+                        },
+                        {
+                            "id": 2,
+                            "filename": "b.wav",
+                            "category": "cats",
+                            "score": 0.7,
+                            "md5": "hash2",
+                        },
+                    ],
+                }
+            },
+        }
+        ls = LabelSet.from_results(results)
+        assert len(ls) == 2
+        assert ls.elements[0].md5 == "hash1"
+        assert ls.elements[0].origin is not None
+        assert ls.elements[1].md5 == "hash2"
+        assert ls.elements[1].origin is None
+
+    def test_from_results_with_clips_fallback(self):
+        """When hits don't have origin, look it up from clips dict."""
+        results = {
+            "results": {
+                "d1": {
+                    "hits": [{"id": 1, "filename": "a.wav", "score": 0.9, "md5": "h1"}]
+                }
+            }
+        }
+        clips = {
+            1: {
+                "md5": "h1",
+                "filename": "a.wav",
+                "origin": {"importer": "folder", "params": {"path": "/tmp"}},
+                "origin_name": "a.wav",
+            }
+        }
+        ls = LabelSet.from_results(results, clips=clips)
+        assert len(ls) == 1
+        assert ls.elements[0].origin is not None
+        assert ls.elements[0].origin["importer"] == "folder"
+
+
+# ---------------------------------------------------------------------------
+# DatasetImporter.build_origin()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOrigin:
+    def test_build_origin_from_fields(self):
+        from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+
+        class TestImporter(DatasetImporter):
+            name = "test"
+            display_name = "Test"
+            description = "Test importer."
+            fields = [
+                ImporterField("path", "Path", "folder"),
+                ImporterField("media_type", "Media Type", "select", options=["sounds", "images"]),
+                ImporterField("file", "File", "file"),  # Should be excluded
+            ]
+
+            def run(self, field_values, clips):
+                pass
+
+        imp = TestImporter()
+        origin = imp.build_origin({"path": "/data/audio", "media_type": "sounds", "file": "ignored"})
+        assert origin == {"importer": "test", "params": {"path": "/data/audio", "media_type": "sounds"}}
+
+    def test_build_origin_excludes_empty_values(self):
+        from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+
+        class TestImporter(DatasetImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = [
+                ImporterField("path", "Path", "folder"),
+                ImporterField("opt", "Opt", "text", required=False),
+            ]
+
+            def run(self, field_values, clips):
+                pass
+
+        imp = TestImporter()
+        origin = imp.build_origin({"path": "/data", "opt": ""})
+        assert origin == {"importer": "t", "params": {"path": "/data"}}
+
+
+# ---------------------------------------------------------------------------
+# Integration: clips have origin after init_clips
+# ---------------------------------------------------------------------------
+
+
+class TestClipOrigins:
+    def test_init_clips_have_origin(self):
+        """Every clip created by init_clips should have origin and origin_name."""
+        for cid, clip in app_module.clips.items():
+            assert "origin" in clip, f"Clip {cid} missing origin"
+            assert "origin_name" in clip, f"Clip {cid} missing origin_name"
+            assert clip["origin"]["importer"] == "test"
+            assert clip["origin_name"] == clip["filename"]
+
+    def test_init_clips_have_filename(self):
+        for cid, clip in app_module.clips.items():
+            assert "filename" in clip, f"Clip {cid} missing filename"
+            assert clip["filename"].startswith("test_clip_")
+
+
+# ---------------------------------------------------------------------------
+# Integration: label export includes origin
+# ---------------------------------------------------------------------------
+
+
+class TestLabelExportOrigin:
+    def test_export_includes_origin(self, client):
+        app_module.good_votes[1] = None
+        resp = client.get("/api/labels/export")
+        data = resp.get_json()
+        assert len(data["labels"]) == 1
+        entry = data["labels"][0]
+        assert "md5" in entry
+        assert "label" in entry
+        assert "origin" in entry
+        assert "origin_name" in entry
+        assert entry["origin"]["importer"] == "test"
+
+    def test_export_roundtrip_with_origin(self, client):
+        """Export labels with origin, re-import via legacy route, verify match."""
+        app_module.good_votes.update({k: None for k in [1, 3]})
+        app_module.bad_votes.update({k: None for k in [2]})
+        resp = client.get("/api/labels/export")
+        exported = resp.get_json()
+
+        # Verify origin info is present
+        for entry in exported["labels"]:
+            assert "origin" in entry
+
+        # Clear and re-import
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        resp = client.post("/api/labels/import", json=exported)
+        data = resp.get_json()
+        assert data["applied"] == 3
+        assert set(app_module.good_votes) == {1, 3}
+        assert set(app_module.bad_votes) == {2}
+
+    def test_export_backwards_compatible(self, client):
+        """Exported labels still have md5 and label keys for legacy consumers."""
+        app_module.good_votes[1] = None
+        resp = client.get("/api/labels/export")
+        data = resp.get_json()
+        entry = data["labels"][0]
+        assert "md5" in entry
+        assert "label" in entry
+        assert entry["label"] == "good"
+
+    def test_labelset_from_dict_legacy_format(self):
+        """LabelSet.from_dict handles legacy label format (md5+label only)."""
+        legacy_data = {
+            "labels": [
+                {"md5": "abc", "label": "good"},
+                {"md5": "def", "label": "bad"},
+            ]
+        }
+        ls = LabelSet.from_dict(legacy_data)
+        assert len(ls) == 2
+        assert ls.elements[0].origin is None
+        assert ls.elements[0].md5 == "abc"

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -77,14 +77,19 @@ def _score_clips_with_detector(
     for cid, score in zip(all_ids, scores):
         if score >= threshold:
             clip = clips[cid]
-            positive_hits.append(
-                {
-                    "id": cid,
-                    "filename": clip.get("filename", f"clip_{cid}"),
-                    "category": clip.get("category", "unknown"),
-                    "score": round(score, 4),
-                }
-            )
+            hit: dict[str, Any] = {
+                "id": cid,
+                "filename": clip.get("filename", f"clip_{cid}"),
+                "category": clip.get("category", "unknown"),
+                "score": round(score, 4),
+            }
+            if clip.get("origin") is not None:
+                hit["origin"] = clip["origin"]
+            if clip.get("origin_name"):
+                hit["origin_name"] = clip["origin_name"]
+            if clip.get("md5"):
+                hit["md5"] = clip["md5"]
+            positive_hits.append(hit)
 
     # Sort by score descending
     positive_hits.sort(key=lambda x: x["score"], reverse=True)

--- a/vtsearch/datasets/__init__.py
+++ b/vtsearch/datasets/__init__.py
@@ -10,6 +10,7 @@ from vtsearch.datasets.downloader import (
 )
 from vtsearch.datasets.importers import get_importer, list_importers
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+from vtsearch.datasets.labelset import LabelSet, LabeledElement
 from vtsearch.datasets.loader import (
     export_dataset_to_file,
     load_cifar10_batch,
@@ -21,10 +22,15 @@ from vtsearch.datasets.loader import (
     load_paragraph_metadata_from_folders,
     load_video_metadata_from_folders,
 )
+from vtsearch.datasets.origin import Origin
 from vtsearch.datasets.split import split_dataset
 
 __all__ = [
     "DEMO_DATASETS",
+    # Origin & LabelSet
+    "Origin",
+    "LabelSet",
+    "LabeledElement",
     # Importer registry
     "DatasetImporter",
     "ImporterField",

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -231,6 +231,31 @@ class DatasetImporter:
                 parts.append(f"{arg_name} {value}")
         return " ".join(parts)
 
+    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
+        """Build an origin dict for elements imported by this importer.
+
+        The returned dict is the serialised form of an
+        :class:`~vtsearch.datasets.origin.Origin` object and is stored on
+        each clip as ``clip["origin"]``.  It captures enough information to
+        identify the data source (importer name + string-serialisable
+        field values).
+
+        Args:
+            field_values: The field values used for the import.
+
+        Returns:
+            A dict with ``"importer"`` (str) and ``"params"`` (dict of str)
+            keys.
+        """
+        params: dict[str, str] = {}
+        for f in self.fields:
+            if f.field_type == "file":
+                continue
+            val = field_values.get(f.key, "")
+            if val:
+                params[f.key] = str(val)
+        return {"importer": self.name, "params": params}
+
     def build_creation_info(self, field_values: dict[str, Any]) -> dict[str, Any]:
         """Build a creation-info dict describing how a dataset was imported.
 

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -19,7 +19,7 @@ work; new consumers get the additional provenance fields.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -1,0 +1,217 @@
+"""LabelSet — a dataset of labeled elements with origin tracking.
+
+A :class:`LabelSet` is conceptually an extension of a dataset: each element
+knows its *origin* (where it came from), its *origin_name* (a unique
+identifier within that origin), **and** its *label* (``"good"`` or
+``"bad"``).
+
+This structure is the canonical format for:
+
+* Exporting labels (``GET /api/labels/export``)
+* Importing labels (label importers)
+* Passing labeled results to
+  :class:`~vtsearch.exporters.base.ResultsExporter` instances
+
+The serialised format is a strict superset of the legacy label-export
+format.  Old consumers that only read ``md5`` and ``label`` keys still
+work; new consumers get the additional provenance fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class LabeledElement:
+    """A single element in a :class:`LabelSet`.
+
+    Attributes:
+        md5: Content hash of the element's media bytes.
+        label: ``"good"`` or ``"bad"``.
+        origin: Serialised :class:`~vtsearch.datasets.origin.Origin` dict
+            (with ``"importer"`` and ``"params"`` keys), or ``None`` when
+            origin information is unavailable (e.g. imported from a legacy
+            label file).
+        origin_name: Name of the element within its origin (typically the
+            filename, e.g. ``"clip_123.wav"``).
+        filename: Original filename of the media file.
+        category: Category or class label from the dataset structure.
+    """
+
+    md5: str
+    label: str
+    origin: dict[str, Any] | None = None
+    origin_name: str = ""
+    filename: str = ""
+    category: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict.
+
+        Only non-empty optional fields are included so the output stays
+        compact for legacy consumers.
+        """
+        d: dict[str, Any] = {"md5": self.md5, "label": self.label}
+        if self.origin is not None:
+            d["origin"] = self.origin
+        if self.origin_name:
+            d["origin_name"] = self.origin_name
+        if self.filename:
+            d["filename"] = self.filename
+        if self.category:
+            d["category"] = self.category
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LabeledElement:
+        """Reconstruct a :class:`LabeledElement` from a dict."""
+        return cls(
+            md5=d.get("md5", ""),
+            label=d.get("label", ""),
+            origin=d.get("origin"),
+            origin_name=d.get("origin_name", ""),
+            filename=d.get("filename", ""),
+            category=d.get("category", ""),
+        )
+
+
+class LabelSet:
+    """An ordered collection of :class:`LabeledElement` instances.
+
+    A ``LabelSet`` extends the concept of a dataset: each element carries
+    its provenance (origin + origin_name) and its label.
+
+    Parameters:
+        elements: Initial list of :class:`LabeledElement` instances.
+    """
+
+    def __init__(self, elements: list[LabeledElement] | None = None) -> None:
+        self.elements: list[LabeledElement] = list(elements) if elements else []
+
+    def __len__(self) -> int:
+        return len(self.elements)
+
+    def __iter__(self):
+        return iter(self.elements)
+
+    # ------------------------------------------------------------------
+    # Factory methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_clips_and_votes(
+        cls,
+        clips: dict[int, dict[str, Any]],
+        good_votes: dict[int, None],
+        bad_votes: dict[int, None],
+    ) -> LabelSet:
+        """Build a ``LabelSet`` from the current clip and vote state.
+
+        Args:
+            clips: The global clips dict.
+            good_votes: Dict of clip IDs voted "good".
+            bad_votes: Dict of clip IDs voted "bad".
+
+        Returns:
+            A new ``LabelSet`` containing one :class:`LabeledElement` per
+            voted clip, in vote-insertion order (good votes first, then bad).
+        """
+        elements: list[LabeledElement] = []
+        for cid in good_votes:
+            clip = clips.get(cid)
+            if clip:
+                elements.append(_clip_to_element(clip, "good"))
+        for cid in bad_votes:
+            clip = clips.get(cid)
+            if clip:
+                elements.append(_clip_to_element(clip, "bad"))
+        return cls(elements)
+
+    @classmethod
+    def from_results(
+        cls,
+        results: dict[str, Any],
+        clips: dict[int, dict[str, Any]] | None = None,
+    ) -> LabelSet:
+        """Build a ``LabelSet`` from an auto-detect results dict.
+
+        Each hit that scored at or above the detector's threshold is
+        treated as a ``"good"`` label.
+
+        Args:
+            results: A results dict as produced by ``/api/auto-detect`` or
+                :func:`~vtsearch.cli._build_results_dict`.
+            clips: Optional clips dict for enriching hits with origin info.
+                When provided, origin data is looked up from the clip; when
+                absent, origin data is taken from the hit dict itself (if
+                present).
+
+        Returns:
+            A new ``LabelSet`` with one element per hit across all detectors.
+        """
+        elements: list[LabeledElement] = []
+        for det_result in results.get("results", {}).values():
+            for hit in det_result.get("hits", []):
+                origin = hit.get("origin")
+                origin_name = hit.get("origin_name", "")
+                if clips and not origin:
+                    clip = clips.get(hit.get("id"))
+                    if clip:
+                        origin = clip.get("origin")
+                        origin_name = origin_name or clip.get(
+                            "origin_name", clip.get("filename", "")
+                        )
+                elements.append(
+                    LabeledElement(
+                        md5=hit.get("md5", ""),
+                        label="good",
+                        origin=origin,
+                        origin_name=origin_name,
+                        filename=hit.get("filename", ""),
+                        category=hit.get("category", ""),
+                    )
+                )
+        return cls(elements)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict.
+
+        Returns:
+            ``{"labels": [<element dict>, ...]}``.  The format is a
+            superset of the legacy label-export format (which only had
+            ``md5`` and ``label`` keys), so existing consumers remain
+            compatible.
+        """
+        return {"labels": [e.to_dict() for e in self.elements]}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LabelSet:
+        """Reconstruct a ``LabelSet`` from a dict produced by :meth:`to_dict`.
+
+        Also accepts the legacy label format (entries with only ``md5`` and
+        ``label`` keys) for backward compatibility.
+        """
+        elements: list[LabeledElement] = []
+        for entry in d.get("labels", []):
+            if not isinstance(entry, dict):
+                continue
+            elements.append(LabeledElement.from_dict(entry))
+        return cls(elements)
+
+
+def _clip_to_element(clip: dict[str, Any], label: str) -> LabeledElement:
+    """Convert a clip dict into a :class:`LabeledElement`."""
+    return LabeledElement(
+        md5=clip["md5"],
+        label=label,
+        origin=clip.get("origin"),
+        origin_name=clip.get("origin_name", clip.get("filename", "")),
+        filename=clip.get("filename", ""),
+        category=clip.get("category", ""),
+    )

--- a/vtsearch/datasets/origin.py
+++ b/vtsearch/datasets/origin.py
@@ -1,0 +1,75 @@
+"""Origin tracking for dataset elements.
+
+An :class:`Origin` records *where* a data element came from — the importer
+that produced it and the parameters that were used.  Each element in a
+dataset carries its own ``Origin`` so that:
+
+* Future data from a different source can be added to the same dataset.
+* Exported label sets can be re-imported and matched back to their source.
+* Provenance is preserved when datasets are saved and reloaded.
+
+Examples::
+
+    >>> Origin("folder", {"path": "/data/audio", "media_type": "sounds"})
+    Origin(importer='folder', params={'path': '/data/audio', 'media_type': 'sounds'})
+
+    >>> Origin("http_archive", {"url": "https://example.com/data.zip"}).display()
+    'http_archive(https://example.com/data.zip)'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Origin:
+    """Identifies the source of one or more data elements.
+
+    Attributes:
+        importer: The name of the importer that produced the elements, e.g.
+            ``"folder"``, ``"http_archive"``, ``"demo"``.
+        params: A dict of the identifying parameters for the import, e.g.
+            ``{"path": "/data/audio", "media_type": "sounds"}``.  File-upload
+            parameters are excluded (they cannot be reconstructed from a
+            string).
+    """
+
+    importer: str
+    params: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict suitable for JSON or pickle."""
+        return {"importer": self.importer, "params": dict(self.params)}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Origin:
+        """Reconstruct an ``Origin`` from a dict produced by :meth:`to_dict`.
+
+        Args:
+            d: A dict with ``"importer"`` (str) and optional ``"params"``
+                (dict) keys.
+
+        Returns:
+            A new :class:`Origin` instance.
+        """
+        return cls(importer=d["importer"], params=d.get("params", {}))
+
+    def display(self) -> str:
+        """Return a short human-readable representation.
+
+        Examples: ``"folder(/data/audio)"``, ``"demo(esc50_animals)"``.
+        """
+        if self.params:
+            first_val = next(iter(self.params.values()))
+            return f"{self.importer}({first_val})"
+        return self.importer
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Origin):
+            return NotImplemented
+        return self.importer == other.importer and self.params == other.params
+
+    def __hash__(self) -> int:
+        return hash((self.importer, tuple(sorted(self.params.items()))))

--- a/vtsearch/exporters/csv_file/__init__.py
+++ b/vtsearch/exporters/csv_file/__init__.py
@@ -50,12 +50,18 @@ class CsvExporter(ResultsExporter):
         total_hits = 0
         with open(filepath, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerow(["detector", "threshold", "filename", "category", "score"])
+            writer.writerow(["detector", "threshold", "filename", "category", "score", "origin", "origin_name"])
 
             for det_result in results.get("results", {}).values():
                 detector_name = det_result.get("detector_name", "unknown")
                 threshold = det_result.get("threshold", "")
                 for hit in det_result.get("hits", []):
+                    origin = hit.get("origin")
+                    origin_str = ""
+                    if origin:
+                        from vtsearch.datasets.origin import Origin
+
+                        origin_str = Origin.from_dict(origin).display()
                     writer.writerow(
                         [
                             detector_name,
@@ -63,6 +69,8 @@ class CsvExporter(ResultsExporter):
                             hit.get("filename", ""),
                             hit.get("category", ""),
                             hit.get("score", ""),
+                            origin_str,
+                            hit.get("origin_name", ""),
                         ]
                     )
                     total_hits += 1


### PR DESCRIPTION
## Summary

This PR introduces element-level origin tracking to VTSearch, enabling each data element (clip) to carry provenance information about where it came from. This is implemented through two new classes (`Origin` and `LabelSet`) and integrated throughout the data pipeline.

## Key Changes

### New Classes
- **`Origin` class** (`vtsearch/datasets/origin.py`): Dataclass that captures the importer name and parameters used to produce data elements. Supports serialization, display formatting, equality, and hashing.
- **`LabeledElement` class** (`vtsearch/datasets/labelset.py`): Represents a single labeled element with md5, label, origin, origin_name, filename, and category fields.
- **`LabelSet` class** (`vtsearch/datasets/labelset.py`): Collection of labeled elements with factory methods to build from clips+votes, auto-detect results, or dicts. Supports roundtrip serialization.

### Data Model Updates
- Each clip now carries two provenance fields:
  - `clip["origin"]`: Serialized Origin dict (e.g., `{"importer": "folder", "params": {...}}`)
  - `clip["origin_name"]`: Unique identifier within the origin (typically filename)
- Updated `load_dataset_from_folder()` to accept and set origin on clips
- Updated `load_dataset_from_pickle()` to preserve per-element origins and fall back to dataset-level creation_info for legacy pickles

### Importer Integration
- Added `DatasetImporter.build_origin()` method that automatically generates origin dicts from field values, excluding file-upload fields
- Updated `_run_importer_in_background()` to call `_set_clip_origins()` after import completion
- Origins are set on all clips that don't already have them

### API & Export Changes
- Updated `/api/labels/export` endpoint to return a `LabelSet` with full origin information per element
- Format is backward-compatible: old consumers reading only `md5` and `label` keys continue to work
- Updated `/api/auto-detect` results to include origin and origin_name in hit objects
- Updated CSV exporter to include origin and origin_name columns

### Testing
- Comprehensive test suite (`tests/test_origin_labelset.py`) covering:
  - Origin serialization, display, equality, hashing
  - LabeledElement and LabelSet serialization
  - Factory methods (from_clips_and_votes, from_results)
  - Roundtrip serialization
  - DatasetImporter.build_origin()
  - Integration tests for clip origins and label export/import

### Documentation
- Updated `ARCHITECTURE.md` with element-level origin tracking section
- Updated `EXTENDING.md` with origin tracking details for importer developers
- Updated label export format documentation

## Implementation Details

- Origins are stored as plain dicts (not Origin objects) on clips for JSON serialization compatibility
- The `LabelSet.from_dict()` method gracefully handles legacy label format (md5+label only) for backward compatibility
- Pickle loads preserve per-element origins; old pickles without origins fall back to dataset-level creation_info
- File-upload field types are excluded from origin params since they cannot be reconstructed from strings

https://claude.ai/code/session_011UZWz2uKhzXjBZWqp83uDB