### PR TITLE
Add chunked/piecewise dataset loading for memory-efficient processing

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,6 +93,17 @@ if __name__ == "__main__":
         type=str,
         help="Name of the results exporter to use (e.g. file, email_smtp, gui). Used with --autodetect.",
     )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=None,
+        dest="chunk_size",
+        help=(
+            "Process the dataset in chunks of N clips at a time to limit "
+            "memory usage. Used with --autodetect. When omitted the entire "
+            "dataset is loaded at once (original behaviour)."
+        ),
+    )
 
     # Two-pass parsing: first pass gets --importer and --exporter names;
     # second pass adds their plugin-specific arguments and re-parses.
@@ -136,20 +147,37 @@ if __name__ == "__main__":
 
         settings_path = getattr(args, "settings", None)
 
+        chunk_size = getattr(args, "chunk_size", None)
+
         if args.importer:
             # Importer-based path
-            from vtsearch.cli import autodetect_importer_main
-
             field_values = {f.key: getattr(args, f.key, f.default or None) for f in importer.fields}
-            autodetect_importer_main(
-                args.importer, field_values, settings_path, args.exporter, exporter_field_values
-            )
+
+            if chunk_size:
+                from vtsearch.cli import autodetect_importer_main_chunked
+
+                autodetect_importer_main_chunked(
+                    args.importer, field_values, chunk_size, settings_path, args.exporter, exporter_field_values
+                )
+            else:
+                from vtsearch.cli import autodetect_importer_main
+
+                autodetect_importer_main(
+                    args.importer, field_values, settings_path, args.exporter, exporter_field_values
+                )
 
         elif args.dataset:
             # Pickle-file path
-            from vtsearch.cli import autodetect_main
+            if chunk_size:
+                from vtsearch.cli import autodetect_main_chunked
 
-            autodetect_main(args.dataset, settings_path, args.exporter, exporter_field_values)
+                autodetect_main_chunked(
+                    args.dataset, chunk_size, settings_path, args.exporter, exporter_field_values
+                )
+            else:
+                from vtsearch.cli import autodetect_main
+
+                autodetect_main(args.dataset, settings_path, args.exporter, exporter_field_values)
 
         else:
             parser.error("--autodetect requires either --dataset <file.pkl> or --importer <name>")

