### PR TITLE
Make embed_text a null embedder by default in MediaType base class

### DIFF
--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -274,15 +274,20 @@ class MediaType(ABC):
         corrupt file, etc.).
         """
 
-    @abstractmethod
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.
 
         This is used for text-query sorting: the resulting vector is compared
         against media embeddings via cosine similarity.
 
-        Returns ``None`` if the model is not loaded or encoding fails.
+        The default implementation returns ``None`` (null embedder), which
+        means text-query sorting is unavailable for this media type.  Media
+        types that support text sorting should override this method.
+
+        Returns ``None`` if the model is not loaded, encoding fails, or the
+        media type does not support text embedding.
         """
+        return None
 
     @property
     def description_wrappers(self) -> list[str]:


### PR DESCRIPTION
Media types that lack a text encoder (no description embedder) can now
omit embed_text and inherit the default null implementation that returns
None.  This lets them still support sort-by-example and learned sort
while gracefully declining text-query sorting.

https://claude.ai/code/session_01TquFFcTutnLUFetiKXWGNF