### PR TITLE
Clean up unused imports and refactor lambda to function definition

### DIFF
--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -41,8 +41,6 @@ class TestInitClips:
 
     def test_deterministic_embeddings(self):
         """CLAP embeddings should be deterministic for the same input audio."""
-        from pathlib import Path
-
         from config import DATA_DIR
         from vtsearch.models import embed_audio_file
 

--- a/tests/test_creation_info.py
+++ b/tests/test_creation_info.py
@@ -5,17 +5,15 @@ arguments) so that exported references can describe how to reproduce the
 dataset.
 """
 
-import io
 import pickle
 
 import numpy as np
-import pytest
 
 import app as app_module
 from vtsearch.datasets.importers import get_importer
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 from vtsearch.datasets.loader import export_dataset_to_file, load_dataset_from_pickle
-from vtsearch.utils import clips, get_dataset_creation_info, set_dataset_creation_info
+from vtsearch.utils import get_dataset_creation_info, set_dataset_creation_info
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -393,7 +393,7 @@ class TestLoadDatasetContentVectors:
         mt = self._make_fake_media_type(embed_return=np.zeros(3))
 
         clips: dict = {}
-        _noop = lambda *a: None
+        def _noop(*a): None
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "sounds", clips, content_vectors={"a.wav": pre_vector}, on_progress=_noop)
 
@@ -416,7 +416,7 @@ class TestLoadDatasetContentVectors:
         mt = self._make_fake_media_type(embed_return=model_vector)
 
         clips: dict = {}
-        _noop = lambda *a: None
+        def _noop(*a): None
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "sounds", clips, content_vectors={}, on_progress=_noop)
 
@@ -442,7 +442,7 @@ class TestLoadDatasetContentVectors:
         mt = self._make_fake_media_type(embed_return=model_vector)
 
         clips: dict = {}
-        _noop = lambda *a: None
+        def _noop(*a): None
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "sounds", clips, content_vectors={"a.wav": pre_vector}, on_progress=_noop)
 
@@ -467,7 +467,7 @@ class TestLoadDatasetContentVectors:
         mt = self._make_fake_media_type(embed_return=model_vector)
 
         clips: dict = {}
-        _noop = lambda *a: None
+        def _noop(*a): None
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "sounds", clips, on_progress=_noop)
 
@@ -491,7 +491,7 @@ class TestLoadDatasetContentVectors:
         mt = self._make_fake_media_type(embed_return=None)
 
         clips: dict = {}
-        _noop = lambda *a: None
+        def _noop(*a): None
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "sounds", clips, content_vectors={"d.wav": pre_vector}, on_progress=_noop)
 

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -12,9 +12,6 @@ from __future__ import annotations
 
 import io
 import json
-import tempfile
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,5 +1,5 @@
 import app as app_module
-from vtsearch.utils import get_dataset_creation_info, set_dataset_creation_info
+from vtsearch.utils import set_dataset_creation_info
 
 
 class TestExportLabels:

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -23,7 +23,6 @@ from vtsearch.media.base import (
     MediaType,
     Processor,
     ProgressCallback,
-    _noop_progress,
 )
 
 _registry: dict[str, "MediaType"] = {}

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -18,7 +18,7 @@ the registry.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 


### PR DESCRIPTION
## Summary
This PR removes unused imports across multiple test files and the main codebase, and refactors lambda function definitions to proper function definitions for improved code clarity.

## Key Changes
- **Test files cleanup**: Removed unused imports (`io`, `pytest`, `tempfile`, `Path`, `patch`, `clips`) from test modules (`test_creation_info.py`, `test_label_importers.py`, `test_clips.py`, `test_labels.py`)
- **Lambda to function refactor**: Converted 5 lambda function assignments (`_noop = lambda *a: None`) to proper function definitions (`def _noop(*a): None`) in `test_importers.py` for better readability and PEP 8 compliance
- **Source code cleanup**: 
  - Removed unused `field` import from `vtsearch/media/base.py`
  - Removed unused `_noop_progress` export from `vtsearch/media/__init__.py`
  - Removed unused `get_dataset_creation_info` import from `test_labels.py`

## Implementation Details
The lambda-to-function refactoring improves code style by following PEP 8 guidelines which recommend using `def` statements instead of lambda assignments for named functions. This makes the code more maintainable and consistent with Python best practices.

https://claude.ai/code/session_01MX3rTNFHgvLY97R2hksqkR