### PR TITLE
Add export filtering and fill-from-sort labeling features

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1453,6 +1453,16 @@
     window.autodetectResultsData = data;
     window.autodetectAllHits = allHits;
 
+    // Reset export controls
+    const goodRadio = document.querySelector('input[name="export-sides"][value="good"]');
+    if (goodRadio) goodRadio.checked = true;
+    if (fillFromSortCheckbox) fillFromSortCheckbox.checked = false;
+    if (fillFromSortInfo) fillFromSortInfo.textContent = "";
+    setExportStatus("", "var(--text-muted)");
+
+    // Load exporters if not already loaded
+    if (exportersList.length === 0) loadExportersList();
+
     // Show modal
     autodetectModal.classList.add("show");
   }
@@ -1503,6 +1513,287 @@
         }, 2000);
       });
     });
+  }
+
+  // ---- Export section in auto-detect modal ----
+
+  const exportExporterSelect = document.getElementById("export-exporter-select");
+  const exportExporterFields = document.getElementById("export-exporter-fields");
+  const exportRunBtn = document.getElementById("export-run-btn");
+  const exportStatus = document.getElementById("export-status");
+  const fillFromSortCheckbox = document.getElementById("fill-from-sort-checkbox");
+  const fillFromSortInfo = document.getElementById("fill-from-sort-info");
+  let exportersList = [];
+
+  function getSelectedExportSides() {
+    const checked = document.querySelector('input[name="export-sides"]:checked');
+    return checked ? checked.value : "good";
+  }
+
+  async function loadExportersList() {
+    try {
+      const res = await fetch("/api/exporters");
+      if (res.ok) {
+        exportersList = await res.json();
+        renderExporterDropdown();
+      }
+    } catch (_) {}
+  }
+
+  function renderExporterDropdown() {
+    if (!exportExporterSelect) return;
+    exportExporterSelect.innerHTML = "";
+    for (const exp of exportersList) {
+      const opt = document.createElement("option");
+      opt.value = exp.name;
+      opt.textContent = `${exp.icon} ${exp.display_name}`;
+      exportExporterSelect.appendChild(opt);
+    }
+    renderExporterFields();
+  }
+
+  function renderExporterFields() {
+    if (!exportExporterFields || !exportExporterSelect) return;
+    const name = exportExporterSelect.value;
+    const exp = exportersList.find(e => e.name === name);
+    if (!exp || exp.fields.length === 0) {
+      exportExporterFields.innerHTML = "";
+      return;
+    }
+    const inputStyle = "width:100%;padding:6px 8px;background:var(--bg-hover);border:1px solid var(--border);border-radius:4px;color:var(--text-primary);box-sizing:border-box;font-size:0.85rem;";
+    let html = "";
+    for (const field of exp.fields) {
+      html += `<div style="margin-bottom:8px;">`;
+      html += `<label style="display:block;margin-bottom:3px;color:var(--text-secondary);font-size:0.8rem;">${escapeHtml(field.label)}${field.required ? " *" : ""}</label>`;
+      if (field.field_type === "select") {
+        html += `<select name="${escapeHtml(field.key)}" data-export-field style="${inputStyle}">`;
+        for (const opt of field.options) {
+          html += `<option value="${escapeHtml(opt)}"${opt === field.default ? " selected" : ""}>${escapeHtml(opt)}</option>`;
+        }
+        html += `</select>`;
+      } else {
+        const itype = field.field_type === "password" ? "password" : (field.field_type === "email" ? "email" : "text");
+        const placeholder = escapeHtml(field.placeholder || field.description || "");
+        html += `<input type="${itype}" name="${escapeHtml(field.key)}" value="${escapeHtml(field.default)}" placeholder="${placeholder}" data-export-field style="${inputStyle}" ${field.required ? "required" : ""}>`;
+      }
+      html += `</div>`;
+    }
+    exportExporterFields.innerHTML = html;
+  }
+
+  if (exportExporterSelect) {
+    exportExporterSelect.addEventListener("change", renderExporterFields);
+  }
+
+  function buildFilteredResults(sides) {
+    const data = window.autodetectResultsData;
+    if (!data || !data.results) return data || {};
+    const filtered = {};
+    for (const [detName, detResult] of Object.entries(data.results)) {
+      const entry = { ...detResult };
+      if (sides === "good") {
+        entry.hits = detResult.hits || [];
+        delete entry.negative_hits;
+      } else if (sides === "bad") {
+        entry.hits = detResult.negative_hits || [];
+        entry.total_hits = entry.hits.length;
+        delete entry.negative_hits;
+      } else {
+        // both
+        const good = (detResult.hits || []).map(h => ({ ...h, label: "good" }));
+        const bad = (detResult.negative_hits || []).map(h => ({ ...h, label: "bad" }));
+        entry.hits = [...good, ...bad];
+        entry.total_hits = entry.hits.length;
+        delete entry.negative_hits;
+      }
+      filtered[detName] = entry;
+    }
+    return { ...data, results: filtered };
+  }
+
+  function updateFillFromSortInfo() {
+    if (!fillFromSortInfo) return;
+    if (!fillFromSortCheckbox || !fillFromSortCheckbox.checked) {
+      fillFromSortInfo.textContent = "";
+      return;
+    }
+    if (!sortOrder || threshold === null) {
+      fillFromSortInfo.textContent = "No sort results available. Run a sort first.";
+      fillFromSortInfo.style.color = "var(--text-muted)";
+      return;
+    }
+    const sides = getSelectedExportSides();
+    const votedIds = new Set([...votes.good, ...votes.bad]);
+    let goodCount = 0;
+    let badCount = 0;
+    for (const entry of sortOrder) {
+      if (votedIds.has(entry.id)) continue;
+      if (entry.score >= threshold) goodCount++;
+      else badCount++;
+    }
+    let msg = "";
+    if (sides === "good") msg = `${goodCount} unlabeled element${goodCount !== 1 ? "s" : ""} above threshold will be labeled Good.`;
+    else if (sides === "bad") msg = `${badCount} unlabeled element${badCount !== 1 ? "s" : ""} below threshold will be labeled Bad.`;
+    else msg = `${goodCount} Good + ${badCount} Bad unlabeled element${goodCount + badCount !== 1 ? "s" : ""} will be labeled.`;
+    fillFromSortInfo.textContent = msg;
+    fillFromSortInfo.style.color = "var(--accent)";
+  }
+
+  if (fillFromSortCheckbox) {
+    fillFromSortCheckbox.addEventListener("change", updateFillFromSortInfo);
+  }
+  document.querySelectorAll('input[name="export-sides"]').forEach(radio => {
+    radio.addEventListener("change", () => {
+      updateFillFromSortInfo();
+      updateAutodetectSummary();
+    });
+  });
+
+  function updateAutodetectSummary() {
+    const data = window.autodetectResultsData;
+    if (!data || !autodetectSummary) return;
+    const sides = getSelectedExportSides();
+    let goodTotal = 0;
+    let badTotal = 0;
+    for (const result of Object.values(data.results)) {
+      goodTotal += (result.hits || []).length;
+      badTotal += (result.negative_hits || []).length;
+    }
+    let countText;
+    if (sides === "good") countText = `<strong>Good Results:</strong> ${goodTotal}`;
+    else if (sides === "bad") countText = `<strong>Bad Results:</strong> ${badTotal}`;
+    else countText = `<strong>Good:</strong> ${goodTotal} &nbsp; <strong>Bad:</strong> ${badTotal}`;
+    autodetectSummary.innerHTML = `
+      <p style="color: var(--text-primary);">
+        <strong>Media Type:</strong> ${data.media_type} &nbsp;|&nbsp;
+        <strong>Detectors Run:</strong> ${data.detectors_run} &nbsp;|&nbsp;
+        ${countText}
+      </p>
+    `;
+  }
+
+  function setExportStatus(msg, color) {
+    if (exportStatus) {
+      exportStatus.textContent = msg;
+      exportStatus.style.color = color || "var(--text-muted)";
+    }
+  }
+
+  if (exportRunBtn) {
+    exportRunBtn.addEventListener("click", async () => {
+      const sides = getSelectedExportSides();
+      const useFill = fillFromSortCheckbox && fillFromSortCheckbox.checked;
+
+      if (useFill) {
+        // Fill from Sort mode
+        if (!sortOrder || threshold === null) {
+          await vtAlert("No sort results available. Run a sort first.", "warning");
+          return;
+        }
+
+        // Dry run to get counts
+        const dryRes = await fetch("/api/labels/fill-from-sort", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sort_results: sortOrder,
+            threshold: threshold,
+            sides: sides,
+            confirm: false,
+          }),
+        });
+        if (!dryRes.ok) {
+          setExportStatus("Failed to compute fill counts.", "#f44336");
+          return;
+        }
+        const counts = await dryRes.json();
+        const total = (counts.good_count || 0) + (counts.bad_count || 0);
+        if (total === 0) {
+          await vtAlert("No unlabeled elements to fill. All elements in the sort results are already labeled.", "info");
+          return;
+        }
+
+        let desc;
+        if (sides === "good") desc = `${counts.good_count} Good label${counts.good_count !== 1 ? "s" : ""}`;
+        else if (sides === "bad") desc = `${counts.bad_count} Bad label${counts.bad_count !== 1 ? "s" : ""}`;
+        else desc = `${counts.good_count} Good + ${counts.bad_count} Bad label${total !== 1 ? "s" : ""}`;
+
+        const confirmed = await vtConfirm(`This will add ${desc} to the LabelSet and export. Continue?`);
+        if (!confirmed) return;
+
+        setExportStatus("Filling labels\u2026", "var(--text-muted)");
+        const fillRes = await fetch("/api/labels/fill-from-sort", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sort_results: sortOrder,
+            threshold: threshold,
+            sides: sides,
+            confirm: true,
+          }),
+        });
+        if (!fillRes.ok) {
+          setExportStatus("Failed to fill labels.", "#f44336");
+          return;
+        }
+        const fillData = await fillRes.json();
+        const resultsForExport = fillData.results;
+
+        // Now export using selected exporter
+        await runExporterWithResults(resultsForExport);
+
+        // Refresh votes
+        try {
+          const vRes = await fetch("/api/votes");
+          if (vRes.ok) {
+            const vData = await vRes.json();
+            votes = vData;
+            renderVotes();
+          }
+        } catch (_) {}
+      } else {
+        // Standard auto-detect export
+        const filteredResults = buildFilteredResults(sides);
+        await runExporterWithResults(filteredResults);
+      }
+    });
+  }
+
+  async function runExporterWithResults(results) {
+    if (!exportExporterSelect) return;
+    const exporterName = exportExporterSelect.value;
+    if (!exporterName) {
+      setExportStatus("Select an exporter.", "var(--text-muted)");
+      return;
+    }
+
+    // Gather field values
+    const fieldEls = exportExporterFields.querySelectorAll("[data-export-field]");
+    const fieldValues = {};
+    for (const el of fieldEls) {
+      fieldValues[el.name] = el.value;
+    }
+
+    setExportStatus("Exporting\u2026", "var(--text-muted)");
+    try {
+      const res = await fetch("/api/exporters/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          exporter_name: exporterName,
+          field_values: fieldValues,
+          results: results,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok && data.success) {
+        setExportStatus(data.message || "Export complete.", "#4caf50");
+      } else {
+        setExportStatus(data.error || "Export failed.", "#f44336");
+      }
+    } catch (err) {
+      setExportStatus(`Export error: ${err.message}`, "#f44336");
+    }
   }
 
   // ---- Settings modal ----