--- a/tests/test_chunked_loading.py
+++ b/tests/test_chunked_loading.py
@@ -1,0 +1,443 @@
+"""Tests for chunked (piecewise) dataset loading.
+
+Verifies that datasets can be loaded in chunks via the new
+``load_dataset_from_folder_chunked``, ``load_dataset_from_pickle_chunked``
+functions, the ``DatasetImporter.run_chunked`` / ``run_chunked_cli``
+interface, and the CLI ``_merge_detector_results`` helper.
+"""
+
+import hashlib
+import pickle
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from vtsearch.datasets.loader import (
+    load_dataset_from_folder,
+    load_dataset_from_folder_chunked,
+    load_dataset_from_pickle_chunked,
+)
+
+
+def _make_wav_bytes(frequency: float = 440.0, duration: float = 0.1) -> bytes:
+    """Generate a minimal WAV file for testing."""
+    from vtsearch.audio import generate_wav
+
+    return generate_wav(frequency, duration)
+
+
+def _make_wav_file(tmp_dir: Path, name: str, frequency: float = 440.0) -> Path:
+    """Write a WAV file and return its path."""
+    p = tmp_dir / name
+    p.write_bytes(_make_wav_bytes(frequency))
+    return p
+
+
+def _make_pickle(tmp_path: Path, num_clips: int, inline_bytes: bool = True) -> Path:
+    """Create a test pickle with *num_clips* audio clips."""
+    clips_data: dict[int, dict[str, Any]] = {}
+    for i in range(1, num_clips + 1):
+        wav_bytes = _make_wav_bytes(frequency=440.0 + i)
+        clip: dict[str, Any] = {
+            "id": i,
+            "type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "embedding": np.random.randn(512).tolist(),
+            "filename": f"clip_{i}.wav",
+            "category": f"cat_{i % 3}",
+        }
+        if inline_bytes:
+            clip["clip_bytes"] = wav_bytes
+        clips_data[i] = clip
+
+    pkl_path = tmp_path / "test_chunked.pkl"
+    with open(pkl_path, "wb") as f:
+        pickle.dump({"clips": clips_data}, f)
+    return pkl_path
+
+
+# ======================================================================
+# load_dataset_from_folder_chunked
+# ======================================================================
+
+
+class TestFolderChunked:
+    """Test load_dataset_from_folder_chunked."""
+
+    def test_single_chunk_when_fewer_than_chunk_size(self, tmp_path):
+        """When total files < chunk_size, yields exactly one chunk."""
+        _make_wav_file(tmp_path, "a.wav")
+        _make_wav_file(tmp_path, "b.wav")
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=10, thin=True))
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 2
+
+    def test_multiple_chunks(self, tmp_path):
+        """Files are split across multiple chunks of the correct size."""
+        for i in range(5):
+            _make_wav_file(tmp_path, f"file_{i}.wav", frequency=440.0 + i * 10)
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=2, thin=True))
+        assert len(chunks) == 3  # 2, 2, 1
+        assert len(chunks[0]) == 2
+        assert len(chunks[1]) == 2
+        assert len(chunks[2]) == 1
+
+    def test_chunk_ids_start_at_one(self, tmp_path):
+        """Each chunk's clip IDs start at 1 (not continuing from prior chunk)."""
+        for i in range(4):
+            _make_wav_file(tmp_path, f"file_{i}.wav", frequency=440.0 + i * 10)
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=2, thin=True))
+        for chunk in chunks:
+            assert 1 in chunk
+
+    def test_thin_mode_no_bytes(self, tmp_path):
+        """Thin mode: clip_bytes is None, media_path is set."""
+        _make_wav_file(tmp_path, "test.wav")
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=10, thin=True))
+        clip = chunks[0][1]
+        assert clip["clip_bytes"] is None
+        assert clip["media_path"] is not None
+        assert Path(clip["media_path"]).exists()
+
+    def test_full_mode_has_bytes(self, tmp_path):
+        """Full mode: clip_bytes is populated."""
+        _make_wav_file(tmp_path, "test.wav")
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=10, thin=False))
+        clip = chunks[0][1]
+        assert clip["clip_bytes"] is not None
+
+    def test_embeddings_present(self, tmp_path):
+        """Each clip in a chunk has an embedding array."""
+        _make_wav_file(tmp_path, "test.wav")
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=10, thin=True))
+        clip = chunks[0][1]
+        assert isinstance(clip["embedding"], np.ndarray)
+        assert len(clip["embedding"]) > 0
+
+    def test_all_files_covered(self, tmp_path):
+        """The total number of clips across all chunks equals total files."""
+        for i in range(7):
+            _make_wav_file(tmp_path, f"f_{i}.wav", frequency=440.0 + i * 10)
+        chunks = list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=3, thin=True))
+        total_clips = sum(len(c) for c in chunks)
+        assert total_clips == 7
+
+    def test_matches_monolithic_load(self, tmp_path):
+        """Chunked loading produces the same filenames as monolithic loading."""
+        for i in range(5):
+            _make_wav_file(tmp_path, f"f_{i}.wav", frequency=440.0 + i * 10)
+
+        # Monolithic
+        mono_clips: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "sounds", mono_clips, thin=True)
+        mono_filenames = {c["filename"] for c in mono_clips.values()}
+
+        # Chunked
+        chunked_filenames: set[str] = set()
+        for chunk in load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=2, thin=True):
+            for clip in chunk.values():
+                chunked_filenames.add(clip["filename"])
+
+        assert mono_filenames == chunked_filenames
+
+    def test_invalid_media_type_raises(self, tmp_path):
+        _make_wav_file(tmp_path, "test.wav")
+        try:
+            list(load_dataset_from_folder_chunked(tmp_path, "bogus", chunk_size=10, thin=True))
+            assert False, "Expected ValueError"
+        except ValueError as e:
+            assert "Invalid media type" in str(e)
+
+    def test_empty_folder_raises(self, tmp_path):
+        try:
+            list(load_dataset_from_folder_chunked(tmp_path, "sounds", chunk_size=10, thin=True))
+            assert False, "Expected ValueError"
+        except ValueError as e:
+            assert "No sounds files found" in str(e)
+
+
+# ======================================================================
+# load_dataset_from_pickle_chunked
+# ======================================================================
+
+
+class TestPickleChunked:
+    """Test load_dataset_from_pickle_chunked."""
+
+    def test_single_chunk(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 3)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 3
+
+    def test_multiple_chunks(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 5)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=2, thin=True))
+        assert len(chunks) == 3  # 2, 2, 1
+        assert len(chunks[0]) == 2
+        assert len(chunks[1]) == 2
+        assert len(chunks[2]) == 1
+
+    def test_chunk_ids_start_at_one(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 4)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=2, thin=True))
+        for chunk in chunks:
+            assert 1 in chunk
+
+    def test_thin_mode_drops_bytes(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 2, inline_bytes=True)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        for clip in chunks[0].values():
+            assert clip["clip_bytes"] is None
+
+    def test_full_mode_keeps_bytes(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 2, inline_bytes=True)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        for clip in chunks[0].values():
+            assert clip["clip_bytes"] is not None
+
+    def test_embeddings_are_numpy(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 2)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        for clip in chunks[0].values():
+            assert isinstance(clip["embedding"], np.ndarray)
+
+    def test_all_clips_covered(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 7)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=3, thin=True))
+        total = sum(len(c) for c in chunks)
+        assert total == 7
+
+    def test_metadata_preserved(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 1)
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        clip = chunks[0][1]
+        assert clip["type"] == "audio"
+        assert clip["filename"] == "clip_1.wav"
+        assert clip["category"] == "cat_1"
+
+
+# ======================================================================
+# DatasetImporter.run_chunked / run_chunked_cli (base class default)
+# ======================================================================
+
+
+class TestBaseImporterChunkedDefault:
+    """Test that the default run_chunked/run_chunked_cli on the base class
+    delegates to run/run_cli and yields one chunk."""
+
+    def test_default_run_chunked_yields_one_chunk(self, tmp_path):
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        # Use a non-chunked importer-like test: create a custom subclass
+        # that uses the default run_chunked.
+        from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+
+        class DummyImporter(DatasetImporter):
+            name = "dummy"
+            display_name = "Dummy"
+            description = "Test"
+            icon = ""
+            fields: list[ImporterField] = []
+
+            def run(self, field_values, clips, thin=False):
+                clips[1] = {"id": 1, "type": "audio", "embedding": np.zeros(4)}
+                clips[2] = {"id": 2, "type": "audio", "embedding": np.ones(4)}
+
+        imp = DummyImporter()
+        assert imp.supports_chunked is False
+
+        chunks = list(imp.run_chunked({}, chunk_size=1, thin=True))
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 2
+
+
+# ======================================================================
+# Folder importer run_chunked
+# ======================================================================
+
+
+class TestFolderImporterChunked:
+    def test_supports_chunked(self):
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        assert FolderDatasetImporter().supports_chunked is True
+
+    def test_run_chunked(self, tmp_path):
+        for i in range(4):
+            _make_wav_file(tmp_path, f"s_{i}.wav", frequency=440.0 + i * 10)
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        imp = FolderDatasetImporter()
+        chunks = list(imp.run_chunked({"path": str(tmp_path), "media_type": "sounds"}, chunk_size=2, thin=True))
+        assert len(chunks) == 2
+        for chunk in chunks:
+            assert len(chunk) == 2
+
+    def test_run_chunked_cli(self, tmp_path):
+        _make_wav_file(tmp_path, "test.wav")
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        imp = FolderDatasetImporter()
+        chunks = list(imp.run_chunked_cli({"path": str(tmp_path), "media_type": "sounds"}, chunk_size=10, thin=True))
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 1
+
+    def test_run_chunked_cli_missing_folder(self, tmp_path):
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        imp = FolderDatasetImporter()
+        try:
+            list(imp.run_chunked_cli({"path": "/nonexistent/path", "media_type": "sounds"}, chunk_size=10))
+            assert False, "Expected FileNotFoundError"
+        except FileNotFoundError:
+            pass
+
+
+# ======================================================================
+# Pickle importer run_chunked_cli
+# ======================================================================
+
+
+class TestPickleImporterChunked:
+    def test_supports_chunked(self):
+        from vtsearch.datasets.importers.pickle import PickleDatasetImporter
+
+        assert PickleDatasetImporter().supports_chunked is True
+
+    def test_run_chunked_cli(self, tmp_path):
+        pkl_path = _make_pickle(tmp_path, 4)
+        from vtsearch.datasets.importers.pickle import PickleDatasetImporter
+
+        imp = PickleDatasetImporter()
+        chunks = list(imp.run_chunked_cli({"file": str(pkl_path)}, chunk_size=2, thin=True))
+        assert len(chunks) == 2
+        total = sum(len(c) for c in chunks)
+        assert total == 4
+
+    def test_run_chunked_cli_missing_file(self, tmp_path):
+        from vtsearch.datasets.importers.pickle import PickleDatasetImporter
+
+        imp = PickleDatasetImporter()
+        try:
+            list(imp.run_chunked_cli({"file": "/nonexistent.pkl"}, chunk_size=10))
+            assert False, "Expected FileNotFoundError"
+        except FileNotFoundError:
+            pass
+
+
+# ======================================================================
+# CombineDatasets importer run_chunked
+# ======================================================================
+
+
+class TestCombineDatasetsImporterChunked:
+    def test_supports_chunked(self):
+        from vtsearch.datasets.importers.combine_datasets import CombineDatasetsImporter
+
+        assert CombineDatasetsImporter().supports_chunked is True
+
+    def test_yields_one_chunk_per_source(self, tmp_path):
+        pkl1 = _make_pickle(tmp_path / "d1", 3)
+        pkl2 = _make_pickle(tmp_path / "d2", 2)
+        (tmp_path / "d1").mkdir(exist_ok=True)
+        (tmp_path / "d2").mkdir(exist_ok=True)
+        pkl1 = _make_pickle(tmp_path / "d1", 3)
+        pkl2 = _make_pickle(tmp_path / "d2", 2)
+
+        from vtsearch.datasets.importers.combine_datasets import CombineDatasetsImporter
+
+        imp = CombineDatasetsImporter()
+        chunks = list(imp.run_chunked({"datasets": f"{pkl1},{pkl2}"}, chunk_size=100))
+        assert len(chunks) == 2
+        assert len(chunks[0]) == 3
+        assert len(chunks[1]) == 2
+
+
+# ======================================================================
+# _merge_detector_results
+# ======================================================================
+
+
+class TestMergeDetectorResults:
+    def test_merge_new_detector(self):
+        from vtsearch.cli import _merge_detector_results
+
+        acc: dict[str, dict[str, Any]] = {}
+        new = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 2,
+                "hits": [
+                    {"filename": "f1.wav", "score": 0.9},
+                    {"filename": "f2.wav", "score": 0.6},
+                ],
+            }
+        }
+        _merge_detector_results(acc, new)
+        assert acc["det_a"]["total_hits"] == 2
+        assert len(acc["det_a"]["hits"]) == 2
+
+    def test_merge_extends_existing(self):
+        from vtsearch.cli import _merge_detector_results
+
+        acc = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 1,
+                "hits": [{"filename": "f1.wav", "score": 0.9}],
+            }
+        }
+        new = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 1,
+                "hits": [{"filename": "f2.wav", "score": 0.7}],
+            }
+        }
+        _merge_detector_results(acc, new)
+        assert acc["det_a"]["total_hits"] == 2
+        assert len(acc["det_a"]["hits"]) == 2
+        # Verify sorted by score descending
+        assert acc["det_a"]["hits"][0]["score"] >= acc["det_a"]["hits"][1]["score"]
+
+    def test_merge_sorts_descending(self):
+        from vtsearch.cli import _merge_detector_results
+
+        acc = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 1,
+                "hits": [{"filename": "low.wav", "score": 0.5}],
+            }
+        }
+        new = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 1,
+                "hits": [{"filename": "high.wav", "score": 0.99}],
+            }
+        }
+        _merge_detector_results(acc, new)
+        assert acc["det_a"]["hits"][0]["filename"] == "high.wav"
+        assert acc["det_a"]["hits"][1]["filename"] == "low.wav"
+
+    def test_merge_multiple_detectors(self):
+        from vtsearch.cli import _merge_detector_results
+
+        acc: dict[str, dict[str, Any]] = {}
+        new = {
+            "det_a": {"detector_name": "det_a", "threshold": 0.5, "total_hits": 1, "hits": [{"score": 0.9}]},
+            "det_b": {"detector_name": "det_b", "threshold": 0.3, "total_hits": 1, "hits": [{"score": 0.8}]},
+        }
+        _merge_detector_results(acc, new)
+        assert "det_a" in acc
+        assert "det_b" in acc

