### PR TITLE
Add elapsed_seconds tracking to evaluation metrics

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -211,6 +211,7 @@ class TestDatasetResult:
         assert "text_sort" in d
         assert d["text_sort"]["mAP"] == 0.8
         assert len(d["text_sort"]["per_query"]) == 1
+        assert "elapsed_seconds" in d["text_sort"]["per_query"][0]
 
     def test_to_dict_learned(self):
         dr = DatasetResult(dataset_id="test", media_type="image")
@@ -222,6 +223,7 @@ class TestDatasetResult:
         d = dr.to_dict()
         assert "learned_sort" in d
         assert d["learned_sort"]["mean_f1"] == 0.75
+        assert "elapsed_seconds" in d["learned_sort"]["per_category"][0]
 
 
 # =====================================================================
@@ -353,6 +355,32 @@ class TestEvalTextSort:
         assert 5 in qm.recall_at_k
         assert qm.num_total == 20
 
+    def test_text_sort_elapsed_seconds_without_start_time(self):
+        """Without start_time, elapsed_seconds defaults to 0."""
+        clips, cat_dir, _ = self._make_synthetic_clips()
+        queries = [EvalQuery("a cat", "cat")]
+        with patch("vtsearch.models.embeddings.embed_text_query", return_value=cat_dir.copy()):
+            results = eval_text_sort(clips, queries, "image", k_values=[5])
+        assert results[0].elapsed_seconds == 0.0
+
+    def test_text_sort_elapsed_seconds_with_start_time(self):
+        """With start_time, elapsed_seconds is populated and non-negative."""
+        import time
+
+        clips, cat_dir, _ = self._make_synthetic_clips()
+        queries = [EvalQuery("a cat", "cat"), EvalQuery("a dog", "dog")]
+
+        def mock_embed(text, media_type, enrich=False):
+            return cat_dir.copy()
+
+        start = time.monotonic()
+        with patch("vtsearch.models.embeddings.embed_text_query", side_effect=mock_embed):
+            results = eval_text_sort(clips, queries, "image", k_values=[5], start_time=start)
+        for qm in results:
+            assert qm.elapsed_seconds >= 0.0
+        # Second query should have equal or later timestamp
+        assert results[1].elapsed_seconds >= results[0].elapsed_seconds
+
 
 # =====================================================================
 # Runner: eval_learned_sort with synthetic clips
@@ -403,6 +431,17 @@ class TestEvalLearnedSort:
         queries = [EvalQuery("rare stuff", "rare")]
         results = eval_learned_sort(clips, queries, train_fraction=0.5)
         assert len(results) == 0  # skipped due to too few clips
+
+    def test_learned_sort_elapsed_seconds(self):
+        """With start_time, elapsed_seconds is populated on results."""
+        import time
+
+        clips = self._make_synthetic_clips()
+        queries = [EvalQuery("category a stuff", "cat_a")]
+        start = time.monotonic()
+        results = eval_learned_sort(clips, queries, train_fraction=0.5, seed=42, start_time=start)
+        assert len(results) == 1
+        assert results[0].elapsed_seconds > 0.0
 
 
 # =====================================================================

--- a/tests/test_eval_visualize.py
+++ b/tests/test_eval_visualize.py
@@ -88,10 +88,22 @@ def _make_voting_iterations_df(n_seeds=2, n_steps=10) -> pd.DataFrame:
             cost = max(0, 1.0 - t * 0.08 + rng.normal(0, 0.05))
             fpr = max(0, 0.5 - t * 0.04 + rng.normal(0, 0.03))
             fnr = max(0, 0.5 - t * 0.04 + rng.normal(0, 0.03))
+            elapsed = (t - 2) * 0.1 + seed * n_steps * 0.1
             rows.append(
-                {"seed": seed, "dataset": "ds1", "category": "alpha", "t": t, "cost": cost, "fpr": fpr, "fnr": fnr}
+                {
+                    "seed": seed,
+                    "dataset": "ds1",
+                    "category": "alpha",
+                    "t": t,
+                    "cost": cost,
+                    "fpr": fpr,
+                    "fnr": fnr,
+                    "elapsed_seconds": elapsed,
+                }
             )
