### PR TITLE
Lazy load heavy dependencies to improve startup time

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,8 +19,6 @@ warnings.filterwarnings("ignore", message=".*unauthenticated requests.*HF Hub.*"
 # Visual feedback for startup
 print("⏳ Initializing VTSearch...", flush=True)
 
-print("⏳ Importing ML libraries (this may take a few seconds)...", flush=True)
-
 from flask import Flask
 
 # Import refactored modules

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import torch
 
 from vtsearch.datasets.loader import load_dataset_from_pickle
 
@@ -55,6 +54,8 @@ def _score_clips_with_detector(
     threshold = detector_data["threshold"]
 
     # Reconstruct the MLP model from weights
+    import torch  # noqa: PLC0415
+
     from vtsearch.models.training import build_model
 
     input_dim = len(weights["0.weight"][0])
@@ -255,6 +256,8 @@ def _score_clips_with_detectors(
         raise ValueError("No clips loaded from dataset")
     if not detectors:
         raise ValueError("No favorite processors found for the dataset's media type")
+
+    import torch  # noqa: PLC0415
 
     all_ids = sorted(clips.keys())
     all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import librosa
 import numpy as np
-import torch
-from transformers import ClapModel, ClapProcessor
 
 from vtsearch.config import CLAP_MODEL_ID, DATA_DIR, MODELS_CACHE_DIR, SAMPLE_RATE
+
+if TYPE_CHECKING:
+    from transformers import ClapModel, ClapProcessor
 from vtsearch.media.base import (
     DemoDataset,
     MediaResponse,
@@ -198,6 +198,8 @@ class AudioMediaType(MediaType):
             return
         import gc
 
+        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading CLAP model weights…", 0, 2)
@@ -213,6 +215,9 @@ class AudioMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            import librosa  # noqa: PLC0415
+            import torch  # noqa: PLC0415
+
             audio_data, _sr = librosa.load(file_path, sr=SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,
@@ -236,6 +241,8 @@ class AudioMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            import torch  # noqa: PLC0415
+
             inputs = self._processor(text=[text], return_tensors="pt")
             with torch.no_grad():
                 outputs = self._model.text_model(**inputs)
@@ -256,6 +263,8 @@ class AudioMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def load_clip_data(self, file_path: Path) -> dict:
+        import librosa  # noqa: PLC0415
+
         with open(file_path, "rb") as f:
             clip_bytes = f.read()
         try:

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import torch
-from PIL import Image
-from transformers import CLIPModel, CLIPProcessor
 
 from vtsearch.config import CLIP_MODEL_ID, MODELS_CACHE_DIR
+
+if TYPE_CHECKING:
+    import torch
+    from PIL import Image
+    from transformers import CLIPModel, CLIPProcessor
 from vtsearch.media.base import (
     DemoDataset,
     MediaResponse,
@@ -28,6 +30,8 @@ def _extract_tensor(output: object) -> torch.Tensor:
     may return either a raw tensor or a BaseModelOutputWithPooling dataclass.
     This helper handles both cases.
     """
+    import torch  # noqa: PLC0415
+
     if isinstance(output, torch.Tensor):
         return output
     for attr in ("image_embeds", "text_embeds", "pooler_output"):
@@ -194,6 +198,8 @@ class ImageMediaType(MediaType):
             return
         import gc
 
+        from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
+
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading CLIP model weights…", 0, 2)
@@ -212,6 +218,8 @@ class ImageMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            from PIL import Image  # noqa: PLC0415
+
             image = Image.open(file_path).convert("RGB")
             return self.embed_pil_image(image)
         except Exception as e:
@@ -225,6 +233,8 @@ class ImageMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            import torch  # noqa: PLC0415
+
             image = image.convert("RGB")
             inputs = self._processor(images=image, return_tensors="pt")
             with torch.no_grad():
@@ -241,6 +251,8 @@ class ImageMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            import torch  # noqa: PLC0415
+
             inputs = self._processor(text=[text], return_tensors="pt")
             with torch.no_grad():
                 text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
@@ -260,6 +272,8 @@ class ImageMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def load_clip_data(self, file_path: Path) -> dict:
+        from PIL import Image  # noqa: PLC0415
+
         with open(file_path, "rb") as f:
             clip_bytes = f.read()
         try:

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-from sentence_transformers import SentenceTransformer
 
 from vtsearch.config import E5_MODEL_ID, MODELS_CACHE_DIR
+
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
 from vtsearch.media.base import (
     DemoDataset,
     MediaResponse,
@@ -158,6 +160,8 @@ class TextMediaType(MediaType):
         if self._model is not None:
             return
         import gc
+
+        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import torch
-from PIL import Image
-from transformers import XCLIPModel, XCLIPProcessor
 
 from vtsearch.config import MODELS_CACHE_DIR, VIDEO_DIR, XCLIP_MODEL_ID
+
+if TYPE_CHECKING:
+    import torch
+    from transformers import XCLIPModel, XCLIPProcessor
 from vtsearch.media.base import (
     DemoDataset,
     MediaResponse,
@@ -28,6 +29,8 @@ def _extract_tensor(output: object) -> torch.Tensor:
     may return either a raw tensor or a BaseModelOutputWithPooling dataclass.
     This helper handles both cases.
     """
+    import torch  # noqa: PLC0415
+
     if isinstance(output, torch.Tensor):
         return output
     for attr in ("video_embeds", "text_embeds", "pooler_output"):
@@ -180,6 +183,8 @@ class VideoMediaType(MediaType):
             return
         import gc
 
+        from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
+
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading X-CLIP model weights…", 0, 2)
@@ -196,6 +201,8 @@ class VideoMediaType(MediaType):
             return None
         try:
             import cv2  # noqa: PLC0415  (lazy import — cv2 is optional)
+            import torch  # noqa: PLC0415
+            from PIL import Image  # noqa: PLC0415
 
             cap = cv2.VideoCapture(str(file_path))
             if not cap.isOpened():
@@ -240,6 +247,8 @@ class VideoMediaType(MediaType):
         if self._model is None or self._processor is None:
             return None
         try:
+            import torch  # noqa: PLC0415
+
             inputs = self._processor(text=[text], return_tensors="pt")
             with torch.no_grad():
                 text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from collections import deque
 
 import numpy as np
-from sklearn.cluster import KMeans
 
 DIVERSITY_TREE_DEFAULT_K = 2
 DIVERSITY_TREE_MAX_DEPTH = 10
@@ -108,6 +107,8 @@ class DiversityTree:
             return
 
         # Run k-means
+        from sklearn.cluster import KMeans  # noqa: PLC0415
+
         kmeans = KMeans(n_clusters=actual_k, random_state=42, n_init=10)
         labels = kmeans.fit_predict(vecs)
 

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -5,13 +5,16 @@ repeated queries (the progress button, the auto-indicator) never retrain
 models that have already been computed.
 """
 
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
-import torch
-import torch.nn as nn
 
 from vtsearch.models.training import find_optimal_threshold, train_model
+
+if TYPE_CHECKING:
+    import torch.nn as nn
 
 # ---------------------------------------------------------------------------
 # Module-level cache
@@ -102,6 +105,8 @@ def _ensure_cache(
                     y_list.append(0.0)
 
             if len(X_list) >= 2:
+                import torch  # noqa: PLC0415
+
                 X = torch.tensor(np.array(X_list), dtype=torch.float32)
                 y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
                 input_dim = X.shape[1]
@@ -205,6 +210,8 @@ def _eval_cached_models(
 
     if not eval_embs:
         return []
+
+    import torch  # noqa: PLC0415
 
     X_eval = torch.tensor(np.array(eval_embs), dtype=torch.float32)
     total_positives = sum(1 for lbl in eval_labels if lbl == 1)

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -1,14 +1,17 @@
 """ML training utilities for learned sorting."""
 
+from __future__ import annotations
+
 import math
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import torch
-import torch.nn as nn
-from sklearn.mixture import GaussianMixture
 
 from vtsearch.config import TRAIN_EPOCHS
+
+if TYPE_CHECKING:
+    import torch
+    import torch.nn as nn
 
 
 def calculate_gmm_threshold(scores: list[float]) -> float:
@@ -28,6 +31,8 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
     """
     if len(scores) < 2:
         return 0.5
+
+    from sklearn.mixture import GaussianMixture  # noqa: PLC0415
 
     # Reshape for sklearn
     X = np.array(scores).reshape(-1, 1)
@@ -71,6 +76,8 @@ def build_model(input_dim: int, generator: torch.Generator | None = None) -> nn.
         An ``nn.Sequential`` model with layers:
         ``Linear(input_dim, 64) -> ReLU -> Linear(64, 1)``.
     """
+    import torch.nn as nn  # noqa: PLC0415
+
     model = nn.Sequential(
         nn.Linear(input_dim, 64),
         nn.ReLU(),
@@ -122,6 +129,9 @@ def train_model(
         ``Linear(input_dim, 64) -> ReLU -> Linear(64, 1)``.
         The model outputs raw logits — apply ``torch.sigmoid`` at inference.
     """
+    import torch  # noqa: PLC0415
+    import torch.nn as nn  # noqa: PLC0415
+
     g = torch.Generator()
     g.manual_seed(seed)
 
@@ -298,6 +308,8 @@ def calculate_cross_calibration_threshold(
     if n_train < 2 or n_cal < 1:
         return float("inf")
 
+    import torch  # noqa: PLC0415
+
     calibrate_count = max(1, calibrate_count)
     thresholds: list[float] = []
 
@@ -393,6 +405,8 @@ def train_and_score(
         - ``threshold`` is the decision boundary as a float (cross-calibrated,
           or blended with GMM when ``safe_thresholds`` is ``True``).
     """
+    import torch  # noqa: PLC0415
+
     X_list = []
     y_list = []
     for cid in good_votes:

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -5,7 +5,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
-import torch
 from flask import Blueprint, jsonify, request
 
 from vtsearch.models import (
@@ -47,6 +46,8 @@ detectors_bp = Blueprint("detectors", __name__)
 @detectors_bp.route("/api/detector/export", methods=["POST"])
 def export_detector():
     """Train MLP on current votes and export the model weights."""
+    import torch  # noqa: PLC0415
+
     from vtsearch.utils import bad_votes, good_votes
 
     if not good_votes or not bad_votes:
@@ -103,6 +104,8 @@ def export_detector():
 @detectors_bp.route("/api/detector-sort", methods=["POST"])
 def detector_sort():
     """Score all clips using a loaded detector model."""
+    import torch  # noqa: PLC0415
+
     data = request.get_json(force=True)
     if data is None:
         return jsonify({"error": "Invalid request body"}), 400
@@ -365,6 +368,8 @@ def import_detector_labels():
                 400,
             )
 
+        import torch  # noqa: PLC0415
+
         X = torch.tensor(np.array(X_list), dtype=torch.float32)
         y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
         input_dim = X.shape[1]
@@ -496,6 +501,8 @@ def train_from_label_import(importer_name: str):
     if num_good == 0 or num_bad == 0:
         return jsonify({"error": "Need at least one good and one bad labeled example"}), 400
 
+    import torch  # noqa: PLC0415
+
     X = torch.tensor(np.array(X_list), dtype=torch.float32)
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
@@ -543,6 +550,8 @@ def auto_detect():
         return jsonify({"error": f"No favorite detectors found for media type: {media_type}"}), 400
 
     # Prepare shared data for all detectors
+    import torch  # noqa: PLC0415
+
     all_ids = sorted(clips.keys())
     all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
     X_all = torch.tensor(all_embs, dtype=torch.float32)

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import numpy as np
-import torch
 from flask import Blueprint, jsonify, request
 
 from vtsearch.config import DATA_DIR
@@ -434,6 +433,8 @@ def label_file_sort():
             )
 
         # Train MLP using the same approach as learned sort
+        import torch  # noqa: PLC0415
+
         X = torch.tensor(np.array(X_list), dtype=torch.float32)
         y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
 


### PR DESCRIPTION
## Summary
Refactor imports throughout the codebase to use lazy loading for heavy ML dependencies (torch, transformers, PIL, librosa, sklearn, sentence_transformers). This significantly improves application startup time by deferring the import of these libraries until they are actually needed.

## Key Changes

- **Type checking imports**: Moved heavy dependencies under `if TYPE_CHECKING:` blocks in module headers for type hints, with runtime imports deferred to function scope
- **Lazy imports in functions**: Added local imports within functions that use heavy dependencies, marked with `# noqa: PLC0415` to suppress linting warnings
- **Affected modules**:
  - `vtsearch/media/image/media_type.py`: Deferred torch, PIL, transformers imports
  - `vtsearch/media/audio/media_type.py`: Deferred librosa, torch, transformers imports
  - `vtsearch/media/video/media_type.py`: Deferred torch, PIL, transformers imports
  - `vtsearch/media/text/media_type.py`: Deferred sentence_transformers imports
  - `vtsearch/models/training.py`: Deferred torch, sklearn imports
  - `vtsearch/models/progress.py`: Deferred torch imports
  - `vtsearch/routes/detectors.py`: Deferred torch imports
  - `vtsearch/routes/sorting.py`: Deferred torch imports
  - `vtsearch/models/diversity_tree.py`: Deferred sklearn imports
  - `vtsearch/cli.py`: Deferred torch imports
  - `app.py`: Removed startup message about importing ML libraries

## Implementation Details

- All lazy imports follow the pattern of importing at the point of use within function bodies
- Type hints remain available through `TYPE_CHECKING` blocks without runtime overhead
- Imports are only loaded when the corresponding functionality is actually invoked
- This approach maintains full backward compatibility while reducing initial startup latency

https://claude.ai/code/session_01QHYrE8KZkGi2RYcSVj5hND