### PR TITLE
Support multiple detectors via settings file instead of single --detector flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 - **Run GPU tests**: `python -m pytest tests/test_gpu.py -v -m gpu` (requires CUDA GPU; downloads models on first run)
 - **Run all tests (CPU + GPU)**: `python -m pytest tests/ -v -m ''`
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
-- **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --detector <file.json>`
-- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --detector <file.json> --exporter file --filepath results.json`
+- **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
+- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter file --filepath results.json`
 - **CLI label import**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-labels --dataset <file.pkl> --label-importer json_file --file labels.json`
 - **CLI label import (CSV)**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-labels --dataset <file.pkl> --label-importer csv_file --file labels.csv`
 - **CLI processor import**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-processor --processor-importer detector_file --processor-name "my detector" --file detector.json`

--- a/app.py
+++ b/app.py
@@ -165,7 +165,14 @@ if __name__ == "__main__":
         help="Run a detector on a dataset from the command line and print predicted-Good items",
     )
     parser.add_argument("--dataset", type=str, help="Path to a dataset pickle file (used with --autodetect)")
-    parser.add_argument("--detector", type=str, help="Path to a detector JSON file (used with --autodetect)")
+    parser.add_argument(
+        "--settings",
+        type=str,
+        help=(
+            "Path to a settings JSON file containing favorite processors. "
+            "Used with --autodetect. Defaults to data/settings.json."
+        ),
+    )
     parser.add_argument(
         "--importer",
         type=str,
@@ -300,24 +307,22 @@ if __name__ == "__main__":
         if exporter:
             exporter_field_values = {f.key: getattr(args, f.key, f.default or None) for f in exporter.fields}
 
-        if args.importer:
-            # New importer-based path
-            if not args.detector:
-                parser.error("--autodetect with --importer requires --detector")
+        settings_path = getattr(args, "settings", None)
 
+        if args.importer:
+            # Importer-based path
             from vtsearch.cli import autodetect_importer_main
 
             field_values = {f.key: getattr(args, f.key, f.default or None) for f in importer.fields}
-            autodetect_importer_main(args.importer, field_values, args.detector, args.exporter, exporter_field_values)
+            autodetect_importer_main(
+                args.importer, field_values, settings_path, args.exporter, exporter_field_values
+            )
 
         elif args.dataset:
-            # Legacy pickle-file path
-            if not args.detector:
-                parser.error("--autodetect requires --detector")
-
+            # Pickle-file path
             from vtsearch.cli import autodetect_main
 
-            autodetect_main(args.dataset, args.detector, args.exporter, exporter_field_values)
+            autodetect_main(args.dataset, settings_path, args.exporter, exporter_field_values)
 
         else:
             parser.error("--autodetect requires either --dataset <file.pkl> or --importer <name>")

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -79,12 +79,14 @@ _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 @pytest.fixture(autouse=True)
 def _reset_processors():
     """Clean up global favorite detectors and settings cache after each test."""
+    import vtsearch.settings as settings_mod
+
+    original_path = settings_mod.SETTINGS_PATH
     yield
     from vtsearch.utils.state import favorite_detectors
 
-    import vtsearch.settings as settings_mod
-
     favorite_detectors.clear()
+    settings_mod.SETTINGS_PATH = original_path
     settings_mod.reset()
 
 

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -11,9 +11,11 @@ import pytest
 
 import app as app_module
 from vtsearch.cli import (
+    _build_multi_results_dict,
     _build_results_dict,
     _detect_media_type,
     _run_exporter,
+    _score_clips_with_detectors,
     run_autodetect,
     run_autodetect_with_importer,
 )
@@ -48,7 +50,42 @@ def _make_detector_file(tmp_path, client, good_ids, bad_ids, name="detector.json
     return detector_path, detector
 
 
+def _make_settings_file(tmp_path, detector_paths, name="settings.json"):
+    """Create a settings JSON file with favorite_processors pointing to detector files.
+
+    Each detector file becomes a favorite processor recipe using the
+    ``detector_file`` processor importer.
+    """
+    processors = []
+    for i, det_path in enumerate(detector_paths):
+        det_data = json.loads(Path(det_path).read_text())
+        proc_name = det_data.get("name", f"detector_{i}")
+        processors.append(
+            {
+                "processor_name": proc_name,
+                "processor_importer": "detector_file",
+                "field_values": {"file": str(det_path)},
+            }
+        )
+    settings = {"favorite_processors": processors}
+    settings_path = tmp_path / name
+    settings_path.write_text(json.dumps(settings))
+    return settings_path
+
+
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+
+
+@pytest.fixture(autouse=True)
+def _reset_processors():
+    """Clean up global favorite detectors and settings cache after each test."""
+    yield
+    from vtsearch.utils.state import favorite_detectors
+
+    import vtsearch.settings as settings_mod
+
+    favorite_detectors.clear()
+    settings_mod.reset()
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +310,130 @@ class TestRunAutodetectWithImporter:
 
 
 # ---------------------------------------------------------------------------
+# Tests for _score_clips_with_detectors() (multi-processor)
+# ---------------------------------------------------------------------------
+
+
+class TestScoreClipsWithDetectors:
+    """Tests for the multi-detector scoring function."""
+
+    def test_single_detector_returns_one_result(self, client, tmp_path):
+        _, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        detectors = {"det_a": {"weights": detector["weights"], "threshold": detector["threshold"]}}
+        results = _score_clips_with_detectors(app_module.clips, detectors)
+
+        assert len(results) == 1
+        assert "det_a" in results
+        assert results["det_a"]["detector_name"] == "det_a"
+        assert isinstance(results["det_a"]["hits"], list)
+
+    def test_two_detectors_return_two_results(self, client, tmp_path):
+        _, det_a = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20], name="det_a.json")
+        _, det_b = _make_detector_file(tmp_path, client, [5, 6, 7], [15, 16, 17], name="det_b.json")
+        detectors = {
+            "det_a": {"weights": det_a["weights"], "threshold": det_a["threshold"]},
+            "det_b": {"weights": det_b["weights"], "threshold": det_b["threshold"]},
+        }
+        results = _score_clips_with_detectors(app_module.clips, detectors)
+
+        assert len(results) == 2
+        assert "det_a" in results
+        assert "det_b" in results
+
+    def test_hits_sorted_descending(self, client, tmp_path):
+        _, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        detector["threshold"] = 0.0  # include all clips
+        detectors = {"det": {"weights": detector["weights"], "threshold": 0.0}}
+        results = _score_clips_with_detectors(app_module.clips, detectors)
+
+        scores = [h["score"] for h in results["det"]["hits"]]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_hits_have_required_fields(self, client, tmp_path):
+        _, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        detectors = {"det": {"weights": detector["weights"], "threshold": 0.0}}
+        results = _score_clips_with_detectors(app_module.clips, detectors)
+
+        for hit in results["det"]["hits"]:
+            assert "id" in hit
+            assert "filename" in hit
+            assert "category" in hit
+            assert "score" in hit
+
+    def test_empty_clips_raises_error(self, client, tmp_path):
+        _, detector = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        detectors = {"det": {"weights": detector["weights"], "threshold": detector["threshold"]}}
+
+        with pytest.raises(ValueError, match="No clips loaded"):
+            _score_clips_with_detectors({}, detectors)
+
+    def test_empty_detectors_raises_error(self):
+        with pytest.raises(ValueError, match="No favorite processors"):
+            _score_clips_with_detectors(app_module.clips, {})
+
+    def test_threshold_zero_returns_all_clips(self, client, tmp_path):
+        _, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        detectors = {"det": {"weights": detector["weights"], "threshold": 0.0}}
+        results = _score_clips_with_detectors(app_module.clips, detectors)
+
+        assert results["det"]["total_hits"] == len(app_module.clips)
+
+    def test_different_detectors_may_flag_different_clips(self, client, tmp_path):
+        """Two detectors trained on different goods should have different hit sets."""
+        _, det_a = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20], name="a.json")
+        _, det_b = _make_detector_file(tmp_path, client, [18, 19, 20], [1, 2, 3], name="b.json")
+        detectors = {
+            "det_a": {"weights": det_a["weights"], "threshold": 0.0},
+            "det_b": {"weights": det_b["weights"], "threshold": 0.0},
+        }
+        results = _score_clips_with_detectors(app_module.clips, detectors)
+
+        # Both should return all clips (threshold=0), but with different score orderings
+        ids_a = [h["id"] for h in results["det_a"]["hits"]]
+        ids_b = [h["id"] for h in results["det_b"]["hits"]]
+        assert set(ids_a) == set(ids_b)  # same clips
+        assert ids_a != ids_b  # different ordering (different scores)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_multi_results_dict
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMultiResultsDict:
+    """Tests for the _build_multi_results_dict helper."""
+
+    def test_basic_structure(self, client, tmp_path):
+        _, detector = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        detectors = {"det_a": {"weights": detector["weights"], "threshold": detector["threshold"]}}
+        detector_results = _score_clips_with_detectors(app_module.clips, detectors)
+        results = _build_multi_results_dict(detector_results, "audio")
+
+        assert results["media_type"] == "audio"
+        assert results["detectors_run"] == 1
+        assert isinstance(results["results"], dict)
+        assert len(results["results"]) == 1
+
+    def test_two_detectors(self, client, tmp_path):
+        _, det_a = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20], name="a.json")
+        _, det_b = _make_detector_file(tmp_path, client, [5, 6, 7], [15, 16, 17], name="b.json")
+        detectors = {
+            "det_a": {"weights": det_a["weights"], "threshold": det_a["threshold"]},
+            "det_b": {"weights": det_b["weights"], "threshold": det_b["threshold"]},
+        }
+        detector_results = _score_clips_with_detectors(app_module.clips, detectors)
+        results = _build_multi_results_dict(detector_results, "audio")
+
+        assert results["detectors_run"] == 2
+        assert len(results["results"]) == 2
+
+    def test_default_media_type_is_unknown(self):
+        results = _build_multi_results_dict({})
+        assert results["media_type"] == "unknown"
+        assert results["detectors_run"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Tests for importer CLI argument generation
 # ---------------------------------------------------------------------------
 
@@ -359,6 +520,7 @@ class TestAutodetectCLI:
     def test_autodetect_prints_output(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -367,8 +529,8 @@ class TestAutodetectCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
             ],
             capture_output=True,
             text=True,
@@ -380,9 +542,10 @@ class TestAutodetectCLI:
 
     def test_autodetect_missing_dataset_flag(self, client, tmp_path):
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
-            [sys.executable, "app.py", "--autodetect", "--detector", str(detector_path)],
+            [sys.executable, "app.py", "--autodetect", "--settings", str(settings_path)],
             capture_output=True,
             text=True,
             cwd=_PROJECT_ROOT,
@@ -390,20 +553,33 @@ class TestAutodetectCLI:
         )
         assert result.returncode != 0
 
