### PR TITLE
Add combine-datasets importer to merge multiple .pkl datasets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_processors.py` — Media processor tests
   - `test_processor_importers.py` — Processor importer base class, registry, detector_file/label_file importers, API routes
   - `test_origin_labelset.py` — Origin class, LabeledElement, LabelSet, build_origin(), label export/import with origins, integration
+  - `test_combine_datasets.py` — Combine-datasets importer: metadata, dedup, media type validation, CLI, API routes
   - `test_creation_info.py` — Legacy creation_info handling in pickle datasets
   - `test_enrich_descriptions.py` — Enriched text-sort description embedding
   - `test_eval.py` — Evaluation framework runner and metrics

--- a/tests/test_combine_datasets.py
+++ b/tests/test_combine_datasets.py
@@ -1,0 +1,393 @@
+"""Tests for the combine-datasets importer.
+
+Covers:
+- Importer metadata (name, icon, description, fields)
+- Importer is excluded from the generic /api/dataset/importers list
+- Combining two pickle datasets with the same media type
+- Duplicate detection by MD5 hash
+- Media type mismatch rejection
+- Fewer than two datasets rejection
+- Missing file error handling
+- Available-files endpoint
+- Combine API endpoint
+- CLI support (run_cli)
+- build_origin method
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pytest
+
+
+def _make_audio_clip(clip_id: int, md5: str = "", filename: str = "") -> dict:
+    """Return a minimal clip dict for testing."""
+    if not filename:
+        filename = f"clip_{clip_id}.wav"
+    if not md5:
+        md5 = f"md5_{clip_id:04d}"
+    return {
+        "id": clip_id,
+        "type": "audio",
+        "duration": 1.0,
+        "file_size": 1000,
+        "md5": md5,
+        "embedding": np.array([float(clip_id), float(clip_id) + 0.5]),
+        "clip_bytes": b"\x00" * 100,
+        "clip_string": None,
+        "media_path": None,
+        "filename": filename,
+        "category": "test",
+        "origin": None,
+        "origin_name": filename,
+    }
+
+
+def _make_image_clip(clip_id: int, md5: str = "") -> dict:
+    """Return a minimal image clip dict for testing."""
+    if not md5:
+        md5 = f"md5_{clip_id:04d}"
+    return {
+        "id": clip_id,
+        "type": "image",
+        "duration": 0,
+        "file_size": 2000,
+        "md5": md5,
+        "embedding": np.array([float(clip_id)]),
+        "clip_bytes": b"\x89PNG" + b"\x00" * 100,
+        "clip_string": None,
+        "media_path": None,
+        "filename": f"img_{clip_id}.png",
+        "category": "test",
+        "origin": None,
+        "origin_name": f"img_{clip_id}.png",
+        "width": 32,
+        "height": 32,
+    }
+
+
+def _write_pickle_dataset(path, clips_dict):
+    """Write a pickle dataset file in the standard format."""
+    data = {
+        "clips": {
+            cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items()}
+            for cid, clip in clips_dict.items()
+        }
+    }
+    with open(path, "wb") as f:
+        pickle.dump(data, f)
+
+
+# ---------------------------------------------------------------------------
+# Importer metadata
+# ---------------------------------------------------------------------------
+
+
+class TestCombineDatasetsMetadata:
+    def _get_importer(self):
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        return IMPORTER
+
+    def test_name(self):
+        assert self._get_importer().name == "combine_datasets"
+
+    def test_display_name(self):
+        assert "Combine" in self._get_importer().display_name
+
+    def test_icon(self):
+        assert self._get_importer().icon == "\U0001f500"
+
+    def test_description_mentions_merge_or_combine(self):
+        desc = self._get_importer().description.lower()
+        assert "merge" in desc or "combine" in desc
+
+    def test_description_mentions_duplicates(self):
+        desc = self._get_importer().description.lower()
+        assert "duplicate" in desc
+
+    def test_to_dict_includes_icon(self):
+        d = self._get_importer().to_dict()
+        assert d["icon"] == "\U0001f500"
+        assert d["name"] == "combine_datasets"
+
+    def test_fields_include_datasets(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "datasets" in fields
+
+
+# ---------------------------------------------------------------------------
+# Excluded from generic importer list (has dedicated UI)
+# ---------------------------------------------------------------------------
+
+
+class TestCombineDatasetsBuiltinExclusion:
+    def test_combine_datasets_in_builtin_names(self):
+        from vtsearch.routes.datasets import _BUILTIN_IMPORTER_NAMES
+
+        assert "combine_datasets" in _BUILTIN_IMPORTER_NAMES
+
+    def test_combine_datasets_not_in_extended_list(self, client):
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        names = [imp["name"] for imp in data["importers"]]
+        assert "combine_datasets" not in names
+
+
+# ---------------------------------------------------------------------------
+# Core combining logic
+# ---------------------------------------------------------------------------
+
+
+class TestCombineDatasetsRun:
+    def test_combine_two_datasets(self, tmp_path):
+        """Two datasets with the same media type are merged."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1), 2: _make_audio_clip(2)}
+        ds2 = {1: _make_audio_clip(3), 2: _make_audio_clip(4)}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        clips: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2)]}, clips)
+
+        assert len(clips) == 4
+        # IDs should be re-assigned sequentially
+        assert set(clips.keys()) == {1, 2, 3, 4}
+
+    def test_deduplication_by_md5(self, tmp_path):
+        """Clips with the same MD5 across datasets are included only once."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        shared_md5 = "deadbeef1234567890abcdef12345678"
+        ds1 = {1: _make_audio_clip(1, md5=shared_md5), 2: _make_audio_clip(2)}
+        ds2 = {1: _make_audio_clip(3, md5=shared_md5), 2: _make_audio_clip(4)}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        clips: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2)]}, clips)
+
+        assert len(clips) == 3  # 4 total minus 1 duplicate
+        md5s = [c["md5"] for c in clips.values()]
+        assert md5s.count(shared_md5) == 1
+
+    def test_media_type_mismatch_raises(self, tmp_path):
+        """Combining audio and image datasets raises ValueError."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        ds2 = {1: _make_image_clip(2)}
+        p1, p2 = tmp_path / "audio.pkl", tmp_path / "image.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        clips: dict = {}
+        with pytest.raises(ValueError, match="Media type mismatch"):
+            IMPORTER.run({"datasets": [str(p1), str(p2)]}, clips)
+
+    def test_fewer_than_two_datasets_raises(self, tmp_path):
+        """Providing only one dataset raises ValueError."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        p1 = tmp_path / "ds1.pkl"
+        _write_pickle_dataset(p1, ds1)
+
+        clips: dict = {}
+        with pytest.raises(ValueError, match="At least two"):
+            IMPORTER.run({"datasets": [str(p1)]}, clips)
+
+    def test_missing_file_raises(self, tmp_path):
+        """A non-existent path raises FileNotFoundError."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        p1 = tmp_path / "ds1.pkl"
+        _write_pickle_dataset(p1, ds1)
+
+        clips: dict = {}
+        with pytest.raises(FileNotFoundError):
+            IMPORTER.run({"datasets": [str(p1), str(tmp_path / "missing.pkl")]}, clips)
+
+    def test_comma_separated_string_input(self, tmp_path):
+        """The datasets field also accepts a comma-separated string."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        ds2 = {1: _make_audio_clip(2)}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        clips: dict = {}
+        IMPORTER.run({"datasets": f"{p1},{p2}"}, clips)
+
+        assert len(clips) == 2
+
+    def test_empty_dataset_skipped(self, tmp_path):
+        """An empty pickle file is skipped without error."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        empty = {}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "empty.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, empty)
+
+        # Need a third non-empty dataset to meet minimum of 2 datasets
+        ds3 = {1: _make_audio_clip(3)}
+        p3 = tmp_path / "ds3.pkl"
+        _write_pickle_dataset(p3, ds3)
+
+        clips: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2), str(p3)]}, clips)
+
+        assert len(clips) == 2
+
+    def test_preserves_clip_data_fields(self, tmp_path):
+        """Merged clips retain their original data fields."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1, filename="song_a.wav")}
+        ds2 = {1: _make_audio_clip(2, filename="song_b.wav")}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        clips: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2)]}, clips)
+
+        filenames = {c["filename"] for c in clips.values()}
+        assert "song_a.wav" in filenames
+        assert "song_b.wav" in filenames
+
+    def test_three_datasets_combined(self, tmp_path):
+        """Three datasets combine correctly."""
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        ds2 = {1: _make_audio_clip(2)}
+        ds3 = {1: _make_audio_clip(3)}
+        p1, p2, p3 = tmp_path / "a.pkl", tmp_path / "b.pkl", tmp_path / "c.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+        _write_pickle_dataset(p3, ds3)
+
+        clips: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2), str(p3)]}, clips)
+
+        assert len(clips) == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI support
+# ---------------------------------------------------------------------------
+
+
+class TestCombineDatasetsCli:
+    def test_run_cli_delegates_to_run(self, tmp_path):
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_audio_clip(1)}
+        ds2 = {1: _make_audio_clip(2)}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        clips: dict = {}
+        IMPORTER.run_cli({"datasets": f"{p1},{p2}"}, clips)
+
+        assert len(clips) == 2
+
+
+# ---------------------------------------------------------------------------
+# build_origin
+# ---------------------------------------------------------------------------
+
+
+class TestCombineDatasetsOrigin:
+    def test_build_origin_with_list(self):
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        origin = IMPORTER.build_origin({"datasets": ["/a.pkl", "/b.pkl"]})
+        assert origin["importer"] == "combine_datasets"
+        assert "/a.pkl" in origin["params"]["datasets"]
+        assert "/b.pkl" in origin["params"]["datasets"]
+
+    def test_build_origin_with_string(self):
+        from vtsearch.datasets.importers.combine_datasets import IMPORTER
+
+        origin = IMPORTER.build_origin({"datasets": "/a.pkl,/b.pkl"})
+        assert origin["importer"] == "combine_datasets"
+        assert origin["params"]["datasets"] == "/a.pkl,/b.pkl"
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableFilesEndpoint:
+    def test_returns_list(self, client):
+        resp = client.get("/api/dataset/available-files")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "files" in data
+        assert isinstance(data["files"], list)
+
+    def test_lists_pkl_files(self, client, tmp_path):
+        """When EMBEDDINGS_DIR contains .pkl files, they appear in the list."""
+        from vtsearch.config import EMBEDDINGS_DIR
+
+        EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+        test_pkl = EMBEDDINGS_DIR / "_test_combine.pkl"
+        test_pkl.write_bytes(pickle.dumps({"clips": {}}))
+        try:
+            resp = client.get("/api/dataset/available-files")
+            data = resp.get_json()
+            names = [f["name"] for f in data["files"]]
+            assert "_test_combine" in names
+            # Check fields
+            entry = next(f for f in data["files"] if f["name"] == "_test_combine")
+            assert "path" in entry
+            assert "size_mb" in entry
+        finally:
+            test_pkl.unlink(missing_ok=True)
+
+
+class TestCombineEndpoint:
+    def test_rejects_fewer_than_two(self, client):
+        resp = client.post(
+            "/api/dataset/combine",
+            json={"datasets": ["/one.pkl"]},
+        )
+        assert resp.status_code == 400
+
+    def test_rejects_missing_file(self, client, tmp_path):
+        resp = client.post(
+            "/api/dataset/combine",
+            json={"datasets": ["/nonexistent_a.pkl", "/nonexistent_b.pkl"]},
+        )
+        assert resp.status_code == 404
+
+    def test_accepts_valid_request(self, client, tmp_path):
+        """A valid request returns 200 with ok=True."""
+        ds1 = {1: _make_audio_clip(1)}
+        ds2 = {1: _make_audio_clip(2)}
+        p1, p2 = tmp_path / "ds1.pkl", tmp_path / "ds2.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        resp = client.post(
+            "/api/dataset/combine",
+            json={"datasets": [str(p1), str(p2)]},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -1,0 +1,146 @@
+"""Combine-datasets importer -- merge multiple pickle datasets into one.
+
+All source datasets must share the same media type.  Duplicate entries
+(identified by MD5 hash) are kept only once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+
+
+def _get_progress():
+    from vtsearch.utils import update_progress
+
+    return update_progress
+
+
+def _load_clips_from_pickle(file_path: Path) -> dict[int, dict[str, Any]]:
+    """Load clips from a pickle file without clearing a target dict.
+
+    Returns a fresh dict mapping clip-id to clip-data.  This is a
+    simplified version of :func:`~vtsearch.datasets.loader.load_dataset_from_pickle`
+    that avoids side-effects on any global state.
+    """
+    from vtsearch.datasets.loader import load_dataset_from_pickle
+
+    temp_clips: dict[int, dict[str, Any]] = {}
+    load_dataset_from_pickle(file_path, temp_clips)
+    return temp_clips
+
+
+class CombineDatasetsImporter(DatasetImporter):
+    """Merge two or more existing ``.pkl`` datasets into a single dataset.
+
+    All datasets must be of the same media type.  Entries with duplicate
+    MD5 hashes are included only once (the first occurrence wins).
+    """
+
+    name = "combine_datasets"
+    display_name = "Combine Existing Datasets"
+    description = "Merge multiple .pkl datasets into one, skipping duplicates."
+    icon = "\U0001f500"  # twisted rightwards arrows
+    fields = [
+        ImporterField(
+            key="datasets",
+            label="Dataset Files",
+            field_type="text",
+            description="Comma-separated paths to .pkl dataset files.",
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
+        """Combine datasets specified by *field_values['datasets']*.
+
+        ``field_values["datasets"]`` may be either:
+        - a comma-separated string of file paths, or
+        - a Python list of path strings (when called from the API route).
+        """
+        raw = field_values.get("datasets", "")
+        if isinstance(raw, list):
+            paths = [Path(p) for p in raw if p]
+        else:
+            paths = [Path(p.strip()) for p in raw.split(",") if p.strip()]
+
+        if len(paths) < 2:
+            raise ValueError("At least two datasets are required to combine.")
+
+        for p in paths:
+            if not p.exists():
+                raise FileNotFoundError(f"Dataset file not found: {p}")
+
+        progress = _get_progress()
+
+        # Load each dataset, validate media types, collect clips
+        all_clips: list[dict[str, Any]] = []
+        media_type: str | None = None
+        seen_md5s: set[str] = set()
+        total_dupes = 0
+
+        for i, pkl_path in enumerate(paths):
+            progress(
+                "loading",
+                f"Loading dataset {i + 1}/{len(paths)}: {pkl_path.name}...",
+                i + 1,
+                len(paths),
+            )
+            source_clips = _load_clips_from_pickle(pkl_path)
+
+            if not source_clips:
+                progress("loading", f"Skipping empty dataset: {pkl_path.name}", i + 1, len(paths))
+                continue
+
+            # Check media type consistency
+            first_clip = next(iter(source_clips.values()))
+            source_media_type = first_clip.get("type", "audio")
+
+            if media_type is None:
+                media_type = source_media_type
+            elif source_media_type != media_type:
+                raise ValueError(
+                    f"Media type mismatch: expected '{media_type}' but "
+                    f"'{pkl_path.name}' contains '{source_media_type}' clips."
+                )
+
+            # Collect clips, deduplicating by MD5
+            for clip in source_clips.values():
+                md5 = clip.get("md5", "")
+                if md5 and md5 in seen_md5s:
+                    total_dupes += 1
+                    continue
+                if md5:
+                    seen_md5s.add(md5)
+                all_clips.append(clip)
+
+        if not all_clips:
+            raise ValueError("No clips found in any of the selected datasets.")
+
+        # Assign fresh sequential IDs and populate the target clips dict
+        clips.clear()
+        for new_id, clip in enumerate(all_clips, start=1):
+            clip["id"] = new_id
+            clips[new_id] = clip
+
+        msg = f"Combined {len(clips)} clips from {len(paths)} datasets"
+        if total_dupes:
+            msg += f" ({total_dupes} duplicate(s) skipped)"
+        progress("idle", msg)
+
+    def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
+        """CLI entry point -- *datasets* is a comma-separated path string."""
+        self.run(field_values, clips, thin=thin)
+
+    def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
+        """Build an origin dict listing the source dataset paths."""
+        raw = field_values.get("datasets", "")
+        if isinstance(raw, list):
+            datasets_str = ",".join(raw)
+        else:
+            datasets_str = raw
+        return {"importer": self.name, "params": {"datasets": datasets_str}}
+
+
+IMPORTER = CombineDatasetsImporter()


### PR DESCRIPTION
Adds a new DatasetImporter that lets users select two or more existing
.pkl dataset files and merge them into a single dataset. Validates that
all datasets share the same media type and deduplicates entries by MD5
hash (first occurrence wins).

- New importer at vtsearch/datasets/importers/combine_datasets/
- API routes: /api/dataset/available-files lists .pkl files,
  /api/dataset/combine performs the merge in a background thread
- Frontend: "Combine Existing Datasets" button in Change Dataset panel
  with checkbox selection of available files and manual path entry
- Tests covering metadata, dedup, type mismatch, CLI, and API routes

https://claude.ai/code/session_015qAG12QZuYVk2haSsapDtW