### PR TITLE
Handle nested tar.gz in Caltech-101 zip archive

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -420,3 +420,114 @@ class TestExtractArchive:
         with mock.patch.dict(sys.modules, {"rarfile": None}):
             with pytest.raises((RuntimeError, ImportError, Exception)):
                 _extract_archive(rar_path, extract_dir)
+
+
+class TestCaltech101Download:
+    """Verify download_caltech101 handles the nested zip→tar.gz structure."""
+
+    def _make_caltech101_zip(self, zip_path):
+        """Create a mock caltech-101.zip matching the real archive structure.
+
+        The real archive contains ``caltech-101/101_ObjectCategories.tar.gz``
+        (a nested tar.gz) rather than bare category directories.
+        """
+        # Build the inner tar.gz with a few dummy category images
+        inner_tar_buf = io.BytesIO()
+        with tarfile.open(fileobj=inner_tar_buf, mode="w:gz") as tf:
+            for cat in ("butterfly", "dolphin"):
+                for i in range(3):
+                    fname = f"101_ObjectCategories/{cat}/image_{i:04d}.jpg"
+                    # Minimal JPEG: SOI + EOI markers
+                    data = b"\xff\xd8\xff\xe0" + b"\x00" * 20 + b"\xff\xd9"
+                    info = tarfile.TarInfo(name=fname)
+                    info.size = len(data)
+                    tf.addfile(info, io.BytesIO(data))
+        inner_tar_bytes = inner_tar_buf.getvalue()
+
+        # Build the outer zip
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("caltech-101/", "")
+            zf.writestr("caltech-101/101_ObjectCategories.tar.gz", inner_tar_bytes)
+            zf.writestr("caltech-101/show_annotation.m", "% annotation script\n")
+
+    def test_extracts_nested_tar_gz(self, tmp_path):
+        """download_caltech101 should extract the inner tar.gz to produce category dirs."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_caltech101
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        zip_path = data_dir / "caltech-101.zip"
+        self._make_caltech101_zip(zip_path)
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.IMAGE_DIR", data_dir / "images"),
+        ):
+            result = download_caltech101(on_progress=lambda *a: None)
+
+        assert result.exists(), f"Expected {result} to exist"
+        assert result.name == "101_ObjectCategories"
+        assert (result / "butterfly").is_dir()
+        assert (result / "dolphin").is_dir()
+        assert len(list((result / "butterfly").glob("*.jpg"))) == 3
+
+    def test_inner_tar_cleaned_up(self, tmp_path):
+        """The inner 101_ObjectCategories.tar.gz should be deleted after extraction."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_caltech101
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        zip_path = data_dir / "caltech-101.zip"
+        self._make_caltech101_zip(zip_path)
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.IMAGE_DIR", data_dir / "images"),
+        ):
+            download_caltech101(on_progress=lambda *a: None)
+
+        inner_tar = data_dir / "caltech-101" / "101_ObjectCategories.tar.gz"
+        assert not inner_tar.exists(), "Inner tar.gz should be deleted after extraction"
+
+    def test_outer_zip_cleaned_up(self, tmp_path):
+        """The outer caltech-101.zip should be deleted after extraction."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_caltech101
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        zip_path = data_dir / "caltech-101.zip"
+        self._make_caltech101_zip(zip_path)
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.IMAGE_DIR", data_dir / "images"),
+        ):
+            download_caltech101(on_progress=lambda *a: None)
+
+        assert not zip_path.exists(), "Outer zip should be deleted after extraction"
+
+    def test_skips_if_already_extracted(self, tmp_path):
+        """If 101_ObjectCategories already exists, skip download and extraction."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_caltech101
+
+        data_dir = tmp_path / "data"
+        categories_dir = data_dir / "caltech-101" / "101_ObjectCategories" / "butterfly"
+        categories_dir.mkdir(parents=True)
+        (categories_dir / "image_0001.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.IMAGE_DIR", data_dir / "images"),
+        ):
+            result = download_caltech101(on_progress=lambda *a: None)
+
+        assert result.exists()
+        assert (result / "butterfly" / "image_0001.jpg").exists()

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -7,6 +7,7 @@ When omitted the functions fall back to the application-wide
 to use these functions outside the Flask app (scripts, notebooks, tests).
 """
 
+import tarfile
 import zipfile
 from pathlib import Path
 from typing import Callable, Optional
@@ -138,8 +139,6 @@ def download_cifar10(on_progress: Optional[ProgressCallback] = None) -> Path:
     if on_progress is None:
         on_progress = _default_progress()
 
-    import tarfile
-
     tar_path = DATA_DIR / "cifar-10-python.tar.gz"
     extract_dir = DATA_DIR / "cifar-10-batches-py"
     DATA_DIR.mkdir(exist_ok=True)
@@ -162,8 +161,11 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
     """Download and extract the Caltech-101 image classification dataset.
 
     Downloads ``caltech-101.zip`` from the configured ``CALTECH101_URL``