-    def test_autodetect_missing_detector_flag(self, tmp_path):
+    def test_autodetect_no_processors_fails(self, tmp_path):
+        """Autodetect with an empty settings file should fail (no processors)."""
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        empty_settings = tmp_path / "empty_settings.json"
+        empty_settings.write_text(json.dumps({"favorite_processors": []}))
 
         result = subprocess.run(
-            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path)],
+            [
+                sys.executable,
+                "app.py",
+                "--autodetect",
+                "--dataset",
+                str(dataset_path),
+                "--settings",
+                str(empty_settings),
+            ],
             capture_output=True,
             text=True,
             cwd=_PROJECT_ROOT,
             timeout=120,
         )
-        assert result.returncode != 0
+        assert result.returncode == 1
+        assert "No favorite processors" in result.stderr
 
     def test_autodetect_nonexistent_dataset(self, client, tmp_path):
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -412,8 +588,8 @@ class TestAutodetectCLI:
                 "--autodetect",
                 "--dataset",
                 "/tmp/nonexistent.pkl",
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
             ],
             capture_output=True,
             text=True,
@@ -431,9 +607,18 @@ class TestAutodetectCLI:
         detector["threshold"] = 0.0
         zero_path = tmp_path / "zero_threshold.json"
         zero_path.write_text(json.dumps(detector))
