### PR TITLE
Move Enrich Sort Descriptions toggle to Settings modal

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -221,7 +221,6 @@
   const stripeContainer = document.getElementById("stripe-container");
   const inclusionSlider = document.getElementById("inclusion-slider");
   const inclusionValue = document.getElementById("inclusion-value");
-  const enrichDescCheckbox = document.getElementById("enrich-descriptions-checkbox");
   const calibrateCountInput = document.getElementById("calibrate-count-input");
   const calibrationFractionInput = document.getElementById("calibration-fraction-input");
 
@@ -289,6 +288,7 @@
   const settingsModal = document.getElementById("settings-modal");
   const settingsModalClose = document.getElementById("settings-modal-close");
   const safeThresholdsCheckbox = document.getElementById("safe-thresholds-checkbox");
+  const enrichDescCheckbox = document.getElementById("enrich-descriptions-checkbox");
   const settingsDefaultBtn = document.getElementById("settings-default-btn");
   const settingsImportBtn = document.getElementById("settings-import-btn");
   const settingsImportFile = document.getElementById("settings-import-file");
@@ -1508,6 +1508,7 @@
     if (calibrateCountInput) calibrateCountInput.value = data.calibrate_count;
     if (calibrationFractionInput) calibrationFractionInput.value = data.calibration_fraction;
     if (safeThresholdsCheckbox) safeThresholdsCheckbox.checked = !!data.safe_thresholds;
+    if (enrichDescCheckbox) enrichDescCheckbox.checked = !!data.enrich_descriptions;
   }
 
   if (menuSettings && settingsModal && burgerDropdown) {
@@ -1538,6 +1539,21 @@
     });
   }
 
+  // Enrich Sort Descriptions toggle
+  if (enrichDescCheckbox) {
+    enrichDescCheckbox.addEventListener("change", () => {
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enrich_descriptions: enrichDescCheckbox.checked }),
+      }).catch(() => {});
+      // Re-trigger text sort if active
+      if (sortMode === "text") {
+        onTextSortInput();
+      }
+    });
+  }
+
   // Default button — reset all settings to defaults
   if (settingsDefaultBtn) {
     settingsDefaultBtn.addEventListener("click", async () => {
@@ -1556,7 +1572,6 @@
         // Apply theme immediately
         applyTheme(defaults.theme || "dark");
         // Update main UI controls that live outside the modal
-        if (enrichDescCheckbox) enrichDescCheckbox.checked = !!defaults.enrich_descriptions;
         if (inclusionSlider) { inclusionSlider.value = defaults.inclusion || 0; inclusionValue.textContent = defaults.inclusion || 0; inclusion = defaults.inclusion || 0; }
         audioVolume = defaults.volume != null ? defaults.volume : 1.0;
         const audioEl = document.getElementById("clip-audio");
@@ -1589,7 +1604,6 @@
           const data = await res.json();
           populateSettingsModal(data);
           applyTheme(data.theme || "dark");
-          if (enrichDescCheckbox) enrichDescCheckbox.checked = !!data.enrich_descriptions;
           if (inclusionSlider) { inclusionSlider.value = data.inclusion || 0; inclusionValue.textContent = data.inclusion || 0; inclusion = data.inclusion || 0; }
           audioVolume = typeof data.volume === "number" ? data.volume : 1.0;
           const audioEl = document.getElementById("clip-audio");
@@ -1717,21 +1731,7 @@
     });
   }
 
-  // ---- Enrich Sort Descriptions toggle ----
 
-  if (enrichDescCheckbox) {
-    enrichDescCheckbox.addEventListener("change", () => {
-      fetch("/api/settings", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enrich_descriptions: enrichDescCheckbox.checked }),
-      }).catch(() => {});
-      // Re-trigger text sort if active
-      if (sortMode === "text") {
-        onTextSortInput();
-      }
-    });
-  }
 
   // ---- Calibrate Count ----
 

--- a/static/index.html
+++ b/static/index.html
@@ -85,10 +85,6 @@
       <div style="text-align:center; font-size:0.75rem; color:var(--text-secondary); margin-top:2px">
         <span id="inclusion-value">0</span>
       </div>
-      <div style="display:flex; align-items:center; gap:6px; margin-top:8px">
-        <input type="checkbox" id="enrich-descriptions-checkbox" style="accent-color:var(--accent)">
-        <label for="enrich-descriptions-checkbox" style="font-size:0.78rem; color:var(--text-secondary); cursor:pointer">Enrich Sort Descriptions</label>
-      </div>
       <div id="sort-status" class="sort-status" aria-live="polite"></div>
       <div id="sort-progress" class="sort-progress" role="status" aria-live="polite">
         <div class="sort-progress-bar">
@@ -380,6 +376,14 @@
         <div class="settings-row">
           <label for="safe-thresholds-checkbox" class="settings-label">Safe Thresholds</label>
           <input type="checkbox" id="safe-thresholds-checkbox" style="accent-color:var(--accent)">
+        </div>
+      </div>
+      <!-- Sorting -->
+      <div class="settings-section">
+        <div class="settings-section-title">Sorting</div>
+        <div class="settings-row">
+          <label for="enrich-descriptions-checkbox" class="settings-label">Enrich Sort Descriptions</label>
+          <input type="checkbox" id="enrich-descriptions-checkbox" style="accent-color:var(--accent)">
         </div>
       </div>
       <!-- Actions -->


### PR DESCRIPTION
## Summary
Relocated the "Enrich Sort Descriptions" checkbox from the main clips panel to the Settings modal under a new "Sorting" section, improving UI organization and consistency with other configuration options.

## Key Changes
- **Moved UI element**: Removed the checkbox from the main clips panel (index.html) and added it to the Settings modal under a new "Sorting" section
- **Reorganized initialization**: Moved the `enrichDescCheckbox` variable declaration from the main controls section to the settings modal section in app.js
- **Consolidated settings handling**: 
  - Added checkbox state population in `populateSettingsModal()` function
  - Moved the change event listener to be grouped with other settings modal handlers
  - Removed redundant checkbox state assignments from the default settings and import handlers
- **Maintained functionality**: The checkbox still triggers the same API call and re-triggers text sort when active

## Implementation Details
- The checkbox is now properly initialized alongside other settings modal controls
- Settings are consistently applied through the `populateSettingsModal()` function rather than scattered throughout the code
- The event listener placement groups related settings functionality together, improving code maintainability

https://claude.ai/code/session_01M3GYjpfS2BrvbQ8FB2SbQ9