### PR TITLE
Fix Caltech101 dataset extraction to use DATA_DIR

### DIFF
--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -202,7 +202,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
                         i,
                         total,
                     )
-                zip_ref.extract(member, extract_dir)
+                zip_ref.extract(member, DATA_DIR)
 
         zip_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
Fixed the Caltech101 dataset downloader to extract files to the correct data directory instead of a local extract directory variable.

## Key Changes
- Changed `zip_ref.extract(member, extract_dir)` to `zip_ref.extract(member, DATA_DIR)` in the `download_caltech101()` function
- This ensures downloaded files are extracted to the configured data directory rather than a temporary/local path

## Implementation Details
The extraction now uses the module-level `DATA_DIR` constant, which is the intended destination for all downloaded datasets. This fixes a bug where files were being extracted to an incorrect location, potentially causing dataset loading failures or files being placed outside the expected data directory structure.

https://claude.ai/code/session_01DHRNkaCcDp6HWYCcu8ryht