### PR TITLE
Add thin media loading for memory-efficient CLI autodetect

### DIFF
--- a/tests/test_thin_loading.py
+++ b/tests/test_thin_loading.py
@@ -1,0 +1,365 @@
+"""Tests for thin (lazy-loading) media reference support.
+
+Verifies that datasets can be loaded in thin mode (storing media_path
+instead of clip_bytes) and that lazy loading correctly resolves media
+content when needed.
+"""
+
+import hashlib
+import pickle
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from vtsearch.datasets.loader import (
+    _streaming_md5,
+    load_dataset_from_folder,
+    load_dataset_from_pickle,
+)
+
+
+def _make_wav_bytes(frequency: float = 440.0, duration: float = 0.1) -> bytes:
+    """Generate a minimal WAV file for testing."""
+    from vtsearch.audio import generate_wav
+
+    return generate_wav(frequency, duration)
+
+
+def _make_text_file(tmp_dir: Path, name: str, content: str) -> Path:
+    """Write a text file and return its path."""
+    p = tmp_dir / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _make_wav_file(tmp_dir: Path, name: str) -> Path:
+    """Write a WAV file and return its path."""
+    p = tmp_dir / name
+    p.write_bytes(_make_wav_bytes())
+    return p
+
+
+class TestStreamingMD5:
+    def test_matches_regular_md5(self, tmp_path):
+        content = b"hello world test data"
+        p = tmp_path / "test.bin"
+        p.write_bytes(content)
+        assert _streaming_md5(p) == hashlib.md5(content).hexdigest()
+
+    def test_large_file(self, tmp_path):
+        # File larger than the 8192 chunk size
+        content = b"x" * 20000
+        p = tmp_path / "large.bin"
+        p.write_bytes(content)
+        assert _streaming_md5(p) == hashlib.md5(content).hexdigest()
+
+
+class TestThinLoadFromFolder:
+    """Test load_dataset_from_folder with thin=True."""
+
+    def test_thin_clips_have_media_path(self, tmp_path):
+        _make_wav_file(tmp_path, "test1.wav")
+        _make_wav_file(tmp_path, "test2.wav")
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=True)
+        assert len(clips) == 2
+        for clip in clips.values():
+            assert clip["media_path"] is not None
+            assert Path(clip["media_path"]).exists()
+
+    def test_thin_clips_have_no_bytes(self, tmp_path):
+        _make_wav_file(tmp_path, "test.wav")
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=True)
+        clip = clips[1]
+        assert clip["clip_bytes"] is None
+        assert clip["clip_string"] is None
+
+    def test_thin_clips_have_embedding(self, tmp_path):
+        _make_wav_file(tmp_path, "test.wav")
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=True)
+        clip = clips[1]
+        assert isinstance(clip["embedding"], np.ndarray)
+        assert len(clip["embedding"]) > 0
+
+    def test_thin_clips_have_correct_file_size(self, tmp_path):
+        wav_path = _make_wav_file(tmp_path, "test.wav")
+        expected_size = wav_path.stat().st_size
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=True)
+        assert clips[1]["file_size"] == expected_size
+
+    def test_thin_clips_have_correct_md5(self, tmp_path):
+        wav_path = _make_wav_file(tmp_path, "test.wav")
+        expected_md5 = hashlib.md5(wav_path.read_bytes()).hexdigest()
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=True)
+        assert clips[1]["md5"] == expected_md5
+
+    def test_thin_no_duration(self, tmp_path):
+        """Thin mode skips load_clip_data, so duration stays at default 0."""
+        _make_wav_file(tmp_path, "test.wav")
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=True)
+        assert clips[1]["duration"] == 0
+
+    def test_full_mode_has_bytes(self, tmp_path):
+        """Full mode (thin=False) should still load bytes as before."""
+        _make_wav_file(tmp_path, "test.wav")
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=False)
+        assert clips[1]["clip_bytes"] is not None
+        assert isinstance(clips[1]["clip_bytes"], bytes)
+
+    def test_full_mode_also_has_media_path(self, tmp_path):
+        """Full mode should also store media_path for potential future use."""
+        _make_wav_file(tmp_path, "test.wav")
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", clips, thin=False)
+        assert clips[1]["media_path"] is not None
+
+
+class TestThinLoadFromPickle:
+    """Test load_dataset_from_pickle with thin=True."""
+
+    def _make_pickle(self, tmp_path, inline_bytes=True, audio_dir=None):
+        """Create a test pickle with one audio clip."""
+        wav_bytes = _make_wav_bytes()
+        clip_data: dict[str, Any] = {
+            "id": 1,
+            "type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "embedding": np.zeros(512).tolist(),
+            "filename": "test.wav",
+            "category": "test",
+        }
+        if inline_bytes:
+            clip_data["clip_bytes"] = wav_bytes
+
+        pkl_data: dict[str, Any] = {"clips": {1: clip_data}}
+        if audio_dir:
+            pkl_data["audio_dir"] = str(audio_dir)
+            # Write the actual file
+            audio_dir.mkdir(exist_ok=True)
+            (audio_dir / "test.wav").write_bytes(wav_bytes)
+
+        pkl_path = tmp_path / "test.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump(pkl_data, f)
+        return pkl_path
+
+    def test_thin_pickle_skips_inline_bytes(self, tmp_path):
+        pkl_path = self._make_pickle(tmp_path, inline_bytes=True)
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, clips, thin=True)
+        assert len(clips) == 1
+        assert clips[1]["clip_bytes"] is None
+
+    def test_thin_pickle_has_embedding(self, tmp_path):
+        pkl_path = self._make_pickle(tmp_path, inline_bytes=True)
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, clips, thin=True)
+        assert isinstance(clips[1]["embedding"], np.ndarray)
+
+    def test_thin_pickle_resolves_media_path_from_audio_dir(self, tmp_path):
+        audio_dir = tmp_path / "audio"
+        pkl_path = self._make_pickle(tmp_path, inline_bytes=False, audio_dir=audio_dir)
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, clips, thin=True)
+        assert clips[1]["media_path"] is not None
+        assert Path(clips[1]["media_path"]).exists()
+
+    def test_thin_pickle_preserves_metadata(self, tmp_path):
+        pkl_path = self._make_pickle(tmp_path, inline_bytes=True)
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, clips, thin=True)
+        assert clips[1]["type"] == "audio"
+        assert clips[1]["filename"] == "test.wav"
+        assert clips[1]["category"] == "test"
+
+    def test_full_pickle_still_works(self, tmp_path):
+        pkl_path = self._make_pickle(tmp_path, inline_bytes=True)
+        clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, clips, thin=False)
+        assert clips[1]["clip_bytes"] is not None
+
+
+class TestThinImporters:
+    """Test that importers pass thin parameter through correctly."""
+
+    def test_folder_importer_thin(self, tmp_path):
+        _make_wav_file(tmp_path, "test.wav")
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        importer = FolderDatasetImporter()
+        clips: dict[int, dict[str, Any]] = {}
+        importer.run({"path": str(tmp_path), "media_type": "sounds"}, clips, thin=True)
+        assert len(clips) > 0
+        assert clips[1]["clip_bytes"] is None
+        assert clips[1]["media_path"] is not None
+
+    def test_folder_importer_run_cli_thin(self, tmp_path):
+        _make_wav_file(tmp_path, "test.wav")
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        importer = FolderDatasetImporter()
+        clips: dict[int, dict[str, Any]] = {}
+        importer.run_cli({"path": str(tmp_path), "media_type": "sounds"}, clips, thin=True)
+        assert len(clips) > 0
+        assert clips[1]["clip_bytes"] is None
+
+    def test_pickle_importer_thin(self, tmp_path):
+        # Create a pickle first
+        wav_bytes = _make_wav_bytes()
+        pkl_data = {
+            "clips": {
+                1: {
+                    "id": 1,
+                    "type": "audio",
+                    "duration": 0.1,
+                    "file_size": len(wav_bytes),
+                    "md5": hashlib.md5(wav_bytes).hexdigest(),
+                    "embedding": np.zeros(512).tolist(),
+                    "filename": "test.wav",
+                    "category": "test",
+                    "clip_bytes": wav_bytes,
+                }
+            }
+        }
+        pkl_path = tmp_path / "test.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump(pkl_data, f)
+
+        from vtsearch.datasets.importers.pickle import PickleDatasetImporter
+
+        importer = PickleDatasetImporter()
+        clips: dict[int, dict[str, Any]] = {}
+        importer.run_cli({"file": str(pkl_path)}, clips, thin=True)
+        assert len(clips) == 1
+        assert clips[1]["clip_bytes"] is None
+
+
+class TestLazyLoadingMediaType:
+    """Test that MediaType._resolve_clip_bytes/string lazy-loads from media_path."""
+
+    def test_resolve_bytes_from_preloaded(self):
+        from vtsearch.media.audio.media_type import AudioMediaType
+
+        mt = AudioMediaType()
+        clip = {"clip_bytes": b"hello", "media_path": None}
+        assert mt._resolve_clip_bytes(clip) == b"hello"
+
+    def test_resolve_bytes_from_media_path(self, tmp_path):
+        from vtsearch.media.audio.media_type import AudioMediaType
+
+        content = b"lazy loaded content"
+        p = tmp_path / "test.wav"
+        p.write_bytes(content)
+
+        mt = AudioMediaType()
+        clip = {"clip_bytes": None, "media_path": str(p)}
+        assert mt._resolve_clip_bytes(clip) == content
+
+    def test_resolve_bytes_missing_file(self):
+        from vtsearch.media.audio.media_type import AudioMediaType
+
+        mt = AudioMediaType()
+        clip = {"clip_bytes": None, "media_path": "/nonexistent/file.wav"}
+        assert mt._resolve_clip_bytes(clip) is None
+
+    def test_resolve_bytes_no_path(self):
+        from vtsearch.media.audio.media_type import AudioMediaType
+
+        mt = AudioMediaType()
+        clip = {"clip_bytes": None, "media_path": None}
+        assert mt._resolve_clip_bytes(clip) is None
+
+    def test_resolve_string_from_preloaded(self):
+        from vtsearch.media.text.media_type import TextMediaType
+
+        mt = TextMediaType()
+        clip = {"clip_string": "hello world", "media_path": None}
+        assert mt._resolve_clip_string(clip) == "hello world"
+
+    def test_resolve_string_from_media_path(self, tmp_path):
+        from vtsearch.media.text.media_type import TextMediaType
+
+        content = "lazy loaded text content"
+        p = tmp_path / "test.txt"
+        p.write_text(content, encoding="utf-8")
+
+        mt = TextMediaType()
+        clip = {"clip_string": None, "media_path": str(p)}
+        assert mt._resolve_clip_string(clip) == content
+
+
+class TestClipResponseLazyLoading:
+    """Test that clip_response works with lazy-loaded media."""
+
+    def test_audio_clip_response_lazy(self, tmp_path):
+        from vtsearch.media.audio.media_type import AudioMediaType
+
+        wav_bytes = _make_wav_bytes()
+        p = tmp_path / "test.wav"
+        p.write_bytes(wav_bytes)
+
+        mt = AudioMediaType()
+        clip = {"id": 1, "clip_bytes": None, "media_path": str(p), "filename": "test.wav"}
+        resp = mt.clip_response(clip)
+        assert resp.data == wav_bytes
+        assert resp.mimetype == "audio/wav"
+
+    def test_image_clip_response_lazy(self, tmp_path):
+        from vtsearch.media.image.media_type import ImageMediaType
+
+        # Create a minimal PNG
+        from PIL import Image as PILImage
+        import io
+
+        img = PILImage.new("RGB", (2, 2), color="red")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        p = tmp_path / "test.png"
+        p.write_bytes(png_bytes)
+
+        mt = ImageMediaType()
+        clip = {"id": 1, "clip_bytes": None, "media_path": str(p), "filename": "test.png"}
+        resp = mt.clip_response(clip)
+        assert resp.data == png_bytes
+        assert resp.mimetype == "image/png"
+
+    def test_text_clip_response_lazy(self, tmp_path):
+        from vtsearch.media.text.media_type import TextMediaType
+
+        content = "lazy loaded paragraph"
+        p = tmp_path / "test.txt"
+        p.write_text(content, encoding="utf-8")
+
+        mt = TextMediaType()
+        clip = {
+            "id": 1,
+            "clip_string": None,
+            "media_path": str(p),
+            "word_count": 0,
+            "character_count": 0,
+        }
+        resp = mt.clip_response(clip)
+        assert resp.data["content"] == content
+        assert resp.data["word_count"] == 3  # "lazy loaded paragraph"
+        assert resp.data["character_count"] == len(content)
+
+    def test_audio_clip_response_no_data(self):
+        """clip_response returns empty bytes when no data is available."""
+        from vtsearch.media.audio.media_type import AudioMediaType
+
+        mt = AudioMediaType()
+        clip = {"id": 1, "clip_bytes": None, "media_path": None, "filename": "test.wav"}
+        resp = mt.clip_response(clip)
+        assert resp.data == b""

