### PR TITLE
Fix flaky voting test by using local RNG for model init

### DIFF
--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -181,9 +181,11 @@ class TestTrainModelConfig:
 
             model = train_model(X, y, 16)
 
-            # Train without weight decay for comparison
-            torch.manual_seed(42)
-            model_no_wd = build_model(16)
+            # Train without weight decay for comparison (use same local
+            # generator approach as train_model for identical init weights)
+            g = torch.Generator()
+            g.manual_seed(42)
+            model_no_wd = build_model(16, generator=g)
             optimizer = torch.optim.Adam(model_no_wd.parameters(), lr=0.001, weight_decay=0.0)
             loss_fn = torch.nn.BCEWithLogitsLoss()
             model_no_wd.train()


### PR DESCRIPTION
Replace global torch.manual_seed(42) with a local torch.Generator in
train_model and build_model, making weight initialisation thread-safe
and deterministic without mutating PyTorch's global RNG.

https://claude.ai/code/session_01LF4UqzJaN4stbhQQRLez3t