### PR TITLE
Make DisplayLabelsetExporter the default exporter for CLI autodetect

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -225,9 +225,26 @@
     </div>
     <div class="modal-body">
       <div id="autodetect-summary" style="margin-bottom: 16px;"></div>
-      <div id="autodetect-results"></div>
-      <div style="margin-top: 16px;">
-        <button id="copy-results-btn" style="padding: 8px 16px; background: #7c8aff; color: #fff; border: none; border-radius: 4px; cursor: pointer;">Copy Results to Clipboard</button>
+      <div id="autodetect-results" style="max-height: 500px; overflow-y: auto;"></div>
+      <div style="margin-top: 16px; display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+        <label style="color: #aaa; font-size: 0.85rem;">Column:
+          <select id="copy-column-select" style="padding: 4px 8px; background: #1a1d27; color: #e0e0e0; border: 1px solid #2a2d3a; border-radius: 4px; font-size: 0.85rem; margin-left: 4px;">
+            <option value="origin+name">origin+name</option>
+            <option value="name">name</option>
+            <option value="md5">md5</option>
+            <option value="filename">filename</option>
+            <option value="origin">origin</option>
+          </select>
+        </label>
+        <label style="color: #aaa; font-size: 0.85rem;">Separator:
+          <select id="copy-separator-select" style="padding: 4px 8px; background: #1a1d27; color: #e0e0e0; border: 1px solid #2a2d3a; border-radius: 4px; font-size: 0.85rem; margin-left: 4px;">
+            <option value="newline">newline</option>
+            <option value=",">,</option>
+            <option value="tab">tab</option>
+            <option value="space">space</option>
+          </select>
+        </label>
+        <button id="copy-results-btn" style="padding: 8px 16px; background: #7c8aff; color: #fff; border: none; border-radius: 4px; cursor: pointer;">Copy To Clipboard</button>
       </div>
     </div>
   </div>

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -217,6 +217,58 @@ class TestDisplayLabelsetExporter:
         assert "message" in result
         assert result["display_results"] is EMPTY_RESULTS
 
+    def test_export_cli_prints_origins_and_names(self, capsys):
+        from vtsearch.exporters import get_exporter
+
+        results_with_origin = {
+            "media_type": "audio",
+            "detectors_run": 1,
+            "results": {
+                "det1": {
+                    "detector_name": "det1",
+                    "threshold": 0.5,
+                    "total_hits": 2,
+                    "hits": [
+                        {
+                            "id": 1,
+                            "filename": "bark1.wav",
+                            "origin_name": "bark1.wav",
+                            "origin": {"importer": "folder", "params": {"path": "/data"}},
+                            "score": 0.9,
+                            "category": "dog",
+                        },
+                        {
+                            "id": 2,
+                            "filename": "bark2.wav",
+                            "origin_name": "bark2.wav",
+                            "score": 0.7,
+                            "category": "dog",
+                        },
+                    ],
+                },
+            },
+        }
+        exp = get_exporter("gui")
+        result = exp.export_cli(results_with_origin, {})
+        captured = capsys.readouterr()
+        assert "message" in result
+        # Should list origin and name, not scores or categories
+        assert "folder(/data)" in captured.out
+        assert "bark1.wav" in captured.out
+        assert "bark2.wav" in captured.out
+        assert "score" not in captured.out.lower()
+        assert "category" not in captured.out.lower()
+        assert "dog" not in captured.out
+
+    def test_export_cli_no_hits(self, capsys):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("gui")
+        result = exp.export_cli(EMPTY_RESULTS, {})
+        captured = capsys.readouterr()
+        assert "No items predicted as Good" in captured.out
+        assert "message" in result
+
 
 # ---------------------------------------------------------------------------
 # File exporter

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -304,12 +304,9 @@ def autodetect_main(
 
         hits = _score_clips_with_detector(clips, detector_path)
 
-        if exporter_name:
-            media_type = _detect_media_type(clips)
-            results = _build_results_dict(hits, detector_path, media_type)
-            _run_exporter(exporter_name, exporter_field_values or {}, results)
-        else:
-            _print_hits(hits)
+        media_type = _detect_media_type(clips)
+        results = _build_results_dict(hits, detector_path, media_type)
+        _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -462,12 +459,9 @@ def autodetect_importer_main(
 
         hits = _score_clips_with_detector(clips, detector_path)
 
-        if exporter_name:
-            media_type = _detect_media_type(clips)
-            results = _build_results_dict(hits, detector_path, media_type)
-            _run_exporter(exporter_name, exporter_field_values or {}, results)
-        else:
-            _print_hits(hits)
+        media_type = _detect_media_type(clips)
+        results = _build_results_dict(hits, detector_path, media_type)
+        _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
     except (FileNotFoundError, ValueError, NotADirectoryError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
- DisplayLabelsetExporter is now the default exporter when no --exporter
  is specified in CLI autodetect mode (both legacy pickle and importer paths)
- CLI output shows only origins and names of Good results (no categories,
  no scores) for a cleaner, more actionable listing
- GUI auto-detect modal now shows a table of all Good results with columns
  for origin, name, md5, and filename
- Added pulldown menus at bottom of modal: column selector (origin+name,
  name, md5, filename, origin) and separator selector (newline, comma, tab,
  space) with a "Copy To Clipboard" button
- Updated tests for new output format

https://claude.ai/code/session_01DpfJ1jtr8rJTLwnHh78SN7