### PR TITLE
Add inclusion setting persistence and API endpoints

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2778,12 +2778,16 @@
       if (enrichDescCheckbox) {
         enrichDescCheckbox.checked = !!data.enrich_descriptions;
       }
+      if (typeof data.inclusion === "number") {
+        inclusion = data.inclusion;
+        inclusionSlider.value = inclusion;
+        inclusionValue.textContent = inclusion;
+      }
     } catch (_) {
       // Settings not available yet; use defaults
     }
   }
 
-  fetchInclusion();
   updateLabelCounts();
   loadFavoriteDetectors();
   fetchLabelingStatus();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,12 @@ app_module.init_clips()
 @pytest.fixture(autouse=True)
 def reset_votes():
     """Reset vote state and progress cache before each test."""
+    import vtsearch.utils.state as _state
+
     good_votes.clear()
     bad_votes.clear()
     label_history.clear()
+    _state.inclusion = None  # reset to "not loaded" so it re-reads from settings
     clear_progress_cache()
 
 

--- a/tests/test_inclusion.py
+++ b/tests/test_inclusion.py
@@ -1,3 +1,18 @@
+import pytest
+
+from vtsearch import settings as settings_mod
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(tmp_path, monkeypatch):
+    """Use a temp file so inclusion persistence doesn't affect other tests."""
+    test_settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
+    settings_mod.reset()
+    yield test_settings_path
+    settings_mod.reset()
+
+
 class TestInclusionEndpoints:
     def test_get_default_inclusion(self, client):
         resp = client.get("/api/inclusion")

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -56,6 +56,19 @@ def update_settings():
         except ValueError:
             return jsonify({"error": "theme must be 'dark' or 'light'"}), 400
 
+    if "inclusion" in body:
+        try:
+            val = body["inclusion"]
+            if not isinstance(val, (int, float)):
+                return jsonify({"error": "inclusion must be a number"}), 400
+            clamped = int(max(-10, min(10, int(val))))
+            # Update runtime state (which also persists to settings file)
+            from vtsearch.utils import set_inclusion
+
+            set_inclusion(clamped)
+        except (TypeError, ValueError):
+            return jsonify({"error": "inclusion must be a number"}), 400
+
     if "enrich_descriptions" in body:
         settings.set_enrich_descriptions(bool(body["enrich_descriptions"]))
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -7,6 +7,7 @@ Schema (all keys optional, missing keys use defaults)::
 
     {
         "volume": 1.0,
+        "inclusion": 0,
         "favorite_processors": [
             {
                 "processor_name": "my detector",
@@ -36,6 +37,7 @@ SETTINGS_PATH: Path = DATA_DIR / "settings.json"
 
 _DEFAULTS: dict[str, Any] = {
     "volume": 1.0,
+    "inclusion": 0,
     "theme": "dark",
     "enrich_descriptions": False,
     "favorite_processors": [],
@@ -93,6 +95,18 @@ def set_volume(value: float) -> None:
     """Set and persist the playback volume."""
     s = _ensure_loaded()
     s["volume"] = max(0.0, min(1.0, float(value)))
+    _save(s)
+
+
+def get_inclusion() -> int:
+    """Return the persisted inclusion setting (-10 to +10)."""
+    return int(_ensure_loaded().get("inclusion", _DEFAULTS["inclusion"]))
+
+
+def set_inclusion(value: int) -> None:
+    """Set and persist the inclusion setting."""
+    s = _ensure_loaded()
+    s["inclusion"] = int(max(-10, min(10, int(value))))
     _save(s)
 
 


### PR DESCRIPTION
## Summary
This PR adds persistence for the inclusion setting, allowing users to configure the inclusion bias (-10 to +10) through the settings API and have it survive app restarts.

## Key Changes
- **Settings persistence**: Added `get_inclusion()` and `set_inclusion()` functions to `vtsearch/settings.py` to persist the inclusion value to disk, with automatic clamping to the [-10, 10] range
- **Runtime state management**: Modified `vtsearch/utils/state.py` to lazily load the inclusion setting from the persisted settings file on first access, ensuring it survives restarts
- **API endpoint**: Added inclusion parameter handling to the `/api/settings` PUT endpoint in `vtsearch/routes/settings.py` with validation and error handling
- **Frontend integration**: Updated `static/app.js` to load the inclusion setting from the settings API response instead of a separate fetch call
- **Test coverage**: Added comprehensive tests for inclusion persistence, clamping, defaults, and API endpoints in `tests/test_settings.py` and `tests/test_inclusion.py`
- **Test isolation**: Added `isolated_settings` fixture to ensure inclusion persistence doesn't affect other tests

## Notable Implementation Details
- The inclusion value in `state.py` is initialized as `None` to indicate "not yet loaded", allowing lazy loading from the persisted settings file on first access
- Clamping is applied consistently at both the settings layer and the API layer to ensure the value stays within [-10, 10]
- The `set_inclusion()` function in `state.py` now also persists changes to the settings file, maintaining consistency between runtime state and disk storage
- Test fixtures properly reset the inclusion state between tests to prevent cross-test contamination

https://claude.ai/code/session_01XmXjXMSaUqZd1cd4oL74jZ