### PR TITLE
Fix dataset welcome container width on smaller screens

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -294,7 +294,7 @@ video { max-width: 600px; max-height: 400px; }
 .label-io-status { font-size: 0.7rem; color: var(--text-dim); padding: 0 16px 8px; }
 
 /* Dataset management */
-.dataset-welcome { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px; padding: 48px; max-width: 800px; margin: 0 auto; text-align: center; }
+.dataset-welcome { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px; padding: 48px; width: 100%; max-width: 800px; margin: 0 auto; text-align: center; }
 .dataset-welcome.wide { max-width: min(1040px, 95vw); }
 .dataset-welcome h2 { font-size: 1.8rem; color: var(--accent); margin-bottom: 8px; }
 .dataset-welcome p { font-size: 1rem; color: var(--text-secondary); margin-bottom: 16px; }


### PR DESCRIPTION
## Summary
Fixed the `.dataset-welcome` container to properly respect its maximum width constraint on all screen sizes by explicitly setting `width: 100%`.

## Changes
- Added `width: 100%` to `.dataset-welcome` CSS rule to ensure the container scales responsively while respecting the `max-width: 800px` constraint
- This prevents the container from exceeding its intended maximum width on smaller viewports while maintaining proper centering with `margin: 0 auto`

## Details
The container now properly constrains itself to 800px maximum width on all screen sizes, with the existing `.dataset-welcome.wide` variant still available for cases requiring up to 1040px width. This ensures consistent layout behavior across responsive breakpoints.

https://claude.ai/code/session_01LNzWkkTpjpACCDf8Em6Rig