### PR TITLE
Update documentation to match current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-A media explorer web app. Browse collections of audio clips, images, or text paragraphs — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, CLIP, or E5-large-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python) and vanilla JavaScript.
+A media explorer web app. Browse collections of audio clips, images, text paragraphs, or videos — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, CLIP, X-CLIP, or E5-base-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python) and vanilla JavaScript.
 
 ## Setup
 
@@ -69,12 +69,13 @@ python -m pytest tests/ -v
 ├── vtsearch/                       # Main application package
 │   ├── config.py                   # Constants (SAMPLE_RATE, paths, model IDs)
 │   ├── clips.py                    # Test clip generation & embedding cache
-│   ├── cli.py                      # CLI utilities: autodetect, label import, processor import
+│   ├── cli.py                      # CLI utilities: autodetect workflow
 │   ├── settings.py                 # Persistent settings & favorite processors
 │   ├── routes/                     # Flask blueprints
 │   ├── models/                     # ML models (embeddings, training, progress)
 │   ├── media/                      # Media type plugins (audio, image, text, video)
 │   ├── datasets/                   # Dataset loading, downloading, importers
+│   ├── eval/                       # Evaluation framework (metrics, runner, visualisation)
 │   ├── exporters/                  # Results exporter plugins
 │   ├── labels/importers/           # Label importer plugins
 │   ├── processors/importers/       # Processor importer plugins
@@ -113,9 +114,11 @@ This runs text-sort and learned-sort evaluations across all demo datasets, print
 
 ## Extending with plugins
 
-VTSearch has a plugin architecture for media types, data importers, and results exporters. See [docs/EXTENDING.md](docs/EXTENDING.md) for full documentation, including:
+VTSearch has a plugin architecture for media types, data importers, results exporters, label importers, and processor importers. See [docs/EXTENDING.md](docs/EXTENDING.md) for full documentation, including:
 
 - **[Adding a Data Importer](docs/EXTENDING.md#adding-a-data-importer)** — Auto-discovered plugins that load datasets from new sources (S3, databases, APIs, etc.). Subclass `DatasetImporter`, expose an `IMPORTER` instance, and the system wires up API routes and UI forms automatically.
-- **[Adding a Results Exporter](docs/EXTENDING.md#adding-a-results-exporter)** — Export votes, labels, or detector weights in new formats by adding routes to the appropriate blueprint.
+- **[Adding a Results Exporter](docs/EXTENDING.md#adding-a-results-exporter)** — Auto-discovered plugins that export autodetect results to new destinations (files, webhooks, email, etc.). Subclass `LabelsetExporter` and expose an `EXPORTER` instance.
+- **[Adding a Label Importer](docs/EXTENDING.md#adding-a-label-importer)** — Auto-discovered plugins that import pre-existing labels from external sources (JSON, CSV, databases). Subclass `LabelImporter` and expose a `LABEL_IMPORTER` instance.
+- **[Adding a Processor Importer](docs/EXTENDING.md#adding-a-processor-importer)** — Auto-discovered plugins that import processors (detectors/extractors) from external sources. Subclass `ProcessorImporter` and expose a `PROCESSOR_IMPORTER` instance.
 - **[Adding a Media Type](docs/EXTENDING.md#adding-a-media-type)** — Support new content types (code, 3D models, etc.) by subclassing `MediaType` with embedding, serving, and clip-loading methods.
 - **[Dependency Management](docs/EXTENDING.md#dependency-management)** — How the layered requirements file structure works and where to add new dependencies.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,12 +18,12 @@ python app.py --autodetect --dataset path/to/dataset.pkl --settings settings.jso
 
 ```bash
 python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings settings.json
-python app.py --autodetect --importer http_archive --url https://example.com/data.zip --settings settings.json
+python app.py --autodetect --importer http_zip --url https://example.com/data.zip --settings settings.json
 python app.py --autodetect --importer rss_feed --url https://example.com/feed.xml --settings settings.json
 python app.py --autodetect --importer youtube_playlist --url https://youtube.com/playlist?list=... --settings settings.json
 ```
 
-Available importers: `folder`, `pickle`, `http_archive`, `rss_feed`, `youtube_playlist`. Each importer adds its own flags — run `python app.py --autodetect --importer <name> --help` to see them (e.g. `--max-episodes` for RSS, `--max-videos` for YouTube).
+Available importers: `folder`, `pickle`, `http_zip`, `rss_feed`, `youtube_playlist`. Each importer adds its own flags — run `python app.py --autodetect --importer <name> --help` to see them (e.g. `--max-episodes` for RSS, `--max-videos` for YouTube).
 
 **Exporting results** — by default results are printed to the console. Add `--exporter <name>` to send them elsewhere:
 
@@ -80,10 +80,23 @@ Predicted Good (5 items):
   1-77445-A-1.wav  (score: 0.6204, category: cat)
 ```
 
-## Development mode
+## Web server modes
 
-Run the server bound to `0.0.0.0` for access from other devices on the network:
+**Default (production) mode** — loads all embedding models eagerly at startup,
+then starts the server.  The app is fully ready when the startup message
+appears:
+
+```bash
+python app.py
+```
+
+**Development mode** (`--local`) — skips eager model loading; models load
+lazily the first time a dataset of that media type is opened.  Faster to
+start, but the first dataset load is slower:
 
 ```bash
 python app.py --local
 ```
+
+Both modes bind to `0.0.0.0:5000` (accessible from other devices on the
+network).

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -94,4 +94,4 @@ To reconstruct a model from saved weights, use `build_model(input_dim)` followed
 - `vtsearch/models/progress.py` — Cached per-step training and stability analysis
 - `vtsearch/models/loader.py` — Model initialization and thread configuration
 - `vtsearch/eval/voting_iterations.py` — Voting simulation evaluation
-- `config.py` — `TRAIN_EPOCHS` and model IDs
+- `vtsearch/config.py` — `TRAIN_EPOCHS` and model IDs


### PR DESCRIPTION
- Fix E5-large-v2 → E5-base-v2 and add video/X-CLIP to README intro
- Add missing modules to CLAUDE.md: settings.py, eval/, datasets/ingest.py,
  csv_label_file processor importer, settings route
- Add 9 missing test files to CLAUDE.md test list
- Fix ARCHITECTURE.md: config.py path, add processors/importers/ and eval/
  to directory map, add settings route, update state table with
  textsort_suggestions and persistent settings
- Rewrite EXTENDING.md exporters section: document actual LabelsetExporter
  plugin system with auto-discovery (was incorrectly described as manual
  route-based). Add new sections for label importers and processor importers.
  Update dependency management to include requirements-exporters.txt.
- Fix CLI.md: correct http_archive → http_zip importer name, rewrite
  --local description to accurately describe lazy vs eager model loading
- Fix ML.md: config.py → vtsearch/config.py path reference

https://claude.ai/code/session_018m6j8NqUSsRZquFH9bCQJv