### PR TITLE
Fix progress bar jiggle and add remaining time estimates

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -14,6 +14,7 @@
   let audioVolume = 1.0; // Persisted volume across clip loads
   let volumeSaveTimer = null;
   let progressTimer = null;
+  let progressEtaState = null; // { startTime, lastCurrent, lastTime } for ETA calculation
   let learnedSortController = null; // AbortController for in-flight background training
   let learnedSortDebounce = null;   // Debounce timer for background training
   const clipList = document.getElementById("clip-list");
@@ -32,6 +33,7 @@
   const sortProgressLabel = document.getElementById("sort-progress-label");
   const sortProgressFill = document.querySelector(".sort-progress-fill");
   let sortProgressTimer = null;
+  let sortEtaState = null;
 
   // --- Theme helper: read CSS custom property values for canvas drawing ---
   function themeColor(varName) {
@@ -127,6 +129,7 @@
     sortProgressFill.style.width = "";
     sortProgressFill.classList.remove("determinate");
     sortProgress.classList.add("active");
+    sortEtaState = null;
   }
 
   function showSortProgressWithPolling(label) {
@@ -137,6 +140,7 @@
   function hideSortProgress() {
     stopSortProgressPolling();
     sortProgress.classList.remove("active");
+    sortEtaState = null;
   }
 
   async function pollSortProgress() {
@@ -148,6 +152,20 @@
         const pct = Math.round((progress.current / progress.total) * 100);
         sortProgressFill.classList.add("determinate");
         sortProgressFill.style.width = `${pct}%`;
+
+        // Calculate ETA for sort operations with many items
+        const now = Date.now();
+        if (!sortEtaState || sortEtaState.total !== progress.total) {
+          sortEtaState = { startTime: now, startCurrent: progress.current, total: progress.total };
+        }
+        const elapsed = (now - sortEtaState.startTime) / 1000;
+        const done = progress.current - sortEtaState.startCurrent;
+        if (done > 0 && elapsed > 1 && progress.current < progress.total && progress.total >= 20) {
+          const rate = done / elapsed;
+          const remaining = (progress.total - progress.current) / rate;
+          sortProgressLabel.textContent = `${pct}% — ${formatETA(remaining)}`;
+          return;
+        }
       }
       if (progress.message) {
         sortProgressLabel.textContent = progress.message;
@@ -168,6 +186,21 @@
       sortProgressTimer = null;
     }
   }
+
+  // ---- ETA formatting helper ----
+  function formatETA(secondsRemaining) {
+    if (secondsRemaining < 5) return "Less than 5 seconds remaining";
+    if (secondsRemaining < 30) return "Less than 30 seconds remaining";
+    if (secondsRemaining < 60) return "Less than a minute remaining";
+    if (secondsRemaining < 90) return "About a minute remaining";
+    if (secondsRemaining < 300) return `About ${Math.round(secondsRemaining / 60)} minutes remaining`;
+    if (secondsRemaining < 3600) return `About ${Math.round(secondsRemaining / 60)} minutes remaining`;
+    const hours = Math.floor(secondsRemaining / 3600);
+    const mins = Math.round((secondsRemaining % 3600) / 60);
+    if (hours === 1) return mins > 0 ? `About 1 hour ${mins} minutes remaining` : "About 1 hour remaining";
+    return `About ${hours} hours remaining`;
+  }
+
   const stripeOverview = document.getElementById("stripe-overview");
   const stripeContainer = document.getElementById("stripe-container");
   const inclusionSlider = document.getElementById("inclusion-slider");
@@ -181,6 +214,7 @@
   const progressFill = document.getElementById("progress-fill");
   const progressText = document.getElementById("progress-text");
   const progressMessage = document.getElementById("progress-message");
+  const progressEta = document.getElementById("progress-eta");
   const demoDatasetsDiv = document.getElementById("demo-datasets");
   const extendedImporterForm = document.getElementById("extended-importer-form");
   const backButton = document.getElementById("back-button");
@@ -299,6 +333,8 @@
     progressText.textContent = "";
     progressMessage.textContent = "Loading...";
     progressMessage.style.color = "var(--text-secondary)";
