### PR TITLE
Fix video filename path in demo dataset loader

### DIFF
--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -1382,6 +1382,10 @@ def load_demo_dataset(
 
                 media_fields = video_mt.load_clip_data(video_path)
 
+                # Use the category-relative path (e.g. "Archery/v_Archery_g01_c01.avi")
+                # so that load_dataset_from_pickle can find the file under video_dir.
+                rel_filename = str(video_path.relative_to(video_dir))
+
                 clips[clip_id] = {
                     "id": clip_id,
                     "type": "video",
@@ -1390,7 +1394,7 @@ def load_demo_dataset(
                     "md5": hashlib.md5(video_bytes).hexdigest(),
                     "embedding": embedding,
                     "clip_bytes": video_bytes,
-                    "filename": video_path.name,
+                    "filename": rel_filename,
                     "category": meta["category"],
                     "origin": demo_origin,
                     "origin_name": video_path.name,


### PR DESCRIPTION
## Summary
Fixed the video filename stored in demo datasets to use category-relative paths instead of just the filename, enabling `load_dataset_from_pickle` to correctly locate video files under the video directory.

## Key Changes
- Changed `filename` field from `video_path.name` (just the filename) to a category-relative path (e.g., "Archery/v_Archery_g01_c01.avi")
- This ensures that when datasets are pickled and later loaded, the relative path structure is preserved and files can be found under the `video_dir` parameter

## Implementation Details
- The relative path is computed using `video_path.relative_to(video_dir)` and converted to a string
- The original filename is still preserved in the `origin_name` field for reference
- This change maintains backward compatibility while fixing file resolution in downstream dataset loading operations

https://claude.ai/code/session_019ungMkyQUW5w6Sb9m38hXr