### PR TITLE
Suppress huggingface_hub unauthenticated requests warning

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,9 @@ os.environ["MKL_NUM_THREADS"] = "1"
 
 # Suppress Werkzeug request logging (GET/POST lines) — only show errors
 logging.getLogger("werkzeug").setLevel(logging.ERROR)
+# Suppress huggingface_hub "unauthenticated requests" console warning —
+# all models we use are public, so no token is needed.
+logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
 
 # All HF models we use are public — no token needed.  Each from_pretrained()
 # call passes token=False to signal this explicitly.  The env var + warnings


### PR DESCRIPTION
## Summary
Suppresses the huggingface_hub library's console warning about unauthenticated requests by setting its logger to ERROR level, similar to the existing Werkzeug logging suppression.

## Changes
- Added logging configuration to suppress huggingface_hub "unauthenticated requests" warnings
- Set `huggingface_hub` logger to ERROR level to only display actual errors, not informational warnings

## Details
Since all models used in this application are public and don't require authentication tokens, the unauthenticated requests warning from huggingface_hub is unnecessary noise in the console output. This change aligns with the existing pattern of suppressing verbose logging from dependencies while maintaining error visibility.

https://claude.ai/code/session_01CmXoc2zUT7YcVfkZ4dwsE7