### PR TITLE
Reorganize demo datasets: same categories across S/M/L, disjoint elements

### DIFF
--- a/vtsearch/eval/config.py
+++ b/vtsearch/eval/config.py
@@ -27,118 +27,51 @@ class EvalQuery:
 
 
 # ------------------------------------------------------------------
-# Audio eval datasets  (ESC-50)
+# Audio eval queries  (ESC-50)
+# All S/M/L share the same 10 categories; queries are identical.
 # ------------------------------------------------------------------
 
-_SOUNDS_S_QUERIES = [
+_SOUNDS_QUERIES = [
     EvalQuery("a dog barking", "dog"),
     EvalQuery("a cat meowing", "cat"),
     EvalQuery("a rooster crowing at dawn", "rooster"),
-    EvalQuery("church bells ringing", "church_bells"),
-    EvalQuery("crackling fire in a fireplace", "crackling_fire"),
-]
-
-_SOUNDS_M_QUERIES = [
-    EvalQuery("a baby crying", "crying_baby"),
-    EvalQuery("people laughing", "laughing"),
-    EvalQuery("hands clapping", "clapping"),
-    EvalQuery("footsteps walking", "footsteps"),
-    EvalQuery("someone sneezing", "sneezing"),
-    EvalQuery("a chainsaw cutting wood", "chainsaw"),
-    EvalQuery("an airplane flying overhead", "airplane"),
-    EvalQuery("fireworks exploding", "fireworks"),
-    EvalQuery("a pig oinking", "pig"),
-    EvalQuery("a cow mooing", "cow"),
-]
-
-_SOUNDS_L_QUERIES = [
     EvalQuery("birds singing and chirping", "chirping_birds"),
-    EvalQuery("a crow cawing", "crow"),
-    EvalQuery("frogs croaking near a pond", "frog"),
-    EvalQuery("buzzing insects", "insects"),
     EvalQuery("rain falling", "rain"),
-    EvalQuery("ocean waves crashing on shore", "sea_waves"),
     EvalQuery("thunderstorm with loud thunder", "thunderstorm"),
-    EvalQuery("strong wind blowing", "wind"),
-    EvalQuery("dripping water drops", "water_drops"),
-    EvalQuery("crickets chirping at night", "crickets"),
     EvalQuery("a car horn honking", "car_horn"),
-    EvalQuery("emergency siren wailing", "siren"),
-    EvalQuery("engine running and revving", "engine"),
-    EvalQuery("a train passing by on rails", "train"),
-    EvalQuery("helicopter flying overhead", "helicopter"),
-    EvalQuery("vacuum cleaner running", "vacuum_cleaner"),
-    EvalQuery("washing machine spinning", "washing_machine"),
+    EvalQuery("a chainsaw cutting wood", "chainsaw"),
+    EvalQuery("crackling fire in a fireplace", "crackling_fire"),
     EvalQuery("an alarm clock ringing", "clock_alarm"),
-    EvalQuery("someone typing on a keyboard", "keyboard_typing"),
-    EvalQuery("knocking on a wooden door", "door_wood_knock"),
 ]
 
 # ------------------------------------------------------------------
-# Image eval datasets  (Caltech-101)
+# Image eval queries  (Caltech-101)
+# All S/M/L share the same 8 categories; queries are identical.
 # ------------------------------------------------------------------
 
-_IMAGES_S_QUERIES = [
+_IMAGES_QUERIES = [
     EvalQuery("a photograph of a butterfly", "butterfly"),
-    EvalQuery("a photograph of a sunflower", "sunflower"),
-    EvalQuery("a photograph of a starfish", "starfish"),
-    EvalQuery("a photograph of a helicopter", "helicopter"),
-]
-
-_IMAGES_M_QUERIES = [
     EvalQuery("a photograph of a dolphin", "dolphin"),
-    EvalQuery("a photograph of a grand piano", "grand_piano"),
     EvalQuery("a photograph of an elephant", "elephant"),
-    EvalQuery("a photograph of a kangaroo", "kangaroo"),
-    EvalQuery("a photograph of a laptop computer", "laptop"),
+    EvalQuery("a photograph of a grand piano", "grand_piano"),
+    EvalQuery("a photograph of a helicopter", "helicopter"),
     EvalQuery("a photograph of a lobster", "lobster"),
-    EvalQuery("a photograph of a wristwatch", "watch"),
-    EvalQuery("a photograph of a flamingo", "flamingo"),
-]
-
-_IMAGES_L_QUERIES = [
-    EvalQuery("a photograph of a scorpion", "scorpion"),
+    EvalQuery("a photograph of a starfish", "starfish"),
     EvalQuery("a photograph of a stop sign", "stop_sign"),
-    EvalQuery("a photograph of a chandelier", "chandelier"),
-    EvalQuery("a photograph of a rhinoceros", "rhino"),
-    EvalQuery("a photograph of a rooster", "rooster"),
-    EvalQuery("a photograph of a soccer ball", "soccer_ball"),
-    EvalQuery("a photograph of a yin-yang symbol", "yin_yang"),
-    EvalQuery("a photograph of a leopard", "leopards"),
-    EvalQuery("a photograph of a hawksbill sea turtle", "hawksbill"),
-    EvalQuery("a photograph of a revolver", "revolver"),
-    EvalQuery("a photograph of a schooner sailing ship", "schooner"),
-    EvalQuery("a photograph of an ibis bird", "ibis"),
-    EvalQuery("a photograph of a trilobite fossil", "trilobite"),
-    EvalQuery("a photograph of a ceiling fan", "ceiling_fan"),
-    EvalQuery("a photograph of a dalmatian dog", "dalmatian"),
 ]
 
 # ------------------------------------------------------------------
-# Text / paragraph eval datasets  (20 Newsgroups)
+# Text / paragraph eval queries  (20 Newsgroups)
+# All S/M/L share the same 6 categories; queries are identical.
 # ------------------------------------------------------------------
 
-_PARAGRAPHS_S_QUERIES = [
+_PARAGRAPHS_QUERIES = [
     EvalQuery("baseball games and athletic competition", "sports"),
     EvalQuery("outer space exploration and astronomy", "science"),
-]
-
-_PARAGRAPHS_M_QUERIES = [
-    EvalQuery("international politics and world affairs", "world"),
-    EvalQuery("buying and selling goods and products", "business"),
-    EvalQuery("computer graphics and rendering", "technology"),
-    EvalQuery("medical treatment and healthcare", "medicine"),
-]
-
-_PARAGRAPHS_L_QUERIES = [
     EvalQuery("automobiles and car reviews", "cars"),
     EvalQuery("ice hockey games and NHL scores", "hockey"),
     EvalQuery("electronic circuits and components", "electronics"),
-    EvalQuery("encryption and computer security", "crypto"),
     EvalQuery("christian faith and religious practice", "religion"),
-    EvalQuery("firearms and gun control debate", "guns"),
-    EvalQuery("arguments about atheism and belief", "atheism"),
-    EvalQuery("apple macintosh hardware and troubleshooting", "mac"),
 ]
 
 # ------------------------------------------------------------------
@@ -169,41 +102,41 @@ EVAL_DATASETS: dict[str, dict] = {
     # Audio
     "sounds_s": {
         "demo_dataset": "sounds_s",
-        "queries": _SOUNDS_S_QUERIES,
+        "queries": _SOUNDS_QUERIES,
     },
     "sounds_m": {
         "demo_dataset": "sounds_m",
-        "queries": _SOUNDS_M_QUERIES,
+        "queries": _SOUNDS_QUERIES,
     },
     "sounds_l": {
         "demo_dataset": "sounds_l",
-        "queries": _SOUNDS_L_QUERIES,
+        "queries": _SOUNDS_QUERIES,
     },
     # Image
     "images_s": {
         "demo_dataset": "images_s",
-        "queries": _IMAGES_S_QUERIES,
+        "queries": _IMAGES_QUERIES,
     },
     "images_m": {
         "demo_dataset": "images_m",
-        "queries": _IMAGES_M_QUERIES,
+        "queries": _IMAGES_QUERIES,
     },
     "images_l": {
         "demo_dataset": "images_l",
-        "queries": _IMAGES_L_QUERIES,
+        "queries": _IMAGES_QUERIES,
     },
     # Text
     "paragraphs_s": {
         "demo_dataset": "paragraphs_s",
-        "queries": _PARAGRAPHS_S_QUERIES,
+        "queries": _PARAGRAPHS_QUERIES,
     },
     "paragraphs_m": {
         "demo_dataset": "paragraphs_m",
-        "queries": _PARAGRAPHS_M_QUERIES,
+        "queries": _PARAGRAPHS_QUERIES,
     },
     "paragraphs_l": {
         "demo_dataset": "paragraphs_l",
-        "queries": _PARAGRAPHS_L_QUERIES,
+        "queries": _PARAGRAPHS_QUERIES,
     },
     # Video
     "activities_video": {

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -76,6 +76,8 @@ def all_demo_datasets() -> dict:
                 "description": ds.description,
                 "categories": ds.categories,
                 "media_type": mt.type_id,
+                "slice_start": ds.slice_start,
+                "slice_end": ds.slice_end,
             }
             if ds.source:
                 entry["source"] = ds.source

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -68,76 +68,62 @@ class AudioMediaType(MediaType):
     # Demo datasets
     # ------------------------------------------------------------------
 
+    # Shared categories for all S/M/L audio demo datasets.
+    # All three sizes use the same 10 categories; only the underlying
+    # clips differ (disjoint slices of each category's 40 ESC-50 clips).
+    _DEMO_CATEGORIES = [
+        "dog",
+        "cat",
+        "rooster",
+        "chirping_birds",
+        "rain",
+        "thunderstorm",
+        "car_horn",
+        "chainsaw",
+        "crackling_fire",
+        "clock_alarm",
+    ]
+
     @property
     def demo_datasets(self) -> list:
+        cats = self._DEMO_CATEGORIES
+        folder = DATA_DIR / "ESC-50-master" / "audio"
         return [
             DemoDataset(
                 id="sounds_s",
-                label="ESC-50 Animals & Fireside (S)",
+                label="ESC-50 Sound Mix (S)",
                 description=(
-                    "200 clips of dogs, cats, roosters, church bells, and crackling"
-                    " fire from the ESC-50 collection."
+                    "80 clips across 10 sound categories — animals, nature, urban,"
+                    " and household sounds from the ESC-50 collection."
                 ),
-                categories=[
-                    "dog",
-                    "cat",
-                    "rooster",
-                    "church_bells",
-                    "crackling_fire",
-                ],
-                required_folder=DATA_DIR / "ESC-50-master" / "audio",
+                categories=cats,
+                required_folder=folder,
+                slice_start=0,
+                slice_end=8,
             ),
             DemoDataset(
                 id="sounds_m",
-                label="ESC-50 Everyday Sounds (M)",
+                label="ESC-50 Sound Mix (M)",
                 description=(
-                    "400 clips of babies, laughter, clapping, footsteps, chainsaws,"
-                    " airplanes, and more from the ESC-50 collection."
+                    "160 clips across 10 sound categories — animals, nature, urban,"
+                    " and household sounds from the ESC-50 collection."
                 ),
-                categories=[
-                    "crying_baby",
-                    "laughing",
-                    "clapping",
-                    "footsteps",
-                    "sneezing",
-                    "chainsaw",
-                    "airplane",
-                    "fireworks",
-                    "pig",
-                    "cow",
-                ],
-                required_folder=DATA_DIR / "ESC-50-master" / "audio",
+                categories=cats,
+                required_folder=folder,
+                slice_start=8,
+                slice_end=24,
             ),
             DemoDataset(
                 id="sounds_l",
-                label="ESC-50 Environmental Mix (L)",
+                label="ESC-50 Sound Mix (L)",
                 description=(
-                    "800 clips spanning nature, animals, weather, traffic, and"
-                    " household sounds from the ESC-50 collection."
+                    "160 clips across 10 sound categories — animals, nature, urban,"
+                    " and household sounds from the ESC-50 collection."
                 ),
-                categories=[
-                    "chirping_birds",
-                    "crow",
-                    "frog",
-                    "insects",
-                    "rain",
-                    "sea_waves",
-                    "thunderstorm",
-                    "wind",
-                    "water_drops",
-                    "crickets",
-                    "car_horn",
-                    "siren",
-                    "engine",
-                    "train",
-                    "helicopter",
-                    "vacuum_cleaner",
-                    "washing_machine",
-                    "clock_alarm",
-                    "keyboard_typing",
-                    "door_wood_knock",
-                ],
-                required_folder=DATA_DIR / "ESC-50-master" / "audio",
+                categories=cats,
+                required_folder=folder,
+                slice_start=24,
+                slice_end=40,
             ),
         ]
 

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -93,6 +93,17 @@ class DemoDataset:
     ``DATA_DIR / "ESC-50-master" / "audio"``).  Leave ``None`` for datasets
     whose ``.pkl`` is entirely self-contained (images, text)."""
 
+    slice_start: int = 0
+    """Per-category start index for element slicing (inclusive).
+
+    When multiple datasets share the same categories, this allows them to
+    use disjoint subsets of elements within each category."""
+
+    slice_end: Optional[int] = None
+    """Per-category end index for element slicing (exclusive).
+
+    ``None`` means take all remaining elements after ``slice_start``."""
+
 
 class MediaType(ABC):
     """Abstract base class that every media type must implement.

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -94,66 +94,63 @@ class ImageMediaType(MediaType):
     # Demo datasets
     # ------------------------------------------------------------------
 
+    # Shared categories for all S/M/L image demo datasets.
+    # All three sizes use the same 8 categories; only the underlying
+    # images differ (disjoint slices of each category's Caltech-101 images).
+    _DEMO_CATEGORIES = [
+        "butterfly",
+        "dolphin",
+        "elephant",
+        "grand_piano",
+        "helicopter",
+        "lobster",
+        "starfish",
+        "stop_sign",
+    ]
+
     @property
     def demo_datasets(self) -> list:
+        cats = self._DEMO_CATEGORIES
+        folder = DATA_DIR / "caltech-101" / "101_ObjectCategories"
         return [
             DemoDataset(
                 id="images_s",
-                label="Caltech-101 Nature & Flight (S)",
+                label="Caltech-101 Object Mix (S)",
                 description=(
-                    "Photographs of butterflies, sunflowers, starfish, and"
-                    " helicopters from the Caltech-101 dataset."
+                    "128 photographs across 8 categories — animals, instruments,"
+                    " vehicles, and objects from the Caltech-101 dataset."
                 ),
-                categories=["butterfly", "sunflower", "starfish", "helicopter"],
+                categories=cats,
                 source="caltech101",
-                required_folder=DATA_DIR / "caltech-101" / "101_ObjectCategories",
+                required_folder=folder,
+                slice_start=0,
+                slice_end=16,
             ),
             DemoDataset(
                 id="images_m",
-                label="Caltech-101 Animals & Objects (M)",
+                label="Caltech-101 Object Mix (M)",
                 description=(
-                    "Photographs of dolphins, grand pianos, elephants, kangaroos,"
-                    " laptops, lobsters, watches, and flamingos from Caltech-101."
+                    "256 photographs across 8 categories — animals, instruments,"
+                    " vehicles, and objects from the Caltech-101 dataset."
                 ),
-                categories=[
-                    "dolphin",
-                    "grand_piano",
-                    "elephant",
-                    "kangaroo",
-                    "laptop",
-                    "lobster",
-                    "watch",
-                    "flamingo",
-                ],
+                categories=cats,
                 source="caltech101",
-                required_folder=DATA_DIR / "caltech-101" / "101_ObjectCategories",
+                required_folder=folder,
+                slice_start=16,
+                slice_end=48,
             ),
             DemoDataset(
                 id="images_l",
-                label="Caltech-101 Diverse Objects (L)",
+                label="Caltech-101 Object Mix (L)",
                 description=(
-                    "Photographs across 15 diverse categories including animals,"
-                    " instruments, vehicles, and objects from Caltech-101."
+                    "256 photographs across 8 categories — animals, instruments,"
+                    " vehicles, and objects from the Caltech-101 dataset."
                 ),
-                categories=[
-                    "scorpion",
-                    "stop_sign",
-                    "chandelier",
-                    "rhino",
-                    "rooster",
-                    "soccer_ball",
-                    "yin_yang",
-                    "leopards",
-                    "hawksbill",
-                    "revolver",
-                    "schooner",
-                    "ibis",
-                    "trilobite",
-                    "ceiling_fan",
-                    "dalmatian",
-                ],
+                categories=cats,
                 source="caltech101",
-                required_folder=DATA_DIR / "caltech-101" / "101_ObjectCategories",
+                required_folder=folder,
+                slice_start=48,
+                slice_end=80,
             ),
         ]
 

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -67,47 +67,57 @@ class TextMediaType(MediaType):
     # Demo datasets
     # ------------------------------------------------------------------
 
+    # Shared categories for all S/M/L text demo datasets.
+    # All three sizes use the same 6 categories; only the underlying
+    # articles differ (disjoint slices of each category's texts).
+    _DEMO_CATEGORIES = [
+        "sports",
+        "science",
+        "cars",
+        "hockey",
+        "electronics",
+        "religion",
+    ]
+
     @property
     def demo_datasets(self) -> list:
+        cats = self._DEMO_CATEGORIES
         return [
             DemoDataset(
                 id="paragraphs_s",
-                label="Newsgroup Sports & Science (S)",
+                label="Newsgroup Topic Mix (S)",
                 description=(
-                    "Short articles about sports and space science from the"
-                    " 20 Newsgroups collection."
+                    "60 articles across 6 topics — sports, science, cars, hockey,"
+                    " electronics, and religion from the 20 Newsgroups collection."
                 ),
-                categories=["sports", "science"],
+                categories=cats,
                 source="ag_news_sample",
+                slice_start=0,
+                slice_end=10,
             ),
             DemoDataset(
                 id="paragraphs_m",
-                label="Newsgroup World News & Tech (M)",
+                label="Newsgroup Topic Mix (M)",
                 description=(
-                    "Articles spanning world affairs, business, computer graphics,"
-                    " and medicine from the 20 Newsgroups collection."
+                    "120 articles across 6 topics — sports, science, cars, hockey,"
+                    " electronics, and religion from the 20 Newsgroups collection."
                 ),
-                categories=["world", "business", "technology", "medicine"],
+                categories=cats,
                 source="ag_news_sample",
+                slice_start=10,
+                slice_end=30,
             ),
             DemoDataset(
                 id="paragraphs_l",
-                label="Newsgroup 8-Topic Mix (L)",
+                label="Newsgroup Topic Mix (L)",
                 description=(
-                    "Articles across eight topics including cars, hockey,"
-                    " electronics, cryptography, and religion from 20 Newsgroups."
+                    "120 articles across 6 topics — sports, science, cars, hockey,"
+                    " electronics, and religion from the 20 Newsgroups collection."
                 ),
-                categories=[
-                    "cars",
-                    "hockey",
-                    "electronics",
-                    "crypto",
-                    "religion",
-                    "guns",
-                    "atheism",
-                    "mac",
-                ],
+                categories=cats,
                 source="ag_news_sample",
+                slice_start=30,
+                slice_end=50,
             ),
         ]
 


### PR DESCRIPTION
Instead of giving S/M/L datasets completely different categories, all three
sizes now share the same categories within each media type. The S/M/L
distinction is made by slicing disjoint subsets of elements per category:

Audio (ESC-50, 10 shared categories, 40 clips/cat):
  S: clips 0-7, M: clips 8-23, L: clips 24-39

Image (Caltech-101, 8 shared categories, 80 images/cat):
  S: images 0-15, M: images 16-47, L: images 48-79

Text (20 Newsgroups, 6 shared categories, 50 texts/cat):
  S: texts 0-9, M: texts 10-29, L: texts 30-49

Changes:
- Add slice_start/slice_end fields to DemoDataset dataclass
- Update all three media types to use shared categories with slice params
- Update loader.py to apply per-category slicing in all loader paths
- Update eval config: all S/M/L sizes now share the same query lists

https://claude.ai/code/session_013LRWgNzEFs2yoH8RtzfU8z