### PR TITLE
Use indeterminate progress bars during model loading

### DIFF
--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -200,10 +200,10 @@ class AudioMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading CLAP model weights…", 0, 2)
+        self._on_progress("loading", "Loading CLAP model weights…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
-        self._on_progress("loading", "Loading CLAP processor…", 1, 2)
+        self._on_progress("loading", "Loading CLAP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -196,13 +196,16 @@ class ImageMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading CLIP model weights…", 0, 2)
+        # Use total=0 so the frontend shows an indeterminate progress bar.
+        # If from_pretrained emits tqdm bars (e.g. first-time download),
+        # intercept_tqdm_progress will override with actual progress.
+        self._on_progress("loading", "Loading CLIP model weights…", 0, 0)
         # Older CLIP checkpoints include position_ids buffers that newer transformers
         # versions compute on-the-fly.  Tell the loader to silently ignore them.
         CLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         with intercept_tqdm_progress(self._on_progress):
             self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
-        self._on_progress("loading", "Loading CLIP processor…", 1, 2)
+        self._on_progress("loading", "Loading CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False)
 

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -161,7 +161,7 @@ class TextMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading E5 model…", 0, 1)
+        self._on_progress("loading", "Loading E5 model…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir, token=False)
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -182,10 +182,10 @@ class VideoMediaType(MediaType):
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
-        self._on_progress("loading", "Loading X-CLIP model weights…", 0, 2)
+        self._on_progress("loading", "Loading X-CLIP model weights…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
-        self._on_progress("loading", "Loading X-CLIP processor…", 1, 2)
+        self._on_progress("loading", "Loading X-CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = XCLIPProcessor.from_pretrained(XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False)
 


### PR DESCRIPTION
## Summary
Changed model loading progress indicators to use indeterminate progress bars (total=0) instead of fixed two-step progress. This allows the `intercept_tqdm_progress` handler to override with actual progress when the underlying model loading libraries emit their own progress updates.

## Changes
- **Image media (CLIP)**: Changed progress total from 2 to 0 for both model weights and processor loading steps, with added explanatory comments
- **Audio media (CLAP)**: Changed progress total from 2 to 0 for both model weights and processor loading steps
- **Video media (X-CLIP)**: Changed progress total from 2 to 0 for both model weights and processor loading steps
- **Text media (E5)**: Changed progress total from 1 to 0 for model loading step

## Implementation Details
The progress reporting now uses `total=0` to signal the frontend to display an indeterminate progress bar. When `from_pretrained()` or similar model loading calls emit their own tqdm progress bars (particularly during first-time downloads), the `intercept_tqdm_progress` context manager will intercept and override these with actual progress information, providing users with more accurate feedback during model loading operations.

https://claude.ai/code/session_01EP3DtmQaWZ8Ee4JP3stmUB