### PR TITLE
Add HighViz high-contrast theme alongside Dark and Light

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -336,6 +336,7 @@ dicts:
 Persistent settings (volume, theme, inclusion, `enrich_descriptions`,
 `safe_thresholds`, favorite processor recipes) live separately in
 `vtsearch/settings.py` and are auto-saved to `data/settings.json`.
+Theme supports three modes: `dark`, `light`, and `highviz` (high-contrast).
 
 **Only Flask routes mutate this state.**  All ML and dataset functions
 accept state as parameters — they never import it directly.  This means

--- a/docs/FEATURE_IDEAS.md
+++ b/docs/FEATURE_IDEAS.md
@@ -164,7 +164,7 @@ Brainstorm of potential features organized by category.
 
 124. **Screen reader support** — Add ARIA labels and keyboard navigation for full accessibility compliance.
 125. **Internationalization (i18n)** — Support multiple UI languages with a language switcher.
-126. **High contrast mode** — A high-contrast theme option beyond the current light/dark toggle.
+126. ~~**High contrast mode** — A high-contrast theme option beyond the current light/dark toggle.~~ *(Implemented: HighViz theme)*
 127. **Configurable font size** — Let users adjust the UI font size for readability.
 128. **Color-blind friendly palettes** — Use colorblind-safe colors for charts, confidence overlays, and the stripe overview.
 

--- a/static/app.js
+++ b/static/app.js
@@ -3126,19 +3126,17 @@
 
   // ---- Theme toggle ----
 
-  const themeToggleCheckbox = document.getElementById("theme-toggle-checkbox");
-  const themeLabel = document.getElementById("theme-label");
+  const themeBtns = document.querySelectorAll(".theme-btn");
 
   function applyTheme(theme) {
-    if (theme === "light") {
-      document.documentElement.setAttribute("data-theme", "light");
-      if (themeToggleCheckbox) themeToggleCheckbox.checked = true;
-      if (themeLabel) themeLabel.textContent = "Light Mode";
+    if (theme === "light" || theme === "highviz") {
+      document.documentElement.setAttribute("data-theme", theme);
     } else {
       document.documentElement.removeAttribute("data-theme");
-      if (themeToggleCheckbox) themeToggleCheckbox.checked = false;
-      if (themeLabel) themeLabel.textContent = "Dark Mode";
     }
+    themeBtns.forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.theme === theme);
+    });
   }
 
   function saveTheme(theme) {
@@ -3149,13 +3147,13 @@
     }).catch(() => {});
   }
 
-  if (themeToggleCheckbox) {
-    themeToggleCheckbox.addEventListener("change", () => {
-      const theme = themeToggleCheckbox.checked ? "light" : "dark";
+  themeBtns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const theme = btn.dataset.theme;
       applyTheme(theme);
       saveTheme(theme);
     });
-  }
+  });
 
   async function loadSettings() {
     try {

--- a/static/index.html
+++ b/static/index.html
@@ -42,12 +42,10 @@
       </div>
       <div class="burger-section">
         <div class="burger-section-title">Appearance</div>
-        <div class="theme-toggle">
-          <span class="theme-toggle-label" id="theme-label">Light Mode</span>
-          <label class="theme-switch">
-            <input type="checkbox" id="theme-toggle-checkbox">
-            <span class="theme-switch-slider"></span>
-          </label>
+        <div class="theme-selector">
+          <button class="theme-btn active" data-theme="dark">Dark</button>
+          <button class="theme-btn" data-theme="light">Light</button>
+          <button class="theme-btn" data-theme="highviz">HighViz</button>
         </div>
       </div>
       <div class="burger-section">

--- a/static/styles.css
+++ b/static/styles.css
@@ -88,6 +88,50 @@
   --status-green-sub: #66bb6a;
 }
 
+[data-theme="highviz"] {
+  --bg-body: #000000;
+  --bg-surface: #0a0a0a;
+  --bg-panel: #050505;
+  --bg-hover: #1a1a1a;
+  --bg-subtle: #111111;
+  --bg-secondary-btn: #222222;
+  --border: #ffffff;
+  --border-secondary: #cccccc;
+  --border-subtle: #666666;
+  --text-primary: #ffffff;
+  --text-secondary: #f0f0f0;
+  --text-muted: #dddddd;
+  --text-dim: #cccccc;
+  --text-placeholder: #999999;
+  --text-vote: #ffffff;
+  --text-btn-secondary: #ffffff;
+  --accent: #ffff00;
+  --accent-light: #ffff66;
+  --accent-hover: #cccc00;
+  --color-good: #00ff00;
+  --color-bad: #ff0000;
+  --shadow-dropdown: rgba(255,255,255,0.2);
+  --modal-backdrop: rgba(0,0,0,0.85);
+  --indicator-border: #ffffff;
+  --indicator-dot: #ffffff;
+  --good-bg: rgba(0, 255, 0, 0.12);
+  --bad-bg: rgba(255, 0, 0, 0.12);
+  --accent-highlight-bg: rgba(255, 255, 0, 0.2);
+  --accent-highlight-border: rgba(255, 255, 0, 0.6);
+  --status-red-border: #ff0000;
+  --status-red-dot: #ff3333;
+  --status-red-label: #ff4444;
+  --status-red-sub: #cc0000;
+  --status-yellow-border: #ffff00;
+  --status-yellow-dot: #ffff33;
+  --status-yellow-label: #ffff00;
+  --status-yellow-sub: #cccc00;
+  --status-green-border: #00ff00;
+  --status-green-dot: #33ff33;
+  --status-green-label: #00ff00;
+  --status-green-sub: #00cc00;
+}
+
 /* ---- Base ---- */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: var(--bg-body); color: var(--text-primary); height: 100vh; display: flex; flex-direction: column; }