--- a/tests/test_chunked_loading.py
+++ b/tests/test_chunked_loading.py
@@ -34,6 +34,30 @@ def _make_wav_file(tmp_dir: Path, name: str, frequency: float = 440.0) -> Path:
     return p
 
 
+def _make_pickle_with_base_freq(tmp_path: Path, num_clips: int, base_freq: float = 440.0) -> Path:
+    """Create a test pickle with distinct WAV bytes per clip (using base_freq)."""
+    clips_data: dict[int, dict[str, Any]] = {}
+    for i in range(1, num_clips + 1):
+        wav_bytes = _make_wav_bytes(frequency=base_freq + i * 10)
+        clip: dict[str, Any] = {
+            "id": i,
+            "type": "audio",
+            "duration": 0.1,
+            "file_size": len(wav_bytes),
+            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "embedding": np.random.randn(512).tolist(),
+            "filename": f"clip_{i}.wav",
+            "category": f"cat_{i % 3}",
+            "clip_bytes": wav_bytes,
+        }
+        clips_data[i] = clip
+
+    pkl_path = tmp_path / "test_chunked.pkl"
+    with open(pkl_path, "wb") as f:
+        pickle.dump({"clips": clips_data}, f)
+    return pkl_path
+
+
 def _make_pickle(tmp_path: Path, num_clips: int, inline_bytes: bool = True) -> Path:
     """Create a test pickle with *num_clips* audio clips."""
     clips_data: dict[int, dict[str, Any]] = {}
