### PR TITLE
Update labeling status thresholds and messages for tree coverage

### DIFF
--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -417,10 +417,12 @@ def compute_labeling_status(
         depth = span_info["depth"]
         nls = span_info["next_level_seen"]
         nlt = span_info["next_level_total"]
-        if level < 0:
-            span = {"status": "red", "reason": "No tree coverage yet.", **span_info}
-        elif level >= depth:
-            span = {"status": "green", "reason": "All tree levels fully covered.", **span_info}
+        if level <= 1:
+            span = {"status": "red", "reason": "No tree coverage yet." if level < 0
+                    else f"Level {level}/{depth} full. {nls}/{nlt} of next level seen.", **span_info}
+        elif level >= 4 or level >= depth:
+            span = {"status": "green", "reason": "All tree levels fully covered." if level >= depth
+                    else f"Level {level}/{depth} full. {nls}/{nlt} of next level seen.", **span_info}
         else:
             span = {"status": "yellow", "reason": f"Level {level}/{depth} full. {nls}/{nlt} of next level seen.",
                     **span_info}


### PR DESCRIPTION
## Summary
Modified the `compute_labeling_status` function to adjust the thresholds for determining tree coverage status and provide more detailed feedback messages across all status levels.

## Key Changes
- **Red status threshold**: Changed from `level < 0` to `level <= 1` to mark levels 0 and 1 as having no tree coverage
- **Green status threshold**: Changed from `level >= depth` to `level >= 4 or level >= depth` to mark level 4+ as fully covered, even if not at max depth
- **Enhanced messages**: Updated all status conditions to include detailed progress information (`Level {level}/{depth} full. {nls}/{nlt} of next level seen.`) instead of generic messages
- **Conditional messaging**: Red status now shows either the generic "No tree coverage yet" message (for level < 0) or the detailed progress message (for level 0-1)
- **Green status messaging**: Green status now shows either the generic "All tree levels fully covered" message (when at max depth) or the detailed progress message (when at level 4+)

## Implementation Details
The changes maintain backward compatibility with the existing span_info structure while providing more granular status reporting. The new thresholds allow for earlier positive feedback (green at level 4) while being more conservative about marking coverage as complete (red for levels 0-1).

https://claude.ai/code/session_01K18t2kEePHjpeW4ZzXgkMm