### PR TITLE
Add three-state demo dataset status: Ready / Needs Embedding / Needs Download

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -492,15 +492,23 @@
 
           items.forEach(dataset => {
             const div = document.createElement("div");
-            div.className = "demo-dataset" + (dataset.ready ? " ready" : "");
-            const sizeText = dataset.ready
+            const st = dataset.status || (dataset.ready ? "ready" : "needs_download");
+            div.className = "demo-dataset" + (st === "ready" ? " ready" : st === "needs_embedding" ? " needs-embedding" : "");
+            const sizeText = st === "ready"
               ? `${dataset.download_size_mb} MB (cached)`
+              : st === "needs_embedding"
+              ? "Embedding required"
               : `${dataset.download_size_mb} MB to download`;
+            const badgeHtml = st === "ready"
+              ? '<span class="ready-badge">Ready</span>'
+              : st === "needs_embedding"
+              ? '<span class="embedding-badge">Needs Embedding</span>'
+              : '<span style="font-size:0.7rem;color:var(--text-dim);display:inline-block;margin-top:6px;">Needs Download &amp; Embedding</span>';
             div.innerHTML = `
               <h4>${dataset.label}</h4>
               <p style="margin: 4px 0 8px; font-size: 0.75rem; color: #999; line-height: 1.45;">${dataset.description}</p>
               <p style="margin: 0; font-size: 0.72rem; color: #666;">${cfg.icon} ${dataset.num_files} ${cfg.fileLabel} &middot; ${sizeText}</p>
-              ${dataset.ready ? '<span class="ready-badge">Ready</span>' : '<span style="font-size:0.7rem;color:var(--text-dim);display:inline-block;margin-top:6px;">Needs download</span>'}
+              ${badgeHtml}
             `;
             div.onclick = () => loadDemo(dataset.name);
             col.appendChild(div);

--- a/static/styles.css
+++ b/static/styles.css
@@ -242,9 +242,11 @@ video { max-width: 600px; max-height: 400px; }
 .demo-dataset { padding: 14px; border: 2px solid var(--border); border-radius: 8px; background: var(--bg-surface); cursor: pointer; transition: all 0.2s; text-align: left; }
 .demo-dataset:hover { border-color: var(--accent); background: var(--bg-subtle); }
 .demo-dataset.ready { border-color: var(--color-good); }
+.demo-dataset.needs-embedding { border-color: #e0a020; }
 .demo-dataset h4 { font-size: 0.88rem; color: var(--text-primary); margin-bottom: 4px; }
 .demo-dataset p { font-size: 0.75rem; color: var(--text-muted); margin: 0; }
 .demo-dataset .ready-badge { display: inline-block; margin-top: 6px; padding: 2px 8px; background: var(--color-good); color: #fff; font-size: 0.7rem; border-radius: 4px; }
+.demo-dataset .embedding-badge { display: inline-block; margin-top: 6px; padding: 2px 8px; background: #e0a020; color: #fff; font-size: 0.7rem; border-radius: 4px; }
 .back-button { margin-top: 16px; padding: 8px 24px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg-surface); color: var(--text-secondary); cursor: pointer; transition: all 0.2s; }
 .back-button:hover { background: var(--bg-hover); color: var(--text-primary); }
 .dataset-bar { padding: 12px 16px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; }


### PR DESCRIPTION
Demo datasets previously used a binary ready/not-ready status. This caused
confusing behavior where e.g. ESC-50 S and M showed "Ready" (had cached pkl
files) while L showed "Needs Download" even though the ESC-50 source data
was already present — it only needed embedding.

The status field now reports one of three values:
- "ready": pkl cache exists and source data is present
- "needs_embedding": source data is downloaded but not yet embedded
- "needs_download": source data must be downloaded first

Backend, frontend, CSS, and tests all updated accordingly.

https://claude.ai/code/session_015nchoEqMsh31PGU7j8F5x4