+        settings_path = _make_settings_file(tmp_path, [zero_path])
 
         result = subprocess.run(
-            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path), "--detector", str(zero_path)],
+            [
+                sys.executable,
+                "app.py",
+                "--autodetect",
+                "--dataset",
+                str(dataset_path),
+                "--settings",
+                str(settings_path),
+            ],
             capture_output=True,
             text=True,
             cwd=_PROJECT_ROOT,
@@ -451,9 +636,18 @@ class TestAutodetectCLI:
         detector["threshold"] = 1.0
         high_path = tmp_path / "high_threshold.json"
         high_path.write_text(json.dumps(detector))
+        settings_path = _make_settings_file(tmp_path, [high_path])
 
         result = subprocess.run(
-            [sys.executable, "app.py", "--autodetect", "--dataset", str(dataset_path), "--detector", str(high_path)],
+            [
+                sys.executable,
+                "app.py",
+                "--autodetect",
+                "--dataset",
+                str(dataset_path),
+                "--settings",
+                str(settings_path),
+            ],
             capture_output=True,
             text=True,
             cwd=_PROJECT_ROOT,
@@ -461,6 +655,39 @@ class TestAutodetectCLI:
         )
         assert result.returncode == 0
         assert "No items predicted as Good" in result.stdout
+
+    def test_autodetect_multiple_processors(self, client, tmp_path):
+        """Multiple processors in settings should produce results from all."""
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        det_a_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20], name="det_a.json")
+        det_b_path, _ = _make_detector_file(tmp_path, client, [5, 6, 7], [15, 16, 17], name="det_b.json")
+        settings_path = _make_settings_file(tmp_path, [det_a_path, det_b_path])
+
+        output_file = tmp_path / "multi_output.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "app.py",
+                "--autodetect",
+                "--dataset",
+                str(dataset_path),
+                "--settings",
+                str(settings_path),
+                "--exporter",
+                "file",
+                "--filepath",
+                str(output_file),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=_PROJECT_ROOT,
+            timeout=120,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert output_file.exists()
+        saved = json.loads(output_file.read_text())
+        assert saved["detectors_run"] == 2
+        assert len(saved["results"]) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +703,7 @@ class TestAutodetectImporterCLI:
         """--importer pickle --file <path> should work like --dataset <path>."""
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -486,8 +714,8 @@ class TestAutodetectImporterCLI:
                 "pickle",
                 "--file",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
             ],
             capture_output=True,
             text=True,