--- a/static/index.html
+++ b/static/index.html
@@ -290,6 +290,41 @@
         </label>
         <button id="copy-results-btn" style="padding: 8px 16px; background: var(--accent); color: #fff; border: none; border-radius: 4px; cursor: pointer;">Copy To Clipboard</button>
       </div>
+      <!-- Export Section -->
+      <div id="autodetect-export-section" style="margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--border);">
+        <div style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 10px;">Export</div>
+        <div style="display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start;">
+          <!-- Left column: options -->
+          <div style="flex: 1; min-width: 200px;">
+            <div style="margin-bottom: 10px;">
+              <label style="display: block; font-size: 0.82rem; color: var(--text-secondary); margin-bottom: 6px;">Include:</label>
+              <div style="display: flex; gap: 12px; font-size: 0.85rem;">
+                <label style="color: var(--text-primary); cursor: pointer;"><input type="radio" name="export-sides" value="good" checked style="accent-color: var(--accent);"> Good</label>
+                <label style="color: var(--text-primary); cursor: pointer;"><input type="radio" name="export-sides" value="bad" style="accent-color: var(--accent);"> Bad</label>
+                <label style="color: var(--text-primary); cursor: pointer;"><input type="radio" name="export-sides" value="both" style="accent-color: var(--accent);"> Both</label>
+              </div>
+            </div>
+            <div style="margin-bottom: 10px;">
+              <label style="color: var(--text-primary); font-size: 0.85rem; cursor: pointer; display: flex; align-items: center; gap: 6px;">
+                <input type="checkbox" id="fill-from-sort-checkbox" style="accent-color: var(--accent);">
+                Fill from Sort
+              </label>
+              <div id="fill-from-sort-info" style="font-size: 0.78rem; color: var(--text-muted); margin-top: 4px; min-height: 1.2em;"></div>
+            </div>
+          </div>
+          <!-- Right column: exporter picker + fields -->
+          <div style="flex: 2; min-width: 280px;">
+            <div style="margin-bottom: 10px;">
+              <label style="display: block; font-size: 0.82rem; color: var(--text-secondary); margin-bottom: 4px;">Exporter:</label>
+              <select id="export-exporter-select" style="width: 100%; padding: 6px 8px; background: var(--bg-surface); color: var(--text-primary); border: 1px solid var(--border); border-radius: 4px; font-size: 0.85rem;">
+              </select>
+            </div>
+            <div id="export-exporter-fields" style="margin-bottom: 10px;"></div>
+            <div id="export-status" style="font-size: 0.78rem; color: var(--text-muted); min-height: 1.2em; margin-bottom: 8px;"></div>
+            <button id="export-run-btn" style="padding: 8px 20px; background: var(--accent); color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;">Export</button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -501,3 +501,46 @@ class TestAutoDetect:
             threshold = result["threshold"]
             for hit in result["hits"]:
                 assert hit["score"] >= threshold - 1e-6  # float tolerance
