### PR TITLE
Add handoff and deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ This runs fast CPU tests only. Additional test modes:
 ├── static/                         # Frontend (HTML, JS, CSS, assets)
 ├── tests/                          # Test suite (pytest)
 ├── docs/                           # Extended documentation
+│   ├── HANDOFF.md                  # Project handoff & orientation guide
+│   ├── DEPLOYMENT.md               # Deployment, offline mode, operations
 │   ├── ARCHITECTURE.md             # Architecture deep-dive
 │   ├── EXTENDING.md                # Plugin authoring guide
 │   ├── EVAL.md                     # Evaluation framework guide
@@ -100,6 +102,12 @@ This runs fast CPU tests only. Additional test modes:
 │   └── FEATURE_IDEAS.md            # Brainstorm of potential features
 └── requirements*.txt               # Dependency files (cpu, gpu, dev, importers, exporters)
 ```
+
+## Deployment
+
+For production deployment, offline/air-gapped operation, Docker hardening, environment variables, network dependency details, and data directory management, see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+
+New to the project? Start with [docs/HANDOFF.md](docs/HANDOFF.md) for a full orientation including a documentation map, key concepts, deployment checklist, and common workflows.
 
 ## Machine learning
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,390 @@
+# Deployment & Operations Guide
+
+This document covers production deployment, offline operation, network
+dependencies, environment variables, and data management. For basic
+installation and getting started, see [SETUP.md](SETUP.md).
+
+## Table of Contents
+
+1. [Environment variables](#environment-variables)
+2. [Network dependencies](#network-dependencies)
+3. [Offline deployment](#offline-deployment)
+4. [Data directory layout](#data-directory-layout)
+5. [Docker production notes](#docker-production-notes)
+6. [Requirements file structure](#requirements-file-structure)
+7. [Troubleshooting](#troubleshooting)
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
+| `HF_HUB_OFFLINE` | unset | Set to `1` to prevent any HuggingFace Hub downloads |
+| `HF_HUB_DISABLE_IMPLICIT_TOKEN` | `1` (set by app) | Disables HuggingFace auth tokens (all models are public) |
+| `OMP_NUM_THREADS` | `1` (set by app) | OpenMP thread count; kept at 1 for memory optimization |
+| `MKL_NUM_THREADS` | `1` (set by app) | Intel MKL thread count; kept at 1 for memory optimization |
+| `PYTHONUNBUFFERED` | `1` (set in Dockerfiles) | Disables Python output buffering for real-time logs |
+| `NVIDIA_VISIBLE_DEVICES` | `all` (GPU Dockerfile) | GPU visibility for NVIDIA Container Toolkit |
+| `NVIDIA_DRIVER_CAPABILITIES` | `compute,utility` (GPU Dockerfile) | GPU driver capabilities |
+
+---
+
+## Network dependencies
+
+### Embedding models (HuggingFace Hub)
+
+VTSearch downloads four embedding models on first use. Each model is
+lazy-loaded when a dataset of the corresponding media type is opened for the
+first time (or at startup if `favorite_media_types` is configured in
+settings).
+
+| Model | Media type | HuggingFace ID | Approx. size |
+|-------|-----------|----------------|-------------|
+| CLAP | Audio | `laion/clap-htsat-unfused` | ~1.1 GB |
+| CLIP | Image | `openai/clip-vit-base-patch32` | ~350 MB |
+| X-CLIP | Video | `microsoft/xclip-base-patch32` | ~1.2 GB |
+| E5 | Text | `intfloat/e5-base-v2` | ~440 MB |
+
+**Total: ~3.1 GB** for all four models.
+
+All model downloads use `token=False` — no HuggingFace account or API
+token is required.
+
+### Demo dataset downloads
+
+Demo datasets are downloaded only when a user selects them through the web
+UI. They are **not** downloaded at startup.
+
+| Dataset | Media type | Source | Approx. size |
+|---------|-----------|--------|-------------|
+| ESC-50 | Audio | GitHub | ~600 MB |
+| CIFAR-10 | Image | U of Toronto | ~170 MB |
+| Caltech-101 | Image | Caltech Data | ~131 MB |
+| Caltech-256 | Image | Caltech Data | ~1200 MB |
+| UCF-101 subset | Video | HuggingFace Datasets | ~171 MB |
+| 20 Newsgroups | Text | scikit-learn | ~14 MB |
+
+### User-triggered network operations
+
+These features require network access only when explicitly used:
+
+| Feature | Network target | Fallback |
+|---------|---------------|----------|
+| YouTube playlist importer | YouTube (via yt-dlp) | Use folder/pickle importer |
+| RSS feed importer | RSS/Atom feed server | Use folder/pickle importer |
+| HTTP archive importer | User-provided URL | Use folder/pickle importer |
+| Webhook exporter | User-provided endpoint | Use file/CSV exporter |
+
+### pip install during build
+
+CPU builds fetch PyTorch wheels from `https://download.pytorch.org/whl/cpu`.
+GPU builds use the default PyPI + NVIDIA indexes.
+
+---
+
+## Offline deployment
+
+VTSearch can run fully offline once models are cached. Follow these steps:
+
+### 1. Pre-download models
+
+Run the provided script on a machine with internet access:
+
+```bash
+./download_models.sh [CACHE_DIR]
+```
+
+This downloads all four embedding models to `CACHE_DIR` (defaults to
+`data/models`). The script prints instructions for offline use when
+finished.
+
+### 2. Set offline environment variables
+
+```bash
+export HF_HUB_OFFLINE=1
+export VTSEARCH_MODELS_DIR=/path/to/cached/models
+```
+
+With `HF_HUB_OFFLINE=1`, the HuggingFace `transformers` library will never
+attempt network requests — it only loads from the local cache.
+
+### 3. Provide datasets locally
+
+In offline mode, demo datasets cannot be downloaded. Use one of these
+local-only importers instead:
+
+- **Folder importer** — point at a directory of media files
+- **Pickle importer** — load a pre-built `.pkl` dataset file
+- **Combine-datasets importer** — merge multiple pickle files
+
+### Docker offline deployment
+
+For Docker, pre-download models and either bake them into the image or
+mount them as a volume:
+
+**Option A — Bake into the image** (larger image, simpler deployment):
+
+```dockerfile
+# Add to the end of Dockerfile, before CMD
+COPY ./pre-downloaded-models/ /app/data/models/
+ENV HF_HUB_OFFLINE=1
+```
+
+**Option B — Mount as a volume** (smaller image, models shared across
+containers):
+
+```bash
+# Pre-download on host
+./download_models.sh /opt/vtsearch-models
+
+# Run with mount
+docker run -p 5000:5000 \
+  -v vtsearch-data:/app/data \
+  -v /opt/vtsearch-models:/app/data/models:ro \
+  -e HF_HUB_OFFLINE=1 \
+  vtsearch
+```
+
+### What breaks without network access
+
+| Component | Impact | Symptom |
+|-----------|--------|---------|
+| Models not cached | **Cannot load any dataset** | Error during model initialization |
+| Demo datasets | Cannot use demo datasets | Download error in web UI |
+| YouTube/RSS/HTTP importers | Those importers fail | Network error in importer |
+| Webhook exporter | That exporter fails | Connection error on export |
+
+Everything else (folder/pickle import, file/CSV export, ML training,
+evaluation, sorting, voting) works fully offline.
+
+---
+
+## Data directory layout
+
+The `data/` directory (or `/app/data` in Docker) holds all runtime state.
+It is created automatically on first startup.
+
+```
+data/
+├── models/                           # HuggingFace model cache (~3.1 GB total)
+│   ├── models--laion--clap-htsat-unfused/
+│   ├── models--openai--clip-vit-base-patch32/
+│   ├── models--microsoft--xclip-base-patch32/
+│   └── models--sentence-transformers--e5-base-v2/
+├── embeddings/                       # Cached dataset embeddings (.pkl files)
+├── settings.json                     # User preferences, favorites, thresholds
+├── audio/                            # Audio media files
+├── video/                            # Video media files
+├── images/                           # Image media files
+└── paragraphs/                       # Text media files
+```
+
+### What to preserve vs. what's safe to delete
+
+| Path | Preserve? | Why |
+|------|-----------|-----|
+| `data/models/` | **Yes** | Re-downloading is slow (~3.1 GB) |
+| `data/embeddings/` | **Yes** | Contains cached embeddings; losing them means recomputing |
+| `data/settings.json` | **Yes** | User preferences, trained detectors, favorite processors |
+| `data/audio/`, `video/`, `images/`, `paragraphs/` | Depends | Media files from imported datasets; re-import if lost |
+| Demo dataset archives (`.zip`, `.tar.gz`) | Safe to delete | Can be re-downloaded |
+| Extracted demo folders (`ESC-50-master/`, etc.) | Safe to delete | Can be re-extracted from archives |
+
+### Settings file schema
+
+The settings file at `data/settings.json` is auto-created on first startup
+and auto-saved on every change. Schema:
+
+```json
+{
+  "volume": 1.0,
+  "inclusion": 0,
+  "theme": "dark",
+  "enrich_descriptions": false,
+  "safe_thresholds": false,
+  "calibrate_count": 2,
+  "calibration_fraction": 0.5,
+  "swipe_animation": true,
+  "show_thumbnails_left": false,
+  "show_thumbnails_right": true,
+  "favorite_media_types": [],
+  "favorite_processors": []
+}
+```
+
+Notable fields:
+
+- `favorite_media_types` — media types to preload at startup (triggers
+  model downloads if models aren't cached)
+- `favorite_processors` — saved detector/extractor configurations with
+  importer name, processor name, and field values
+- `theme` — `"dark"`, `"light"`, or `"highviz"`
+
+---
+
+## Docker production notes
+
+### CPU deployment
+
+```bash
+docker compose up -d
+```
+
+Uses `Dockerfile` (base: `python:3.10-slim`). System packages installed:
+`libsndfile1`, `ffmpeg`, `libgl1`, `libglib2.0-0`.
+
+### GPU deployment
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+```
+
+Uses `Dockerfile.gpu` (base: `nvidia/cuda:12.1.1-runtime-ubuntu22.04`).
+Requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/)
+on the host.
+
+### Data persistence
+
+The Docker volume `vtsearch-data` is mounted at `/app/data`. This persists
+models, embeddings, settings, and media files across container restarts.
+
+To use a host directory instead of a named volume:
+
+```bash
+docker run -p 5000:5000 -v /path/on/host:/app/data vtsearch
+```
+
+### Resource considerations
+
+- **Memory**: Each embedding model uses ~500 MB–1.5 GB of RAM when loaded.
+  With all four loaded simultaneously, expect ~4–6 GB total application
+  memory. Models are loaded lazily — only the media types actually used are
+  loaded.
+- **Disk**: The `data/models/` directory uses ~3.1 GB. Dataset embeddings
+  and media files vary by dataset size.
+- **CPU**: `OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1` are set to reduce
+  per-operation memory. This trades single-operation throughput for lower
+  memory usage — appropriate for a single-user application.
+- **GPU (optional)**: GPU mode accelerates embedding computation and model
+  training. Not required for basic operation.
+
+### Health check
+
+The app serves the web UI at `/`. A simple health check:
+
+```bash
+curl -f http://localhost:5000/ || exit 1
+```
+
+### Rebuilding after code changes
+
+```bash
+docker compose build                  # CPU
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml build  # GPU
+```
+
+Add `--no-cache` after dependency changes to force a full rebuild.
+
+---
+
+## Requirements file structure
+
+Dependencies are organized in a layered structure:
+
+```
+requirements-cpu.txt          ← Main CPU deps (Flask, PyTorch CPU, all media types)
+  └── requirements-importers.txt  ← All importer deps (aggregates per-importer files)
+  └── (inline) per-media-type packages
+
+requirements-gpu.txt          ← Main GPU deps (PyTorch GPU, all media types)
+  └── requirements-importers.txt
+
+requirements-exporters.txt    ← All exporter deps (aggregates per-exporter files)
+
+requirements-dev.txt          ← Dev tools (pytest)
+
+requirements.txt              ← Generic (includes all)
+```
+
+Each plugin has its own `requirements.txt` in its subdirectory:
+
+```
+vtsearch/media/{audio,image,text,video}/requirements.txt
+vtsearch/datasets/importers/{folder,pickle,http_zip,rss_feed,youtube_playlist,combine_datasets}/requirements.txt
+vtsearch/exporters/{file,csv_file,gui,email_smtp,webhook}/requirements.txt
+```
+
+### Key dependencies
+
+| Package | Version constraint | Purpose |
+|---------|-------------------|---------|
+| `torch` | `>=2.0.0` | Neural network training and inference |
+| `transformers` | latest | HuggingFace model loading (CLAP, CLIP, X-CLIP) |
+| `sentence-transformers` | latest | E5 text embeddings |
+| `numpy` | `<2` | Numeric arrays (numpy 2.x has breaking changes) |
+| `flask` | latest | Web server |
+| `opencv-python-headless` | `<4.10` | Video frame extraction |
+| `ultralytics` | latest | YOLO-based image processing |
+| `laion_clap` | latest | Audio embedding preprocessing |
+| `librosa` | latest | Audio file loading and processing |
+| `feedparser` | latest | RSS feed importer |
+| `yt-dlp` | latest | YouTube playlist importer |
+
+---
+
+## Troubleshooting
+
+### Models fail to download
+
+**Symptom**: Error during startup or dataset loading mentioning
+`ConnectionError` or `OSError: We couldn't connect to`.
+
+**Fix**: Ensure the machine has internet access to `huggingface.co`, or
+pre-download models with `./download_models.sh` and set
+`HF_HUB_OFFLINE=1`.
+
+### Out of memory
+
+**Symptom**: Process killed or `torch.cuda.OutOfMemoryError`.
+
+**Fix**: Load fewer media types simultaneously. Set
+`favorite_media_types` in settings to only the types you need, so unused
+models aren't preloaded. For GPU, ensure adequate VRAM (4+ GB
+recommended).
+
+### Docker build fails on pip install
+
+**Symptom**: Network timeout downloading PyTorch wheels.
+
+**Fix**: Retry the build (transient network issue), or use a local PyTorch
+wheel mirror. For air-gapped environments, pre-download all wheels and
+`COPY` them into the build context.
+
+### Settings not persisting across container restarts
+
+**Symptom**: Settings reset to defaults after `docker compose down && up`.
+
+**Fix**: Ensure you're mounting a persistent volume at `/app/data`. Check
+with `docker volume ls` and verify the `vtsearch-data` volume exists.
+
+### Demo dataset download fails
+
+**Symptom**: Error in web UI when selecting a demo dataset.
+
+**Fix**: Check internet connectivity. For offline use, import data locally
+via the folder or pickle importer instead.
+
+### "No module named" errors
+
+**Symptom**: `ModuleNotFoundError` for a media type or importer package.
+
+**Fix**: Install the full requirements:
+```bash
+pip install -r requirements-cpu.txt    # or requirements-gpu.txt
+pip install -r requirements-exporters.txt
+```
+
+For specific importers (RSS, YouTube), install their individual
+`requirements.txt` as well.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,325 @@
+# Project Handoff
+
+This document provides a concise orientation for anyone picking up VTSearch
+for the first time — whether to operate it, extend it, or evaluate it. It
+ties together the full documentation set and highlights the things you need
+to know first.
+
+## Table of Contents
+
+1. [What is VTSearch?](#what-is-vtsearch)
+2. [Documentation map](#documentation-map)
+3. [Quick start](#quick-start)
+4. [Key concepts](#key-concepts)
+5. [Codebase orientation](#codebase-orientation)
+6. [Running the test suite](#running-the-test-suite)
+7. [Deployment checklist](#deployment-checklist)
+8. [Common workflows](#common-workflows)
+9. [Known constraints and trade-offs](#known-constraints-and-trade-offs)
+10. [Feature ideas and future direction](#feature-ideas-and-future-direction)
+
+---
+
+## What is VTSearch?
+
+VTSearch is a media explorer web app for browsing and voting on collections
+of audio, images, text, or video. It supports two sorting strategies:
+
+- **Semantic sorting** — uses pretrained embedding models (CLAP, CLIP,
+  X-CLIP, E5) to rank items by similarity to a text query.
+- **Learned sorting** — trains a small MLP neural network on user votes to
+  predict good/bad labels.
+
+Built with Flask + vanilla JavaScript + PyTorch. Single-user, no auth,
+runs locally or in Docker.
+
+---
+
+## Documentation map
+
+| Document | Purpose |
+|----------|---------|
+| [SETUP.md](SETUP.md) | Installation, prerequisites, getting started, basic Docker usage |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Production deployment, offline mode, network deps, env vars, data directory, troubleshooting |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Module structure, dependency graph, extractability matrix, state management |
+| [CLI.md](CLI.md) | Command-line interface reference (autodetect, importers, exporters) |
+| [ML.md](ML.md) | MLP architecture, training config, embedding models, threshold calibration |
+| [EVAL.md](EVAL.md) | Evaluation framework (metrics, runner, visualisation) |
+| [EXTENDING.md](EXTENDING.md) | Plugin authoring guide (importers, exporters, media types) |
+| [FEATURE_IDEAS.md](FEATURE_IDEAS.md) | 132 brainstormed feature ideas |
+
+---
+
+## Quick start
+
+### Local (fastest for development)
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements-cpu.txt
+python app.py --local        # lazy model loading, faster startup
+```
+
+### Docker (recommended for deployment)
+
+```bash
+docker compose up -d         # CPU
+# or
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d  # GPU
+```
+
+Open `http://localhost:5000`, then use the hamburger menu to load a demo
+dataset or import your own data.
+
+---
+
+## Key concepts
+
+### Clips
+
+A **clip** is the fundamental data unit — a dict with an `id`, media bytes,
+an embedding vector, and optional metadata (`origin`, `origin_name`, `md5`).
+All clips live in a global dict keyed by integer ID.
+
+### Votes
+
+Users vote clips as **good** or **bad**. Votes are stored as
+`dict[int, None]` (not sets) in `vtsearch/utils/state.py`. Votes drive
+both the learned-sort training and the label export.
+
+### Media types
+
+Four media types are supported, each with its own embedding model:
+
+| Media type | Embedding model | Model ID |
+|-----------|----------------|----------|
+| Audio | CLAP | `laion/clap-htsat-unfused` |
+| Image | CLIP | `openai/clip-vit-base-patch32` |
+| Video | X-CLIP | `microsoft/xclip-base-patch32` |
+| Text | E5 | `intfloat/e5-base-v2` |
+
+Models are loaded lazily on first use. Total download size: ~3.1 GB.
+
+### Detectors and processors
+
+A **detector** is a trained MLP that classifies clips as positive/negative.
+An **extractor** groups clips into categories. Both are types of
+**processors** and can be exported/imported as JSON files.
+
+### Plugin systems
+
+Four auto-discovered plugin systems share the same architecture:
+
+- **Dataset importers** — load data from folders, pickles, URLs, RSS feeds,
+  YouTube playlists, or combined datasets.
+- **Results exporters** — write autodetect results to files, CSV, email,
+  webhooks, or the GUI.
+- **Label importers** — import labels from JSON or CSV files.
+- **Processor importers** — import detectors/extractors from JSON files or
+  train them from labeled data.
+
+See [EXTENDING.md](EXTENDING.md) for how to add new plugins.
+
+### Origin tracking
+
+Every clip carries per-element provenance via `origin` (dict) and
+`origin_name` (str). This enables datasets from multiple sources to
+coexist, and exported labels can be matched back to their source.
+
+---
+
+## Codebase orientation
+
+### Entry point
+
+`app.py` — Flask app setup, blueprint registration, startup logic, CLI
+argument parsing. Key startup sequence:
+
+1. Create `data/` directory structure
+2. Initialize model cache directory
+3. Load persistent settings from `data/settings.json`
+4. Preload models for `favorite_media_types` (if configured)
+5. Start Flask server (or run CLI autodetect workflow)
+
+### Where things live
+
+| What | Where |
+|------|-------|
+| Flask routes (REST API) | `vtsearch/routes/` |
+| Global state (clips, votes) | `vtsearch/utils/state.py` |
+| Persistent settings | `vtsearch/settings.py` → `data/settings.json` |
+| ML training and inference | `vtsearch/models/training.py` |
+| Embedding models | `vtsearch/media/{audio,image,text,video}/media_type.py` |
+| Dataset loading and downloading | `vtsearch/datasets/` |
+| Plugin registries | `vtsearch/datasets/importers/`, `vtsearch/exporters/`, `vtsearch/labels/importers/`, `vtsearch/processors/importers/` |
+| Constants and model IDs | `vtsearch/config.py` |
+| Frontend | `static/index.html`, `static/app.js`, `static/styles.css` |
+| Tests | `tests/` (see test list in CLAUDE.md) |
+
+### Architectural boundaries
+
+- **Media types, models, exporters, and importers do NOT import Flask.**
+  They are standalone and can be used in scripts or notebooks.
+- **Only `vtsearch/routes/` imports global state.** All ML and dataset
+  functions accept state as parameters.
+- **Each plugin is self-contained** in its own subdirectory with its own
+  `requirements.txt`.
+
+---
+
+## Running the test suite
+
+```bash
+pip install -r requirements-dev.txt
+
+# Fast CPU tests (~35s)
+python -m pytest tests/ -v
+
+# Full CPU tests including slow CLI subprocess tests (~5 min)
+python -m pytest tests/ -v -m 'not gpu'
+
+# GPU tests only (requires CUDA)
+python -m pytest tests/test_gpu.py -v -m gpu
+
+# All tests
+python -m pytest tests/ -v -m ''
+```
+
+### Test markers
+
+- Default (no marker flag): fast CPU tests only, excludes `gpu` and `slow`
+- `slow`: CLI subprocess tests that spawn `python app.py --autodetect`
+  (~16 seconds each)
+- `gpu`: CUDA-only tests
+
+### Linting and formatting
+
+```bash
+ruff check .       # lint
+ruff format .      # format
+```
+
+Configuration is in `pyproject.toml` (E402 ignored, line-length 120,
+target Python 3.10).
+
+---
+
+## Deployment checklist
+
+Use this checklist when setting up VTSearch for a new environment.
+
+### Minimal deployment
+
+- [ ] Python 3.10+ available (or Docker installed)
+- [ ] System packages: `libsndfile1`, `ffmpeg`, `libgl1`, `libglib2.0-0`
+- [ ] `pip install -r requirements-cpu.txt` (or build Docker image)
+- [ ] `data/` directory writable (models, embeddings, settings stored here)
+- [ ] Port 5000 available (or configure as needed)
+- [ ] Run `python app.py` or `docker compose up`
+
+### For offline / air-gapped environments
+
+- [ ] Pre-download models: `./download_models.sh /path/to/models`
+- [ ] Set `HF_HUB_OFFLINE=1` and `VTSEARCH_MODELS_DIR=/path/to/models`
+- [ ] Prepare datasets locally (folder or pickle files)
+- [ ] If using Docker, bake models into the image or mount as a volume
+
+### For GPU acceleration
+
+- [ ] NVIDIA GPU with CUDA support available
+- [ ] NVIDIA Container Toolkit installed (for Docker)
+- [ ] Use `Dockerfile.gpu` or `requirements-gpu.txt`
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for full details.
+
+---
+
+## Common workflows
+
+### Load and explore a dataset
+
+1. Start the app
+2. Click the hamburger menu (top-left)
+3. Select a demo dataset or use an importer
+4. Browse, listen/view, and vote
+
+### Run autodetect from CLI
+
+```bash
+python app.py --autodetect \
+  --dataset data.pkl \
+  --settings settings.json \
+  --exporter file --filepath results.json
+```
+
+This loads the dataset, runs all detectors from the settings file, and
+exports results without starting the web server.
+
+### Train a detector through the UI
+
+1. Load a dataset
+2. Vote several clips as good/bad (minimum ~10 votes recommended)
+3. Click "Learned Sort" to train the MLP on your votes
+4. Export the detector via the detectors panel
+
+### Import pre-trained processors
+
+Use the processor importers panel or CLI to load detectors/extractors
+from JSON files, labeled media files, or CSV label files.
+
+### Evaluate sorting quality
+
+```bash
+python -m vtsearch.eval --plot-dir eval_output
+```
+
+See [EVAL.md](EVAL.md) for the full evaluation framework guide.
+
+---
+
+## Known constraints and trade-offs
+
+### Single-user design
+
+VTSearch is designed for single-user operation. There is no authentication,
+no session isolation, and global state is shared. Running multiple
+simultaneous users against the same instance will cause vote conflicts.
+
+### Memory usage
+
+All clips and embeddings are held in memory. Large datasets (10k+ clips)
+may require significant RAM. Models add 500 MB–1.5 GB each when loaded.
+
+### Thread settings
+
+`OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1` are set at startup to reduce
+per-operation memory. This is a deliberate trade-off: lower peak memory at
+the cost of slower individual operations.
+
+### Votes are `dict[int, None]`, not sets
+
+This is an intentional design choice throughout the codebase. Always use
+`votes[id] = None` syntax, not `votes.add(id)`.
+
+### numpy < 2 constraint
+
+The `numpy<2` pin avoids breaking changes in numpy 2.x that affect
+PyTorch and other dependencies. Upgrading requires testing across the full
+dependency chain.
+
+---
+
+## Feature ideas and future direction
+
+See [FEATURE_IDEAS.md](FEATURE_IDEAS.md) for a brainstorm of 132 potential
+features spanning sorting, active learning, UI/UX, datasets, export,
+evaluation, media types, infrastructure, and accessibility. Highlights
+include:
+
+- Multi-query and negative-query text sorting
+- Uncertainty sampling and active learning
+- Grid view, keyboard shortcuts, and responsive layout
+- S3 / cloud storage importers
+- ONNX / TorchScript model export
+- Distributed computation and job queues
+- Internationalization and accessibility improvements


### PR DESCRIPTION
Create docs/HANDOFF.md with project orientation, documentation map,
key concepts, deployment checklist, and common workflows.

Create docs/DEPLOYMENT.md with environment variables, network
dependency inventory, offline deployment guide, data directory layout,
Docker production notes, requirements file structure, and
troubleshooting.

Update README.md to reference both new docs and add them to the
project structure tree.

https://claude.ai/code/session_01PxS4BhiXCemJMCyBDRQJwj