### PR TITLE
Refactor demo datasets layout with scrollable content area

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -336,6 +336,7 @@
     center.innerHTML = "";
     center.appendChild(datasetWelcome);
     datasetWelcome.classList.remove("wide");
+    datasetWelcome.classList.remove("demo-mode");
     datasetWelcome.style.display = "flex";
     center.className = "panel-center";
     datasetOptions.style.display = "flex";
@@ -560,6 +561,7 @@
       demoDatasetsDiv.style.display = "flex";
       backButton.style.display = "block";
       datasetWelcome.classList.add("wide");
+      datasetWelcome.classList.add("demo-mode");
 
       // Fetch demo datasets
       try {
@@ -670,6 +672,10 @@
         tabBar.className = "demo-tab-bar";
         demoDatasetsDiv.appendChild(tabBar);
 
+        const demoContentArea = document.createElement("div");
+        demoContentArea.className = "demo-content-area";
+        demoDatasetsDiv.appendChild(demoContentArea);
+
         const sections = {};
 
         availableTypes.forEach(mt => {
@@ -723,7 +729,7 @@
 
           renderTable(items, section);
           sections[mt] = section;
-          demoDatasetsDiv.appendChild(section);
+          demoContentArea.appendChild(section);
         });
 
         // Activate the initial tab

--- a/static/styles.css
+++ b/static/styles.css
@@ -327,7 +327,10 @@ video { max-width: 600px; max-height: 400px; }
 .progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.75rem; color: #fff; font-weight: bold; }
 .progress-message { font-size: 0.85rem; color: var(--text-secondary); margin-top: 8px; text-align: center; width: 100%; max-width: 500px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .progress-eta { font-size: 0.75rem; color: var(--text-muted); margin-top: 4px; text-align: center; min-height: 1.1em; }
-.demo-datasets { display: flex; flex-direction: column; gap: 20px; width: 100%; margin-top: 16px; overflow-y: auto; max-height: calc(100vh - 250px); }
+.demo-datasets { display: flex; flex-direction: column; width: 100%; margin-top: 16px; overflow: hidden; }
+.dataset-welcome.demo-mode { flex: 1; min-height: 0; justify-content: flex-start; }
+.dataset-welcome.demo-mode .demo-datasets { flex: 1; min-height: 0; }
+.demo-content-area { flex: 1; overflow-y: auto; min-height: 0; width: 100%; }
 .demo-tab-bar { display: flex; gap: 4px; width: 100%; border-bottom: 2px solid var(--border); padding-bottom: 0; margin-bottom: 12px; }
 .demo-tab { padding: 8px 16px; border: none; border-bottom: 2px solid transparent; background: transparent; color: var(--text-secondary); font-size: 0.85rem; cursor: pointer; transition: all 0.15s; margin-bottom: -2px; white-space: nowrap; }
 .demo-tab:hover { color: var(--text-primary); background: var(--bg-subtle); }


### PR DESCRIPTION
## Summary
Restructured the demo datasets UI to use a dedicated scrollable content area, improving layout control and preventing overflow issues when displaying tabbed dataset sections.

## Key Changes
- Added a new `demo-content-area` container div that wraps all dataset sections and handles vertical scrolling independently
- Moved dataset section rendering from directly appending to `demoDatasetsDiv` to the new `demoContentArea` container
- Added `demo-mode` CSS class to `datasetWelcome` when entering demo mode and removed it when exiting
- Updated `.demo-datasets` CSS to use flexbox column layout without gap, allowing child elements to control their own spacing
- Added new CSS rules for `.demo-content-area` with `flex: 1`, `overflow-y: auto`, and `min-height: 0` to enable proper scrolling behavior
- Added `.dataset-welcome.demo-mode` styles to ensure proper flex layout when in demo mode

## Implementation Details
- The `demo-content-area` is created as a flex container that grows to fill available space while maintaining proper scroll behavior
- The `min-height: 0` property on flex children ensures the scrollable area respects flex constraints
- The `demo-mode` class serves as a visual/layout indicator for when the welcome panel is in demo datasets display mode
- This change separates the tab bar (which remains fixed) from the scrollable content sections, improving UX for datasets with many items

https://claude.ai/code/session_01SNdXBEpcvD2erNStbUqAAm