### PR TITLE
Refactor demo dataset loading to use media type registry

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -22,6 +22,9 @@
   let waveformAudioCtx = null;       // Shared AudioContext for waveform decoding
   let swipeAnimation = true;         // Swipe animation on vote (persisted setting)
   let isVoting = false;              // Re-entrance guard for castVote
+  // Media type metadata fetched from /api/media-types at startup.
+  // Keyed by type_id → { type_id, name, icon, tab_title, loops, ... }
+  let mediaTypesMap = {};
   const clipList = document.getElementById("clip-list");
   const center = document.getElementById("center");
   const goodList = document.getElementById("good-list");
@@ -314,15 +317,9 @@
 
     if (datasetLoaded) {
       showMainUI();
-      const mediaHeaderConfig = {
-        "audio":     { icon: "🔊", label: "audio" },
-        "video":     { icon: "🎬", label: "video" },
-        "image":     { icon: "🖼️", label: "image" },
-        "paragraph": { icon: "📄", label: "text" },
-      };
-      const mhc = mediaHeaderConfig[status.media_type];
-      datasetInfo.textContent = mhc
-        ? `${mhc.icon} ${status.num_clips} ${mhc.label} clips loaded`
+      const mtInfo = mediaTypesMap[status.media_type];
+      datasetInfo.textContent = mtInfo
+        ? `${mtInfo.icon} ${status.num_clips} ${mtInfo.name.toLowerCase()} clips loaded`
         : `${status.num_clips} clips loaded`;
     } else {
       showWelcomeScreen();
@@ -570,21 +567,16 @@
 
         demoDatasetsDiv.innerHTML = "";
 
-        // Group datasets by media type and display as sortable tables
-        const mediaOrder = ["video", "image", "audio", "paragraph"];
-        const mediaConfig = {
-          video:     { title: "Videos",  icon: "🎬" },
-          image:     { title: "Images",  icon: "🖼" },
-          audio:     { title: "Sounds",  icon: "🔊" },
-          paragraph: { title: "Texts",   icon: "📄" },
-        };
-
+        // Group datasets by media type and display as sortable tables.
+        // Media type metadata comes from the registry-driven mediaTypesMap.
         const grouped = {};
         data.datasets.forEach(ds => {
           const mt = ds.media_type || "audio";
           if (!grouped[mt]) grouped[mt] = [];
           grouped[mt].push(ds);
         });
+        // Use the registration order from the registry (fetched at startup)
+        const mediaOrder = Object.keys(mediaTypesMap).filter(mt => (grouped[mt] || []).length > 0);
 
         // Status sort order: ready=0, needs_embedding=1, needs_download=2
         const statusOrder = { ready: 0, needs_embedding: 1, needs_download: 2 };
@@ -649,10 +641,10 @@
         }
 
         // Build tab bar and content sections
-        const availableTypes = mediaOrder.filter(mt => (grouped[mt] || []).length > 0);
+        const availableTypes = mediaOrder;
 
         // Fetch the user's favorite media type to pick the initial tab
