### PR TITLE
Add show_thumbnails setting for image/video media

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -296,6 +296,8 @@
   const settingsImportBtn = document.getElementById("settings-import-btn");
   const settingsImportFile = document.getElementById("settings-import-file");
   const settingsExportBtn = document.getElementById("settings-export-btn");
+  const showThumbnailsCheckbox = document.getElementById("show-thumbnails-checkbox");
+  let showThumbnails = false;
 
   // ---- Dataset Management ----
 
@@ -1509,6 +1511,10 @@
     if (calibrationFractionInput) calibrationFractionInput.value = data.calibration_fraction;
     if (safeThresholdsCheckbox) safeThresholdsCheckbox.checked = !!data.safe_thresholds;
     if (enrichDescCheckbox) enrichDescCheckbox.checked = !!data.enrich_descriptions;
+    if (showThumbnailsCheckbox) {
+      showThumbnailsCheckbox.checked = !!data.show_thumbnails;
+      showThumbnails = !!data.show_thumbnails;
+    }
   }
 
   if (menuSettings && settingsModal && burgerDropdown) {
@@ -1554,6 +1560,20 @@
     });
   }
 
+  // Show Thumbnails toggle
+  if (showThumbnailsCheckbox) {
+    showThumbnailsCheckbox.addEventListener("change", () => {
+      showThumbnails = showThumbnailsCheckbox.checked;
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ show_thumbnails: showThumbnails }),
+      }).catch(() => {});
+      renderClipList();
+      renderVotes();
+    });
+  }
+
   // Default button — reset all settings to defaults
   if (settingsDefaultBtn) {
     settingsDefaultBtn.addEventListener("click", async () => {
@@ -1576,6 +1596,8 @@
         audioVolume = defaults.volume != null ? defaults.volume : 1.0;
         const audioEl = document.getElementById("clip-audio");
         if (audioEl) audioEl.volume = audioVolume;
+        renderClipList();
+        renderVotes();
       } catch (_) {}
     });
   }
@@ -1591,7 +1613,7 @@
         const imported = JSON.parse(text);
         // Send all importable fields to the server
         const payload = {};
-        const importableKeys = ["volume", "theme", "inclusion", "enrich_descriptions", "safe_thresholds", "calibrate_count", "calibration_fraction"];
+        const importableKeys = ["volume", "theme", "inclusion", "enrich_descriptions", "safe_thresholds", "calibrate_count", "calibration_fraction", "show_thumbnails"];
         for (const k of importableKeys) {
           if (k in imported) payload[k] = imported[k];
         }
@@ -1608,6 +1630,8 @@
           audioVolume = typeof data.volume === "number" ? data.volume : 1.0;
           const audioEl = document.getElementById("clip-audio");
           if (audioEl) audioEl.volume = audioVolume;
+          renderClipList();
+          renderVotes();
         }
       } catch (_) {
         vtAlert("Failed to import settings. Make sure the file is valid JSON.", "error");
@@ -2073,6 +2097,16 @@
     inclusionValue.textContent = inclusion;
   }
 
+  function clipSupportsThumbnail(clip) {
+    return clip && (clip.type === "image" || clip.type === "video");
+  }
+
+  function thumbnailUrl(clip) {
+    if (clip.type === "image") return `/api/clips/${clip.id}/image`;
+    if (clip.type === "video") return `/api/clips/${clip.id}/video`;
+    return "";
+  }
+
   function renderClipList() {
     clipList.innerHTML = "";
     const scoreMap = {};
@@ -2114,7 +2148,19 @@
       if (isBad) labelParts.push("labeled bad");
       if (scoreMap[c.id] !== undefined) labelParts.push(`score ${(scoreMap[c.id] * 100).toFixed(1)}%`);
       div.setAttribute("aria-label", labelParts.join(", "));
-      let html = `<div style="font-weight: 500;">${clipLabel}</div>`;
+      let html = "";
+      const useThumbnail = showThumbnails && clipSupportsThumbnail(c);
+      if (useThumbnail) {
+        div.className += " clip-item-thumb";
+        const poster = c.type === "video" ? ` poster="/api/clips/${c.id}/image"` : "";
+        if (c.type === "video") {
+          html += `<video class="clip-thumbnail" src="${thumbnailUrl(c)}" muted preload="metadata"${poster}></video>`;
+        } else {
+          html += `<img class="clip-thumbnail" src="${thumbnailUrl(c)}" alt="${clipLabel}" loading="lazy">`;
+        }
+        html += `<div class="clip-thumb-info">`;
+      }
+      html += `<div style="font-weight: 500;">${clipLabel}</div>`;
       if (scoreMap[c.id] !== undefined) {
         html += `<span class="sim">${(scoreMap[c.id] * 100).toFixed(1)}%</span>`;
       }
@@ -2133,6 +2179,9 @@
         subInfo.push(`${c.word_count} words`);
       }
       html += `<div class="sub">${subInfo.join(' &middot; ')}</div>`;
