### PR TITLE
Add tooltip titles to labeling indicators and voting buttons

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2697,8 +2697,8 @@
         </div>
       </div>
       <div class="vote-buttons">
-        <button class="btn-bad${isBad ? " voted" : ""}" id="vote-bad">Bad</button>
-        <button class="btn-good${isGood ? " voted" : ""}" id="vote-good">Good</button>
+        <button class="btn-bad${isBad ? " voted" : ""}" id="vote-bad" title="Mark this media as a Bad example.">Bad</button>
+        <button class="btn-good${isGood ? " voted" : ""}" id="vote-good" title="Mark this media as a Good example.">Good</button>
       </div>`;
     document.getElementById("vote-good").onclick = () => castVote(c.id, "good");
     document.getElementById("vote-bad").onclick = () => castVote(c.id, "bad");

--- a/static/index.html
+++ b/static/index.html
@@ -140,17 +140,17 @@
   <aside class="panel-right" aria-label="Labels">
     <!-- import-file removed: label import now uses the label importer modal -->
     <div class="progress-check-bar">
-      <button id="smart-indicator" class="labeling-indicator" data-status="" aria-label="Smart level: error cost flatness">
+      <button id="smart-indicator" class="labeling-indicator" data-status="" aria-label="Smart level: error cost flatness" title="Has the model stopped learning over time?">
         <span class="indicator-dot" aria-hidden="true"></span>
         <span class="indicator-label">Smart</span>
         <span class="indicator-subtext" id="smart-subtext"></span>
       </button>
-      <button id="stable-indicator" class="labeling-indicator" data-status="" aria-label="Stable level: prediction flip stability">
+      <button id="stable-indicator" class="labeling-indicator" data-status="" aria-label="Stable level: prediction flip stability" title="Has the model stopped changing predicted labels?">
         <span class="indicator-dot" aria-hidden="true"></span>
         <span class="indicator-label">Stable</span>
         <span class="indicator-subtext" id="stable-subtext"></span>
       </button>
-      <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Span level: diversity tree coverage">
+      <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Span level: diversity tree coverage" title="Do we have good label coverage over the dataset?">
         <span class="indicator-dot" aria-hidden="true"></span>
         <span class="indicator-label">Span</span>
         <span class="indicator-subtext" id="span-subtext"></span>


### PR DESCRIPTION
## Summary
This PR improves the user experience by adding descriptive tooltip titles to key interactive elements in the labeling interface. These tooltips provide users with quick contextual information about what each indicator and button does.

## Key Changes
- **Labeling Indicators**: Added `title` attributes to the Smart, Stable, and Span level indicator buttons with user-friendly explanations:
  - Smart: "Has the model stopped learning over time?"
  - Stable: "Has the model stopped changing predicted labels?"
  - Span: "Do we have good label coverage over the dataset?"
  
- **Voting Buttons**: Added `title` attributes to the Good and Bad voting buttons:
  - Good: "Mark this media as a Good example."
  - Bad: "Mark this media as a Bad example."

## Implementation Details
The changes are purely additive, adding HTML `title` attributes to existing buttons. These tooltips will display on hover, providing helpful context without cluttering the UI. The existing `aria-label` attributes remain unchanged to maintain accessibility support.

https://claude.ai/code/session_01Ez9SWsr1Pxefvw8P1bHdU3