### PR TITLE
Fix dataset clearing to properly reset UI and state

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -244,6 +244,7 @@
   const datasetBar = document.getElementById("dataset-bar");
   const datasetInfo = document.getElementById("dataset-info");
   const leftPanel = document.getElementById("left-panel");
+  const rightPanel = document.querySelector(".panel-right");
   const sortBar = document.getElementById("sort-bar");
 
   // Burger menu elements
@@ -341,10 +342,15 @@
     sortBar.style.display = "none";
     datasetBar.style.display = "none";
     clipList.innerHTML = "";
+    leftPanel.style.display = "none";
+    if (rightPanel) rightPanel.style.display = "none";
+    stripeContainer.innerHTML = "";
   }
 
   function showMainUI() {
     datasetWelcome.style.display = "none";
+    leftPanel.style.display = "";
+    if (rightPanel) rightPanel.style.display = "";
     sortBar.style.display = "block";
     datasetBar.style.display = "flex";
     if (!selected) {
@@ -1028,11 +1034,13 @@
       if (await vtConfirm("Changing the dataset will erase your current dataset. Continue?")) {
         fetch("/api/dataset/clear", { method: "POST" })
           .then(() => {
-            showWelcomeScreen();
             clips = [];
             votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
             selected = null;
             datasetLoaded = false;
+            showWelcomeScreen();
+            renderVotes();
+            updateLabelCounts();
             closeBurgerMenu();
           });
       } else {

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -21,10 +21,10 @@ from vtsearch.config import (
     UCF101_SUBSET_DOWNLOAD_SIZE_MB,
 )
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers, load_demo_dataset
-from vtsearch.models.progress import clear_progress_cache
 from vtsearch.utils import (
     bad_votes,
     build_diversity_tree,
+    clear_all,
     clips,
     get_progress,
     good_votes,
@@ -75,12 +75,8 @@ def _load_embedder_for_clips() -> None:
 
 
 def clear_dataset():
-    """Clear the current dataset."""
-    clips.clear()
-    good_votes.clear()
-    bad_votes.clear()
-    label_history.clear()
-    clear_progress_cache()
+    """Clear the current dataset, votes, and all related state."""
+    clear_all()
 
 
 def _set_clip_origins(clips_dict: dict, origin: dict) -> None:


### PR DESCRIPTION
## Summary
This PR fixes the dataset clearing functionality to properly reset both the UI and application state when switching datasets. Previously, the UI elements were not being hidden and vote-related state was not being refreshed after clearing.

## Key Changes

**Frontend (static/app.js):**
- Added reference to right panel element for consistent UI state management
- Modified `hideMainUI()` to hide left and right panels and clear stripe container
- Modified `showMainUI()` to restore left and right panel visibility
- Reordered dataset clearing logic to call `showWelcomeScreen()` after state reset
- Added calls to `renderVotes()` and `updateLabelCounts()` after clearing to refresh UI

**Backend (vtsearch/routes/datasets.py):**
- Refactored `clear_dataset()` to use new `clear_all()` utility function instead of manually clearing individual collections
- Updated imports to use `clear_all` from utils instead of `clear_progress_cache` from models
- Improved function documentation to reflect that it clears dataset, votes, and related state

## Implementation Details
The changes ensure that when a user switches datasets, the application properly:
1. Clears all internal state (clips, votes, progress)
2. Hides the main UI panels
3. Shows the welcome screen
4. Refreshes vote counts and labels in the UI

This prevents stale data from being displayed when loading a new dataset.

https://claude.ai/code/session_01UDinMsVT28DhKPcZqrTfTV