### PR TITLE
Rename exporter and importer classes for clarity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,7 +59,7 @@ VTSearch/
 │   │       └── youtube_playlist/   YouTube yt-dlp importer
 │   │
 │   ├── exporters/                  Plugin system for output destinations
-│   │   ├── base.py                 ResultsExporter ABC + ExporterField
+│   │   ├── base.py                 LabelsetExporter ABC + ExporterField
 │   │   ├── file/                   JSON file writer
 │   │   ├── csv_file/               CSV file writer
 │   │   ├── email_smtp/             SMTP email sender

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -281,9 +281,9 @@ class TestImporterCLIArguments:
     """Tests for add_cli_arguments and validate_cli_field_values."""
 
     def test_folder_importer_adds_expected_args(self):
-        from vtsearch.datasets.importers.folder import FolderImporter
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
 
-        imp = FolderImporter()
+        imp = FolderDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -292,9 +292,9 @@ class TestImporterCLIArguments:
         assert args.media_type == "images"
 
     def test_folder_importer_media_type_default(self):
-        from vtsearch.datasets.importers.folder import FolderImporter
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
 
-        imp = FolderImporter()
+        imp = FolderDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -302,9 +302,9 @@ class TestImporterCLIArguments:
         assert args.media_type == "sounds"
 
     def test_folder_importer_rejects_invalid_media_type(self):
-        from vtsearch.datasets.importers.folder import FolderImporter
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
 
-        imp = FolderImporter()
+        imp = FolderDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -312,9 +312,9 @@ class TestImporterCLIArguments:
             parser.parse_args(["--path", "/tmp/data", "--media-type", "invalid"])
 
     def test_pickle_importer_adds_file_arg(self):
-        from vtsearch.datasets.importers.pickle import PickleImporter
+        from vtsearch.datasets.importers.pickle import PickleDatasetImporter
 
-        imp = PickleImporter()
+        imp = PickleDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -322,9 +322,9 @@ class TestImporterCLIArguments:
         assert args.file == "/tmp/dataset.pkl"
 
     def test_http_archive_importer_adds_expected_args(self):
-        from vtsearch.datasets.importers.http_zip import HttpArchiveImporter
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
 
-        imp = HttpArchiveImporter()
+        imp = HttpArchiveDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -333,16 +333,16 @@ class TestImporterCLIArguments:
         assert args.media_type == "images"
 
     def test_validate_catches_missing_required_field(self):
-        from vtsearch.datasets.importers.folder import FolderImporter
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
 
-        imp = FolderImporter()
+        imp = FolderDatasetImporter()
         with pytest.raises(ValueError, match="Missing required argument: --path"):
             imp.validate_cli_field_values({"media_type": "sounds"})
 
     def test_validate_passes_with_all_fields(self):
-        from vtsearch.datasets.importers.folder import FolderImporter
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
 
-        imp = FolderImporter()
+        imp = FolderDatasetImporter()
         # Should not raise
         imp.validate_cli_field_values({"media_type": "sounds", "path": "/tmp/data"})
 
@@ -595,9 +595,9 @@ class TestExporterCLIArguments:
     """Tests for add_cli_arguments and validate_cli_field_values on exporters."""
 
     def test_file_exporter_adds_filepath_arg(self):
-        from vtsearch.exporters.file import FileExporter
+        from vtsearch.exporters.file import FileLabelsetExporter
 
-        exp = FileExporter()
+        exp = FileLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -605,9 +605,9 @@ class TestExporterCLIArguments:
         assert args.filepath == "/tmp/results.json"
 
     def test_file_exporter_filepath_default(self):
-        from vtsearch.exporters.file import FileExporter
+        from vtsearch.exporters.file import FileLabelsetExporter
 
-        exp = FileExporter()
+        exp = FileLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -615,9 +615,9 @@ class TestExporterCLIArguments:
         assert args.filepath == "autodetect_results.json"
 
     def test_email_smtp_exporter_adds_expected_args(self):
-        from vtsearch.exporters.email_smtp import EmailSmtpExporter
+        from vtsearch.exporters.email_smtp import EmailLabelsetExporter
 
