### PR TITLE
Add persistent settings with volume and favorite processors

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from vtsearch.routes import (
     label_importers_bp,
     main_bp,
     processor_importers_bp,
+    settings_bp,
     sorting_bp,
 )
 from vtsearch.media import set_progress_callback
@@ -146,6 +147,7 @@ app.register_blueprint(datasets_bp)
 app.register_blueprint(exporters_bp)
 app.register_blueprint(label_importers_bp)
 app.register_blueprint(processor_importers_bp)
+app.register_blueprint(settings_bp)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,7 +12,6 @@ Covers:
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,317 @@
+"""Tests for the persistent settings module.
+
+Covers:
+- Settings file read/write (vtsearch.settings)
+- Volume persistence
+- Favorite processor recipes: add, remove, list, CLI command generation
+- ensure_favorite_processors_imported (lazy import on autodetect)
+- Flask API routes: GET/PUT /api/settings,
+  GET/POST/DELETE /api/settings/favorite-processors
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import app as app_module  # noqa: F401 — triggers conftest clip init
+from vtsearch import settings as settings_mod
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(tmp_path, monkeypatch):
+    """Use a temp file for each test so tests don't interfere."""
+    test_settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
+    settings_mod.reset()
+    yield test_settings_path
+    settings_mod.reset()
+
+
+@pytest.fixture
+def client():
+    app_module.app.config["TESTING"] = True
+    with app_module.app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Settings module unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsModule:
+    def test_defaults_when_no_file(self):
+        data = settings_mod.get_all()
+        assert data["volume"] == 1.0
+        assert data["favorite_processors"] == []
+
+    def test_get_set_volume(self, isolated_settings):
+        settings_mod.set_volume(0.42)
+        assert settings_mod.get_volume() == pytest.approx(0.42)
+
+        # Persisted to disk
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["volume"] == pytest.approx(0.42)
+
+    def test_volume_clamped(self):
+        settings_mod.set_volume(5.0)
+        assert settings_mod.get_volume() == 1.0
+
+        settings_mod.set_volume(-3.0)
+        assert settings_mod.get_volume() == 0.0
+
+    def test_add_favorite_processor(self, isolated_settings):
+        settings_mod.add_favorite_processor(
+            "my det", "detector_file", {"file": "/tmp/det.json"}
+        )
+        procs = settings_mod.get_favorite_processors()
+        assert len(procs) == 1
+        assert procs[0]["processor_name"] == "my det"
+        assert procs[0]["processor_importer"] == "detector_file"
+        assert procs[0]["field_values"]["file"] == "/tmp/det.json"
+
+    def test_add_overwrites_same_name(self):
+        settings_mod.add_favorite_processor("a", "detector_file", {"file": "1.json"})
+        settings_mod.add_favorite_processor("a", "detector_file", {"file": "2.json"})
+        procs = settings_mod.get_favorite_processors()
+        assert len(procs) == 1
+        assert procs[0]["field_values"]["file"] == "2.json"
+
+    def test_remove_favorite_processor(self):
+        settings_mod.add_favorite_processor("x", "detector_file", {"file": "x.json"})
+        assert settings_mod.remove_favorite_processor("x") is True
+        assert settings_mod.get_favorite_processors() == []
+
+    def test_remove_nonexistent(self):
+        assert settings_mod.remove_favorite_processor("nope") is False
+
+    def test_to_cli_command(self):
+        entry = {
+            "processor_name": "my detector",
+            "processor_importer": "detector_file",
+            "field_values": {"file": "/path/to/det.json"},
+        }
+        cmd = settings_mod.to_cli_command(entry)
+        assert "--import-processor" in cmd
+        assert "--processor-importer detector_file" in cmd
+        assert '--processor-name "my detector"' in cmd
+        assert "--file /path/to/det.json" in cmd
+
+    def test_to_cli_command_quotes_spaces(self):
+        entry = {
+            "processor_name": "det",
+            "processor_importer": "detector_file",
+            "field_values": {"file": "/my path/det.json"},
+        }
+        cmd = settings_mod.to_cli_command(entry)
+        assert '"/my path/det.json"' in cmd
+
+    def test_persistence_survives_reset(self, isolated_settings):
+        settings_mod.set_volume(0.7)
+        settings_mod.add_favorite_processor("p", "detector_file", {"file": "p.json"})
+
+        # Simulate restart
+        settings_mod.reset()
+
+        assert settings_mod.get_volume() == pytest.approx(0.7)
+        procs = settings_mod.get_favorite_processors()
+        assert len(procs) == 1
+        assert procs[0]["processor_name"] == "p"
+
+    def test_corrupt_settings_file(self, isolated_settings):
+        isolated_settings.write_text("not json!!!")
+        settings_mod.reset()
+        # Should fall back to defaults
+        assert settings_mod.get_volume() == 1.0
+        assert settings_mod.get_favorite_processors() == []
+
+
+# ---------------------------------------------------------------------------
+# ensure_favorite_processors_imported
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureFavoriteProcessorsImported:
+    def test_imports_detector_file_processor(self, tmp_path):
+        """A favorite processor recipe with detector_file should be imported."""
+        from vtsearch.utils import favorite_detectors
+
+        # Create a fake detector JSON
+        det_weights = {
+            "0.weight": [[0.1] * 512],
+            "0.bias": [0.0],
+            "2.weight": [[0.2]],
+            "2.bias": [0.1],
+        }
+        det_path = tmp_path / "test_det.json"
+        det_path.write_text(json.dumps({
+            "media_type": "audio",
+            "weights": det_weights,
+            "threshold": 0.5,
+        }))
+
+        # Clear any existing detectors with this name
+        favorite_detectors.pop("settings_test_det", None)
+
+        settings_mod.add_favorite_processor(
+            "settings_test_det", "detector_file", {"file": str(det_path)}
+        )
+
+        imported = settings_mod.ensure_favorite_processors_imported()
+        assert "settings_test_det" in imported
+        assert "settings_test_det" in favorite_detectors
+
+        # Clean up
+        favorite_detectors.pop("settings_test_det", None)
+
+    def test_skips_already_imported(self, tmp_path):
+        """If a detector with the same name already exists, skip it."""
+        from vtsearch.utils import add_favorite_detector, favorite_detectors
+
+        add_favorite_detector("existing", "audio", {"0.weight": [[0.1]], "0.bias": [0.0]}, 0.5)
+
+        settings_mod.add_favorite_processor(
+            "existing", "detector_file", {"file": "/nonexistent.json"}
+        )
+
+        imported = settings_mod.ensure_favorite_processors_imported()
+        assert imported == []
+
+        # Clean up
+        favorite_detectors.pop("existing", None)
+
+    def test_handles_bad_importer_gracefully(self):
+        """Unknown importer name should not crash."""
+        settings_mod.add_favorite_processor(
+            "bad_proc", "totally_fake_importer", {"file": "x.json"}
+        )
+
+        imported = settings_mod.ensure_favorite_processors_imported()
+        assert imported == []
+
+
+# ---------------------------------------------------------------------------
+# Flask API routes
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsAPI:
+    def test_get_settings(self, client):
+        res = client.get("/api/settings")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "volume" in data
+        assert "favorite_processors" in data
+
+    def test_update_volume(self, client):
+        res = client.put(
+            "/api/settings",
+            json={"volume": 0.65},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["volume"] == pytest.approx(0.65)
+
+        # Verify it persisted
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["volume"] == pytest.approx(0.65)
+
+    def test_update_volume_invalid(self, client):
+        res = client.put(
+            "/api/settings",
+            json={"volume": "not a number"},
+        )
+        assert res.status_code == 400
+
+    def test_update_empty_body(self, client):
+        res = client.put(
+            "/api/settings",
+            data="",
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+
+    def test_add_favorite_processor(self, client):
+        res = client.post(
+            "/api/settings/favorite-processors",
+            json={
+                "processor_name": "api_test",
+                "processor_importer": "detector_file",
+                "field_values": {"file": "/tmp/det.json"},
+            },
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert data["processor_name"] == "api_test"
+        assert "cli_command" in data
+
+    def test_add_favorite_processor_missing_name(self, client):
+        res = client.post(
+            "/api/settings/favorite-processors",
+            json={"processor_importer": "detector_file", "field_values": {}},
+        )
+        assert res.status_code == 400
+
+    def test_add_favorite_processor_missing_importer(self, client):
+        res = client.post(
+            "/api/settings/favorite-processors",
+            json={"processor_name": "x", "field_values": {}},
+        )
+        assert res.status_code == 400
+
+    def test_list_favorite_processors(self, client):
+        # Add one first
+        client.post(
+            "/api/settings/favorite-processors",
+            json={
+                "processor_name": "list_test",
+                "processor_importer": "detector_file",
+                "field_values": {"file": "x.json"},
+            },
+        )
+
+        res = client.get("/api/settings/favorite-processors")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert any(p["processor_name"] == "list_test" for p in data["favorite_processors"])
+
+    def test_delete_favorite_processor(self, client):
+        client.post(
+            "/api/settings/favorite-processors",
+            json={
+                "processor_name": "del_test",
+                "processor_importer": "detector_file",
+                "field_values": {"file": "x.json"},
+            },
+        )
+
+        res = client.delete("/api/settings/favorite-processors/del_test")
+        assert res.status_code == 200
+
+        # Verify it's gone
+        res2 = client.get("/api/settings/favorite-processors")
+        data = res2.get_json()
+        assert not any(p["processor_name"] == "del_test" for p in data["favorite_processors"])
+
+    def test_delete_nonexistent(self, client):
+        res = client.delete("/api/settings/favorite-processors/nope")
+        assert res.status_code == 404
+
+    def test_get_settings_includes_cli_command(self, client):
+        client.post(
+            "/api/settings/favorite-processors",
+            json={
+                "processor_name": "cmd_test",
+                "processor_importer": "detector_file",
+                "field_values": {"file": "det.json"},
+            },
+        )
+
+        res = client.get("/api/settings")
+        data = res.get_json()
+        proc = next(p for p in data["favorite_processors"] if p["processor_name"] == "cmd_test")
+        assert "--import-processor" in proc["cli_command"]

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -256,6 +256,21 @@ def _run_exporter(
     print(result.get("message", "Export complete."))
 
 
+def _import_favorite_processors() -> None:
+    """Import favorite processors from settings (if any).
+
+    Errors are logged as warnings but do not halt the autodetect run.
+    """
+    try:
+        from vtsearch.settings import ensure_favorite_processors_imported
+
+        imported = ensure_favorite_processors_imported()
+        if imported:
+            print(f"Imported {len(imported)} favorite processor(s) from settings: {', '.join(imported)}")
+    except Exception as exc:
+        print(f"Warning: could not load favorite processors from settings: {exc}", file=sys.stderr)
+
+
 def autodetect_main(
     dataset_path: str,
     detector_path: str,
@@ -276,6 +291,8 @@ def autodetect_main(
         exporter_field_values: Optional exporter field values.
     """
     try:
+        _import_favorite_processors()
+
         dataset_file = Path(dataset_path)
         if not dataset_file.exists():
             raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
@@ -378,6 +395,8 @@ def autodetect_importer_main(
         exporter_field_values: Optional exporter field values.
     """
     try:
+        _import_favorite_processors()
+
         from vtsearch.datasets.importers import get_importer
 
         importer = get_importer(importer_name)

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -7,6 +7,7 @@ from vtsearch.routes.exporters import exporters_bp
 from vtsearch.routes.label_importers import label_importers_bp
 from vtsearch.routes.main import main_bp
 from vtsearch.routes.processor_importers import processor_importers_bp
+from vtsearch.routes.settings import settings_bp
 from vtsearch.routes.sorting import sorting_bp
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "exporters_bp",
     "label_importers_bp",
     "processor_importers_bp",
+    "settings_bp",
 ]

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -381,6 +381,11 @@ def auto_detect():
     if not clips:
         return jsonify({"error": "No clips loaded"}), 400
 
+    # Import any favorite processors from settings that aren't already loaded
+    from vtsearch.settings import ensure_favorite_processors_imported
+
+    newly_imported = ensure_favorite_processors_imported()
+
     # Determine media type from current clips
     media_type = next(iter(clips.values())).get("type", "audio")
 
@@ -445,13 +450,15 @@ def auto_detect():
             "hits": positive_hits,
         }
 
-    return jsonify(
-        {
-            "media_type": media_type,
-            "detectors_run": len(detectors),
-            "results": results,
-        }
-    )
+    response: dict = {
+        "media_type": media_type,
+        "detectors_run": len(detectors),
+        "results": results,
+    }
+    if newly_imported:
+        response["newly_imported"] = newly_imported
+
+    return jsonify(response)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -1,0 +1,96 @@
+"""Flask routes for the Settings API.
+
+Endpoints
+---------
+GET  /api/settings
+    Return all persisted settings (volume, favorite_processors).
+
+PUT  /api/settings
+    Update one or more settings fields.  Only supplied keys are changed.
+
+GET  /api/settings/favorite-processors
+    List all favorite processor recipes.
+
+POST /api/settings/favorite-processors
+    Add (or overwrite) a favorite processor recipe.
+
+DELETE /api/settings/favorite-processors/<name>
+    Remove a favorite processor recipe by name.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from vtsearch import settings
+
+settings_bp = Blueprint("settings", __name__)
+
+
+@settings_bp.route("/api/settings", methods=["GET"])
+def get_settings():
+    """Return all settings."""
+    data = settings.get_all()
+    # Include CLI command strings for each favorite processor
+    for proc in data.get("favorite_processors", []):
+        proc["cli_command"] = settings.to_cli_command(proc)
+    return jsonify(data)
+
+
+@settings_bp.route("/api/settings", methods=["PUT"])
+def update_settings():
+    """Update settings.  Only supplied keys are changed."""
+    body = request.get_json(force=True, silent=True)
+    if not body or not isinstance(body, dict):
+        return jsonify({"error": "Invalid request body"}), 400
+
+    if "volume" in body:
+        try:
+            settings.set_volume(float(body["volume"]))
+        except (TypeError, ValueError):
+            return jsonify({"error": "volume must be a number"}), 400
+
+    return jsonify(settings.get_all())
+
+
+@settings_bp.route("/api/settings/favorite-processors", methods=["GET"])
+def get_favorite_processors():
+    """List all favorite processor recipes."""
+    procs = settings.get_favorite_processors()
+    for proc in procs:
+        proc["cli_command"] = settings.to_cli_command(proc)
+    return jsonify({"favorite_processors": procs})
+
+
+@settings_bp.route("/api/settings/favorite-processors", methods=["POST"])
+def add_favorite_processor():
+    """Add or overwrite a favorite processor recipe."""
+    body = request.get_json(force=True, silent=True)
+    if not body or not isinstance(body, dict):
+        return jsonify({"error": "Invalid request body"}), 400
+
+    processor_name = (body.get("processor_name") or "").strip()
+    processor_importer = (body.get("processor_importer") or "").strip()
+    field_values = body.get("field_values", {})
+
+    if not processor_name:
+        return jsonify({"error": "processor_name is required"}), 400
+    if not processor_importer:
+        return jsonify({"error": "processor_importer is required"}), 400
+
+    settings.add_favorite_processor(processor_name, processor_importer, field_values)
+    entry = {
+        "processor_name": processor_name,
+        "processor_importer": processor_importer,
+        "field_values": field_values,
+    }
+    entry["cli_command"] = settings.to_cli_command(entry)
+    return jsonify({"success": True, **entry})
+
+
+@settings_bp.route("/api/settings/favorite-processors/<name>", methods=["DELETE"])
+def delete_favorite_processor(name: str):
+    """Remove a favorite processor recipe by name."""
+    if settings.remove_favorite_processor(name):
+        return jsonify({"success": True})
+    return jsonify({"error": "Favorite processor not found"}), 404

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -1,0 +1,210 @@
+"""Persistent settings for VTSearch.
+
+Settings are stored as a JSON file in ``data/settings.json``.  The module
+exposes simple get/set helpers and auto-saves on every mutation.
+
+Schema (all keys optional, missing keys use defaults)::
+
+    {
+        "volume": 1.0,
+        "favorite_processors": [
+            {
+                "processor_name": "my detector",
+                "processor_importer": "detector_file",
+                "field_values": {"file": "/path/to/detector.json"}
+            }
+        ]
+    }
+
+Favorite processors store the *recipe* for importing a processor (the importer
+name, field values, and desired detector name).  They are only materialised
+into favorite detectors on demand — during autodetect.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from config import DATA_DIR
+
+logger = logging.getLogger(__name__)
+
+SETTINGS_PATH: Path = DATA_DIR / "settings.json"
+
+_DEFAULTS: dict[str, Any] = {
+    "volume": 1.0,
+    "favorite_processors": [],
+}
+
+# In-memory cache — loaded once, written on every mutation.
+_settings: dict[str, Any] | None = None
+
+
+def _load() -> dict[str, Any]:
+    """Read settings from disk, returning defaults on any failure."""
+    if SETTINGS_PATH.exists():
+        try:
+            text = SETTINGS_PATH.read_text(encoding="utf-8")
+            data = json.loads(text)
+            if isinstance(data, dict):
+                return data
+        except Exception as exc:
+            logger.warning("Failed to read settings file: %s", exc)
+    return {}
+
+
+def _save(data: dict[str, Any]) -> None:
+    """Write *data* to the settings file (creating parent dirs if needed)."""
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SETTINGS_PATH.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _ensure_loaded() -> dict[str, Any]:
+    global _settings
+    if _settings is None:
+        _settings = _load()
+    return _settings
+
+
+# -------------------------------------------------------------------
+# Public API
+# -------------------------------------------------------------------
+
+
+def get_all() -> dict[str, Any]:
+    """Return the full settings dict (with defaults filled in)."""
+    s = _ensure_loaded()
+    result = dict(_DEFAULTS)
+    result.update(s)
+    return result
+
+
+def get_volume() -> float:
+    """Return the persisted playback volume (0.0–1.0)."""
+    return float(_ensure_loaded().get("volume", _DEFAULTS["volume"]))
+
+
+def set_volume(value: float) -> None:
+    """Set and persist the playback volume."""
+    s = _ensure_loaded()
+    s["volume"] = max(0.0, min(1.0, float(value)))
+    _save(s)
+
+
+def get_favorite_processors() -> list[dict[str, Any]]:
+    """Return the list of favorite processor recipes."""
+    return list(_ensure_loaded().get("favorite_processors", []))
+
+
+def add_favorite_processor(
+    processor_name: str,
+    processor_importer: str,
+    field_values: dict[str, Any],
+) -> None:
+    """Add a favorite processor recipe (or overwrite one with the same name)."""
+    s = _ensure_loaded()
+    procs: list[dict[str, Any]] = s.setdefault("favorite_processors", [])
+    # Remove existing entry with same name
+    procs[:] = [p for p in procs if p.get("processor_name") != processor_name]
+    procs.append(
+        {
+            "processor_name": processor_name,
+            "processor_importer": processor_importer,
+            "field_values": field_values,
+        }
+    )
+    _save(s)
+
+
+def remove_favorite_processor(processor_name: str) -> bool:
+    """Remove a favorite processor by name.  Returns True if found."""
+    s = _ensure_loaded()
+    procs: list[dict[str, Any]] = s.get("favorite_processors", [])
+    before = len(procs)
+    procs[:] = [p for p in procs if p.get("processor_name") != processor_name]
+    if len(procs) < before:
+        s["favorite_processors"] = procs
+        _save(s)
+        return True
+    return False
+
+
+def to_cli_command(entry: dict[str, Any]) -> str:
+    """Build the CLI command string that would import a favorite processor.
+
+    Example output::
+
+        python app.py --import-processor --processor-importer detector_file \\
+            --processor-name "my detector" --file detector.json
+    """
+    parts = [
+        "python app.py --import-processor",
+        f"--processor-importer {entry['processor_importer']}",
+        f"--processor-name \"{entry['processor_name']}\"",
+    ]
+    for key, value in entry.get("field_values", {}).items():
+        flag = f"--{key.replace('_', '-')}"
+        if " " in str(value):
+            parts.append(f'{flag} "{value}"')
+        else:
+            parts.append(f"{flag} {value}")
+    return " ".join(parts)
+
+
+def ensure_favorite_processors_imported() -> list[str]:
+    """Import any favorite processors that are not already loaded as favorite detectors.
+
+    This is the lazy-load mechanism: favorite processor recipes are materialised
+    into real favorite detectors only when this function is called (typically
+    right before autodetect).
+
+    Returns:
+        A list of processor names that were newly imported.
+    """
+    from vtsearch.processors.importers import get_processor_importer
+    from vtsearch.utils import add_favorite_detector, get_favorite_detectors
+
+    existing = get_favorite_detectors()
+    imported: list[str] = []
+
+    for entry in get_favorite_processors():
+        name = entry.get("processor_name", "")
+        if not name or name in existing:
+            continue
+
+        importer_name = entry.get("processor_importer", "")
+        importer = get_processor_importer(importer_name)
+        if importer is None:
+            logger.warning("Favorite processor '%s': unknown importer '%s'", name, importer_name)
+            continue
+
+        field_values = dict(entry.get("field_values", {}))
+
+        try:
+            importer.validate_cli_field_values(field_values)
+            result = importer.run_cli(field_values)
+
+            if not isinstance(result, dict) or not result.get("weights"):
+                logger.warning("Favorite processor '%s': importer returned invalid result", name)
+                continue
+
+            add_favorite_detector(
+                name,
+                result.get("media_type", "audio"),
+                result["weights"],
+                result.get("threshold", 0.5),
+            )
+            imported.append(name)
+        except Exception as exc:
+            logger.warning("Favorite processor '%s': import failed: %s", name, exc)
+
+    return imported
+
+
+def reset() -> None:
+    """Reset the in-memory cache (for testing)."""
+    global _settings
+    _settings = None


### PR DESCRIPTION
Settings are stored as data/settings.json and include:
- Playback volume (persisted from the frontend on change, loaded on startup)
- Favorite Processors: stored as import recipes (importer name + field values)
  that are lazily materialized into favorite detectors when autodetect runs

Favorite processors are imported on-demand during autodetect (both CLI and
GUI paths) via ensure_favorite_processors_imported(), which skips any
processors already loaded as favorite detectors.

New files:
- vtsearch/settings.py: persistence module (load/save/CRUD)
- vtsearch/routes/settings.py: API endpoints (GET/PUT settings, CRUD favorite processors)
- tests/test_settings.py: unit + API tests

https://claude.ai/code/session_014PE9UxifjkNmkt27KtzEUm