### PR TITLE
Fix metadata key collisions and refactor dataset file counting

### DIFF
--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -147,9 +147,10 @@ def load_video_metadata_from_folders(video_dir: Path, categories: list[str]) -> 
             continue
 
         # Find all video files in this category
+        # Use category/filename as key to avoid collisions across categories.
         for ext in ["*.mp4", "*.avi", "*.mov", "*.webm", "*.mkv"]:
             for video_path in category_folder.glob(ext):
-                metadata[video_path.name] = {
+                metadata[f"{category_name}/{video_path.name}"] = {
                     "category": category_name,
                     "path": video_path,
                 }
@@ -187,9 +188,11 @@ def load_image_metadata_from_folders(image_dir: Path, categories: list[str]) -> 
             continue
 
         # Find all image files in this category
+        # Use category/filename as key to avoid collisions across categories
+        # (e.g. Caltech-101 uses image_XXXX.jpg in every category folder).
         for ext in ["*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp", "*.webp"]:
             for image_path in category_folder.glob(ext):
-                metadata[image_path.name] = {
+                metadata[f"{category_name}/{image_path.name}"] = {
                     "category": category_name,
                     "path": image_path,
                 }
@@ -227,9 +230,10 @@ def load_paragraph_metadata_from_folders(text_dir: Path, categories: list[str]) 
             continue
 
         # Find all text files in this category
+        # Use category/filename as key to avoid collisions across categories.
         for ext in ["*.txt", "*.md"]:
             for text_path in category_folder.glob(ext):
-                metadata[text_path.name] = {
+                metadata[f"{category_name}/{text_path.name}"] = {
                     "category": category_name,
                     "path": text_path,
                 }

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -10,7 +10,7 @@ import torch
 from PIL import Image
 from transformers import CLIPModel, CLIPProcessor
 
-from vtsearch.config import CLIP_MODEL_ID, DATA_DIR, MODELS_CACHE_DIR
+from vtsearch.config import CLIP_MODEL_ID, MODELS_CACHE_DIR
 from vtsearch.media.base import DemoDataset, MediaResponse, MediaType, ProgressCallback, _noop_progress
 
 
@@ -111,7 +111,6 @@ class ImageMediaType(MediaType):
     @property
     def demo_datasets(self) -> list:
         cats = self._DEMO_CATEGORIES
-        folder = DATA_DIR / "caltech-101" / "101_ObjectCategories"
         return [
             DemoDataset(
                 id="images_s",
@@ -122,7 +121,6 @@ class ImageMediaType(MediaType):
                 ),
                 categories=cats,
                 source="caltech101",
-                required_folder=folder,
                 slice_start=0,
                 slice_end=11,
             ),
@@ -135,7 +133,6 @@ class ImageMediaType(MediaType):
                 ),
                 categories=cats,
                 source="caltech101",
-                required_folder=folder,
                 slice_start=11,
                 slice_end=33,
             ),
@@ -148,7 +145,6 @@ class ImageMediaType(MediaType):
                 ),
                 categories=cats,
                 source="caltech101",
-                required_folder=folder,
                 slice_start=33,
                 slice_end=77,
             ),

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -320,18 +320,22 @@ def demo_dataset_list():
         # Calculate number of files
         num_categories = len(dataset_info["categories"])
         image_source = dataset_info.get("source", "")
+        slice_start = dataset_info.get("slice_start", 0)
+        slice_end = dataset_info.get("slice_end")
+
         if media_type == "video":
-            num_files = num_categories * CLIPS_PER_VIDEO_CATEGORY
+            per_cat = CLIPS_PER_VIDEO_CATEGORY
         elif media_type == "image":
-            if image_source == "caltech101":
-                num_files = num_categories * IMAGES_PER_CALTECH101_CATEGORY
-            else:
-                num_files = num_categories * IMAGES_PER_CIFAR10_CATEGORY
+            per_cat = IMAGES_PER_CALTECH101_CATEGORY if image_source == "caltech101" else IMAGES_PER_CIFAR10_CATEGORY
         elif media_type == "paragraph":
-            num_files = num_categories * TEXTS_PER_CATEGORY
+            per_cat = TEXTS_PER_CATEGORY
         else:
-            # Audio datasets (ESC-50 has 40 clips per category)
-            num_files = num_categories * CLIPS_PER_CATEGORY
+            per_cat = CLIPS_PER_CATEGORY
+
+        # Use slice parameters when set; otherwise fall back to the default per-category count.
+        if slice_end is not None:
+            per_cat = slice_end - slice_start
+        num_files = num_categories * per_cat
 
         # Calculate download size
         if status == "ready":


### PR DESCRIPTION
## Summary
This PR addresses metadata key collisions in dataset loaders and refactors the demo dataset file counting logic to support dataset slicing. It also removes unused imports and simplifies demo dataset configuration.

## Key Changes

- **Fix metadata key collisions**: Updated `load_video_metadata_from_folders()`, `load_image_metadata_from_folders()`, and `load_paragraph_metadata_from_folders()` to use `category/filename` as metadata keys instead of just `filename`. This prevents collisions when multiple categories contain files with identical names (e.g., Caltech-101's `image_XXXX.jpg` pattern).

- **Refactor file counting logic**: Simplified the demo dataset file counting in `demo_dataset_list()` by:
  - Extracting per-category file counts into a `per_cat` variable
  - Adding support for `slice_start` and `slice_end` parameters to override default per-category counts
  - Reducing code duplication in media type conditionals

- **Clean up demo dataset configuration**: Removed unused `required_folder` parameter and `DATA_DIR` import from image media type demo datasets, as the slicing parameters now provide sufficient control over dataset size.

## Implementation Details

The metadata key change ensures that files with the same name in different category folders are properly distinguished. The slicing logic allows demo datasets to use subsets of categories (e.g., images 0-11, 11-33, 33-77) by calculating the total file count as `num_categories * (slice_end - slice_start)` when slice parameters are provided.

https://claude.ai/code/session_01FPrupoqsNdJkpzTkzvhb7q