-    into ``DATA_DIR`` if it is not already present, then extracts it and
-    deletes the archive to reclaim disk space.
+    into ``DATA_DIR`` if it is not already present, then extracts it.
+    The zip contains a nested ``101_ObjectCategories.tar.gz`` archive
+    which is extracted in a second pass to produce the final category
+    directories.  Both archives are deleted after extraction to reclaim
+    disk space.
 
     Args:
         on_progress: Optional progress callback. Falls back to the
@@ -190,7 +192,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
                 CALTECH101_URL, zip_path, CALTECH101_DOWNLOAD_SIZE_MB * 1024 * 1024, on_progress
             )
 
-        on_progress("downloading", "Extracting Caltech-101...", 0, 0)
+        on_progress("downloading", "Extracting Caltech-101 zip...", 0, 0)
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             members = zip_ref.namelist()
             total = len(members)
@@ -198,13 +200,22 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
                 if i % 100 == 0 or i == total:
                     on_progress(
                         "downloading",
-                        f"Extracting Caltech-101 ({i}/{total})...",
+                        f"Extracting Caltech-101 zip ({i}/{total})...",
                         i,
                         total,
                     )
                 zip_ref.extract(member, DATA_DIR)
 
         zip_path.unlink(missing_ok=True)
+
+        # The zip contains 101_ObjectCategories.tar.gz (a nested archive).
+        # Extract it to produce the actual category directories.
+        inner_tar = extract_dir / "101_ObjectCategories.tar.gz"
+        if inner_tar.exists() and not categories_dir.exists():
+            on_progress("downloading", "Extracting 101_ObjectCategories...", 0, 0)
+            with tarfile.open(inner_tar, "r:gz") as tar_ref:
+                tar_ref.extractall(extract_dir, filter="data")
+            inner_tar.unlink(missing_ok=True)
 
     return categories_dir
 


### PR DESCRIPTION
## Summary
Updated `download_caltech101()` to properly handle the nested archive structure of the Caltech-101 dataset, where the zip file contains a `101_ObjectCategories.tar.gz` archive that must be extracted separately to produce the final category directories.

## Key Changes
- **Two-stage extraction**: Added logic to extract the inner `101_ObjectCategories.tar.gz` after extracting the outer zip file
- **Cleanup**: Both the outer zip and inner tar.gz archives are now deleted after extraction to reclaim disk space
- **Import optimization**: Moved `tarfile` import to module level (alongside `zipfile`) for consistency
- **Updated docstring**: Clarified the nested archive structure and two-stage extraction process
- **Progress messages**: Improved progress callback messages to distinguish between zip and tar.gz extraction stages

## Implementation Details
- The inner tar.gz extraction only occurs if the archive exists and the final `101_ObjectCategories` directory hasn't been created yet
- Uses `filter="data"` parameter in `tarfile.extractall()` for security
- Comprehensive test coverage added:
  - Verifies nested tar.gz extraction produces correct category directories
  - Confirms both archives are cleaned up after extraction
  - Tests skip behavior when dataset already exists
  - Uses mock archive structure matching the real Caltech-101 format

https://claude.ai/code/session_013RvEJEHDnJp7Ff2Qr27ACy