+      if (useThumbnail) {
+        html += `</div>`;
+      }
       div.innerHTML = html;
       div.onclick = () => selectClip(c.id);
       div.addEventListener("keydown", (e) => {
@@ -2452,49 +2501,50 @@
     return entries;
   }
 
+  function renderVoteEntry(entry, label, parentEl) {
+    const clip = clips.find(c => c.id === entry.id);
+    const div = document.createElement("div");
+    div.className = "vote-entry";
+    div.setAttribute("role", "button");
+    div.setAttribute("tabindex", "0");
+    div.setAttribute("aria-label", `${label}: ${entry.name}`);
+    const metaParts = [];
+    if (entry.time >= 0) metaParts.push(`#${entry.time}`);
+    else metaParts.push("imported");
+    if (entry.confidence >= 0) metaParts.push(`${(entry.confidence * 100).toFixed(0)}%`);
+
+    const useThumbnail = showThumbnails && clipSupportsThumbnail(clip);
+    let html = "";
+    if (useThumbnail) {
+      div.className += " vote-entry-thumb";
+      if (clip.type === "video") {
+        html += `<video class="vote-thumbnail" src="${thumbnailUrl(clip)}" muted preload="metadata"></video>`;
+      } else {
+        html += `<img class="vote-thumbnail" src="${thumbnailUrl(clip)}" alt="${entry.name}" loading="lazy">`;
+      }
+      html += `<div class="vote-thumb-info">`;
+    }
+    html += `<span class="vote-name">${entry.name}</span><span class="vote-meta">${metaParts.join(" \u00b7 ")}</span>`;
+    if (useThumbnail) {
+      html += `</div>`;
+    }
+    div.innerHTML = html;
+    div.onclick = () => selectClip(entry.id);
+    div.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); selectClip(entry.id); }
+    });
+    parentEl.appendChild(div);
+  }
+
   function renderVotes() {
     goodList.innerHTML = "";
     badList.innerHTML = "";
 
     const sortedGood = sortLabelEntries(votes.good, "good");
-
-    sortedGood.forEach(entry => {
-      const div = document.createElement("div");
-      div.className = "vote-entry";
-      div.setAttribute("role", "button");
-      div.setAttribute("tabindex", "0");
-      div.setAttribute("aria-label", `Good: ${entry.name}`);
-      const metaParts = [];
-      if (entry.time >= 0) metaParts.push(`#${entry.time}`);
-      else metaParts.push("imported");
-      if (entry.confidence >= 0) metaParts.push(`${(entry.confidence * 100).toFixed(0)}%`);
-      div.innerHTML = `<span class="vote-name">${entry.name}</span><span class="vote-meta">${metaParts.join(" \u00b7 ")}</span>`;
-      div.onclick = () => selectClip(entry.id);
-      div.addEventListener("keydown", (e) => {
-        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); selectClip(entry.id); }
-      });
-      goodList.appendChild(div);
-    });
+    sortedGood.forEach(entry => renderVoteEntry(entry, "Good", goodList));
 
     const sortedBad = sortLabelEntries(votes.bad, "bad");