--- a/tests/test_thin_loading.py
+++ b/tests/test_thin_loading.py
@@ -7,7 +7,6 @@ content when needed.
 
 import hashlib
 import pickle
-import tempfile
 from pathlib import Path
 from typing import Any
 

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -120,9 +120,9 @@ def run_autodetect(dataset_path: str, detector_path: str) -> list[dict[str, Any]
     if not dataset_file.exists():
         raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
 
-    # Load dataset
+    # Load dataset in thin mode — CLI only needs embeddings, not media bytes
     clips: dict[int, dict[str, Any]] = {}
-    load_dataset_from_pickle(dataset_file, clips)
+    load_dataset_from_pickle(dataset_file, clips, thin=True)
 
     if not clips:
         raise ValueError(f"No clips loaded from dataset: {dataset_path}")
@@ -162,8 +162,9 @@ def run_autodetect_with_importer(
 
     importer.validate_cli_field_values(field_values)
 
+    # Use thin mode — CLI only needs embeddings for scoring, not media bytes
     clips: dict[int, dict[str, Any]] = {}
-    importer.run_cli(field_values, clips)
+    importer.run_cli(field_values, clips, thin=True)
 
     if not clips:
         raise ValueError(f"No clips loaded by importer '{importer_name}'")
@@ -415,8 +416,9 @@ def autodetect_main(
         if not dataset_file.exists():
             raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
 
+        # Thin mode — CLI only needs embeddings for scoring, not media bytes
         clips: dict[int, dict[str, Any]] = {}
-        load_dataset_from_pickle(dataset_file, clips)
+        load_dataset_from_pickle(dataset_file, clips, thin=True)
         if not clips:
             raise ValueError(f"No clips loaded from dataset: {dataset_path}")
 
@@ -478,8 +480,9 @@ def autodetect_importer_main(
 
         importer.validate_cli_field_values(field_values)
 
+        # Thin mode — CLI only needs embeddings for scoring, not media bytes
         clips: dict[int, dict[str, Any]] = {}
-        importer.run_cli(field_values, clips)
+        importer.run_cli(field_values, clips, thin=True)
         if not clips:
             raise ValueError(f"No clips loaded by importer '{importer_name}'")
 

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -141,7 +141,7 @@ class DatasetImporter:
         #: skip the embedding model for any file whose name appears here.
         self.content_vectors: dict[str, Any] = {}
 
-    def run(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         """Perform the import, populating *clips* in-place.
 
         Args:
@@ -151,6 +151,9 @@ class DatasetImporter:
                 other fields receive plain strings.
             clips: The global clips dict to populate.  Modify it in-place;
                 do not replace the reference.
+            thin: When ``True``, store a ``media_path`` file reference
+                instead of loading media bytes into ``clip_bytes``.  This
+                saves memory for CLI workflows that only need embeddings.
 
         Raises:
             NotImplementedError: If the subclass has not implemented this.
@@ -186,15 +189,21 @@ class DatasetImporter:
                 kwargs["choices"] = f.options
             parser.add_argument(arg_name, **kwargs)
 
-    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         """Load a dataset from CLI-provided *field_values* into *clips*.
 
         The default implementation simply delegates to :meth:`run`, which
         works for importers whose ``run()`` only expects plain string values.
         Importers that expect non-string objects (e.g. ``FileStorage``) must
         override this method to handle file-path strings appropriately.
+
+        Args:
+            field_values: Mapping of importer field keys to their CLI values.
+            clips: The global clips dict to populate.
+            thin: When ``True``, store file path references instead of
+                loading media bytes.  Passed through to :meth:`run`.
         """
-        self.run(field_values, clips)
+        self.run(field_values, clips, thin=thin)
 
     def validate_cli_field_values(self, field_values: dict[str, Any]) -> None:
         """Raise ``ValueError`` if any required field is missing or empty."""

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -41,18 +41,18 @@ class FolderDatasetImporter(DatasetImporter):
         ),
     ]
 
-    def run(self, field_values: dict, clips: dict) -> None:
+    def run(self, field_values: dict, clips: dict, thin: bool = False) -> None:
         folder = Path(field_values["path"])
         media_type = field_values.get("media_type", "sounds")
-        load_dataset_from_folder(folder, media_type, clips)
+        load_dataset_from_folder(folder, media_type, clips, thin=thin)
 
-    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         folder = Path(field_values["path"])
         if not folder.exists():
             raise FileNotFoundError(f"Folder not found: {folder}")
         if not folder.is_dir():
             raise NotADirectoryError(f"Not a directory: {folder}")
-        self.run(field_values, clips)
+        self.run(field_values, clips, thin=thin)
 
 
 IMPORTER = FolderDatasetImporter()

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -123,7 +123,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         ),
     ]
 
-    def run(self, field_values: dict, clips: dict) -> None:
+    def run(self, field_values: dict, clips: dict, thin: bool = False) -> None:
         url = field_values["url"]
         media_type = field_values.get("media_type", "sounds")
 
@@ -145,13 +145,13 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         _extract_archive(archive_path, extract_dir, on_progress=progress)
         archive_path.unlink(missing_ok=True)
 
-        load_dataset_from_folder(extract_dir, media_type, clips, on_progress=progress)
+        load_dataset_from_folder(extract_dir, media_type, clips, on_progress=progress, thin=thin)
 
-    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         url = field_values.get("url", "")
         if not url.startswith(("http://", "https://")):
             raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
-        self.run(field_values, clips)
+        self.run(field_values, clips, thin=thin)
 
 
 IMPORTER = HttpArchiveDatasetImporter()

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -41,7 +41,7 @@ class PickleDatasetImporter(DatasetImporter):
         ),
     ]
 
-    def run(self, field_values: dict, clips: dict) -> None:
+    def run(self, field_values: dict, clips: dict, thin: bool = False) -> None:
         file_obj = field_values["file"]  # werkzeug FileStorage
         progress = _get_progress()
         progress("loading", "Loading dataset from file...", 0, 0)
@@ -49,17 +49,17 @@ class PickleDatasetImporter(DatasetImporter):
         DATA_DIR.mkdir(exist_ok=True)
         file_obj.save(temp_path)
         try:
-            load_dataset_from_pickle(temp_path, clips)
+            load_dataset_from_pickle(temp_path, clips, thin=thin)
         finally:
             temp_path.unlink(missing_ok=True)
         progress("idle", f"Loaded {len(clips)} clips from file")
 
-    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         """Load from a pickle file path (string) instead of FileStorage."""
         file_path = Path(field_values["file"])
         if not file_path.exists():
             raise FileNotFoundError(f"Dataset file not found: {file_path}")
-        load_dataset_from_pickle(file_path, clips)
+        load_dataset_from_pickle(file_path, clips, thin=thin)
 
 
 IMPORTER = PickleDatasetImporter()

--- a/vtsearch/datasets/importers/rss_feed/__init__.py
+++ b/vtsearch/datasets/importers/rss_feed/__init__.py
@@ -70,7 +70,7 @@ class RSSDatasetImporter(DatasetImporter):
         ),
     ]
 
-    def run(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         try:
             import feedparser
         except ImportError as exc:
@@ -152,13 +152,13 @@ class RSSDatasetImporter(DatasetImporter):
                 )
                 continue
 
-        load_dataset_from_folder(download_dir, media_type, clips, on_progress=progress)
+        load_dataset_from_folder(download_dir, media_type, clips, on_progress=progress, thin=thin)
 
-    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         url = field_values.get("url", "")
         if not url.startswith(("http://", "https://")):
             raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
-        self.run(field_values, clips)
+        self.run(field_values, clips, thin=thin)
 
 
 IMPORTER = RSSDatasetImporter()

--- a/vtsearch/datasets/importers/youtube_playlist/__init__.py
+++ b/vtsearch/datasets/importers/youtube_playlist/__init__.py
@@ -57,7 +57,7 @@ class YouTubePlaylistDatasetImporter(DatasetImporter):
         ),
     ]
 
-    def run(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         try:
             import yt_dlp  # noqa: F401
         except ImportError as exc:
@@ -129,13 +129,13 @@ class YouTubePlaylistDatasetImporter(DatasetImporter):
         if not any_files:
             raise ValueError("No videos were downloaded. Check the URL and try again.")
 
-        load_dataset_from_folder(download_dir, media_type, clips, on_progress=progress)
+        load_dataset_from_folder(download_dir, media_type, clips, on_progress=progress, thin=thin)
 
-    def run_cli(self, field_values: dict[str, Any], clips: dict) -> None:
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         url = field_values.get("url", "")
         if not url.startswith(("http://", "https://")):
             raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
-        self.run(field_values, clips)
+        self.run(field_values, clips, thin=thin)
 
 
 IMPORTER = YouTubePlaylistDatasetImporter()

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -237,6 +237,15 @@ def load_paragraph_metadata_from_folders(text_dir: Path, categories: list[str]) 
     return metadata
 
 
+def _streaming_md5(file_path: Path) -> str:
+    """Compute MD5 hash of a file using constant memory."""
+    h = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def load_dataset_from_folder(
     folder_path: Path,
     media_type: str,
@@ -244,6 +253,7 @@ def load_dataset_from_folder(
     content_vectors: dict[str, Any] | None = None,
     on_progress: Optional[ProgressCallback] = None,
     origin: dict[str, Any] | None = None,
+    thin: bool = False,
 ) -> None:
     """Generate a dataset in-place from a flat folder of media files.
 
@@ -276,6 +286,10 @@ def load_dataset_from_folder(
             :class:`~vtsearch.datasets.origin.Origin` dict to attach to each
             clip (as ``clip["origin"]``).  When ``None`` no origin is set
             and the caller is expected to set it afterwards.
+        thin: When ``True``, store a ``media_path`` reference to the file on
+            disk instead of reading all bytes into ``clip_bytes``.  This saves
+            memory for CLI workflows that only need embeddings for scoring.
+            MD5 is still computed via streaming (constant memory).
 
     Raises:
         ValueError: If ``media_type`` is not recognised, or if no matching
@@ -320,29 +334,49 @@ def load_dataset_from_folder(
             if embedding is None:
                 continue
 
-        with open(file_path, "rb") as f:
-            file_bytes = f.read()
+        if thin:
+            # Thin mode: store file path reference, skip loading bytes.
+            # Use stat for file_size and streaming hash for MD5.
+            clip_data: dict[str, Any] = {
+                "id": clip_id,
+                "type": mt.type_id,
+                "file_size": file_path.stat().st_size,
+                "md5": _streaming_md5(file_path),
+                "embedding": embedding,
+                "filename": file_path.name,
+                "category": "custom",
+                "origin": origin,
+                "origin_name": file_path.name,
+                "clip_bytes": None,
+                "clip_string": None,
+                "media_path": str(file_path.resolve()),
+                "duration": 0,
+            }
+        else:
+            with open(file_path, "rb") as f:
+                file_bytes = f.read()
 
-        # Build the base clip dict
-        clip_data: dict[str, Any] = {
-            "id": clip_id,
-            "type": mt.type_id,
-            "file_size": len(file_bytes),
-            "md5": hashlib.md5(file_bytes).hexdigest(),
-            "embedding": embedding,
-            "filename": file_path.name,
-            "category": "custom",
-            "origin": origin,
-            "origin_name": file_path.name,
-            # Null-out optional media fields so clips from different types
-            # stored in the same dict have consistent keys.
-            "clip_bytes": None,
-            "clip_string": None,
-            "duration": 0,
-        }
+            # Build the base clip dict
+            clip_data = {
+                "id": clip_id,
+                "type": mt.type_id,
+                "file_size": len(file_bytes),
+                "md5": hashlib.md5(file_bytes).hexdigest(),
+                "embedding": embedding,
+                "filename": file_path.name,
+                "category": "custom",
+                "origin": origin,
+                "origin_name": file_path.name,
+                # Null-out optional media fields so clips from different types
+                # stored in the same dict have consistent keys.
+                "clip_bytes": None,
+                "clip_string": None,
+                "media_path": str(file_path.resolve()),
+                "duration": 0,
+            }
 
-        # Merge in media-specific fields from the media type
-        clip_data.update(mt.load_clip_data(file_path))
+            # Merge in media-specific fields from the media type
+            clip_data.update(mt.load_clip_data(file_path))
 
         clips[clip_id] = clip_data
         clip_id += 1
@@ -353,6 +387,7 @@ def load_dataset_from_folder(
 def load_dataset_from_pickle(
     file_path: Path,
     clips: dict[int, dict[str, Any]],
+    thin: bool = False,
 ) -> dict[str, Any] | None:
     """Load a dataset from a pickle file into the clips dict in-place.
 
@@ -377,6 +412,10 @@ def load_dataset_from_pickle(
             :func:`export_dataset_to_file` or :func:`load_demo_dataset`.
         clips: Dict to populate in-place. Existing entries are removed before
             loading. Keys are clip IDs (int); values are clip data dicts.
+        thin: When ``True``, skip loading media bytes into memory.  Inline
+            bytes from the pickle are discarded and external-dir files are
+            referenced by ``media_path`` instead of read.  Useful for CLI
+            workflows that only need embeddings for scoring.
 
     Returns:
         ``None``.  (Formerly returned ``creation_info``; that field has been
@@ -404,12 +443,64 @@ def load_dataset_from_pickle(
             "params": creation_info.get("field_values", {}),
         }
 
+    # Map media type to the pickle key that holds the external directory.
+    _dir_keys = {
+        "audio": "audio_dir",
+        "video": "video_dir",
+        "image": "image_dir",
+        "paragraph": "text_dir",
+    }
+
     # Convert to the app's clip format
     missing_media = 0
     for clip_id, clip_info in clips_data.items():
         # Determine media type
         media_type = clip_info.get("type", "audio")
 
+        if thin:
+            # ── Thin mode: skip bytes, store media_path if available ──
+            media_path: str | None = clip_info.get("media_path")
+
+            # Try to resolve a media_path from the external directory
+            if not media_path:
+                dir_key = _dir_keys.get(media_type)
+                if dir_key and dir_key in data and "filename" in clip_info:
+                    candidate = Path(data[dir_key]) / clip_info["filename"]
+                    if candidate.exists():
+                        media_path = str(candidate.resolve())
+
+            # We still need the embedding to be useful
+            if "embedding" not in clip_info:
+                missing_media += 1
+                continue
+
+            fname = clip_info.get("filename", f"clip_{clip_id}.{media_type}")
+            clip_data: dict[str, Any] = {
+                "id": clip_id,
+                "type": media_type,
+                "duration": clip_info.get("duration", 0),
+                "file_size": clip_info.get("file_size", 0),
+                "md5": clip_info.get("md5", ""),
+                "embedding": np.array(clip_info["embedding"]),
+                "clip_bytes": None,
+                "clip_string": None,
+                "media_path": media_path,
+                "filename": fname,
+                "category": clip_info.get("category", "unknown"),
+                "origin": clip_info.get("origin", fallback_origin),
+                "origin_name": clip_info.get("origin_name", fname),
+            }
+            if media_type == "image":
+                clip_data["width"] = clip_info.get("width")
+                clip_data["height"] = clip_info.get("height")
+            elif media_type == "paragraph":
+                clip_data["word_count"] = clip_info.get("word_count")
+                clip_data["character_count"] = clip_info.get("character_count")
+
+            clips[clip_id] = clip_data
+            continue
+
+        # ── Full mode (original behaviour) ──
         # Load the actual media content.
         # Support both new key names (clip_bytes/clip_string) and legacy
         # per-media-type key names (wav_bytes/video_bytes/image_bytes/
@@ -417,6 +508,7 @@ def load_dataset_from_pickle(
         clip_bytes = None
         clip_string = None
         media_bytes = None
+        media_path = None
 
         if media_type == "audio":
             clip_bytes = clip_info.get("clip_bytes") or clip_info.get("wav_bytes")
@@ -428,6 +520,7 @@ def load_dataset_from_pickle(
                     with open(audio_path, "rb") as f:
                         clip_bytes = f.read()
                         media_bytes = clip_bytes
+                    media_path = str(audio_path.resolve())
                 else:
                     missing_media += 1
 
@@ -441,6 +534,7 @@ def load_dataset_from_pickle(
                     with open(video_path, "rb") as f:
                         clip_bytes = f.read()
                         media_bytes = clip_bytes
+                    media_path = str(video_path.resolve())
                 else:
                     missing_media += 1
 
@@ -454,6 +548,7 @@ def load_dataset_from_pickle(
                     with open(image_path, "rb") as f:
                         clip_bytes = f.read()
                         media_bytes = clip_bytes
+                    media_path = str(image_path.resolve())
                 else:
                     missing_media += 1
 
@@ -467,6 +562,7 @@ def load_dataset_from_pickle(
                     with open(text_path, "r", encoding="utf-8") as f:
                         clip_string = f.read()
                         media_bytes = clip_string.encode("utf-8")
+                    media_path = str(text_path.resolve())
                 else:
                     missing_media += 1
 
@@ -481,6 +577,7 @@ def load_dataset_from_pickle(
                 "embedding": np.array(clip_info["embedding"]),
                 "clip_bytes": clip_bytes,
                 "clip_string": clip_string,
+                "media_path": media_path or clip_info.get("media_path"),
                 "filename": fname,
                 "category": clip_info.get("category", "unknown"),
                 "origin": clip_info.get("origin", fallback_origin),
@@ -1058,6 +1155,7 @@ def export_dataset_to_file(
                 "origin_name": clip.get("origin_name", clip.get("filename", "")),
                 "clip_bytes": clip.get("clip_bytes"),
                 "clip_string": clip.get("clip_string"),
+                "media_path": clip.get("media_path"),
                 "word_count": clip.get("word_count"),
                 "character_count": clip.get("character_count"),
                 "width": clip.get("width"),

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -229,8 +229,11 @@ class AudioMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def clip_response(self, clip: dict) -> MediaResponse:
+        data = self._resolve_clip_bytes(clip)
+        if data is None:
+            return MediaResponse(data=b"", mimetype="audio/wav", download_name=f"clip_{clip['id']}.wav")
         return MediaResponse(
-            data=clip["clip_bytes"],
+            data=data,
             mimetype="audio/wav",
             download_name=f"clip_{clip['id']}.wav",
         )

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -270,6 +270,42 @@ class MediaType(ABC):
     # HTTP serving
     # ------------------------------------------------------------------
 
+    def _resolve_clip_bytes(self, clip: dict) -> bytes | None:
+        """Return binary media data, lazy-loading from ``media_path`` if needed.
+
+        In thin mode, ``clip_bytes`` is ``None`` but ``media_path`` points to
+        the source file on disk.  This helper transparently loads the bytes on
+        demand so that :meth:`clip_response` works regardless of how the clip
+        was loaded.
+        """
+        clip_bytes = clip.get("clip_bytes")
+        if clip_bytes is not None:
+            return clip_bytes
+        media_path = clip.get("media_path")
+        if media_path:
+            path = Path(media_path)
+            if path.exists():
+                with open(path, "rb") as f:
+                    return f.read()
+        return None
+
+    def _resolve_clip_string(self, clip: dict) -> str:
+        """Return text content, lazy-loading from ``media_path`` if needed.
+
+        Same lazy-loading pattern as :meth:`_resolve_clip_bytes` but for
+        text media types that store ``clip_string`` instead of ``clip_bytes``.
+        """
+        clip_string = clip.get("clip_string")
+        if clip_string is not None:
+            return clip_string
+        media_path = clip.get("media_path")
+        if media_path:
+            path = Path(media_path)
+            if path.exists():
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read().strip()
+        return ""
+
     @abstractmethod
     def clip_response(self, clip: dict) -> MediaResponse:
         """Return a :class:`MediaResponse` with the clip's media content.
@@ -277,6 +313,10 @@ class MediaType(ABC):
         For binary media, set ``data`` to raw bytes with an appropriate
         ``mimetype``.  For structured data (e.g. text paragraphs), set
         ``data`` to a JSON-serialisable dict with ``mimetype="application/json"``.
+
+        Implementations should use :meth:`_resolve_clip_bytes` or
+        :meth:`_resolve_clip_string` to transparently support both preloaded
+        clips and thin (lazy-loaded) clips.
         """
 
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -261,8 +261,11 @@ class ImageMediaType(MediaType):
         filename = clip.get("filename", "")
         ext = Path(filename).suffix.lower() if filename else ".jpg"
         mimetype = _IMAGE_MIME_TYPES.get(ext, "image/jpeg")
+        data = self._resolve_clip_bytes(clip)
+        if data is None:
+            return MediaResponse(data=b"", mimetype=mimetype, download_name=f"clip_{clip['id']}{ext}")
         return MediaResponse(
-            data=clip["clip_bytes"],
+            data=data,
             mimetype=mimetype,
             download_name=f"clip_{clip['id']}{ext}",
         )

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -202,11 +202,12 @@ class TextMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def clip_response(self, clip: dict) -> MediaResponse:
+        content = self._resolve_clip_string(clip)
         return MediaResponse(
             data={
-                "content": clip.get("clip_string", ""),
-                "word_count": clip.get("word_count", 0),
-                "character_count": clip.get("character_count", 0),
+                "content": content,
+                "word_count": clip.get("word_count", 0) or len(content.split()),
+                "character_count": clip.get("character_count", 0) or len(content),
             },
             mimetype="application/json",
         )

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -242,8 +242,11 @@ class VideoMediaType(MediaType):
         filename = clip.get("filename", "")
         ext = Path(filename).suffix.lower() if filename else ".mp4"
         mimetype = _VIDEO_MIME_TYPES.get(ext, "video/mp4")
+        data = self._resolve_clip_bytes(clip)
+        if data is None:
+            return MediaResponse(data=b"", mimetype=mimetype, download_name=f"clip_{clip['id']}{ext}")
         return MediaResponse(
-            data=clip["clip_bytes"],
+            data=data,
             mimetype=mimetype,
             download_name=f"clip_{clip['id']}{ext}",
         )


### PR DESCRIPTION
When loading datasets for CLI autodetect (scoring only, no GUI), media
bytes are never served to a browser — loading them all into memory is
wasteful and prevents processing large datasets. This adds a thin=True
mode that stores a media_path file reference instead of clip_bytes,
with streaming MD5 for constant memory usage.

- Add thin parameter to load_dataset_from_folder/pickle and all importers
- CLI autodetect paths now use thin=True automatically
- Add lazy-loading fallback in clip_response (reads from media_path on
  demand) so thin-loaded clips can still be served if needed
- Legacy clip endpoints updated to resolve bytes via media_path
- Full mode (GUI) unchanged — still preloads bytes for responsiveness

https://claude.ai/code/session_01CUUgx212puPyVgBJU451kY