### PR TITLE
Reorganize demo datasets with size variants and add video demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,17 @@ Available demos:
 
 | Demo | Media type | Description |
 |------|-----------|-------------|
-| **animals** | Audio | Animal and nature sounds (ESC-50) |
-| **natural** | Audio | Natural environmental sounds (ESC-50) |
-| **urban** | Audio | Urban and mechanical sounds (ESC-50) |
-| **household** | Audio | Household and human sounds (ESC-50) |
-| **objects_images** | Image | Common objects and animals (CIFAR-10) |
-| **news_paragraphs** | Text | News article paragraphs (20 Newsgroups) |
+| **sounds_s** | Audio | Animals & fireside — dogs, cats, roosters, church bells, crackling fire (ESC-50, ~200 clips) |
+| **sounds_m** | Audio | Everyday sounds — babies, laughter, clapping, footsteps, chainsaws, airplanes, and more (ESC-50, ~400 clips) |
+| **sounds_l** | Audio | Environmental mix — nature, weather, traffic, and household sounds (ESC-50, ~800 clips) |
+| **images_s** | Image | Nature & flight — butterflies, sunflowers, starfish, helicopters (Caltech-101) |
+| **images_m** | Image | Animals & objects — dolphins, pianos, elephants, kangaroos, laptops, and more (Caltech-101) |
+| **images_l** | Image | Diverse objects — 15 categories including scorpions, vehicles, and instruments (Caltech-101) |
+| **paragraphs_s** | Text | Sports & science articles from 20 Newsgroups |
+| **paragraphs_m** | Text | World news, business, technology, and medicine articles from 20 Newsgroups |
+| **paragraphs_l** | Text | Eight-topic mix — cars, hockey, electronics, crypto, religion, and more (20 Newsgroups) |
+| **activities_video** | Video | Personal activities — grooming, drumming, yo-yo (UCF-101) |
+| **sports_video** | Video | Sports & exercise — cliff diving, jump rope, push-ups, tai chi (UCF-101) |
 
 You can also load your own data from pickle files or folders via the same menu.
 


### PR DESCRIPTION
## Summary
Updated the demo datasets documentation to reflect a reorganized dataset structure with size-based variants (small, medium, large) across multiple modalities, and added support for video demos.

## Key Changes
- **Reorganized audio demos**: Replaced single `animals`, `natural`, `urban`, and `household` demos with three size-variant demos (`sounds_s`, `sounds_m`, `sounds_l`) that provide progressive complexity and dataset size
- **Reorganized image demos**: Replaced single `objects_images` demo with three size-variant demos (`images_s`, `images_m`, `images_l`) using Caltech-101 dataset instead of CIFAR-10
- **Reorganized text demos**: Replaced single `news_paragraphs` demo with three size-variant demos (`paragraphs_s`, `paragraphs_m`, `paragraphs_l`) with more specific topic descriptions
- **Added video demos**: Introduced two new video demo categories (`activities_video` and `sports_video`) using UCF-101 dataset

## Notable Details
- All demos now follow a consistent naming convention with size suffixes (`_s`, `_m`, `_l`) for non-video modalities
- Dataset sources remain consistent (ESC-50 for audio, 20 Newsgroups for text) with updated dataset references (Caltech-101 for images, UCF-101 for video)
- Descriptions now include specific example content to help users understand what each demo contains
- Approximate clip/sample counts are provided for audio demos to indicate dataset size

https://claude.ai/code/session_01AA1N2xcvGrDKRUH8fzkEXp