-        let initialTab = availableTypes[0] || "audio";
+        let initialTab = availableTypes[0] || Object.keys(mediaTypesMap)[0] || "audio";
         try {
           const settingsRes = await fetch("/api/settings");
           if (settingsRes.ok) {
@@ -672,13 +664,13 @@
 
         availableTypes.forEach(mt => {
           const items = grouped[mt];
-          const cfg = mediaConfig[mt];
+          const mtInfo = mediaTypesMap[mt] || { icon: "📁", tab_title: mt };
 
           // Create tab button
           const tab = document.createElement("button");
           tab.className = "demo-tab";
           tab.dataset.mediaType = mt;
-          tab.textContent = `${cfg.icon} ${cfg.title}`;
+          tab.textContent = `${mtInfo.icon} ${mtInfo.tab_title}`;
           tab.addEventListener("click", () => {
             // Activate this tab, deactivate others
             tabBar.querySelectorAll(".demo-tab").forEach(t => t.classList.remove("active"));
@@ -1190,7 +1182,7 @@
       return;
     }
 
-    const mediaIcons = { audio: "🔊", image: "🖼️", video: "🎬", paragraph: "📄" };
+    const mediaIcons = Object.fromEntries(Object.entries(mediaTypesMap).map(([k, v]) => [k, v.icon]));
     favoritesList.innerHTML = favoriteDetectors.map(detector => {
       const icon = mediaIcons[detector.media_type] || "🔍";
       const created = detector.created_at
@@ -2573,8 +2565,9 @@
   }
 
   function thumbnailUrl(clip) {
-    if (clip.type === "image") return `/api/clips/${clip.id}/image`;
-    if (clip.type === "video") return `/api/clips/${clip.id}/video`;
+    if (clip.type === "image" || clip.type === "video") {
+      return `/api/clips/${clip.id}/media`;
+    }
     return "";
   }
 
@@ -2623,7 +2616,7 @@
       const useThumbnail = showThumbnailsLeft && clipSupportsThumbnail(c);
       if (useThumbnail) {
         div.className += " clip-item-thumb";
-        const poster = c.type === "video" ? ` poster="/api/clips/${c.id}/image"` : "";
+        const poster = c.type === "video" ? ` poster="/api/clips/${c.id}/media"` : "";
         if (c.type === "video") {
           html += `<video class="clip-thumbnail" src="${thumbnailUrl(c)}" muted preload="metadata"${poster}></video>`;
         } else {
@@ -2642,11 +2635,13 @@
       if (c.category && c.category !== "unknown") {
         subInfo.push(c.category);
       }
-      if (c.type === "audio" || c.type === "video") {
+      if (c.duration && c.duration > 0) {
         subInfo.push(`${c.duration.toFixed(1)}s`);
-      } else if (c.type === "image" && c.width && c.height) {
+      }
+      if (c.width && c.height) {
         subInfo.push(`${c.width}×${c.height}`);
-      } else if (c.type === "paragraph" && c.word_count) {
+      }
+      if (c.word_count) {
         subInfo.push(`${c.word_count} words`);
       }
       html += `<div class="sub">${subInfo.join(' &middot; ')}</div>`;
@@ -2695,33 +2690,46 @@
     if (c.category && c.category !== "unknown") {
       metaInfo.push(c.category);
     }
-    if (mediaType === "audio" || mediaType === "video") {
+    // Use media type metadata from the registry for duration/details display
+    const mtInfo = mediaTypesMap[mediaType];
+    if (c.duration && c.duration > 0) {
       metaInfo.push(`${c.duration.toFixed(1)}s`);
     }
-    if (mediaType === "image" && c.width && c.height) {
+    if (c.width && c.height) {
       metaInfo.push(`${c.width}×${c.height}`);
     }
-    if (mediaType === "paragraph" && c.word_count) {
+    if (c.word_count) {
       metaInfo.push(`${c.word_count} words`);
     }
     metaInfo.push(`${(c.file_size / 1024).toFixed(1)} KB`);
 
-    // Render media player based on media type
+    // Render media player based on media type.
+    // Known types get specialised players; new/unknown types fall back to
+    // the generic /api/clips/{id}/media endpoint.
     let playerHTML = '';
     if (mediaType === "video") {
-      playerHTML = `<video controls loop autoplay src="/api/clips/${c.id}/video" id="clip-video" aria-label="${escapeHtml(c.filename || 'Video clip')}" style="width: 600px; max-height: 400px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface);"></video>`;
+      playerHTML = `<video controls loop autoplay src="/api/clips/${c.id}/media" id="clip-video" aria-label="${escapeHtml(c.filename || 'Video clip')}" style="width: 600px; max-height: 400px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface);"></video>`;
     } else if (mediaType === "image") {
-      playerHTML = `<div style="flex: 1; min-height: 0; width: 100%; display: flex; align-items: center; justify-content: center;"><img src="/api/clips/${c.id}/image" id="clip-image" alt="${escapeHtml(c.filename || 'Image clip')}" style="max-width: 100%; max-height: 100%; object-fit: contain; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface);"></div>`;
+      playerHTML = `<div style="flex: 1; min-height: 0; width: 100%; display: flex; align-items: center; justify-content: center;"><img src="/api/clips/${c.id}/media" id="clip-image" alt="${escapeHtml(c.filename || 'Image clip')}" style="max-width: 100%; max-height: 100%; object-fit: contain; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface);"></div>`;
     } else if (mediaType === "paragraph") {
       playerHTML = `
         <div id="clip-paragraph" style="max-width: 600px; max-height: 400px; overflow-y: auto; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); white-space: pre-wrap; line-height: 1.6; text-align: left;">
           Loading...
         </div>`;
-    } else {
+    } else if (mediaType === "audio") {
       // Audio/Sound
       playerHTML = `
         <canvas id="waveform-canvas" width="600" height="120" role="img" aria-label="Audio waveform visualization"></canvas>
-        <audio controls controlslist="nodownload" loop autoplay src="/api/clips/${c.id}/audio" id="clip-audio" aria-label="${escapeHtml(c.filename || 'Audio clip')}"></audio>`;
+        <audio controls controlslist="nodownload" loop autoplay src="/api/clips/${c.id}/media" id="clip-audio" aria-label="${escapeHtml(c.filename || 'Audio clip')}"></audio>`;
+    } else {
+      // Unknown/new media type: try to render via generic endpoint.
+      // If it loops, use a video element; otherwise use a generic embed.
+      const loops = mtInfo && mtInfo.loops;
+      if (loops) {
+        playerHTML = `<video controls loop autoplay src="/api/clips/${c.id}/media" id="clip-video" style="width: 600px; max-height: 400px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface);"></video>`;
+      } else {
+        playerHTML = `<div style="flex: 1; min-height: 0; width: 100%; display: flex; align-items: center; justify-content: center;"><object data="/api/clips/${c.id}/media" style="max-width: 100%; max-height: 100%; border: 1px solid var(--border); border-radius: 8px;">${escapeHtml(c.filename || 'Media clip')}</object></div>`;
+      }
     }
 
     center.innerHTML = `
@@ -2745,19 +2753,19 @@
         </div>` : ''}
         <div class="metadata-item">
           <span class="metadata-label">Media Type</span>
-          <span class="metadata-value">${mediaType}</span>
+          <span class="metadata-value">${mtInfo ? mtInfo.name : mediaType}</span>
         </div>
-        ${(mediaType === 'audio' || mediaType === 'video') ? `
+        ${(c.duration && c.duration > 0) ? `
         <div class="metadata-item">
           <span class="metadata-label">Duration</span>
           <span class="metadata-value">${c.duration.toFixed(1)}s</span>
         </div>` : ''}
-        ${(mediaType === 'image' && c.width && c.height) ? `
+        ${(c.width && c.height) ? `
         <div class="metadata-item">
           <span class="metadata-label">Dimensions</span>
           <span class="metadata-value">${c.width}×${c.height}</span>
         </div>` : ''}
-        ${(mediaType === 'paragraph' && c.word_count) ? `
+        ${(c.word_count) ? `
         <div class="metadata-item">
           <span class="metadata-label">Word Count</span>
           <span class="metadata-value">${c.word_count}</span>
@@ -2804,7 +2812,7 @@
       if (paragraphController) paragraphController.abort();
       paragraphController = new AbortController();
       const expectedId = c.id;
-      fetch(`/api/clips/${c.id}/paragraph`, { signal: paragraphController.signal })
+      fetch(`/api/clips/${c.id}/media`, { signal: paragraphController.signal })
         .then(res => res.json())
         .then(data => {
           if (selected !== expectedId) return; // selection changed, discard stale response
@@ -2903,7 +2911,7 @@
 
     try {
       // Fetch audio data
-      const response = await fetch(`/api/clips/${clipId}/audio`);
+      const response = await fetch(`/api/clips/${clipId}/media`);
       const arrayBuffer = await response.arrayBuffer();
 
       // Decode audio data (reuse a single AudioContext to avoid leaks)
@@ -4012,8 +4020,20 @@
     updateLabelCounts();
   };
 
+  // Fetch media type metadata from the registry so the UI is data-driven.
+  async function fetchMediaTypes() {
+    try {
+      const res = await fetch("/api/media-types");
+      const data = await res.json();
+      mediaTypesMap = {};
+      (data.media_types || []).forEach(mt => { mediaTypesMap[mt.type_id] = mt; });
+    } catch (_) {
+      // Fallback: leave empty, the UI will degrade gracefully.
+    }
+  }
+
   // Initialize
-  checkDatasetStatus().then(async () => {
+  fetchMediaTypes().then(() => checkDatasetStatus()).then(async () => {
     if (datasetLoaded) {
       await fetchClips();
       await fetchVotes();

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -18,16 +18,8 @@ from typing import Any, Callable, Iterator, Optional
 import numpy as np
 from PIL import Image
 
-from vtsearch.config import EMBEDDINGS_DIR, IMAGES_PER_CALTECH101_CATEGORY, IMAGES_PER_CALTECH256_CATEGORY, IMAGES_PER_CIFAR10_CATEGORY, TEXTS_PER_CATEGORY
+from vtsearch.config import EMBEDDINGS_DIR
 from vtsearch.datasets.config import DEMO_DATASETS
-from vtsearch.datasets.downloader import (
-    download_20newsgroups,
-    download_caltech101,
-    download_caltech256,
-    download_cifar10,
-    download_esc50,
-    download_ucf101_subset,
-)
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -608,13 +600,15 @@ def load_dataset_from_pickle(
             "params": creation_info.get("field_values", {}),
         }
 
-    # Map media type to the pickle key that holds the external directory.
-    _dir_keys = {
-        "audio": "audio_dir",
-        "video": "video_dir",
-        "image": "image_dir",
-        "paragraph": "text_dir",
-    }
+    # Build the dir_key mapping dynamically from the media type registry.
+    # Also build the legacy-bytes-key mapping for backward compat with old pickles.
+    from vtsearch.media import all_types
+
+    _dir_keys: dict[str, str] = {}
+    _legacy_bytes: dict[str, list[str]] = {}
+    for mt in all_types():
+        _dir_keys[mt.type_id] = mt.dir_key
+        _legacy_bytes[mt.type_id] = mt.legacy_bytes_keys
 
     # Convert to the app's clip format
     missing_media = 0
@@ -655,12 +649,10 @@ def load_dataset_from_pickle(
                 "origin": clip_info.get("origin", fallback_origin),
                 "origin_name": clip_info.get("origin_name", fname),
             }
-            if media_type == "image":
-                clip_data["width"] = clip_info.get("width")
-                clip_data["height"] = clip_info.get("height")
-            elif media_type == "paragraph":
-                clip_data["word_count"] = clip_info.get("word_count")
-                clip_data["character_count"] = clip_info.get("character_count")
+            # Preserve any extra metadata fields from the pickle
+            for extra_key in ("width", "height", "word_count", "character_count"):
+                if extra_key in clip_info:
+                    clip_data[extra_key] = clip_info[extra_key]
 
             clips[clip_id] = clip_data
             continue
@@ -668,66 +660,48 @@ def load_dataset_from_pickle(
         # ── Full mode (original behaviour) ──
         # Load the actual media content.
         # Support both new key names (clip_bytes/clip_string) and legacy
-        # per-media-type key names (wav_bytes/video_bytes/image_bytes/
-        # text_content) for backward compatibility with old pickles.
+        # per-media-type key names for backward compatibility with old pickles.
         clip_bytes = None
         clip_string = None
         media_bytes = None
         media_path = None
 
-        if media_type == "audio":
-            clip_bytes = clip_info.get("clip_bytes") or clip_info.get("wav_bytes")
-            if clip_bytes is not None:
-                media_bytes = clip_bytes
-            elif "filename" in clip_info and "audio_dir" in data:
-                audio_path = Path(data["audio_dir"]) / clip_info["filename"]
-                if audio_path.exists():
-                    with open(audio_path, "rb") as f:
-                        clip_bytes = f.read()
-                        media_bytes = clip_bytes
-                    media_path = str(audio_path.resolve())
-                else:
-                    missing_media += 1
+        # Try clip_bytes first (binary media), then legacy keys
+        clip_bytes = clip_info.get("clip_bytes")
+        if clip_bytes is None:
+            for legacy_key in _legacy_bytes.get(media_type, []):
+                clip_bytes = clip_info.get(legacy_key)
+                if clip_bytes is not None:
+                    break
 
-        elif media_type == "video":
-            clip_bytes = clip_info.get("clip_bytes") or clip_info.get("video_bytes")
-            if clip_bytes is not None:
-                media_bytes = clip_bytes
-            elif "filename" in clip_info and "video_dir" in data:
-                video_path = Path(data["video_dir"]) / clip_info["filename"]
-                if video_path.exists():
-                    with open(video_path, "rb") as f:
-                        clip_bytes = f.read()
-                        media_bytes = clip_bytes
-                    media_path = str(video_path.resolve())
-                else:
-                    missing_media += 1
+        # Try clip_string (text media), then legacy keys
+        clip_string = clip_info.get("clip_string")
+        if clip_string is None:
+            for legacy_key in _legacy_bytes.get(media_type, []):
+                val = clip_info.get(legacy_key)
+                if isinstance(val, str):
+                    clip_string = val
+                    break
 
-        elif media_type == "image":
-            clip_bytes = clip_info.get("clip_bytes") or clip_info.get("image_bytes")
-            if clip_bytes is not None:
-                media_bytes = clip_bytes
-            elif "filename" in clip_info and "image_dir" in data:
-                image_path = Path(data["image_dir"]) / clip_info["filename"]
-                if image_path.exists():
-                    with open(image_path, "rb") as f:
-                        clip_bytes = f.read()
-                        media_bytes = clip_bytes
-                    media_path = str(image_path.resolve())
-                else:
-                    missing_media += 1
-
-        elif media_type == "paragraph":
-            clip_string = clip_info.get("clip_string") or clip_info.get("text_content")
-            if clip_string is not None:
-                media_bytes = clip_string.encode("utf-8")  # For MD5 hash
-            elif "filename" in clip_info and "text_dir" in data:
-                text_path = Path(data["text_dir"]) / clip_info["filename"]
-                if text_path.exists():
-                    with open(text_path, "r", encoding="utf-8") as f:
-                        clip_string = f.read()
-                        media_bytes = clip_string.encode("utf-8")
-                    media_path = str(text_path.resolve())
+        if clip_bytes is not None:
+            media_bytes = clip_bytes
+        elif clip_string is not None:
+            media_bytes = clip_string.encode("utf-8")
+        else:
+            # Try loading from the external directory
+            dir_key = _dir_keys.get(media_type)
+            if dir_key and dir_key in data and "filename" in clip_info:
+                ext_path = Path(data[dir_key]) / clip_info["filename"]
+                if ext_path.exists():
+                    if clip_string is None and ext_path.suffix in (".txt", ".md"):
+                        with open(ext_path, "r", encoding="utf-8") as f:
+                            clip_string = f.read()
+                            media_bytes = clip_string.encode("utf-8")
+                    else:
+                        with open(ext_path, "rb") as f:
+                            clip_bytes = f.read()
+                            media_bytes = clip_bytes
+                    media_path = str(ext_path.resolve())
                 else:
                     missing_media += 1
 
@@ -748,13 +722,10 @@ def load_dataset_from_pickle(
                 "origin": clip_info.get("origin", fallback_origin),
                 "origin_name": clip_info.get("origin_name", fname),
             }
-            # Add media-specific metadata
-            if media_type == "image":
-                clip_data["width"] = clip_info.get("width")
-                clip_data["height"] = clip_info.get("height")
-            elif media_type == "paragraph":
-                clip_data["word_count"] = clip_info.get("word_count")
-                clip_data["character_count"] = clip_info.get("character_count")
+            # Preserve any extra metadata fields from the pickle
+            for extra_key in ("width", "height", "word_count", "character_count"):
+                if extra_key in clip_info:
+                    clip_data[extra_key] = clip_info[extra_key]
 
             clips[clip_id] = clip_data
 
@@ -978,16 +949,10 @@ def load_demo_dataset(
     from that file. If the cache is missing or the media bytes it references can
     no longer be found on disk, the raw data is re-downloaded and re-embedded.
 
-    Supported datasets and their sources:
-
-    - Audio datasets (ESC-50 subsets): downloaded from ``ESC50_URL``, embedded
-      with CLAP.
-    - Image datasets (CIFAR-10 subsets): downloaded from ``CIFAR10_URL``,
-      embedded with CLIP.
-    - Paragraph datasets (20 Newsgroups subsets): downloaded via
-      ``sklearn.datasets.fetch_20newsgroups``, embedded with E5-base-v2.
-    - Video datasets (UCF-101): must be manually placed at
-      ``VIDEO_DIR/ucf101/``; embedded with X-CLIP.
+    Each media type implements its own
+    :meth:`~vtsearch.media.base.MediaType.load_demo_source` method that
+    handles downloading, embedding, and populating clips for its demo sources.
+    This function simply orchestrates pickle caching around that delegation.
 
     Progress throughout the operation is reported via :func:`update_progress`.
 
@@ -1002,7 +967,7 @@ def load_demo_dataset(
 
     Raises:
         ValueError: If ``dataset_name`` is not in ``DEMO_DATASETS``, or if the
-            UCF-101 dataset is requested but not yet downloaded.
+            media type does not support the requested demo source.
     """
     if on_progress is None:
         on_progress = _default_progress()
@@ -1011,8 +976,7 @@ def load_demo_dataset(
         raise ValueError(f"Unknown dataset: {dataset_name}")
 
     dataset_info = DEMO_DATASETS[dataset_name]
-    media_type = dataset_info.get("media_type", "audio")
-    demo_origin: dict[str, Any] = {"importer": "demo", "params": {"name": dataset_name}}
+    media_type_id = dataset_info.get("media_type", "audio")
 
     # Check if already embedded
     pkl_file = EMBEDDINGS_DIR / f"{dataset_name}.pkl"
@@ -1029,589 +993,55 @@ def load_demo_dataset(
             on_progress("idle", f"Loaded {dataset_name} dataset")
             return
 
-    # Process based on media type
-    if media_type == "image":
-        # Handle image datasets
-        image_source = dataset_info.get("source", "cifar10_sample")
-
-        if image_source == "cifar10_sample":
-            # Download CIFAR-10 if needed
-            cifar_dir = download_cifar10()
-
-            # Load CIFAR-10 training batch
-            batch_file = cifar_dir / "data_batch_1"
-            images, labels, label_names = load_cifar10_batch(batch_file)
-
-            # Filter to requested categories
-            category_indices = {label_names[i]: i for i in range(len(label_names))}
-            requested_categories = dataset_info["categories"]
-
-            # Collect images for requested categories, applying per-category slicing
-            slice_start = dataset_info.get("slice_start", 0)
-            slice_end = dataset_info.get("slice_end", IMAGES_PER_CIFAR10_CATEGORY)
-            selected_images = []
-            selected_labels = []
-
-            for cat in requested_categories:
-                if cat in category_indices:
-                    cat_idx = category_indices[cat]
-                    cat_mask = [i for i, lbl in enumerate(labels) if lbl == cat_idx]
-                    for idx in cat_mask[slice_start:slice_end]:
-                        selected_images.append(images[idx])
-                        selected_labels.append(cat)
-
-            # Generate embeddings for images
-            clips.clear()
-            clip_id = 1
-            total = len(selected_images)
-
-            # Eagerly load models before starting the embedding timer so that
-            # download / weight-loading time does not pollute the progress bar.
-            from vtsearch.media import get as media_get
-
-            image_mt = media_get("image")
-            if getattr(image_mt, "_model", None) is None:
-                on_progress("loading", "Loading image embedding model…", 0, 0)
-                image_mt.load_models()
-
-            on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
-
-            for i, (image_array, category) in enumerate(zip(selected_images, selected_labels)):
-                on_progress(
-                    "embedding",
-                    f"Embedding {category}: image {i + 1}/{total}",
-                    i + 1,
-                    total,
-                )
-
-                # Convert numpy array to PIL Image
-                img = Image.fromarray(image_array.astype("uint8"), "RGB")
-
-                # Convert to bytes
-                img_buffer = io.BytesIO()
-                img.save(img_buffer, format="PNG")
-                image_bytes = img_buffer.getvalue()
-
-                # Get embedding via registry
-                embedding = embed_image_file_from_pil(img)
-                if embedding is None:
-                    continue
-
-                fname = f"{category}_{clip_id}.png"
-                clips[clip_id] = {
-                    "id": clip_id,
-                    "type": "image",
-                    "duration": 0,  # Images don't have duration
-                    "file_size": len(image_bytes),
-                    "md5": hashlib.md5(image_bytes).hexdigest(),
-                    "embedding": embedding,
-                    "clip_bytes": image_bytes,
-                    "clip_string": None,
-                    "filename": fname,
-                    "category": category,
-                    "width": img.width,
-                    "height": img.height,
-                    "origin": demo_origin,
-                    "origin_name": fname,
-                }
-                clip_id += 1
-
-            # Save for future use
-            EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
-            with open(pkl_file, "wb") as f:
-                pickle.dump(
-                    {
-                        "name": dataset_name,
-                        "clips": {
-                            cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items()}
-                            for cid, clip in clips.items()
-                        },
-                    },
-                    f,
-                )
-
-            on_progress("idle", f"Loaded {dataset_name} dataset")
-            return
-
-        elif image_source == "caltech101":
-            # Download Caltech-101 if needed
-            caltech_dir = download_caltech101()
-
-            # Scan category folders for images
-            metadata = load_image_metadata_from_folders(caltech_dir, dataset_info["categories"])
-
-            # Group by category (sorted order within each), then slice
-            slice_start = dataset_info.get("slice_start", 0)
-            slice_end = dataset_info.get("slice_end", IMAGES_PER_CALTECH101_CATEGORY)
-            by_cat: dict[str, list[tuple[Path, str]]] = {}
-            for fname, meta in sorted(metadata.items()):
-                cat = meta["category"]
-                by_cat.setdefault(cat, []).append((meta["path"], cat))
-
-            selected: list[tuple[Path, str]] = []
-            for cat in dataset_info["categories"]:
-                selected.extend(by_cat.get(cat, [])[slice_start:slice_end])
-
-            from vtsearch.media import get as media_get
-
-            image_mt = media_get("image")
-
-            # Eagerly load models before starting the embedding timer so that
-            # download / weight-loading time does not pollute the progress bar.
-            if getattr(image_mt, "_model", None) is None:
-                on_progress("loading", "Loading image embedding model…", 0, 0)
-                image_mt.load_models()
-
-            clips.clear()
-            clip_id = 1
-            total = len(selected)
-            on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
-
-            for i, (img_path, category) in enumerate(selected):
-                on_progress(
-                    "embedding",
-                    f"Embedding {category}: {img_path.name} ({i + 1}/{total})",
-                    i + 1,
-                    total,
-                )
-
-                embedding = image_mt.embed_media(img_path)
-                if embedding is None:
-                    continue
-
-                with open(img_path, "rb") as f:
-                    image_bytes = f.read()
-
-                try:
-                    img = Image.open(img_path)
-                    width, height = img.width, img.height
-                except Exception:
-                    width, height = None, None
-
-                clips[clip_id] = {
-                    "id": clip_id,
-                    "type": "image",
-                    "duration": 0,
-                    "file_size": len(image_bytes),
-                    "md5": hashlib.md5(image_bytes).hexdigest(),
-                    "embedding": embedding,
-                    "clip_bytes": image_bytes,
-                    "clip_string": None,
-                    "filename": img_path.name,
-                    "category": category,
-                    "width": width,
-                    "height": height,
-                    "origin": demo_origin,
-                    "origin_name": img_path.name,
-                }
-                clip_id += 1
-
-            # Save for future use
-            EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
-            with open(pkl_file, "wb") as f:
-                pickle.dump(
-                    {
-                        "name": dataset_name,
-                        "clips": {
-                            cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items()}
-                            for cid, clip in clips.items()
-                        },
-                    },
-                    f,
-                )
-
-            on_progress("idle", f"Loaded {dataset_name} dataset")
-            return
-
-        elif image_source == "caltech256":
-            # Download Caltech-256 if needed
-            caltech_dir = download_caltech256()
-
-            # Scan category folders for images
-            metadata = load_image_metadata_from_folders(caltech_dir, dataset_info["categories"])
-
-            # Group by category (sorted order within each), then slice
-            slice_start = dataset_info.get("slice_start", 0)
-            slice_end = dataset_info.get("slice_end", IMAGES_PER_CALTECH256_CATEGORY)
-            by_cat: dict[str, list[tuple[Path, str]]] = {}
-            for fname, meta in sorted(metadata.items()):
-                cat = meta["category"]
-                by_cat.setdefault(cat, []).append((meta["path"], cat))
-
-            selected: list[tuple[Path, str]] = []
-            for cat in dataset_info["categories"]:
-                selected.extend(by_cat.get(cat, [])[slice_start:slice_end])
-
-            from vtsearch.media import get as media_get
-
-            image_mt = media_get("image")
-
-            # Eagerly load models before starting the embedding timer so that
-            # download / weight-loading time does not pollute the progress bar.
-            if getattr(image_mt, "_model", None) is None:
-                on_progress("loading", "Loading image embedding model…", 0, 0)
-                image_mt.load_models()
-
-            clips.clear()
-            clip_id = 1
-            total = len(selected)
-            on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
-
-            for i, (img_path, category) in enumerate(selected):
-                on_progress(
-                    "embedding",
-                    f"Embedding {category}: {img_path.name} ({i + 1}/{total})",
-                    i + 1,
-                    total,
-                )
-
-                embedding = image_mt.embed_media(img_path)
-                if embedding is None:
-                    continue
-
-                with open(img_path, "rb") as f:
-                    image_bytes = f.read()
-
-                try:
-                    img = Image.open(img_path)
-                    width, height = img.width, img.height
-                except Exception:
-                    width, height = None, None
-
-                clips[clip_id] = {
-                    "id": clip_id,
-                    "type": "image",
-                    "duration": 0,
-                    "file_size": len(image_bytes),
-                    "md5": hashlib.md5(image_bytes).hexdigest(),
-                    "embedding": embedding,
-                    "clip_bytes": image_bytes,
-                    "clip_string": None,
-                    "filename": img_path.name,
-                    "category": category,
-                    "width": width,
-                    "height": height,
-                    "origin": demo_origin,
-                    "origin_name": img_path.name,
-                }
-                clip_id += 1
-
-            # Save for future use
-            EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
-            with open(pkl_file, "wb") as f:
-                pickle.dump(
-                    {
-                        "name": dataset_name,
-                        "clips": {
-                            cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items()}
-                            for cid, clip in clips.items()
-                        },
-                    },
-                    f,
-                )
-
-            on_progress("idle", f"Loaded {dataset_name} dataset")
-            return
-
-        else:
-            raise ValueError(f"Unsupported image source: {image_source!r} for dataset {dataset_name!r}")
-
-    elif media_type == "paragraph":
-        # Handle paragraph datasets — use text media type from registry
-        from vtsearch.media import get as media_get
-
-        text_mt = media_get("paragraph")
-
-        paragraph_source = dataset_info.get("source", "ag_news_sample")
-
-        if paragraph_source == "ag_news_sample":
-            # Use 20 Newsgroups dataset from scikit-learn
-            texts, labels, category_names = download_20newsgroups(dataset_info["categories"])
-
-            # Slice per category for disjoint S/M/L demo datasets
-            slice_start = dataset_info.get("slice_start", 0)
-            slice_end = dataset_info.get("slice_end", TEXTS_PER_CATEGORY)
-            selected_texts = []
-            selected_categories = []
-
-            for cat_name in dataset_info["categories"]:
-                if cat_name in category_names:
-                    cat_idx = category_names.index(cat_name)
-                    cat_texts = [texts[i] for i, lbl in enumerate(labels) if lbl == cat_idx]
-                    for text in cat_texts[slice_start:slice_end]:
-                        selected_texts.append(text)
-                        selected_categories.append(cat_name)
-
-            # Eagerly load models before starting the embedding timer so that
-            # download / weight-loading time does not pollute the progress bar.
-            if getattr(text_mt, "_model", None) is None:
-                on_progress("loading", "Loading text embedding model…", 0, 0)
-                text_mt.load_models()
-
-            # Generate embeddings for paragraphs
-            clips.clear()
-            clip_id = 1
-            total = len(selected_texts)
-            on_progress(
-                "embedding",
-                f"Starting embedding for {total} paragraphs...",
-                0,
-                total,
-            )
-
-            for i, (text_content, category) in enumerate(zip(selected_texts, selected_categories)):
-                on_progress(
-                    "embedding",
-                    f"Embedding {category}: paragraph {i + 1}/{total}",
-                    i + 1,
-                    total,
-                )
-
-                # Truncate very long texts (keep first 1000 chars for demo)
-                text_content = text_content[:1000].strip()
-                if not text_content:
-                    continue
-
-                # Embed via text media type
-                try:
-                    embedding = text_mt.embed_text_passage(text_content)
-                except Exception as e:
-                    print(f"Error embedding paragraph: {e}")
-                    continue
-
-                if embedding is None:
-                    continue
-
-                word_count = len(text_content.split())
-                character_count = len(text_content)
-                text_bytes = text_content.encode("utf-8")
-
-                fname = f"{category}_{clip_id}.txt"
-                clips[clip_id] = {
-                    "id": clip_id,
-                    "type": "paragraph",
-                    "duration": 0,  # Paragraphs don't have duration
-                    "file_size": len(text_bytes),
-                    "md5": hashlib.md5(text_bytes).hexdigest(),
-                    "embedding": embedding,
-                    "clip_bytes": None,
-                    "clip_string": text_content,
-                    "filename": fname,
-                    "category": category,
-                    "word_count": word_count,
-                    "character_count": character_count,
-                    "origin": demo_origin,
-                    "origin_name": fname,
-                }
-                clip_id += 1
-
-            # Save for future use
-            EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
-            with open(pkl_file, "wb") as f:
-                pickle.dump(
-                    {
-                        "name": dataset_name,
-                        "clips": {
-                            cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items()}
-                            for cid, clip in clips.items()
-                        },
-                    },
-                    f,
-                )
-
-            on_progress("idle", f"Loaded {dataset_name} dataset")
-            return
-
-        else:
-            raise ValueError(f"Unsupported text source: {paragraph_source!r} for dataset {dataset_name!r}")
-
-    elif media_type == "video":
-        # Handle video datasets
-        video_source = dataset_info.get("source", "ucf101")
-
-        if video_source == "ucf101":
-            from vtsearch.media import get as media_get
-
-            video_mt = media_get("video")
-
-            video_dir = download_ucf101_subset(on_progress=on_progress)
-
-            metadata = load_video_metadata_from_folders(video_dir, dataset_info["categories"])
-
-            # Apply per-category slicing for disjoint S/M/L datasets
-            slice_start = dataset_info.get("slice_start", 0)
-            slice_end = dataset_info.get("slice_end")
-            by_cat: dict[str, list] = {}
-            for fname, meta in sorted(metadata.items()):
-                cat = meta["category"]
-                by_cat.setdefault(cat, []).append((meta["path"], meta))
-
-            video_files: list[tuple] = []
-            for cat in dataset_info["categories"]:
-                video_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
-
-            # Eagerly load models before starting the embedding timer so that
-            # download / weight-loading time does not pollute the progress bar.
-            if getattr(video_mt, "_model", None) is None:
-                on_progress("loading", "Loading video embedding model…", 0, 0)
-                video_mt.load_models()
-
-            # Generate embeddings for videos
-            clips.clear()
-            clip_id = 1
-            total = len(video_files)
-            on_progress("embedding", f"Starting embedding for {total} video files...", 0, total)
-
-            for i, (video_path, meta) in enumerate(video_files):
-                on_progress(
-                    "embedding",
-                    f"Embedding {meta['category']}: {video_path.name} ({i + 1}/{total})",
-                    i + 1,
-                    total,
-                )
-
-                embedding = video_mt.embed_media(video_path)
-                if embedding is None:
-                    continue
-
-                with open(video_path, "rb") as f:
-                    video_bytes = f.read()
-
-                media_fields = video_mt.load_clip_data(video_path)
-
-                # Use the category-relative path (e.g. "Archery/v_Archery_g01_c01.avi")
-                # so that load_dataset_from_pickle can find the file under video_dir.
-                rel_filename = str(video_path.relative_to(video_dir))
-
-                clips[clip_id] = {
-                    "id": clip_id,
-                    "type": "video",
-                    "duration": media_fields["duration"],
-                    "file_size": len(video_bytes),
-                    "md5": hashlib.md5(video_bytes).hexdigest(),
-                    "embedding": embedding,
-                    "clip_bytes": video_bytes,
-                    "filename": rel_filename,
-                    "category": meta["category"],
-                    "origin": demo_origin,
-                    "origin_name": video_path.name,
-                }
-                clip_id += 1
-
-            # Save for future use
-            EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
-            with open(pkl_file, "wb") as f:
-                pickle.dump(
-                    {
-                        "name": dataset_name,
-                        "clips": {
-                            cid: {
-                                k: v.tolist() if isinstance(v, np.ndarray) else v
-                                for k, v in clip.items()
-                                if k != "clip_bytes"
-                            }
-                            for cid, clip in clips.items()
-                        },
-                        "video_dir": str(video_dir.absolute()),
-                    },
-                    f,
-                )
-
-            on_progress("idle", f"Loaded {dataset_name} dataset")
-            return
-
-        else:
-            raise ValueError(f"Unsupported video source: {video_source!r} for dataset {dataset_name!r}")
-
-    # Handle audio datasets (ESC-50 logic)
-    audio_source = dataset_info.get("source", "")
-    if audio_source and audio_source != "esc50":
-        raise ValueError(f"Unsupported audio source: {audio_source!r} for dataset {dataset_name!r}")
+    # Delegate to the media type's load_demo_source() method
     from vtsearch.media import get as media_get
 
-    audio_mt = media_get("audio")
+    mt = media_get(media_type_id)
 
-    audio_dir = download_esc50()
-    metadata = load_esc50_metadata(audio_dir.parent)
-
-    # Filter files for this dataset, applying per-category slicing
-    categories = DEMO_DATASETS[dataset_name]["categories"]
+    source = dataset_info.get("source", "")
+    categories = dataset_info["categories"]
     slice_start = dataset_info.get("slice_start", 0)
     slice_end = dataset_info.get("slice_end")
 
-    # Group files by category (sorted order within each)
-    by_cat: dict[str, list] = {}
-    for audio_path in sorted(audio_dir.glob("*.wav")):
-        if audio_path.name in metadata:
-            cat = metadata[audio_path.name]["category"]
-            if cat in categories:
-                by_cat.setdefault(cat, []).append((audio_path, metadata[audio_path.name]))
-
-    # Slice each category and flatten
-    audio_files = []
-    for cat in categories:
-        audio_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
-
-    # Eagerly load models before starting the embedding timer so that
-    # download / weight-loading time does not pollute the progress bar.
-    if getattr(audio_mt, "_model", None) is None:
-        on_progress("loading", "Loading audio embedding model…", 0, 0)
-        audio_mt.load_models()
-
-    # Generate embeddings
     clips.clear()
-    clip_id = 1
-    total = len(audio_files)
-    on_progress("embedding", f"Starting embedding for {total} audio files...", 0, total)
+    external_dir = mt.load_demo_source(
+        source=source,
+        categories=categories,
+        slice_start=slice_start,
+        slice_end=slice_end,
+        clips=clips,
+        on_progress=on_progress,
+    )
 
-    for i, (audio_path, meta) in enumerate(audio_files):
-        on_progress(
-            "embedding",
-            f"Embedding {meta['category']}: {audio_path.name} ({i + 1}/{total})",
-            i + 1,
-            total,
-        )
+    # Stamp the demo origin on all clips
+    demo_origin: dict[str, Any] = {"importer": "demo", "params": {"name": dataset_name}}
+    for clip in clips.values():
+        clip["origin"] = demo_origin
 
-        embedding = audio_mt.embed_media(audio_path)
-        if embedding is None:
-            continue
-
-        with open(audio_path, "rb") as f:
-            wav_bytes = f.read()
-
-        media_fields = audio_mt.load_clip_data(audio_path)
-
-        clips[clip_id] = {
-            "id": clip_id,
-            "type": "audio",
-            "duration": media_fields["duration"],
-            "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
-            "embedding": embedding,
-            "clip_bytes": wav_bytes,
-            "filename": audio_path.name,
-            "category": meta["category"],
-            "origin": demo_origin,
-            "origin_name": audio_path.name,
+    # Build the pickle cache payload
+    # For types with external media dirs (audio, video), exclude clip_bytes
+    # from the pickle and store the dir path so reloading can find the files.
+    if external_dir is not None:
+        pkl_data: dict[str, Any] = {
+            "name": dataset_name,
+            "clips": {
+                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items() if k != "clip_bytes"}
+                for cid, clip in clips.items()
+            },
+            mt.dir_key: external_dir,
         }
-        clip_id += 1
+    else:
+        pkl_data = {
+            "name": dataset_name,
+            "clips": {
+                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items()}
+                for cid, clip in clips.items()
+            },
+        }
 
-    # Save for future use
     EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
     with open(pkl_file, "wb") as f:
-        pickle.dump(
-            {
-                "name": dataset_name,
-                "clips": {
-                    cid: {
-                        k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in clip.items() if k != "clip_bytes"
-                    }
-                    for cid, clip in clips.items()
-                },
-                "audio_dir": str(audio_dir.absolute()),
-            },
-            f,
-        )
+        pickle.dump(pkl_data, f)
 
     on_progress("idle", f"Loaded {dataset_name} dataset")
 

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -61,6 +61,30 @@ def all_types() -> list["MediaType"]:
     return list(_registry.values())
 
 
+def get_by_extension(ext: str) -> "MediaType | None":
+    """Return the :class:`MediaType` that handles files with extension *ext*.
+
+    *ext* should include the leading dot (e.g. ``".wav"``).
+    Returns ``None`` if no registered type handles that extension.
+    """
+    ext = ext.lower()
+    for mt in _registry.values():
+        for pattern in mt.file_extensions:
+            # pattern looks like "*.wav" — extract the extension part
+            if ext == pattern.lstrip("*"):
+                return mt
+    return None
+
+
+def all_types_dict() -> list[dict]:
+    """Return a list of JSON-serialisable dicts describing all registered types.
+
+    Used by the ``/api/media-types`` endpoint so the frontend can render UI
+    elements dynamically.
+    """
+    return [mt.to_dict() for mt in _registry.values()]
+
+
 def all_demo_datasets() -> dict:
     """Return a flat ``{dataset_id: info_dict}`` mapping built from every
     registered media type's :attr:`~MediaType.demo_datasets` list.
@@ -79,6 +103,7 @@ def all_demo_datasets() -> dict:
                 "media_type": mt.type_id,
                 "slice_start": ds.slice_start,
                 "slice_end": ds.slice_end,
+                "download_size_mb": ds.download_size_mb,
             }
             if ds.source:
                 entry["source"] = ds.source
@@ -129,7 +154,9 @@ __all__ = [
     "register",
     "get",
     "get_by_folder_name",
+    "get_by_extension",
     "all_types",
+    "all_types_dict",
     "all_demo_datasets",
     "set_progress_callback",
 ]

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtsearch.config import CLAP_MODEL_ID, DATA_DIR, MODELS_CACHE_DIR, SAMPLE_RATE
+from vtsearch.config import CLAP_MODEL_ID, DATA_DIR, ESC50_DOWNLOAD_SIZE_MB, MODELS_CACHE_DIR, SAMPLE_RATE
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -62,6 +62,18 @@ class AudioMediaType(MediaType):
     @property
     def folder_import_name(self) -> str:
         return "sounds"
+
+    @property
+    def tab_title(self) -> str:
+        return "Sounds"
+
+    @property
+    def dir_key(self) -> str:
+        return "audio_dir"
+
+    @property
+    def legacy_bytes_keys(self) -> list[str]:
+        return ["wav_bytes"]
 
     # ------------------------------------------------------------------
     # Viewer
@@ -216,6 +228,7 @@ class AudioMediaType(MediaType):
                 required_folder=folder,
                 slice_start=0,
                 slice_end=7,
+                download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="esc50_m",
@@ -225,6 +238,7 @@ class AudioMediaType(MediaType):
                 required_folder=folder,
                 slice_start=7,
                 slice_end=20,
+                download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="esc50_l",
@@ -234,6 +248,7 @@ class AudioMediaType(MediaType):
                 required_folder=folder,
                 slice_start=20,
                 slice_end=40,
+                download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="gtzan_a",
@@ -243,6 +258,7 @@ class AudioMediaType(MediaType):
                 source="gtzan",
                 slice_start=0,
                 slice_end=100,
+                download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="speech_commands_v2_a",
@@ -252,6 +268,7 @@ class AudioMediaType(MediaType):
                 source="speech_commands_v2",
                 slice_start=0,
                 slice_end=3000,
+                download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="urbansound8k_a",
@@ -261,8 +278,85 @@ class AudioMediaType(MediaType):
                 source="urbansound8k",
                 slice_start=0,
                 slice_end=873,
+                download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
         ]
+
+    # ------------------------------------------------------------------
+    # Demo dataset loading
+    # ------------------------------------------------------------------
+
+    def load_demo_source(self, source, categories, slice_start, slice_end, clips, on_progress=None):
+        import hashlib  # noqa: PLC0415
+
+        from vtsearch.datasets.downloader import download_esc50  # noqa: PLC0415
+        from vtsearch.datasets.loader import load_esc50_metadata  # noqa: PLC0415
+
+        if on_progress is None:
+            from vtsearch.utils import update_progress
+
+            on_progress = update_progress
+
+        if source and source != "esc50":
+            raise ValueError(f"Unsupported audio source: {source!r}")
+
+        audio_dir = download_esc50(on_progress=on_progress)
+        metadata = load_esc50_metadata(audio_dir.parent)
+
+        # Group files by category (sorted order within each)
+        by_cat: dict[str, list] = {}
+        for audio_path in sorted(audio_dir.glob("*.wav")):
+            if audio_path.name in metadata:
+                cat = metadata[audio_path.name]["category"]
+                if cat in categories:
+                    by_cat.setdefault(cat, []).append((audio_path, metadata[audio_path.name]))
+
+        # Slice each category and flatten
+        audio_files = []
+        for cat in categories:
+            audio_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
+
+        # Load models
+        if getattr(self, "_model", None) is None:
+            on_progress("loading", "Loading audio embedding model…", 0, 0)
+            self.load_models()
+
+        clip_id = 1
+        total = len(audio_files)
+        on_progress("embedding", f"Starting embedding for {total} audio files...", 0, total)
+        demo_origin: dict = {"importer": "demo", "params": {}}
+
+        for i, (audio_path, meta) in enumerate(audio_files):
+            on_progress(
+                "embedding",
+                f"Embedding {meta['category']}: {audio_path.name} ({i + 1}/{total})",
+                i + 1,
+                total,
+            )
+            embedding = self.embed_media(audio_path)
+            if embedding is None:
+                continue
+
+            with open(audio_path, "rb") as f:
+                wav_bytes = f.read()
+
+            media_fields = self.load_clip_data(audio_path)
+            clips[clip_id] = {
+                "id": clip_id,
+                "type": self.type_id,
+                "duration": media_fields["duration"],
+                "file_size": len(wav_bytes),
+                "md5": hashlib.md5(wav_bytes).hexdigest(),
+                "embedding": embedding,
+                "clip_bytes": wav_bytes,
+                "filename": audio_path.name,
+                "category": meta["category"],
+                "origin": demo_origin,
+                "origin_name": audio_path.name,
+            }
+            clip_id += 1
+
+        return str(audio_dir.absolute())
 
     # ------------------------------------------------------------------
     # Embeddings
@@ -289,7 +383,9 @@ class AudioMediaType(MediaType):
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading CLAP model weights…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+            self._model = ClapModel.from_pretrained(
+                CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            )
         self._on_progress("loading", "Loading CLAP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
@@ -300,7 +396,6 @@ class AudioMediaType(MediaType):
         # the first embedding stalls inside the progress-bar loop and skews
         # the ETA estimate for all remaining items.
         self._on_progress("loading", "Warming up audio pipeline…", 0, 0)
-        import librosa  # noqa: PLC0415
         import torch  # noqa: PLC0415
 
         dummy_audio = np.zeros(SAMPLE_RATE, dtype=np.float32)

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -175,6 +175,13 @@ class DemoDataset:
 
     ``None`` means take all remaining elements after ``slice_start``."""
 
+    download_size_mb: float = 0
+    """Estimated download size in megabytes for this demo dataset's raw data.
+
+    Used by the frontend to display the expected download size before the
+    user starts loading.  Set to ``0`` for datasets that don't require a
+    network download (e.g. scikit-learn datasets that download automatically)."""
+
 
 class MediaType(ABC):
     """Abstract base class that every media type must implement.
@@ -234,6 +241,41 @@ class MediaType(ABC):
         plural name (e.g. ``"sounds"``, ``"videos"``).
         """
         return self.type_id
+
+    @property
+    def tab_title(self) -> str:
+        """Plural display name used for UI tabs (e.g. ``"Videos"``, ``"Sounds"``).
+
+        Defaults to :attr:`name` + ``"s"``.  Override for irregular plurals
+        or custom labels.
+        """
+        return self.name + "s"
+
+    @property
+    def dir_key(self) -> str:
+        """Key used in pickle files to store the external media directory path.
+
+        For example ``"audio_dir"``, ``"video_dir"``.  When a pickle file
+        contains this key, its value is a path to a directory where media
+        files for this type are stored externally.
+
+        Defaults to ``type_id + "_dir"``.  Override for legacy naming
+        (e.g. ``"text_dir"`` for the paragraph type).
+        """
+        return self.type_id + "_dir"
+
+    @property
+    def legacy_bytes_keys(self) -> list[str]:
+        """Legacy key names for inline bytes in old pickle files.
+
+        Old pickle formats stored media bytes under type-specific keys
+        (e.g. ``"wav_bytes"``, ``"video_bytes"``).  New pickles use the
+        generic ``"clip_bytes"`` / ``"clip_string"`` keys.  When loading
+        old pickles, these keys are tried in order as fallbacks.
+
+        Defaults to an empty list (no legacy keys).
+        """
+        return []
 
     # ------------------------------------------------------------------
     # Viewer behaviour
@@ -332,6 +374,45 @@ class MediaType(ABC):
         return avg
 
     # ------------------------------------------------------------------
+    # Demo dataset loading
+    # ------------------------------------------------------------------
+
+    def load_demo_source(
+        self,
+        source: str,
+        categories: list,
+        slice_start: int,
+        slice_end: int | None,
+        clips: dict[int, dict],
+        on_progress: "ProgressCallback | None" = None,
+    ) -> str | None:
+        """Download and embed a demo dataset source, populating *clips* in-place.
+
+        Each media type overrides this to handle its own demo sources (e.g.
+        the audio type handles ESC-50, the image type handles CIFAR-10 /
+        Caltech-101/256, etc.).
+
+        Args:
+            source: The ``source`` identifier from the :class:`DemoDataset`.
+            categories: List of category names to include.
+            slice_start: Per-category start index for element slicing.
+            slice_end: Per-category end index for element slicing (``None``
+                means take all remaining).
+            clips: Dict to populate in-place.  The caller has already cleared
+                it.  Keys should be sequential integer clip IDs starting at 1.
+            on_progress: Optional progress callback.
+
+        Returns:
+            An optional external media directory path (absolute string) to
+            embed in the pickle cache (e.g. ``"audio_dir"`` value).  Return
+            ``None`` when all media bytes are stored inline in the clips.
+
+        Raises:
+            ValueError: If *source* is not recognised by this media type.
+        """
+        raise ValueError(f"Media type {self.type_id!r} does not support demo source {source!r}")
+
+    # ------------------------------------------------------------------
     # Clip data
     # ------------------------------------------------------------------
 
@@ -392,6 +473,26 @@ class MediaType(ABC):
                 with open(path, "r", encoding="utf-8") as f:
                     return f.read().strip()
         return ""
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable summary of this media type's metadata.
+
+        Used by the ``/api/media-types`` endpoint to let the frontend render
+        media type UI dynamically without hardcoding.
+        """
+        return {
+            "type_id": self.type_id,
+            "name": self.name,
+            "icon": self.icon,
+            "tab_title": self.tab_title,
+            "folder_import_name": self.folder_import_name,
+            "loops": self.loops,
+            "file_extensions": self.file_extensions,
+        }
 
     @abstractmethod
     def clip_response(self, clip: dict) -> MediaResponse:

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtsearch.config import CLIP_MODEL_ID, MODELS_CACHE_DIR
+from vtsearch.config import (
+    CALTECH101_DOWNLOAD_SIZE_MB,
+    CALTECH256_DOWNLOAD_SIZE_MB,
+    CIFAR10_DOWNLOAD_SIZE_MB,
+    CLIP_MODEL_ID,
+    MODELS_CACHE_DIR,
+)
 
 if TYPE_CHECKING:
     import torch
@@ -93,6 +99,18 @@ class ImageMediaType(MediaType):
     def folder_import_name(self) -> str:
         return "images"
 
+    @property
+    def tab_title(self) -> str:
+        return "Images"
+
+    @property
+    def dir_key(self) -> str:
+        return "image_dir"
+
+    @property
+    def legacy_bytes_keys(self) -> list[str]:
+        return ["image_bytes"]
+
     # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
@@ -168,58 +186,213 @@ class ImageMediaType(MediaType):
 
     # Categories for Oxford Flowers 102 (102 flower species).
     _OXFORD_FLOWERS_CATEGORIES = [
-        "pink primrose", "hard-leaved pocket orchid", "canterbury bells",
-        "sweet pea", "english marigold", "tiger lily", "moon orchid",
-        "bird of paradise", "monkshood", "globe thistle", "snapdragon",
-        "colt's foot", "king protea", "spear thistle", "yellow iris",
-        "globe-flower", "purple coneflower", "peruvian lily", "balloon flower",
-        "giant white arum lily", "fire lily", "pincushion flower", "fritillary",
-        "red ginger", "grape hyacinth", "corn poppy", "prince of wales feathers",
-        "stemless gentian", "artichoke", "sweet william", "carnation",
-        "garden phlox", "love in the mist", "mexican aster", "alpine sea holly",
-        "ruby-lipped cattleya", "cape flower", "great masterwort", "siam tulip",
-        "lenten rose", "barbeton daisy", "daffodil", "sword lily", "poinsettia",
-        "bolero deep blue", "wallflower", "marigold", "buttercup", "oxeye daisy",
-        "common dandelion", "petunia", "wild pansy", "primula", "sunflower",
-        "pelargonium", "bishop of llandaff", "gaura", "geranium", "orange dahlia",
-        "pink-yellow dahlia", "cautleya spicata", "japanese anemone",
-        "black-eyed susan", "silverbush", "californian poppy", "osteospermum",
-        "spring crocus", "bearded iris", "windflower", "tree poppy", "gazania",
-        "azalea", "water lily", "rose", "thorn apple", "morning glory",
-        "passion flower", "lotus", "toad lily", "anthurium", "frangipani",
-        "clematis", "hibiscus", "columbine", "desert-rose", "tree mallow",
-        "magnolia", "cyclamen", "watercress", "canna lily", "hippeastrum",
-        "bee balm", "ball moss", "foxglove", "bougainvillea", "camellia",
-        "mallow", "mexican petunia", "bromelia", "blanket flower",
-        "trumpet creeper", "blackberry lily",
+        "pink primrose",
+        "hard-leaved pocket orchid",
+        "canterbury bells",
+        "sweet pea",
+        "english marigold",
+        "tiger lily",
+        "moon orchid",
+        "bird of paradise",
+        "monkshood",
+        "globe thistle",
+        "snapdragon",
+        "colt's foot",
+        "king protea",
+        "spear thistle",
+        "yellow iris",
+        "globe-flower",
+        "purple coneflower",
+        "peruvian lily",
+        "balloon flower",
+        "giant white arum lily",
+        "fire lily",
+        "pincushion flower",
+        "fritillary",
+        "red ginger",
+        "grape hyacinth",
+        "corn poppy",
+        "prince of wales feathers",
+        "stemless gentian",
+        "artichoke",
+        "sweet william",
+        "carnation",
+        "garden phlox",
+        "love in the mist",
+        "mexican aster",
+        "alpine sea holly",
+        "ruby-lipped cattleya",
+        "cape flower",
+        "great masterwort",
+        "siam tulip",
+        "lenten rose",
+        "barbeton daisy",
+        "daffodil",
+        "sword lily",
+        "poinsettia",
+        "bolero deep blue",
+        "wallflower",
+        "marigold",
+        "buttercup",
+        "oxeye daisy",
+        "common dandelion",
+        "petunia",
+        "wild pansy",
+        "primula",
+        "sunflower",
+        "pelargonium",
+        "bishop of llandaff",
+        "gaura",
+        "geranium",
+        "orange dahlia",
+        "pink-yellow dahlia",
+        "cautleya spicata",
+        "japanese anemone",
+        "black-eyed susan",
+        "silverbush",
+        "californian poppy",
+        "osteospermum",
+        "spring crocus",
+        "bearded iris",
+        "windflower",
+        "tree poppy",
+        "gazania",
+        "azalea",
+        "water lily",
+        "rose",
+        "thorn apple",
+        "morning glory",
+        "passion flower",
+        "lotus",
+        "toad lily",
+        "anthurium",
+        "frangipani",
+        "clematis",
+        "hibiscus",
+        "columbine",
+        "desert-rose",
+        "tree mallow",
+        "magnolia",
+        "cyclamen",
+        "watercress",
+        "canna lily",
+        "hippeastrum",
+        "bee balm",
+        "ball moss",
+        "foxglove",
+        "bougainvillea",
+        "camellia",
+        "mallow",
+        "mexican petunia",
+        "bromelia",
+        "blanket flower",
+        "trumpet creeper",
+        "blackberry lily",
     ]
 
     # Categories for Food-101 (101 food categories).
     _FOOD101_CATEGORIES = [
-        "apple_pie", "baby_back_ribs", "baklava", "beef_carpaccio",
-        "beef_tartare", "beet_salad", "beignets", "bibimbap", "bread_pudding",
-        "breakfast_burrito", "bruschetta", "caesar_salad", "cannoli",
-        "caprese_salad", "carrot_cake", "ceviche", "cheesecake",
-        "cheese_plate", "chicken_curry", "chicken_quesadilla", "chicken_wings",
-        "chocolate_cake", "chocolate_mousse", "churros", "clam_chowder",
-        "club_sandwich", "crab_cakes", "creme_brulee", "croque_madame",
-        "cup_cakes", "deviled_eggs", "donuts", "dumplings", "edamame",
-        "eggs_benedict", "escargots", "falafel", "filet_mignon",
-        "fish_and_chips", "foie_gras", "french_fries", "french_onion_soup",
-        "french_toast", "fried_calamari", "fried_rice", "frozen_yogurt",
-        "garlic_bread", "gnocchi", "greek_salad", "grilled_cheese_sandwich",
-        "grilled_salmon", "guacamole", "gyoza", "hamburger", "hot_and_sour_soup",
-        "hot_dog", "huevos_rancheros", "hummus", "ice_cream", "lasagna",
-        "lobster_bisque", "lobster_roll_sandwich", "macaroni_and_cheese",
-        "macarons", "miso_soup", "mussels", "nachos", "omelette",
-        "onion_rings", "oysters", "pad_thai", "paella", "pancakes",
-        "panna_cotta", "peking_duck", "pho", "pizza", "pork_chop",
-        "poutine", "prime_rib", "pulled_pork_sandwich", "ramen",
-        "ravioli", "red_velvet_cake", "risotto", "samosa",
-        "sashimi", "scallops", "seaweed_salad", "shrimp_and_grits",
-        "spaghetti_bolognese", "spaghetti_carbonara", "spring_rolls",
-        "steak", "strawberry_shortcake", "sushi", "tacos", "takoyaki",
-        "tiramisu", "tuna_tartare", "waffles",
+        "apple_pie",
+        "baby_back_ribs",
+        "baklava",
+        "beef_carpaccio",
+        "beef_tartare",
+        "beet_salad",
+        "beignets",
+        "bibimbap",
+        "bread_pudding",
+        "breakfast_burrito",
+        "bruschetta",
+        "caesar_salad",
+        "cannoli",
+        "caprese_salad",
+        "carrot_cake",
+        "ceviche",
+        "cheesecake",
+        "cheese_plate",
+        "chicken_curry",
+        "chicken_quesadilla",
+        "chicken_wings",
+        "chocolate_cake",
+        "chocolate_mousse",
+        "churros",
+        "clam_chowder",
+        "club_sandwich",
+        "crab_cakes",
+        "creme_brulee",
+        "croque_madame",
+        "cup_cakes",
+        "deviled_eggs",
+        "donuts",
+        "dumplings",
+        "edamame",
+        "eggs_benedict",
+        "escargots",
+        "falafel",
+        "filet_mignon",
+        "fish_and_chips",
+        "foie_gras",
+        "french_fries",
+        "french_onion_soup",
+        "french_toast",
+        "fried_calamari",
+        "fried_rice",
+        "frozen_yogurt",
+        "garlic_bread",
+        "gnocchi",
+        "greek_salad",
+        "grilled_cheese_sandwich",
+        "grilled_salmon",
+        "guacamole",
+        "gyoza",
+        "hamburger",
+        "hot_and_sour_soup",
+        "hot_dog",
+        "huevos_rancheros",
+        "hummus",
+        "ice_cream",
+        "lasagna",
+        "lobster_bisque",
+        "lobster_roll_sandwich",
+        "macaroni_and_cheese",
+        "macarons",
+        "miso_soup",
+        "mussels",
+        "nachos",
+        "omelette",
+        "onion_rings",
+        "oysters",
+        "pad_thai",
+        "paella",
+        "pancakes",
+        "panna_cotta",
+        "peking_duck",
+        "pho",
+        "pizza",
+        "pork_chop",
+        "poutine",
+        "prime_rib",
+        "pulled_pork_sandwich",
+        "ramen",
+        "ravioli",
+        "red_velvet_cake",
+        "risotto",
+        "samosa",
+        "sashimi",
+        "scallops",
+        "seaweed_salad",
+        "shrimp_and_grits",
+        "spaghetti_bolognese",
+        "spaghetti_carbonara",
+        "spring_rolls",
+        "steak",
+        "strawberry_shortcake",
+        "sushi",
+        "tacos",
+        "takoyaki",
+        "tiramisu",
+        "tuna_tartare",
+        "waffles",
     ]
 
     # Categories for EuroSAT (10 land use classes).
@@ -238,39 +411,126 @@ class ImageMediaType(MediaType):
 
     # Categories for Stanford Dogs (120 breeds).
     _STANFORD_DOGS_CATEGORIES = [
-        "Chihuahua", "Japanese_spaniel", "Maltese_dog", "Pekinese", "Shih-Tzu",
-        "Blenheim_spaniel", "papillon", "toy_terrier", "Rhodesian_ridgeback",
-        "Afghan_hound", "basset", "beagle", "bloodhound", "bluetick",
-        "black-and-tan_coonhound", "Walker_hound", "English_foxhound",
-        "redbone", "borzoi", "Irish_wolfhound", "Italian_greyhound",
-        "whippet", "Ibizan_hound", "Norwegian_elkhound", "otterhound",
-        "Saluki", "Scottish_deerhound", "Weimaraner", "Staffordshire_bullterrier",
-        "American_Staffordshire_terrier", "Bedlington_terrier", "Border_terrier",
-        "Kerry_blue_terrier", "Irish_terrier", "Norfolk_terrier",
-        "Norwich_terrier", "Yorkshire_terrier", "wire-haired_fox_terrier",
-        "Lakeland_terrier", "Sealyham_terrier", "Airedale", "cairn",
-        "Australian_terrier", "Dandie_Dinmont", "Boston_bull", "miniature_schnauzer",
-        "giant_schnauzer", "standard_schnauzer", "Scotch_terrier",
-        "Tibetan_terrier", "silky_terrier", "soft-coated_wheaten_terrier",
-        "West_Highland_white_terrier", "Lhasa", "flat-coated_retriever",
-        "curly-coated_retriever", "golden_retriever", "Labrador_retriever",
-        "Chesapeake_Bay_retriever", "German_short-haired_pointer", "vizsla",
-        "English_setter", "Irish_setter", "Gordon_setter", "Brittany_spaniel",
-        "clumber", "English_springer", "Welsh_springer_spaniel",
-        "cocker_spaniel", "Sussex_spaniel", "Irish_water_spaniel", "kuvasz",
-        "schipperke", "groenendael", "malinois", "briard", "kelpie",
-        "komondor", "Old_English_sheepdog", "Shetland_sheepdog", "collie",
-        "Border_collie", "Bouvier_des_Flandres", "Rottweiler",
-        "German_shepherd", "Doberman", "miniature_pinscher",
-        "Greater_Swiss_Mountain_dog", "Bernese_mountain_dog",
-        "Appenzeller", "EntleBucher", "boxer", "bull_mastiff",
-        "Tibetan_mastiff", "French_bulldog", "Great_Dane",
-        "Saint_Bernard", "Eskimo_dog", "malamute", "Siberian_husky",
-        "affenpinscher", "basenji", "pug", "Leonberg", "Newfoundland",
-        "Great_Pyrenees", "Samoyed", "Pomeranian", "chow",
-        "keeshond", "Brabancon_griffon", "Pembroke", "Cardigan",
-        "toy_poodle", "miniature_poodle", "standard_poodle",
-        "Mexican_hairless", "dingo", "dhole", "African_hunting_dog",
+        "Chihuahua",
+        "Japanese_spaniel",
+        "Maltese_dog",
+        "Pekinese",
+        "Shih-Tzu",
+        "Blenheim_spaniel",
+        "papillon",
+        "toy_terrier",
+        "Rhodesian_ridgeback",
+        "Afghan_hound",
+        "basset",
+        "beagle",
+        "bloodhound",
+        "bluetick",
+        "black-and-tan_coonhound",
+        "Walker_hound",
+        "English_foxhound",
+        "redbone",
+        "borzoi",
+        "Irish_wolfhound",
+        "Italian_greyhound",
+        "whippet",
+        "Ibizan_hound",
+        "Norwegian_elkhound",
+        "otterhound",
+        "Saluki",
+        "Scottish_deerhound",
+        "Weimaraner",
+        "Staffordshire_bullterrier",
+        "American_Staffordshire_terrier",
+        "Bedlington_terrier",
+        "Border_terrier",
+        "Kerry_blue_terrier",
+        "Irish_terrier",
+        "Norfolk_terrier",
+        "Norwich_terrier",
+        "Yorkshire_terrier",
+        "wire-haired_fox_terrier",
+        "Lakeland_terrier",
+        "Sealyham_terrier",
+        "Airedale",
+        "cairn",
+        "Australian_terrier",
+        "Dandie_Dinmont",
+        "Boston_bull",
+        "miniature_schnauzer",
+        "giant_schnauzer",
+        "standard_schnauzer",
+        "Scotch_terrier",
+        "Tibetan_terrier",
+        "silky_terrier",
+        "soft-coated_wheaten_terrier",
+        "West_Highland_white_terrier",
+        "Lhasa",
+        "flat-coated_retriever",
+        "curly-coated_retriever",
+        "golden_retriever",
+        "Labrador_retriever",
+        "Chesapeake_Bay_retriever",
+        "German_short-haired_pointer",
+        "vizsla",
+        "English_setter",
+        "Irish_setter",
+        "Gordon_setter",
+        "Brittany_spaniel",
+        "clumber",
+        "English_springer",
+        "Welsh_springer_spaniel",
+        "cocker_spaniel",
+        "Sussex_spaniel",
+        "Irish_water_spaniel",
+        "kuvasz",
+        "schipperke",
+        "groenendael",
+        "malinois",
+        "briard",
+        "kelpie",
+        "komondor",
+        "Old_English_sheepdog",
+        "Shetland_sheepdog",
+        "collie",
+        "Border_collie",
+        "Bouvier_des_Flandres",
+        "Rottweiler",
+        "German_shepherd",
+        "Doberman",
+        "miniature_pinscher",
+        "Greater_Swiss_Mountain_dog",
+        "Bernese_mountain_dog",
+        "Appenzeller",
+        "EntleBucher",
+        "boxer",
+        "bull_mastiff",
+        "Tibetan_mastiff",
+        "French_bulldog",
+        "Great_Dane",
+        "Saint_Bernard",
+        "Eskimo_dog",
+        "malamute",
+        "Siberian_husky",
+        "affenpinscher",
+        "basenji",
+        "pug",
+        "Leonberg",
+        "Newfoundland",
+        "Great_Pyrenees",
+        "Samoyed",
+        "Pomeranian",
+        "chow",
+        "keeshond",
+        "Brabancon_griffon",
+        "Pembroke",
+        "Cardigan",
+        "toy_poodle",
+        "miniature_poodle",
+        "standard_poodle",
+        "Mexican_hairless",
+        "dingo",
+        "dhole",
+        "African_hunting_dog",
     ]
 
     @property
@@ -286,6 +546,7 @@ class ImageMediaType(MediaType):
                 source="caltech101",
                 slice_start=0,
                 slice_end=20,
+                download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="caltech101_m",
@@ -295,6 +556,7 @@ class ImageMediaType(MediaType):
                 source="caltech101",
                 slice_start=20,
                 slice_end=60,
+                download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="caltech256_l",
@@ -304,6 +566,7 @@ class ImageMediaType(MediaType):
                 source="caltech256",
                 slice_start=0,
                 slice_end=80,
+                download_size_mb=CALTECH256_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="oxford_flowers_102_a",
@@ -313,6 +576,7 @@ class ImageMediaType(MediaType):
                 source="oxford_flowers_102",
                 slice_start=0,
                 slice_end=80,
+                download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="food101_a",
@@ -322,6 +586,7 @@ class ImageMediaType(MediaType):
                 source="food101",
                 slice_start=0,
                 slice_end=1000,
+                download_size_mb=CIFAR10_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="eurosat_a",
@@ -331,6 +596,7 @@ class ImageMediaType(MediaType):
                 source="eurosat",
                 slice_start=0,
                 slice_end=2700,
+                download_size_mb=CIFAR10_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="stanford_dogs_a",
@@ -340,8 +606,148 @@ class ImageMediaType(MediaType):
                 source="stanford_dogs",
                 slice_start=0,
                 slice_end=171,
+                download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
             ),
         ]
+
+    # ------------------------------------------------------------------
+    # Demo dataset loading
+    # ------------------------------------------------------------------
+
+    def load_demo_source(self, source, categories, slice_start, slice_end, clips, on_progress=None):
+        import hashlib  # noqa: PLC0415
+        import io as _io  # noqa: PLC0415
+
+        from PIL import Image  # noqa: PLC0415
+
+        if on_progress is None:
+            from vtsearch.utils import update_progress
+
+            on_progress = update_progress
+
+        from vtsearch.datasets.loader import load_image_metadata_from_folders  # noqa: PLC0415
+
+        demo_origin: dict = {"importer": "demo", "params": {}}
+
+        if source in ("caltech101", "caltech256"):
+            if source == "caltech101":
+                from vtsearch.datasets.downloader import download_caltech101  # noqa: PLC0415
+
+                img_dir = download_caltech101(on_progress=on_progress)
+            else:
+                from vtsearch.datasets.downloader import download_caltech256  # noqa: PLC0415
+
+                img_dir = download_caltech256(on_progress=on_progress)
+
+            metadata = load_image_metadata_from_folders(img_dir, categories)
+            by_cat: dict[str, list[tuple[Path, str]]] = {}
+            for fname, meta in sorted(metadata.items()):
+                cat = meta["category"]
+                by_cat.setdefault(cat, []).append((meta["path"], cat))
+
+            selected: list[tuple[Path, str]] = []
+            for cat in categories:
+                selected.extend(by_cat.get(cat, [])[slice_start:slice_end])
+
+            if getattr(self, "_model", None) is None:
+                on_progress("loading", "Loading image embedding model…", 0, 0)
+                self.load_models()
+
+            clip_id = 1
+            total = len(selected)
+            on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+
+            for i, (img_path, category) in enumerate(selected):
+                on_progress("embedding", f"Embedding {category}: {img_path.name} ({i + 1}/{total})", i + 1, total)
+                embedding = self.embed_media(img_path)
+                if embedding is None:
+                    continue
+                with open(img_path, "rb") as f:
+                    image_bytes = f.read()
+                try:
+                    img = Image.open(img_path)
+                    width, height = img.width, img.height
+                except Exception:
+                    width, height = None, None
+                clips[clip_id] = {
+                    "id": clip_id,
+                    "type": self.type_id,
+                    "duration": 0,
+                    "file_size": len(image_bytes),
+                    "md5": hashlib.md5(image_bytes).hexdigest(),
+                    "embedding": embedding,
+                    "clip_bytes": image_bytes,
+                    "clip_string": None,
+                    "filename": img_path.name,
+                    "category": category,
+                    "width": width,
+                    "height": height,
+                    "origin": demo_origin,
+                    "origin_name": img_path.name,
+                }
+                clip_id += 1
+            return None  # bytes are inline
+
+        elif source == "cifar10_sample" or not source:
+            from vtsearch.datasets.downloader import download_cifar10  # noqa: PLC0415
+            from vtsearch.datasets.loader import load_cifar10_batch  # noqa: PLC0415
+
+            cifar_dir = download_cifar10(on_progress=on_progress)
+            batch_file = cifar_dir / "data_batch_1"
+            images, labels, label_names = load_cifar10_batch(batch_file)
+            category_indices = {label_names[i]: i for i in range(len(label_names))}
+
+            selected_images = []
+            selected_labels = []
+            for cat in categories:
+                if cat in category_indices:
+                    cat_idx = category_indices[cat]
+                    cat_mask = [i for i, lbl in enumerate(labels) if lbl == cat_idx]
+                    for idx in cat_mask[slice_start : (slice_end or len(cat_mask))]:
+                        selected_images.append(images[idx])
+                        selected_labels.append(cat)
+
+            if getattr(self, "_model", None) is None:
+                on_progress("loading", "Loading image embedding model…", 0, 0)
+                self.load_models()
+
+            clip_id = 1
+            total = len(selected_images)
+            on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+
+            from vtsearch.datasets.loader import embed_image_file_from_pil  # noqa: PLC0415
+
+            for i, (image_array, category) in enumerate(zip(selected_images, selected_labels)):
+                on_progress("embedding", f"Embedding {category}: image {i + 1}/{total}", i + 1, total)
+                img = Image.fromarray(image_array.astype("uint8"), "RGB")
+                img_buffer = _io.BytesIO()
+                img.save(img_buffer, format="PNG")
+                image_bytes = img_buffer.getvalue()
+                embedding = embed_image_file_from_pil(img)
+                if embedding is None:
+                    continue
+                fname = f"{category}_{clip_id}.png"
+                clips[clip_id] = {
+                    "id": clip_id,
+                    "type": self.type_id,
+                    "duration": 0,
+                    "file_size": len(image_bytes),
+                    "md5": hashlib.md5(image_bytes).hexdigest(),
+                    "embedding": embedding,
+                    "clip_bytes": image_bytes,
+                    "clip_string": None,
+                    "filename": fname,
+                    "category": category,
+                    "width": img.width,
+                    "height": img.height,
+                    "origin": demo_origin,
+                    "origin_name": fname,
+                }
+                clip_id += 1
+            return None  # bytes are inline
+
+        else:
+            raise ValueError(f"Unsupported image source: {source!r}")
 
     # ------------------------------------------------------------------
     # Embeddings
@@ -374,10 +780,14 @@ class ImageMediaType(MediaType):
         # versions compute on-the-fly.  Tell the loader to silently ignore them.
         CLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         with intercept_tqdm_progress(self._on_progress):
-            self._model = CLIPModel.from_pretrained(CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+            self._model = CLIPModel.from_pretrained(
+                CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            )
         self._on_progress("loading", "Loading CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = CLIPProcessor.from_pretrained(CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False)
+            self._processor = CLIPProcessor.from_pretrained(
+                CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False
+            )
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -64,6 +64,18 @@ class TextMediaType(MediaType):
     def folder_import_name(self) -> str:
         return "paragraphs"
 
+    @property
+    def tab_title(self) -> str:
+        return "Texts"
+
+    @property
+    def dir_key(self) -> str:
+        return "text_dir"
+
+    @property
+    def legacy_bytes_keys(self) -> list[str]:
+        return ["text_content"]
+
     # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
@@ -132,6 +144,7 @@ class TextMediaType(MediaType):
                 source="ag_news_sample",
                 slice_start=0,
                 slice_end=25,
+                download_size_mb=15,
             ),
             DemoDataset(
                 id="20newsgroups_m",
@@ -141,6 +154,7 @@ class TextMediaType(MediaType):
                 source="ag_news_sample",
                 slice_start=25,
                 slice_end=75,
+                download_size_mb=15,
             ),
             DemoDataset(
                 id="20newsgroups_l",
@@ -150,6 +164,7 @@ class TextMediaType(MediaType):
                 source="ag_news_sample",
                 slice_start=75,
                 slice_end=200,
+                download_size_mb=15,
             ),
             DemoDataset(
                 id="ag_news_a",
@@ -159,6 +174,7 @@ class TextMediaType(MediaType):
                 source="ag_news",
                 slice_start=0,
                 slice_end=30000,
+                download_size_mb=15,
             ),
             DemoDataset(
                 id="bbc_news_a",
@@ -168,6 +184,7 @@ class TextMediaType(MediaType):
                 source="bbc_news",
                 slice_start=0,
                 slice_end=445,
+                download_size_mb=15,
             ),
             DemoDataset(
                 id="imdb_a",
@@ -177,8 +194,83 @@ class TextMediaType(MediaType):
                 source="imdb",
                 slice_start=0,
                 slice_end=25000,
+                download_size_mb=15,
             ),
         ]
+
+    # ------------------------------------------------------------------
+    # Demo dataset loading
+    # ------------------------------------------------------------------
+
+    def load_demo_source(self, source, categories, slice_start, slice_end, clips, on_progress=None):
+        import hashlib  # noqa: PLC0415
+
+        if on_progress is None:
+            from vtsearch.utils import update_progress
+
+            on_progress = update_progress
+
+        if source != "ag_news_sample":
+            raise ValueError(f"Unsupported text source: {source!r}")
+
+        from vtsearch.datasets.downloader import download_20newsgroups  # noqa: PLC0415
+
+        texts, labels, category_names = download_20newsgroups(categories, on_progress=on_progress)
+
+        selected_texts = []
+        selected_categories = []
+        for cat_name in categories:
+            if cat_name in category_names:
+                cat_idx = category_names.index(cat_name)
+                cat_texts = [texts[i] for i, lbl in enumerate(labels) if lbl == cat_idx]
+                for text in cat_texts[slice_start : (slice_end or len(cat_texts))]:
+                    selected_texts.append(text)
+                    selected_categories.append(cat_name)
+
+        if getattr(self, "_model", None) is None:
+            on_progress("loading", "Loading text embedding model…", 0, 0)
+            self.load_models()
+
+        clip_id = 1
+        total = len(selected_texts)
+        on_progress("embedding", f"Starting embedding for {total} paragraphs...", 0, total)
+        demo_origin: dict = {"importer": "demo", "params": {}}
+
+        for i, (text_content, category) in enumerate(zip(selected_texts, selected_categories)):
+            on_progress("embedding", f"Embedding {category}: paragraph {i + 1}/{total}", i + 1, total)
+            text_content = text_content[:1000].strip()
+            if not text_content:
+                continue
+            try:
+                embedding = self.embed_text_passage(text_content)
+            except Exception as e:
+                print(f"Error embedding paragraph: {e}")
+                continue
+            if embedding is None:
+                continue
+            word_count = len(text_content.split())
+            character_count = len(text_content)
+            text_bytes = text_content.encode("utf-8")
+            fname = f"{category}_{clip_id}.txt"
+            clips[clip_id] = {
+                "id": clip_id,
+                "type": self.type_id,
+                "duration": 0,
+                "file_size": len(text_bytes),
+                "md5": hashlib.md5(text_bytes).hexdigest(),
+                "embedding": embedding,
+                "clip_bytes": None,
+                "clip_string": text_content,
+                "filename": fname,
+                "category": category,
+                "word_count": word_count,
+                "character_count": character_count,
+                "origin": demo_origin,
+                "origin_name": fname,
+            }
+            clip_id += 1
+
+        return None  # text content is inline
 
     # ------------------------------------------------------------------
     # Embeddings

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtsearch.config import MODELS_CACHE_DIR, VIDEO_DIR, XCLIP_MODEL_ID
+from vtsearch.config import MODELS_CACHE_DIR, UCF101_SUBSET_DOWNLOAD_SIZE_MB, VIDEO_DIR, XCLIP_MODEL_ID
 
 if TYPE_CHECKING:
     import torch
@@ -90,6 +90,18 @@ class VideoMediaType(MediaType):
     def folder_import_name(self) -> str:
         return "videos"
 
+    @property
+    def tab_title(self) -> str:
+        return "Videos"
+
+    @property
+    def dir_key(self) -> str:
+        return "video_dir"
+
+    @property
+    def legacy_bytes_keys(self) -> list[str]:
+        return ["video_bytes"]
+
     # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
@@ -132,6 +144,7 @@ class VideoMediaType(MediaType):
                 required_folder=folder,
                 slice_start=0,
                 slice_end=15,
+                download_size_mb=UCF101_SUBSET_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="ucf101_m",
@@ -142,6 +155,7 @@ class VideoMediaType(MediaType):
                 required_folder=folder,
                 slice_start=15,
                 slice_end=40,
+                download_size_mb=UCF101_SUBSET_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="ucf101_l",
@@ -152,8 +166,79 @@ class VideoMediaType(MediaType):
                 required_folder=folder,
                 slice_start=40,
                 slice_end=150,
+                download_size_mb=UCF101_SUBSET_DOWNLOAD_SIZE_MB,
             ),
         ]
+
+    # ------------------------------------------------------------------
+    # Demo dataset loading
+    # ------------------------------------------------------------------
+
+    def load_demo_source(self, source, categories, slice_start, slice_end, clips, on_progress=None):
+        import hashlib  # noqa: PLC0415
+
+        if on_progress is None:
+            from vtsearch.utils import update_progress
+
+            on_progress = update_progress
+
+        if source != "ucf101":
+            raise ValueError(f"Unsupported video source: {source!r}")
+
+        from vtsearch.datasets.downloader import download_ucf101_subset  # noqa: PLC0415
+        from vtsearch.datasets.loader import load_video_metadata_from_folders  # noqa: PLC0415
+
+        video_dir = download_ucf101_subset(on_progress=on_progress)
+        metadata = load_video_metadata_from_folders(video_dir, categories)
+
+        by_cat: dict[str, list] = {}
+        for fname, meta in sorted(metadata.items()):
+            cat = meta["category"]
+            by_cat.setdefault(cat, []).append((meta["path"], meta))
+
+        video_files: list[tuple] = []
+        for cat in categories:
+            video_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
+
+        if getattr(self, "_model", None) is None:
+            on_progress("loading", "Loading video embedding model…", 0, 0)
+            self.load_models()
+
+        clip_id = 1
+        total = len(video_files)
+        on_progress("embedding", f"Starting embedding for {total} video files...", 0, total)
+        demo_origin: dict = {"importer": "demo", "params": {}}
+
+        for i, (video_path, meta) in enumerate(video_files):
+            on_progress(
+                "embedding",
+                f"Embedding {meta['category']}: {video_path.name} ({i + 1}/{total})",
+                i + 1,
+                total,
+            )
+            embedding = self.embed_media(video_path)
+            if embedding is None:
+                continue
+            with open(video_path, "rb") as f:
+                video_bytes = f.read()
+            media_fields = self.load_clip_data(video_path)
+            rel_filename = str(video_path.relative_to(video_dir))
+            clips[clip_id] = {
+                "id": clip_id,
+                "type": self.type_id,
+                "duration": media_fields["duration"],
+                "file_size": len(video_bytes),
+                "md5": hashlib.md5(video_bytes).hexdigest(),
+                "embedding": embedding,
+                "clip_bytes": video_bytes,
+                "filename": rel_filename,
+                "category": meta["category"],
+                "origin": demo_origin,
+                "origin_name": video_path.name,
+            }
+            clip_id += 1
+
+        return str(video_dir.absolute())
 
     # ------------------------------------------------------------------
     # Embeddings
@@ -180,10 +265,14 @@ class VideoMediaType(MediaType):
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading X-CLIP model weights…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._model = XCLIPModel.from_pretrained(XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False)
+            self._model = XCLIPModel.from_pretrained(
+                XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            )
         self._on_progress("loading", "Loading X-CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = XCLIPProcessor.from_pretrained(XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False)
+            self._processor = XCLIPProcessor.from_pretrained(
+                XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False
+            )
 
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -6,20 +6,7 @@ from pathlib import Path
 
 from flask import Blueprint, jsonify, request, send_file
 
-from vtsearch.config import (
-    CALTECH101_DOWNLOAD_SIZE_MB,
-    CALTECH256_DOWNLOAD_SIZE_MB,
-    CIFAR10_DOWNLOAD_SIZE_MB,
-    CLIPS_PER_CATEGORY,
-    CLIPS_PER_VIDEO_CATEGORY,
-    EMBEDDINGS_DIR,
-    ESC50_DOWNLOAD_SIZE_MB,
-    IMAGES_PER_CALTECH101_CATEGORY,
-    IMAGES_PER_CALTECH256_CATEGORY,
-    IMAGES_PER_CIFAR10_CATEGORY,
-    TEXTS_PER_CATEGORY,
-    UCF101_SUBSET_DOWNLOAD_SIZE_MB,
-)
+from vtsearch.config import EMBEDDINGS_DIR
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers, load_demo_dataset
 from vtsearch.utils import (
     bad_votes,
@@ -28,7 +15,6 @@ from vtsearch.utils import (
     clips,
     get_progress,
     good_votes,
-    label_history,
     update_progress,
 )
 
@@ -38,6 +24,36 @@ datasets_bp = Blueprint("datasets", __name__)
 # frontend.  They are excluded from the generic /api/dataset/importers list
 # so the frontend doesn't render a duplicate panel for them.
 _BUILTIN_IMPORTER_NAMES = {"pickle", "combine_datasets"}
+
+
+@datasets_bp.route("/api/media-types")
+def media_types_list():
+    """Return all registered media types with their metadata.
+
+    The frontend uses this endpoint to render media type UI dynamically
+    (icons, tab titles, clip rendering modes, etc.) instead of hardcoding
+    the available media types.
+
+    Returns a JSON object::
+
+        {
+          "media_types": [
+            {
+              "type_id": "audio",
+              "name": "Audio",
+              "icon": "🔊",
+              "tab_title": "Sounds",
+              "folder_import_name": "sounds",
+              "loops": true,
+              "file_extensions": ["*.wav", "*.mp3", ...]
+            },
+            ...
+          ]
+        }
+    """
+    from vtsearch.media import all_types_dict
+
+    return jsonify({"media_types": all_types_dict()})
 
 
 def _load_embedder_for_clips() -> None:
@@ -294,12 +310,22 @@ def demo_dataset_list():
     * ``"needs_embedding"`` – source data is downloaded but not yet embedded.
     * ``"needs_download"`` – source data must be downloaded (and then embedded).
     """
+    # Only include demo datasets whose media type is currently registered.
+    from vtsearch.media import get as media_get
+
     demos = []
     for name, dataset_info in DEMO_DATASETS.items():
+        media_type = dataset_info.get("media_type", "audio")
+
+        # Skip datasets whose media type is not loaded into VTSearch.
+        try:
+            media_get(media_type)
+        except KeyError:
+            continue
+
         pkl_file = EMBEDDINGS_DIR / f"{name}.pkl"
         has_pkl = pkl_file.exists()
 
-        media_type = dataset_info.get("media_type", "audio")
         required_folder = dataset_info.get("required_folder")
         has_source = _folder_has_content(required_folder)
 
@@ -316,51 +342,24 @@ def demo_dataset_list():
             else:
                 status = "needs_download"
 
-        # Calculate number of files
+        # Calculate number of files from slice parameters
         num_categories = len(dataset_info["categories"])
-        image_source = dataset_info.get("source", "")
         slice_start = dataset_info.get("slice_start", 0)
         slice_end = dataset_info.get("slice_end")
-
-        if media_type == "video":
-            per_cat = CLIPS_PER_VIDEO_CATEGORY
-        elif media_type == "image":
-            if image_source == "caltech101":
-                per_cat = IMAGES_PER_CALTECH101_CATEGORY
-            elif image_source == "caltech256":
-                per_cat = IMAGES_PER_CALTECH256_CATEGORY
-            else:
-                per_cat = IMAGES_PER_CIFAR10_CATEGORY
-        elif media_type == "paragraph":
-            per_cat = TEXTS_PER_CATEGORY
-        else:
-            per_cat = CLIPS_PER_CATEGORY
-
-        # Use slice parameters when set; otherwise fall back to the default per-category count.
         if slice_end is not None:
             per_cat = slice_end - slice_start
+        else:
+            per_cat = 40  # generic fallback
         num_files = num_categories * per_cat
 
-        # Calculate download size
+        # Calculate download size from the DemoDataset metadata
         if status == "ready":
             download_size_mb = pkl_file.stat().st_size / (1024 * 1024)
         elif status == "needs_embedding":
             download_size_mb = 0
         else:
-            # needs_download – estimate total download
-            if media_type == "video":
-                download_size_mb = UCF101_SUBSET_DOWNLOAD_SIZE_MB
-            elif media_type == "image":
-                if image_source == "caltech101":
-                    download_size_mb = CALTECH101_DOWNLOAD_SIZE_MB
-                elif image_source == "caltech256":
-                    download_size_mb = CALTECH256_DOWNLOAD_SIZE_MB
-                else:
-                    download_size_mb = CIFAR10_DOWNLOAD_SIZE_MB
-            elif media_type == "paragraph":
-                download_size_mb = 15  # scikit-learn downloads automatically
-            else:
-                download_size_mb = ESC50_DOWNLOAD_SIZE_MB
+            # Use the download_size_mb from DemoDataset metadata
+            download_size_mb = dataset_info.get("download_size_mb", 0)
 
         demos.append(
             {
@@ -371,7 +370,7 @@ def demo_dataset_list():
                 "num_files": num_files,
                 "download_size_mb": round(download_size_mb, 1),
                 "description": dataset_info.get("description", ""),
-                "media_type": dataset_info.get("media_type", "audio"),
+                "media_type": media_type,
                 "num_categories": num_categories,
             }
         )

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -11,10 +11,6 @@ from vtsearch.models import (
     build_model,
     calculate_cross_calibration_threshold,
     calculate_safe_threshold,
-    embed_audio_file,
-    embed_image_file,
-    embed_paragraph_file,
-    embed_video_file,
     train_model,
 )
 from vtsearch.utils import (
@@ -268,34 +264,19 @@ def import_detector_labels():
     # Optional explicit media type override
     media_type_hint = request.form.get("media_type", "").strip()
 
-    # Extension → media-type lookup tables
-    _AUDIO_EXTS = {".wav", ".mp3", ".flac", ".ogg", ".m4a"}
-    _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
-    _VIDEO_EXTS = {".mp4", ".avi", ".mov", ".webm", ".mkv"}
-    _TEXT_EXTS = {".txt", ".md"}
+    # Use the media type registry for extension → type lookup and embedding.
+    from vtsearch.media import get as media_get
+    from vtsearch.media import get_by_extension
 
     def _media_type_for_path(p: Path) -> str | None:
-        ext = p.suffix.lower()
-        if ext in _AUDIO_EXTS:
-            return "audio"
-        if ext in _IMAGE_EXTS:
-            return "image"
-        if ext in _VIDEO_EXTS:
-            return "video"
-        if ext in _TEXT_EXTS:
-            return "paragraph"
-        return None
+        mt = get_by_extension(p.suffix)
+        return mt.type_id if mt else None
 
     def _embed(media_type: str, p: Path):
-        if media_type == "audio":
-            return embed_audio_file(p)
-        if media_type == "image":
-            return embed_image_file(p)
-        if media_type == "video":
-            return embed_video_file(p)
-        if media_type == "paragraph":
-            return embed_paragraph_file(p)
-        return None
+        try:
+            return media_get(media_type).embed_media(p)
+        except KeyError:
+            return None
 
     try:
         text = file.read().decode("utf-8")
@@ -742,11 +723,7 @@ def run_extract():
         clip = clips[clip_id]
         extractions = extractor.extract(clip)
         if extractions:
-            clip_info = {
-                k: v
-                for k, v in clip.items()
-                if k not in ("embedding", "clip_bytes", "clip_string")
-            }
+            clip_info = {k: v for k, v in clip.items() if k not in ("embedding", "clip_bytes", "clip_string")}
             clip_info["extractions"] = extractions
             results.append(clip_info)
 
@@ -786,11 +763,7 @@ def auto_extract():
             clip = clips[clip_id]
             extractions = extractor.extract(clip)
             if extractions:
-                clip_info = {
-                    k: v
-                    for k, v in clip.items()
-                    if k not in ("embedding", "clip_bytes", "clip_string")
-                }
+                clip_info = {k: v for k, v in clip.items() if k not in ("embedding", "clip_bytes", "clip_string")}
                 clip_info["extractions"] = extractions
                 ext_results.append(clip_info)
 


### PR DESCRIPTION
## Summary

This PR refactors the demo dataset loading system to be driven by the media type registry rather than hardcoded logic. Each media type now implements its own `load_demo_source()` method, making the system extensible and eliminating large blocks of duplicated code in the loader.

## Key Changes

- **Media type registry-driven architecture**: Moved demo dataset loading logic from `load_demo_dataset()` in `loader.py` into individual `load_demo_source()` methods in each media type class (audio, video, image, text).

- **Pickle loading generalization**: Refactored `load_dataset_from_pickle()` to dynamically build media type mappings (`_dir_keys`, `_legacy_bytes`) from the registry instead of hardcoding per-type logic. This eliminates ~100 lines of repetitive if/elif chains.

- **New media type properties**: Added three new properties to the `MediaType` base class:
  - `tab_title`: Plural display name for UI tabs (e.g., "Sounds", "Videos")
  - `dir_key`: Key name for external media directory in pickles (e.g., "audio_dir")
  - `legacy_bytes_keys`: List of legacy key names for backward compatibility with old pickles

- **Frontend media type discovery**: Added `/api/media-types` endpoint that returns all registered media types with their metadata (icons, tab titles, file extensions, etc.). The frontend now uses this dynamic data instead of hardcoded media type configurations.

- **Demo dataset metadata**: Added `download_size_mb` field to `DemoDataset` class so the frontend can display expected download sizes before loading begins.

- **Removed hardcoded imports**: Eliminated imports of downloader functions and config constants from `loader.py` that are now handled by individual media types.

## Implementation Details

- The `load_demo_dataset()` function now acts as a thin orchestration layer that handles pickle caching and delegates to `media_type.load_demo_source()`.
- Each media type's `load_demo_source()` method is responsible for downloading, embedding, and populating clips for its demo sources.
- The frontend dynamically renders media type tabs and dataset tables based on the `/api/media-types` response, making it easy to add new media types without UI changes.
- Backward compatibility with old pickle files is maintained through the `legacy_bytes_keys` property, which allows fallback to old key names when loading.

https://claude.ai/code/session_01AfkyDBuqku1HoyAr51zfYN