### PR TITLE
Improve model loading progress reporting with granular steps

### DIFF
--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -155,9 +155,11 @@ class AudioMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading audio embedder (CLAP model)…", 0, 0)
+        self._on_progress("loading", "Loading CLAP model weights…", 0, 2)
         with intercept_tqdm_progress(self._on_progress):
             self._model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+        self._on_progress("loading", "Loading CLAP processor…", 1, 2)
+        with intercept_tqdm_progress(self._on_progress):
             self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -178,12 +178,14 @@ class ImageMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading image embedder (CLIP model)…", 0, 0)
+        self._on_progress("loading", "Loading CLIP model weights…", 0, 2)
         # Older CLIP checkpoints include position_ids buffers that newer transformers
         # versions compute on-the-fly.  Tell the loader to silently ignore them.
         CLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         with intercept_tqdm_progress(self._on_progress):
             self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+        self._on_progress("loading", "Loading CLIP processor…", 1, 2)
+        with intercept_tqdm_progress(self._on_progress):
             self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -149,7 +149,7 @@ class TextMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading text embedder (E5 model)…", 0, 0)
+        self._on_progress("loading", "Loading E5 model…", 0, 1)
         with intercept_tqdm_progress(self._on_progress):
             self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir, token=False)
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -159,9 +159,11 @@ class VideoMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading video embedder (X-CLIP model)…", 0, 0)
+        self._on_progress("loading", "Loading X-CLIP model weights…", 0, 2)
         with intercept_tqdm_progress(self._on_progress):
             self._model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+        self._on_progress("loading", "Loading X-CLIP processor…", 1, 2)
+        with intercept_tqdm_progress(self._on_progress):
             self._processor = XCLIPProcessor.from_pretrained(XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False)
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:


### PR DESCRIPTION
## Summary
Enhanced the model loading progress reporting across all media type embedders (audio, image, video, and text) to provide more granular feedback to users during the model initialization process.

## Key Changes
- **Audio (CLAP)**: Split loading into two distinct steps - model weights and processor, with progress tracking from 0/2 to 1/2
- **Image (CLIP)**: Split loading into two distinct steps - model weights and processor, with progress tracking from 0/2 to 1/2
- **Video (X-CLIP)**: Split loading into two distinct steps - model weights and processor, with progress tracking from 0/2 to 1/2
- **Text (E5)**: Updated progress reporting to reflect single-step loading (0/1)
- Updated progress messages to be more specific about what is being loaded (e.g., "Loading CLAP model weights…" and "Loading CLAP processor…" instead of generic "Loading audio embedder (CLAP model)…")
- Wrapped processor loading with `intercept_tqdm_progress` context manager for consistent progress tracking

## Implementation Details
The changes ensure that users receive more detailed feedback during model initialization, particularly for multi-component models (CLAP, CLIP, X-CLIP) where both model weights and processors need to be loaded. The progress counter now accurately reflects the total number of steps and current progress, improving the user experience during potentially long-running model loading operations.

https://claude.ai/code/session_01AhwzcRK2H1aWCcGYa2xgEt