### PR TITLE
Revert dialog icons to standard emoji symbols

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -39,17 +39,16 @@
   const vtDialogActions = document.getElementById("vt-dialog-actions");
 
   const VT_ICONS = {
-    warning: "/favicon-surprised.ico",
-    error: "/favicon-frown.ico",
-    success: "/favicon-smile.ico",
-    info: "/favicon-smile.ico",
+    warning: "\u26A0\uFE0F",
+    error: "\u274C",
+    success: "\u2705",
+    info: "\u2139\uFE0F",
   };
 
   function vtShowDialog({ message, type, showInput, inputDefault, buttons }) {
     return new Promise((resolve) => {
-      const iconSrc = VT_ICONS[type] || VT_ICONS.info;
-      vtDialogIcon.innerHTML = '<img src="' + iconSrc + '" alt="">';
-      vtDialogIcon.className = "vt-dialog-icon";
+      vtDialogIcon.textContent = VT_ICONS[type] || VT_ICONS.info;
+      vtDialogIcon.className = "vt-dialog-icon " + (type || "info");
       vtDialogMessage.textContent = message;
 
       if (showInput) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -209,8 +209,11 @@ video { max-width: 600px; max-height: 400px; }
 .vt-dialog-box { max-width: 440px; min-width: 320px; }
 .vt-dialog-header { display: flex; align-items: center; gap: 10px; margin-bottom: 16px; }
 .vt-dialog-header h2 { font-size: 1.1rem; color: #7c8aff; margin: 0; }
-.vt-dialog-icon { flex-shrink: 0; width: 28px; height: 28px; }
-.vt-dialog-icon img { width: 100%; height: 100%; object-fit: contain; image-rendering: pixelated; }
+.vt-dialog-icon { font-size: 1.4rem; line-height: 1; flex-shrink: 0; }
+.vt-dialog-icon.warning { color: #f0c040; }
+.vt-dialog-icon.error { color: #f44336; }
+.vt-dialog-icon.success { color: #4caf50; }
+.vt-dialog-icon.info { color: #7c8aff; }
 .vt-dialog-body { color: #e0e0e0; font-size: 0.92rem; margin-bottom: 20px; line-height: 1.5; }
 .vt-dialog-body p { margin: 0; }
 .vt-dialog-input { width: 100%; padding: 8px 10px; margin-top: 12px; border: 1px solid #2a2d3a; border-radius: 4px; background: #14161e; color: #e0e0e0; font-size: 0.9rem; outline: none; }


### PR DESCRIPTION
Keep favicon variants (smile/frown/surprised) as static assets but restore the original emoji-based alert icons in the dialog system.

https://claude.ai/code/session_01AugGEdwNmbsrtqFYsWoarm