### PR TITLE
Improve span indicator layout and remove redundant level display

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3445,11 +3445,6 @@
     }
     if (data.span) {
       _applyIndicator(spanIndicator, document.getElementById("span-subtext"), data.span);
-      // Show compact level info as subtext for Span
-      const sp = data.span;
-      if (sp.status !== "red" && sp.level >= 0) {
-        document.getElementById("span-subtext").textContent = `L${sp.level}`;
-      }
     }
   }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -335,9 +335,10 @@ video { max-width: 600px; max-height: 400px; }
 /* Progress indicator buttons */
 .progress-check-bar { padding: 10px 8px; border-bottom: 1px solid var(--border); display: flex; gap: 4px; }
 .labeling-indicator {
-  flex: 1; padding: 5px 6px; border-radius: 4px; background: transparent;
+  flex: 1; min-width: 0; padding: 5px 6px; border-radius: 4px; background: transparent;
   font-size: 0.72rem; cursor: pointer; transition: border-color 0.4s, opacity 0.2s;
   display: flex; align-items: center; gap: 4px; border: 1px solid var(--indicator-border); text-align: left;
+  overflow: hidden;
 }
 .labeling-indicator:hover { opacity: 0.82; }
 .labeling-indicator:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -345,7 +346,7 @@ video { max-width: 600px; max-height: 400px; }
   width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
   background: var(--indicator-dot); transition: background 0.4s, box-shadow 0.4s;
 }
-.indicator-label { flex: 1; color: var(--text-secondary); font-size: 0.72rem; transition: color 0.4s; }
+.indicator-label { flex: 1; min-width: 0; color: var(--text-secondary); font-size: 0.72rem; transition: color 0.4s; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .indicator-subtext { font-size: 0.62rem; color: var(--text-dim); transition: color 0.4s; text-align: right; }
 
 /* Red – too few labels */


### PR DESCRIPTION
## Summary
This PR improves the visual layout of progress indicator buttons and removes redundant span level information that was being displayed as subtext.

## Key Changes
- **Removed redundant span level display**: Deleted code that was overwriting the span subtext with compact level info (e.g., "L5"). This information appears to be redundant or conflicting with the intended subtext display.
- **Enhanced indicator button layout stability**: Added `min-width: 0` to `.labeling-indicator` and `.indicator-label` to prevent flex items from overflowing their containers
- **Improved text truncation**: Added `overflow: hidden`, `white-space: nowrap`, and `text-overflow: ellipsis` to `.indicator-label` to properly truncate long labels with ellipsis instead of breaking the layout

## Implementation Details
The CSS changes follow flexbox best practices by explicitly setting `min-width: 0` on flex children, which allows them to shrink below their content size and respect overflow constraints. The text truncation properties ensure that long indicator labels degrade gracefully without distorting the button layout.

https://claude.ai/code/session_011TvrhLoAaTV7FiWoW6iL5V