-    return pd.DataFrame(rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr"])
+    return pd.DataFrame(
+        rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"]
+    )
 
 
 # ------------------------------------------------------------------
@@ -190,7 +202,7 @@ class TestPlotVotingIterations:
             assert p.stat().st_size > 0
 
     def test_empty_dataframe_generates_no_plots(self, tmp_dir):
-        df = pd.DataFrame(columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr"])
+        df = pd.DataFrame(columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"])
         paths = plot_voting_iterations(df, output_dir=tmp_dir)
         assert paths == []
 

--- a/tests/test_eval_voting_iterations.py
+++ b/tests/test_eval_voting_iterations.py
@@ -177,7 +177,10 @@ class TestSimulateVotingIterations:
         rows2 = simulate_voting_iterations(clips, "alpha", seed=42)
         assert len(rows1) == len(rows2)
         for r1, r2 in zip(rows1, rows2):
-            assert r1 == r2
+            # Compare all fields except elapsed_seconds (wall-clock timing varies between runs)
+            r1_cmp = {k: v for k, v in r1.items() if k != "elapsed_seconds"}
+            r2_cmp = {k: v for k, v in r2.items() if k != "elapsed_seconds"}
+            assert r1_cmp == r2_cmp
 
     def test_different_seeds_differ(self):
         clips = _make_separable_clips(n_per_cat=10)

--- a/tests/test_eval_voting_iterations.py
+++ b/tests/test_eval_voting_iterations.py
@@ -167,7 +167,7 @@ class TestSimulateVotingIterations:
             seed=42,
             dataset_name="test_ds",
         )
-        expected_keys = {"seed", "dataset", "category", "t", "cost", "fpr", "fnr"}
+        expected_keys = {"seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"}
         for row in rows:
             assert set(row.keys()) == expected_keys
 
@@ -238,6 +238,15 @@ class TestSimulateVotingIterations:
         costs5 = [r["cost"] for r in rows_inc5]
         assert costs0 != costs5
 
+    def test_elapsed_seconds_non_negative_and_increasing(self):
+        """elapsed_seconds should be non-negative and non-decreasing over rows."""
+        clips = _make_separable_clips(n_per_cat=10)
+        rows = simulate_voting_iterations(clips, "alpha", seed=42)
+        times = [r["elapsed_seconds"] for r in rows]
+        assert all(t >= 0.0 for t in times)
+        for i in range(1, len(times)):
+            assert times[i] >= times[i - 1]
+
 
 # ------------------------------------------------------------------
 # Integration test: run_voting_iterations_eval
@@ -253,7 +262,7 @@ class TestRunVotingIterationsEval:
             categories={"ds1": ["alpha"]},
         )
         assert isinstance(df, pd.DataFrame)
-        assert list(df.columns) == ["seed", "dataset", "category", "t", "cost", "fpr", "fnr"]
+        assert list(df.columns) == ["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"]
 
     def test_multiple_seeds(self):
         clips = _make_separable_clips(n_per_cat=10)

--- a/vtsearch/eval/metrics.py
+++ b/vtsearch/eval/metrics.py
@@ -19,6 +19,7 @@ class QueryMetrics:
     recall_at_k: dict[int, float] = field(default_factory=dict)
     num_relevant: int = 0
     num_total: int = 0
+    elapsed_seconds: float = 0.0
 
 
 @dataclass
@@ -32,6 +33,7 @@ class LearnedSortMetrics:
     num_train: int
     num_test: int
     target_category: str = ""
+    elapsed_seconds: float = 0.0
 
 
 @dataclass
@@ -75,6 +77,7 @@ class DatasetResult:
                         "num_relevant": q.num_relevant,
                         "precision_at_k": {str(k): round(v, 4) for k, v in sorted(q.precision_at_k.items())},
                         "recall_at_k": {str(k): round(v, 4) for k, v in sorted(q.recall_at_k.items())},
+                        "elapsed_seconds": round(q.elapsed_seconds, 3),
                     }
                     for q in self.text_sort
                 ],
