### PR TITLE
WIP: pre-test checkpoint — auto-download video demo dataset

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -531,3 +531,140 @@ class TestCaltech101Download:
 
         assert result.exists()
         assert (result / "butterfly" / "image_0001.jpg").exists()
+
+
+class TestUCF101SubsetDownload:
+    """Verify download_ucf101_subset downloads, extracts, and flattens splits."""
+
+    def _make_ucf101_subset_tar(self, tar_path):
+        """Create a mock UCF101_subset.tar.gz matching the real archive structure.
+
+        The real archive has UCF101_subset/{train,val,test}/<Category>/*.avi.
+        """
+        with tarfile.open(tar_path, "w:gz") as tf:
+            for split in ("train", "val", "test"):
+                for cat in ("Archery", "BabyCrawling"):
+                    for i in range(3):
+                        fname = f"UCF101_subset/{split}/{cat}/v_{cat}_g{i:02d}_c01.avi"
+                        # Minimal AVI-like data (just enough for a file)
+                        data = b"RIFF" + b"\x00" * 20 + b"AVI "
+                        info = tarfile.TarInfo(name=fname)
+                        info.size = len(data)
+                        tf.addfile(info, io.BytesIO(data))
+
+    def test_extracts_and_flattens_splits(self, tmp_path):
+        """download_ucf101_subset should flatten train/val/test into category dirs."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_ucf101_subset
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+        tar_path = data_dir / "UCF101_subset.tar.gz"
+        self._make_ucf101_subset_tar(tar_path)
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.VIDEO_DIR", video_dir),
+        ):
+            result = download_ucf101_subset(on_progress=lambda *a: None)
+
+        assert result.exists(), f"Expected {result} to exist"
+        assert result.name == "ucf101"
+        assert (result / "Archery").is_dir()
+        assert (result / "BabyCrawling").is_dir()
+        # All splits merged: 3 files per split × 3 splits = 9 per category
+        assert len(list((result / "Archery").glob("*.avi"))) == 9
+        assert len(list((result / "BabyCrawling").glob("*.avi"))) == 9
+
+    def test_tar_cleaned_up(self, tmp_path):
+        """The UCF101_subset.tar.gz should be deleted after extraction."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_ucf101_subset
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+        tar_path = data_dir / "UCF101_subset.tar.gz"
+        self._make_ucf101_subset_tar(tar_path)
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.VIDEO_DIR", video_dir),
+        ):
+            download_ucf101_subset(on_progress=lambda *a: None)
+
+        assert not tar_path.exists(), "tar.gz should be deleted after extraction"
+
+    def test_staging_dir_cleaned_up(self, tmp_path):
+        """The UCF101_subset staging directory should be removed after flattening."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_ucf101_subset
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+        tar_path = data_dir / "UCF101_subset.tar.gz"
+        self._make_ucf101_subset_tar(tar_path)
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.VIDEO_DIR", video_dir),
+        ):
+            download_ucf101_subset(on_progress=lambda *a: None)
+
+        staging = data_dir / "UCF101_subset"
+        assert not staging.exists(), "Staging directory should be removed after flattening"
+
+    def test_skips_if_already_present(self, tmp_path):
+        """If ucf101/ already has videos, skip download entirely."""
+        from unittest.mock import patch
+
+        from vtsearch.datasets.downloader import download_ucf101_subset
+
+        data_dir = tmp_path / "data"
+        video_dir = data_dir / "video"
+        ucf_dir = video_dir / "ucf101" / "Archery"
+        ucf_dir.mkdir(parents=True)
+        (ucf_dir / "v_Archery_g01_c01.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+        with (
+            patch("vtsearch.datasets.downloader.DATA_DIR", data_dir),
+            patch("vtsearch.datasets.downloader.VIDEO_DIR", video_dir),
+        ):
+            result = download_ucf101_subset(on_progress=lambda *a: None)
+
+        assert result.exists()
+        assert (result / "Archery" / "v_Archery_g01_c01.avi").exists()
+
+    def test_demo_list_shows_video_download_size(self, client):
+        """Video demo datasets should report a non-zero download size."""
+        from vtsearch.config import UCF101_SUBSET_DOWNLOAD_SIZE_MB
+
+        resp = client.get("/api/dataset/demo-list")
+        data = resp.get_json()
+        video_ds = [d for d in data["datasets"] if d["media_type"] == "video"]
+        assert len(video_ds) > 0, "Should have at least one video demo dataset"
+        for ds in video_ds:
+            if ds["status"] == "needs_download":
+                assert ds["download_size_mb"] == UCF101_SUBSET_DOWNLOAD_SIZE_MB
+
+    def test_video_demo_categories_match_subset(self, client):
+        """Video demo datasets should only use categories from the UCF-101 subset."""
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        subset_categories = {
+            "ApplyEyeMakeup", "ApplyLipstick", "Archery", "BabyCrawling",
+            "BalanceBeam", "BandMarching", "BaseballPitch", "Basketball",
+            "BasketballDunk", "BenchPress",
+        }
+        for name, info in DEMO_DATASETS.items():
+            if info.get("media_type") == "video":
+                for cat in info["categories"]:
+                    assert cat in subset_categories, (
+                        f"Video demo '{name}' uses category '{cat}' "
+                        f"not in UCF-101 subset"
+                    )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -536,16 +536,22 @@ class TestCaltech101Download:
 class TestUCF101SubsetDownload:
     """Verify download_ucf101_subset downloads, extracts, and flattens splits."""
 
+    # Map split names to group-number offsets so every file across all
+    # three splits gets a unique filename (the real dataset does this too).
+    _SPLIT_OFFSETS = {"train": 0, "val": 10, "test": 20}
+
     def _make_ucf101_subset_tar(self, tar_path):
         """Create a mock UCF101_subset.tar.gz matching the real archive structure.
 
         The real archive has UCF101_subset/{train,val,test}/<Category>/*.avi.
+        Filenames are unique across splits (different group numbers).
         """
         with tarfile.open(tar_path, "w:gz") as tf:
-            for split in ("train", "val", "test"):
+            for split, offset in self._SPLIT_OFFSETS.items():
                 for cat in ("Archery", "BabyCrawling"):
                     for i in range(3):
-                        fname = f"UCF101_subset/{split}/{cat}/v_{cat}_g{i:02d}_c01.avi"
+                        g = offset + i
+                        fname = f"UCF101_subset/{split}/{cat}/v_{cat}_g{g:02d}_c01.avi"
                         # Minimal AVI-like data (just enough for a file)
                         data = b"RIFF" + b"\x00" * 20 + b"AVI "
                         info = tarfile.TarInfo(name=fname)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -172,7 +172,6 @@ class TestDemoDatasetReadiness:
 
     def test_no_pkl_with_source_folder_shows_needs_embedding(self, client):
         """No pkl but required_folder exists with content → needs_embedding."""
-        import pickle
         import struct
         import wave
 

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -20,12 +20,14 @@ ESC50_URL = "https://github.com/karolpiczak/ESC-50/archive/master.zip"
 SAMPLE_VIDEOS_URL = "https://github.com/sample-datasets/video-clips/archive/refs/heads/main.zip"
 CIFAR10_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
 CALTECH101_URL = "https://data.caltech.edu/records/mzrjq-6wc02/files/caltech-101.zip"
+UCF101_SUBSET_URL = "https://huggingface.co/datasets/sayakpaul/ucf101-subset/resolve/main/UCF101_subset.tar.gz"
 
 # Dataset size estimates
 ESC50_DOWNLOAD_SIZE_MB = 600
 SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB = 150
 CIFAR10_DOWNLOAD_SIZE_MB = 170
 CALTECH101_DOWNLOAD_SIZE_MB = 131
+UCF101_SUBSET_DOWNLOAD_SIZE_MB = 171
 CLIPS_PER_CATEGORY = 40
 CLIPS_PER_VIDEO_CATEGORY = 10
 IMAGES_PER_CIFAR10_CATEGORY = 100

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -23,6 +23,8 @@ from vtsearch.config import (
     ESC50_DOWNLOAD_SIZE_MB,
     ESC50_URL,
     IMAGE_DIR,
+    UCF101_SUBSET_DOWNLOAD_SIZE_MB,
+    UCF101_SUBSET_URL,
     VIDEO_DIR,
 )
 
@@ -220,42 +222,83 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
     return categories_dir
 
 
-def download_ucf101_subset() -> Path:
-    """Return the path to the UCF-101 video dataset, raising if it is not present.
+def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Path:
+    """Download and extract a UCF-101 subset for video demo datasets.
 
-    UCF-101 is distributed as a ~6.5 GB RAR file and cannot be downloaded
-    automatically. This function checks whether the dataset has already been
-    manually placed in the expected directory and returns its path, or raises a
-    descriptive error with setup instructions.
+    Downloads a 171 MB subset of UCF-101 (10 action classes, 405 clips) from
+    HuggingFace and extracts it into ``VIDEO_DIR / "ucf101"`` with one
+    subdirectory per action class.  Videos from all splits (train/val/test) are
+    merged into a single flat category structure so that
+    :func:`~vtsearch.datasets.loader.load_video_metadata_from_folders` can
+    scan them directly.
+
+    If the dataset is already present (at least one ``*.avi`` in a
+    subdirectory), the download is skipped and the existing path is returned.
+
+    Args:
+        on_progress: Optional progress callback. Falls back to the
+            application-wide ``update_progress`` when ``None``.
 
     Returns:
         Path to the ``ucf101/`` directory inside ``VIDEO_DIR`` (e.g.
-        ``data/video/ucf101``), guaranteed to contain at least one ``*.avi`` file
-        in a subdirectory.
-
-    Raises:
-        ValueError: If the UCF-101 directory does not exist or contains no
-            ``*.avi`` files. The error message includes manual download
-            instructions.
+        ``data/video/ucf101``), containing category subdirectories with
+        ``.avi`` files.
     """
-    # Try to download from a ZIP mirror or subset
+    if on_progress is None:
+        on_progress = _default_progress()
+
     video_dir = VIDEO_DIR / "ucf101"
     VIDEO_DIR.mkdir(exist_ok=True, parents=True)
 
-    # For now, check if videos already exist
+    # Already downloaded and extracted — nothing to do.
     if video_dir.exists() and any(video_dir.glob("*/*.avi")):
         return video_dir
 
