### PR TITLE
Add abort controller for paragraph content fetch requests

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -17,6 +17,7 @@
   let progressTimer = null;
   let progressEtaState = null; // { startTime, lastCurrent, lastTime } for ETA calculation
   let learnedSortController = null; // AbortController for in-flight background training
+  let paragraphController = null;   // AbortController for in-flight paragraph content fetch
   let learnedSortDebounce = null;   // Debounce timer for background training
   let waveformAudioCtx = null;       // Shared AudioContext for waveform decoding
   const clipList = document.getElementById("clip-list");
@@ -2278,15 +2279,20 @@
 
     // Load paragraph text content
     if (mediaType === "paragraph") {
-      fetch(`/api/clips/${c.id}/paragraph`)
+      if (paragraphController) paragraphController.abort();
+      paragraphController = new AbortController();
+      const expectedId = c.id;
+      fetch(`/api/clips/${c.id}/paragraph`, { signal: paragraphController.signal })
         .then(res => res.json())
         .then(data => {
+          if (selected !== expectedId) return; // selection changed, discard stale response
           const paragraphDiv = document.getElementById("clip-paragraph");
           if (paragraphDiv) {
             paragraphDiv.textContent = data.content;
           }
         })
         .catch(err => {
+          if (err.name === "AbortError") return; // expected when selection changes
           console.error("Error loading paragraph:", err);
         });
     }


### PR DESCRIPTION
## Summary
This change improves the paragraph content loading behavior by implementing request cancellation when the user selects a different clip before the previous request completes.

## Key Changes
- Added `paragraphController` AbortController variable to manage in-flight paragraph fetch requests
- Implemented request cancellation by aborting the previous controller before initiating a new fetch
- Added stale response detection by capturing the expected clip ID and discarding responses if the selection has changed
- Added proper error handling to suppress AbortError logging when requests are intentionally cancelled

## Implementation Details
- The AbortController pattern prevents unnecessary network requests and DOM updates when users rapidly switch between clips
- The `expectedId` variable ensures that even if a stale response arrives after selection changes, it will be discarded before updating the DOM
- AbortError exceptions are caught and silently ignored since they represent expected cancellations rather than actual errors

https://claude.ai/code/session_01KNMCUnkWoh1oFE7aDL1NjA