### PR TITLE
Refactor model architecture: output logits instead of probabilities

### DIFF
--- a/ML.md
+++ b/ML.md
@@ -1,0 +1,97 @@
+# Machine Learning Details
+
+VTSearch uses a small MLP (multi-layer perceptron) neural network to learn a binary classifier from user votes ("good" vs "bad"). The model operates on embeddings produced by pretrained feature extractors and outputs a score in [0, 1] for each item in the dataset.
+
+## Architecture
+
+The MLP is defined in `vtsearch/models/training.py` via `build_model()`:
+
+```
+Linear(input_dim, 64) -> ReLU -> Linear(64, 1)
+```
+
+- **Input dimension**: Dynamic, depends on the embedding model for the current media type (see [Embedding Models](#embedding-models) below).
+- **Hidden layer**: 64 neurons with ReLU activation.
+- **Output**: A single logit. `torch.sigmoid` is applied at inference time to produce a probability in [0, 1].
+
+The model outputs raw logits (not probabilities) during training. This allows the use of `BCEWithLogitsLoss`, which fuses the sigmoid and binary cross-entropy computation using the log-sum-exp trick for better numerical stability. At inference time, `torch.sigmoid()` is applied explicitly to convert logits to probabilities.
+
+## Training Configuration
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| **Loss function** | `BCEWithLogitsLoss` | Per-sample (unreduced), with manual class weighting |
+| **Optimizer** | Adam | `lr=0.001`, `weight_decay=1e-4` |
+| **Epochs** | 200 | Configurable via `TRAIN_EPOCHS` in `config.py` |
+| **Batching** | Full-batch | All labeled data in every forward pass |
+| **Reproducibility** | `torch.manual_seed(42)` | Set before model construction for deterministic weight init |
+| **Gradient scoping** | `torch.enable_grad()` | Explicitly enabled during training loop |
+
+### Class Weighting
+
+Training uses inverse-frequency weighting to balance classes, with an additional `inclusion_value` parameter (range [-10, +10]) that lets users bias the model toward recall or precision:
+
+- **Base weights**: `weight_true = num_false / num_true`, `weight_false = 1.0`
+- **Inclusion >= 0**: `weight_true *= 2^inclusion_value` (include more items)
+- **Inclusion < 0**: `weight_false *= 2^(-inclusion_value)` (exclude more items)
+
+### Threshold Calibration
+
+A decision threshold separating "good" from "bad" predictions is computed via **cross-calibration**:
+
+1. Split labeled data into two halves (D1, D2).
+2. Train model M1 on D1, find optimal threshold t1 by evaluating M1 on D2.
+3. Train model M2 on D2, find optimal threshold t2 by evaluating M2 on D1.
+4. Return `(t1 + t2) / 2`.
+
+The optimal threshold at each split minimizes a weighted combination of false-positive rate and false-negative rate, governed by the same `inclusion_value`.
+
+For semantic (text/example) sorts, a **GMM-based threshold** is used instead: a 2-component Gaussian Mixture Model is fitted to the score distribution and the midpoint between component means serves as the threshold.
+
+## PyTorch Environment Settings
+
+| Setting | Where | Value |
+|---------|-------|-------|
+| `OMP_NUM_THREADS` | `app.py` | `1` |
+| `MKL_NUM_THREADS` | `app.py` | `1` |
+| `torch.set_num_threads` | `vtsearch/models/loader.py` | `1` |
+| dtype | `training.py` | `torch.float32` |
+| Device | default | CPU (GPU supported, see tests) |
+
+Threading is restricted to 1 to minimize memory overhead — the real cost is the embedding models, not the MLP.
+
+## Embedding Models
+
+Each media type uses a different pretrained model to produce fixed-size embedding vectors:
+
+| Media type | Model | Embedding dim |
+|------------|-------|--------------|
+| Audio | LAION CLAP (`laion/clap-htsat-unfused`) | 512 |
+| Image | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 512 |
+| Video | Microsoft X-CLIP (`microsoft/xclip-base-patch32`) | 768 |
+| Text | E5 (`intfloat/e5-base-v2`) | 768 |
+
+Embeddings are computed once when a dataset is loaded and stored as `numpy.ndarray` in each clip's `"embedding"` field. The MLP trains on these pre-computed vectors, so training is fast (typically < 1 second for 200 epochs on a few hundred labeled examples).
+
+## Model Serialization
+
+Trained models are serialized as JSON dictionaries mapping state_dict keys to nested lists:
+
+```json
+{
+    "0.weight": [[...], ...],
+    "0.bias": [...],
+    "2.weight": [[...]],
+    "2.bias": [...]
+}
+```
+
+To reconstruct a model from saved weights, use `build_model(input_dim)` followed by `load_state_dict()`. The `input_dim` can be inferred from the first layer weights: `len(weights["0.weight"][0])`.
+
+## Key Files
+
+- `vtsearch/models/training.py` — `build_model`, `train_model`, `train_and_score`, threshold functions
+- `vtsearch/models/progress.py` — Cached per-step training and stability analysis
+- `vtsearch/models/loader.py` — Model initialization and thread configuration
+- `vtsearch/eval/voting_iterations.py` — Voting simulation evaluation
+- `config.py` — `TRAIN_EPOCHS` and model IDs

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ vtsearch/
 └── README.md
 ```
 
+## Machine learning
+
+VTSearch trains a small MLP neural network on user votes to learn a binary classifier over pretrained embeddings. See [ML.md](ML.md) for full details on the model architecture, training configuration, PyTorch settings, and embedding models.
+
 ## Evaluation
 
 VTSearch includes an evaluation framework that measures sorting quality on demo datasets. Run it with:

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -37,7 +37,7 @@ class TestDetectorExport:
         resp = client.post("/api/detector/export")
         data = resp.get_json()
         weights = data["weights"]
-        # MLP has 3 layers: Linear(input_dim, 64), ReLU, Linear(64, 1), Sigmoid
+        # MLP has 3 layers: Linear(input_dim, 64), ReLU, Linear(64, 1)
         # So we expect 4 keys: 0.weight, 0.bias, 2.weight, 2.bias
         assert "0.weight" in weights
         assert "0.bias" in weights

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -258,12 +258,10 @@ def _score_clips_with_detectors(
         threshold = detector_data["threshold"]
 
         input_dim = len(weights["0.weight"][0])
-        model = nn.Sequential(
-            nn.Linear(input_dim, 64),
-            nn.ReLU(),
-            nn.Linear(64, 1),
-            nn.Sigmoid(),
-        )
+
+        from vtsearch.models.training import build_model
+
+        model = build_model(input_dim)
 
         state_dict = {}
         for key, value in weights.items():
@@ -272,7 +270,7 @@ def _score_clips_with_detectors(
         model.eval()
 
         with torch.no_grad():
-            scores = model(X_all).squeeze(1).tolist()
+            scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
         positive_hits: list[dict[str, Any]] = []
         for cid, score in zip(all_ids, scores):

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import numpy as np
 import torch
-from torch import nn
 
 from vtsearch.datasets.loader import load_dataset_from_pickle
 
@@ -49,14 +48,11 @@ def _score_clips_with_detector(
     threshold = detector_data["threshold"]
 
     # Reconstruct the MLP model from weights
+    from vtsearch.models.training import build_model
+
     input_dim = len(weights["0.weight"][0])
 
-    model = nn.Sequential(
-        nn.Linear(input_dim, 64),
-        nn.ReLU(),
-        nn.Linear(64, 1),
-        nn.Sigmoid(),
-    )
+    model = build_model(input_dim)
 
     state_dict = {}
     for key, value in weights.items():
@@ -70,7 +66,7 @@ def _score_clips_with_detector(
     X_all = torch.tensor(all_embs, dtype=torch.float32)
 
     with torch.no_grad():
-        scores = model(X_all).squeeze(1).tolist()
+        scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
     # Collect positive hits (score >= threshold)
     positive_hits = []

--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -83,7 +83,7 @@ def _evaluate_on_test(
     X = torch.tensor(embs, dtype=torch.float32)
 
     with torch.no_grad():
-        scores = model(X).squeeze(1).tolist()
+        scores = torch.sigmoid(model(X)).squeeze(1).tolist()
 
     true_labels = [1.0 if clips_dict[cid]["category"] == target_category else 0.0 for cid in test_ids]
 

--- a/vtsearch/models/__init__.py
+++ b/vtsearch/models/__init__.py
@@ -10,6 +10,7 @@ from vtsearch.models.embeddings import (
 from vtsearch.models.loader import get_clap_model, get_clip_model, get_e5_model, get_xclip_model, initialize_models
 from vtsearch.models.progress import analyze_labeling_progress, clear_progress_cache, compute_labeling_status
 from vtsearch.models.training import (
+    build_model,
     calculate_cross_calibration_threshold,
     calculate_gmm_threshold,
     find_optimal_threshold,
@@ -31,6 +32,7 @@ __all__ = [
     "get_clip_model",
     "get_e5_model",
     # Training
+    "build_model",
     "train_model",
     "train_and_score",
     "calculate_gmm_threshold",

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -109,7 +109,7 @@ def _ensure_cache(
                 model = train_model(X, y, input_dim, inclusion_value)
 
                 with torch.no_grad():
-                    scores = model(X).squeeze(1).tolist()
+                    scores = torch.sigmoid(model(X)).squeeze(1).tolist()
                 threshold = find_optimal_threshold(scores, y_list, inclusion_value)
 
                 # --- Stability ---
@@ -128,7 +128,7 @@ def _ensure_cache(
                     X_unlabeled = torch.tensor(unlabeled_embs, dtype=torch.float32)
 
                     with torch.no_grad():
-                        scores_unl = model(X_unlabeled).squeeze(1).tolist()
+                        scores_unl = torch.sigmoid(model(X_unlabeled)).squeeze(1).tolist()
 
                     predictions: dict[int, int] = {
                         cid: 1 if score >= threshold else 0 for cid, score in zip(unlabeled_ids, scores_unl)
@@ -220,7 +220,7 @@ def _eval_cached_models(
             continue
 
         with torch.no_grad():
-            scores = step["model"](X_eval).squeeze(1).tolist()
+            scores = torch.sigmoid(step["model"](X_eval)).squeeze(1).tolist()
 
         fp = fn = 0
         for score, true_label in zip(scores, eval_labels):

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-import torch.nn as nn
 from flask import Blueprint, jsonify, request
 
 from vtsearch.models import (
+    build_model,
     calculate_cross_calibration_threshold,
     embed_audio_file,
     embed_image_file,
@@ -98,12 +98,7 @@ def detector_sort():
     # Determine input_dim from the first layer weights
     input_dim = len(weights["0.weight"][0])
 
-    model = nn.Sequential(
-        nn.Linear(input_dim, 64),
-        nn.ReLU(),
-        nn.Linear(64, 1),
-        nn.Sigmoid(),
-    )
+    model = build_model(input_dim)
 
     # Load weights
     state_dict = {}
@@ -117,7 +112,7 @@ def detector_sort():
     all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
     X_all = torch.tensor(all_embs, dtype=torch.float32)
     with torch.no_grad():
-        scores = model(X_all).squeeze(1).tolist()
+        scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
     results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
     results.sort(key=lambda x: x["score"], reverse=True)
@@ -408,12 +403,7 @@ def auto_detect():
         # Reconstruct the model from weights
         input_dim = len(weights["0.weight"][0])
 
-        model = nn.Sequential(
-            nn.Linear(input_dim, 64),
-            nn.ReLU(),
-            nn.Linear(64, 1),
-            nn.Sigmoid(),
-        )
+        model = build_model(input_dim)
 
         # Load weights
         state_dict = {}
@@ -424,7 +414,7 @@ def auto_detect():
 
         # Score all clips
         with torch.no_grad():
-            scores = model(X_all).squeeze(1).tolist()
+            scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
         # Collect positive hits (score >= threshold)
         positive_hits = []

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -10,6 +10,7 @@ from flask import Blueprint, jsonify, request
 from config import DATA_DIR
 from vtsearch.models import (
     analyze_labeling_progress,
+    build_model,
     calculate_cross_calibration_threshold,
     calculate_gmm_threshold,
     compute_labeling_status,
@@ -369,7 +370,7 @@ def label_file_sort():
         all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
         X_all = torch.tensor(all_embs, dtype=torch.float32)
         with torch.no_grad():
-            scores = model(X_all).squeeze(1).tolist()
+            scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
         # Sort by raw scores (full precision) before rounding for display.
         paired = sorted(zip(all_ids, scores), key=lambda x: x[1], reverse=True)


### PR DESCRIPTION
## Summary

This PR refactors the neural network model to output raw logits instead of probabilities, improving numerical stability during training and making the architecture more flexible for different loss functions.

## Key Changes

- **Extracted `build_model()` function**: Created a reusable helper in `vtsearch/models/training.py` that constructs the MLP architecture (`Linear(input_dim, 64) -> ReLU -> Linear(64, 1)`) without a sigmoid layer. This eliminates code duplication across the codebase.

- **Removed sigmoid from model architecture**: The trained model now outputs raw logits instead of probabilities. Sigmoid is applied explicitly at inference time via `torch.sigmoid()`.

- **Updated loss function**: Changed from `BCELoss` to `BCEWithLogitsLoss`, which fuses sigmoid and binary cross-entropy computation using the log-sum-exp trick for better numerical stability.

- **Improved training configuration**:
  - Set fixed seed (`torch.manual_seed(42)`) before model construction for deterministic training
  - Reduced learning rate from 0.01 to 0.001
  - Added weight decay (1e-4) to the Adam optimizer
  - Wrapped training loop with `torch.enable_grad()` for explicit gradient management

- **Updated all inference calls**: Applied `torch.sigmoid()` to model outputs in:
  - `train_and_score()`
  - `calculate_cross_calibration_threshold()`
  - `detector_sort()` and `auto_detect()` routes
  - GPU tests and evaluation code
  - Progress tracking and CLI utilities

- **Added comprehensive tests**: New test classes `TestBuildModel` and `TestTrainModelConfig` verify:
  - Model architecture correctness
  - Logit output (no sigmoid clamping)
  - Deterministic training behavior
  - Weight decay effectiveness
  - Proper loss function usage

- **Added ML.md documentation**: Comprehensive guide covering model architecture, training configuration, PyTorch environment settings, embedding models, and serialization format.

## Implementation Details

- The refactoring maintains backward compatibility at the API level—all public functions still return probability scores in [0, 1] by applying sigmoid at the boundary.
- Model serialization format remains unchanged (state_dict keys: `"0.weight"`, `"0.bias"`, `"2.weight"`, `"2.bias"`).
- The change improves numerical stability during training while keeping inference behavior identical from the caller's perspective.

https://claude.ai/code/session_01CxTUK4C8BCeq137CnoFF2p