### PR TITLE
Split thumbnail display setting into left and right panels

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -298,8 +298,10 @@
   const settingsImportFile = document.getElementById("settings-import-file");
   const settingsExportBtn = document.getElementById("settings-export-btn");
   const swipeAnimationCheckbox = document.getElementById("swipe-animation-checkbox");
-  const showThumbnailsCheckbox = document.getElementById("show-thumbnails-checkbox");
-  let showThumbnails = false;
+  const showThumbnailsLeftCheckbox = document.getElementById("show-thumbnails-left-checkbox");
+  const showThumbnailsRightCheckbox = document.getElementById("show-thumbnails-right-checkbox");
+  let showThumbnailsLeft = false;
+  let showThumbnailsRight = true;
 
   // ---- Dataset Management ----
 
@@ -1867,9 +1869,14 @@
       swipeAnimationCheckbox.checked = val;
       swipeAnimation = val;
     }
-    if (showThumbnailsCheckbox) {
-      showThumbnailsCheckbox.checked = !!data.show_thumbnails;
-      showThumbnails = !!data.show_thumbnails;
+    if (showThumbnailsLeftCheckbox) {
+      showThumbnailsLeftCheckbox.checked = !!data.show_thumbnails_left;
+      showThumbnailsLeft = !!data.show_thumbnails_left;
+    }
+    if (showThumbnailsRightCheckbox) {
+      const val = data.show_thumbnails_right !== undefined ? !!data.show_thumbnails_right : true;
+      showThumbnailsRightCheckbox.checked = val;
+      showThumbnailsRight = val;
     }
   }
 
@@ -1928,16 +1935,28 @@
     });
   }
 
-  // Show Thumbnails toggle
-  if (showThumbnailsCheckbox) {
-    showThumbnailsCheckbox.addEventListener("change", () => {
-      showThumbnails = showThumbnailsCheckbox.checked;
+  // Show Thumbnails Left toggle
+  if (showThumbnailsLeftCheckbox) {
+    showThumbnailsLeftCheckbox.addEventListener("change", () => {
+      showThumbnailsLeft = showThumbnailsLeftCheckbox.checked;
       fetch("/api/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ show_thumbnails: showThumbnails }),
+        body: JSON.stringify({ show_thumbnails_left: showThumbnailsLeft }),
       }).catch(() => {});
       renderClipList();
+    });
+  }
+
+  // Show Thumbnails Right toggle
+  if (showThumbnailsRightCheckbox) {
+    showThumbnailsRightCheckbox.addEventListener("change", () => {
+      showThumbnailsRight = showThumbnailsRightCheckbox.checked;
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ show_thumbnails_right: showThumbnailsRight }),
+      }).catch(() => {});
       renderVotes();
     });
   }
@@ -1981,7 +2000,7 @@
         const imported = JSON.parse(text);
         // Send all importable fields to the server
         const payload = {};
-        const importableKeys = ["volume", "theme", "inclusion", "enrich_descriptions", "safe_thresholds", "calibrate_count", "calibration_fraction", "swipe_animation", "show_thumbnails"];
+        const importableKeys = ["volume", "theme", "inclusion", "enrich_descriptions", "safe_thresholds", "calibrate_count", "calibration_fraction", "swipe_animation", "show_thumbnails_left", "show_thumbnails_right"];
         for (const k of importableKeys) {
           if (k in imported) payload[k] = imported[k];
         }
@@ -2537,7 +2556,7 @@
       if (scoreMap[c.id] !== undefined) labelParts.push(`score ${(scoreMap[c.id] * 100).toFixed(1)}%`);
       div.setAttribute("aria-label", labelParts.join(", "));
       let html = "";