@@ -230,10 +254,6 @@ class TestBaseImporterChunkedDefault:
     delegates to run/run_cli and yields one chunk."""
 
     def test_default_run_chunked_yields_one_chunk(self, tmp_path):
-        from vtsearch.datasets.importers.folder import FolderDatasetImporter
-
-        # Use a non-chunked importer-like test: create a custom subclass
-        # that uses the default run_chunked.
         from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 
         class DummyImporter(DatasetImporter):
@@ -341,12 +361,12 @@ class TestCombineDatasetsImporterChunked:
         assert CombineDatasetsImporter().supports_chunked is True
 
     def test_yields_one_chunk_per_source(self, tmp_path):
-        pkl1 = _make_pickle(tmp_path / "d1", 3)
-        pkl2 = _make_pickle(tmp_path / "d2", 2)
         (tmp_path / "d1").mkdir(exist_ok=True)
         (tmp_path / "d2").mkdir(exist_ok=True)
-        pkl1 = _make_pickle(tmp_path / "d1", 3)
-        pkl2 = _make_pickle(tmp_path / "d2", 2)
+        # Use different base frequencies so the WAV bytes (and MD5s) differ
+        # between pickles, avoiding cross-source dedup.
+        pkl1 = _make_pickle_with_base_freq(tmp_path / "d1", 3, base_freq=440.0)
+        pkl2 = _make_pickle_with_base_freq(tmp_path / "d2", 2, base_freq=880.0)
 
         from vtsearch.datasets.importers.combine_datasets import CombineDatasetsImporter
 

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -384,6 +384,29 @@ def _import_favorite_processors(settings_path: str | None = None) -> None:
         print(f"Warning: could not load favorite processors from settings: {exc}", file=sys.stderr)
 
 
+def _merge_detector_results(
+    accumulated: dict[str, dict[str, Any]],
+    new_chunk: dict[str, dict[str, Any]],
+) -> None:
+    """Merge detector results from a new chunk into *accumulated* in-place.
+
+    For each detector, the hit lists are concatenated and re-sorted by
+    score descending, and ``total_hits`` is updated.
+
+    Args:
+        accumulated: The running results dict (mutated in-place).
+        new_chunk: Results from the latest chunk (same shape as
+            :func:`_score_clips_with_detectors` output).
+    """
+    for det_name, det_result in new_chunk.items():
+        if det_name not in accumulated:
+            accumulated[det_name] = det_result
+        else:
+            accumulated[det_name]["hits"].extend(det_result["hits"])
+            accumulated[det_name]["total_hits"] += det_result["total_hits"]
+            accumulated[det_name]["hits"].sort(key=lambda x: x["score"], reverse=True)
+
+
 def autodetect_main(
     dataset_path: str,
     settings_path: str | None = None,
@@ -499,6 +522,150 @@ def autodetect_importer_main(
 
         detector_results = _score_clips_with_detectors(clips, detectors)
         results = _build_multi_results_dict(detector_results, media_type)
+        _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
+    except (FileNotFoundError, ValueError, NotADirectoryError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def autodetect_main_chunked(
+    dataset_path: str,
+    chunk_size: int,
+    settings_path: str | None = None,
+    exporter_name: str | None = None,
+    exporter_field_values: dict[str, Any] | None = None,
+) -> None:
+    """CLI entry point: chunked autodetect on a pickle dataset.
+
+    Identical to :func:`autodetect_main` but processes the dataset in
+    chunks of *chunk_size* clips at a time, merging results across
+    chunks.  This bounds peak memory usage regardless of dataset size.
+
+    Args:
+        dataset_path: Path to the dataset pickle file.
+        chunk_size: Maximum number of clips to load at once.
+        settings_path: Optional path to a settings JSON file.
+        exporter_name: Optional registered exporter name.
+        exporter_field_values: Optional exporter field values.
+    """
+    try:
+        _import_favorite_processors(settings_path)
+
+        from vtsearch.datasets.loader import load_dataset_from_pickle_chunked
+
+        dataset_file = Path(dataset_path)
+        if not dataset_file.exists():
+            raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
+
+        merged_results: dict[str, dict[str, Any]] = {}
+        media_type: str | None = None
+        detectors: dict[str, dict[str, Any]] | None = None
+        total_clips = 0
+
+        for chunk_num, chunk_clips in enumerate(
+            load_dataset_from_pickle_chunked(dataset_file, chunk_size, thin=True), 1
+        ):
+            if not chunk_clips:
+                continue
+
+            total_clips += len(chunk_clips)
+
+            if media_type is None:
+                media_type = _detect_media_type(chunk_clips)
+
+                from vtsearch.utils import get_favorite_detectors_by_media
+
+                detectors = get_favorite_detectors_by_media(media_type)
+                if not detectors:
+                    raise ValueError(
+                        f"No favorite processors found for media type: {media_type}. "
+                        "Add processors to the settings file or use --settings to specify one."
+                    )
+
+            print(f"Processing chunk {chunk_num} ({len(chunk_clips)} clips)...", flush=True)
+            chunk_results = _score_clips_with_detectors(chunk_clips, detectors)
+            _merge_detector_results(merged_results, chunk_results)
+
+        if not merged_results:
+            raise ValueError(f"No clips loaded from dataset: {dataset_path}")
+
+        print(f"Finished processing {total_clips} clips across {chunk_num} chunk(s).", flush=True)
+        results = _build_multi_results_dict(merged_results, media_type or "unknown")
+        _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def autodetect_importer_main_chunked(
+    importer_name: str,
+    field_values: dict[str, Any],
+    chunk_size: int,
+    settings_path: str | None = None,
+    exporter_name: str | None = None,
+    exporter_field_values: dict[str, Any] | None = None,
+) -> None:
+    """CLI entry point: chunked autodetect with a named importer.
+
+    Identical to :func:`autodetect_importer_main` but uses the importer's
+    :meth:`~DatasetImporter.run_chunked_cli` to load the dataset in chunks
+    of *chunk_size* clips, processing each chunk independently and merging
+    results.  This bounds peak memory usage regardless of dataset size.
+
+    Args:
+        importer_name: Registered name of the importer.
+        field_values: Mapping of importer field keys to their CLI values.
+        chunk_size: Maximum number of clips to load at once.
+        settings_path: Optional path to a settings JSON file.
+        exporter_name: Optional registered exporter name.
+        exporter_field_values: Optional exporter field values.
+    """
+    try:
+        _import_favorite_processors(settings_path)
+
+        from vtsearch.datasets.importers import get_importer
+
+        importer = get_importer(importer_name)
+        if importer is None:
+            available = _list_importer_names()
+            raise ValueError(f"Unknown importer: {importer_name}. Available: {', '.join(available)}")
+
+        importer.validate_cli_field_values(field_values)
+
+        merged_results: dict[str, dict[str, Any]] = {}
+        media_type: str | None = None
+        detectors: dict[str, dict[str, Any]] | None = None
+        total_clips = 0
+
+        for chunk_num, chunk_clips in enumerate(
+            importer.run_chunked_cli(field_values, chunk_size, thin=True), 1
+        ):
+            if not chunk_clips:
+                continue
+
+            total_clips += len(chunk_clips)
+
+            if media_type is None:
+                media_type = _detect_media_type(chunk_clips)
+
+                from vtsearch.utils import get_favorite_detectors_by_media
+
+                detectors = get_favorite_detectors_by_media(media_type)
+                if not detectors:
+                    raise ValueError(
+                        f"No favorite processors found for media type: {media_type}. "
+                        "Add processors to the settings file or use --settings to specify one."
+                    )
+
+            print(f"Processing chunk {chunk_num} ({len(chunk_clips)} clips)...", flush=True)
+            chunk_results = _score_clips_with_detectors(chunk_clips, detectors)
+            _merge_detector_results(merged_results, chunk_results)
+
+        if not merged_results:
+            raise ValueError(f"No clips loaded by importer '{importer_name}'")
+
+        print(f"Finished processing {total_clips} clips across {chunk_num} chunk(s).", flush=True)
+        results = _build_multi_results_dict(merged_results, media_type or "unknown")
         _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
     except (FileNotFoundError, ValueError, NotADirectoryError) as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Iterator, Literal
 
 FieldType = Literal["file", "folder", "url", "text", "select"]
 
@@ -176,6 +176,72 @@ class DatasetImporter:
                 stores it in the progress tracker as an error message.
         """
         raise NotImplementedError(f"{type(self).__name__}.run() is not implemented")