@@ -112,15 +156,11 @@ header h1 { font-size: 1.3rem; color: var(--accent); }
 .burger-status { font-size: 0.7rem; color: var(--text-dim); padding: 4px 16px 8px; }
 header h1 { margin-left: 48px; }
 
-/* Theme toggle */
-.theme-toggle { display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; font-size: 0.85rem; color: var(--text-secondary); }
-.theme-toggle-label { display: flex; align-items: center; gap: 6px; }
-.theme-switch { position: relative; width: 36px; height: 20px; flex-shrink: 0; }
-.theme-switch input { opacity: 0; width: 0; height: 0; }
-.theme-switch-slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background: var(--bg-secondary-btn); border: 1px solid var(--border-secondary); border-radius: 20px; transition: background 0.2s; }
-.theme-switch-slider::before { content: ""; position: absolute; height: 14px; width: 14px; left: 2px; bottom: 2px; background: var(--text-secondary); border-radius: 50%; transition: transform 0.2s; }
-.theme-switch input:checked + .theme-switch-slider { background: var(--accent); border-color: var(--accent); }
-.theme-switch input:checked + .theme-switch-slider::before { transform: translateX(16px); background: #fff; }
+/* Theme selector */
+.theme-selector { display: flex; gap: 4px; padding: 8px 16px; }
+.theme-btn { flex: 1; padding: 5px 8px; font-size: 0.78rem; border: 1px solid var(--border-secondary); border-radius: 4px; background: var(--bg-secondary-btn); color: var(--text-secondary); cursor: pointer; transition: all 0.15s; text-align: center; }
+.theme-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.theme-btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
 
 /* Left panel – clip list */
 .panel-left { width: 240px; border-right: 1px solid var(--border); overflow-y: auto; background: var(--bg-panel); display: flex; flex-direction: column; position: relative; }

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -54,7 +54,7 @@ def update_settings():
         try:
             settings.set_theme(str(body["theme"]))
         except ValueError:
-            return jsonify({"error": "theme must be 'dark' or 'light'"}), 400
+            return jsonify({"error": "theme must be 'dark', 'light', or 'highviz'"}), 400
 
     if "inclusion" in body:
         try:

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -112,14 +112,17 @@ def set_inclusion(value: int) -> None:
     _save(s)
 
 
+VALID_THEMES = ("dark", "light", "highviz")
+
+
 def get_theme() -> str:
-    """Return the persisted theme ('dark' or 'light')."""
+    """Return the persisted theme ('dark', 'light', or 'highviz')."""
     return str(_ensure_loaded().get("theme", _DEFAULTS["theme"]))
 
 
 def set_theme(value: str) -> None:
-    """Set and persist the theme.  Must be 'dark' or 'light'."""
-    if value not in ("dark", "light"):
+    """Set and persist the theme.  Must be 'dark', 'light', or 'highviz'."""
+    if value not in VALID_THEMES:
         raise ValueError(f"Invalid theme: {value!r}")
     s = _ensure_loaded()
     s["theme"] = value


### PR DESCRIPTION
Adds a third theme option ("highviz") with black backgrounds, white
borders/text, and vivid yellow/green/red accents for maximum contrast.
Replaces the dark/light toggle checkbox with a 3-button segmented
selector in the burger menu. Updates settings validation, API error
messages, and docs.

https://claude.ai/code/session_01VWtNmvucJ656TcHiohAkqe