-      const useThumbnail = showThumbnails && clipSupportsThumbnail(c);
+      const useThumbnail = showThumbnailsLeft && clipSupportsThumbnail(c);
       if (useThumbnail) {
         div.className += " clip-item-thumb";
         const poster = c.type === "video" ? ` poster="/api/clips/${c.id}/image"` : "";
@@ -2923,7 +2942,7 @@
     else metaParts.push("imported");
     if (entry.confidence >= 0) metaParts.push(`${(entry.confidence * 100).toFixed(0)}%`);
 
-    const useThumbnail = showThumbnails && clipSupportsThumbnail(clip);
+    const useThumbnail = showThumbnailsRight && clipSupportsThumbnail(clip);
     let html = "";
     if (useThumbnail) {
       div.className += " vote-entry-thumb";
@@ -4007,9 +4026,14 @@
         swipeAnimation = !!data.swipe_animation;
         if (swipeAnimationCheckbox) swipeAnimationCheckbox.checked = swipeAnimation;
       }
-      if (showThumbnailsCheckbox) {
-        showThumbnailsCheckbox.checked = !!data.show_thumbnails;
-        showThumbnails = !!data.show_thumbnails;
+      if (showThumbnailsLeftCheckbox) {
+        showThumbnailsLeftCheckbox.checked = !!data.show_thumbnails_left;
+        showThumbnailsLeft = !!data.show_thumbnails_left;
+      }
+      if (showThumbnailsRightCheckbox) {
+        const val = data.show_thumbnails_right !== undefined ? !!data.show_thumbnails_right : true;
+        showThumbnailsRightCheckbox.checked = val;
+        showThumbnailsRight = val;
       }
     } catch (_) {
       // Settings not available yet; use defaults

--- a/static/index.html
+++ b/static/index.html
@@ -429,8 +429,12 @@
           <input type="checkbox" id="swipe-animation-checkbox" checked style="accent-color:var(--accent)">
         </div>
         <div class="settings-row">
-          <label for="show-thumbnails-checkbox" class="settings-label">Show Thumbnails</label>
-          <input type="checkbox" id="show-thumbnails-checkbox" style="accent-color:var(--accent)">
+          <label for="show-thumbnails-left-checkbox" class="settings-label">Show Left Thumbnails</label>
+          <input type="checkbox" id="show-thumbnails-left-checkbox" style="accent-color:var(--accent)">
+        </div>
+        <div class="settings-row">
+          <label for="show-thumbnails-right-checkbox" class="settings-label">Show Right Thumbnails</label>
+          <input type="checkbox" id="show-thumbnails-right-checkbox" checked style="accent-color:var(--accent)">
         </div>
       </div>
       <!-- Calibration -->

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -181,20 +181,35 @@ class TestSettingsModule:
     def test_safe_thresholds_default(self):
         assert settings_mod.get_safe_thresholds() is False
 
-    def test_get_set_show_thumbnails(self, isolated_settings):
-        settings_mod.set_show_thumbnails(True)
-        assert settings_mod.get_show_thumbnails() is True
+    def test_get_set_show_thumbnails_left(self, isolated_settings):
+        settings_mod.set_show_thumbnails_left(True)
+        assert settings_mod.get_show_thumbnails_left() is True
 
         raw = json.loads(isolated_settings.read_text())
-        assert raw["show_thumbnails"] is True
+        assert raw["show_thumbnails_left"] is True
 
-    def test_show_thumbnails_default(self):
-        assert settings_mod.get_show_thumbnails() is False
+    def test_show_thumbnails_left_default(self):
+        assert settings_mod.get_show_thumbnails_left() is False
 
-    def test_show_thumbnails_persists_across_reset(self, isolated_settings):
-        settings_mod.set_show_thumbnails(True)
+    def test_show_thumbnails_left_persists_across_reset(self, isolated_settings):
+        settings_mod.set_show_thumbnails_left(True)
         settings_mod.reset()
-        assert settings_mod.get_show_thumbnails() is True
+        assert settings_mod.get_show_thumbnails_left() is True
+
+    def test_get_set_show_thumbnails_right(self, isolated_settings):
+        settings_mod.set_show_thumbnails_right(False)
+        assert settings_mod.get_show_thumbnails_right() is False
+
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["show_thumbnails_right"] is False
+
+    def test_show_thumbnails_right_default(self):
+        assert settings_mod.get_show_thumbnails_right() is True
+
+    def test_show_thumbnails_right_persists_across_reset(self, isolated_settings):
+        settings_mod.set_show_thumbnails_right(False)
+        settings_mod.reset()
+        assert settings_mod.get_show_thumbnails_right() is False
 
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()
@@ -203,7 +218,8 @@ class TestSettingsModule:
         assert defaults["calibrate_count"] == 2
         assert defaults["calibration_fraction"] == 0.5
         assert defaults["safe_thresholds"] is False
-        assert defaults["show_thumbnails"] is False
+        assert defaults["show_thumbnails_left"] is False
+        assert defaults["show_thumbnails_right"] is True
         assert "favorite_processors" not in defaults
 
     def test_corrupt_settings_file(self, isolated_settings):
@@ -475,23 +491,39 @@ class TestSettingsAPI:
         assert res.status_code == 200
         assert res.get_json()["safe_thresholds"] is False
 
-    def test_update_show_thumbnails(self, client):
-        res = client.put("/api/settings", json={"show_thumbnails": True})
+    def test_update_show_thumbnails_left(self, client):
+        res = client.put("/api/settings", json={"show_thumbnails_left": True})
         assert res.status_code == 200
-        assert res.get_json()["show_thumbnails"] is True
+        assert res.get_json()["show_thumbnails_left"] is True
 
         # Verify it persisted
         res2 = client.get("/api/settings")
-        assert res2.get_json()["show_thumbnails"] is True
+        assert res2.get_json()["show_thumbnails_left"] is True
 
-    def test_update_show_thumbnails_false(self, client):
-        client.put("/api/settings", json={"show_thumbnails": True})
-        res = client.put("/api/settings", json={"show_thumbnails": False})
+    def test_update_show_thumbnails_left_false(self, client):
+        client.put("/api/settings", json={"show_thumbnails_left": True})
+        res = client.put("/api/settings", json={"show_thumbnails_left": False})
         assert res.status_code == 200
-        assert res.get_json()["show_thumbnails"] is False
+        assert res.get_json()["show_thumbnails_left"] is False
+
+    def test_update_show_thumbnails_right(self, client):
+        res = client.put("/api/settings", json={"show_thumbnails_right": True})
+        assert res.status_code == 200
+        assert res.get_json()["show_thumbnails_right"] is True
+
+        # Verify it persisted
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["show_thumbnails_right"] is True
+
+    def test_update_show_thumbnails_right_false(self, client):
+        client.put("/api/settings", json={"show_thumbnails_right": True})
+        res = client.put("/api/settings", json={"show_thumbnails_right": False})
+        assert res.status_code == 200
+        assert res.get_json()["show_thumbnails_right"] is False
 
     def test_get_settings_includes_show_thumbnails(self, client):
         res = client.get("/api/settings")
         assert res.status_code == 200
         data = res.get_json()
-        assert "show_thumbnails" in data
+        assert "show_thumbnails_left" in data
+        assert "show_thumbnails_right" in data

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -99,8 +99,11 @@ def update_settings():
         except (TypeError, ValueError):
             return jsonify({"error": "calibrate_count must be a number"}), 400
 
-    if "show_thumbnails" in body:
-        settings.set_show_thumbnails(bool(body["show_thumbnails"]))
+    if "show_thumbnails_left" in body:
+        settings.set_show_thumbnails_left(bool(body["show_thumbnails_left"]))
+
+    if "show_thumbnails_right" in body:
+        settings.set_show_thumbnails_right(bool(body["show_thumbnails_right"]))
 
     return jsonify(settings.get_all())
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -44,7 +44,8 @@ _DEFAULTS: dict[str, Any] = {
     "calibrate_count": 2,
     "calibration_fraction": 0.5,
     "swipe_animation": True,
-    "show_thumbnails": False,
+    "show_thumbnails_left": False,
+    "show_thumbnails_right": True,
     "favorite_processors": [],
 }
 
@@ -197,15 +198,27 @@ def set_swipe_animation(value: bool) -> None:
     _save(s)
 
 
-def get_show_thumbnails() -> bool:
-    """Return whether thumbnail display is enabled."""
-    return bool(_ensure_loaded().get("show_thumbnails", _DEFAULTS["show_thumbnails"]))
+def get_show_thumbnails_left() -> bool:
+    """Return whether left-panel (clip list) thumbnail display is enabled."""
+    return bool(_ensure_loaded().get("show_thumbnails_left", _DEFAULTS["show_thumbnails_left"]))
 
 
-def set_show_thumbnails(value: bool) -> None:
-    """Set and persist the show_thumbnails flag."""
+def set_show_thumbnails_left(value: bool) -> None:
+    """Set and persist the show_thumbnails_left flag."""
     s = _ensure_loaded()
-    s["show_thumbnails"] = bool(value)
+    s["show_thumbnails_left"] = bool(value)
+    _save(s)
+
+
+def get_show_thumbnails_right() -> bool:
+    """Return whether right-panel (vote list) thumbnail display is enabled."""
+    return bool(_ensure_loaded().get("show_thumbnails_right", _DEFAULTS["show_thumbnails_right"]))
+
+
+def set_show_thumbnails_right(value: bool) -> None:
+    """Set and persist the show_thumbnails_right flag."""
+    s = _ensure_loaded()
+    s["show_thumbnails_right"] = bool(value)
     _save(s)
 
 


### PR DESCRIPTION
## Summary
This PR refactors the thumbnail display setting from a single boolean flag into two separate settings: one for the left panel (clip list) and one for the right panel (vote list). This allows users to independently control thumbnail visibility in each panel.

## Key Changes
- **Settings Module** (`vtsearch/settings.py`):
  - Replaced `show_thumbnails` with `show_thumbnails_left` (default: False) and `show_thumbnails_right` (default: True)
  - Added getter/setter functions for both new settings
  - Updated defaults dictionary

- **API Routes** (`vtsearch/routes/settings.py`):
  - Updated settings endpoint to handle both `show_thumbnails_left` and `show_thumbnails_right` parameters

- **Frontend** (`static/app.js`):
  - Split single `showThumbnails` variable into `showThumbnailsLeft` and `showThumbnailsRight`
  - Updated checkbox references and event listeners for both settings
  - Modified `renderClipList()` to use `showThumbnailsLeft` for left panel thumbnails
  - Modified `renderVotes()` to use `showThumbnailsRight` for right panel thumbnails
  - Updated settings import/export to include both new keys

- **UI** (`static/index.html`):
  - Replaced single "Show Thumbnails" checkbox with two separate checkboxes:
    - "Show Left Thumbnails" (unchecked by default)
    - "Show Right Thumbnails" (checked by default)

- **Tests** (`tests/test_settings.py`):
  - Updated all test cases to use the new split settings
  - Added comprehensive tests for both left and right thumbnail settings
  - Updated defaults verification test

## Implementation Details
- The right panel thumbnails default to enabled (True) while left panel defaults to disabled (False), reflecting different use cases for each panel
- Settings are independently persisted and can be toggled without affecting the other
- Backward compatibility is handled through default values in the settings module

https://claude.ai/code/session_014bcqwE7FP5PEd5jTD8UHa5