@@ -92,6 +95,7 @@ class DatasetResult:
                         "f1": round(f.f1, 4),
                         "num_train": f.num_train,
                         "num_test": f.num_test,
+                        "elapsed_seconds": round(f.elapsed_seconds, 3),
                     }
                     for f in self.learned_sort
                 ],

--- a/vtsearch/eval/runner.py
+++ b/vtsearch/eval/runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
 import numpy as np
@@ -67,6 +68,7 @@ def eval_text_sort(
     media_type: str,
     k_values: list[int] | None = None,
     enrich: bool = False,
+    start_time: float | None = None,
 ) -> list:
     """Run text-sort evaluation for a list of queries.
 
@@ -79,6 +81,8 @@ def eval_text_sort(
         media_type: The media type string for embedding dispatch.
         k_values: Optional k values for P@k/R@k.
         enrich: If ``True``, use enriched (wrapper-averaged) text embeddings.
+        start_time: Monotonic timestamp from the start of the eval run.
+            When provided, each result records ``elapsed_seconds``.
 
     Returns:
         List of :class:`~vtsearch.eval.metrics.QueryMetrics`.
@@ -92,6 +96,8 @@ def eval_text_sort(
         relevant_ids = {cid for cid, c in clips.items() if c.get("category") == query.target_category}
 
         qm = compute_metrics(ranked_ids, relevant_ids, query.text, query.target_category, k_values)
+        if start_time is not None:
+            qm.elapsed_seconds = time.monotonic() - start_time
         results.append(qm)
 
     return results
@@ -105,6 +111,7 @@ def eval_learned_sort(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    start_time: float | None = None,
 ) -> list[LearnedSortMetrics]:
     """Run learned-sort evaluation via simulated voting.
 
