### PR TITLE
Fix autodetect toggle visibility in dataset import flow

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -341,6 +341,8 @@
     demoDatasetsDiv.style.display = "none";
     extendedImporterForm.style.display = "none";
     backButton.style.display = "none";
+    const autodetectToggle = document.getElementById("autodetect-toggle");
+    if (autodetectToggle) autodetectToggle.style.display = "";
     sortBar.style.display = "none";
     datasetBar.style.display = "none";
     clipList.innerHTML = "";
@@ -368,6 +370,8 @@
     extendedImporterForm.style.display = "none";
     datasetProgress.style.display = "block";
     backButton.style.display = "none";
+    const autodetectToggle = document.getElementById("autodetect-toggle");
+    if (autodetectToggle) autodetectToggle.style.display = "none";
     // Reset progress bar to indeterminate state
     progressFill.style.width = "0%";
     progressFill.classList.add("indeterminate");
@@ -697,7 +701,7 @@
       </label>
       <p style="font-size: 0.85rem; color: var(--text-secondary); margin: 8px 0 0 0;">When checked, automatically runs all favorite detectors and shows positive hits.</p>
     `;
-    datasetOptions.appendChild(autodetectDiv);
+    datasetWelcome.insertBefore(autodetectDiv, backButton);
   }
 
   function showExtendedImporterForm(importer) {


### PR DESCRIPTION
## Summary
This PR fixes the visibility and positioning of the autodetect toggle element during the dataset import workflow. The toggle now correctly shows/hides based on the current step and is positioned properly in the UI hierarchy.

## Key Changes
- Added logic to show the autodetect toggle when entering the dataset selection view (display: "")
- Added logic to hide the autodetect toggle when starting a dataset import (display: "none")
- Moved the autodetect toggle from being appended to `datasetOptions` to being inserted before the back button in `datasetWelcome`, ensuring proper DOM positioning and styling context

## Implementation Details
- The autodetect toggle is now conditionally displayed/hidden at appropriate points in the import workflow
- Null-safety checks are included when accessing the toggle element via `getElementById`
- The repositioning of the element in the DOM ensures it appears in the correct visual location within the welcome section rather than in the options area

https://claude.ai/code/session_01Bqsa3UJkXgRLchFYU44nUY