### PR TITLE
Improve model stability indicator thresholds and validation

### DIFF
--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -1,5 +1,11 @@
 import app as app_module
-from vtsearch.models.progress import _cache_good_ids, _cache_bad_ids, _ensure_cache
+from vtsearch.models.progress import (
+    _cache_good_ids,
+    _cache_bad_ids,
+    _cached_steps,
+    _compute_stable_status,
+    _ensure_cache,
+)
 from vtsearch.utils import clips, label_history
 
 
@@ -228,3 +234,73 @@ class TestProgressCacheWithLabelChanges:
         data = resp.get_json()
         assert data["good_count"] == 5  # lost 1, gained 1
         assert data["bad_count"] == 4  # lost 1
+
+
+class TestStableIndicatorThresholds:
+    """The Stable indicator should not turn green prematurely."""
+
+    def _inject_stability(self, entries):
+        """Inject fake stability entries into the progress cache."""
+        _cached_steps.clear()
+        for entry in entries:
+            _cached_steps.append({"model": None, "threshold": None, "good_ids": [], "bad_ids": [], "stability": entry})
+
+    def test_not_green_with_only_first_zero_entry(self, client):
+        """The first entry always has 0 flips (no prior predictions).
+
+        Even with a few subsequent low-flip steps, the indicator should
+        stay yellow — the first zero must not count toward stability.
+        """
+        self._inject_stability(
+            [
+                {"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 90},  # always-zero first
+                {"time_index": 1, "num_labels": 11, "num_flips": 0, "num_unlabeled": 89},
+                {"time_index": 2, "num_labels": 12, "num_flips": 0, "num_unlabeled": 88},
+                {"time_index": 3, "num_labels": 13, "num_flips": 0, "num_unlabeled": 87},
+            ]
+        )
+        result = _compute_stable_status(good=5, bad=5, total=10)
+        assert result["status"] == "yellow", (
+            "Should be yellow: only 3 real entries after dropping the bogus first zero"
+        )
+
+    def test_needs_five_real_entries_for_green(self, client):
+        """Green requires at least 5 non-trivial stability entries."""
+        # 1 bogus first + 4 real = only 4 usable → yellow
+        self._inject_stability(
+            [
+                {"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 90},
+                {"time_index": 1, "num_labels": 11, "num_flips": 0, "num_unlabeled": 89},
+                {"time_index": 2, "num_labels": 12, "num_flips": 0, "num_unlabeled": 88},
+                {"time_index": 3, "num_labels": 13, "num_flips": 0, "num_unlabeled": 87},
+                {"time_index": 4, "num_labels": 14, "num_flips": 0, "num_unlabeled": 86},
+            ]
+        )
+        result = _compute_stable_status(good=5, bad=5, total=10)
+        assert result["status"] == "yellow", "4 real entries (after dropping first) is not enough"
+
+        # Add one more → 5 usable → green
+        self._inject_stability(
+            [
+                {"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 90},
+                {"time_index": 1, "num_labels": 11, "num_flips": 0, "num_unlabeled": 89},
+                {"time_index": 2, "num_labels": 12, "num_flips": 0, "num_unlabeled": 88},
+                {"time_index": 3, "num_labels": 13, "num_flips": 0, "num_unlabeled": 87},
+                {"time_index": 4, "num_labels": 14, "num_flips": 0, "num_unlabeled": 86},
+                {"time_index": 5, "num_labels": 15, "num_flips": 0, "num_unlabeled": 85},
+            ]
+        )
+        result = _compute_stable_status(good=5, bad=5, total=10)
+        assert result["status"] == "green", "5 real low-flip entries should be enough"
+
+    def test_single_spike_prevents_green(self, client):
+        """One spike above the max threshold should keep the indicator yellow."""
+        entries = [{"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 100}]
+        for i in range(1, 7):
+            entries.append({"time_index": i, "num_labels": 10 + i, "num_flips": 0, "num_unlabeled": 100 - i})
+        # Inject one spike: 6 flips out of 93 unlabeled → ~6.5%, above 5% max threshold
+        entries[-1] = {"time_index": 6, "num_labels": 16, "num_flips": 6, "num_unlabeled": 93}
+
+        self._inject_stability(entries)
+        result = _compute_stable_status(good=8, bad=8, total=16)
+        assert result["status"] == "yellow", "A single >5% spike should prevent green"

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -378,7 +378,15 @@ def _compute_stable_status(
         }
 
     stability = [step["stability"] for step in _cached_steps if step["stability"] is not None]
-    if len(stability) < 3:
+
+    # The first stability entry always reports 0 flips because there are no
+    # prior predictions to compare against.  Drop it so it doesn't
+    # artificially drag the average toward zero.
+    if len(stability) > 1:
+        stability = stability[1:]
+
+    MIN_STABLE_ENTRIES = 5
+    if len(stability) < MIN_STABLE_ENTRIES:
         return {"status": "yellow", "reason": "Not enough history to assess prediction stability."}
 
     recent = stability[-10:]
@@ -394,10 +402,12 @@ def _compute_stable_status(
             flip_rates.append(0.0)
 
     avg_flip_rate = sum(flip_rates) / len(flip_rates)
+    max_flip_rate = max(flip_rates)
 
-    STABLE_RATE_THRESHOLD = 0.02  # less than 2% of predictions flipping
+    STABLE_RATE_THRESHOLD = 0.02  # average less than 2% of predictions flipping
+    STABLE_MAX_THRESHOLD = 0.05  # no single recent step above 5%
 
-    if avg_flip_rate < STABLE_RATE_THRESHOLD:
+    if avg_flip_rate < STABLE_RATE_THRESHOLD and max_flip_rate < STABLE_MAX_THRESHOLD:
         return {"status": "green", "reason": "Predictions have stabilized.", "avg_flip_rate": round(avg_flip_rate, 4)}
     return {
         "status": "yellow",


### PR DESCRIPTION
## Summary
This PR enhances the model stability indicator logic to prevent premature "green" status and ensure more reliable stability assessment. The changes address edge cases where the indicator would turn green too early by implementing stricter validation criteria.

## Key Changes
- **Increased minimum stability entries requirement**: Changed from 3 to 5 entries to ensure sufficient historical data before marking predictions as stable
- **Exclude first stability entry**: The first entry always reports 0 flips (no prior predictions to compare), which artificially skews stability assessment. Now explicitly dropped from calculations
- **Added spike detection threshold**: Introduced a maximum flip rate threshold (5%) to prevent single outlier spikes from being masked by low averages. The indicator now requires both:
  - Average flip rate < 2% (existing threshold)
  - Maximum flip rate < 5% (new threshold)
- **Enhanced test coverage**: Added comprehensive test suite (`TestStableIndicatorThresholds`) with three test cases covering:
  - Behavior with only the bogus first zero entry
  - Minimum entry count validation (5 real entries required)
  - Single spike prevention (one high-flip step blocks green status)

## Implementation Details
- The stability calculation now filters out the first entry before checking the minimum threshold, ensuring we validate against actual meaningful data points
- The `_compute_stable_status` function now checks both average and maximum flip rates, providing more robust stability detection
- Tests use a helper method `_inject_stability` to inject fake stability entries for controlled testing of edge cases

https://claude.ai/code/session_01P4jgb7YUjxWfKTaEx2LXWH