-
-    sortedBad.forEach(entry => {
-      const div = document.createElement("div");
-      div.className = "vote-entry";
-      div.setAttribute("role", "button");
-      div.setAttribute("tabindex", "0");
-      div.setAttribute("aria-label", `Bad: ${entry.name}`);
-      const metaParts = [];
-      if (entry.time >= 0) metaParts.push(`#${entry.time}`);
-      else metaParts.push("imported");
-      if (entry.confidence >= 0) metaParts.push(`${(entry.confidence * 100).toFixed(0)}%`);
-      div.innerHTML = `<span class="vote-name">${entry.name}</span><span class="vote-meta">${metaParts.join(" \u00b7 ")}</span>`;
-      div.onclick = () => selectClip(entry.id);
-      div.addEventListener("keydown", (e) => {
-        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); selectClip(entry.id); }
-      });
-      badList.appendChild(div);
-    });
+    sortedBad.forEach(entry => renderVoteEntry(entry, "Bad", badList));
   }
 
   function renderStripe() {
@@ -3472,6 +3522,10 @@
       }
       if (safeThresholdsCheckbox) {
         safeThresholdsCheckbox.checked = !!data.safe_thresholds;
+      }
+      if (showThumbnailsCheckbox) {
+        showThumbnailsCheckbox.checked = !!data.show_thumbnails;
+        showThumbnails = !!data.show_thumbnails;
       }
     } catch (_) {
       // Settings not available yet; use defaults

--- a/static/index.html
+++ b/static/index.html
@@ -369,6 +369,10 @@
             <button class="theme-btn" data-theme="highviz">HighViz</button>
           </div>
         </div>
+        <div class="settings-row">
+          <label for="show-thumbnails-checkbox" class="settings-label">Show Thumbnails</label>
+          <input type="checkbox" id="show-thumbnails-checkbox" style="accent-color:var(--accent)">
+        </div>
       </div>
       <!-- Calibration -->
       <div class="settings-section">

--- a/static/styles.css
+++ b/static/styles.css
@@ -215,6 +215,17 @@ header h1 { margin-left: 48px; }
 .clip-threshold-line::before { content: ''; position: absolute; left: 0; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent; border-left: 6px solid var(--accent); }
 .clip-threshold-line::after { content: ''; position: absolute; right: 20px; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent; border-right: 6px solid var(--accent); }
 
+/* Thumbnail mode — clip list */
+.clip-item.clip-item-thumb { display: flex; align-items: center; gap: 10px; padding: 6px 16px; }
+.clip-item.clip-item-thumb .clip-thumbnail { width: 60px; height: 45px; object-fit: cover; border-radius: 3px; flex-shrink: 0; background: var(--bg-surface); }
+.clip-item.clip-item-thumb .clip-thumb-info { min-width: 0; flex: 1; overflow: hidden; }
+.clip-item.clip-item-thumb .sim { float: none; display: block; }
+
+/* Thumbnail mode — vote entries */
+.vote-entry.vote-entry-thumb { display: flex; align-items: center; gap: 8px; padding: 4px 0; }
+.vote-entry.vote-entry-thumb .vote-thumbnail { width: 48px; height: 36px; object-fit: cover; border-radius: 3px; flex-shrink: 0; background: var(--bg-surface); }
+.vote-entry.vote-entry-thumb .vote-thumb-info { min-width: 0; flex: 1; overflow: hidden; }
+
 /* Stripe overview */
 .stripe-overview { position: absolute; right: 0; top: 0; bottom: 0; width: 20px; background: var(--bg-surface); border-left: 1px solid var(--border); cursor: pointer; }
 .stripe-container { position: relative; height: 100%; }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -181,6 +181,21 @@ class TestSettingsModule:
     def test_safe_thresholds_default(self):
         assert settings_mod.get_safe_thresholds() is False
 
+    def test_get_set_show_thumbnails(self, isolated_settings):
+        settings_mod.set_show_thumbnails(True)
+        assert settings_mod.get_show_thumbnails() is True
+
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["show_thumbnails"] is True
+
+    def test_show_thumbnails_default(self):
+        assert settings_mod.get_show_thumbnails() is False
+
+    def test_show_thumbnails_persists_across_reset(self, isolated_settings):
+        settings_mod.set_show_thumbnails(True)
+        settings_mod.reset()
+        assert settings_mod.get_show_thumbnails() is True
+
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()
         assert defaults["volume"] == 1.0
@@ -188,6 +203,7 @@ class TestSettingsModule:
         assert defaults["calibrate_count"] == 2
         assert defaults["calibration_fraction"] == 0.5
         assert defaults["safe_thresholds"] is False
+        assert defaults["show_thumbnails"] is False
         assert "favorite_processors" not in defaults
 
     def test_corrupt_settings_file(self, isolated_settings):
@@ -458,3 +474,24 @@ class TestSettingsAPI:
         res = client.put("/api/settings", json={"safe_thresholds": False})
         assert res.status_code == 200
         assert res.get_json()["safe_thresholds"] is False
+
+    def test_update_show_thumbnails(self, client):
+        res = client.put("/api/settings", json={"show_thumbnails": True})
+        assert res.status_code == 200
+        assert res.get_json()["show_thumbnails"] is True
+
+        # Verify it persisted
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["show_thumbnails"] is True
+
+    def test_update_show_thumbnails_false(self, client):
+        client.put("/api/settings", json={"show_thumbnails": True})
+        res = client.put("/api/settings", json={"show_thumbnails": False})
+        assert res.status_code == 200
+        assert res.get_json()["show_thumbnails"] is False
+
+    def test_get_settings_includes_show_thumbnails(self, client):
+        res = client.get("/api/settings")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "show_thumbnails" in data

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -96,6 +96,9 @@ def update_settings():
         except (TypeError, ValueError):
             return jsonify({"error": "calibrate_count must be a number"}), 400
 
+    if "show_thumbnails" in body:
+        settings.set_show_thumbnails(bool(body["show_thumbnails"]))
+
     return jsonify(settings.get_all())
 
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -43,6 +43,7 @@ _DEFAULTS: dict[str, Any] = {
     "safe_thresholds": False,
     "calibrate_count": 2,
     "calibration_fraction": 0.5,
+    "show_thumbnails": False,
     "favorite_processors": [],
 }
 
@@ -180,6 +181,18 @@ def set_safe_thresholds(value: bool) -> None:
     """Set and persist the safe_thresholds flag."""
     s = _ensure_loaded()
     s["safe_thresholds"] = bool(value)
+    _save(s)
+
+
+def get_show_thumbnails() -> bool:
+    """Return whether thumbnail display is enabled."""
+    return bool(_ensure_loaded().get("show_thumbnails", _DEFAULTS["show_thumbnails"]))
+
+
+def set_show_thumbnails(value: bool) -> None:
+    """Set and persist the show_thumbnails flag."""
+    s = _ensure_loaded()
+    s["show_thumbnails"] = bool(value)
     _save(s)
 
 


### PR DESCRIPTION
When enabled, the clip list and label columns display small
thumbnails (images or video frames) instead of just filenames.
The setting is persisted in data/settings.json, exposed via
the /api/settings API, and toggled in the Settings modal under
Appearance.

https://claude.ai/code/session_01YQDcT1uVDV2YiQ8fDwwDqZ