### PR TITLE
Add exhausted flag to diversity tree API and handle in UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1733,8 +1733,12 @@
       if (!radio.checked) return;
       selectMode = radio.value;
       if (selectMode === "new") {
-        const nextId = await fetchDiversityTreeNext();
-        if (nextId != null) selectClip(nextId);
+        const data = await fetchDiversityTreeNext();
+        if (data.id != null) {
+          selectClip(data.id);
+        } else if (data.exhausted) {
+          vtAlert("You have seen every branch of the diversity tree. Switch to Top or Hard mode, or add more data.", "warning");
+        }
       } else {
         const nextClip = findNextClip();
         if (nextClip) selectClip(nextClip.id);
@@ -2036,9 +2040,9 @@
     try {
       const res = await fetch("/api/diversity-tree/next");
       const data = await res.json();
-      return data.id;  // int | null
+      return data;  // { id: int|null, diversity_level: int, exhausted: bool }
     } catch {
-      return null;
+      return { id: null, diversity_level: -1, exhausted: false };
     }
   }
 
@@ -2408,9 +2412,17 @@
     // Auto-advance to next clip.  When swipe animation is enabled, play a
     // fast swipe-out before switching; otherwise advance immediately.
     // In "new" select mode, use the diversity tree for the next clip.
-    const nextId = selectMode === "new"
-      ? await fetchDiversityTreeNext()
-      : (() => { const c = findNextClip(); return c ? c.id : null; })();
+    let nextId;
+    if (selectMode === "new") {
+      const data = await fetchDiversityTreeNext();
+      nextId = data.id;
+      if (nextId == null && data.exhausted) {
+        vtAlert("You have seen every branch of the diversity tree. Switch to Top or Hard mode, or add more data.", "warning");
+      }
+    } else {
+      const c = findNextClip();
+      nextId = c ? c.id : null;
+    }
     if (nextId != null && nextId !== selected) {
       if (swipeAnimation) {
         const dir = vote === "good" ? "swipe-right" : "swipe-left";

--- a/tests/test_diversity_tree_integration.py
+++ b/tests/test_diversity_tree_integration.py
@@ -126,9 +126,11 @@ class TestDiversityTreeNextEndpoint:
         data = resp.get_json()
         assert "id" in data
         assert "diversity_level" in data
+        assert "exhausted" in data
         assert data["id"] is not None
         assert data["id"] in clips
         assert data["diversity_level"] == -1  # nothing labeled yet
+        assert data["exhausted"] is False
 
     def test_returns_null_when_no_tree(self, client):
         resp = client.get("/api/diversity-tree/next")
@@ -136,6 +138,7 @@ class TestDiversityTreeNextEndpoint:
         data = resp.get_json()
         assert data["id"] is None
         assert data["diversity_level"] == -1
+        assert data["exhausted"] is False  # no tree != exhausted
 
     def test_diversity_level_after_labeling(self, client):
         tree = _build_tree()
@@ -144,6 +147,17 @@ class TestDiversityTreeNextEndpoint:
         resp = client.get("/api/diversity-tree/next")
         data = resp.get_json()
         assert data["diversity_level"] >= 0
+
+    def test_exhausted_when_all_nodes_seen(self, client):
+        """When every node in the tree has been seen, exhausted should be True."""
+        tree = _build_tree()
+        # Label every vector so all leaves (and ancestors) become seen
+        for vid in tree.vector_to_leaf:
+            diversity_tree_label(vid)
+        resp = client.get("/api/diversity-tree/next")
+        data = resp.get_json()
+        assert data["id"] is None
+        assert data["exhausted"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -517,9 +517,12 @@ def diversity_tree_next():
 
     Returns ``{"id": <clip_id>}`` or ``{"id": null}`` when the tree is
     exhausted or not yet built.  Also includes ``diversity_level`` so the
-    frontend can display how many tree levels have been fully covered.
+    frontend can display how many tree levels have been fully covered,
+    and ``exhausted`` (bool) which is true when the tree exists but every
+    node has already been seen.
     """
     tree = get_diversity_tree()
     next_id = diversity_tree_next_sample()
     level = tree.diversity_level() if tree is not None else -1
-    return jsonify({"id": next_id, "diversity_level": level})
+    exhausted = tree is not None and next_id is None
+    return jsonify({"id": next_id, "diversity_level": level, "exhausted": exhausted})


### PR DESCRIPTION
## Summary
Enhanced the diversity tree API to distinguish between "no tree exists" and "tree exists but all nodes have been seen" by adding an `exhausted` boolean flag to the response. Updated the frontend to handle this distinction and show an appropriate warning message when the tree is exhausted.

## Key Changes
- **Backend API (`vtsearch/routes/sorting.py`)**: Modified `/api/diversity-tree/next` endpoint to return an object with three fields: `id`, `diversity_level`, and `exhausted`. The `exhausted` flag is `true` only when a tree exists but all nodes have been visited.

- **Frontend (`static/app.js`)**: 
  - Updated `fetchDiversityTreeNext()` to return the full response object instead of just the ID
  - Modified mode selection handler to check `data.exhausted` and display a warning when the diversity tree is exhausted
  - Updated auto-advance logic to handle the exhausted state and show the same warning message

- **Tests (`tests/test_diversity_tree_integration.py`)**: 
  - Added assertions for the new `exhausted` field in existing tests
  - Added new test `test_exhausted_when_all_nodes_seen()` to verify the exhausted flag is set correctly when all tree nodes have been visited

## Implementation Details
- The `exhausted` flag is computed as `tree is not None and next_id is None`, ensuring it's only true when a tree exists but no unvisited nodes remain
- When exhausted, users see a warning: "You have seen every branch of the diversity tree. Switch to Top or Hard mode, or add more data."
- The change maintains backward compatibility by always returning all three fields in the response

https://claude.ai/code/session_011i6eZidi5NVD7KUNa4EnDR