### PR TITLE
Remove Recommendation region from Span progress detail page

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3722,8 +3722,6 @@
     document.getElementById("smart-section").style.display = "none";
     document.getElementById("stable-section").style.display = "none";
     document.getElementById("span-section").style.display = "";
-    document.getElementById("recommendation-text").textContent =
-      sp && sp.reason ? sp.reason : "No span data available.";
     document.getElementById("progress-modal-title").textContent = "Span: Diversity Coverage";
 
     pauseActiveMedia();
@@ -3812,9 +3810,6 @@
       }
     }
 
-    // Generate recommendation
-    const recommendation = generateRecommendation(data);
-    document.getElementById("recommendation-text").textContent = recommendation;
   }
 
   function renderErrorCostChart(errorCostData) {
@@ -4130,44 +4125,6 @@
     ctx.textAlign = "right";
     ctx.fillText(maxLevel.toFixed(1), padding.left - 5, padding.top + 5);
     ctx.fillText(minLevel.toFixed(1), padding.left - 5, padding.top + chartHeight + 5);
-  }
-
-  function generateRecommendation(data) {
-    const errorCostData = data.error_cost_over_time;
-    const stabilityData = data.stability_over_time;
-
-    if (errorCostData.length < 5) {
-      return "Keep labeling! You need more labels to assess progress (at least 5 training steps).";
-    }
-
-    // Check if error cost has plateaued (last 30% of data)
-    const last30PercentCount = Math.max(3, Math.floor(errorCostData.length * 0.3));
-    const recentErrorCosts = errorCostData.slice(-last30PercentCount).map(d => d.error_cost);
-    const errorCostRange = Math.max(...recentErrorCosts) - Math.min(...recentErrorCosts);
-    const avgErrorCost = recentErrorCosts.reduce((a, b) => a + b, 0) / recentErrorCosts.length;
-    const errorCostStability = errorCostRange / (avgErrorCost || 1);
-
-    // Check if prediction flip *rate* has decreased (scales with dataset size)
-    const recentStability = stabilityData.slice(-last30PercentCount);
-    const recentFlipRates = recentStability.map(d => {
-      const nUnlabeled = d.num_unlabeled || 0;
-      return nUnlabeled > 0 ? d.num_flips / nUnlabeled : 0;
-    });
-    const avgFlipRate = recentFlipRates.reduce((a, b) => a + b, 0) / (recentFlipRates.length || 1);
-
-    let recommendation = "";
-
-    if (errorCostStability < 0.1 && avgFlipRate < 0.03) {
-      recommendation = "🛑 STOP LABELING: Both error cost and predictions have stabilized. Additional labels are unlikely to improve the model significantly. You've reached a good stopping point!";
-    } else if (errorCostStability < 0.15) {
-      recommendation = "⚠️ CONSIDER STOPPING: Error cost has mostly plateaued. You may be approaching diminishing returns. Consider stopping or labeling a few more diverse examples.";
-    } else if (avgFlipRate < 0.02) {
-      recommendation = "⚠️ PREDICTIONS STABLE: Predictions on unlabeled clips aren't changing much. The model's decisions are solidifying. Consider whether additional labels will help.";
-    } else {
-      recommendation = "✅ KEEP LABELING: The model is still learning! Both error cost and predictions are changing, indicating that new labels are improving the model.";
-    }
-
-    return recommendation;
   }
 
   // Modify fetchVotes to update label counts

--- a/static/index.html
+++ b/static/index.html
@@ -225,10 +225,6 @@
           <p id="span-info-text" style="margin:0; font-size: 0.9rem; color: var(--text-secondary);">No diversity tree available.</p>
         </div>
       </div>
-      <div class="progress-recommendation">
-        <h3>Recommendation</h3>
-        <p id="recommendation-text">Loading...</p>
-      </div>
     </div>
   </div>
 </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -414,7 +414,6 @@ video { max-width: 600px; max-height: 400px; }
 .progress-stat-label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; margin-bottom: 4px; }
 .progress-stat-value { font-size: 1.2rem; color: var(--accent); font-weight: bold; }
 .progress-recommendation { background: var(--bg-hover); padding: 12px; border-radius: 4px; border-left: 3px solid var(--accent); margin-top: 16px; }
-.progress-recommendation h3 { font-size: 0.9rem; color: var(--accent); margin-bottom: 4px; }
 .progress-recommendation p { font-size: 0.85rem; color: var(--text-secondary); margin: 0; }
 
 /* Custom VTSearch dialog */


### PR DESCRIPTION
Remove the recommendation div, generateRecommendation() function,
and all references to recommendation-text from the progress modal.
The span-info-box retains the progress-recommendation CSS class
for its own styling.

https://claude.ai/code/session_018mrMrpjKp1ykALVXBr6wdP