### PR TITLE
Add Settings GUI modal with Default/Import/Export buttons

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -270,6 +270,16 @@
   const autodetectProgressText = document.getElementById("autodetect-progress-text");
   const autodetectProgressBar = document.getElementById("autodetect-progress-bar");
 
+  // Settings modal elements
+  const menuSettings = document.getElementById("menu-settings");
+  const settingsModal = document.getElementById("settings-modal");
+  const settingsModalClose = document.getElementById("settings-modal-close");
+  const safeThresholdsCheckbox = document.getElementById("safe-thresholds-checkbox");
+  const settingsDefaultBtn = document.getElementById("settings-default-btn");
+  const settingsImportBtn = document.getElementById("settings-import-btn");
+  const settingsImportFile = document.getElementById("settings-import-file");
+  const settingsExportBtn = document.getElementById("settings-export-btn");
+
   // ---- Dataset Management ----
 
   async function checkDatasetStatus() {
@@ -1415,6 +1425,128 @@
           copyResultsBtn.textContent = "Copy To Clipboard";
         }, 2000);
       });
+    });
+  }
+
+  // ---- Settings modal ----
+
+  function populateSettingsModal(data) {
+    if (themeToggleCheckbox) themeToggleCheckbox.checked = data.theme === "light";
+    if (themeLabel) themeLabel.textContent = data.theme === "light" ? "Light Mode" : "Dark Mode";
+    if (calibrateCountInput) calibrateCountInput.value = data.calibrate_count;
+    if (calibrationFractionInput) calibrationFractionInput.value = data.calibration_fraction;
+    if (safeThresholdsCheckbox) safeThresholdsCheckbox.checked = !!data.safe_thresholds;
+  }
+
+  if (menuSettings && settingsModal && burgerDropdown) {
+    menuSettings.addEventListener("click", async () => {
+      burgerDropdown.classList.remove("show");
+      try {
+        const res = await fetch("/api/settings");
+        if (res.ok) populateSettingsModal(await res.json());
+      } catch (_) {}
+      settingsModal.classList.add("show");
+    });
+  }
+
+  if (settingsModalClose) {
+    settingsModalClose.addEventListener("click", () => {
+      settingsModal.classList.remove("show");
+    });
+  }
+
+  // Safe thresholds toggle
+  if (safeThresholdsCheckbox) {
+    safeThresholdsCheckbox.addEventListener("change", () => {
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ safe_thresholds: safeThresholdsCheckbox.checked }),
+      }).catch(() => {});
+    });
+  }
+
+  // Default button — reset all settings to defaults
+  if (settingsDefaultBtn) {
+    settingsDefaultBtn.addEventListener("click", async () => {
+      try {
+        const res = await fetch("/api/settings/defaults");
+        if (!res.ok) return;
+        const defaults = await res.json();
+        // Apply defaults to server
+        await fetch("/api/settings", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(defaults),
+        });
+        // Update modal controls
+        populateSettingsModal(defaults);
+        // Apply theme immediately
+        applyTheme(defaults.theme || "dark");
+        // Update main UI controls that live outside the modal
+        if (enrichDescCheckbox) enrichDescCheckbox.checked = !!defaults.enrich_descriptions;
+        if (inclusionSlider) { inclusionSlider.value = defaults.inclusion || 0; inclusionValue.textContent = defaults.inclusion || 0; inclusion = defaults.inclusion || 0; }
+        audioVolume = defaults.volume != null ? defaults.volume : 1.0;
+        const audioEl = document.getElementById("clip-audio");
+        if (audioEl) audioEl.volume = audioVolume;
+      } catch (_) {}
+    });
+  }
+
+  // Import settings from file
+  if (settingsImportBtn && settingsImportFile) {
+    settingsImportBtn.addEventListener("click", () => settingsImportFile.click());
+    settingsImportFile.addEventListener("change", async () => {
+      const file = settingsImportFile.files[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const imported = JSON.parse(text);
+        // Send all importable fields to the server
+        const payload = {};
+        const importableKeys = ["volume", "theme", "inclusion", "enrich_descriptions", "safe_thresholds", "calibrate_count", "calibration_fraction"];
+        for (const k of importableKeys) {
+          if (k in imported) payload[k] = imported[k];
+        }
+        const res = await fetch("/api/settings", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          populateSettingsModal(data);
+          applyTheme(data.theme || "dark");
+          if (enrichDescCheckbox) enrichDescCheckbox.checked = !!data.enrich_descriptions;
+          if (inclusionSlider) { inclusionSlider.value = data.inclusion || 0; inclusionValue.textContent = data.inclusion || 0; inclusion = data.inclusion || 0; }
+          audioVolume = typeof data.volume === "number" ? data.volume : 1.0;
+          const audioEl = document.getElementById("clip-audio");
+          if (audioEl) audioEl.volume = audioVolume;
+        }
+      } catch (_) {
+        vtAlert("Failed to import settings. Make sure the file is valid JSON.", "error");
+      }
+      settingsImportFile.value = "";
+    });
+  }
+
+  // Export settings to file
+  if (settingsExportBtn) {
+    settingsExportBtn.addEventListener("click", async () => {
+      try {
+        const res = await fetch("/api/settings");
+        if (!res.ok) return;
+        const data = await res.json();
+        // Exclude runtime-only fields
+        delete data.favorite_processors;
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "vtsearch-settings.json";
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (_) {}
     });
   }
 
@@ -3198,6 +3330,9 @@
       }
       if (calibrationFractionInput && typeof data.calibration_fraction === "number") {
         calibrationFractionInput.value = data.calibration_fraction;
+      }
+      if (safeThresholdsCheckbox) {
+        safeThresholdsCheckbox.checked = !!data.safe_thresholds;
       }
     } catch (_) {
       // Settings not available yet; use defaults

--- a/static/index.html
+++ b/static/index.html
@@ -41,25 +41,7 @@
         <div class="burger-status" id="menu-favorites-status"></div>
       </div>
       <div class="burger-section">
-        <div class="burger-section-title">Appearance</div>
-        <div class="theme-toggle">
-          <span class="theme-toggle-label" id="theme-label">Light Mode</span>
-          <label class="theme-switch">
-            <input type="checkbox" id="theme-toggle-checkbox">
-            <span class="theme-switch-slider"></span>
-          </label>
-        </div>
-      </div>
-      <div class="burger-section">
-        <div class="burger-section-title">Calibration</div>
-        <div style="display:flex; align-items:center; gap:6px">
-          <label for="calibrate-count-input" style="font-size:0.78rem; color:var(--text-secondary); cursor:pointer; white-space:nowrap">Calibrate Count</label>
-          <input type="number" id="calibrate-count-input" min="1" max="100" value="2" step="1" style="width:56px; padding:4px 6px; border:1px solid var(--border); border-radius:4px; background:var(--bg-surface); color:var(--text-primary); font-size:0.85rem; text-align:center; outline:none">
-        </div>
-        <div style="display:flex; align-items:center; gap:6px; margin-top:6px">
-          <label for="calibration-fraction-input" style="font-size:0.78rem; color:var(--text-secondary); cursor:pointer; white-space:nowrap">Calibration Fraction</label>
-          <input type="number" id="calibration-fraction-input" min="0" max="1" value="0.5" step="0.05" style="width:56px; padding:4px 6px; border:1px solid var(--border); border-radius:4px; background:var(--bg-surface); color:var(--text-primary); font-size:0.85rem; text-align:center; outline:none">
-        </div>
+        <div class="burger-item" id="menu-settings">Settings</div>
       </div>
     </div>
   </div>
@@ -356,6 +338,52 @@
       <div style="background: var(--border); border-radius: 8px; overflow: hidden; height: 24px; position: relative;">
         <div id="labeling-analysis-bar" style="background: linear-gradient(90deg, var(--accent), var(--accent-light)); height: 100%; width: 0%; transition: width 0.3s;"></div>
         <div id="labeling-analysis-pct" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.75rem; color: #fff; font-weight: bold;">0%</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Settings Modal -->
+<div id="settings-modal" class="modal">
+  <div class="modal-content" style="max-width: 520px;">
+    <div class="modal-header">
+      <h2>Settings</h2>
+      <button class="modal-close" id="settings-modal-close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <!-- Appearance -->
+      <div class="settings-section">
+        <div class="settings-section-title">Appearance</div>
+        <div class="settings-row">
+          <span class="settings-label" id="theme-label">Light Mode</span>
+          <label class="theme-switch">
+            <input type="checkbox" id="theme-toggle-checkbox">
+            <span class="theme-switch-slider"></span>
+          </label>
+        </div>
+      </div>
+      <!-- Calibration -->
+      <div class="settings-section">
+        <div class="settings-section-title">Calibration</div>
+        <div class="settings-row">
+          <label for="calibrate-count-input" class="settings-label">Calibrate Count</label>
+          <input type="number" id="calibrate-count-input" min="1" max="100" value="2" step="1" class="settings-number-input">
+        </div>
+        <div class="settings-row">
+          <label for="calibration-fraction-input" class="settings-label">Calibration Fraction</label>
+          <input type="number" id="calibration-fraction-input" min="0" max="1" value="0.5" step="0.05" class="settings-number-input">
+        </div>
+        <div class="settings-row">
+          <label for="safe-thresholds-checkbox" class="settings-label">Safe Thresholds</label>
+          <input type="checkbox" id="safe-thresholds-checkbox" style="accent-color:var(--accent)">
+        </div>
+      </div>
+      <!-- Actions -->
+      <div class="settings-actions">
+        <button id="settings-default-btn" class="settings-btn secondary">Default</button>
+        <input type="file" id="settings-import-file" accept=".json" style="display:none">
+        <button id="settings-import-btn" class="settings-btn secondary">Import</button>
+        <button id="settings-export-btn" class="settings-btn secondary">Export</button>
       </div>
     </div>
   </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -332,5 +332,18 @@ video { max-width: 600px; max-height: 400px; }
 .vt-dialog-btn.secondary { background: var(--bg-surface); color: var(--text-secondary); }
 .vt-dialog-btn.secondary:hover { background: var(--bg-hover); color: var(--text-primary); }
 
+/* Settings modal */
+.settings-section { margin-bottom: 20px; }
+.settings-section-title { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 10px; }
+.settings-row { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; }
+.settings-row + .settings-row { border-top: 1px solid var(--border-subtle); }
+.settings-label { font-size: 0.85rem; color: var(--text-secondary); cursor: pointer; }
+.settings-number-input { width: 72px; padding: 5px 8px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg-panel); color: var(--text-primary); font-size: 0.85rem; text-align: center; outline: none; }
+.settings-number-input:focus { border-color: var(--accent); }
+.settings-actions { display: flex; gap: 8px; padding-top: 16px; border-top: 1px solid var(--border); }
+.settings-btn { flex: 1; padding: 8px 12px; border-radius: 4px; font-size: 0.82rem; cursor: pointer; transition: all 0.15s; border: 1px solid var(--border); }
+.settings-btn.secondary { background: var(--bg-surface); color: var(--text-secondary); }
+.settings-btn.secondary:hover { background: var(--bg-hover); color: var(--text-primary); }
+
 /* Label count display */
 .label-count { font-size: 0.75rem; color: var(--text-muted); font-weight: normal; }

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -8,6 +8,9 @@ GET  /api/settings
 PUT  /api/settings
     Update one or more settings fields.  Only supplied keys are changed.
 