+
+    # -- negative_hits --
+
+    def test_each_result_has_negative_hits(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            assert "negative_hits" in result
+            assert isinstance(result["negative_hits"], list)
+
+    def test_negative_hits_score_below_threshold(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            threshold = result["threshold"]
+            for hit in result["negative_hits"]:
+                assert hit["score"] < threshold + 1e-6
+
+    def test_negative_hits_do_not_contain_embeddings(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            for hit in result["negative_hits"]:
+                assert "embedding" not in hit
+                assert "clip_bytes" not in hit
+
+    def test_hits_and_negative_hits_cover_all_clips(self, client):
+        """Positive + negative hits should cover every clip in the dataset."""
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        from vtsearch.utils import clips
+
+        total_clips = len(clips)
+        for result in data["results"].values():
+            total_returned = len(result["hits"]) + len(result["negative_hits"])
+            assert total_returned == total_clips
+
+    def test_negative_hits_sorted_descending_by_score(self, client):
+        self._add_audio_detector(client)
+        data = client.post("/api/auto-detect").get_json()
+        for result in data["results"].values():
+            scores = [h["score"] for h in result["negative_hits"]]
+            assert scores == sorted(scores, reverse=True)

--- a/tests/test_export_options.py
+++ b/tests/test_export_options.py
@@ -12,8 +12,6 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
-
 import app as app_module
 
 SAMPLE_RESULTS = {
@@ -261,31 +259,18 @@ class TestFillFromSortConfirm:
 
 
 class TestCliScoringNegativeHits:
-    def test_score_clips_with_detectors_returns_negative_hits(self):
+    def test_score_clips_with_detectors_returns_negative_hits(self, client):
         """The multi-detector CLI scorer should include negative_hits."""
         from vtsearch.utils import clips
 
-        # Train a detector to get weights
+        # Train a detector via the API to get valid weights
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        from vtsearch.models import train_and_score
+        export_resp = client.post("/api/detector/export")
+        assert export_resp.status_code == 200
+        detector = export_resp.get_json()
 
-        results, threshold = train_and_score(clips, app_module.good_votes, app_module.bad_votes)
-
-        from vtsearch.models.training import build_model, train_model
-
-        all_ids = sorted(clips.keys())
-        import numpy as np
-        import torch
-
-        all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
-        X_all = torch.tensor(all_embs, dtype=torch.float32)
-        good_ids = list(app_module.good_votes.keys())
-        bad_ids = list(app_module.bad_votes.keys())
-        model = train_model(clips, good_ids, bad_ids)
-
-        weights = {k: v.tolist() for k, v in model.state_dict().items()}
-        detectors = {"test": {"weights": weights, "threshold": threshold}}
+        detectors = {"test": {"weights": detector["weights"], "threshold": detector["threshold"]}}
 
         from vtsearch.cli import _score_clips_with_detectors
 

--- a/tests/test_export_options.py
+++ b/tests/test_export_options.py
@@ -1,0 +1,431 @@
+"""Tests for export boolean options and fill-from-sort.
+
+Covers:
+- Auto-detect negative_hits in CLI scoring
+- POST /api/labels/fill-from-sort (dry run and confirm)
+- Export filtering with Good/Bad/Both sides
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import app as app_module
+
+SAMPLE_RESULTS = {
+    "media_type": "audio",
+    "detectors_run": 1,
+    "results": {
+        "test_det": {
+            "detector_name": "test_det",
+            "threshold": 0.5,
+            "total_hits": 2,
+            "hits": [
+                {"id": 1, "filename": "a.wav", "score": 0.9, "label": "good"},
+                {"id": 2, "filename": "b.wav", "score": 0.7, "label": "good"},
+            ],
+            "negative_hits": [
+                {"id": 3, "filename": "c.wav", "score": 0.3, "label": "bad"},
+            ],
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Fill from Sort – dry run
+# ---------------------------------------------------------------------------
+
+
+class TestFillFromSortDryRun:
+    def _sort_results(self):
+        """Build a simple sort_results list with all clip ids."""
+        from vtsearch.utils import clips
+
+        results = []
+        for i, cid in enumerate(sorted(clips.keys())):
+            # Alternate scores: first half above 0.5, second half below
+            score = 0.9 - (i * 0.04)
+            results.append({"id": cid, "score": round(score, 4)})
+        return results
+
+    def test_dry_run_returns_counts(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "good",
+                "confirm": False,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "good_count" in data
+        assert "bad_count" in data
+        assert data["good_count"] >= 0
+        assert data["bad_count"] == 0  # sides="good" ignores bad
+
+    def test_dry_run_bad_side(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "bad",
+                "confirm": False,
+            },
+        )
+        data = resp.get_json()
+        assert data["good_count"] == 0  # sides="bad" ignores good
+        assert data["bad_count"] >= 0
+
+    def test_dry_run_both_sides(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "both",
+                "confirm": False,
+            },
+        )
+        data = resp.get_json()
+        assert data["good_count"] + data["bad_count"] > 0
+
+    def test_dry_run_excludes_already_voted(self, client):
+        """Clips that already have votes should not be counted."""
+        app_module.good_votes.update({1: None, 2: None})
+        app_module.bad_votes.update({3: None})
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "both",
+                "confirm": False,
+            },
+        )
+        data = resp.get_json()
+        total = data["good_count"] + data["bad_count"]
+        from vtsearch.utils import clips
+
+        assert total == len(clips) - 3
+
+    def test_missing_sort_results_returns_400(self, client):
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={"threshold": 0.5, "sides": "good"},
+        )
+        assert resp.status_code == 400
+
+    def test_missing_threshold_returns_400(self, client):
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={"sort_results": [], "sides": "good"},
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_sides_returns_400(self, client):
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={"sort_results": [], "threshold": 0.5, "sides": "invalid"},
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Fill from Sort – confirm
+# ---------------------------------------------------------------------------
+
+
+class TestFillFromSortConfirm:
+    def _sort_results(self):
+        from vtsearch.utils import clips
+
+        results = []
+        for i, cid in enumerate(sorted(clips.keys())):
+            score = 0.9 - (i * 0.04)
+            results.append({"id": cid, "score": round(score, 4)})
+        return results
+
+    def test_confirm_applies_labels(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "both",
+                "confirm": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "good_applied" in data
+        assert "bad_applied" in data
+        assert "results" in data
+
+        # Verify labels were actually applied
+        total_applied = data["good_applied"] + data["bad_applied"]
+        from vtsearch.utils import clips
+
+        assert total_applied == len(clips)  # all were unlabeled
+        assert len(app_module.good_votes) == data["good_applied"]
+        assert len(app_module.bad_votes) == data["bad_applied"]
+
+    def test_confirm_returns_exporter_compatible_results(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "good",
+                "confirm": True,
+            },
+        )
+        data = resp.get_json()
+        r = data["results"]
+        assert "media_type" in r
+        assert "detectors_run" in r
+        assert "results" in r
+        det = r["results"]["fill_from_sort"]
+        assert "detector_name" in det
+        assert "threshold" in det
+        assert "hits" in det
+
+    def test_confirm_does_not_relabel_already_voted(self, client):
+        # Pre-label some clips
+        app_module.good_votes.update({1: None})
+        app_module.bad_votes.update({2: None})
+
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "both",
+                "confirm": True,
+            },
+        )
+        data = resp.get_json()
+        from vtsearch.utils import clips
+
+        total_applied = data["good_applied"] + data["bad_applied"]
+        assert total_applied == len(clips) - 2  # 2 already voted
+
+    def test_confirm_good_only(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "good",
+                "confirm": True,
+            },
+        )
+        data = resp.get_json()
+        assert data["bad_applied"] == 0
+        assert len(app_module.bad_votes) == 0
+
+    def test_confirm_bad_only(self, client):
+        results = self._sort_results()
+        resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": results,
+                "threshold": 0.5,
+                "sides": "bad",
+                "confirm": True,
+            },
+        )
+        data = resp.get_json()
+        assert data["good_applied"] == 0
+        assert len(app_module.good_votes) == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI _score_clips_with_detectors negative_hits
+# ---------------------------------------------------------------------------
+
+
+class TestCliScoringNegativeHits:
+    def test_score_clips_with_detectors_returns_negative_hits(self):
+        """The multi-detector CLI scorer should include negative_hits."""
+        from vtsearch.utils import clips
+
+        # Train a detector to get weights
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        from vtsearch.models import train_and_score
+
+        results, threshold = train_and_score(clips, app_module.good_votes, app_module.bad_votes)
+
+        from vtsearch.models.training import build_model, train_model
+
+        all_ids = sorted(clips.keys())
+        import numpy as np
+        import torch
+
+        all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
+        X_all = torch.tensor(all_embs, dtype=torch.float32)
+        good_ids = list(app_module.good_votes.keys())
+        bad_ids = list(app_module.bad_votes.keys())
+        model = train_model(clips, good_ids, bad_ids)
+
+        weights = {k: v.tolist() for k, v in model.state_dict().items()}
+        detectors = {"test": {"weights": weights, "threshold": threshold}}
+
+        from vtsearch.cli import _score_clips_with_detectors
+
+        det_results = _score_clips_with_detectors(clips, detectors)
+        for det_result in det_results.values():
+            assert "negative_hits" in det_result
+            assert isinstance(det_result["negative_hits"], list)
+            total = len(det_result["hits"]) + len(det_result["negative_hits"])
+            assert total == len(clips)
+
+
+# ---------------------------------------------------------------------------
+# Export with Good/Bad/Both filtered results via API
+# ---------------------------------------------------------------------------
+
+
+class TestExportWithFilteredResults:
+    def test_export_good_only(self, client):
+        """Exporting with only Good hits sends only positive hits to the exporter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "good_only.json"
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": {
+                        "media_type": "audio",
+                        "detectors_run": 1,
+                        "results": {
+                            "det": {
+                                "detector_name": "det",
+                                "threshold": 0.5,
+                                "total_hits": 2,
+                                "hits": [
+                                    {"id": 1, "filename": "a.wav", "score": 0.9},
+                                    {"id": 2, "filename": "b.wav", "score": 0.7},
+                                ],
+                            },
+                        },
+                    },
+                },
+            )
+            assert resp.status_code == 200
+            written = json.loads(fpath.read_text())
+            assert len(written["results"]["det"]["hits"]) == 2
+
+    def test_export_filtered_bad_only(self, client):
+        """When frontend sends only negative hits as 'hits', they export correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "bad_only.json"
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": {
+                        "media_type": "audio",
+                        "detectors_run": 1,
+                        "results": {
+                            "det": {
+                                "detector_name": "det",
+                                "threshold": 0.5,
+                                "total_hits": 3,
+                                "hits": [
+                                    {"id": 3, "filename": "c.wav", "score": 0.3, "label": "bad"},
+                                    {"id": 4, "filename": "d.wav", "score": 0.2, "label": "bad"},
+                                    {"id": 5, "filename": "e.wav", "score": 0.1, "label": "bad"},
+                                ],
+                            },
+                        },
+                    },
+                },
+            )
+            assert resp.status_code == 200
+            written = json.loads(fpath.read_text())
+            assert len(written["results"]["det"]["hits"]) == 3
+            for hit in written["results"]["det"]["hits"]:
+                assert hit["label"] == "bad"
+
+    def test_export_both_sides(self, client):
+        """When frontend sends combined good+bad hits, they export correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "both.json"
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": {
+                        "media_type": "audio",
+                        "detectors_run": 1,
+                        "results": {
+                            "det": {
+                                "detector_name": "det",
+                                "threshold": 0.5,
+                                "total_hits": 3,
+                                "hits": [
+                                    {"id": 1, "filename": "a.wav", "score": 0.9, "label": "good"},
+                                    {"id": 2, "filename": "b.wav", "score": 0.7, "label": "good"},
+                                    {"id": 3, "filename": "c.wav", "score": 0.3, "label": "bad"},
+                                ],
+                            },
+                        },
+                    },
+                },
+            )
+            assert resp.status_code == 200
+            written = json.loads(fpath.read_text())
+            assert len(written["results"]["det"]["hits"]) == 3
+
+    def test_fill_from_sort_results_exportable(self, client):
+        """Results from fill-from-sort should be exportable via the file exporter."""
+        from vtsearch.utils import clips
+
+        sort_results = [{"id": cid, "score": round(0.9 - (i * 0.04), 4)} for i, cid in enumerate(sorted(clips.keys()))]
+
+        fill_resp = client.post(
+            "/api/labels/fill-from-sort",
+            json={
+                "sort_results": sort_results,
+                "threshold": 0.5,
+                "sides": "good",
+                "confirm": True,
+            },
+        )
+        assert fill_resp.status_code == 200
+        fill_data = fill_resp.get_json()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "fill_export.json"
+            export_resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": fill_data["results"],
+                },
+            )
+            assert export_resp.status_code == 200
+            assert fpath.exists()
+            written = json.loads(fpath.read_text())
+            assert "fill_from_sort" in written["results"]

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -281,30 +281,35 @@ def _score_clips_with_detectors(
             scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
         positive_hits: list[dict[str, Any]] = []
+        negative_hits: list[dict[str, Any]] = []
         for cid, score in zip(all_ids, scores):
+            clip = clips[cid]
+            hit: dict[str, Any] = {
+                "id": cid,
+                "filename": clip.get("filename", f"clip_{cid}"),
+                "category": clip.get("category", "unknown"),
+                "score": round(score, 4),
+            }
+            if clip.get("origin") is not None:
+                hit["origin"] = clip["origin"]
+            if clip.get("origin_name"):
+                hit["origin_name"] = clip["origin_name"]
+            if clip.get("md5"):
+                hit["md5"] = clip["md5"]
             if score >= threshold:
-                clip = clips[cid]
-                hit: dict[str, Any] = {
-                    "id": cid,
-                    "filename": clip.get("filename", f"clip_{cid}"),
-                    "category": clip.get("category", "unknown"),
-                    "score": round(score, 4),
-                }
-                if clip.get("origin") is not None:
-                    hit["origin"] = clip["origin"]
-                if clip.get("origin_name"):
-                    hit["origin_name"] = clip["origin_name"]
-                if clip.get("md5"):
-                    hit["md5"] = clip["md5"]
                 positive_hits.append(hit)
+            else:
+                negative_hits.append(hit)
 
         positive_hits.sort(key=lambda x: x["score"], reverse=True)
+        negative_hits.sort(key=lambda x: x["score"], reverse=True)
 
         results[detector_name] = {
             "detector_name": detector_name,
             "threshold": round(threshold, 4),
             "total_hits": len(positive_hits),
             "hits": positive_hits,
+            "negative_hits": negative_hits,
         }
 
     return results

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -566,22 +566,27 @@ def auto_detect():
             scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
         positive_hits = []
+        negative_hits = []
         for cid, score in zip(all_ids, scores):
+            clip_info = clips[cid].copy()
+            clip_info.pop("embedding", None)
+            clip_info.pop("clip_bytes", None)
+            clip_info.pop("clip_string", None)
+            clip_info["score"] = round(score, 4)
             if score >= threshold:
-                clip_info = clips[cid].copy()
-                clip_info.pop("embedding", None)
-                clip_info.pop("clip_bytes", None)
-                clip_info.pop("clip_string", None)
-                clip_info["score"] = round(score, 4)
                 positive_hits.append(clip_info)
+            else:
+                negative_hits.append(clip_info)
 
         positive_hits.sort(key=lambda x: x["score"], reverse=True)
+        negative_hits.sort(key=lambda x: x["score"], reverse=True)
 
         return detector_name, {
             "detector_name": detector_name,
             "threshold": round(threshold, 4),
             "total_hits": len(positive_hits),
             "hits": positive_hits,
+            "negative_hits": negative_hits,
         }
 
     # Run all detectors in parallel (PyTorch releases GIL during tensor ops)

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -258,6 +258,157 @@ def import_labels():
     return jsonify({"applied": applied, "skipped": skipped})
 
 
+@sorting_bp.route("/api/labels/fill-from-sort", methods=["POST"])
+def fill_labels_from_sort():
+    """Fill labels from the current sort results.
+
+    Assigns Good/Bad labels to currently-unlabeled clips based on their
+    position relative to the sort threshold.
+
+    Request body (JSON)::
+
+        {
+            "sort_results": [{"id": 1, "score": 0.8}, ...],
+            "threshold": 0.5,
+            "sides": "good" | "bad" | "both",
+            "confirm": false
+        }
+
+    When ``confirm`` is false (dry run), returns the counts of unlabeled
+    clips that would be labeled.  When ``confirm`` is true, applies the
+    labels and returns the resulting data as a results dict suitable for
+    any exporter.
+    """
+    data = request.get_json(force=True, silent=True) or {}
+
+    sort_results = data.get("sort_results")
+    if not isinstance(sort_results, list):
+        return jsonify({"error": "sort_results must be a list"}), 400
+
+    thresh = data.get("threshold")
+    if thresh is None:
+        return jsonify({"error": "threshold is required"}), 400
+    thresh = float(thresh)
+
+    sides = data.get("sides", "good")
+    if sides not in ("good", "bad", "both"):
+        return jsonify({"error": "sides must be 'good', 'bad', or 'both'"}), 400
+
+    confirm = bool(data.get("confirm", False))
+
+    # Find unlabeled clips above/below threshold
+    good_candidates = []
+    bad_candidates = []
+    for entry in sort_results:
+        cid = entry.get("id")
+        score = entry.get("score", entry.get("similarity"))
+        if cid is None or score is None:
+            continue
+        if cid in good_votes or cid in bad_votes:
+            continue
+        if cid not in clips:
+            continue
+        if score >= thresh:
+            good_candidates.append({"id": cid, "score": float(score)})
+        else:
+            bad_candidates.append({"id": cid, "score": float(score)})
+
+    if sides == "good":
+        bad_candidates = []
+    elif sides == "bad":
+        good_candidates = []
+    # "both" keeps both lists
+
+    if not confirm:
+        return jsonify({
+            "good_count": len(good_candidates),
+            "bad_count": len(bad_candidates),
+        })
+
+    # Apply labels
+    from vtsearch.utils import assign_click_time
+
+    for entry in good_candidates:
+        cid = entry["id"]
+        bad_votes.pop(cid, None)
+        good_votes[cid] = None
+        add_label_to_history(cid, "good")
+        assign_click_time(cid)
+        diversity_tree_label(cid)
+
+    for entry in bad_candidates:
+        cid = entry["id"]
+        good_votes.pop(cid, None)
+        bad_votes[cid] = None
+        add_label_to_history(cid, "bad")
+        assign_click_time(cid)
+        diversity_tree_label(cid)
+
+    # Build a results dict compatible with exporters
+    good_hits = []
+    for entry in good_candidates:
+        cid = entry["id"]
+        clip = clips.get(cid, {})
+        hit = {
+            "id": cid,
+            "filename": clip.get("filename", f"clip_{cid}"),
+            "category": clip.get("category", "unknown"),
+            "score": round(entry["score"], 4),
+            "label": "good",
+        }
+        if clip.get("origin") is not None:
+            hit["origin"] = clip["origin"]
+        if clip.get("origin_name"):
+            hit["origin_name"] = clip["origin_name"]
+        if clip.get("md5"):
+            hit["md5"] = clip["md5"]
+        good_hits.append(hit)
+
+    bad_hits = []
+    for entry in bad_candidates:
+        cid = entry["id"]
+        clip = clips.get(cid, {})
+        hit = {
+            "id": cid,
+            "filename": clip.get("filename", f"clip_{cid}"),
+            "category": clip.get("category", "unknown"),
+            "score": round(entry["score"], 4),
+            "label": "bad",
+        }
+        if clip.get("origin") is not None:
+            hit["origin"] = clip["origin"]
+        if clip.get("origin_name"):
+            hit["origin_name"] = clip["origin_name"]
+        if clip.get("md5"):
+            hit["md5"] = clip["md5"]
+        bad_hits.append(hit)
+
+    media_type = "unknown"
+    for clip in clips.values():
+        media_type = clip.get("type", "unknown")
+        break
+
+    results_dict = {
+        "media_type": media_type,
+        "detectors_run": 1,
+        "results": {
+            "fill_from_sort": {
+                "detector_name": "fill_from_sort",
+                "threshold": round(thresh, 4),
+                "total_hits": len(good_hits),
+                "hits": good_hits,
+                "negative_hits": bad_hits,
+            },
+        },
+    }
+
+    return jsonify({
+        "good_applied": len(good_candidates),
+        "bad_applied": len(bad_candidates),
+        "results": results_dict,
+    })
+
+
 @sorting_bp.route("/api/inclusion")
 def get_inclusion_route():
     """Get the current Inclusion setting."""


### PR DESCRIPTION
## Summary
This PR adds two major features to the auto-detect workflow: (1) the ability to filter and export detection results by Good/Bad/Both sides, and (2) a "fill-from-sort" feature that automatically labels unlabeled clips based on their position relative to a sort threshold, then exports the results.

## Key Changes

### Backend (Python/Flask)
- **`vtsearch/routes/sorting.py`**: Added `/api/labels/fill-from-sort` endpoint that:
  - Accepts sort results, threshold, and sides parameter (good/bad/both)
  - Supports dry-run mode to preview label counts
  - Applies labels to unlabeled clips and returns exporter-compatible results
  - Properly handles clip metadata (filename, category, origin, md5)

- **`vtsearch/routes/detectors.py`**: Modified detector scoring to include `negative_hits`:
  - Splits results into positive hits (above threshold) and negative hits (below threshold)
  - Negative hits are returned without embeddings/clip data to reduce payload size
  - All clips are now accounted for in results (positive + negative = total)

- **`vtsearch/cli.py`**: Updated CLI detector scoring to match API behavior:
  - Generates both positive and negative hits
  - Maintains consistent hit structure across CLI and API

### Frontend (JavaScript/HTML)
- **`static/app.js`**: Added comprehensive export UI logic:
  - Export section in auto-detect modal with exporter selection and field configuration
  - Radio buttons to filter results by Good/Bad/Both sides
  - "Fill from Sort" checkbox with live preview of label counts
  - Dynamic exporter dropdown and field rendering based on selected exporter
  - Handles both standard export and fill-from-sort workflows
  - Updates vote counts after fill-from-sort confirmation

- **`static/index.html`**: Added export UI elements:
  - Export section with side selection (Good/Bad/Both)
  - Fill-from-sort checkbox with info display
  - Exporter selection dropdown
  - Dynamic field inputs for exporter configuration
  - Export status display

### Tests
- **`tests/test_export_options.py`**: Comprehensive test suite covering:
  - Fill-from-sort dry run with various side filters
  - Fill-from-sort confirmation and label application
  - Exclusion of already-voted clips
  - Input validation (missing/invalid parameters)
  - Export filtering with Good/Bad/Both sides
  - Integration between fill-from-sort and exporters

- **`tests/test_detectors.py`**: Added tests for negative_hits:
  - Verification that negative_hits are present in results
  - Validation that negative hits are below threshold
  - Confirmation that positive + negative hits cover all clips
  - Verification that negative hits don't contain embeddings

## Notable Implementation Details
- The fill-from-sort feature respects existing votes and only labels unlabeled clips
- Results from fill-from-sort are formatted as a standard detector result with "fill_from_sort" as the detector name
- Export filtering is done client-side by remapping negative_hits to hits when "bad" or "both" is selected
- The feature integrates seamlessly with existing exporters without requiring exporter modifications

https://claude.ai/code/session_01Qq5uNbrF8nozQGx1AuwhMB