### PR TITLE
Convert favorite_media_type to list-based favorite_media_types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
 - `vtsearch/config.py` — Constants (SAMPLE_RATE, NUM_CLIPS, paths, model IDs)
 - `vtsearch/clips.py` — Test clip generation and embedding cache management
 - `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detectors from settings, run inference, export results)
-- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails, favorite_processors); auto-saves to `data/settings.json`
+- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails, favorite_media_types, favorite_processors); auto-saves to `data/settings.json`
 - `vtsearch/routes/` — Flask blueprints: `main.py`, `clips.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking, diversity tree
 - `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/rss_feed/youtube_playlist/combine_datasets); auto-discovered via `IMPORTER` sentinel
@@ -91,7 +91,7 @@ This ensures work is recoverable if the session crashes during a test run.
 ## Key Details
 - Global state lives in `vtsearch/utils/state.py`: `clips`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `last_learned_scores`, `inclusion`, `textsort_suggestions`, `favorite_detectors`, `favorite_extractors` are module-level dicts/lists
 - Votes are `dict[int, None]` (not sets) — use `votes[id] = None` syntax
-- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails, favorite_processors
+- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails, favorite_media_types, favorite_processors
 - Each clip has `origin` (dict or None) and `origin_name` (str) for per-element provenance tracking
 - `Origin` class in `vtsearch/datasets/origin.py`; `LabelSet`/`LabeledElement` in `vtsearch/datasets/labelset.py`
 - Label export (`/api/labels/export`) returns a `LabelSet` with per-element origin info (superset of legacy format)

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ from flask import Flask
 
 # Import refactored modules
 from vtsearch.clips import init_clips  # noqa: E402, F401 — used by tests via app_module.init_clips()
-from vtsearch.models import initialize_models  # noqa: E402
+from vtsearch.models import initialize_models, preload_favorite_media_types  # noqa: E402
 from vtsearch.routes import (  # noqa: E402
     clips_bp,
     datasets_bp,
@@ -188,11 +188,18 @@ if __name__ == "__main__":
     elif args.local:
         # Local development mode
         print("\U0001f680 Running in LOCAL mode (accessible from other devices)", flush=True)
+        initialize_models()
+        preloaded = preload_favorite_media_types()
+        if preloaded:
+            print(f"\u2705 Preloaded favorite media types: {', '.join(preloaded)}", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)
     else:
         # Production mode \u2014 models load lazily when the first dataset is loaded
         print("\U0001f680 Running in PRODUCTION mode", flush=True)
         initialize_models()
+        preloaded = preload_favorite_media_types()
+        if preloaded:
+            print(f"\u2705 Preloaded favorite media types: {', '.join(preloaded)}", flush=True)
 
         print("\u2705 VTSearch is ready!", flush=True)
         print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)

--- a/static/app.js
+++ b/static/app.js
@@ -304,6 +304,7 @@
   const showThumbnailsRightCheckbox = document.getElementById("show-thumbnails-right-checkbox");
   let showThumbnailsLeft = false;
   let showThumbnailsRight = true;
+  const favMtCheckboxes = document.querySelectorAll("[data-media-type]");
 
   // ---- Dataset Management ----
 
@@ -651,15 +652,16 @@
         // Build tab bar and content sections
         const availableTypes = mediaOrder.filter(mt => (grouped[mt] || []).length > 0);
 
-        // Fetch the user's favorite media type to pick the initial tab
+        // Fetch the user's favorite media types to pick the initial tab
         let initialTab = availableTypes[0] || "audio";
         try {
           const settingsRes = await fetch("/api/settings");
           if (settingsRes.ok) {
             const settingsData = await settingsRes.json();
-            const fav = settingsData.favorite_media_type;
-            if (fav && availableTypes.includes(fav)) {
-              initialTab = fav;
+            const favs = settingsData.favorite_media_types || [];
+            const firstFav = favs.find(f => availableTypes.includes(f));
+            if (firstFav) {
+              initialTab = firstFav;
             }
           }
         } catch (_) { /* ignore – just use first available tab */ }
@@ -686,12 +688,6 @@
             Object.keys(sections).forEach(k => {
               sections[k].style.display = k === mt ? "" : "none";
             });
-            // Persist favorite media type
-            fetch("/api/settings", {
-              method: "PUT",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ favorite_media_type: mt }),
-            }).catch(() => {});
           });
           tabBar.appendChild(tab);
 
@@ -1942,6 +1938,10 @@
       showThumbnailsRightCheckbox.checked = val;
       showThumbnailsRight = val;
     }
+    const favList = data.favorite_media_types || [];
+    favMtCheckboxes.forEach(cb => {
+      cb.checked = favList.includes(cb.dataset.mediaType);
+    });
   }
 
   if (menuSettings && settingsModal && burgerDropdown) {
@@ -2024,6 +2024,19 @@
       renderVotes();
     });
   }
+
+  // Favorite media type toggles
+  favMtCheckboxes.forEach(cb => {
+    cb.addEventListener("change", () => {
+      const selected = [];
+      favMtCheckboxes.forEach(c => { if (c.checked) selected.push(c.dataset.mediaType); });
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ favorite_media_types: selected }),
+      }).catch(() => {});
+    });
+  });
 
   // Default button — reset all settings to defaults
   if (settingsDefaultBtn) {

--- a/static/index.html
+++ b/static/index.html
@@ -453,6 +453,26 @@
           <input type="checkbox" id="safe-thresholds-checkbox" style="accent-color:var(--accent)">
         </div>
       </div>
+      <!-- Favorite Media Types -->
+      <div class="settings-section">
+        <div class="settings-section-title">Favorite Media Types</div>
+        <div class="settings-row">
+          <label for="fav-mt-audio" class="settings-label">Audio</label>
+          <input type="checkbox" id="fav-mt-audio" data-media-type="audio" style="accent-color:var(--accent)">
+        </div>
+        <div class="settings-row">
+          <label for="fav-mt-image" class="settings-label">Image</label>
+          <input type="checkbox" id="fav-mt-image" data-media-type="image" style="accent-color:var(--accent)">
+        </div>
+        <div class="settings-row">
+          <label for="fav-mt-paragraph" class="settings-label">Text</label>
+          <input type="checkbox" id="fav-mt-paragraph" data-media-type="paragraph" style="accent-color:var(--accent)">
+        </div>
+        <div class="settings-row">
+          <label for="fav-mt-video" class="settings-label">Video</label>
+          <input type="checkbox" id="fav-mt-video" data-media-type="video" style="accent-color:var(--accent)">
+        </div>
+      </div>
       <!-- Sorting -->
       <div class="settings-section">
         <div class="settings-section-title">Sorting</div>

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -220,37 +220,64 @@ class TestSettingsModule:
         assert defaults["safe_thresholds"] is False
         assert defaults["show_thumbnails_left"] is False
         assert defaults["show_thumbnails_right"] is True
-        assert defaults["favorite_media_type"] == ""
+        assert defaults["favorite_media_types"] == []
         assert "favorite_processors" not in defaults
 
-    def test_get_set_favorite_media_type(self, isolated_settings):
-        settings_mod.set_favorite_media_type("audio")
-        assert settings_mod.get_favorite_media_type() == "audio"
+    def test_get_set_favorite_media_types(self, isolated_settings):
+        settings_mod.set_favorite_media_types(["audio", "video"])
+        assert settings_mod.get_favorite_media_types() == ["audio", "video"]
 
         raw = json.loads(isolated_settings.read_text())
-        assert raw["favorite_media_type"] == "audio"
+        assert raw["favorite_media_types"] == ["audio", "video"]
 
-    def test_favorite_media_type_default(self):
-        assert settings_mod.get_favorite_media_type() == ""
+    def test_favorite_media_types_default(self):
+        assert settings_mod.get_favorite_media_types() == []
 
-    def test_favorite_media_type_invalid(self):
+    def test_favorite_media_types_invalid(self):
         with pytest.raises(ValueError):
-            settings_mod.set_favorite_media_type("invalid_type")
+            settings_mod.set_favorite_media_types(["invalid_type"])
 
-    def test_favorite_media_type_clear(self):
-        settings_mod.set_favorite_media_type("video")
-        settings_mod.set_favorite_media_type("")
-        assert settings_mod.get_favorite_media_type() == ""
+    def test_favorite_media_types_clear(self):
+        settings_mod.set_favorite_media_types(["video"])
+        settings_mod.set_favorite_media_types([])
+        assert settings_mod.get_favorite_media_types() == []
 
-    def test_favorite_media_type_persists_across_reset(self, isolated_settings):
-        settings_mod.set_favorite_media_type("image")
+    def test_favorite_media_types_persists_across_reset(self, isolated_settings):
+        settings_mod.set_favorite_media_types(["image", "audio"])
         settings_mod.reset()
-        assert settings_mod.get_favorite_media_type() == "image"
+        assert settings_mod.get_favorite_media_types() == ["image", "audio"]
 
-    def test_favorite_media_type_all_valid_types(self):
-        for mt in ("audio", "image", "paragraph", "video"):
-            settings_mod.set_favorite_media_type(mt)
-            assert settings_mod.get_favorite_media_type() == mt
+    def test_favorite_media_types_all_valid_types(self):
+        settings_mod.set_favorite_media_types(["audio", "image", "paragraph", "video"])
+        assert settings_mod.get_favorite_media_types() == ["audio", "image", "paragraph", "video"]
+
+    def test_toggle_favorite_media_type(self):
+        result = settings_mod.toggle_favorite_media_type("audio")
+        assert result == ["audio"]
+        result = settings_mod.toggle_favorite_media_type("video")
+        assert result == ["audio", "video"]
+        result = settings_mod.toggle_favorite_media_type("audio")
+        assert result == ["video"]
+
+    def test_toggle_favorite_media_type_invalid(self):
+        with pytest.raises(ValueError):
+            settings_mod.toggle_favorite_media_type("invalid")
+
+    def test_favorite_media_types_deduplicates(self):
+        settings_mod.set_favorite_media_types(["audio", "audio", "video"])
+        assert settings_mod.get_favorite_media_types() == ["audio", "video"]
+
+    def test_migrate_legacy_favorite_media_type(self, isolated_settings):
+        """Legacy favorite_media_type string is migrated to favorite_media_types list."""
+        isolated_settings.write_text(json.dumps({"favorite_media_type": "audio"}))
+        settings_mod.reset()
+        assert settings_mod.get_favorite_media_types() == ["audio"]
+
+    def test_migrate_legacy_empty_favorite_media_type(self, isolated_settings):
+        """Legacy empty favorite_media_type is migrated to empty list."""
+        isolated_settings.write_text(json.dumps({"favorite_media_type": ""}))
+        settings_mod.reset()
+        assert settings_mod.get_favorite_media_types() == []
 
     def test_corrupt_settings_file(self, isolated_settings):
         isolated_settings.write_text("not json!!!")
@@ -504,7 +531,7 @@ class TestSettingsAPI:
         assert data["calibrate_count"] == 2
         assert data["calibration_fraction"] == 0.5
         assert data["safe_thresholds"] is False
-        assert data["favorite_media_type"] == ""
+        assert data["favorite_media_types"] == []
         assert "favorite_processors" not in data
 
     def test_update_safe_thresholds(self, client):
@@ -559,32 +586,35 @@ class TestSettingsAPI:
         assert "show_thumbnails_left" in data
         assert "show_thumbnails_right" in data
 
-    def test_update_favorite_media_type(self, client):
-        res = client.put("/api/settings", json={"favorite_media_type": "audio"})
+    def test_update_favorite_media_types(self, client):
+        res = client.put("/api/settings", json={"favorite_media_types": ["audio", "video"]})
         assert res.status_code == 200
-        assert res.get_json()["favorite_media_type"] == "audio"
+        assert res.get_json()["favorite_media_types"] == ["audio", "video"]
 
         # Verify it persisted
         res2 = client.get("/api/settings")
-        assert res2.get_json()["favorite_media_type"] == "audio"
+        assert res2.get_json()["favorite_media_types"] == ["audio", "video"]
 
-    def test_update_favorite_media_type_all_types(self, client):
-        for mt in ("audio", "image", "paragraph", "video"):
-            res = client.put("/api/settings", json={"favorite_media_type": mt})
-            assert res.status_code == 200
-            assert res.get_json()["favorite_media_type"] == mt
-
-    def test_update_favorite_media_type_clear(self, client):
-        client.put("/api/settings", json={"favorite_media_type": "video"})
-        res = client.put("/api/settings", json={"favorite_media_type": ""})
+    def test_update_favorite_media_types_all_types(self, client):
+        res = client.put("/api/settings", json={"favorite_media_types": ["audio", "image", "paragraph", "video"]})
         assert res.status_code == 200
-        assert res.get_json()["favorite_media_type"] == ""
+        assert res.get_json()["favorite_media_types"] == ["audio", "image", "paragraph", "video"]
 
-    def test_update_favorite_media_type_invalid(self, client):
-        res = client.put("/api/settings", json={"favorite_media_type": "invalid"})
+    def test_update_favorite_media_types_clear(self, client):
+        client.put("/api/settings", json={"favorite_media_types": ["video"]})
+        res = client.put("/api/settings", json={"favorite_media_types": []})
+        assert res.status_code == 200
+        assert res.get_json()["favorite_media_types"] == []
+
+    def test_update_favorite_media_types_invalid(self, client):
+        res = client.put("/api/settings", json={"favorite_media_types": ["invalid"]})
         assert res.status_code == 400
 
-    def test_get_settings_includes_favorite_media_type(self, client):
+    def test_update_favorite_media_types_not_list(self, client):
+        res = client.put("/api/settings", json={"favorite_media_types": "audio"})
+        assert res.status_code == 400
+
+    def test_get_settings_includes_favorite_media_types(self, client):
         res = client.get("/api/settings")
         assert res.status_code == 200
-        assert "favorite_media_type" in res.get_json()
+        assert "favorite_media_types" in res.get_json()

--- a/vtsearch/models/__init__.py
+++ b/vtsearch/models/__init__.py
@@ -8,7 +8,14 @@ from vtsearch.models.embeddings import (
     embed_text_query,
     embed_video_file,
 )
-from vtsearch.models.loader import get_clap_model, get_clip_model, get_e5_model, get_xclip_model, initialize_models
+from vtsearch.models.loader import (
+    get_clap_model,
+    get_clip_model,
+    get_e5_model,
+    get_xclip_model,
+    initialize_models,
+    preload_favorite_media_types,
+)
 from vtsearch.models.progress import analyze_labeling_progress, clear_progress_cache, compute_labeling_status
 from vtsearch.models.training import (
     build_model,
@@ -31,6 +38,7 @@ __all__ = [
     "embed_text_query",
     # Loader
     "initialize_models",
+    "preload_favorite_media_types",
     "get_clap_model",
     "get_xclip_model",
     "get_clip_model",

--- a/vtsearch/models/loader.py
+++ b/vtsearch/models/loader.py
@@ -32,6 +32,30 @@ def initialize_models() -> None:
     gc.collect()
 
 
+def preload_favorite_media_types() -> list[str]:
+    """Eagerly load embedding models for all favorite media types.
+
+    Reads ``favorite_media_types`` from persisted settings and calls
+    :meth:`~vtsearch.media.base.MediaType.load_models` on each one so
+    that models are warm before the user opens the GUI.
+
+    Returns the list of type IDs that were preloaded.
+    """
+    from vtsearch.media import get as media_get
+    from vtsearch.settings import get_favorite_media_types
+
+    preloaded: list[str] = []
+    for type_id in get_favorite_media_types():
+        try:
+            mt = media_get(type_id)
+            print(f"  Preloading {mt.name} embedder...", flush=True)
+            mt.load_models()
+            preloaded.append(type_id)
+        except Exception as exc:
+            print(f"  Warning: failed to preload {type_id}: {exc}", flush=True)
+    return preloaded
+
+
 # ---------------------------------------------------------------------------
 # Backward-compatible getter functions
 #

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -105,11 +105,14 @@ def update_settings():
     if "show_thumbnails_right" in body:
         settings.set_show_thumbnails_right(bool(body["show_thumbnails_right"]))
 
-    if "favorite_media_type" in body:
+    if "favorite_media_types" in body:
+        val = body["favorite_media_types"]
+        if not isinstance(val, list) or not all(isinstance(v, str) for v in val):
+            return jsonify({"error": "favorite_media_types must be a list of strings"}), 400
         try:
-            settings.set_favorite_media_type(str(body["favorite_media_type"]))
-        except ValueError:
-            return jsonify({"error": "favorite_media_type must be a valid media type or empty string"}), 400
+            settings.set_favorite_media_types(val)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     return jsonify(settings.get_all())
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -46,7 +46,7 @@ _DEFAULTS: dict[str, Any] = {
     "swipe_animation": True,
     "show_thumbnails_left": False,
     "show_thumbnails_right": True,
-    "favorite_media_type": "",
+    "favorite_media_types": [],
     "favorite_processors": [],
 }
 
@@ -77,12 +77,20 @@ def _ensure_loaded() -> dict[str, Any]:
     global _settings
     if _settings is None:
         _settings = _load()
+        _migrate_favorite_media_type(_settings)
     return _settings
 
 
 # -------------------------------------------------------------------
 # Public API
 # -------------------------------------------------------------------
+
+
+def _migrate_favorite_media_type(data: dict[str, Any]) -> None:
+    """Migrate legacy ``favorite_media_type`` (string) to ``favorite_media_types`` (list)."""
+    if "favorite_media_type" in data and "favorite_media_types" not in data:
+        old = data.pop("favorite_media_type")
+        data["favorite_media_types"] = [old] if old else []
 
 
 def get_defaults() -> dict[str, Any]:
@@ -226,18 +234,35 @@ def set_show_thumbnails_right(value: bool) -> None:
 VALID_MEDIA_TYPES = ("audio", "image", "paragraph", "video")
 
 
-def get_favorite_media_type() -> str:
-    """Return the persisted favorite media type (empty string if unset)."""
-    return str(_ensure_loaded().get("favorite_media_type", _DEFAULTS["favorite_media_type"]))
+def get_favorite_media_types() -> list[str]:
+    """Return the list of favorite media type IDs (empty list if none set)."""
+    raw = _ensure_loaded().get("favorite_media_types", _DEFAULTS["favorite_media_types"])
+    if isinstance(raw, list):
+        return [v for v in raw if v in VALID_MEDIA_TYPES]
+    return []
 
 
-def set_favorite_media_type(value: str) -> None:
-    """Set and persist the favorite media type.  Must be a valid media type or empty string."""
-    if value != "" and value not in VALID_MEDIA_TYPES:
-        raise ValueError(f"Invalid media type: {value!r}")
+def set_favorite_media_types(value: list[str]) -> None:
+    """Set and persist the full list of favorite media types."""
+    for v in value:
+        if v not in VALID_MEDIA_TYPES:
+            raise ValueError(f"Invalid media type: {v!r}")
     s = _ensure_loaded()
-    s["favorite_media_type"] = value
+    s["favorite_media_types"] = list(dict.fromkeys(value))  # deduplicate, preserve order
     _save(s)
+
+
+def toggle_favorite_media_type(type_id: str) -> list[str]:
+    """Toggle a single media type's favorite status.  Returns the updated list."""
+    if type_id not in VALID_MEDIA_TYPES:
+        raise ValueError(f"Invalid media type: {type_id!r}")
+    current = get_favorite_media_types()
+    if type_id in current:
+        current.remove(type_id)
+    else:
+        current.append(type_id)
+    set_favorite_media_types(current)
+    return current
 
 
 def get_favorite_processors() -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
This PR refactors the favorite media type feature from a single string value to a list of media types, allowing users to mark multiple media types as favorites. It includes migration logic for legacy settings, UI updates with checkboxes, and model preloading for favorite types.

## Key Changes

- **Settings API**: Renamed `favorite_media_type` (string) to `favorite_media_types` (list) with automatic migration of legacy data
  - `get_favorite_media_type()` → `get_favorite_media_types()` returns `list[str]`
  - `set_favorite_media_type(str)` → `set_favorite_media_types(list[str])` with deduplication
  - Added `toggle_favorite_media_type(type_id)` for toggling individual types

- **Migration**: Added `_migrate_favorite_media_type()` to automatically convert legacy string settings to lists on load, handling both populated and empty values

- **UI Updates**:
  - Replaced single media type selection with checkboxes for each media type (audio, image, text, video) in settings modal
  - Updated tab selection logic to use first favorite type from the list
  - Removed automatic persistence on tab click; now only persists via settings checkboxes

- **Model Preloading**: Added `preload_favorite_media_types()` function to eagerly load embedding models for all favorite media types at startup, improving responsiveness when opening the GUI

- **API Validation**: Enhanced `/api/settings` endpoint to validate that `favorite_media_types` is a list of strings

- **Tests**: Comprehensive test coverage including migration tests, deduplication, toggle functionality, and API validation

## Implementation Details

- Deduplication is handled via `dict.fromkeys()` to preserve insertion order
- Migration runs automatically on settings load, transparently converting old format
- Invalid media types are filtered out when reading settings for robustness
- Preloading happens after `initialize_models()` and provides user feedback on startup

https://claude.ai/code/session_01SAeRbi8bkTAW9x8sNAmays