+
+    # ------------------------------------------------------------------
+    # Chunked / piecewise loading
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_chunked(self) -> bool:
+        """Whether this importer supports chunked (piecewise) loading.
+
+        Importers that override :meth:`run_chunked` should return ``True``
+        here so the CLI can advertise the capability.
+        """
+        return False
+
+    def run_chunked(
+        self,
+        field_values: dict[str, Any],
+        chunk_size: int,
+        thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        """Yield chunks of clips for memory-efficient piecewise processing.
+
+        Each yielded dict is a self-contained clips dict with sequential
+        IDs starting at 1.  The caller processes each chunk independently
+        and discards it before consuming the next, bounding memory usage
+        to roughly *chunk_size* clips at a time.
+
+        The default implementation calls :meth:`run` once and yields the
+        result as a single chunk.  This means callers can always use the
+        chunked code path — importers that have not overridden this method
+        simply produce one chunk equal to the full dataset.
+
+        Importers that handle large data sources should override this
+        method (and set :attr:`supports_chunked` to ``True``) to yield
+        genuine incremental chunks.
+
+        Args:
+            field_values: Same mapping as :meth:`run`.
+            chunk_size: Maximum number of clips per yielded chunk.
+            thin: When ``True``, store file path references instead of
+                loading media bytes.
+
+        Yields:
+            A dict mapping int clip IDs to clip data dicts.  Each yielded
+            dict contains at most *chunk_size* clips.
+        """
+        clips: dict[int, dict[str, Any]] = {}
+        self.run(field_values, clips, thin=thin)
+        yield clips
+
+    def run_chunked_cli(
+        self,
+        field_values: dict[str, Any],
+        chunk_size: int,
+        thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        """CLI variant of :meth:`run_chunked`.
+
+        The default implementation calls :meth:`run_cli` once and yields
+        the result as a single chunk.  Importers that override
+        :meth:`run_chunked` should also override this if their CLI path
+        differs (e.g. file-path strings instead of ``FileStorage`` objects).
+        """
+        clips: dict[int, dict[str, Any]] = {}
+        self.run_cli(field_values, clips, thin=thin)
+        yield clips
 
     # ------------------------------------------------------------------
     # CLI support

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -7,7 +7,7 @@ All source datasets must share the same media type.  Duplicate entries
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 
@@ -132,6 +132,79 @@ class CombineDatasetsImporter(DatasetImporter):
     def run_cli(self, field_values: dict[str, Any], clips: dict, thin: bool = False) -> None:
         """CLI entry point -- *datasets* is a comma-separated path string."""
         self.run(field_values, clips, thin=thin)
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def run_chunked(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        """Yield one chunk per source pickle, deduplicating across chunks.
+
+        Each source pickle is loaded as its own chunk (with fresh IDs
+        starting at 1).  Cross-source deduplication by MD5 is maintained
+        across yields via a running ``seen_md5s`` set.
+        """
+        raw = field_values.get("datasets", "")
+        if isinstance(raw, list):
+            paths = [Path(p) for p in raw if p]
+        else:
+            paths = [Path(p.strip()) for p in raw.split(",") if p.strip()]
+
+        if len(paths) < 2:
+            raise ValueError("At least two datasets are required to combine.")
+
+        for p in paths:
+            if not p.exists():
+                raise FileNotFoundError(f"Dataset file not found: {p}")
+
+        progress = _get_progress()
+        media_type: str | None = None
+        seen_md5s: set[str] = set()
+
+        for i, pkl_path in enumerate(paths):
+            progress(
+                "loading",
+                f"Loading dataset {i + 1}/{len(paths)}: {pkl_path.name}...",
+                i + 1,
+                len(paths),
+            )
+            source_clips = _load_clips_from_pickle(pkl_path)
+
+            if not source_clips:
+                continue
+
+            first_clip = next(iter(source_clips.values()))
+            source_media_type = first_clip.get("type", "audio")
+
+            if media_type is None:
+                media_type = source_media_type
+            elif source_media_type != media_type:
+                raise ValueError(
+                    f"Media type mismatch: expected '{media_type}' but "
+                    f"'{pkl_path.name}' contains '{source_media_type}' clips."
+                )
+
+            chunk_clips: dict[int, dict[str, Any]] = {}
+            new_id = 1
+            for clip in source_clips.values():
+                md5 = clip.get("md5", "")
+                if md5 and md5 in seen_md5s:
+                    continue
+                if md5:
+                    seen_md5s.add(md5)
+                clip["id"] = new_id
+                chunk_clips[new_id] = clip
+                new_id += 1
+
+            if chunk_clips:
+                yield chunk_clips
+
+    def run_chunked_cli(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         """Build an origin dict listing the source dataset paths."""

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -7,10 +7,10 @@ already in the core requirements.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
-from vtsearch.datasets.loader import load_dataset_from_folder
+from vtsearch.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
 
 
 class FolderDatasetImporter(DatasetImporter):
@@ -53,6 +53,27 @@ class FolderDatasetImporter(DatasetImporter):
         if not folder.is_dir():
             raise NotADirectoryError(f"Not a directory: {folder}")
         self.run(field_values, clips, thin=thin)
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def run_chunked(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        folder = Path(field_values["path"])
+        media_type = field_values.get("media_type", "sounds")
+        yield from load_dataset_from_folder_chunked(folder, media_type, chunk_size, thin=thin)
+
+    def run_chunked_cli(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        folder = Path(field_values["path"])
+        if not folder.exists():
+            raise FileNotFoundError(f"Folder not found: {folder}")
+        if not folder.is_dir():
+            raise NotADirectoryError(f"Not a directory: {folder}")
+        yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
 
 IMPORTER = FolderDatasetImporter()

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets.downloader import download_file_with_progress
@@ -152,6 +152,49 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         if not url.startswith(("http://", "https://")):
             raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
         self.run(field_values, clips, thin=thin)
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def _download_and_extract(self, field_values: dict[str, Any]) -> Path:
+        """Download and extract the archive, returning the extraction dir."""
+        url = field_values["url"]
+
+        DATA_DIR.mkdir(exist_ok=True)
+        progress = _default_progress()
+
+        url_path = url.split("?")[0].rstrip("/")
+        url_filename = url_path.split("/")[-1] or "archive"
+        archive_path = DATA_DIR / f"http_archive_download_{url_filename}"
+        extract_dir = DATA_DIR / "http_archive_extract"
+
+        progress("downloading", "Downloading archive...", 0, 0)
+        download_file_with_progress(url, archive_path, on_progress=progress)
+
+        progress("loading", "Extracting archive...", 0, 0)
+        extract_dir.mkdir(exist_ok=True)
+        _extract_archive(archive_path, extract_dir, on_progress=progress)
+        archive_path.unlink(missing_ok=True)
+
+        return extract_dir
+
+    def run_chunked(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        extract_dir = self._download_and_extract(field_values)
+        media_type = field_values.get("media_type", "sounds")
+        yield from load_dataset_from_folder_chunked(extract_dir, media_type, chunk_size, thin=thin)
+
+    def run_chunked_cli(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        url = field_values.get("url", "")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
 
 IMPORTER = HttpArchiveDatasetImporter()

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -7,11 +7,11 @@ the core requirements.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
-from vtsearch.datasets.loader import load_dataset_from_pickle
+from vtsearch.datasets.loader import load_dataset_from_pickle, load_dataset_from_pickle_chunked
 
 
 def _get_progress():
@@ -60,6 +60,19 @@ class PickleDatasetImporter(DatasetImporter):
         if not file_path.exists():
             raise FileNotFoundError(f"Dataset file not found: {file_path}")
         load_dataset_from_pickle(file_path, clips, thin=thin)
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def run_chunked_cli(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        """Yield chunks from a pickle file path (string)."""
+        file_path = Path(field_values["file"])
+        if not file_path.exists():
+            raise FileNotFoundError(f"Dataset file not found: {file_path}")
+        yield from load_dataset_from_pickle_chunked(file_path, chunk_size, thin=thin)
 
 
 IMPORTER = PickleDatasetImporter()

--- a/vtsearch/datasets/importers/rss_feed/__init__.py
+++ b/vtsearch/datasets/importers/rss_feed/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 import requests
 
@@ -159,6 +159,97 @@ class RSSDatasetImporter(DatasetImporter):
         if not url.startswith(("http://", "https://")):
             raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
         self.run(field_values, clips, thin=thin)
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def _download_enclosures(self, field_values: dict[str, Any]) -> Path:
+        """Download RSS enclosures to a temp folder and return its path.
+
+        This separates the download phase (which must complete fully) from
+        the embed phase (which can be chunked).
+        """
+        try:
+            import feedparser
+        except ImportError as exc:
+            raise RuntimeError(
+                "RSS feed import requires the 'feedparser' package. Install it with: pip install feedparser"
+            ) from exc
+
+        from vtsearch.media import get_by_folder_name
+
+        progress = _default_progress()
+
+        url = field_values["url"]
+        media_type = field_values.get("media_type", "sounds")
+        max_episodes = int(field_values.get("max_episodes", "0") or "0")
+
+        progress("downloading", "Parsing feed...", 0, 0)
+        feed = feedparser.parse(url)
+
+        if feed.bozo and not feed.entries:
+            raise ValueError(f"Failed to parse feed: {feed.bozo_exception}")
+
+        mt = get_by_folder_name(media_type)
+        valid_exts = {ext.lstrip("*.").lower() for ext in mt.file_extensions}
+
+        enclosures: list[tuple[str, str]] = []
+        for entry in feed.entries:
+            for link in getattr(entry, "enclosures", []):
+                href = link.get("href", "")
+                if not href:
+                    continue
+                enclosures.append((entry.get("title", ""), href))
+            if max_episodes and len(enclosures) >= max_episodes:
+                enclosures = enclosures[:max_episodes]
+                break
+
+        if not enclosures:
+            raise ValueError("No media enclosures found in the feed.")
+
+        download_dir = DATA_DIR / "rss_feed_download"
+        download_dir.mkdir(parents=True, exist_ok=True)
+
+        total = len(enclosures)
+        for i, (title, href) in enumerate(enclosures, 1):
+            url_path = href.split("?")[0].rstrip("/")
+            url_filename = url_path.split("/")[-1] or f"episode_{i}"
+
+            suffix = Path(url_filename).suffix.lstrip(".").lower()
+            if suffix not in valid_exts:
+                default_ext = sorted(valid_exts)[0]
+                url_filename = f"{Path(url_filename).stem}.{default_ext}"
+
+            short_hash = hashlib.md5(href.encode()).hexdigest()[:8]
+            dest_name = f"{short_hash}_{url_filename}"
+            dest = download_dir / dest_name
+
+            progress("downloading", f"Downloading {url_filename} ({i}/{total})...", i, total)
+            try:
+                _download_enclosure(href, dest)
+            except Exception as exc:
+                progress("downloading", f"Skipped {url_filename}: {exc}", i, total)
+                continue
+
+        return download_dir
+
+    def run_chunked(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        download_dir = self._download_enclosures(field_values)
+        media_type = field_values.get("media_type", "sounds")
+        yield from load_dataset_from_folder_chunked(download_dir, media_type, chunk_size, thin=thin)
+
+    def run_chunked_cli(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        url = field_values.get("url", "")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
 
 IMPORTER = RSSDatasetImporter()

--- a/vtsearch/datasets/importers/youtube_playlist/__init__.py
+++ b/vtsearch/datasets/importers/youtube_playlist/__init__.py
@@ -6,7 +6,7 @@ Requires the ``yt-dlp`` package.  Install with: ``pip install yt-dlp``.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
@@ -136,6 +136,100 @@ class YouTubePlaylistDatasetImporter(DatasetImporter):
         if not url.startswith(("http://", "https://")):
             raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
         self.run(field_values, clips, thin=thin)
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def _download_videos(self, field_values: dict[str, Any]) -> Path:
+        """Download videos to a temp folder and return its path.
+
+        Separates the download phase from the embed phase so that
+        embedding can be chunked.
+        """
+        try:
+            import yt_dlp  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError(
+                "YouTube import requires the 'yt-dlp' package. Install it with: pip install yt-dlp"
+            ) from exc
+
+        progress = _default_progress()
+
+        url = field_values["url"]
+        media_type = field_values.get("media_type", "videos")
+        max_videos = int(field_values.get("max_videos", "0") or "0")
+
+        download_dir = DATA_DIR / "youtube_playlist_download"
+        download_dir.mkdir(parents=True, exist_ok=True)
+
+        progress("downloading", "Fetching playlist info...", 0, 0)
+
+        ydl_opts: dict[str, Any] = {
+            "format": "mp4[height<=720]/best[height<=720]/mp4/best",
+            "outtmpl": str(download_dir / "%(id)s.%(ext)s"),
+            "quiet": True,
+            "no_warnings": True,
+            "ignoreerrors": True,
+        }
+
+        if max_videos:
+            ydl_opts["playlistend"] = max_videos
+
+        if media_type == "sounds":
+            ydl_opts["format"] = "bestaudio/best"
+            ydl_opts["postprocessors"] = [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "wav",
+                    "preferredquality": "192",
+                }
+            ]
+            ydl_opts["outtmpl"] = str(download_dir / "%(id)s.%(ext)s")
+
+        downloaded_count = 0
+
+        def _progress_hook(d: dict) -> None:
+            nonlocal downloaded_count
+            if d["status"] == "finished":
+                downloaded_count += 1
+                filename = Path(d.get("filename", "")).name
+                progress(
+                    "downloading",
+                    f"Downloaded {filename} ({downloaded_count})...",
+                    downloaded_count,
+                    max_videos or 0,
+                )
+
+        ydl_opts["progress_hooks"] = [_progress_hook]
+
+        import yt_dlp
+
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([url])
+
+        any_files = list(download_dir.iterdir())
+        if not any_files:
+            raise ValueError("No videos were downloaded. Check the URL and try again.")
+
+        return download_dir
+
+    def run_chunked(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        download_dir = self._download_videos(field_values)
+        media_type = field_values.get("media_type", "videos")
+        yield from load_dataset_from_folder_chunked(download_dir, media_type, chunk_size, thin=thin)
+
+    def run_chunked_cli(
+        self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        url = field_values.get("url", "")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL (must start with http:// or https://): {url}")
+        yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
 
 IMPORTER = YouTubePlaylistDatasetImporter()

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -13,7 +13,7 @@ import hashlib
 import io
 import pickle
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
 
 import numpy as np
 from PIL import Image
@@ -401,6 +401,139 @@ def load_dataset_from_folder(
     on_progress("idle", f"Loaded {len(clips)} {media_type} clips from folder")
 
 
+def load_dataset_from_folder_chunked(
+    folder_path: Path,
+    media_type: str,
+    chunk_size: int,
+    content_vectors: dict[str, Any] | None = None,
+    content_md5s: dict[str, str] | None = None,
+    on_progress: Optional[ProgressCallback] = None,
+    origin: dict[str, Any] | None = None,
+    thin: bool = False,
+) -> Iterator[dict[int, dict[str, Any]]]:
+    """Yield chunks of clips from a flat folder of media files.
+
+    Works identically to :func:`load_dataset_from_folder` but yields the
+    clips in groups of at most *chunk_size*.  Each yielded dict is a
+    self-contained clips dict with IDs starting at 1.  After the caller
+    has processed a chunk, the dict can be discarded to free memory.
+
+    Args:
+        folder_path: Path to a flat directory containing media files.
+        media_type: Folder-import alias (e.g. ``"sounds"``).
+        chunk_size: Maximum number of clips per chunk.
+        content_vectors: Optional pre-computed embeddings keyed by filename.
+        content_md5s: Optional pre-computed MD5s keyed by filename.
+        origin: Optional origin dict to attach to each clip.
+        thin: When ``True``, store ``media_path`` instead of ``clip_bytes``.
+
+    Yields:
+        A dict mapping int clip IDs (starting at 1) to clip data dicts.
+        Each yielded dict contains at most *chunk_size* clips.
+
+    Raises:
+        ValueError: If ``media_type`` is not recognised, or if no matching
+            files are found in ``folder_path``.
+    """
+    from vtsearch.media import get_by_folder_name
+
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    on_progress("embedding", "Scanning media files...", 0, 0)
+
+    try:
+        mt = get_by_folder_name(media_type)
+    except KeyError:
+        raise ValueError(f"Invalid media type: {media_type}")
+
+    # Find all files of the specified media type
+    media_files: list[Path] = []
+    for ext in mt.file_extensions:
+        media_files.extend(folder_path.glob(ext))
+
+    if not media_files:
+        raise ValueError(f"No {media_type} files found in folder")
+
+    total_files = len(media_files)
+
+    # Process in groups of chunk_size
+    for start in range(0, total_files, chunk_size):
+        batch = media_files[start : start + chunk_size]
+        chunk_clips: dict[int, dict[str, Any]] = {}
+        clip_id = 1
+
+        for i, file_path in enumerate(batch):
+            global_idx = start + i
+            on_progress(
+                "embedding",
+                f"Embedding {media_type} {file_path.name} (chunk {start // chunk_size + 1})...",
+                global_idx + 1,
+                total_files,
+            )
+
+            if content_vectors and file_path.name in content_vectors:
+                embedding = content_vectors[file_path.name]
+            else:
+                embedding = mt.embed_media(file_path)
+                if embedding is None:
+                    continue
+
+            if thin:
+                if content_md5s and file_path.name in content_md5s:
+                    md5 = content_md5s[file_path.name]
+                else:
+                    md5 = _streaming_md5(file_path)
+                clip_data: dict[str, Any] = {
+                    "id": clip_id,
+                    "type": mt.type_id,
+                    "file_size": file_path.stat().st_size,
+                    "md5": md5,
+                    "embedding": embedding,
+                    "filename": file_path.name,
+                    "category": "custom",
+                    "origin": origin,
+                    "origin_name": file_path.name,
+                    "clip_bytes": None,
+                    "clip_string": None,
+                    "media_path": str(file_path.resolve()),
+                    "duration": 0,
+                }
+            else:
+                with open(file_path, "rb") as f:
+                    file_bytes = f.read()
+
+                if content_md5s and file_path.name in content_md5s:
+                    md5 = content_md5s[file_path.name]
+                else:
+                    md5 = hashlib.md5(file_bytes).hexdigest()
+
+                clip_data = {
+                    "id": clip_id,
+                    "type": mt.type_id,
+                    "file_size": len(file_bytes),
+                    "md5": md5,
+                    "embedding": embedding,
+                    "filename": file_path.name,
+                    "category": "custom",
+                    "origin": origin,
+                    "origin_name": file_path.name,
+                    "clip_bytes": None,
+                    "clip_string": None,
+                    "media_path": str(file_path.resolve()),
+                    "duration": 0,
+                }
+                clip_data.update(mt.load_clip_data(file_path))
+
+            chunk_clips[clip_id] = clip_data
+            clip_id += 1
+
+        if chunk_clips:
+            yield chunk_clips
+
+    on_progress("idle", f"Finished chunked loading of {total_files} {media_type} files")
+
+
 def load_dataset_from_pickle(
     file_path: Path,
     clips: dict[int, dict[str, Any]],
@@ -614,6 +747,188 @@ def load_dataset_from_pickle(
         print(f"WARNING: {missing_media} media files missing from {file_path}", flush=True)
 
     return None
+
+
+def load_dataset_from_pickle_chunked(
+    file_path: Path,
+    chunk_size: int,
+    thin: bool = False,
+) -> Iterator[dict[int, dict[str, Any]]]:
+    """Yield chunks of clips from a pickle dataset file.
+
+    Works identically to :func:`load_dataset_from_pickle` but yields the
+    clips in groups of at most *chunk_size*.  Each yielded dict is a
+    self-contained clips dict with IDs starting at 1.
+
+    The entire pickle is deserialized once (unavoidable for ``.pkl``
+    format), but media bytes are dropped or skipped per-chunk so that
+    only one chunk's worth of clip data is alive at a time.
+
+    Args:
+        file_path: Path to a ``.pkl`` dataset file.
+        chunk_size: Maximum number of clips per yielded chunk.
+        thin: When ``True``, skip loading media bytes into memory.
+
+    Yields:
+        A dict mapping int clip IDs (starting at 1) to clip data dicts.
+    """
+    with open(file_path, "rb") as f:
+        data = pickle.load(f)
+
+    if isinstance(data, dict) and "clips" in data:
+        clips_data = data["clips"]
+        creation_info = data.get("creation_info")
+    else:
+        clips_data = data
+        creation_info = None
+
+    fallback_origin = None
+    if creation_info:
+        fallback_origin = {
+            "importer": creation_info.get("importer", "unknown"),
+            "params": creation_info.get("field_values", {}),
+        }
+
+    _dir_keys = {
+        "audio": "audio_dir",
+        "video": "video_dir",
+        "image": "image_dir",
+        "paragraph": "text_dir",
+    }
+
+    all_clip_ids = sorted(clips_data.keys())
+
+    for start in range(0, len(all_clip_ids), chunk_size):
+        batch_ids = all_clip_ids[start : start + chunk_size]
+        chunk_clips: dict[int, dict[str, Any]] = {}
+        new_id = 1
+
+        for clip_id in batch_ids:
+            clip_info = clips_data[clip_id]
+            media_type = clip_info.get("type", "audio")
+
+            if thin:
+                media_path: str | None = clip_info.get("media_path")
+                if not media_path:
+                    dir_key = _dir_keys.get(media_type)
+                    if dir_key and dir_key in data and "filename" in clip_info:
+                        candidate = Path(data[dir_key]) / clip_info["filename"]
+                        if candidate.exists():
+                            media_path = str(candidate.resolve())
+
+                if "embedding" not in clip_info:
+                    continue
+
+                fname = clip_info.get("filename", f"clip_{clip_id}.{media_type}")
+                clip_data: dict[str, Any] = {
+                    "id": new_id,
+                    "type": media_type,
+                    "duration": clip_info.get("duration", 0),
+                    "file_size": clip_info.get("file_size", 0),
+                    "md5": clip_info.get("md5", ""),
+                    "embedding": np.array(clip_info["embedding"]),
+                    "clip_bytes": None,
+                    "clip_string": None,
+                    "media_path": media_path,
+                    "filename": fname,
+                    "category": clip_info.get("category", "unknown"),
+                    "origin": clip_info.get("origin", fallback_origin),
+                    "origin_name": clip_info.get("origin_name", fname),
+                }
+                if media_type == "image":
+                    clip_data["width"] = clip_info.get("width")
+                    clip_data["height"] = clip_info.get("height")
+                elif media_type == "paragraph":
+                    clip_data["word_count"] = clip_info.get("word_count")
+                    clip_data["character_count"] = clip_info.get("character_count")
+
+                chunk_clips[new_id] = clip_data
+                new_id += 1
+                continue
+
+            # Full mode — same logic as load_dataset_from_pickle
+            clip_bytes = None
+            clip_string = None
+            media_bytes = None
+            media_path = None
+
+            if media_type == "audio":
+                clip_bytes = clip_info.get("clip_bytes") or clip_info.get("wav_bytes")
+                if clip_bytes is not None:
+                    media_bytes = clip_bytes
+                elif "filename" in clip_info and "audio_dir" in data:
+                    audio_path = Path(data["audio_dir"]) / clip_info["filename"]
+                    if audio_path.exists():
+                        with open(audio_path, "rb") as f:
+                            clip_bytes = f.read()
+                            media_bytes = clip_bytes
+                        media_path = str(audio_path.resolve())
+
+            elif media_type == "video":
+                clip_bytes = clip_info.get("clip_bytes") or clip_info.get("video_bytes")
+                if clip_bytes is not None:
+                    media_bytes = clip_bytes
+                elif "filename" in clip_info and "video_dir" in data:
+                    video_path = Path(data["video_dir"]) / clip_info["filename"]
+                    if video_path.exists():
+                        with open(video_path, "rb") as f:
+                            clip_bytes = f.read()
+                            media_bytes = clip_bytes
+                        media_path = str(video_path.resolve())
+
+            elif media_type == "image":
+                clip_bytes = clip_info.get("clip_bytes") or clip_info.get("image_bytes")
+                if clip_bytes is not None:
+                    media_bytes = clip_bytes
+                elif "filename" in clip_info and "image_dir" in data:
+                    image_path = Path(data["image_dir"]) / clip_info["filename"]
+                    if image_path.exists():
+                        with open(image_path, "rb") as f:
+                            clip_bytes = f.read()
+                            media_bytes = clip_bytes
+                        media_path = str(image_path.resolve())
+
+            elif media_type == "paragraph":
+                clip_string = clip_info.get("clip_string") or clip_info.get("text_content")
+                if clip_string is not None:
+                    media_bytes = clip_string.encode("utf-8")
+                elif "filename" in clip_info and "text_dir" in data:
+                    text_path = Path(data["text_dir"]) / clip_info["filename"]
+                    if text_path.exists():
+                        with open(text_path, "r", encoding="utf-8") as f:
+                            clip_string = f.read()
+                            media_bytes = clip_string.encode("utf-8")
+                        media_path = str(text_path.resolve())
+
+            if media_bytes:
+                fname = clip_info.get("filename", f"clip_{clip_id}.{media_type}")
+                clip_data = {
+                    "id": new_id,
+                    "type": media_type,
+                    "duration": clip_info.get("duration", 0),
+                    "file_size": clip_info.get("file_size", len(media_bytes)),
+                    "md5": clip_info.get("md5") or hashlib.md5(media_bytes).hexdigest(),
+                    "embedding": np.array(clip_info["embedding"]),
+                    "clip_bytes": clip_bytes,
+                    "clip_string": clip_string,
+                    "media_path": media_path or clip_info.get("media_path"),
+                    "filename": fname,
+                    "category": clip_info.get("category", "unknown"),
+                    "origin": clip_info.get("origin", fallback_origin),
+                    "origin_name": clip_info.get("origin_name", fname),
+                }
+                if media_type == "image":
+                    clip_data["width"] = clip_info.get("width")
+                    clip_data["height"] = clip_info.get("height")
+                elif media_type == "paragraph":
+                    clip_data["word_count"] = clip_info.get("word_count")
+                    clip_data["character_count"] = clip_info.get("character_count")
+
+                chunk_clips[new_id] = clip_data
+                new_id += 1
+
+        if chunk_clips:
+            yield chunk_clips
 
 
 def embed_image_file_from_pil(image: Image.Image) -> Optional[np.ndarray]:


### PR DESCRIPTION
## Summary

This PR introduces chunked (piecewise) dataset loading capabilities to vtsearch, allowing large datasets to be processed in memory-bounded chunks rather than loading the entire dataset at once. This is particularly useful for autodetection workflows on large datasets where peak memory usage needs to be controlled.

## Key Changes

- **New loader functions**: Added `load_dataset_from_folder_chunked()` and `load_dataset_from_pickle_chunked()` that yield clips in configurable chunk sizes, with each chunk having independent IDs starting at 1.

- **Base importer interface**: Extended `DatasetImporter` with:
  - `supports_chunked` property to advertise chunked loading capability
  - `run_chunked()` method (with default implementation delegating to `run()`)
  - `run_chunked_cli()` method for CLI-based chunked loading

- **Importer implementations**: Added chunked support to:
  - `FolderDatasetImporter`: Chunks files from a directory
  - `PickleDatasetImporter`: Chunks clips from pickle files
  - `CombineDatasetsImporter`: Yields one chunk per source dataset with cross-source deduplication
  - `YouTubePlaylistImporter`: Downloads all videos first, then chunks embedding
  - `RSSFeedImporter`: Downloads all enclosures first, then chunks embedding
  - `HTTPZipImporter`: Downloads and extracts archive, then chunks embedding

- **CLI enhancements**:
  - Added `--chunk-size` argument to `app.py` for chunked autodetection
  - New `autodetect_main_chunked()` entry point for chunked pickle processing
  - New `autodetect_importer_main_chunked()` entry point for chunked importer-based processing
  - Added `_merge_detector_results()` helper to merge detector results across chunks

- **Comprehensive test suite**: Added 463 lines of tests covering:
  - Folder and pickle chunked loading with various chunk sizes
  - Thin vs. full mode behavior
  - Metadata preservation and deduplication
  - Importer chunked implementations
  - Result merging across chunks

## Implementation Details

- Each chunk is a self-contained clips dict with IDs reset to start at 1, allowing independent processing
- Thin mode stores `media_path` references instead of loading bytes into memory
- Full mode loads media bytes but still processes in chunks to bound memory
- Detector results are merged across chunks by concatenating hit lists and re-sorting by score
- Cross-source deduplication in `CombineDatasetsImporter` is maintained across chunk boundaries via a running `seen_md5s` set
- Importers that require full downloads (YouTube, RSS, HTTP) separate the download phase from the chunked embedding phase

https://claude.ai/code/session_01WNaXPFePLbp5xmJrzVtqpn