-        exp = EmailSmtpExporter()
+        exp = EmailLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -638,9 +638,9 @@ class TestExporterCLIArguments:
         assert args.smtp_port == "587"
 
     def test_email_smtp_exporter_custom_host_and_port(self):
-        from vtsearch.exporters.email_smtp import EmailSmtpExporter
+        from vtsearch.exporters.email_smtp import EmailLabelsetExporter
 
-        exp = EmailSmtpExporter()
+        exp = EmailLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -662,9 +662,9 @@ class TestExporterCLIArguments:
         assert args.smtp_port == "465"
 
     def test_gui_exporter_adds_no_args(self):
-        from vtsearch.exporters.gui import GuiExporter
+        from vtsearch.exporters.gui import DisplayLabelsetExporter
 
-        exp = GuiExporter()
+        exp = DisplayLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -673,16 +673,16 @@ class TestExporterCLIArguments:
         assert not hasattr(args, "filepath")
 
     def test_validate_catches_missing_required_field(self):
-        from vtsearch.exporters.email_smtp import EmailSmtpExporter
+        from vtsearch.exporters.email_smtp import EmailLabelsetExporter
 
-        exp = EmailSmtpExporter()
+        exp = EmailLabelsetExporter()
         with pytest.raises(ValueError, match="Missing required argument: --to"):
             exp.validate_cli_field_values({})
 
     def test_validate_passes_with_all_fields(self):
-        from vtsearch.exporters.email_smtp import EmailSmtpExporter
+        from vtsearch.exporters.email_smtp import EmailLabelsetExporter
 