@@ -499,6 +727,7 @@ class TestAutodetectImporterCLI:
 
     def test_importer_unknown_name_fails(self, client, tmp_path):
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -507,8 +736,8 @@ class TestAutodetectImporterCLI:
                 "--autodetect",
                 "--importer",
                 "nonexistent_importer",
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
             ],
             capture_output=True,
             text=True,
@@ -518,8 +747,11 @@ class TestAutodetectImporterCLI:
         assert result.returncode != 0
         assert "Unknown importer" in result.stderr
 
-    def test_importer_missing_detector_fails(self, tmp_path):
+    def test_importer_no_processors_fails(self, tmp_path):
+        """Autodetect with importer but no processors should fail."""
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        empty_settings = tmp_path / "empty_settings.json"
+        empty_settings.write_text(json.dumps({"favorite_processors": []}))
 
         result = subprocess.run(
             [
@@ -530,6 +762,8 @@ class TestAutodetectImporterCLI:
                 "pickle",
                 "--file",
                 str(dataset_path),
+                "--settings",
+                str(empty_settings),
             ],
             capture_output=True,
             text=True,
@@ -541,6 +775,7 @@ class TestAutodetectImporterCLI:
     def test_importer_missing_required_field_fails(self, client, tmp_path):
         """Omitting a required importer field should produce an error."""
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -549,8 +784,8 @@ class TestAutodetectImporterCLI:
                 "--autodetect",
                 "--importer",
                 "pickle",
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 # --file intentionally omitted
             ],
             capture_output=True,
@@ -563,6 +798,7 @@ class TestAutodetectImporterCLI:
 
     def test_importer_folder_nonexistent_path_fails(self, client, tmp_path):
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2], [3, 4])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -575,8 +811,8 @@ class TestAutodetectImporterCLI:
                 "/nonexistent/folder",
                 "--media-type",
                 "sounds",
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
             ],
             capture_output=True,
             text=True,
@@ -842,7 +1078,7 @@ class TestRunExporter:
 
 
 # ---------------------------------------------------------------------------