-    # If not available, raise an error with instructions
-    raise ValueError(
-        "UCF-101 video dataset not found. To use video datasets:\n"
-        "1. Download UCF-101 from https://www.crcv.ucf.edu/data/UCF101.php\n"
-        "2. Extract to data/video/ucf101/ directory\n"
-        "3. Or use 'Load from Folder' to import your own video files\n\n"
-        "The UCF-101 dataset is ~6.5GB and distributed as a RAR file.\n"
-        "For automatic download support, we recommend using smaller datasets\n"
-        "or organizing your own video collection in folders by category."
-    )
+    tar_path = DATA_DIR / "UCF101_subset.tar.gz"
+    extract_dir = DATA_DIR / "UCF101_subset"
+    DATA_DIR.mkdir(exist_ok=True)
+
+    # Download the tar.gz if we don't already have the extracted tree.
+    if not extract_dir.exists():
+        if not tar_path.exists():
+            on_progress("downloading", "Starting UCF-101 subset download...", 0, 0)
+            download_file_with_progress(
+                UCF101_SUBSET_URL,
+                tar_path,
+                UCF101_SUBSET_DOWNLOAD_SIZE_MB * 1024 * 1024,
+                on_progress,
+            )
+
+        on_progress("downloading", "Extracting UCF-101 subset...", 0, 0)
+        with tarfile.open(tar_path, "r:gz") as tar_ref:
+            tar_ref.extractall(DATA_DIR, filter="data")
+
+        tar_path.unlink(missing_ok=True)
+
+    # Flatten the train/val/test splits into VIDEO_DIR/ucf101/<Category>/.
+    import shutil
+
+    video_dir.mkdir(parents=True, exist_ok=True)
+
+    for split in ("train", "val", "test"):
+        split_dir = extract_dir / split
+        if not split_dir.is_dir():
+            continue
+        for category_dir in split_dir.iterdir():
+            if not category_dir.is_dir():
+                continue
+            dest_cat = video_dir / category_dir.name
+            dest_cat.mkdir(exist_ok=True)
+            for video_file in category_dir.iterdir():
+                if video_file.is_file():
+                    dest = dest_cat / video_file.name
+                    if not dest.exists():
+                        shutil.move(str(video_file), str(dest))
+
+    # Clean up the extracted staging directory.
+    shutil.rmtree(extract_dir, ignore_errors=True)
+
+    return video_dir
 
 
 def download_20newsgroups(

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -1305,12 +1305,7 @@ def load_demo_dataset(
 
             video_mt = media_get("video")
 
-            try:
-                video_dir = download_ucf101_subset()
-            except ValueError as e:
-                # If UCF-101 is not available, provide helpful error message
-                on_progress("idle", "")
-                raise e
+            video_dir = download_ucf101_subset(on_progress=on_progress)
 
             metadata = load_video_metadata_from_folders(video_dir, dataset_info["categories"])
             video_files = [(meta["path"], meta) for meta in metadata.values()]

--- a/vtsearch/eval/config.py
+++ b/vtsearch/eval/config.py
@@ -81,17 +81,17 @@ _PARAGRAPHS_QUERIES = [
 _ACTIVITIES_VIDEO_QUERIES = [
     EvalQuery("someone applying eye makeup", "ApplyEyeMakeup"),
     EvalQuery("someone applying lipstick", "ApplyLipstick"),
-    EvalQuery("someone brushing their teeth", "BrushingTeeth"),
-    EvalQuery("a person playing drums", "Drumming"),
-    EvalQuery("a person doing yo-yo tricks", "YoYo"),
+    EvalQuery("a baby crawling on the floor", "BabyCrawling"),
+    EvalQuery("a marching band performing", "BandMarching"),
+    EvalQuery("a person doing bench presses", "BenchPress"),
 ]
 
 _SPORTS_VIDEO_QUERIES = [
-    EvalQuery("a person diving off a cliff", "CliffDiving"),
-    EvalQuery("someone walking on their hands", "HandstandWalking"),
-    EvalQuery("a person jumping rope", "JumpRope"),
-    EvalQuery("someone doing push-ups", "PushUps"),
-    EvalQuery("a person practicing tai chi", "TaiChi"),
+    EvalQuery("a person shooting a bow and arrow", "Archery"),
+    EvalQuery("a gymnast on the balance beam", "BalanceBeam"),
+    EvalQuery("a baseball pitcher throwing a pitch", "BaseballPitch"),
+    EvalQuery("people playing basketball", "Basketball"),
+    EvalQuery("a basketball dunk", "BasketballDunk"),
 ]
 
 # ------------------------------------------------------------------

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -104,34 +104,36 @@ class VideoMediaType(MediaType):
         return [
             DemoDataset(
                 id="activities_video",
-                label="Personal Activities",
+                label="Everyday Activities",
                 description=(
-                    "Short clips of everyday personal activities like grooming,"
-                    " playing instruments, and yo-yo from UCF-101."
+                    "Short clips of everyday activities — applying makeup,"
+                    " crawling babies, bench presses, and marching bands"
+                    " from a UCF-101 subset (auto-downloaded, ~171 MB)."
                 ),
                 categories=[
                     "ApplyEyeMakeup",
                     "ApplyLipstick",
-                    "BrushingTeeth",
-                    "Drumming",
-                    "YoYo",
+                    "BabyCrawling",
+                    "BandMarching",
+                    "BenchPress",
                 ],
                 source="ucf101",
                 required_folder=VIDEO_DIR / "ucf101",
             ),
             DemoDataset(
                 id="sports_video",
-                label="Sports & Exercise",
+                label="Sports & Athletics",
                 description=(
-                    "Short clips of physical activities including cliff diving,"
-                    " jump rope, push-ups, and tai chi from UCF-101."
+                    "Short clips of sports and athletics — archery, balance beam,"
+                    " baseball, basketball, and basketball dunks"
+                    " from a UCF-101 subset (auto-downloaded, ~171 MB)."
                 ),
                 categories=[
-                    "CliffDiving",
-                    "HandstandWalking",
-                    "JumpRope",
-                    "PushUps",
-                    "TaiChi",
+                    "Archery",
+                    "BalanceBeam",
+                    "BaseballPitch",
+                    "Basketball",
+                    "BasketballDunk",
                 ],
                 source="ucf101",
                 required_folder=VIDEO_DIR / "ucf101",

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -15,9 +15,8 @@ from vtsearch.config import (
     ESC50_DOWNLOAD_SIZE_MB,
     IMAGES_PER_CALTECH101_CATEGORY,
     IMAGES_PER_CIFAR10_CATEGORY,
-    SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB,
     TEXTS_PER_CATEGORY,
-    VIDEO_DIR,
+    UCF101_SUBSET_DOWNLOAD_SIZE_MB,
 )
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers, load_demo_dataset
 from vtsearch.models.progress import clear_progress_cache
@@ -345,11 +344,7 @@ def demo_dataset_list():
         else:
             # needs_download – estimate total download
             if media_type == "video":
-                video_source = dataset_info.get("source", "ucf101")
-                if video_source == "ucf101":
-                    download_size_mb = 0  # Manual download required
-                else:
-                    download_size_mb = SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB
+                download_size_mb = UCF101_SUBSET_DOWNLOAD_SIZE_MB
             elif media_type == "image":
                 if image_source == "caltech101":
                     download_size_mb = CALTECH101_DOWNLOAD_SIZE_MB


### PR DESCRIPTION
Replace manual UCF-101 download instructions with automatic download
of the sayakpaul/ucf101-subset from HuggingFace (171 MB, 10 categories,
405 AVI clips). Videos from train/val/test splits are flattened into
category directories so existing loader code works unchanged.

https://claude.ai/code/session_01RnKBqfPsnKA9H1TnzLcMMb