### PR TITLE
Explicitly pass token=False to all HuggingFace model loaders

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,8 +9,10 @@ os.environ["MKL_NUM_THREADS"] = "1"
 # Suppress Werkzeug request logging (GET/POST lines) — only show errors
 logging.getLogger("werkzeug").setLevel(logging.ERROR)
 
-# Suppress HF Hub "unauthenticated requests" warning — no token needed for
-# public model downloads; the warning is just noise.
+# All HF models we use are public — no token needed.  Each from_pretrained()
+# call passes token=False to signal this explicitly.  The env var + warnings
+# filter below are belt-and-suspenders in case any transitive HF code still
+# warns about missing tokens.
 os.environ["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1"
 warnings.filterwarnings("ignore", message=".*unauthenticated requests.*HF Hub.*")
 

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -149,8 +149,8 @@ class AudioMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading audio embedder (CLAP model)...", 0, 0)
-        self._model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
-        self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir)
+        self._model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+        self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -175,8 +175,8 @@ class ImageMediaType(MediaType):
         # Older CLIP checkpoints include position_ids buffers that newer transformers
         # versions compute on-the-fly.  Tell the loader to silently ignore them.
         CLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
-        self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
-        self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True)
+        self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+        self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -143,7 +143,7 @@ class TextMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading text embedder (E5 model)...", 0, 0)
-        self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir)
+        self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -153,8 +153,8 @@ class VideoMediaType(MediaType):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading video embedder (X-CLIP model)...", 0, 0)
-        self._model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir)
-        self._processor = XCLIPProcessor.from_pretrained(XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False)
+        self._model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+        self._processor = XCLIPProcessor.from_pretrained(XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:


### PR DESCRIPTION
## Summary
Updated all HuggingFace model loading calls to explicitly pass `token=False`, signaling that no authentication token is needed for public models. This makes the token handling explicit and reduces reliance on environment variables and warning filters.

## Changes
- **app.py**: Enhanced comments explaining the token handling strategy as "belt-and-suspenders" approach
- **vtsearch/media/audio/media_type.py**: Added `token=False` to `ClapModel.from_pretrained()` and `ClapProcessor.from_pretrained()` calls
- **vtsearch/media/image/media_type.py**: Added `token=False` to `CLIPModel.from_pretrained()` and `CLIPProcessor.from_pretrained()` calls
- **vtsearch/media/video/media_type.py**: Added `token=False` to `XCLIPModel.from_pretrained()` and `XCLIPProcessor.from_pretrained()` calls
- **vtsearch/media/text/media_type.py**: Added `token=False` to `SentenceTransformer()` call

## Implementation Details
All public HuggingFace models used in the application now explicitly declare they don't require authentication tokens. This approach:
- Makes the intent explicit in the code rather than relying solely on environment variables
- Complements the existing `HF_HUB_DISABLE_IMPLICIT_TOKEN` environment variable setting
- Provides defense-in-depth against potential warnings from transitive HuggingFace dependencies

https://claude.ai/code/session_01AWkwfnnWcNeggDE8rK2CyQ