### PR TITLE
Fix documentation errors and missing requirements.txt files

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,7 +130,7 @@ VTSearch/
 
 ## Dependency graph
 
-Arrows point from dependant → dependency.  Modules on the left import
+Arrows point from dependent → dependency.  Modules on the left import
 modules on the right.
 
 ```

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -73,7 +73,7 @@ Each eval dataset wraps a demo dataset and defines text queries targeting specif
 | `20newsgroups_s` | Text | 20newsgroups_s | 15 topics (sports, science, cars, religion, politics, medicine, etc.) |
 | `20newsgroups_m` | Text | 20newsgroups_m | 15 topics |
 | `20newsgroups_l` | Text | 20newsgroups_l | 15 topics |
-| `ucf101_s` | Video | ucf101_s | 10 UCF-101 actions (ApplyEyeMakeup, CliffDiving, Drumming, JumpRope, etc.) |
+| `ucf101_s` | Video | ucf101_s | 10 UCF-101 actions (ApplyEyeMakeup, ApplyLipstick, Archery, BabyCrawling, BalanceBeam, etc.) |
 | `ucf101_m` | Video | ucf101_m | 10 UCF-101 actions |
 | `ucf101_l` | Video | ucf101_l | 10 UCF-101 actions |
 
@@ -143,7 +143,7 @@ from vtsearch.eval.runner import run_eval
 from vtsearch.eval.visualize import plot_eval_results
 
 train_fractions = [0.3, 0.5, 0.7, 0.9]
-datasets = ["animals_images"]
+datasets = ["caltech101_s"]
 
 for frac in train_fractions:
     print(f"\n=== train_fraction={frac} ===")
@@ -182,7 +182,7 @@ from vtsearch.eval.runner import run_eval
 from vtsearch.eval.visualize import plot_eval_results
 
 seeds = [1, 2, 3, 42, 100]
-datasets = ["animals_images", "nature_sounds"]
+datasets = ["caltech101_s", "esc50_s"]
 all_results = []
 
 for seed in seeds:
@@ -223,7 +223,7 @@ from vtsearch.eval.visualize import plot_voting_iterations
 from vtsearch.eval.voting_iterations import run_voting_iterations_eval
 
 # Load datasets
-datasets_to_eval = ["nature_sounds", "animals_images"]
+datasets_to_eval = ["esc50_s", "caltech101_s"]
 dataset_clips = {}
 for name in datasets_to_eval:
     clips = {}
@@ -235,8 +235,8 @@ df = run_voting_iterations_eval(
     dataset_clips=dataset_clips,
     seeds=[1, 2, 3, 42, 100],           # multiple seeds for averaging
     categories={                          # specific categories to test
-        "nature_sounds": ["rain", "frog"],
-        "animals_images": ["cat", "dog"],
+        "esc50_s": ["rain", "frog"],
+        "caltech101_s": ["dolphin", "flamingo"],
     },
     inclusion=0,                          # inclusion bias setting
     sim_fraction=0.5,                     # fraction used for simulated voting

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -838,11 +838,16 @@ requirements.txt              # Core deps + includes per-media + per-importer + 
 ├── requirements-importers.txt          # Aggregates all data importer deps
 │   ├── vtsearch/datasets/importers/pickle/requirements.txt
 │   ├── vtsearch/datasets/importers/folder/requirements.txt
-│   └── vtsearch/datasets/importers/http_zip/requirements.txt
+│   ├── vtsearch/datasets/importers/http_zip/requirements.txt
+│   ├── vtsearch/datasets/importers/rss_feed/requirements.txt
+│   ├── vtsearch/datasets/importers/youtube_playlist/requirements.txt
+│   └── vtsearch/datasets/importers/combine_datasets/requirements.txt
 ├── requirements-exporters.txt          # Aggregates all exporter deps
 │   ├── vtsearch/exporters/gui/requirements.txt
 │   ├── vtsearch/exporters/file/requirements.txt
-│   └── vtsearch/exporters/email_smtp/requirements.txt
+│   ├── vtsearch/exporters/email_smtp/requirements.txt
+│   ├── vtsearch/exporters/csv_file/requirements.txt
+│   └── vtsearch/exporters/webhook/requirements.txt
 requirements-cpu.txt          # CPU-specific pins (lists packages INLINE)
 requirements-gpu.txt          # GPU-specific (minimal, includes importers)
 requirements-dev.txt          # Dev tools (pytest)

--- a/requirements-exporters.txt
+++ b/requirements-exporters.txt
@@ -10,3 +10,5 @@
 -r vtsearch/exporters/gui/requirements.txt
 -r vtsearch/exporters/file/requirements.txt
 -r vtsearch/exporters/email_smtp/requirements.txt
+-r vtsearch/exporters/csv_file/requirements.txt
+-r vtsearch/exporters/webhook/requirements.txt

--- a/requirements-importers.txt
+++ b/requirements-importers.txt
@@ -10,3 +10,6 @@
 -r vtsearch/datasets/importers/pickle/requirements.txt
 -r vtsearch/datasets/importers/folder/requirements.txt
 -r vtsearch/datasets/importers/http_zip/requirements.txt
+-r vtsearch/datasets/importers/rss_feed/requirements.txt
+-r vtsearch/datasets/importers/youtube_playlist/requirements.txt
+-r vtsearch/datasets/importers/combine_datasets/requirements.txt

--- a/vtsearch/datasets/importers/combine_datasets/requirements.txt
+++ b/vtsearch/datasets/importers/combine_datasets/requirements.txt
@@ -1,0 +1,1 @@
+# combine_datasets importer — no additional dependencies beyond core deps.

--- a/vtsearch/datasets/importers/rss_feed/requirements.txt
+++ b/vtsearch/datasets/importers/rss_feed/requirements.txt
@@ -1,0 +1,2 @@
+# RSS/Podcast feed importer dependencies
+feedparser

--- a/vtsearch/datasets/importers/youtube_playlist/requirements.txt
+++ b/vtsearch/datasets/importers/youtube_playlist/requirements.txt
@@ -1,0 +1,2 @@
+# YouTube playlist importer dependencies
+yt-dlp

--- a/vtsearch/exporters/csv_file/requirements.txt
+++ b/vtsearch/exporters/csv_file/requirements.txt
@@ -1,0 +1,1 @@
+# csv_file exporter — no additional dependencies beyond core deps.

--- a/vtsearch/exporters/webhook/requirements.txt
+++ b/vtsearch/exporters/webhook/requirements.txt
@@ -1,0 +1,1 @@
+# webhook exporter — no additional dependencies beyond core deps (uses requests).


### PR DESCRIPTION
- EVAL.md: Fix code examples using non-existent dataset IDs
  (animals_images/nature_sounds → caltech101_s/esc50_s) and non-existent
  category names; these would silently produce no results
- EVAL.md: Fix UCF-101 example categories in Available eval datasets table
  (CliffDiving/Drumming/JumpRope → ApplyLipstick/Archery/BabyCrawling
  to match actual vtsearch/eval/config.py entries)
- ARCHITECTURE.md: Fix typo 'dependant' → 'dependent'
- Add missing requirements.txt stubs for rss_feed, youtube_playlist,
  combine_datasets importers and csv_file, webhook exporters — required
  by the documented pattern in EXTENDING.md ("even if empty (required)")
- Update requirements-importers.txt and requirements-exporters.txt to
  include all built-in plugins (previously only 3/6 and 3/5 were listed)
- EXTENDING.md: Update dependency tree to show all built-in importers
  and exporters (was incomplete, showing only a partial list)

https://claude.ai/code/session_01B85dfowSUJb3RiQ2A7HHEW