@@ -128,6 +135,8 @@ def eval_learned_sort(
             calibration (default 2).
         calibration_fraction: Fraction of labelled data reserved for
             calibration in each split (default 0.5).
+        start_time: Monotonic timestamp from the start of the eval run.
+            When provided, each result records ``elapsed_seconds``.
 
     Returns:
         List of :class:`LearnedSortMetrics`, one per query.
@@ -182,6 +191,7 @@ def eval_learned_sort(
 
         acc, prec, rec, f1 = compute_binary_classification_metrics(predictions, labels)
 
+        elapsed = (time.monotonic() - start_time) if start_time is not None else 0.0
         results.append(
             LearnedSortMetrics(
                 accuracy=acc,
@@ -191,6 +201,7 @@ def eval_learned_sort(
                 num_train=len(train_good) + len(train_bad),
                 num_test=len(test_ids),
                 target_category=query.target_category,
+                elapsed_seconds=elapsed,
             )
         )
 
@@ -239,6 +250,7 @@ def run_eval(
     if dataset_ids is None:
         dataset_ids = list(EVAL_DATASETS.keys())
 
+    start_time = time.monotonic()
     all_results: list[DatasetResult] = []
 
     for ds_id in dataset_ids:
@@ -278,7 +290,7 @@ def run_eval(
         # --- Text sort ---
         if mode in ("text", "both"):
             print(f"\n--- Text Sort Evaluation ({len(queries)} queries) ---")
-            text_results = eval_text_sort(clips, queries, media_type, k_values, enrich=enrich)
+            text_results = eval_text_sort(clips, queries, media_type, k_values, enrich=enrich, start_time=start_time)
             ds_result.text_sort = text_results
 
             for qm in text_results:
@@ -287,7 +299,8 @@ def run_eval(
                 print(
                     f"  [{qm.target_category:20s}] AP={qm.average_precision:.3f}  "
                     f"P@5={p5:.2f}  P@10={p10:.2f}  "
-                    f"({qm.num_relevant} relevant / {qm.num_total} total)"
+                    f"({qm.num_relevant} relevant / {qm.num_total} total)  "
+                    f"t={qm.elapsed_seconds:.1f}s"
                 )
             print(f"  mAP = {ds_result.mean_average_precision:.4f}")
 
@@ -302,6 +315,7 @@ def run_eval(
                 safe_thresholds=safe_thresholds,
                 calibrate_count=calibrate_count,
                 calibration_fraction=calibration_fraction,
+                start_time=start_time,
             )
             ds_result.learned_sort = learned_results
 
@@ -309,7 +323,8 @@ def run_eval(
                 print(
                     f"  [{lm.target_category:20s}] Acc={lm.accuracy:.3f}  "
                     f"P={lm.precision:.3f}  R={lm.recall:.3f}  F1={lm.f1:.3f}  "
-                    f"(train={lm.num_train}, test={lm.num_test})"
+                    f"(train={lm.num_train}, test={lm.num_test})  "
+                    f"t={lm.elapsed_seconds:.1f}s"
                 )
             print(f"  Mean F1 = {ds_result.mean_learned_f1:.4f}")
 

--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -18,6 +18,7 @@ The result is a :class:`pandas.DataFrame` with columns
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -142,10 +143,11 @@ def simulate_voting_iterations(
 
     Returns:
         List of row dicts with keys
-        ``seed, dataset, category, t, cost, fpr, fnr``.
+        ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``.
     """
     rng = np.random.RandomState(seed)
     torch.manual_seed(seed)
+    start_time = time.monotonic()
 
     sim_ids, test_ids = _split_clip_ids(clips_dict, sim_fraction, rng)
 
@@ -220,6 +222,7 @@ def simulate_voting_iterations(
                 "category": target_category,
                 "t": t,
                 **metrics,
+                "elapsed_seconds": round(time.monotonic() - start_time, 3),
             }
         )
 
@@ -262,7 +265,7 @@ def run_voting_iterations_eval(
 
     Returns:
         A :class:`~pandas.DataFrame` with columns
-        ``seed, dataset, category, t, cost, fpr, fnr``.
+        ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``.
     """
     all_rows: list[dict[str, Any]] = []
 
@@ -288,7 +291,7 @@ def run_voting_iterations_eval(
                 )
                 all_rows.extend(rows)
 
-    return pd.DataFrame(all_rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr"])
+    return pd.DataFrame(all_rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"])
 
 
 def run_voting_iterations_eval_from_pickles(
@@ -316,7 +319,8 @@ def run_voting_iterations_eval_from_pickles(
             calibration in each split (default 0.5).
 
     Returns:
-        A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`.
+        A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`
+        (columns: ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``).
     """
     from vtsearch.datasets.loader import load_dataset_from_pickle
 


### PR DESCRIPTION
## Summary
This PR adds elapsed time tracking to evaluation results across text-sort, learned-sort, and voting iterations evaluations. Each evaluation now records how long it took to process, providing visibility into performance characteristics.

## Key Changes

- **QueryMetrics & LearnedSortMetrics**: Added `elapsed_seconds` field (defaults to 0.0) to track evaluation duration
- **eval_text_sort()**: Added optional `start_time` parameter; when provided, calculates and records elapsed time for each query
- **eval_learned_sort()**: Added optional `start_time` parameter; calculates elapsed time per category evaluation
- **run_eval()**: Captures monotonic start time at beginning of evaluation run and passes it to both text and learned sort evaluators; displays elapsed time in console output
- **simulate_voting_iterations()**: Tracks elapsed time from start of simulation and records it (rounded to 3 decimals) in each iteration row
- **DatasetResult.to_dict()**: Includes `elapsed_seconds` in serialized output for both text_sort and learned_sort per-query/per-category results
- **Test coverage**: Added tests verifying elapsed_seconds behavior with and without start_time, monotonic increase over iterations, and proper serialization

## Implementation Details

- Uses `time.monotonic()` for reliable elapsed time measurement (not affected by system clock adjustments)
- Elapsed time is optional—when `start_time` is None, defaults to 0.0 for backward compatibility
- Console output now displays elapsed time in seconds (formatted to 1 decimal place) for each query/category result
- Voting iterations track cumulative elapsed time across all iterations, ensuring monotonic increase
- All elapsed times are rounded to 3 decimal places in serialized output for consistency

https://claude.ai/code/session_01HT9tu7opNYc4MzBiQG89Cv