### PR TITLE
Use origin+origin_name for clip matching instead of assuming MD5 uniqueness

### DIFF
--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -67,10 +67,6 @@ class TestClipMD5:
             expected_md5 = hashlib.md5(clip["wav_bytes"]).hexdigest()
             assert clip["md5"] == expected_md5
 
-    def test_different_clips_have_different_md5(self):
-        md5_hashes = {clip["md5"] for clip in app_module.clips.values()}
-        assert len(md5_hashes) == len(app_module.clips)
-
     def test_md5_deterministic(self):
         """MD5 should be the same for the same clip across re-generation."""
         clip = app_module.clips[1]

--- a/vtsearch/utils/__init__.py
+++ b/vtsearch/utils/__init__.py
@@ -6,6 +6,7 @@ from vtsearch.utils.state import (
     add_favorite_extractor,
     add_label_to_history,
     bad_votes,
+    build_clip_lookup,
     clear_all,
     clear_clips,
     clear_votes,
@@ -26,6 +27,7 @@ from vtsearch.utils.state import (
     remove_favorite_extractor,
     rename_favorite_detector,
     rename_favorite_extractor,
+    resolve_clip_ids,
     set_dataset_creation_info,
     set_inclusion,
 )
@@ -63,4 +65,6 @@ __all__ = [
     "rename_favorite_extractor",
     "get_favorite_extractors",
     "get_favorite_extractors_by_media",
+    "build_clip_lookup",
+    "resolve_clip_ids",
 ]


### PR DESCRIPTION
MD5 should not be treated as unique within a dataset — the same file
(e.g. a bomb picture) can appear in multiple locations, and a detector
should find all copies. This changes label import to match clips by
(origin, origin_name) first, falling back to MD5 for legacy label
files. The MD5 fallback now correctly returns ALL clips sharing that
hash instead of silently dropping duplicates.

https://claude.ai/code/session_01MvVMbP3Hk2p2z37kGV3GQv