-        exp = EmailSmtpExporter()
+        exp = EmailLabelsetExporter()
         # Should not raise
         exp.validate_cli_field_values(
             {
@@ -695,15 +695,15 @@ class TestExporterCLIArguments:
         )
 
     def test_file_exporter_validate_passes(self):
-        from vtsearch.exporters.file import FileExporter
+        from vtsearch.exporters.file import FileLabelsetExporter
 
-        exp = FileExporter()
+        exp = FileLabelsetExporter()
         exp.validate_cli_field_values({"filepath": "/tmp/out.json"})
 
     def test_gui_exporter_validate_passes_empty(self):
-        from vtsearch.exporters.gui import GuiExporter
+        from vtsearch.exporters.gui import DisplayLabelsetExporter
 
-        exp = GuiExporter()
+        exp = DisplayLabelsetExporter()
         # No required fields — empty dict is fine
         exp.validate_cli_field_values({})
 

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -116,9 +116,9 @@ class TestCsvExporterCLI:
     """CLI argument parsing for the CSV exporter."""
 
     def test_adds_filepath_arg(self):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -126,9 +126,9 @@ class TestCsvExporterCLI:
         assert args.filepath == "/tmp/results.csv"
 
     def test_filepath_default(self):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -136,15 +136,15 @@ class TestCsvExporterCLI:
         assert args.filepath == "autodetect_results.csv"
 
     def test_validate_passes(self):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         exp.validate_cli_field_values({"filepath": "/tmp/out.csv"})
 
     def test_validate_missing_filepath(self):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         with pytest.raises(ValueError, match="Missing required argument: --filepath"):
             exp.validate_cli_field_values({})
 
@@ -158,9 +158,9 @@ class TestCsvExporterExport:
     """Tests for the CSV export() method."""
 
     def test_creates_csv_file(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -170,9 +170,9 @@ class TestCsvExporterExport:
         assert "Saved" in result["message"]
 
     def test_csv_has_correct_header(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -183,9 +183,9 @@ class TestCsvExporterExport:
         assert header == ["detector", "threshold", "filename", "category", "score"]
 
     def test_csv_has_correct_row_count(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -197,9 +197,9 @@ class TestCsvExporterExport:
         assert len(rows) == 4
 
     def test_csv_row_values(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -214,9 +214,9 @@ class TestCsvExporterExport:
         assert first_row[4] == "0.95"
 
     def test_csv_empty_results(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = {"media_type": "audio", "detectors_run": 0, "results": {}}
         filepath = tmp_path / "empty.csv"
 
@@ -225,9 +225,9 @@ class TestCsvExporterExport:
         assert "0 hit(s)" in result["message"]
 
     def test_csv_creates_parent_dirs(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "sub" / "dir" / "output.csv"
 
@@ -235,16 +235,16 @@ class TestCsvExporterExport:
         assert filepath.exists()
 
     def test_csv_empty_filepath_raises(self):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         with pytest.raises(ValueError, match="file path is required"):
             exp.export({}, {"filepath": ""})
 
     def test_csv_multiple_detectors(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvExporter
+        from vtsearch.exporters.csv_file import CsvLabelsetExporter
 
-        exp = CsvExporter()
+        exp = CsvLabelsetExporter()
         results = {
             "media_type": "audio",
             "detectors_run": 2,
@@ -363,9 +363,9 @@ class TestWebhookExporterCLI:
     """CLI argument parsing for the Webhook exporter."""
 
     def test_adds_url_arg(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -373,23 +373,23 @@ class TestWebhookExporterCLI:
         assert args.url == "https://example.com/hook"
 
     def test_validate_passes_with_url(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         # auth_header is optional, so only url is needed
         exp.validate_cli_field_values({"url": "https://example.com/hook"})
 
     def test_validate_missing_url(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         with pytest.raises(ValueError, match="Missing required argument: --url"):
             exp.validate_cli_field_values({})
 
     def test_validate_passes_without_auth_header(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         # Should not raise
         exp.validate_cli_field_values({"url": "https://example.com/hook"})
 
@@ -403,9 +403,9 @@ class TestWebhookExporterExport:
     """Tests for the Webhook export() method using mocked HTTP."""
 
     def test_posts_json_to_url(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -422,9 +422,9 @@ class TestWebhookExporterExport:
         assert "200" in result["message"]
 
     def test_sends_auth_header_when_provided(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -438,9 +438,9 @@ class TestWebhookExporterExport:
         assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer my-token"
 
     def test_no_auth_header_when_empty(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -454,16 +454,16 @@ class TestWebhookExporterExport:
         assert "Authorization" not in call_kwargs.kwargs["headers"]
 
     def test_empty_url_raises(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         with pytest.raises(ValueError, match="webhook URL is required"):
             exp.export({}, {"url": ""})
 
     def test_http_error_propagates(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -474,9 +474,9 @@ class TestWebhookExporterExport:
                 exp.export(results, {"url": "https://example.com/hook"})
 
     def test_message_contains_hit_count(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -490,9 +490,9 @@ class TestWebhookExporterExport:
         assert "1 detector(s)" in result["message"]
 
     def test_result_includes_status_code_and_url(self):
-        from vtsearch.exporters.webhook import WebhookExporter
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
-        exp = WebhookExporter()
+        exp = WebhookLabelsetExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,7 +1,7 @@
-"""Tests for the Results Exporter abstraction.
+"""Tests for the Labelset Exporter abstraction.
 
 Covers:
-- ExporterField and ResultsExporter base classes
+- ExporterField and LabelsetExporter base classes
 - Auto-discovery registry
 - Built-in exporters: gui, file, email_smtp
 - Flask API routes: GET /api/exporters, POST /api/exporters/export
@@ -98,22 +98,22 @@ class TestExporterField:
 
 
 # ---------------------------------------------------------------------------
-# ResultsExporter base class
+# LabelsetExporter base class
 # ---------------------------------------------------------------------------
 
 
-class TestResultsExporterBase:
+class TestLabelsetExporterBase:
     def test_export_raises_not_implemented(self):
-        from vtsearch.exporters.base import ResultsExporter
+        from vtsearch.exporters.base import LabelsetExporter
 
-        exp = ResultsExporter()
+        exp = LabelsetExporter()
         with pytest.raises(NotImplementedError):
             exp.export({}, {})
 
     def test_to_dict_contains_standard_keys(self):
-        from vtsearch.exporters.base import ExporterField, ResultsExporter
+        from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
-        class Dummy(ResultsExporter):
+        class Dummy(LabelsetExporter):
             name = "dummy"
             display_name = "Dummy"
             description = "A test exporter."
@@ -184,7 +184,7 @@ class TestExporterRegistry:
 # ---------------------------------------------------------------------------
 
 
-class TestGuiExporter:
+class TestDisplayLabelsetExporter:
     def test_has_no_fields(self):
         from vtsearch.exporters import get_exporter
 
@@ -223,7 +223,7 @@ class TestGuiExporter:
 # ---------------------------------------------------------------------------
 
 
-class TestFileExporter:
+class TestFileLabelsetExporter:
     def test_has_filepath_field(self):
         from vtsearch.exporters import get_exporter
 
@@ -283,7 +283,7 @@ class TestFileExporter:
 # ---------------------------------------------------------------------------
 
 
-class TestEmailSmtpExporter:
+class TestEmailLabelsetExporter:
     def test_has_required_fields(self):
         from vtsearch.exporters import get_exporter
 

--- a/tests/test_rss_youtube_importers.py
+++ b/tests/test_rss_youtube_importers.py
@@ -60,9 +60,9 @@ class TestRssFeedImporterCLI:
     """CLI argument parsing for the RSS feed importer."""
 
     def test_adds_expected_args(self):
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -71,9 +71,9 @@ class TestRssFeedImporterCLI:
         assert args.media_type == "sounds"
 
     def test_media_type_choices(self):
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -81,9 +81,9 @@ class TestRssFeedImporterCLI:
         assert args.media_type == "images"
 
     def test_rejects_invalid_media_type(self):
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -91,23 +91,23 @@ class TestRssFeedImporterCLI:
             parser.parse_args(["--url", "https://example.com/feed.xml", "--media-type", "invalid"])
 
     def test_validate_missing_url(self):
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         with pytest.raises(ValueError, match="Missing required argument: --url"):
             imp.validate_cli_field_values({"media_type": "sounds"})
 
     def test_validate_passes_with_url(self):
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         # Should not raise — max_episodes is not required
         imp.validate_cli_field_values({"url": "https://example.com/feed.xml", "media_type": "sounds"})
 
     def test_run_cli_rejects_invalid_url(self):
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         with pytest.raises(ValueError, match="Invalid URL"):
             imp.run_cli({"url": "not-a-url", "media_type": "sounds"}, {})
 
@@ -119,18 +119,18 @@ class TestRssFeedImporterRun:
         """Attempting import without feedparser installed raises RuntimeError."""
         import sys
 
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
         with mock.patch.dict(sys.modules, {"feedparser": None}):
             with pytest.raises((RuntimeError, ImportError)):
                 imp.run({"url": "https://example.com/feed.xml", "media_type": "sounds"}, {})
 
     def test_empty_feed_raises_value_error(self):
         """A feed with no enclosures raises ValueError."""
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
 
         fake_feed = mock.MagicMock()
         fake_feed.bozo = False
@@ -147,9 +147,9 @@ class TestRssFeedImporterRun:
 
     def test_bozo_feed_with_no_entries_raises(self):
         """A bozo (malformed) feed with no entries raises ValueError."""
-        from vtsearch.datasets.importers.rss_feed import RssFeedImporter
+        from vtsearch.datasets.importers.rss_feed import RSSDatasetImporter
 
-        imp = RssFeedImporter()
+        imp = RSSDatasetImporter()
 
         fake_feed = mock.MagicMock()
         fake_feed.bozo = True
@@ -227,9 +227,9 @@ class TestYouTubePlaylistImporterCLI:
     """CLI argument parsing for the YouTube playlist importer."""
 
     def test_adds_expected_args(self):
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -238,9 +238,9 @@ class TestYouTubePlaylistImporterCLI:
         assert args.media_type == "videos"
 
     def test_media_type_choices(self):
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -248,9 +248,9 @@ class TestYouTubePlaylistImporterCLI:
         assert args.media_type == "sounds"
 
     def test_rejects_invalid_media_type(self):
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         parser = argparse.ArgumentParser()
         imp.add_cli_arguments(parser)
 
@@ -258,23 +258,23 @@ class TestYouTubePlaylistImporterCLI:
             parser.parse_args(["--url", "https://youtube.com", "--media-type", "invalid"])
 
     def test_validate_missing_url(self):
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         with pytest.raises(ValueError, match="Missing required argument: --url"):
             imp.validate_cli_field_values({"media_type": "videos"})
 
     def test_validate_passes_with_url(self):
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         # Should not raise — max_videos is not required
         imp.validate_cli_field_values({"url": "https://www.youtube.com/playlist?list=PLtest", "media_type": "videos"})
 
     def test_run_cli_rejects_invalid_url(self):
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         with pytest.raises(ValueError, match="Invalid URL"):
             imp.run_cli({"url": "not-a-url", "media_type": "videos"}, {})
 
@@ -286,9 +286,9 @@ class TestYouTubePlaylistImporterRun:
         """Attempting import without yt-dlp installed raises RuntimeError."""
         import sys
 
-        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistImporter
+        from vtsearch.datasets.importers.youtube_playlist import YouTubePlaylistDatasetImporter
 
-        imp = YouTubePlaylistImporter()
+        imp = YouTubePlaylistDatasetImporter()
         with mock.patch.dict(sys.modules, {"yt_dlp": None}):
             with pytest.raises((RuntimeError, ImportError)):
                 imp.run({"url": "https://www.youtube.com/watch?v=test", "media_type": "videos"}, {})

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -202,7 +202,7 @@ def _build_results_dict(
 
     Returns:
         A dict matching the shape expected by
-        :meth:`~vtsearch.exporters.base.ResultsExporter.export`.
+        :meth:`~vtsearch.exporters.base.LabelsetExporter.export`.
     """
     detector_data = json.loads(Path(detector_path).read_text())
     detector_name = detector_data.get("name", Path(detector_path).stem)

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -13,7 +13,7 @@ from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 from vtsearch.datasets.loader import load_dataset_from_folder
 
 
-class FolderImporter(DatasetImporter):
+class FolderDatasetImporter(DatasetImporter):
     """Embed all media files found in a local directory into a dataset.
 
     The user supplies an absolute filesystem path and selects the media type
@@ -55,4 +55,4 @@ class FolderImporter(DatasetImporter):
         self.run(field_values, clips)
 
 
-IMPORTER = FolderImporter()
+IMPORTER = FolderDatasetImporter()

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -90,7 +90,7 @@ def _extract_archive(
         )
 
 
-class HttpArchiveImporter(DatasetImporter):
+class HttpArchiveDatasetImporter(DatasetImporter):
     """Download a publicly-accessible archive and load its media files.
 
     The archive is streamed to a temporary file in ``DATA_DIR``, extracted
@@ -154,4 +154,4 @@ class HttpArchiveImporter(DatasetImporter):
         self.run(field_values, clips)
 
 
-IMPORTER = HttpArchiveImporter()
+IMPORTER = HttpArchiveDatasetImporter()

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -20,7 +20,7 @@ def _get_progress():
     return update_progress
 
 
-class PickleImporter(DatasetImporter):
+class PickleDatasetImporter(DatasetImporter):
     """Load a dataset from a ``.pkl`` file exported by VTSearch.
 
     The user picks the file via the browser's file-upload input.  The file
@@ -74,4 +74,4 @@ class PickleImporter(DatasetImporter):
             set_dataset_creation_info(creation_info)
 
 
-IMPORTER = PickleImporter()
+IMPORTER = PickleDatasetImporter()

--- a/vtsearch/datasets/importers/rss_feed/__init__.py
+++ b/vtsearch/datasets/importers/rss_feed/__init__.py
@@ -33,7 +33,7 @@ def _download_enclosure(url: str, dest: Path, timeout: int = 120) -> None:
             f.write(chunk)
 
 
-class RssFeedImporter(DatasetImporter):
+class RSSDatasetImporter(DatasetImporter):
     """Download audio episodes from an RSS or podcast feed and embed them.
 
     The importer parses the feed, downloads each audio enclosure, then
@@ -161,4 +161,4 @@ class RssFeedImporter(DatasetImporter):
         self.run(field_values, clips)
 
 
-IMPORTER = RssFeedImporter()
+IMPORTER = RSSDatasetImporter()

--- a/vtsearch/datasets/importers/youtube_playlist/__init__.py
+++ b/vtsearch/datasets/importers/youtube_playlist/__init__.py
@@ -20,7 +20,7 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
-class YouTubePlaylistImporter(DatasetImporter):
+class YouTubePlaylistDatasetImporter(DatasetImporter):
     """Download videos from a YouTube playlist or channel and embed them.
 
     Uses ``yt-dlp`` to download videos in mp4 format, then embeds them using
@@ -138,4 +138,4 @@ class YouTubePlaylistImporter(DatasetImporter):
         self.run(field_values, clips)
 
 
-IMPORTER = YouTubePlaylistImporter()
+IMPORTER = YouTubePlaylistDatasetImporter()

--- a/vtsearch/exporters/__init__.py
+++ b/vtsearch/exporters/__init__.py
@@ -1,8 +1,8 @@
-"""Results-exporter registry with auto-discovery.
+"""Labelset-exporter registry with auto-discovery.
 
 Any package placed directly under this directory is automatically registered
 if it exposes a module-level ``EXPORTER`` attribute that is a
-:class:`~vtsearch.exporters.base.ResultsExporter` instance.
+:class:`~vtsearch.exporters.base.LabelsetExporter` instance.
 
 Usage::
 
@@ -22,9 +22,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from vtsearch.exporters.base import ResultsExporter
+    from vtsearch.exporters.base import LabelsetExporter
 
-_registry: dict[str, ResultsExporter] = {}
+_registry: dict[str, LabelsetExporter] = {}
 
 
 def _discover() -> None:
@@ -40,7 +40,7 @@ def _discover() -> None:
                 _registry[exporter.name] = exporter
         except Exception as exc:  # pragma: no cover
             warnings.warn(
-                f"Failed to load results exporter '{module_name}': {exc}",
+                f"Failed to load labelset exporter '{module_name}': {exc}",
                 stacklevel=2,
             )
 
@@ -50,13 +50,13 @@ def _ensure_discovered() -> None:
         _discover()
 
 
-def get_exporter(name: str) -> ResultsExporter | None:
+def get_exporter(name: str) -> LabelsetExporter | None:
     """Return the registered exporter with *name*, or ``None`` if not found."""
     _ensure_discovered()
     return _registry.get(name)
 
 
-def list_exporters() -> list[ResultsExporter]:
+def list_exporters() -> list[LabelsetExporter]:
     """Return all registered exporters in discovery order."""
     _ensure_discovered()
     return list(_registry.values())

--- a/vtsearch/exporters/base.py
+++ b/vtsearch/exporters/base.py
@@ -1,12 +1,12 @@
-"""Base classes for Results Exporters.
+"""Base classes for Labelset Exporters.
 
-To add a new exporter, subclass :class:`ResultsExporter`, define its class
-attributes and :meth:`~ResultsExporter.export`, then expose a module-level
+To add a new exporter, subclass :class:`LabelsetExporter`, define its class
+attributes and :meth:`~LabelsetExporter.export`, then expose a module-level
 ``EXPORTER`` instance from a package under this directory.  The registry will
 discover it automatically.
 
-Each exporter also supports CLI usage via :meth:`~ResultsExporter.add_cli_arguments`
-and :meth:`~ResultsExporter.export_cli`.  The base class provides default
+Each exporter also supports CLI usage via :meth:`~LabelsetExporter.add_cli_arguments`
+and :meth:`~LabelsetExporter.export_cli`.  The base class provides default
 implementations that derive CLI arguments from the :attr:`fields` list, so most
 exporters work on the command line without any extra code.  Exporters whose
 :meth:`export` expects non-string values should override :meth:`export_cli` to
@@ -15,9 +15,9 @@ handle the CLI-appropriate types.
 Example – a minimal SFTP exporter skeleton::
 
     # vtsearch/exporters/sftp/__init__.py
-    from vtsearch.exporters.base import ResultsExporter, ExporterField
+    from vtsearch.exporters.base import LabelsetExporter, ExporterField
 
-    class SftpExporter(ResultsExporter):
+    class SftpLabelsetExporter(LabelsetExporter):
         name         = "sftp"
         display_name = "SFTP Upload"
         description  = "Upload results JSON to a remote SFTP server."
@@ -35,7 +35,7 @@ Example – a minimal SFTP exporter skeleton::
             ...  # connect, write JSON, disconnect
             return {"message": f"Uploaded to {field_values['host']}:{field_values['path']}"}
 
-    EXPORTER = SftpExporter()
+    EXPORTER = SftpLabelsetExporter()
 
 Then create ``vtsearch/exporters/sftp/requirements.txt`` containing
 ``paramiko>=2.0.0`` and add::
@@ -53,7 +53,7 @@ from typing import Any, Literal
 
 FieldType = Literal["text", "password", "email", "file", "folder", "select"]
 
-__all__ = ["ExporterField", "FieldType", "ResultsExporter"]
+__all__ = ["ExporterField", "FieldType", "LabelsetExporter"]
 
 
 @dataclass
@@ -96,7 +96,7 @@ class ExporterField:
         }
 
 
-class ResultsExporter:
+class LabelsetExporter:
     """Abstract base class for results exporters.
 
     Subclass this, set the class-level attributes, implement :meth:`export`,

--- a/vtsearch/exporters/csv_file/__init__.py
+++ b/vtsearch/exporters/csv_file/__init__.py
@@ -10,10 +10,10 @@ import csv
 from pathlib import Path
 from typing import Any
 
-from vtsearch.exporters.base import ExporterField, ResultsExporter
+from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
-class CsvExporter(ResultsExporter):
+class CsvLabelsetExporter(LabelsetExporter):
     """Save auto-detect results as a CSV file.
 
     Produces one row per hit across all detectors, with columns for the
@@ -77,4 +77,4 @@ class CsvExporter(ResultsExporter):
         }
 
 
-EXPORTER = CsvExporter()
+EXPORTER = CsvLabelsetExporter()

--- a/vtsearch/exporters/email_smtp/__init__.py
+++ b/vtsearch/exporters/email_smtp/__init__.py
@@ -15,7 +15,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
 
-from vtsearch.exporters.base import ExporterField, ResultsExporter
+from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
 def _build_plain_text(results: dict[str, Any]) -> str:
@@ -68,7 +68,7 @@ def _build_html(results: dict[str, Any]) -> str:
     )
 
 
-class EmailSmtpExporter(ResultsExporter):
+class EmailLabelsetExporter(LabelsetExporter):
     """Send auto-detect results by e-mail via an SMTP server.
 
     Supports any STARTTLS-capable SMTP server (Gmail, Outlook, custom, etc.).
@@ -161,4 +161,4 @@ class EmailSmtpExporter(ResultsExporter):
         }
 
 
-EXPORTER = EmailSmtpExporter()
+EXPORTER = EmailLabelsetExporter()

--- a/vtsearch/exporters/file/__init__.py
+++ b/vtsearch/exporters/file/__init__.py
@@ -10,10 +10,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from vtsearch.exporters.base import ExporterField, ResultsExporter
+from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
-class FileExporter(ResultsExporter):
+class FileLabelsetExporter(LabelsetExporter):
     """Save auto-detect results as a JSON file at a path chosen by the user.
 
     The user supplies the destination path (absolute or relative to the
@@ -58,4 +58,4 @@ class FileExporter(ResultsExporter):
         }
 
 
-EXPORTER = FileExporter()
+EXPORTER = FileLabelsetExporter()

--- a/vtsearch/exporters/gui/__init__.py
+++ b/vtsearch/exporters/gui/__init__.py
@@ -1,27 +1,28 @@
-"""GUI exporter – returns results to the browser for display in a modal.
+"""Display labelset exporter – shows results in the browser (GUI) or prints to console (CLI).
 
-No additional pip packages are required; this exporter is handled entirely
-by the frontend JavaScript.
+No additional pip packages are required; in GUI mode this exporter is handled
+entirely by the frontend JavaScript, and in CLI mode it prints to stdout.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from vtsearch.exporters.base import ResultsExporter
+from vtsearch.exporters.base import LabelsetExporter
 
 
-class GuiExporter(ResultsExporter):
-    """Display auto-detect results in the browser's built-in results modal.
+class DisplayLabelsetExporter(LabelsetExporter):
+    """Display auto-detect results in the browser (GUI) or print to console (CLI).
 
-    This is the default exporter: it performs no server-side work and simply
-    passes the results back to the frontend, which renders them in the
-    Auto-Detect Results modal.  No configuration fields are needed.
+    This is the default exporter: in GUI mode it performs no server-side work
+    and simply passes the results back to the frontend, which renders them in
+    the Auto-Detect Results modal.  In CLI mode it prints a summary to stdout.
+    No configuration fields are needed.
     """
 
     name = "gui"
-    display_name = "Show in Browser"
-    description = "Display the results in a popup window in the browser."
+    display_name = "Display Results"
+    description = "Display the results in the browser (GUI) or print to console (CLI)."
     icon = "🖥️"
     fields = []  # no questions to ask
 
@@ -53,4 +54,4 @@ class GuiExporter(ResultsExporter):
         }
 
 
-EXPORTER = GuiExporter()
+EXPORTER = DisplayLabelsetExporter()

--- a/vtsearch/exporters/webhook/__init__.py
+++ b/vtsearch/exporters/webhook/__init__.py
@@ -9,10 +9,10 @@ from typing import Any
 
 import requests
 
-from vtsearch.exporters.base import ExporterField, ResultsExporter
+from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
-class WebhookExporter(ResultsExporter):
+class WebhookLabelsetExporter(LabelsetExporter):
     """POST the results JSON to a user-specified URL.
 
     Enables integration with automation platforms (Zapier, n8n, Make,
@@ -66,4 +66,4 @@ class WebhookExporter(ResultsExporter):
         }
 
 
-EXPORTER = WebhookExporter()
+EXPORTER = WebhookLabelsetExporter()

--- a/vtsearch/routes/exporters.py
+++ b/vtsearch/routes/exporters.py
@@ -1,4 +1,4 @@
-"""Flask routes for the Results Exporter API.
+"""Flask routes for the Labelset Exporter API.
 
 Endpoints
 ---------
@@ -36,7 +36,7 @@ exporters_bp = Blueprint("exporters", __name__)
 
 @exporters_bp.route("/api/exporters", methods=["GET"])
 def get_exporters():
-    """Return a list of all registered results exporters."""
+    """Return a list of all registered labelset exporters."""
     return jsonify([exp.to_dict() for exp in list_exporters()])
 
 


### PR DESCRIPTION
## Summary
This PR renames exporter and importer classes to follow a more consistent and descriptive naming convention. The changes clarify the purpose of each class by using suffixes that indicate what type of data they handle.

## Key Changes

**Exporters:**
- `ResultsExporter` → `LabelsetExporter` (base class)
- `GuiExporter` → `DisplayLabelsetExporter`
- `FileExporter` → `FileLabelsetExporter`
- `CsvExporter` → `CsvLabelsetExporter`
- `EmailSmtpExporter` → `EmailLabelsetExporter`
- `WebhookExporter` → `WebhookLabelsetExporter`

**Importers:**
- `FolderImporter` → `FolderDatasetImporter`
- `PickleImporter` → `PickleDatasetImporter`
- `HttpArchiveImporter` → `HttpArchiveDatasetImporter`
- `RssFeedImporter` → `RSSDatasetImporter`
- `YouTubePlaylistImporter` → `YouTubePlaylistDatasetImporter`

**Documentation Updates:**
- Updated docstrings and comments throughout to reflect the new naming convention
- Updated `DisplayLabelsetExporter` description to clarify it works in both GUI and CLI modes
- Updated module docstrings in `vtsearch/exporters/base.py` and `vtsearch/exporters/__init__.py`
- Updated Flask route docstrings in `vtsearch/routes/exporters.py`

**Test Updates:**
- Updated all test imports and class instantiations to use the new class names
- Updated test class names to match the new exporter/importer names (e.g., `TestGuiExporter` → `TestDisplayLabelsetExporter`)

## Implementation Details
- All functionality remains unchanged; this is purely a naming refactor
- The `EXPORTER` and `IMPORTER` module-level instances are updated to use the new class names
- The auto-discovery registry continues to work as before, using the `name` attribute rather than class names

https://claude.ai/code/session_01Wf81X4RjbD1GWkVbEXLMN2