+GET  /api/settings/defaults
+    Return the default values for all settings (excluding favorite_processors).
+
 GET  /api/settings/favorite-processors
     List all favorite processor recipes.
 
@@ -72,6 +75,9 @@ def update_settings():
     if "enrich_descriptions" in body:
         settings.set_enrich_descriptions(bool(body["enrich_descriptions"]))
 
+    if "safe_thresholds" in body:
+        settings.set_safe_thresholds(bool(body["safe_thresholds"]))
+
     if "calibration_fraction" in body:
         try:
             val = body["calibration_fraction"]
@@ -91,6 +97,12 @@ def update_settings():
             return jsonify({"error": "calibrate_count must be a number"}), 400
 
     return jsonify(settings.get_all())
+
+
+@settings_bp.route("/api/settings/defaults", methods=["GET"])
+def get_defaults():
+    """Return the default values for all settings (excluding favorite_processors)."""
+    return jsonify(settings.get_defaults())
 
 
 @settings_bp.route("/api/settings/favorite-processors", methods=["GET"])

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -81,6 +81,11 @@ def _ensure_loaded() -> dict[str, Any]:
 # -------------------------------------------------------------------
 
 
+def get_defaults() -> dict[str, Any]:
+    """Return a copy of the default settings (excluding favorite_processors)."""
+    return {k: v for k, v in _DEFAULTS.items() if k != "favorite_processors"}
+
+
 def get_all() -> dict[str, Any]:
     """Return the full settings dict (with defaults filled in)."""
     s = _ensure_loaded()


### PR DESCRIPTION
Move theme toggle, calibration count, calibration fraction, and safe
thresholds controls from the burger menu into a dedicated Settings modal
accessible via a "Settings" item at the bottom of the burger bar.

Add Default button (resets to server defaults), Import button (load
settings from JSON file), and Export button (download settings as JSON).

Add /api/settings/defaults endpoint and wire safe_thresholds through the
PUT /api/settings route.

https://claude.ai/code/session_019tVxeTjZqbNGonq7x1rxZr