+    progressEta.textContent = "";
+    progressEtaState = null;
   }
 
   async function pollProgress() {
@@ -345,10 +381,26 @@
       progressFill.classList.remove("indeterminate");
       progressFill.style.width = `${percentage}%`;
       progressText.textContent = `${percentage}%`;
+
+      // Calculate ETA
+      const now = Date.now();
+      if (!progressEtaState || progressEtaState.total !== progress.total) {
+        progressEtaState = { startTime: now, startCurrent: progress.current, total: progress.total };
+      }
+      const elapsed = (now - progressEtaState.startTime) / 1000;
+      const done = progress.current - progressEtaState.startCurrent;
+      if (done > 0 && elapsed > 1 && progress.current < progress.total) {
+        const rate = done / elapsed;
+        const remaining = (progress.total - progress.current) / rate;
+        progressEta.textContent = formatETA(remaining);
+      } else if (progress.current >= progress.total) {
+        progressEta.textContent = "";
+      }
     } else {
       // Indeterminate state - no total known yet
       progressFill.classList.add("indeterminate");
       progressText.textContent = "";
+      progressEta.textContent = "";
     }
     progressMessage.textContent = progress.message || "Loading...";
     progressMessage.style.color = "var(--text-secondary)";
@@ -366,6 +418,8 @@
       progressTimer = null;
     }
     progressFill.classList.remove("indeterminate");
+    progressEta.textContent = "";
+    progressEtaState = null;
   }
 
   // Load from file

--- a/static/index.html
+++ b/static/index.html
@@ -127,6 +127,7 @@
           <div class="progress-text" id="progress-text">0%</div>
         </div>
         <div class="progress-message" id="progress-message">Loading...</div>
+        <div class="progress-eta" id="progress-eta"></div>
       </div>
       <div class="demo-datasets" id="demo-datasets" style="display:none"></div>
       <div id="extended-importer-form" style="display:none"></div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -140,7 +140,7 @@ header h1 { margin-left: 48px; }
 .sort-progress-fill { height: 100%; width: 30%; background: linear-gradient(90deg, var(--accent), var(--accent-light)); border-radius: 3px; position: absolute; animation: sort-progress-slide 1.2s ease-in-out infinite; transition: width 0.2s; }
 .sort-progress-fill.determinate { animation: none; left: 0; }
 @keyframes sort-progress-slide { 0% { left: -30%; } 100% { left: 100%; } }
-.sort-progress-label { font-size: 0.7rem; color: var(--text-muted); margin-top: 3px; text-align: center; }
+.sort-progress-label { font-size: 0.7rem; color: var(--text-muted); margin-top: 3px; text-align: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #clip-list { overflow-y: auto; flex: 1; }
 .clip-item { padding: 10px 16px; cursor: pointer; font-size: 0.9rem; border-bottom: 1px solid var(--border-subtle); transition: background 0.15s; border-left: 3px solid transparent; }
 .clip-item:hover { background: var(--bg-subtle); }
@@ -235,7 +235,8 @@ video { max-width: 600px; max-height: 400px; }
 .progress-fill.indeterminate { width: 30% !important; animation: indeterminate 1.5s ease-in-out infinite; }
 @keyframes indeterminate { 0% { margin-left: 0%; } 50% { margin-left: 70%; } 100% { margin-left: 0%; } }
 .progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.75rem; color: #fff; font-weight: bold; }
-.progress-message { font-size: 0.85rem; color: var(--text-secondary); margin-top: 8px; text-align: center; }
+.progress-message { font-size: 0.85rem; color: var(--text-secondary); margin-top: 8px; text-align: center; width: 100%; max-width: 500px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.progress-eta { font-size: 0.75rem; color: var(--text-muted); margin-top: 4px; text-align: center; min-height: 1.1em; }
 .demo-datasets { display: grid; grid-template-columns: repeat(4, minmax(180px, 1fr)); gap: 16px; width: 100%; margin-top: 16px; }
 .demo-column { display: flex; flex-direction: column; gap: 8px; }
 .demo-column-header { font-size: 0.7rem; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.08em; padding-bottom: 6px; border-bottom: 1px solid var(--border); margin-bottom: 2px; }


### PR DESCRIPTION
- Fix dataset progress message width jiggle by constraining to max-width
  with text-overflow ellipsis truncation
- Fix sort progress label jiggle with overflow/ellipsis in left panel
- Add ETA display below dataset progress bar ("About 10 minutes remaining",
  "Less than a minute remaining", etc.) using elapsed-rate calculation
- Add ETA to sort progress label for operations with 20+ items
- Reset ETA state on progress start/stop to avoid stale estimates

https://claude.ai/code/session_012umQEX5eC8uPewACoa8urg