### PR TITLE
Add model pre-download script and support offline model caching

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pre-download all VTSearch embedding models for offline use.
+#
+# Usage:
+#   ./download_models.sh [CACHE_DIR]
+#
+# CACHE_DIR defaults to $VTSEARCH_MODELS_DIR if set, otherwise data/models.
+#
+# After downloading, point the app at the cache folder:
+#   export VTSEARCH_MODELS_DIR=/path/to/cache
+#   python app.py
+#
+# Or just run this script with no arguments and the default data/models
+# folder will be used (same place the app looks by default).
+
+set -euo pipefail
+
+CACHE_DIR="${1:-${VTSEARCH_MODELS_DIR:-data/models}}"
+
+echo "Downloading all VTSearch embedding models to: $CACHE_DIR"
+mkdir -p "$CACHE_DIR"
+
+python3 - "$CACHE_DIR" <<'PYEOF'
+import sys
+
+cache_dir = sys.argv[1]
+
+# ------------------------------------------------------------------
+# 1. CLAP  (audio)  —  laion/clap-htsat-unfused
+# ------------------------------------------------------------------
+print("\n[1/4] Downloading CLAP model (laion/clap-htsat-unfused) ...")
+from transformers import ClapModel, ClapProcessor
+
+ClapModel.from_pretrained("laion/clap-htsat-unfused", cache_dir=cache_dir)
+ClapProcessor.from_pretrained("laion/clap-htsat-unfused", cache_dir=cache_dir)
+print("  CLAP done.")
+
+# ------------------------------------------------------------------
+# 2. CLIP  (image)  —  openai/clip-vit-base-patch32
+# ------------------------------------------------------------------
+print("\n[2/4] Downloading CLIP model (openai/clip-vit-base-patch32) ...")
+from transformers import CLIPModel, CLIPProcessor
+
+CLIPModel.from_pretrained("openai/clip-vit-base-patch32", cache_dir=cache_dir)
+CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32", cache_dir=cache_dir)
+print("  CLIP done.")
+
+# ------------------------------------------------------------------
+# 3. X-CLIP  (video)  —  microsoft/xclip-base-patch32
+# ------------------------------------------------------------------
+print("\n[3/4] Downloading X-CLIP model (microsoft/xclip-base-patch32) ...")
+from transformers import XCLIPModel, XCLIPProcessor
+
+XCLIPModel.from_pretrained("microsoft/xclip-base-patch32", cache_dir=cache_dir)
+XCLIPProcessor.from_pretrained("microsoft/xclip-base-patch32", cache_dir=cache_dir)
+print("  X-CLIP done.")
+
+# ------------------------------------------------------------------
+# 4. E5  (text)  —  intfloat/e5-base-v2
+# ------------------------------------------------------------------
+print("\n[4/4] Downloading E5 model (intfloat/e5-base-v2) ...")
+from sentence_transformers import SentenceTransformer
+
+SentenceTransformer("intfloat/e5-base-v2", cache_folder=cache_dir)
+print("  E5 done.")
+
+print("\nAll models downloaded successfully to:", cache_dir)
+print("To use offline, set HF_HUB_OFFLINE=1 and (if needed) VTSEARCH_MODELS_DIR=" + cache_dir)
+PYEOF

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -1,5 +1,6 @@
 """Configuration and constants for VTSearch."""
 
+import os
 from pathlib import Path
 
 # Audio settings
@@ -13,7 +14,7 @@ VIDEO_DIR = DATA_DIR / "video"
 IMAGE_DIR = DATA_DIR / "images"
 PARAGRAPH_DIR = DATA_DIR / "paragraphs"
 EMBEDDINGS_DIR = DATA_DIR / "embeddings"
-MODELS_CACHE_DIR = DATA_DIR / "models"
+MODELS_CACHE_DIR = Path(os.environ["VTSEARCH_MODELS_DIR"]) if "VTSEARCH_MODELS_DIR" in os.environ else DATA_DIR / "models"
 
 # Dataset URLs
 ESC50_URL = "https://github.com/karolpiczak/ESC-50/archive/master.zip"


### PR DESCRIPTION
## Summary
This PR adds support for pre-downloading VTSearch embedding models for offline use and makes the model cache directory configurable via environment variable.

## Key Changes
- **New `download_models.sh` script**: Bash script that pre-downloads all four embedding models (CLAP, CLIP, X-CLIP, and E5) to a local cache directory for offline use
  - Accepts optional `CACHE_DIR` argument, defaults to `$VTSEARCH_MODELS_DIR` or `data/models`
  - Provides clear usage instructions and offline setup guidance
  - Downloads both model weights and processors/tokenizers from Hugging Face

- **Updated `vtsearch/config.py`**: Made `MODELS_CACHE_DIR` configurable
  - Now respects `VTSEARCH_MODELS_DIR` environment variable if set
  - Falls back to `data/models` for backward compatibility
  - Enables users to point the app at pre-downloaded models

## Implementation Details
- The download script uses Python's `from_pretrained()` with `cache_dir` parameter to leverage Hugging Face's built-in caching
- Supports offline mode via `HF_HUB_OFFLINE=1` environment variable after models are cached
- Clear progress indicators (1/4, 2/4, etc.) guide users through the download process
- Script uses bash strict mode (`set -euo pipefail`) for reliability

https://claude.ai/code/session_01PUeirKURy6zDMugWL927pA