### PR TITLE
Fix swipe animation by applying it to media wrapper instead of panel

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2293,7 +2293,9 @@
         <h2>${c.filename || 'Clip #' + c.id}</h2>
         <p>${metaInfo.join(' &middot; ')}</p>
       </div>
-      ${playerHTML}
+      <div class="media-swipe-wrapper" id="media-swipe-wrapper">
+        ${playerHTML}
+      </div>
       <div class="metadata-grid">
         ${c.frequency ? `
         <div class="metadata-item">
@@ -2414,9 +2416,12 @@
     if (nextId != null && nextId !== selected) {
       if (swipeAnimation) {
         const dir = vote === "good" ? "swipe-right" : "swipe-left";
-        center.classList.add(dir);
-        await new Promise(r => setTimeout(r, 180));
-        center.classList.remove(dir);
+        const wrapper = document.getElementById("media-swipe-wrapper");
+        if (wrapper) {
+          wrapper.classList.add(dir);
+          await new Promise(r => setTimeout(r, 180));
+          wrapper.classList.remove(dir);
+        }
       }
       selectClip(nextId);
     }

--- a/static/styles.css
+++ b/static/styles.css
@@ -431,5 +431,5 @@ video { max-width: 600px; max-height: 400px; }
   0%   { transform: translateX(0) rotate(0deg) scale(1); opacity: 1; }
   100% { transform: translateX(-60vw) rotate(-8deg) scale(0.9); opacity: 0; }
 }
-.panel-center.swipe-right { animation: swipe-right 0.18s cubic-bezier(0.4, 0, 1, 1) forwards; }
-.panel-center.swipe-left  { animation: swipe-left  0.18s cubic-bezier(0.4, 0, 1, 1) forwards; }
+.media-swipe-wrapper.swipe-right { animation: swipe-right 0.18s cubic-bezier(0.4, 0, 1, 1) forwards; }
+.media-swipe-wrapper.swipe-left  { animation: swipe-left  0.18s cubic-bezier(0.4, 0, 1, 1) forwards; }

--- a/static/styles.css
+++ b/static/styles.css
@@ -422,6 +422,10 @@ video { max-width: 600px; max-height: 400px; }
 /* Label count display */
 .label-count { font-size: 0.75rem; color: var(--text-muted); font-weight: normal; }
 
+/* Media swipe wrapper – must participate in panel-center flex layout so that
+   children (especially images with flex:1/min-height:0) are properly constrained. */
+.media-swipe-wrapper { flex: 1; min-height: 0; width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+
 /* Swipe vote animation */
 @keyframes swipe-right {
   0%   { transform: translateX(0) rotate(0deg) scale(1); opacity: 1; }


### PR DESCRIPTION
## Summary
Refactored the swipe vote animation to apply to a dedicated media wrapper element instead of the parent panel container. This fixes layout constraints and ensures media elements (images/videos) are properly sized during the animation.

## Key Changes
- Created a new `.media-swipe-wrapper` div that wraps the player HTML in the clip detail view
- Updated the swipe animation logic to target the wrapper element instead of the `panel-center` container
- Added flexbox styling to the wrapper (`flex: 1; min-height: 0`) to properly constrain child media elements within the panel layout
- Migrated swipe animation CSS rules from `.panel-center.swipe-right/left` to `.media-swipe-wrapper.swipe-right/left`

## Implementation Details
The wrapper uses `display: flex; flex-direction: column; align-items: center; justify-content: center` to center media content while maintaining proper flex constraints. The `min-height: 0` is critical for preventing flex children (especially images) from overflowing their container during layout calculations.

https://claude.ai/code/session_018j2WCVeu9rEnpf5Nf5BpFq