### PR TITLE
Use flip rate instead of absolute flip count for stability

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3830,18 +3830,21 @@
     const avgErrorCost = recentErrorCosts.reduce((a, b) => a + b, 0) / recentErrorCosts.length;
     const errorCostStability = errorCostRange / (avgErrorCost || 1);
 
-    // Check if prediction flips have decreased
+    // Check if prediction flip *rate* has decreased (scales with dataset size)
     const recentStability = stabilityData.slice(-last30PercentCount);
-    const recentFlips = recentStability.map(d => d.num_flips);
-    const avgRecentFlips = recentFlips.reduce((a, b) => a + b, 0) / (recentFlips.length || 1);
+    const recentFlipRates = recentStability.map(d => {
+      const nUnlabeled = d.num_unlabeled || 0;
+      return nUnlabeled > 0 ? d.num_flips / nUnlabeled : 0;
+    });
+    const avgFlipRate = recentFlipRates.reduce((a, b) => a + b, 0) / (recentFlipRates.length || 1);
 
     let recommendation = "";
 
-    if (errorCostStability < 0.1 && avgRecentFlips < 5) {
+    if (errorCostStability < 0.1 && avgFlipRate < 0.03) {
       recommendation = "🛑 STOP LABELING: Both error cost and predictions have stabilized. Additional labels are unlikely to improve the model significantly. You've reached a good stopping point!";
     } else if (errorCostStability < 0.15) {
       recommendation = "⚠️ CONSIDER STOPPING: Error cost has mostly plateaued. You may be approaching diminishing returns. Consider stopping or labeling a few more diverse examples.";
-    } else if (avgRecentFlips < 3) {
+    } else if (avgFlipRate < 0.02) {
       recommendation = "⚠️ PREDICTIONS STABLE: Predictions on unlabeled clips aren't changing much. The model's decisions are solidifying. Consider whether additional labels will help.";
     } else {
       recommendation = "✅ KEEP LABELING: The model is still learning! Both error cost and predictions are changing, indicating that new labels are improving the model.";

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -382,12 +382,28 @@ def _compute_stable_status(
         return {"status": "yellow", "reason": "Not enough history to assess prediction stability."}
 
     recent = stability[-10:]
-    recent_flips = [s["num_flips"] for s in recent]
-    avg_flips = sum(recent_flips) / len(recent_flips)
 
-    if avg_flips < 3:
-        return {"status": "green", "reason": "Predictions have stabilized."}
-    return {"status": "yellow", "reason": f"Average {avg_flips:.0f} prediction flips in recent steps."}
+    # Use flip *rate* (fraction of unlabeled predictions that changed) so the
+    # threshold scales with dataset size instead of using a fixed absolute count.
+    flip_rates: list[float] = []
+    for s in recent:
+        n_unlabeled = s.get("num_unlabeled", 0)
+        if n_unlabeled > 0:
+            flip_rates.append(s["num_flips"] / n_unlabeled)
+        else:
+            flip_rates.append(0.0)
+
+    avg_flip_rate = sum(flip_rates) / len(flip_rates)
+
+    STABLE_RATE_THRESHOLD = 0.02  # less than 2% of predictions flipping
+
+    if avg_flip_rate < STABLE_RATE_THRESHOLD:
+        return {"status": "green", "reason": "Predictions have stabilized.", "avg_flip_rate": round(avg_flip_rate, 4)}
+    return {
+        "status": "yellow",
+        "reason": f"Average {avg_flip_rate:.1%} of predictions flipping in recent steps.",
+        "avg_flip_rate": round(avg_flip_rate, 4),
+    }
 
 
 def compute_labeling_status(


### PR DESCRIPTION
## Summary
Changed prediction stability assessment to use flip *rate* (fraction of unlabeled predictions that changed) instead of absolute flip counts. This makes the stability threshold scale with dataset size, providing more meaningful stability metrics regardless of how many unlabeled predictions exist.

## Key Changes
- **Backend (progress.py)**: Modified `_compute_stable_status()` to calculate flip rate as `num_flips / num_unlabeled` for each recent stability checkpoint
  - Changed threshold from fixed count (3 flips) to rate-based (2% of predictions)
  - Added `avg_flip_rate` to returned status dictionary for transparency
  - Updated status messages to display flip rate as percentage
  
- **Frontend (app.js)**: Updated labeling recommendation logic to use flip rate instead of absolute counts
  - Changed STOP condition from `avgRecentFlips < 5` to `avgFlipRate < 0.03` (3%)
  - Changed PREDICTIONS_STABLE condition from `avgRecentFlips < 3` to `avgFlipRate < 0.02` (2%)
  - Mirrors backend calculation of flip rate from `num_flips / num_unlabeled`

## Implementation Details
- Handles edge case where `num_unlabeled` is 0 by treating flip rate as 0.0
- Maintains backward compatibility by gracefully handling missing `num_unlabeled` field with `.get()` and default value
- Thresholds are now dataset-size-agnostic, making stability assessment more consistent across different labeling scenarios

https://claude.ai/code/session_019LdLHXetuk9WsMdLYxNH3V