### PR TITLE
Reorganize dataset options into Load and Generate columns

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -237,6 +237,8 @@
   const backButton = document.getElementById("back-button");
   const loadFileBtn = document.getElementById("load-file-btn");
   const fileInput = document.getElementById("file-input");
+  const datasetLoadColumn = document.getElementById("dataset-load-column");
+  const datasetGenerateColumn = document.getElementById("dataset-generate-column");
   const datasetBar = document.getElementById("dataset-bar");
   const datasetInfo = document.getElementById("dataset-info");
   const leftPanel = document.getElementById("left-panel");
@@ -515,7 +517,7 @@
         btn.className = "dataset-option";
         btn.innerHTML = `<h3>${importer.icon || "🔌"} ${importer.display_name}</h3><p>${importer.description}</p>`;
         btn.addEventListener("click", () => showExtendedImporterForm(importer));
-        datasetOptions.appendChild(btn);
+        datasetGenerateColumn.appendChild(btn);
       }
     } catch (_) {
       // Extended importers are optional – silently ignore failures.
@@ -527,7 +529,7 @@
     combineBtnEl.id = "combine-datasets-btn";
     combineBtnEl.innerHTML = `<h3>\uD83D\uDD00 Combine Existing Datasets</h3><p>Merge multiple .pkl datasets into one, skipping duplicates</p>`;
     combineBtnEl.addEventListener("click", () => showCombineDatasetsForm());
-    datasetOptions.appendChild(combineBtnEl);
+    datasetLoadColumn.appendChild(combineBtnEl);
 
     // Append the Load Demo Dataset button after all dynamic importers
     const demoBtnEl = document.createElement("button");
@@ -611,12 +613,12 @@
         demoDatasetsDiv.innerHTML = `<div style="color:var(--color-bad); text-align:center;">Error loading demo datasets: ${e.message}</div>`;
       }
     });
-    datasetOptions.appendChild(demoBtnEl);
+    datasetLoadColumn.appendChild(demoBtnEl);
 
     // Always render the autodetect toggle last, after all import options
     const autodetectDiv = document.createElement("div");
     autodetectDiv.id = "autodetect-toggle";
-    autodetectDiv.style = "margin-top: 16px; padding: 12px; background: var(--border); border-radius: 4px;";
+    autodetectDiv.style = "width: 100%; margin-top: 16px; padding: 12px; background: var(--border); border-radius: 4px; box-sizing: border-box;";
     autodetectDiv.innerHTML = `
       <label style="display: flex; align-items: center; color: var(--text-primary); cursor: pointer;">
         <input type="checkbox" id="autodetect-mode-checkbox" style="margin-right: 8px;">

--- a/static/index.html
+++ b/static/index.html
@@ -107,10 +107,18 @@
         <p>Load or generate a dataset to get started</p>
       </div>
       <div class="dataset-options" id="dataset-options">
-        <button class="dataset-option" id="load-file-btn">
-          <h3>📁 Load from File</h3>
-          <p>Load a previously saved dataset file (.pkl)</p>
-        </button>
+        <div class="dataset-columns" id="dataset-columns">
+          <div class="dataset-column" id="dataset-load-column">
+            <div class="dataset-column-header">Load</div>
+            <button class="dataset-option" id="load-file-btn">
+              <h3>📁 Load from File</h3>
+              <p>Load a previously saved dataset file (.pkl)</p>
+            </button>
+          </div>
+          <div class="dataset-column" id="dataset-generate-column">
+            <div class="dataset-column-header">Generate</div>
+          </div>
+        </div>
       </div>
       <div class="dataset-progress" id="dataset-progress" style="display:none" role="status" aria-live="polite">
         <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Dataset loading progress">

--- a/static/styles.css
+++ b/static/styles.css
@@ -283,11 +283,14 @@ video { max-width: 600px; max-height: 400px; }
 .label-io-status { font-size: 0.7rem; color: var(--text-dim); padding: 0 16px 8px; }
 
 /* Dataset management */
-.dataset-welcome { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px; padding: 48px; max-width: 600px; margin: 0 auto; text-align: center; }
+.dataset-welcome { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px; padding: 48px; max-width: 800px; margin: 0 auto; text-align: center; }
 .dataset-welcome.wide { max-width: min(1040px, 95vw); }
 .dataset-welcome h2 { font-size: 1.8rem; color: var(--accent); margin-bottom: 8px; }
 .dataset-welcome p { font-size: 1rem; color: var(--text-secondary); margin-bottom: 16px; }
-.dataset-options { display: flex; flex-direction: column; gap: 12px; width: 100%; }
+.dataset-options { display: flex; flex-direction: column; align-items: center; gap: 16px; width: 100%; }
+.dataset-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; width: 100%; }
+.dataset-column { display: flex; flex-direction: column; gap: 12px; }
+.dataset-column-header { font-size: 0.8rem; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.08em; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
 .dataset-option { padding: 16px 20px; border: 2px solid var(--border); border-radius: 8px; background: var(--bg-surface); color: var(--text-primary); cursor: pointer; transition: all 0.2s; text-align: left; }
 .dataset-option:hover { border-color: var(--accent); background: var(--bg-subtle); }
 .dataset-option h3 { font-size: 1.1rem; margin-bottom: 4px; color: var(--accent); }


### PR DESCRIPTION
## Summary
Restructured the dataset management UI to organize options into two distinct columns: "Load" for loading existing datasets and "Generate" for creating new ones. This improves visual organization and user navigation.

## Key Changes
- **HTML Structure**: Wrapped dataset options in a two-column grid layout with separate containers for Load and Generate sections
  - Added `dataset-columns` grid container with two equal-width columns
  - Added `dataset-column-header` elements to label each section
  - Moved "Load from File" button into the Load column

- **JavaScript Logic**: Updated button placement logic to append options to the appropriate columns
  - Extended importers now append to `datasetGenerateColumn`
  - "Combine Existing Datasets" button appends to `datasetLoadColumn`
  - "Load Demo Dataset" button appends to `datasetLoadColumn`
  - Autodetect toggle now spans full width with proper box-sizing

- **Styling**: Enhanced CSS for the new layout
  - Increased `.dataset-welcome` max-width from 600px to 800px to accommodate two columns
  - Added `.dataset-columns` grid with 1fr 1fr columns and 24px gap
  - Added `.dataset-column` flex container for vertical stacking
  - Added `.dataset-column-header` styling with uppercase text, accent color, and bottom border
  - Updated `.dataset-options` gap from 12px to 16px and added center alignment

## Implementation Details
- The two-column layout uses CSS Grid for responsive organization
- Column headers use uppercase styling with letter-spacing for visual hierarchy
- The autodetect toggle is explicitly set to `width: 100%` with `box-sizing: border-box` to prevent overflow
- All existing functionality is preserved; this is purely a UI reorganization

https://claude.ai/code/session_01A5GbEpEXqDJVy3qow9bbDd