-# Tests for autodetect_main with --exporter
+# Tests for autodetect_main with --exporter (settings-based)
 # ---------------------------------------------------------------------------
 
 
@@ -852,13 +1088,14 @@ class TestAutodetectMainWithExporter:
     def test_file_exporter_via_function(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         output_file = tmp_path / "fn_export.json"
         from vtsearch.cli import autodetect_main
 
         autodetect_main(
             str(dataset_path),
-            str(detector_path),
+            settings_path=str(settings_path),
             exporter_name="file",
             exporter_field_values={"filepath": str(output_file)},
         )
@@ -870,16 +1107,39 @@ class TestAutodetectMainWithExporter:
     def test_no_exporter_uses_gui_default(self, client, tmp_path, capsys):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         from vtsearch.cli import autodetect_main
 
-        autodetect_main(str(dataset_path), str(detector_path))
+        autodetect_main(str(dataset_path), settings_path=str(settings_path))
 
         captured = capsys.readouterr()
         # Default exporter is gui, which prints origins+names or "No items predicted"
         assert "Predicted Good" in captured.out or "No items predicted as Good" in captured.out
         # Should NOT contain score or category info (gui exporter strips those)
         assert "score:" not in captured.out.lower()
+
+    def test_multi_processor_file_export(self, client, tmp_path):
+        """autodetect_main with two processors should produce two-detector results."""
+        dataset_path = _make_dataset_file(tmp_path, app_module.clips)
+        det_a_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20], name="det_a.json")
+        det_b_path, _ = _make_detector_file(tmp_path, client, [5, 6, 7], [15, 16, 17], name="det_b.json")
+        settings_path = _make_settings_file(tmp_path, [det_a_path, det_b_path])
+
+        output_file = tmp_path / "multi_export.json"
+        from vtsearch.cli import autodetect_main
+
+        autodetect_main(
+            str(dataset_path),
+            settings_path=str(settings_path),
+            exporter_name="file",
+            exporter_field_values={"filepath": str(output_file)},
+        )
+
+        assert output_file.exists()
+        saved = json.loads(output_file.read_text())
+        assert saved["detectors_run"] == 2
+        assert len(saved["results"]) == 2
 
 
 class TestAutodetectImporterMainWithExporter:
