### PR TITLE
Add custom scrollbar styling across all themes

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -42,6 +42,8 @@
   --status-green-dot: #2ecc71;
   --status-green-label: #7deba0;
   --status-green-sub: #3a8a55;
+  --scrollbar-thumb: #3a3d52;
+  --scrollbar-thumb-hover: #7c8aff;
 }
 
 [data-theme="light"] {
@@ -86,6 +88,8 @@
   --status-green-dot: #43a047;
   --status-green-label: #2e7d32;
   --status-green-sub: #66bb6a;
+  --scrollbar-thumb: #c0c3cc;
+  --scrollbar-thumb-hover: #5a68d8;
 }
 
 [data-theme="highviz"] {
@@ -130,7 +134,16 @@
   --status-green-dot: #33ff33;
   --status-green-label: #00ff00;
   --status-green-sub: #00cc00;
+  --scrollbar-thumb: #888888;
+  --scrollbar-thumb-hover: #ffff00;
 }
+
+/* ---- Scrollbars ---- */
+* { scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) var(--bg-panel); }
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--bg-panel); }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
 /* ---- Accessibility ---- */
 .sr-only {


### PR DESCRIPTION
## Summary
This PR adds consistent, theme-aware scrollbar styling across the application by introducing custom scrollbar CSS variables and styles that work across both Firefox and Chromium-based browsers.

## Key Changes
- Added `--scrollbar-thumb` and `--scrollbar-thumb-hover` CSS variables to all three themes (dark, light, and highviz) with appropriate colors for each theme
- Implemented cross-browser scrollbar styling using:
  - `scrollbar-width` and `scrollbar-color` properties for Firefox compatibility
  - `-webkit-scrollbar` pseudo-elements for Chrome, Safari, and Edge support
- Scrollbar styling includes:
  - Thin scrollbar width (6px)
  - Custom thumb color that matches each theme's color palette
  - Hover state with distinct color for better UX
  - Rounded corners (3px border-radius) on the scrollbar thumb
  - Track background inherits from `--bg-panel` variable

## Implementation Details
- All three themes now have coordinated scrollbar colors:
  - **Dark theme**: Gray thumb (#3a3d52) with blue hover (#7c8aff)
  - **Light theme**: Light gray thumb (#c0c3cc) with blue hover (#5a68d8)
  - **Highviz theme**: Gray thumb (#888888) with yellow hover (#ffff00)
- Scrollbar styling is applied globally to all elements using the universal selector
- The implementation respects the existing theme system and uses CSS custom properties for maintainability

https://claude.ai/code/session_01MiPU9Tzy1vqkjWu17eJXGa