### PR TITLE
Fix double-click vote toggle and add scrolling to center panel

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -21,6 +21,7 @@
   let learnedSortDebounce = null;   // Debounce timer for background training
   let waveformAudioCtx = null;       // Shared AudioContext for waveform decoding
   let swipeAnimation = true;         // Swipe animation on vote (persisted setting)
+  let isVoting = false;              // Re-entrance guard for castVote
   const clipList = document.getElementById("clip-list");
   const center = document.getElementById("center");
   const goodList = document.getElementById("good-list");
@@ -2738,60 +2739,71 @@
   }
 
   async function castVote(id, vote) {
-    const clipName = (clips.find(c => c.id === id) || {}).filename || `Clip #${id}`;
-    await fetch(`/api/clips/${id}/vote`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ vote }),
-    });
-    announce(`Voted ${vote} on ${clipName}`);
-    await fetchVotes();
+    if (isVoting) return; // Prevent double-click from toggling the vote off
+    isVoting = true;
+    try {
+      const clipName = (clips.find(c => c.id === id) || {}).filename || `Clip #${id}`;
+      await fetch(`/api/clips/${id}/vote`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ vote }),
+      });
+      announce(`Voted ${vote} on ${clipName}`);
+      await fetchVotes();
 
-    // When voting Good while a text-sort query is active, store the query
-    // as a suggested name for saving detectors / labelsets later.
-    if (vote === "good" && sortMode === "text") {
-      const textQuery = textSortInput.value.trim();
-      if (textQuery) {
-        fetch("/api/textsort-suggestions", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text: textQuery }),
-        }).catch(() => {}); // fire-and-forget
-      }
-    }
-
-    // Auto-advance to next clip.  When swipe animation is enabled, play a
-    // fast swipe-out before switching; otherwise advance immediately.
-    // In "new" select mode, use the diversity tree for the next clip.
-    let nextId;
-    if (selectMode === "new") {
-      const data = await fetchDiversityTreeNext();
-      nextId = data.id;
-      if (nextId == null && data.exhausted) {
-        vtAlert("You have seen every branch of the diversity tree. Switch to Top or Hard mode, or add more data.", "warning");
-      }
-    } else {
-      const c = findNextClip();
-      nextId = c ? c.id : null;
-    }
-    if (nextId != null && nextId !== selected) {
-      if (swipeAnimation) {
-        const dir = vote === "good" ? "swipe-right" : "swipe-left";
-        const wrapper = document.getElementById("media-swipe-wrapper");
-        if (wrapper) {
-          wrapper.classList.add(dir);
-          await new Promise(r => setTimeout(r, 180));
-          wrapper.classList.remove(dir);
+      // When voting Good while a text-sort query is active, store the query
+      // as a suggested name for saving detectors / labelsets later.
+      if (vote === "good" && sortMode === "text") {
+        const textQuery = textSortInput.value.trim();
+        if (textQuery) {
+          fetch("/api/textsort-suggestions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text: textQuery }),
+          }).catch(() => {}); // fire-and-forget
         }
       }
-      selectClip(nextId);
-    }
 
-    // Kick off learned sort in the background (non-blocking).
-    // When training completes, sortOrder/threshold update and the clip list
-    // re-renders — but the user can keep voting in the meantime.
-    if (sortMode === "learned") {
-      scheduleLearnedSort();
+      // Auto-advance to next clip.  When swipe animation is enabled, play a
+      // fast swipe-out before switching; otherwise advance immediately.
+      // In "new" select mode, use the diversity tree for the next clip.
+      let nextId;
+      if (selectMode === "new") {
+        const data = await fetchDiversityTreeNext();
+        nextId = data.id;
+        if (nextId == null && data.exhausted) {
+          vtAlert("You have seen every branch of the diversity tree. Switch to Top or Hard mode, or add more data.", "warning");
+        }
+      } else {
+        const c = findNextClip();
+        nextId = c ? c.id : null;
+      }
+      if (nextId != null && nextId !== selected) {
+        if (swipeAnimation) {
+          const dir = vote === "good" ? "swipe-right" : "swipe-left";
+          const wrapper = document.getElementById("media-swipe-wrapper");
+          if (wrapper) {
+            wrapper.classList.add(dir);
+            await new Promise(r => setTimeout(r, 180));
+            wrapper.classList.remove(dir);
+          }
+        }
+        selectClip(nextId);
+      } else {
+        // No auto-advance (all clips voted, or toggled a vote off) —
+        // refresh clip list and center panel so vote button state updates.
+        renderClipList();
+        renderCenter();
+      }
+
+      // Kick off learned sort in the background (non-blocking).
+      // When training completes, sortOrder/threshold update and the clip list
+      // re-renders — but the user can keep voting in the meantime.
+      if (sortMode === "learned") {
+        scheduleLearnedSort();
+      }
+    } finally {
+      isVoting = false;
     }
   }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -239,7 +239,7 @@ header h1 { margin-left: 48px; }
 .stripe-highlight { position: absolute; left: 0; right: 0; background: var(--accent-highlight-bg); border-top: 1px solid var(--accent-highlight-border); border-bottom: 1px solid var(--accent-highlight-border); pointer-events: none; transition: top 0.05s, height 0.05s; z-index: 0; }
 
 /* Center panel – player */
-.panel-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; padding: 32px; }
+.panel-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; padding: 32px; overflow-y: auto; }
 .panel-center.empty { color: var(--text-placeholder); font-size: 1rem; }
 .meta { text-align: center; }
 .meta h2 { font-size: 1.5rem; color: var(--accent); margin-bottom: 8px; }


### PR DESCRIPTION
## Summary
This PR fixes a bug where rapid clicks on the vote button could toggle a vote off unintentionally, and improves the center panel layout to handle overflow content.

## Key Changes
- **Re-entrance guard for castVote**: Added an `isVoting` flag that prevents the vote function from executing while a vote is already in progress. This prevents double-click scenarios from toggling votes off when the user clicks the same vote button twice in quick succession.
- **Wrapped castVote logic in try/finally**: The entire vote processing logic is now wrapped in a try/finally block to ensure the `isVoting` flag is always reset, even if an error occurs during voting.
- **Added scrolling to center panel**: Added `overflow-y: auto` to `.panel-center` CSS to allow vertical scrolling when content exceeds the available viewport height, improving usability when displaying longer clip metadata or information.

## Implementation Details
- The `isVoting` guard is checked at the start of `castVote()` and returns early if a vote is already in progress
- The flag is set to `true` before any async operations and reset to `false` in the finally block
- This approach is non-blocking and doesn't require debouncing, providing immediate feedback to prevent accidental double-votes

https://claude.ai/code/session_01PQxHGUNUebVy4ooxFqMjNM