@@ -888,6 +1148,7 @@ class TestAutodetectImporterMainWithExporter:
     def test_pickle_importer_file_exporter(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         output_file = tmp_path / "importer_export.json"
         from vtsearch.cli import autodetect_importer_main
@@ -895,7 +1156,7 @@ class TestAutodetectImporterMainWithExporter:
         autodetect_importer_main(
             "pickle",
             {"file": str(dataset_path)},
-            str(detector_path),
+            settings_path=str(settings_path),
             exporter_name="file",
             exporter_field_values={"filepath": str(output_file)},
         )
@@ -918,6 +1179,7 @@ class TestAutodetectExporterCLI:
     def test_file_exporter_via_cli(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         output_file = tmp_path / "cli_export.json"
         result = subprocess.run(
@@ -927,8 +1189,8 @@ class TestAutodetectExporterCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "file",
                 "--filepath",
@@ -947,6 +1209,7 @@ class TestAutodetectExporterCLI:
     def test_file_exporter_with_importer_via_cli(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         output_file = tmp_path / "cli_imp_export.json"
         result = subprocess.run(
@@ -958,8 +1221,8 @@ class TestAutodetectExporterCLI:
                 "pickle",
                 "--file",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "file",
                 "--filepath",
@@ -978,6 +1241,7 @@ class TestAutodetectExporterCLI:
     def test_gui_exporter_via_cli(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -986,8 +1250,8 @@ class TestAutodetectExporterCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "gui",
             ],
@@ -1008,6 +1272,7 @@ class TestAutodetectExporterCLI:
     def test_unknown_exporter_fails(self, client, tmp_path):
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -1016,8 +1281,8 @@ class TestAutodetectExporterCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "nonexistent_exporter",
             ],
@@ -1033,6 +1298,7 @@ class TestAutodetectExporterCLI:
         """Omitting required email_smtp fields should produce an error."""
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         result = subprocess.run(
             [
@@ -1041,8 +1307,8 @@ class TestAutodetectExporterCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "email_smtp",
                 # --to and other required fields intentionally omitted
@@ -1059,6 +1325,7 @@ class TestAutodetectExporterCLI:
         """File exporter output should include the media_type from the dataset."""
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         output_file = tmp_path / "media_type_test.json"
         result = subprocess.run(
@@ -1068,8 +1335,8 @@ class TestAutodetectExporterCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "file",
                 "--filepath",
@@ -1088,6 +1355,7 @@ class TestAutodetectExporterCLI:
         """The CLI should print the exporter's confirmation message."""
         dataset_path = _make_dataset_file(tmp_path, app_module.clips)
         detector_path, _ = _make_detector_file(tmp_path, client, [1, 2, 3], [18, 19, 20])
+        settings_path = _make_settings_file(tmp_path, [detector_path])
 
         output_file = tmp_path / "confirm_test.json"
         result = subprocess.run(
@@ -1097,8 +1365,8 @@ class TestAutodetectExporterCLI:
                 "--autodetect",
                 "--dataset",
                 str(dataset_path),
-                "--detector",
-                str(detector_path),
+                "--settings",
+                str(settings_path),
                 "--exporter",
                 "file",
                 "--filepath",

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -227,6 +227,108 @@ def _build_results_dict(
     }
 
 
+def _score_clips_with_detectors(
+    clips: dict[int, dict[str, Any]],
+    detectors: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Score all *clips* against every detector in *detectors*.
+
+    Embeddings are extracted once and reused across all detectors.
+
+    Args:
+        clips: The clips dict (must contain ``"embedding"`` per clip).
+        detectors: Mapping of detector name to detector data dict (with
+            ``"weights"`` and ``"threshold"`` keys).
+
+    Returns:
+        A dict mapping detector name to its results sub-dict (with
+        ``"detector_name"``, ``"threshold"``, ``"total_hits"``, ``"hits"``).
+
+    Raises:
+        ValueError: If *clips* or *detectors* is empty.
+    """
+    if not clips:
+        raise ValueError("No clips loaded from dataset")
+    if not detectors:
+        raise ValueError("No favorite processors found for the dataset's media type")
+
+    all_ids = sorted(clips.keys())
+    all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
+    X_all = torch.tensor(all_embs, dtype=torch.float32)
+
+    results: dict[str, dict[str, Any]] = {}
+    for detector_name, detector_data in detectors.items():
+        weights = detector_data["weights"]
+        threshold = detector_data["threshold"]
+
+        input_dim = len(weights["0.weight"][0])
+        model = nn.Sequential(
+            nn.Linear(input_dim, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1),
+            nn.Sigmoid(),
+        )
+
+        state_dict = {}
+        for key, value in weights.items():
+            state_dict[key] = torch.tensor(value, dtype=torch.float32)
+        model.load_state_dict(state_dict)
+        model.eval()
+
+        with torch.no_grad():
+            scores = model(X_all).squeeze(1).tolist()
+
+        positive_hits: list[dict[str, Any]] = []
+        for cid, score in zip(all_ids, scores):
+            if score >= threshold:
+                clip = clips[cid]
+                hit: dict[str, Any] = {
+                    "id": cid,
+                    "filename": clip.get("filename", f"clip_{cid}"),
+                    "category": clip.get("category", "unknown"),
+                    "score": round(score, 4),
+                }
+                if clip.get("origin") is not None:
+                    hit["origin"] = clip["origin"]
+                if clip.get("origin_name"):
+                    hit["origin_name"] = clip["origin_name"]
+                if clip.get("md5"):
+                    hit["md5"] = clip["md5"]
+                positive_hits.append(hit)
+
+        positive_hits.sort(key=lambda x: x["score"], reverse=True)
+
+        results[detector_name] = {
+            "detector_name": detector_name,
+            "threshold": round(threshold, 4),
+            "total_hits": len(positive_hits),
+            "hits": positive_hits,
+        }
+
+    return results
+
+
+def _build_multi_results_dict(
+    detector_results: dict[str, dict[str, Any]],
+    media_type: str = "unknown",
+) -> dict[str, Any]:
+    """Build the full results dict from multi-detector scoring.
+
+    Args:
+        detector_results: Per-detector results from
+            :func:`_score_clips_with_detectors`.
+        media_type: The media type string for the dataset.
+
+    Returns:
+        A dict matching the shape expected by exporters.
+    """
+    return {
+        "media_type": media_type,
+        "detectors_run": len(detector_results),
+        "results": detector_results,
+    }
+
+
 def _detect_media_type(clips: dict[int, dict[str, Any]]) -> str:
     """Return the media type from the first clip, or ``"unknown"``."""
     for clip in clips.values():
@@ -256,12 +358,21 @@ def _run_exporter(
     print(result.get("message", "Export complete."))
 
 
-def _import_favorite_processors() -> None:
+def _import_favorite_processors(settings_path: str | None = None) -> None:
     """Import favorite processors from settings (if any).
+
+    When *settings_path* is provided the settings module is pointed at that
+    file before importing; otherwise the default ``data/settings.json`` is
+    used.
 
     Errors are logged as warnings but do not halt the autodetect run.
     """
     try:
+        if settings_path:
+            from vtsearch.settings import set_settings_path
+
+            set_settings_path(settings_path)
+
         from vtsearch.settings import ensure_favorite_processors_imported
 
         imported = ensure_favorite_processors_imported()
@@ -273,11 +384,16 @@ def _import_favorite_processors() -> None:
 
 def autodetect_main(
     dataset_path: str,
-    detector_path: str,
+    settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
 ) -> None:
-    """CLI entry point: run autodetect and output results.
+    """CLI entry point: run autodetect with all favorite processors and output results.
+
+    Loads favorite processors from the settings file (defaulting to the
+    normal ``data/settings.json``), scores the dataset against every
+    processor matching the dataset's media type, and exports a combined
+    result set with one column per processor.
 
     When *exporter_name* is ``None`` the hits are printed to stdout.
     Otherwise the named exporter is used to deliver the results.
@@ -286,12 +402,13 @@ def autodetect_main(
 
     Args:
         dataset_path: Path to the dataset pickle file.
-        detector_path: Path to the detector JSON file.
+        settings_path: Optional path to a settings JSON file.  When ``None``
+            the default ``data/settings.json`` is used.
         exporter_name: Optional registered exporter name.
         exporter_field_values: Optional exporter field values.
     """
     try:
-        _import_favorite_processors()
+        _import_favorite_processors(settings_path)
 
         dataset_file = Path(dataset_path)
         if not dataset_file.exists():
@@ -302,10 +419,19 @@ def autodetect_main(
         if not clips:
             raise ValueError(f"No clips loaded from dataset: {dataset_path}")
 
-        hits = _score_clips_with_detector(clips, detector_path)
-
         media_type = _detect_media_type(clips)
-        results = _build_results_dict(hits, detector_path, media_type)
+
+        from vtsearch.utils import get_favorite_detectors_by_media
+
+        detectors = get_favorite_detectors_by_media(media_type)
+        if not detectors:
+            raise ValueError(
+                f"No favorite processors found for media type: {media_type}. "
+                "Add processors to the settings file or use --settings to specify one."
+            )
+
+        detector_results = _score_clips_with_detectors(clips, detectors)
+        results = _build_multi_results_dict(detector_results, media_type)
         _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -422,11 +548,16 @@ def import_labels_main(
 def autodetect_importer_main(
     importer_name: str,
     field_values: dict[str, Any],
-    detector_path: str,
+    settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
 ) -> None:
     """CLI entry point: run autodetect with a named importer and output results.
+
+    Loads favorite processors from the settings file (defaulting to the
+    normal ``data/settings.json``), scores the imported dataset against
+    every processor matching the dataset's media type, and exports a
+    combined result set with one column per processor.
 
     When *exporter_name* is ``None`` the hits are printed to stdout.
     Otherwise the named exporter is used to deliver the results.
@@ -436,12 +567,13 @@ def autodetect_importer_main(
     Args:
         importer_name: Registered name of the importer.
         field_values: Mapping of importer field keys to their CLI values.
-        detector_path: Path to the detector JSON file.
+        settings_path: Optional path to a settings JSON file.  When ``None``
+            the default ``data/settings.json`` is used.
         exporter_name: Optional registered exporter name.
         exporter_field_values: Optional exporter field values.
     """
     try:
-        _import_favorite_processors()
+        _import_favorite_processors(settings_path)
 
         from vtsearch.datasets.importers import get_importer
 
@@ -457,10 +589,19 @@ def autodetect_importer_main(
         if not clips:
             raise ValueError(f"No clips loaded by importer '{importer_name}'")
 
-        hits = _score_clips_with_detector(clips, detector_path)
-
         media_type = _detect_media_type(clips)
-        results = _build_results_dict(hits, detector_path, media_type)
+
+        from vtsearch.utils import get_favorite_detectors_by_media
+
+        detectors = get_favorite_detectors_by_media(media_type)
+        if not detectors:
+            raise ValueError(
+                f"No favorite processors found for media type: {media_type}. "
+                "Add processors to the settings file or use --settings to specify one."
+            )
+
+        detector_results = _score_clips_with_detectors(clips, detectors)
+        results = _build_multi_results_dict(detector_results, media_type)
         _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
     except (FileNotFoundError, ValueError, NotADirectoryError) as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -114,7 +114,7 @@ class DatasetImporter:
     CLI support
     -----------
     Every importer is automatically usable from the command line via
-    ``python app.py --autodetect --importer <name> [importer args] --detector <file>``.
+    ``python app.py --autodetect --importer <name> [importer args] --settings <file>``.
 
     The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
     :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override
@@ -209,7 +209,7 @@ class DatasetImporter:
         The returned string contains only the importer-specific portion, e.g.
         ``"--importer folder --media-type sounds --path /data/audio"``.  The
         caller can prepend ``python app.py --autodetect`` and append
-        ``--detector <file>`` as needed.
+        ``--settings <file>`` as needed.
 
         Fields with ``field_type="file"`` are skipped because they correspond
         to browser uploads that don't translate directly to a CLI flag.

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -219,6 +219,18 @@ def ensure_favorite_processors_imported() -> list[str]:
     return imported
 
 
+def set_settings_path(path: str | Path) -> None:
+    """Override the settings file path and reset the in-memory cache.
+
+    Call this before :func:`ensure_favorite_processors_imported` to load
+    favorite processors from a custom settings file (e.g. the ``--settings``
+    CLI flag).
+    """
+    global SETTINGS_PATH, _settings
+    SETTINGS_PATH = Path(path)
+    _settings = None  # force reload on next access
+
+
 def reset() -> None:
     """Reset the in-memory cache (for testing)."""
     global _settings


### PR DESCRIPTION
## Summary
This PR refactors the autodetect CLI to support running multiple detectors simultaneously by loading them from a settings file, replacing the single `--detector` flag with a `--settings` flag. The new architecture allows users to configure multiple "favorite processors" in a settings file and run them all against a dataset in one operation.

## Key Changes

- **New CLI flag**: Replaced `--detector <file>` with `--settings <file>` that points to a settings JSON file containing multiple favorite processors
- **Multi-detector scoring**: Added `_score_clips_with_detectors()` function that scores clips against multiple detectors in a single pass, reusing embeddings across all detectors
- **Multi-result building**: Added `_build_multi_results_dict()` to structure results from multiple detectors with a `detectors_run` count and per-detector result objects
- **Settings integration**: Added `set_settings_path()` to `vtsearch/settings.py` to allow overriding the settings file path at runtime
- **Updated entry points**: Modified `autodetect_main()` and `autodetect_importer_main()` to accept optional `settings_path` parameter instead of `detector_path`
- **Backward compatibility**: The functions now load favorite processors from settings using `get_favorite_detectors_by_media()` instead of loading a single detector file
- **Test infrastructure**: Added `_make_settings_file()` helper and `_reset_processors` fixture to support testing with settings files; updated all existing tests to use the new settings-based approach

## Implementation Details

- Embeddings are extracted once and reused across all detectors for efficiency
- Results are sorted by score in descending order per detector
- Each detector result includes `detector_name`, `threshold`, `total_hits`, and `hits` array
- The settings file format uses `favorite_processors` array with `processor_name`, `processor_importer`, and `field_values`
- Error handling validates that clips and detectors are non-empty before processing
- Global state cleanup via pytest fixture ensures test isolation

https://claude.ai/code/session_0187Gn9PhFSBShd59FUdSS1v