### PR TITLE
Add missing clip ingestion and union-based clip matching

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,6 +187,15 @@ if __name__ == "__main__":
         help="Name of the label importer to use (e.g. json_file, csv_file). Used with --import-labels.",
     )
     parser.add_argument(
+        "--import-missing",
+        choices=["yes", "no", "ask"],
+        default="ask",
+        help=(
+            "When --import-labels finds elements not in the dataset: "
+            "'yes' to auto-import from origins, 'no' to skip, 'ask' to prompt (default: ask)."
+        ),
+    )
+    parser.add_argument(
         "--import-processor",
         action="store_true",
         help="Import a processor (detector) via a named processor importer from the command line.",
@@ -281,7 +290,9 @@ if __name__ == "__main__":
         from vtsearch.cli import import_labels_main
 
         field_values = {f.key: getattr(args, f.key, f.default or None) for f in label_importer.fields}
-        import_labels_main(args.dataset, args.label_importer, field_values)
+        import_missing_flag = getattr(args, "import_missing", "ask")
+        auto_import_missing = {"yes": True, "no": False, "ask": None}[import_missing_flag]
+        import_labels_main(args.dataset, args.label_importer, field_values, auto_import_missing=auto_import_missing)
 
     elif args.autodetect:
         # Collect exporter field values if an exporter was specified

--- a/tests/test_origin_labelset.py
+++ b/tests/test_origin_labelset.py
@@ -501,10 +501,10 @@ class TestResolveClipIds:
         ids = resolve_clip_ids(entry, origin_lookup, md5_lookup)
         assert ids == []
 
-    def test_origin_preferred_over_md5(self):
-        """When origin matches, MD5 is not used even if it would match more clips."""
+    def test_union_of_origin_and_md5(self):
+        """Origin and MD5 matches are unioned: all matching clips are returned."""
         origin_lookup, md5_lookup = self._make_lookups()
-        # h1 matches clips 1 and 3 by MD5, but origin narrows it to just clip 1
+        # Origin matches clip 1, md5 "h1" matches clips 1 and 3 → union is [1, 3]
         entry = {"md5": "h1", "origin": {"importer": "folder", "params": {"path": "/a"}}, "origin_name": "a.wav"}
         ids = resolve_clip_ids(entry, origin_lookup, md5_lookup)
-        assert ids == [1]
+        assert sorted(ids) == [1, 3]

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from typing import Any, Callable, Optional
 
-from vtsearch.utils.state import _origin_key, next_clip_id
+from vtsearch.utils.state import next_clip_id
 
 ProgressCallback = Callable[[str, str, int, int], None]
 

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -11,7 +11,6 @@ appended to the in-memory dataset.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from typing import Any, Callable, Optional
 
@@ -131,5 +130,5 @@ def ingest_missing_clips(
                 cid += 1
                 total_ingested += 1
 
-    on_progress("idle", f"Ingested {total_ingested} clip(s) from origins.")
+    on_progress("idle", f"Ingested {total_ingested} clip(s) from origins.", 0, 0)
     return total_ingested

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -1,0 +1,135 @@
+"""Ingest missing clips into an existing dataset by re-running their origins.
+
+When a label-set references elements that are not present in the current
+dataset, the user may choose to pull them in from their original sources.
+This module groups the missing entries by origin, runs the appropriate
+dataset importer for each origin, and cherry-picks only the clips that
+match the missing entries (by ``origin_name``).  The recovered clips are
+assigned fresh IDs that do not collide with existing clips and are
+appended to the in-memory dataset.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Optional
+
+from vtsearch.utils.state import _origin_key, next_clip_id
+
+ProgressCallback = Callable[[str, str, int, int], None]
+
+
+def _default_progress() -> ProgressCallback:
+    from vtsearch.utils import update_progress
+
+    return update_progress
+
+
+def _group_by_origin(
+    entries: list[dict[str, Any]],
+) -> dict[str, tuple[dict[str, Any], list[dict[str, Any]]]]:
+    """Group label entries by their serialised origin.
+
+    Returns a dict mapping ``json.dumps(origin, sort_keys=True)`` to a tuple
+    of ``(origin_dict, [entries_with_that_origin])``.  Entries without an
+    origin are silently skipped (they cannot be re-ingested).
+    """
+    groups: dict[str, tuple[dict[str, Any], list[dict[str, Any]]]] = {}
+    for entry in entries:
+        origin = entry.get("origin")
+        if origin is None:
+            continue
+        key = json.dumps(origin, sort_keys=True)
+        if key not in groups:
+            groups[key] = (origin, [])
+        groups[key][1].append(entry)
+    return groups
+
+
+def ingest_missing_clips(
+    missing_entries: list[dict[str, Any]],
+    clips: dict[int, dict[str, Any]],
+    on_progress: Optional[ProgressCallback] = None,
+) -> int:
+    """Re-ingest missing clips from their origins into *clips*.
+
+    Groups *missing_entries* by origin, runs each origin's dataset importer
+    to recover the full clip data (media bytes + embedding), then appends
+    the matched clips to *clips* with fresh, non-colliding IDs.
+
+    Args:
+        missing_entries: Label entries (dicts with ``origin``,
+            ``origin_name``, ``md5``, ``label``, etc.) that were not found
+            in the current dataset.
+        clips: The live dataset dict to extend in-place.
+        on_progress: Optional progress callback.
+
+    Returns:
+        The number of clips successfully ingested.
+    """
+    from vtsearch.datasets.importers import get_importer
+
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    groups = _group_by_origin(missing_entries)
+    if not groups:
+        return 0
+
+    total_ingested = 0
+
+    for origin_key, (origin_dict, entries) in groups.items():
+        importer_name = origin_dict.get("importer", "")
+        importer = get_importer(importer_name)
+        if importer is None:
+            continue
+
+        params = origin_dict.get("params", {})
+
+        # Build a set of origin_names we're looking for
+        wanted_names: set[str] = set()
+        wanted_md5s: set[str] = set()
+        for entry in entries:
+            name = entry.get("origin_name", "")
+            if name:
+                wanted_names.add(name)
+            md5 = entry.get("md5", "")
+            if md5:
+                wanted_md5s.add(md5)
+
+        on_progress(
+            "ingesting",
+            f"Re-ingesting from {importer_name} ({len(wanted_names)} clips)...",
+            0,
+            0,
+        )
+
+        # Run the importer into a temporary clips dict
+        temp_clips: dict[int, dict[str, Any]] = {}
+        try:
+            importer.run_cli(params, temp_clips)
+        except Exception:
+            # If the importer fails (e.g. folder not found), skip this origin
+            continue
+
+        # Set origin on temp clips that don't have one
+        for clip in temp_clips.values():
+            if clip.get("origin") is None:
+                clip["origin"] = origin_dict
+            if not clip.get("origin_name"):
+                clip["origin_name"] = clip.get("filename", "")
+
+        # Cherry-pick matching clips
+        cid = next_clip_id(clips)
+        for temp_clip in temp_clips.values():
+            clip_origin_name = temp_clip.get("origin_name", "")
+            clip_md5 = temp_clip.get("md5", "")
+            if clip_origin_name in wanted_names or clip_md5 in wanted_md5s:
+                temp_clip["id"] = cid
+                clips[cid] = temp_clip
+                cid += 1
+                total_ingested += 1
+
+    on_progress("idle", f"Ingested {total_ingested} clip(s) from origins.")
+    return total_ingested

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -11,7 +11,23 @@ POST /api/label-importers/import/<importer_name>
 
     Returns::
 
-        {"applied": <int>, "skipped": <int>, "message": "<str>"}
+        {
+          "applied": <int>,
+          "skipped": <int>,
+          "missing_count": <int>,
+          "missing": [<entry>, ...],
+          "message": "<str>"
+        }
+
+    When ``missing_count`` is non-zero the response contains the label entries
+    that could not be matched to any clip in the current dataset (neither by
+    ``origin`` + ``origin_name`` nor by ``md5``).  The frontend can prompt the
+    user and then call ``POST /api/label-importers/ingest-missing`` to pull
+    those clips from their origins.
+
+POST /api/label-importers/ingest-missing
+    Accept a list of missing label entries, re-ingest them from their origins,
+    and apply the labels.
 """
 
 from __future__ import annotations
@@ -19,9 +35,53 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.labels.importers import get_label_importer, list_label_importers
-from vtsearch.utils import add_label_to_history, bad_votes, build_clip_lookup, clips, good_votes, resolve_clip_ids
+from vtsearch.utils import (
+    add_label_to_history,
+    bad_votes,
+    build_clip_lookup,
+    clips,
+    find_missing_entries,
+    good_votes,
+    resolve_clip_ids,
+)
 
 label_importers_bp = Blueprint("label_importers", __name__)
+
+
+def _apply_labels(
+    label_entries: list[dict],
+    origin_lookup: dict[str, list[int]],
+    md5_lookup: dict[str, list[int]],
+) -> tuple[int, int]:
+    """Apply label entries to the global vote state.
+
+    Returns ``(applied, skipped)`` counts.
+    """
+    applied = 0
+    skipped = 0
+
+    for entry in label_entries:
+        label = entry.get("label", "")
+        if label not in ("good", "bad"):
+            skipped += 1
+            continue
+        cids = resolve_clip_ids(entry, origin_lookup, md5_lookup)
+        if not cids:
+            skipped += 1
+            continue
+
+        for cid in cids:
+            if label == "good":
+                bad_votes.pop(cid, None)
+                good_votes[cid] = None
+                add_label_to_history(cid, "good")
+            else:
+                good_votes.pop(cid, None)
+                bad_votes[cid] = None
+                add_label_to_history(cid, "bad")
+        applied += 1
+
+    return applied, skipped
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +109,10 @@ def run_label_import(importer_name: str):
     builds a ``field_values`` dict and passes it to
     :meth:`~vtsearch.labels.importers.base.LabelImporter.run`.
 
-    Returns JSON with ``applied``, ``skipped``, and ``message`` keys.
+    Returns JSON with ``applied``, ``skipped``, ``missing_count``,
+    ``missing``, and ``message`` keys.  When ``missing_count > 0`` the
+    client should prompt the user and optionally call
+    ``POST /api/label-importers/ingest-missing`` with the ``missing`` list.
     """
     importer = get_label_importer(importer_name)
     if importer is None:
@@ -75,14 +138,14 @@ def run_label_import(importer_name: str):
             field_values[f.key] = body.get(f.key, f.default or "")
 
     # Validate required fields (skip file fields — presence checked by importer)
-    missing = [
+    missing_fields = [
         f.key
         for f in importer.fields
         if f.required and f.field_type != "file" and not field_values.get(f.key, "").strip()
     ]
-    if missing:
+    if missing_fields:
         return (
-            jsonify({"error": f"Missing required field(s): {missing}", "missing_fields": missing}),
+            jsonify({"error": f"Missing required field(s): {missing_fields}", "missing_fields": missing_fields}),
             400,
         )
 
@@ -98,34 +161,68 @@ def run_label_import(importer_name: str):
 
     # Apply labels to global vote state
     origin_lookup, md5_lookup = build_clip_lookup(clips)
-    applied = 0
-    skipped = 0
+    applied, skipped = _apply_labels(label_entries, origin_lookup, md5_lookup)
 
-    for entry in label_entries:
-        label = entry.get("label", "")
-        if label not in ("good", "bad"):
-            skipped += 1
-            continue
-        cids = resolve_clip_ids(entry, origin_lookup, md5_lookup)
-        if not cids:
-            skipped += 1
-            continue
+    # Detect entries that could not be matched at all
+    missing = find_missing_entries(label_entries, origin_lookup, md5_lookup)
+    # Adjust skipped count: missing entries were already counted as skipped
+    # by _apply_labels, but we report them separately now.
+    skipped -= len(missing)
 
-        for cid in cids:
-            if label == "good":
-                bad_votes.pop(cid, None)
-                good_votes[cid] = None
-                add_label_to_history(cid, "good")
-            else:
-                good_votes.pop(cid, None)
-                bad_votes[cid] = None
-                add_label_to_history(cid, "bad")
-        applied += 1
+    msg = f"Applied {applied} label(s), skipped {skipped}."
+    if missing:
+        msg += f" {len(missing)} element(s) not found in dataset."
 
     return jsonify(
         {
             "applied": applied,
             "skipped": skipped,
-            "message": f"Applied {applied} label(s), skipped {skipped}.",
+            "missing_count": len(missing),
+            "missing": missing,
+            "message": msg,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/label-importers/ingest-missing
+# ---------------------------------------------------------------------------
+
+
+@label_importers_bp.route("/api/label-importers/ingest-missing", methods=["POST"])
+def ingest_missing():
+    """Re-ingest missing clips from their origins, then apply their labels.
+
+    Expects a JSON body::
+
+        {"entries": [<label-entry>, ...]}
+
+    Groups the entries by origin, runs each origin's dataset importer to
+    recover the full clip data (media bytes + embedding), appends the
+    matched clips to the live dataset, and applies the labels.
+
+    Returns::
+
+        {"ingested": <int>, "applied": <int>, "message": "<str>"}
+    """
+    body = request.get_json(force=True, silent=True) or {}
+    entries = body.get("entries", [])
+
+    if not isinstance(entries, list) or not entries:
+        return jsonify({"error": "Request must contain a non-empty 'entries' list."}), 400
+
+    from vtsearch.datasets.ingest import ingest_missing_clips
+
+    ingested = ingest_missing_clips(entries, clips)
+
+    # Now apply labels to the newly ingested clips
+    origin_lookup, md5_lookup = build_clip_lookup(clips)
+    applied, _ = _apply_labels(entries, origin_lookup, md5_lookup)
+
+    return jsonify(
+        {
+            "ingested": ingested,
+            "applied": applied,
+            "message": f"Ingested {ingested} clip(s), applied {applied} label(s).",
         }
     )

--- a/vtsearch/utils/__init__.py
+++ b/vtsearch/utils/__init__.py
@@ -14,6 +14,7 @@ from vtsearch.utils.state import (
     dataset_creation_info,
     favorite_detectors,
     favorite_extractors,
+    find_missing_entries,
     get_dataset_creation_info,
     get_favorite_detectors,
     get_favorite_detectors_by_media,
@@ -23,6 +24,7 @@ from vtsearch.utils.state import (
     good_votes,
     inclusion,
     label_history,
+    next_clip_id,
     remove_favorite_detector,
     remove_favorite_extractor,
     rename_favorite_detector,
@@ -67,4 +69,6 @@ __all__ = [
     "get_favorite_extractors_by_media",
     "build_clip_lookup",
     "resolve_clip_ids",
+    "find_missing_entries",
+    "next_clip_id",
 ]


### PR DESCRIPTION
## Summary

This PR enhances the label import workflow to handle missing clips by allowing users to re-ingest them from their origins, and changes clip matching from a fallback strategy (origin+name preferred, MD5 fallback) to a union strategy (match by both origin+name AND MD5).

## Key Changes

- **Union-based clip matching**: `resolve_clip_ids()` now returns the union of clips matched by `origin+origin_name` and by `md5`, ensuring all corresponding clips in the dataset are labeled regardless of how they were matched.

- **Missing clip detection**: Added `find_missing_entries()` utility to identify label entries that don't match any clip in the current dataset (by either origin+name or md5).

- **Clip re-ingestion**: New `vtsearch/datasets/ingest.py` module that groups missing entries by origin, runs their dataset importers to recover full clip data (media bytes + embedding), and cherry-picks matching clips into the live dataset with fresh IDs.

- **Enhanced label import API**: 
  - `POST /api/label-importers/import/*` now returns `missing_count` and `missing` fields containing unmatched entries
  - New `POST /api/label-importers/ingest-missing` endpoint accepts missing entries, re-ingests them from origins, and applies their labels

- **Frontend UI**: Added interactive prompt in the label importer modal that appears when missing elements are detected, allowing users to import them from origins or skip.

- **CLI support**: `import_labels_main()` now detects missing entries and prompts the user (or respects `--import-missing` flag) to re-ingest them.

- **Refactored label application**: Extracted `_apply_labels()` helper function to avoid duplication between the initial import and missing clip ingestion workflows.

## Implementation Details

- Missing entries are grouped by their serialized origin dict to efficiently batch re-ingestion by importer
- Entries without an origin cannot be re-ingested and are silently skipped
- The `next_clip_id()` utility ensures newly ingested clips receive non-colliding IDs
- Progress callbacks support long-running ingestion operations
- Tests cover union matching, missing entry detection, and the full ingest workflow including folder-based importers

https://claude.ai/code/session_011VrLqC8BHsvw8qbfRmVYJe