### PR TITLE
Add audio pipeline warmup to improve ETA accuracy

### DIFF
--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -314,6 +314,28 @@ class AudioMediaType(MediaType):
         with intercept_tqdm_progress(self._on_progress):
             self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
 
+        # Warmup: import librosa (heavy — pulls in numba, scipy, etc.) and
+        # run a single dummy forward pass so that the first real embed_media
+        # call runs at the same speed as every subsequent one.  Without this
+        # the first embedding stalls inside the progress-bar loop and skews
+        # the ETA estimate for all remaining items.
+        self._on_progress("loading", "Warming up audio pipeline…", 0, 0)
+        import librosa  # noqa: PLC0415
+        import torch  # noqa: PLC0415
+
+        dummy_audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        inputs = self._processor(
+            audio=dummy_audio,
+            sampling_rate=SAMPLE_RATE,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=480000,
+            truncation=True,
+        )
+        with torch.no_grad():
+            outputs = self._model.audio_model(**inputs)
+            self._model.audio_projection(outputs.pooler_output)
+
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()


### PR DESCRIPTION
## Summary
Added a warmup phase to the CLAP audio model loading process that performs a dummy forward pass. This ensures the first real embedding call runs at the same speed as subsequent calls, preventing stalls that skew progress bar ETA estimates.

## Key Changes
- Added warmup routine in `load_models()` that:
  - Imports librosa and torch (deferred to avoid unnecessary early loading)
  - Creates a dummy audio array and processes it through the full pipeline
  - Runs a forward pass through the audio model and projection layer
  - Reports progress status as "Warming up audio pipeline…"

## Implementation Details
- The warmup uses a zero-filled dummy audio array of `SAMPLE_RATE` samples
- Processes through the same pipeline as real embeddings (processor → model → projection)
- Uses `torch.no_grad()` to avoid unnecessary gradient computation
- Imports are marked with `noqa: PLC0415` to allow deferred imports within the function
- This prevents the first `embed_media()` call from stalling inside the progress bar loop, which was causing inaccurate ETA calculations for batch operations

https://claude.ai/code/session_01G4dW7NxCUJnvN8WthdphoH