### PR TITLE
Remove standalone CLI workflows for labels and processors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,16 +11,14 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter file --filepath results.json`
-- **CLI label import**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-labels --dataset <file.pkl> --label-importer json_file --file labels.json`
-- **CLI label import (CSV)**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-labels --dataset <file.pkl> --label-importer csv_file --file labels.csv`
-- **CLI processor import**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --import-processor --processor-importer detector_file --processor-name "my detector" --file detector.json`
+- **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings <settings.json>`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`
 
 ## Architecture
 - `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing
-- `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detector, run inference, export results), import_labels_main (load dataset + label importer), import_processor_main (import detector via processor importer)
+- `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detectors from settings, run inference, export results)
 - `config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
 - `vtsearch/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking
@@ -51,7 +49,7 @@ Media explorer web app for browsing/voting on audio, images, or text. Semantic s
   - `test_importers.py` — Importer base class, HTTP archive/folder importer metadata, archive extraction
   - `test_extractors.py` — Image class extractor
   - `test_processors.py` — Media processor tests
-  - `test_processor_importers.py` — Processor importer base class, registry, detector_file/label_file importers, API routes, CLI
+  - `test_processor_importers.py` — Processor importer base class, registry, detector_file/label_file importers, API routes
   - `test_origin_labelset.py` — Origin class, LabeledElement, LabelSet, build_origin(), label export/import with origins, integration
   - `test_gpu.py` — GPU tests: training, cross-calibration, detectors, embedding models (CLAP/CLIP/X-CLIP/E5), CPU↔GPU equivalence, memory cleanup (skipped without CUDA)
 

--- a/app.py
+++ b/app.py
@@ -183,50 +183,13 @@ if __name__ == "__main__":
         type=str,
         help="Name of the results exporter to use (e.g. file, email_smtp, gui). Used with --autodetect.",
     )
-    parser.add_argument(
-        "--import-labels",
-        action="store_true",
-        help="Import labels into a loaded dataset from the command line.",
-    )
-    parser.add_argument(
-        "--label-importer",
-        type=str,
-        help="Name of the label importer to use (e.g. json_file, csv_file). Used with --import-labels.",
-    )
-    parser.add_argument(
-        "--import-missing",
-        choices=["yes", "no", "ask"],
-        default="ask",
-        help=(
-            "When --import-labels finds elements not in the dataset: "
-            "'yes' to auto-import from origins, 'no' to skip, 'ask' to prompt (default: ask)."
-        ),
-    )
-    parser.add_argument(
-        "--import-processor",
-        action="store_true",
-        help="Import a processor (detector) via a named processor importer from the command line.",
-    )
-    parser.add_argument(
-        "--processor-importer",
-        type=str,
-        help="Name of the processor importer to use (e.g. detector_file, label_file). Used with --import-processor.",
-    )
-    parser.add_argument(
-        "--processor-name",
-        type=str,
-        help="Name to assign to the imported processor/detector. Used with --import-processor.",
-    )
 
-    # Two-pass parsing: first pass gets --importer, --exporter,
-    # --label-importer, and --processor-importer names; second pass adds
-    # their arguments and re-parses.
+    # Two-pass parsing: first pass gets --importer and --exporter names;
+    # second pass adds their plugin-specific arguments and re-parses.
     args, remaining = parser.parse_known_args()
 
     importer = None
     exporter = None
-    label_importer = None
-    proc_importer = None
 
     if args.autodetect and args.importer:
         from vtsearch.datasets.importers import get_importer, list_importers
@@ -248,60 +211,14 @@ if __name__ == "__main__":
 
         exporter.add_cli_arguments(parser)
 
-    if getattr(args, "import_labels", False) and getattr(args, "label_importer", None):
-        from vtsearch.labels.importers import get_label_importer, list_label_importers
-
-        label_importer = get_label_importer(args.label_importer)
-        if label_importer is None:
-            available = ", ".join(imp.name for imp in list_label_importers())
-            parser.error(f"Unknown label importer: {args.label_importer}. Available: {available}")
-
-        label_importer.add_cli_arguments(parser)
-
-    if getattr(args, "import_processor", False) and getattr(args, "processor_importer", None):
-        from vtsearch.processors.importers import get_processor_importer, list_processor_importers
-
-        proc_importer = get_processor_importer(args.processor_importer)
-        if proc_importer is None:
-            available = ", ".join(imp.name for imp in list_processor_importers())
-            parser.error(f"Unknown processor importer: {args.processor_importer}. Available: {available}")
-
-        proc_importer.add_cli_arguments(parser)
-
-    if importer or exporter or label_importer or proc_importer:
+    if importer or exporter:
         args = parser.parse_args()
     elif remaining:
         # No importer/exporter specified but there are unknown args; let
         # argparse report the error.
         parser.parse_args()
 
-    if getattr(args, "import_processor", False):
-        if not getattr(args, "processor_importer", None):
-            parser.error("--import-processor requires --processor-importer <name>")
-
-        proc_name = getattr(args, "processor_name", None) or ""
-        if not proc_name.strip():
-            parser.error("--import-processor requires --processor-name <name>")
-
-        from vtsearch.cli import import_processor_main
-
-        field_values = {f.key: getattr(args, f.key, f.default or None) for f in proc_importer.fields}
-        import_processor_main(args.processor_importer, field_values, proc_name)
-
-    elif getattr(args, "import_labels", False):
-        if not getattr(args, "label_importer", None):
-            parser.error("--import-labels requires --label-importer <name>")
-        if not args.dataset:
-            parser.error("--import-labels requires --dataset <file.pkl>")
-
-        from vtsearch.cli import import_labels_main
-
-        field_values = {f.key: getattr(args, f.key, f.default or None) for f in label_importer.fields}
-        import_missing_flag = getattr(args, "import_missing", "ask")
-        auto_import_missing = {"yes": True, "no": False, "ask": None}[import_missing_flag]
-        import_labels_main(args.dataset, args.label_importer, field_values, auto_import_missing=auto_import_missing)
-
-    elif args.autodetect:
+    if args.autodetect:
         # Collect exporter field values if an exporter was specified
         exporter_field_values = None
         if exporter:

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -5,7 +5,6 @@ Covers:
 - Auto-discovery registry (list_label_importers, get_label_importer)
 - Built-in importers: json_file, csv_file
 - Flask API routes: GET /api/label-importers, POST /api/label-importers/import/<name>
-- CLI import_labels_main function
 """
 
 from __future__ import annotations

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -5,7 +5,6 @@ Covers:
 - Auto-discovery registry (list_processor_importers, get_processor_importer)
 - Built-in importers: detector_file, label_file
 - Flask API routes: GET /api/processor-importers, POST /api/processor-importers/import/<name>
-- CLI import_processor_main function
 """
 
 from __future__ import annotations
@@ -539,39 +538,3 @@ class TestProcessorImportEndpoint:
         assert res.status_code == 400
 
 
-# ---------------------------------------------------------------------------
-# CLI – import_processor_main
-# ---------------------------------------------------------------------------
-
-
-class TestImportProcessorMainCLI:
-    def test_imports_detector_file(self, tmp_path):
-        from vtsearch.cli import import_processor_main
-        from vtsearch.utils import favorite_detectors
-
-        payload = {
-            "weights": {"0.weight": [[1.0, 2.0]], "0.bias": [0.5]},
-            "threshold": 0.8,
-            "media_type": "audio",
-        }
-        p = tmp_path / "test_det.json"
-        p.write_text(json.dumps(payload))
-
-        import_processor_main("detector_file", {"file": str(p)}, "cli_detector")
-        assert "cli_detector" in favorite_detectors
-        assert favorite_detectors["cli_detector"]["threshold"] == 0.8
-
-        # Clean up
-        favorite_detectors.pop("cli_detector", None)
-
-    def test_unknown_importer_exits(self, tmp_path):
-        from vtsearch.cli import import_processor_main
-
-        with pytest.raises(SystemExit):
-            import_processor_main("no_such_importer", {}, "test")
-
-    def test_missing_required_field_exits(self):
-        from vtsearch.cli import import_processor_main
-
-        with pytest.raises(SystemExit):
-            import_processor_main("detector_file", {"file": ""}, "test")

--- a/vtsearch/labels/importers/base.py
+++ b/vtsearch/labels/importers/base.py
@@ -123,9 +123,9 @@ class LabelImporter:
 
     CLI support
     -----------
-    Every importer is automatically usable from the command line via::
-
-        python app.py --label-importer <name> [importer args]
+    Label importers are used via the web API (``POST /api/label-importers/import/<name>``).
+    From the CLI, labels can be applied indirectly by using the ``label_file``
+    processor importer in a settings file for the autodetect workflow.
 
     The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
     :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override

--- a/vtsearch/processors/importers/base.py
+++ b/vtsearch/processors/importers/base.py
@@ -118,9 +118,10 @@ class ProcessorImporter:
 
     CLI support
     -----------
-    Every importer is automatically usable from the command line via::
+    Processor importers are used indirectly from the CLI via the autodetect
+    workflow: add a processor recipe to the settings JSON file and run::
 
-        python app.py --import-processor --processor-importer <name> [importer args]
+        python app.py --autodetect --dataset <file.pkl> --settings <settings.json>
 
     The default :meth:`add_cli_arguments` derives ``argparse`` arguments from
     :attr:`fields` and :meth:`run_cli` delegates to :meth:`run`.  Override

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -31,9 +31,9 @@ settings_bp = Blueprint("settings", __name__)
 def get_settings():
     """Return all settings."""
     data = settings.get_all()
-    # Include CLI command strings for each favorite processor
+    # Include settings JSON snippets for each favorite processor
     for proc in data.get("favorite_processors", []):
-        proc["cli_command"] = settings.to_cli_command(proc)
+        proc["settings_json"] = settings.to_settings_json(proc)
     return jsonify(data)
 
 
@@ -80,7 +80,7 @@ def get_favorite_processors():
     """List all favorite processor recipes."""
     procs = settings.get_favorite_processors()
     for proc in procs:
-        proc["cli_command"] = settings.to_cli_command(proc)
+        proc["settings_json"] = settings.to_settings_json(proc)
     return jsonify({"favorite_processors": procs})
 
 
@@ -106,7 +106,7 @@ def add_favorite_processor():
         "processor_importer": processor_importer,
         "field_values": field_values,
     }
-    entry["cli_command"] = settings.to_cli_command(entry)
+    entry["settings_json"] = settings.to_settings_json(entry)
     return jsonify({"success": True, **entry})
 
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -174,26 +174,26 @@ def remove_favorite_processor(processor_name: str) -> bool:
     return False
 
 
-def to_cli_command(entry: dict[str, Any]) -> str:
-    """Build the CLI command string that would import a favorite processor.
+def to_settings_json(entry: dict[str, Any]) -> str:
+    """Build the JSON snippet for a favorite processor entry.
+
+    Returns the JSON object that would appear inside the
+    ``favorite_processors`` array in a settings file.  Useful for showing
+    users how to recreate this processor configuration.
 
     Example output::
 
-        python app.py --import-processor --processor-importer detector_file \\
-            --processor-name "my detector" --file detector.json
+        {"processor_name": "my detector", "processor_importer": "detector_file",
+         "field_values": {"file": "detector.json"}}
     """
-    parts = [
-        "python app.py --import-processor",
-        f"--processor-importer {entry['processor_importer']}",
-        f'--processor-name "{entry["processor_name"]}"',
-    ]
-    for key, value in entry.get("field_values", {}).items():
-        flag = f"--{key.replace('_', '-')}"
-        if " " in str(value):
-            parts.append(f'{flag} "{value}"')
-        else:
-            parts.append(f"{flag} {value}")
-    return " ".join(parts)
+    import json
+
+    snippet = {
+        "processor_name": entry["processor_name"],
+        "processor_importer": entry["processor_importer"],
+        "field_values": entry.get("field_values", {}),
+    }
+    return json.dumps(snippet)
 
 
 def ensure_favorite_processors_imported() -> list[str]:


### PR DESCRIPTION
## Summary

This PR removes the standalone CLI workflows for importing labels and processors (`--import-labels` and `--import-processor` flags), consolidating all CLI functionality into the single `--autodetect` workflow. Labels and processors are now configured exclusively through settings JSON files.

## Key Changes

- **Removed CLI entry points**: Deleted `import_labels_main()` and `import_processor_main()` functions from `vtsearch/cli.py`
- **Removed argument parsing**: Stripped `--import-labels`, `--label-importer`, `--import-missing`, `--import-processor`, `--processor-importer`, and `--processor-name` arguments from `app.py`
- **Unified settings approach**: All processor/detector configuration now flows through a single `--settings` JSON file in the autodetect workflow
- **Updated documentation**: Rewrote `CLI.md` to reflect the new unified workflow with examples of settings JSON format
- **Renamed utility function**: Changed `to_cli_command()` to `to_settings_json()` in `vtsearch/settings.py` to generate JSON snippets instead of shell commands
- **Updated API responses**: Modified settings routes to include `settings_json` instead of `cli_command` in responses
- **Updated docstrings**: Modified base importer classes to document the new indirect CLI usage pattern
- **Removed tests**: Deleted test cases for the removed CLI functions in `test_processor_importers.py` and `test_label_importers.py`

## Implementation Details

The settings JSON file now serves as the single source of truth for processor configuration:

```json
{
  "favorite_processors": [
    {
      "processor_name": "my detector",
      "processor_importer": "detector_file",
      "field_values": { "file": "path/to/detector.json" }
    }
  ]
}
```

This approach simplifies the CLI interface while maintaining full functionality through the web UI and programmatic APIs. Label importers remain available via the Flask API (`POST /api/label-importers/import/<name>`) and can be used indirectly through the `label_file` processor importer in settings files.

https://claude.ai/code/session_01LbxTQG5f7ETthtVzbTNhLM