### PR TITLE
Add enriched text embedding for sort descriptions

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -170,6 +170,7 @@
   const stripeContainer = document.getElementById("stripe-container");
   const inclusionSlider = document.getElementById("inclusion-slider");
   const inclusionValue = document.getElementById("inclusion-value");
+  const enrichDescCheckbox = document.getElementById("enrich-descriptions-checkbox");
 
   // Dataset management elements
   const datasetWelcome = document.getElementById("dataset-welcome");
@@ -1259,6 +1260,22 @@
   inclusionSlider.addEventListener("input", () => {
     updateInclusion(parseInt(inclusionSlider.value));
   });
+
+  // ---- Enrich Sort Descriptions toggle ----
+
+  if (enrichDescCheckbox) {
+    enrichDescCheckbox.addEventListener("change", () => {
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enrich_descriptions: enrichDescCheckbox.checked }),
+      }).catch(() => {});
+      // Re-trigger text sort if active
+      if (sortMode === "text") {
+        onTextSortInput();
+      }
+    });
+  }
 
   // ---- Text sort ----
 
@@ -2757,6 +2774,9 @@
       }
       if (data.theme) {
         applyTheme(data.theme);
+      }
+      if (enrichDescCheckbox) {
+        enrichDescCheckbox.checked = !!data.enrich_descriptions;
       }
     } catch (_) {
       // Settings not available yet; use defaults

--- a/static/index.html
+++ b/static/index.html
@@ -90,6 +90,10 @@
       <div style="text-align:center; font-size:0.75rem; color:var(--text-secondary); margin-top:2px">
         <span id="inclusion-value">0</span>
       </div>
+      <div style="display:flex; align-items:center; gap:6px; margin-top:8px">
+        <input type="checkbox" id="enrich-descriptions-checkbox" style="accent-color:var(--accent)">
+        <label for="enrich-descriptions-checkbox" style="font-size:0.78rem; color:var(--text-secondary); cursor:pointer">Enrich Sort Descriptions</label>
+      </div>
       <div id="sort-status" class="sort-status"></div>
       <div id="sort-progress" class="sort-progress">
         <div class="sort-progress-bar">

--- a/tests/test_enrich_descriptions.py
+++ b/tests/test_enrich_descriptions.py
@@ -382,8 +382,6 @@ class TestEvalTextSortEnrich:
 
         call_kwargs = []
 
-        orig_embed = embed_text_query
-
         def mock_embed(text, media_type, enrich=False):
             call_kwargs.append({"enrich": enrich})
             if "cat" in text:

--- a/tests/test_enrich_descriptions.py
+++ b/tests/test_enrich_descriptions.py
@@ -1,0 +1,413 @@
+"""Tests for the Enrich Sort Descriptions feature.
+
+Covers:
+- description_wrappers property on each media type
+- embed_text_enriched method (base class logic)
+- enrich_descriptions setting (get/set/persist)
+- embed_text_query with enrich=True
+- eval runner with enrich=True
+- settings API route for enrich_descriptions
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vtsearch.eval.config import EvalQuery
+from vtsearch.eval.runner import eval_text_sort
+from vtsearch.media.audio.media_type import AudioMediaType
+from vtsearch.media.base import MediaType
+from vtsearch.media.image.media_type import ImageMediaType
+from vtsearch.media.text.media_type import TextMediaType
+from vtsearch.media.video.media_type import VideoMediaType
+from vtsearch.models.embeddings import embed_text_query
+
+
+# =====================================================================
+# description_wrappers property
+# =====================================================================
+
+
+class TestDescriptionWrappers:
+    def test_audio_has_wrappers(self):
+        mt = AudioMediaType()
+        wrappers = mt.description_wrappers
+        assert len(wrappers) >= 3
+        for w in wrappers:
+            assert "{text}" in w
+
+    def test_image_has_wrappers(self):
+        mt = ImageMediaType()
+        wrappers = mt.description_wrappers
+        assert len(wrappers) >= 3
+        for w in wrappers:
+            assert "{text}" in w
+
+    def test_text_has_wrappers(self):
+        mt = TextMediaType()
+        wrappers = mt.description_wrappers
+        assert len(wrappers) >= 3
+        for w in wrappers:
+            assert "{text}" in w
+
+    def test_video_has_wrappers(self):
+        mt = VideoMediaType()
+        wrappers = mt.description_wrappers
+        assert len(wrappers) >= 3
+        for w in wrappers:
+            assert "{text}" in w
+
+    def test_wrappers_include_bare_text(self):
+        """Each media type should include a plain '{text}' wrapper."""
+        for mt_cls in (AudioMediaType, ImageMediaType, TextMediaType, VideoMediaType):
+            mt = mt_cls()
+            assert "{text}" in mt.description_wrappers, f"{mt_cls.__name__} missing bare '{{text}}' wrapper"
+
+    def test_wrappers_format_correctly(self):
+        """All wrappers should format without errors."""
+        for mt_cls in (AudioMediaType, ImageMediaType, TextMediaType, VideoMediaType):
+            mt = mt_cls()
+            for wrapper in mt.description_wrappers:
+                result = wrapper.format(text="test query")
+                assert "test query" in result
+
+
+# =====================================================================
+# embed_text_enriched (base class logic)
+# =====================================================================
+
+
+class TestEmbedTextEnriched:
+    def _make_mock_media_type(self, wrappers, embed_fn):
+        """Create a minimal concrete MediaType subclass for testing."""
+
+        class MockMediaType(MediaType):
+            @property
+            def type_id(self):
+                return "mock"
+
+            @property
+            def name(self):
+                return "Mock"
+
+            @property
+            def icon(self):
+                return "?"
+
+            @property
+            def file_extensions(self):
+                return []
+
+            @property
+            def loops(self):
+                return False
+
+            @property
+            def demo_datasets(self):
+                return []
+
+            @property
+            def description_wrappers(self):
+                return wrappers
+
+            def load_models(self):
+                pass
+
+            def embed_media(self, file_path):
+                return None
+
+            def embed_text(self, text):
+                return embed_fn(text)
+
+            def load_clip_data(self, file_path):
+                return {"duration": 0}
+
+            def clip_response(self, clip):
+                from vtsearch.media.base import MediaResponse
+
+                return MediaResponse(data=b"", mimetype="text/plain")
+
+        return MockMediaType()
+
+    def test_enriched_averages_wrapper_embeddings(self):
+        """embed_text_enriched should average embeddings across wrappers."""
+        call_log = []
+
+        def mock_embed(text):
+            call_log.append(text)
+            # Return different vectors for different wrapped texts
+            if text.startswith("a photo"):
+                return np.array([1.0, 0.0, 0.0])
+            elif text.startswith("an image"):
+                return np.array([0.0, 1.0, 0.0])
+            else:
+                return np.array([0.0, 0.0, 1.0])
+
+        mt = self._make_mock_media_type(
+            wrappers=["a photo of {text}", "an image of {text}", "{text}"],
+            embed_fn=mock_embed,
+        )
+
+        result = mt.embed_text_enriched("cats")
+        assert result is not None
+        assert len(call_log) == 3
+        assert "a photo of cats" in call_log
+        assert "an image of cats" in call_log
+        assert "cats" in call_log
+
+        # Result should be the L2-normalised mean of the three vectors
+        expected = np.mean([[1, 0, 0], [0, 1, 0], [0, 0, 1]], axis=0)
+        expected = expected / np.linalg.norm(expected)
+        np.testing.assert_allclose(result, expected, atol=1e-6)
+
+    def test_enriched_falls_back_when_no_wrappers(self):
+        """If no wrappers, embed_text_enriched should fall back to embed_text."""
+
+        def mock_embed(text):
+            return np.array([1.0, 2.0, 3.0])
+
+        mt = self._make_mock_media_type(wrappers=[], embed_fn=mock_embed)
+        result = mt.embed_text_enriched("test")
+        np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0]))
+
+    def test_enriched_falls_back_when_all_fail(self):
+        """If all wrapper embeddings fail, fall back to plain embed_text."""
+        calls = {"count": 0}
+
+        def mock_embed(text):
+            calls["count"] += 1
+            if calls["count"] <= 2:
+                return None  # Fail for wrapped texts
+            return np.array([1.0, 0.0])  # Succeed for plain fallback
+
+        mt = self._make_mock_media_type(
+            wrappers=["wrapper1 {text}", "wrapper2 {text}"],
+            embed_fn=mock_embed,
+        )
+        result = mt.embed_text_enriched("test")
+        assert result is not None
+        np.testing.assert_array_equal(result, np.array([1.0, 0.0]))
+
+    def test_enriched_skips_failed_wrappers(self):
+        """Wrappers that fail to embed should be skipped, not crash."""
+
+        def mock_embed(text):
+            if "bad" in text:
+                return None
+            return np.array([1.0, 0.0])
+
+        mt = self._make_mock_media_type(
+            wrappers=["good {text}", "bad {text}"],
+            embed_fn=mock_embed,
+        )
+        result = mt.embed_text_enriched("query")
+        assert result is not None
+        # Only one embedding succeeded, so result is just that one (normalised)
+        expected = np.array([1.0, 0.0])
+        np.testing.assert_allclose(result, expected, atol=1e-6)
+
+    def test_enriched_result_is_normalised(self):
+        """The enriched embedding should be L2-normalised."""
+
+        def mock_embed(text):
+            return np.array([3.0, 4.0])
+
+        mt = self._make_mock_media_type(
+            wrappers=["w1 {text}", "w2 {text}"],
+            embed_fn=mock_embed,
+        )
+        result = mt.embed_text_enriched("test")
+        assert abs(np.linalg.norm(result) - 1.0) < 1e-6
+
+
+# =====================================================================
+# embed_text_query with enrich flag
+# =====================================================================
+
+
+class TestEmbedTextQueryEnrich:
+    def test_enrich_false_calls_embed_text(self):
+        """enrich=False should call embed_text, not embed_text_enriched."""
+        mock_vec = np.array([1.0, 0.0])
+
+        class FakeMT:
+            def embed_text(self, text):
+                return mock_vec
+
+            def embed_text_enriched(self, text):
+                raise AssertionError("Should not be called")
+
+        with patch("vtsearch.media.get", return_value=FakeMT()):
+            result = embed_text_query("test", "audio", enrich=False)
+        np.testing.assert_array_equal(result, mock_vec)
+
+    def test_enrich_true_calls_embed_text_enriched(self):
+        """enrich=True should call embed_text_enriched."""
+        mock_vec = np.array([0.0, 1.0])
+
+        class FakeMT:
+            def embed_text(self, text):
+                raise AssertionError("Should not be called")
+
+            def embed_text_enriched(self, text):
+                return mock_vec
+
+        with patch("vtsearch.media.get", return_value=FakeMT()):
+            result = embed_text_query("test", "audio", enrich=True)
+        np.testing.assert_array_equal(result, mock_vec)
+
+
+# =====================================================================
+# enrich_descriptions setting
+# =====================================================================
+
+
+class TestEnrichDescriptionsSetting:
+    @pytest.fixture(autouse=True)
+    def isolated_settings(self, tmp_path, monkeypatch):
+        from vtsearch import settings as settings_mod
+
+        test_settings_path = tmp_path / "settings.json"
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
+        settings_mod.reset()
+        yield test_settings_path
+        settings_mod.reset()
+
+    def test_default_is_false(self):
+        from vtsearch import settings as settings_mod
+
+        assert settings_mod.get_enrich_descriptions() is False
+
+    def test_set_and_get(self):
+        from vtsearch import settings as settings_mod
+
+        settings_mod.set_enrich_descriptions(True)
+        assert settings_mod.get_enrich_descriptions() is True
+
+        settings_mod.set_enrich_descriptions(False)
+        assert settings_mod.get_enrich_descriptions() is False
+
+    def test_persists_to_disk(self, isolated_settings):
+        import json
+
+        from vtsearch import settings as settings_mod
+
+        settings_mod.set_enrich_descriptions(True)
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["enrich_descriptions"] is True
+
+    def test_in_get_all(self):
+        from vtsearch import settings as settings_mod
+
+        data = settings_mod.get_all()
+        assert "enrich_descriptions" in data
+        assert data["enrich_descriptions"] is False
+
+
+# =====================================================================
+# Settings API route
+# =====================================================================
+
+
+class TestEnrichDescriptionsAPI:
+    @pytest.fixture(autouse=True)
+    def isolated_settings(self, tmp_path, monkeypatch):
+        from vtsearch import settings as settings_mod
+
+        test_settings_path = tmp_path / "settings.json"
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
+        settings_mod.reset()
+        yield
+        settings_mod.reset()
+
+    @pytest.fixture
+    def client(self):
+        import app as app_module
+
+        app_module.app.config["TESTING"] = True
+        with app_module.app.test_client() as c:
+            yield c
+
+    def test_get_includes_enrich_descriptions(self, client):
+        res = client.get("/api/settings")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "enrich_descriptions" in data
+        assert data["enrich_descriptions"] is False
+
+    def test_put_enrich_descriptions(self, client):
+        res = client.put("/api/settings", json={"enrich_descriptions": True})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["enrich_descriptions"] is True
+
+        # Verify it persisted
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["enrich_descriptions"] is True
+
+
+# =====================================================================
+# Eval runner with enrich flag
+# =====================================================================
+
+
+class TestEvalTextSortEnrich:
+    def _make_synthetic_clips(self):
+        rng = np.random.RandomState(0)
+        clips = {}
+        clip_id = 1
+        cat_dir = np.zeros(16)
+        cat_dir[0] = 1.0
+        for _ in range(10):
+            emb = cat_dir + rng.normal(0, 0.05, 16)
+            emb /= np.linalg.norm(emb)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "cat", "type": "image"}
+            clip_id += 1
+        dog_dir = np.zeros(16)
+        dog_dir[1] = 1.0
+        for _ in range(10):
+            emb = dog_dir + rng.normal(0, 0.05, 16)
+            emb /= np.linalg.norm(emb)
+            clips[clip_id] = {"id": clip_id, "embedding": emb, "category": "dog", "type": "image"}
+            clip_id += 1
+        return clips, cat_dir, dog_dir
+
+    def test_eval_text_sort_with_enrich(self):
+        """eval_text_sort should pass enrich to embed_text_query."""
+        clips, cat_dir, dog_dir = self._make_synthetic_clips()
+        queries = [EvalQuery("a cat", "cat")]
+
+        call_kwargs = []
+
+        orig_embed = embed_text_query
+
+        def mock_embed(text, media_type, enrich=False):
+            call_kwargs.append({"enrich": enrich})
+            if "cat" in text:
+                return cat_dir.copy()
+            return dog_dir.copy()
+
+        with patch("vtsearch.models.embeddings.embed_text_query", side_effect=mock_embed):
+            results = eval_text_sort(clips, queries, "image", k_values=[5], enrich=True)
+
+        assert len(results) == 1
+        assert all(kw["enrich"] is True for kw in call_kwargs)
+
+    def test_eval_text_sort_without_enrich(self):
+        """eval_text_sort with enrich=False should pass enrich=False."""
+        clips, cat_dir, dog_dir = self._make_synthetic_clips()
+        queries = [EvalQuery("a cat", "cat")]
+
+        call_kwargs = []
+
+        def mock_embed(text, media_type, enrich=False):
+            call_kwargs.append({"enrich": enrich})
+            return cat_dir.copy()
+
+        with patch("vtsearch.models.embeddings.embed_text_query", side_effect=mock_embed):
+            eval_text_sort(clips, queries, "image", k_values=[5], enrich=False)
+
+        assert all(kw["enrich"] is False for kw in call_kwargs)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -325,7 +325,7 @@ class TestEvalTextSort:
         ]
 
         # Mock embed_text_query to return the cluster centre
-        def mock_embed(text, media_type):
+        def mock_embed(text, media_type, enrich=False):
             if "cat" in text:
                 return cat_dir.copy()
             return dog_dir.copy()

--- a/vtsearch/eval/__main__.py
+++ b/vtsearch/eval/__main__.py
@@ -98,6 +98,11 @@ def main() -> None:
         action="store_true",
         help="Disable plot generation even when --plot-dir is set.",
     )
+    parser.add_argument(
+        "--enrich-descriptions",
+        action="store_true",
+        help="Use enriched (wrapper-averaged) text embeddings for text-sort evaluation.",
+    )
 
     args = parser.parse_args()
 
@@ -119,6 +124,7 @@ def main() -> None:
         k_values=args.k,
         train_fraction=args.train_fraction,
         seed=args.seed,
+        enrich=args.enrich_descriptions,
     )
 
     # Print summary

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -145,6 +145,16 @@ class AudioMediaType(MediaType):
     # Embeddings
     # ------------------------------------------------------------------
 
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "the sound of {text}",
+            "a recording of {text}",
+            "{text}",
+            "audio of {text}",
+            "the noise of {text}",
+        ]
+
     def load_models(self) -> None:
         if self._model is not None:
             return

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -161,6 +161,16 @@ class ImageMediaType(MediaType):
     # Embeddings
     # ------------------------------------------------------------------
 
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "a photo of {text}",
+            "a photograph of {text}",
+            "an image of {text}",
+            "{text}",
+            "a picture of {text}",
+        ]
+
     def load_models(self) -> None:
         if self._model is not None:
             return

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -115,6 +115,16 @@ class TextMediaType(MediaType):
     # Embeddings
     # ------------------------------------------------------------------
 
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "a document about {text}",
+            "an article discussing {text}",
+            "{text}",
+            "a text passage about {text}",
+            "writing on the topic of {text}",
+        ]
+
     def load_models(self) -> None:
         if self._model is not None:
             return

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -135,6 +135,16 @@ class VideoMediaType(MediaType):
     # Embeddings
     # ------------------------------------------------------------------
 
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "a video of {text}",
+            "a clip showing {text}",
+            "{text}",
+            "footage of {text}",
+            "a video clip of {text}",
+        ]
+
     def load_models(self) -> None:
         if self._model is not None:
             return

--- a/vtsearch/models/embeddings.py
+++ b/vtsearch/models/embeddings.py
@@ -53,18 +53,21 @@ def embed_paragraph_file(text_path: Path) -> Optional[np.ndarray]:
     return media_get("paragraph").embed_media(text_path)
 
 
-def embed_text_query(text: str, media_type: str) -> Optional[np.ndarray]:
+def embed_text_query(text: str, media_type: str, enrich: bool = False) -> Optional[np.ndarray]:
     """Embed *text* in the vector space of the given *media_type*.
 
     Delegates to the registered :class:`~vtsearch.media.base.MediaType`'s
-    :meth:`~vtsearch.media.base.MediaType.embed_text` method, so the
-    resulting vector can be compared against media embeddings via cosine
-    similarity.
+    :meth:`~vtsearch.media.base.MediaType.embed_text` method (or
+    :meth:`~vtsearch.media.base.MediaType.embed_text_enriched` when
+    *enrich* is ``True``), so the resulting vector can be compared against
+    media embeddings via cosine similarity.
 
     Args:
         text: The natural-language search query to embed.
         media_type: Internal type identifier, e.g. ``"audio"``, ``"video"``,
             ``"image"``, or ``"paragraph"``.
+        enrich: If ``True``, use the average over description-wrapper
+            embeddings instead of the plain text embedding.
 
     Returns:
         A 1-D ``numpy.ndarray`` embedding, or ``None`` if the media type is
@@ -73,6 +76,9 @@ def embed_text_query(text: str, media_type: str) -> Optional[np.ndarray]:
     from vtsearch.media import get as media_get
 
     try:
-        return media_get(media_type).embed_text(text)
+        mt = media_get(media_type)
+        if enrich:
+            return mt.embed_text_enriched(text)
+        return mt.embed_text(text)
     except KeyError:
         return None

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -56,6 +56,9 @@ def update_settings():
         except ValueError:
             return jsonify({"error": "theme must be 'dark' or 'light'"}), 400
 
+    if "enrich_descriptions" in body:
+        settings.set_enrich_descriptions(bool(body["enrich_descriptions"]))
+
     return jsonify(settings.get_all())
 
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -86,7 +86,10 @@ def sort_clips():
         update_sort_progress("sorting", "Embedding text query…", 0, total_steps)
 
     # Embed text query using refactored module
-    text_vec = embed_text_query(text, media_type)
+    from vtsearch import settings
+
+    enrich = settings.get_enrich_descriptions()
+    text_vec = embed_text_query(text, media_type, enrich=enrich)
     if text_vec is None:
         update_sort_progress("idle")
         return (

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -37,6 +37,7 @@ SETTINGS_PATH: Path = DATA_DIR / "settings.json"
 _DEFAULTS: dict[str, Any] = {
     "volume": 1.0,
     "theme": "dark",
+    "enrich_descriptions": False,
     "favorite_processors": [],
 }
 
@@ -106,6 +107,18 @@ def set_theme(value: str) -> None:
         raise ValueError(f"Invalid theme: {value!r}")
     s = _ensure_loaded()
     s["theme"] = value
+    _save(s)
+
+
+def get_enrich_descriptions() -> bool:
+    """Return whether enriched description embedding is enabled."""
+    return bool(_ensure_loaded().get("enrich_descriptions", _DEFAULTS["enrich_descriptions"]))
+
+
+def set_enrich_descriptions(value: bool) -> None:
+    """Set and persist the enrich_descriptions flag."""
+    s = _ensure_loaded()
+    s["enrich_descriptions"] = bool(value)
     _save(s)
 
 


### PR DESCRIPTION
## Summary
This PR adds support for enriched text embeddings when sorting by text queries. Instead of embedding the raw query text, users can now enable a feature that averages embeddings across multiple media-specific description wrappers (e.g., "a photo of {text}", "an image of {text}") to improve search relevance.

## Key Changes

- **Base MediaType class** (`vtsearch/media/base.py`):
  - Added `description_wrappers` property (returns empty list by default)
  - Added `embed_text_enriched()` method that averages embeddings across wrappers with L2 normalization and fallback to plain embedding

- **Media type implementations**:
  - `AudioMediaType`: 5 wrappers including "the sound of {text}", "a recording of {text}"
  - `ImageMediaType`: 5 wrappers including "a photo of {text}", "an image of {text}"
  - `TextMediaType`: 5 wrappers including "a document about {text}", "an article discussing {text}"
  - `VideoMediaType`: 5 wrappers including "a video of {text}", "footage of {text}"

- **Embedding API** (`vtsearch/models/embeddings.py`):
  - `embed_text_query()` now accepts optional `enrich` parameter
  - When `enrich=True`, delegates to `embed_text_enriched()` instead of `embed_text()`

- **Settings** (`vtsearch/settings.py`):
  - Added `enrich_descriptions` boolean setting (default: False)
  - Added `get_enrich_descriptions()` and `set_enrich_descriptions()` functions
  - Setting persists to disk

- **UI** (`static/app.js`, `static/index.html`):
  - Added checkbox toggle for "Enrich Sort Descriptions"
  - Checkbox syncs with settings API and re-triggers text sort when toggled
  - Checkbox state loads from settings on page load

- **API** (`vtsearch/routes/settings.py`):
  - Settings endpoint now includes `enrich_descriptions` in GET/PUT responses

- **Sorting route** (`vtsearch/routes/sorting.py`):
  - Text sort now reads `enrich_descriptions` setting and passes it to `embed_text_query()`

- **Evaluation** (`vtsearch/eval/runner.py`, `vtsearch/eval/__main__.py`):
  - `eval_text_sort()` accepts `enrich` parameter
  - `_run_text_sort_query()` passes `enrich` to `embed_text_query()`
  - CLI adds `--enrich-descriptions` flag for evaluation runs

- **Tests** (`tests/test_enrich_descriptions.py`):
  - Comprehensive test suite covering:
    - Description wrappers on all media types
    - `embed_text_enriched()` averaging and normalization logic
    - Fallback behavior when wrappers fail
    - Settings get/set/persist
    - API endpoint integration
    - Eval runner with enrich flag

## Implementation Details

- Enriched embeddings are computed by formatting each wrapper with the user's text, embedding each result, averaging the vectors, and L2-normalizing
- If all wrappers fail to embed, the method falls back to plain `embed_text()`
- The feature is opt-in via a user-facing toggle and defaults to disabled
- All wrapper embeddings are attempted even if some fail; only successful embeddings are averaged

https://claude.ai/code/session_01DQTAQTNKqM4GKTGQhyAqt7