### PR TITLE
Split labeling progress into three independent metrics

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3083,7 +3083,9 @@
 
   // ---- Progress tracking ----
 
-  const checkProgressBtn = document.getElementById("check-progress-btn");
+  const smartIndicator = document.getElementById("smart-indicator");
+  const stableIndicator = document.getElementById("stable-indicator");
+  const spanIndicator = document.getElementById("span-indicator");
   const progressModal = document.getElementById("progress-modal");
   const modalClose = document.getElementById("modal-close");
   const goodCountSpan = document.getElementById("good-count");
@@ -3092,6 +3094,9 @@
   const labelingAnalysisBar = document.getElementById("labeling-analysis-bar");
   const labelingAnalysisText = document.getElementById("labeling-analysis-text");
   const labelingAnalysisPct = document.getElementById("labeling-analysis-pct");
+
+  // Keep latest status data for span info display
+  let _lastStatusData = null;
 
   // Update label counts and schedule an indicator refresh
   function updateLabelCounts() {
@@ -3121,28 +3126,50 @@
     }
   }
 
-  function applyLabelingStatus(data) {
-    const btn = checkProgressBtn;
-    const subtext = document.getElementById("indicator-subtext");
-    btn.dataset.status = data.status;
-    if (data.status === "red") {
-      subtext.textContent = `${data.good_count}g / ${data.bad_count}b`;
-    } else if (data.status === "yellow") {
-      subtext.textContent = "Continue";
-    } else if (data.status === "green") {
-      subtext.textContent = "Done";
+  function _applyIndicator(btn, subtextEl, metric) {
+    btn.dataset.status = metric.status;
+    if (metric.status === "red") {
+      subtextEl.textContent = "";
+    } else if (metric.status === "yellow") {
+      subtextEl.textContent = "";
+    } else if (metric.status === "green") {
+      subtextEl.textContent = "";
     } else {
-      subtext.textContent = "";
+      subtextEl.textContent = "";
     }
   }
 
-  checkProgressBtn.addEventListener("click", async () => {
+  function applyLabelingStatus(data) {
+    _lastStatusData = data;
+    if (data.smart) {
+      _applyIndicator(smartIndicator, document.getElementById("smart-subtext"), data.smart);
+    }
+    if (data.stable) {
+      _applyIndicator(stableIndicator, document.getElementById("stable-subtext"), data.stable);
+    }
+    if (data.span) {
+      _applyIndicator(spanIndicator, document.getElementById("span-subtext"), data.span);
+      // Show compact level info as subtext for Span
+      const sp = data.span;
+      if (sp.status !== "red" && sp.level >= 0) {
+        document.getElementById("span-subtext").textContent = `L${sp.level}`;
+      }
+    }
+  }
+
+  // Generic handler: fetch full analysis, then show the relevant section
+  async function showMetricDetail(metric, triggerBtn) {
+    // Span doesn't need the full analysis — just show the text box from status data
+    if (metric === "span") {
+      showSpanPopup();
+      return;
+    }
+
     if (votes.good.length === 0 || votes.bad.length === 0) {
       await vtAlert("Need at least one good and one bad vote to check progress", "warning");
       return;
     }
 
-    // Pause any active audio or video playback
     pauseActiveMedia();
 
     // Show loading progress modal
@@ -3151,7 +3178,6 @@
     labelingAnalysisText.textContent = "Training models over label history…";
     labelingAnalysisModal.classList.add("show");
 
-    // Simulate progress while waiting for the backend
     let progress = 0;
     const progressInterval = setInterval(() => {
       progress += 3;
@@ -3160,8 +3186,9 @@
       labelingAnalysisPct.textContent = `${progress}%`;
     }, 250);
 
-    checkProgressBtn.disabled = true;
-    checkProgressBtn.querySelector(".indicator-label").textContent = "Analyzing…";
+    triggerBtn.disabled = true;
+    const origLabel = triggerBtn.querySelector(".indicator-label").textContent;
+    triggerBtn.querySelector(".indicator-label").textContent = "…";
 
     try {
       const res = await fetch("/api/labeling-progress", {
@@ -3184,22 +3211,58 @@
       }
 
       const data = await res.json();
-      displayProgressResults(data);
+      displayProgressResults(data, metric);
       progressModal.classList.add("show");
     } catch (e) {
       clearInterval(progressInterval);
       labelingAnalysisModal.classList.remove("show");
       await vtAlert("Error analyzing progress: " + e.message, "error");
     } finally {
-      checkProgressBtn.disabled = false;
-      checkProgressBtn.querySelector(".indicator-label").textContent = "Progress";
+      triggerBtn.disabled = false;
+      triggerBtn.querySelector(".indicator-label").textContent = origLabel;
       fetchLabelingStatus();
-      // If the progress modal didn't open (error path), resume media now
       if (!progressModal.classList.contains("show")) {
         resumeActiveMedia();
       }
     }
-  });
+  }
+
+  function showSpanPopup() {
+    // Show the progress modal with only the Span section visible
+    const sp = _lastStatusData && _lastStatusData.span ? _lastStatusData.span : null;
+    const infoText = document.getElementById("span-info-text");
+    if (!sp || sp.level < 0) {
+      infoText.textContent = "No diversity tree coverage yet. Keep labeling diverse examples.";
+    } else if (sp.level >= sp.depth) {
+      infoText.textContent = `All ${sp.depth + 1} tree levels fully covered. Excellent diversity!`;
+    } else {
+      let msg = `Deepest full level: ${sp.level} of ${sp.depth}.`;
+      if (sp.next_level_total > 0) {
+        msg += ` Next level (${sp.level + 1}): ${sp.next_level_seen} of ${sp.next_level_total} nodes seen.`;
+      }
+      infoText.textContent = msg;
+    }
+
+    // Update stats from cached status data
+    if (_lastStatusData) {
+      document.getElementById("stat-total-labels").textContent = _lastStatusData.total_count || 0;
+      document.getElementById("stat-total-clips").textContent = "—";
+    }
+
+    document.getElementById("smart-section").style.display = "none";
+    document.getElementById("stable-section").style.display = "none";
+    document.getElementById("span-section").style.display = "";
+    document.getElementById("recommendation-text").textContent =
+      sp && sp.reason ? sp.reason : "No span data available.";
+    document.getElementById("progress-modal-title").textContent = "Span: Diversity Coverage";
+
+    pauseActiveMedia();
+    progressModal.classList.add("show");
+  }
+
+  smartIndicator.addEventListener("click", () => showMetricDetail("smart", smartIndicator));
+  stableIndicator.addEventListener("click", () => showMetricDetail("stable", stableIndicator));
+  spanIndicator.addEventListener("click", () => showMetricDetail("span", spanIndicator));
 
   modalClose.addEventListener("click", () => {
     progressModal.classList.remove("show");
@@ -3213,40 +3276,49 @@
     }
   });
 
-  function displayProgressResults(data) {
+  function displayProgressResults(data, metric) {
     // Update summary stats
     document.getElementById("stat-total-labels").textContent = data.total_labels;
     document.getElementById("stat-total-clips").textContent = data.total_clips;
 
-    // Add ARIA labels to chart canvases
     const ecChart = document.getElementById("error-cost-chart");
     if (ecChart) ecChart.setAttribute("role", "img");
     const stChart = document.getElementById("stability-chart");
     if (stChart) stChart.setAttribute("role", "img");
 
-    // Render error cost chart
-    renderErrorCostChart(data.error_cost_over_time);
+    // Show only the relevant section
+    const smartSec = document.getElementById("smart-section");
+    const stableSec = document.getElementById("stable-section");
+    const spanSec = document.getElementById("span-section");
+    smartSec.style.display = "none";
+    stableSec.style.display = "none";
+    spanSec.style.display = "none";
 
-    // Render stability chart
-    renderStabilityChart(data.stability_over_time);
+    if (metric === "smart") {
+      smartSec.style.display = "";
+      renderErrorCostChart(data.error_cost_over_time);
+      document.getElementById("progress-modal-title").textContent = "Smart: Error Cost Analysis";
+      if (ecChart) {
+        const lastCost = data.error_cost_over_time.length > 0
+          ? data.error_cost_over_time[data.error_cost_over_time.length - 1].error_cost.toFixed(2)
+          : "N/A";
+        ecChart.setAttribute("aria-label", `Error cost chart with ${data.error_cost_over_time.length} data points. Latest error cost: ${lastCost}`);
+      }
+    } else if (metric === "stable") {
+      stableSec.style.display = "";
+      renderStabilityChart(data.stability_over_time);
+      document.getElementById("progress-modal-title").textContent = "Stable: Prediction Flip Analysis";
+      if (stChart) {
+        const lastFlips = data.stability_over_time.length > 1
+          ? data.stability_over_time[data.stability_over_time.length - 1].num_flips
+          : "N/A";
+        stChart.setAttribute("aria-label", `Prediction stability chart with ${data.stability_over_time.length} data points. Latest prediction flips: ${lastFlips}`);
+      }
+    }
 
     // Generate recommendation
     const recommendation = generateRecommendation(data);
     document.getElementById("recommendation-text").textContent = recommendation;
-
-    // Set chart descriptions for screen readers based on data
-    if (ecChart) {
-      const lastCost = data.error_cost_over_time.length > 0
-        ? data.error_cost_over_time[data.error_cost_over_time.length - 1].error_cost.toFixed(2)
-        : "N/A";
-      ecChart.setAttribute("aria-label", `Error cost chart with ${data.error_cost_over_time.length} data points. Latest error cost: ${lastCost}`);
-    }
-    if (stChart) {
-      const lastFlips = data.stability_over_time.length > 1
-        ? data.stability_over_time[data.stability_over_time.length - 1].num_flips
-        : "N/A";
-      stChart.setAttribute("aria-label", `Prediction stability chart with ${data.stability_over_time.length} data points. Latest prediction flips: ${lastFlips}`);
-    }
   }
 
   function renderErrorCostChart(errorCostData) {

--- a/static/index.html
+++ b/static/index.html
@@ -140,10 +140,20 @@
   <aside class="panel-right" aria-label="Labels">
     <!-- import-file removed: label import now uses the label importer modal -->
     <div class="progress-check-bar">
-      <button id="check-progress-btn" class="labeling-indicator" data-status="" aria-label="Check labeling progress">
+      <button id="smart-indicator" class="labeling-indicator" data-status="" aria-label="Smart level: error cost flatness">
         <span class="indicator-dot" aria-hidden="true"></span>
-        <span class="indicator-label">Progress</span>
-        <span class="indicator-subtext" id="indicator-subtext"></span>
+        <span class="indicator-label">Smart</span>
+        <span class="indicator-subtext" id="smart-subtext"></span>
+      </button>
+      <button id="stable-indicator" class="labeling-indicator" data-status="" aria-label="Stable level: prediction flip stability">
+        <span class="indicator-dot" aria-hidden="true"></span>
+        <span class="indicator-label">Stable</span>
+        <span class="indicator-subtext" id="stable-subtext"></span>
+      </button>
+      <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Span level: diversity tree coverage">
+        <span class="indicator-dot" aria-hidden="true"></span>
+        <span class="indicator-label">Span</span>
+        <span class="indicator-subtext" id="span-subtext"></span>
       </button>
     </div>
     <div class="label-sort-bar">
@@ -170,7 +180,7 @@
   </aside>
 </div>
 
-<!-- Progress Modal -->
+<!-- Progress Modal — shown per-metric when clicking Smart, Stable, or Span -->
 <div id="progress-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="progress-modal-title">
   <div class="modal-content">
     <div class="modal-header">
@@ -188,19 +198,28 @@
           <div class="progress-stat-value" id="stat-total-clips">0</div>
         </div>
       </div>
-      <div class="progress-chart">
-        <h3>Error Cost Over Time</h3>
+      <!-- Smart: Error Cost chart -->
+      <div id="smart-section" class="progress-chart" style="display:none;">
+        <h3>Smart: Error Cost Over Time</h3>
         <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px;">
-          Lower is better. When the line levels out, you're probably not making progress.
+          Lower is better. When the line levels out, the model has converged.
         </p>
         <canvas id="error-cost-chart" width="700" height="250"></canvas>
       </div>
-      <div class="progress-chart">
-        <h3>Prediction Stability</h3>
+      <!-- Stable: Prediction Stability chart -->
+      <div id="stable-section" class="progress-chart" style="display:none;">
+        <h3>Stable: Prediction Flips Over Time</h3>
         <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px;">
-          Shows how many unlabeled clips change prediction at each step. When this stabilizes near zero, you're probably not making progress.
+          Shows how many unlabeled clips change prediction at each step. Near zero means stable.
         </p>
         <canvas id="stability-chart" width="700" height="250"></canvas>
+      </div>
+      <!-- Span: Diversity tree text info -->
+      <div id="span-section" class="progress-chart" style="display:none;">
+        <h3>Span: Diversity Tree Coverage</h3>
+        <div id="span-info-box" class="progress-recommendation" style="border-left-color: var(--accent);">
+          <p id="span-info-text" style="margin:0; font-size: 0.9rem; color: var(--text-secondary);">No diversity tree available.</p>
+        </div>
       </div>
       <div class="progress-recommendation">
         <h3>Recommendation</h3>

--- a/static/styles.css
+++ b/static/styles.css
@@ -332,12 +332,12 @@ video { max-width: 600px; max-height: 400px; }
 .dataset-bar button { padding: 6px 16px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg-surface); color: var(--text-secondary); font-size: 0.75rem; cursor: pointer; transition: all 0.2s; }
 .dataset-bar button:hover { background: var(--bg-hover); color: var(--text-primary); }
 
-/* Progress indicator button */
-.progress-check-bar { padding: 10px 8px; border-bottom: 1px solid var(--border); }
+/* Progress indicator buttons */
+.progress-check-bar { padding: 10px 8px; border-bottom: 1px solid var(--border); display: flex; gap: 4px; }
 .labeling-indicator {
-  width: 100%; padding: 7px 10px; border-radius: 4px; background: transparent;
-  font-size: 0.8rem; cursor: pointer; transition: border-color 0.4s, opacity 0.2s;
-  display: flex; align-items: center; gap: 6px; border: 1px solid var(--indicator-border); text-align: left;
+  flex: 1; padding: 5px 6px; border-radius: 4px; background: transparent;
+  font-size: 0.72rem; cursor: pointer; transition: border-color 0.4s, opacity 0.2s;
+  display: flex; align-items: center; gap: 4px; border: 1px solid var(--indicator-border); text-align: left;
 }
 .labeling-indicator:hover { opacity: 0.82; }
 .labeling-indicator:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -345,8 +345,8 @@ video { max-width: 600px; max-height: 400px; }
   width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
   background: var(--indicator-dot); transition: background 0.4s, box-shadow 0.4s;
 }
-.indicator-label { flex: 1; color: var(--text-secondary); font-size: 0.8rem; transition: color 0.4s; }
-.indicator-subtext { font-size: 0.68rem; color: var(--text-dim); transition: color 0.4s; text-align: right; }
+.indicator-label { flex: 1; color: var(--text-secondary); font-size: 0.72rem; transition: color 0.4s; }
+.indicator-subtext { font-size: 0.62rem; color: var(--text-dim); transition: color 0.4s; text-align: right; }
 
 /* Red – too few labels */
 .labeling-indicator[data-status="red"] { border-color: var(--status-red-border); }

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -212,3 +212,35 @@ class DiversityTree:
         if not self.nodes_by_depth:
             return -1
         return max(self.nodes_by_depth.keys())
+
+    def span_info(self) -> dict:
+        """Return span level details for the labeling progress indicator.
+
+        Returns a dict with:
+        - level: deepest fully-seen level (-1 if none)
+        - depth: max tree depth
+        - next_level_seen: how many nodes at the next incomplete level are seen
+        - next_level_total: total nodes at the next incomplete level
+        """
+        level = self.diversity_level()
+        d = self.depth()
+
+        next_level = level + 1
+        if next_level > d:
+            # All levels fully covered
+            return {
+                "level": level,
+                "depth": d,
+                "next_level_seen": 0,
+                "next_level_total": 0,
+            }
+
+        nodes_at_next = self.nodes_by_depth.get(next_level, [])
+        seen_count = sum(1 for name in nodes_at_next if name in self.seen)
+
+        return {
+            "level": level,
+            "depth": d,
+            "next_level_seen": seen_count,
+            "next_level_total": len(nodes_at_next),
+        }

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -303,55 +303,35 @@ def calculate_prediction_stability_over_time(
     return [step["stability"] for step in _cached_steps if step["stability"] is not None]
 
 
-def compute_labeling_status(
+def _compute_smart_status(
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
     current_good_votes: dict[int, None],
     current_bad_votes: dict[int, None],
-    inclusion_value: int = 0,
+    inclusion_value: int,
+    good: int,
+    bad: int,
+    total: int,
 ) -> dict[str, Any]:
-    """Compute a lightweight red/yellow/green labeling status.
-
-    Uses cached models for the last 10 steps — only forward passes, no training.
-    """
-    good = len(current_good_votes)
-    bad = len(current_bad_votes)
-    total = good + bad
-
-    base = {"good_count": good, "bad_count": bad, "total_count": total}
-
+    """Compute Smart (error-cost flatness) red/yellow/green status."""
     if total < 20 or good < 5 or bad < 5:
         return {
-            **base,
             "status": "red",
-            "reason": (
-                f"Need at least 20 labels with 5 good and 5 bad. Currently {total} total ({good} good, {bad} bad)."
-            ),
+            "reason": f"Need at least 20 labels with 5 good and 5 bad. Currently {total} total ({good}g, {bad}b).",
         }
-
-    _ensure_cache(clips_dict, label_history, inclusion_value)
 
     n = len(_cached_steps)
     if n < 3:
-        return {
-            **base,
-            "status": "yellow",
-            "reason": "Not enough label history steps to assess trend.",
-        }
+        return {"status": "yellow", "reason": "Not enough label history steps to assess trend."}
 
     start_idx = max(0, n - 10)
     recent_entries = _eval_cached_models(
         clips_dict, current_good_votes, current_bad_votes, inclusion_value, start_idx, n
     )
-
     recent_error_costs = [e["error_cost"] for e in recent_entries]
 
     if len(recent_error_costs) < 3:
-        return {
-            **base,
-            "status": "yellow",
-            "reason": "Not enough valid model steps in recent history to assess trend.",
-        }
+        return {"status": "yellow", "reason": "Not enough valid model steps in recent history to assess trend."}
 
     # Linear regression slope over the recent error-cost values
     n_pts = len(recent_error_costs)
@@ -362,25 +342,97 @@ def compute_labeling_status(
     numer = sum((x_vals[i] - x_mean) * (recent_error_costs[i] - y_mean) for i in range(n_pts))
     denom = sum((x_vals[i] - x_mean) ** 2 for i in range(n_pts))
     slope = numer / denom if denom != 0 else 0.0
-
     relative_slope = slope / y_mean if y_mean > 0 else slope
 
     FLAT_THRESHOLD = -0.015
-
     if relative_slope < FLAT_THRESHOLD:
         return {
-            **base,
             "status": "yellow",
-            "reason": ("Error cost is still declining over the last 10 labels. Keep labeling to improve the model."),
+            "reason": "Error cost is still declining. Keep labeling.",
             "slope": round(relative_slope, 4),
         }
-    else:
+    return {
+        "status": "green",
+        "reason": "Error cost has leveled off. You can likely stop labeling.",
+        "slope": round(relative_slope, 4),
+    }
+
+
+def _compute_stable_status(
+    good: int,
+    bad: int,
+    total: int,
+) -> dict[str, Any]:
+    """Compute Stable (prediction-flip) red/yellow/green status."""
+    if total < 20 or good < 5 or bad < 5:
         return {
-            **base,
-            "status": "green",
-            "reason": ("Error cost has leveled off over the last 10 labels. You can likely stop labeling."),
-            "slope": round(relative_slope, 4),
+            "status": "red",
+            "reason": f"Need at least 20 labels with 5 good and 5 bad. Currently {total} total ({good}g, {bad}b).",
         }
+
+    stability = [step["stability"] for step in _cached_steps if step["stability"] is not None]
+    if len(stability) < 3:
+        return {"status": "yellow", "reason": "Not enough history to assess prediction stability."}
+
+    recent = stability[-10:]
+    recent_flips = [s["num_flips"] for s in recent]
+    avg_flips = sum(recent_flips) / len(recent_flips)
+
+    if avg_flips < 3:
+        return {"status": "green", "reason": "Predictions have stabilized."}
+    return {"status": "yellow", "reason": f"Average {avg_flips:.0f} prediction flips in recent steps."}
+
+
+def compute_labeling_status(
+    clips_dict: dict[int, dict[str, Any]],
+    label_history: list[tuple[int, str, float]],
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+    inclusion_value: int = 0,
+    span_info: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Compute per-metric red/yellow/green labeling statuses.
+
+    Returns a dict with ``good_count``, ``bad_count``, ``total_count``, and
+    three sub-dicts: ``smart``, ``stable``, and ``span``, each with a
+    ``status`` field of ``"red"``, ``"yellow"``, or ``"green"``.
+    """
+    good = len(current_good_votes)
+    bad = len(current_bad_votes)
+    total = good + bad
+
+    _ensure_cache(clips_dict, label_history, inclusion_value)
+
+    smart = _compute_smart_status(
+        clips_dict, label_history, current_good_votes, current_bad_votes, inclusion_value, good, bad, total
+    )
+    stable = _compute_stable_status(good, bad, total)
+
+    # Span status from diversity tree info (passed in from the route)
+    if span_info is None:
+        span = {"status": "red", "reason": "Diversity tree not available.", "level": -1, "depth": -1,
+                "next_level_seen": 0, "next_level_total": 0}
+    else:
+        level = span_info["level"]
+        depth = span_info["depth"]
+        nls = span_info["next_level_seen"]
+        nlt = span_info["next_level_total"]
+        if level < 0:
+            span = {"status": "red", "reason": "No tree coverage yet.", **span_info}
+        elif level >= depth:
+            span = {"status": "green", "reason": "All tree levels fully covered.", **span_info}
+        else:
+            span = {"status": "yellow", "reason": f"Level {level}/{depth} full. {nls}/{nlt} of next level seen.",
+                    **span_info}
+
+    return {
+        "good_count": good,
+        "bad_count": bad,
+        "total_count": total,
+        "smart": smart,
+        "stable": stable,
+        "span": span,
+    }
 
 
 def analyze_labeling_progress(

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -498,14 +498,15 @@ def labeling_progress():
 
 @sorting_bp.route("/api/labeling-status", methods=["GET"])
 def labeling_status_indicator():
-    """Return a lightweight red/yellow/green labeling status based on the last 10 steps.
+    """Return per-metric red/yellow/green labeling statuses.
 
-    Red  – fewer than 20 labels, or fewer than 5 good or 5 bad.
-    Yellow – minimum counts met but error cost is still declining (keep labeling).
-    Green  – minimum counts met and error cost has leveled off (safe to stop).
+    Returns ``smart``, ``stable``, and ``span`` sub-objects, each with a
+    ``status`` field of ``"red"``, ``"yellow"``, or ``"green"``.
     """
     try:
-        status = compute_labeling_status(clips, label_history, good_votes, bad_votes, get_inclusion())
+        tree = get_diversity_tree()
+        span = tree.span_info() if tree is not None else None
+        status = compute_labeling_status(clips, label_history, good_votes, bad_votes, get_inclusion(), span_info=span)
         return jsonify(status)
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
Refactored the labeling progress indicator from a single "Progress" button into three independent metric buttons—**Smart** (error cost), **Stable** (prediction stability), and **Span** (diversity coverage)—each with its own status indicator and detailed analysis view.

## Key Changes

### Frontend (static/app.js)
- Replaced single `check-progress-btn` with three separate indicator buttons: `smart-indicator`, `stable-indicator`, and `span-indicator`
- Refactored `applyLabelingStatus()` to apply status to individual metric indicators via new `_applyIndicator()` helper
- Renamed `checkProgressBtn.addEventListener()` to generic `showMetricDetail()` function that handles metric-specific logic
- Added `showSpanPopup()` to display diversity tree coverage info without requiring full analysis
- Modified `displayProgressResults()` to accept a `metric` parameter and conditionally render only the relevant chart section
- Updated modal to show metric-specific titles and hide irrelevant sections based on which metric was clicked
- Cached latest status data in `_lastStatusData` for quick Span popup display

### Backend (vtsearch/models/progress.py)
- Split `compute_labeling_status()` into three focused functions:
  - `_compute_smart_status()`: evaluates error cost trend via linear regression
  - `_compute_stable_status()`: checks prediction flip stability
  - Main `compute_labeling_status()`: orchestrates all three and returns a dict with `smart`, `stable`, and `span` sub-objects
- Each metric now returns its own `status` ("red"/"yellow"/"green") and `reason` string
- Added `span_info` parameter to accept diversity tree coverage data from the route

### Backend (vtsearch/models/diversity_tree.py)
- Added `span_info()` method to DiversityTree that returns level, depth, and next-level progress details for the UI

### Backend (vtsearch/routes/sorting.py)
- Updated `/api/labeling-status` route to fetch diversity tree info and pass it to `compute_labeling_status()`

### HTML (static/index.html)
- Replaced single progress button with three buttons in `.progress-check-bar`
- Added separate sections in the progress modal for Smart, Stable, and Span with conditional display
- Added Span-specific info box for diversity tree coverage text

### CSS (static/styles.css)
- Updated `.progress-check-bar` to use flexbox layout with gap for three buttons
- Adjusted button sizing and spacing for compact three-button layout

## Notable Implementation Details
- Span metric doesn't require full analysis—it displays cached status data immediately via `showSpanPopup()`
- Smart and Stable metrics still fetch full analysis from `/api/labeling-progress` when clicked
- Each metric button shows a compact status indicator (red/yellow/green dot) with optional subtext
- Modal title and visible sections change dynamically based on which metric was clicked
- Backward compatibility maintained: status data structure now includes all three metrics in a single response

https://claude.ai/code/session_01RhJKvEvaNpGgKAZGhoprW7