### PR TITLE
Eagerly load embedding models before progress tracking

### DIFF
--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -312,12 +312,17 @@ def load_dataset_from_folder(
     if on_progress is None:
         on_progress = _default_progress()
 
-    on_progress("embedding", "Scanning media files...", 0, 0)
+    on_progress("loading", "Scanning media files...", 0, 0)
 
     try:
         mt = get_by_folder_name(media_type)
     except KeyError:
         raise ValueError(f"Invalid media type: {media_type}")
+
+    # Eagerly load models before starting the embedding timer so that
+    # download / weight-loading time does not pollute the progress bar.
+    if getattr(mt, "_model", None) is None:
+        mt.load_models()
 
     # Find all files of the specified media type
     media_files = []
@@ -444,12 +449,17 @@ def load_dataset_from_folder_chunked(
     if on_progress is None:
         on_progress = _default_progress()
 
-    on_progress("embedding", "Scanning media files...", 0, 0)
+    on_progress("loading", "Scanning media files...", 0, 0)
 
     try:
         mt = get_by_folder_name(media_type)
     except KeyError:
         raise ValueError(f"Invalid media type: {media_type}")
+
+    # Eagerly load models before starting the embedding timer so that
+    # download / weight-loading time does not pollute the progress bar.
+    if getattr(mt, "_model", None) is None:
+        mt.load_models()
 
     # Find all files of the specified media type
     media_files: list[Path] = []
@@ -1053,6 +1063,16 @@ def load_demo_dataset(
             clips.clear()
             clip_id = 1
             total = len(selected_images)
+
+            # Eagerly load models before starting the embedding timer so that
+            # download / weight-loading time does not pollute the progress bar.
+            from vtsearch.media import get as media_get
+
+            image_mt = media_get("image")
+            if getattr(image_mt, "_model", None) is None:
+                on_progress("loading", "Loading image embedding model…", 0, 0)
+                image_mt.load_models()
+
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (image_array, category) in enumerate(zip(selected_images, selected_labels)):
@@ -1134,6 +1154,12 @@ def load_demo_dataset(
             from vtsearch.media import get as media_get
 
             image_mt = media_get("image")
+
+            # Eagerly load models before starting the embedding timer so that
+            # download / weight-loading time does not pollute the progress bar.
+            if getattr(image_mt, "_model", None) is None:
+                on_progress("loading", "Loading image embedding model…", 0, 0)
+                image_mt.load_models()
 
             clips.clear()
             clip_id = 1
@@ -1221,6 +1247,12 @@ def load_demo_dataset(
                     for text in cat_texts[slice_start:slice_end]:
                         selected_texts.append(text)
                         selected_categories.append(cat_name)
+
+            # Eagerly load models before starting the embedding timer so that
+            # download / weight-loading time does not pollute the progress bar.
+            if getattr(text_mt, "_model", None) is None:
+                on_progress("loading", "Loading text embedding model…", 0, 0)
+                text_mt.load_models()
 
             # Generate embeddings for paragraphs
             clips.clear()
@@ -1321,6 +1353,12 @@ def load_demo_dataset(
             for cat in dataset_info["categories"]:
                 video_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
 
+            # Eagerly load models before starting the embedding timer so that
+            # download / weight-loading time does not pollute the progress bar.
+            if getattr(video_mt, "_model", None) is None:
+                on_progress("loading", "Loading video embedding model…", 0, 0)
+                video_mt.load_models()
+
             # Generate embeddings for videos
             clips.clear()
             clip_id = 1
@@ -1406,6 +1444,12 @@ def load_demo_dataset(
     audio_files = []
     for cat in categories:
         audio_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
+
+    # Eagerly load models before starting the embedding timer so that
+    # download / weight-loading time does not pollute the progress bar.
+    if getattr(audio_mt, "_model", None) is None:
+        on_progress("loading", "Loading audio embedding model…", 0, 0)
+        audio_mt.load_models()
 
     # Generate embeddings
     clips.clear()


### PR DESCRIPTION
## Summary
This PR improves the user experience by eagerly loading embedding models before starting the embedding progress timer. This prevents model download and weight-loading time from being included in the progress bar, which can make the initial progress appear stuck or misleading.

## Key Changes
- Changed initial progress event type from `"embedding"` to `"loading"` in `load_dataset_from_folder()` and `load_dataset_from_folder_chunked()` to better reflect the scanning phase
- Added eager model loading before embedding starts in `load_dataset_from_folder()` and `load_dataset_from_folder_chunked()` to prevent model initialization time from polluting the embedding progress bar
- Added eager model loading for all media types (image, text, video, audio) in `load_demo_dataset()` with appropriate progress notifications
- Models are only loaded if not already initialized (checked via `getattr(mt, "_model", None) is None`)

## Implementation Details
- The model loading is performed immediately after media type validation and before the main embedding loop begins
- Each media type gets its own progress notification (e.g., "Loading image embedding model…") during the eager loading phase
- This ensures that the embedding progress bar accurately reflects only the actual embedding work, not the one-time model initialization overhead

https://claude.ai/code/session_01MSVHsYrTPrdyBvzPUaJ3d3