### PR TITLE
Remove download option from audio player menu

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1691,7 +1691,7 @@
       // Audio/Sound
       playerHTML = `
         <canvas id="waveform-canvas" width="600" height="120"></canvas>
-        <audio controls loop autoplay src="/api/clips/${c.id}/audio" id="clip-audio"></audio>`;
+        <audio controls controlslist="nodownload" loop autoplay src="/api/clips/${c.id}/audio" id="clip-audio"></audio>`;
     }
 
     center.innerHTML = `


### PR DESCRIPTION
Add controlslist="nodownload" to the <audio> element to hide the
browser's built-in "Download" option from the three-dot menu.

https://claude.ai/code/session_01Hg5iWr2Td6WLgMRkpj6WjV