### PR TITLE
Tighten stability thresholds for prediction flip rate detection

### DIFF
--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -298,9 +298,30 @@ class TestStableIndicatorThresholds:
         entries = [{"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 100}]
         for i in range(1, 7):
             entries.append({"time_index": i, "num_labels": 10 + i, "num_flips": 0, "num_unlabeled": 100 - i})
-        # Inject one spike: 6 flips out of 93 unlabeled → ~6.5%, above 5% max threshold
+        # Inject one spike: 6 flips out of 93 unlabeled → ~6.5%, above 1% max threshold
         entries[-1] = {"time_index": 6, "num_labels": 16, "num_flips": 6, "num_unlabeled": 93}
 
         self._inject_stability(entries)
         result = _compute_stable_status(good=8, bad=8, total=16)
-        assert result["status"] == "yellow", "A single >5% spike should prevent green"
+        assert result["status"] == "yellow", "A single >1% spike should prevent green"
+
+    def test_low_flip_rate_still_yellow(self, client):
+        """Even a modest flip rate (~1.5%) should stay yellow under the tight thresholds."""
+        entries = [{"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 200}]
+        for i in range(1, 7):
+            # 3 flips out of ~194 unlabeled → ~1.5% per step
+            entries.append({"time_index": i, "num_labels": 10 + i, "num_flips": 3, "num_unlabeled": 200 - i})
+        self._inject_stability(entries)
+        result = _compute_stable_status(good=8, bad=8, total=16)
+        assert result["status"] == "yellow", "~1.5% flip rate should stay yellow (threshold is 0.5% avg / 1% max)"
+
+    def test_near_zero_flips_green(self, client):
+        """Green requires practically zero flips — only the rare single flip tolerated."""
+        entries = [{"time_index": 0, "num_labels": 10, "num_flips": 0, "num_unlabeled": 500}]
+        for i in range(1, 7):
+            # Mostly 0 flips, one step with 1 flip out of ~496 → 0.2%
+            flips = 1 if i == 3 else 0
+            entries.append({"time_index": i, "num_labels": 10 + i, "num_flips": flips, "num_unlabeled": 500 - i})
+        self._inject_stability(entries)
+        result = _compute_stable_status(good=8, bad=8, total=16)
+        assert result["status"] == "green", "Near-zero flips with rare single flip on large dataset should be green"

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -404,8 +404,8 @@ def _compute_stable_status(
     avg_flip_rate = sum(flip_rates) / len(flip_rates)
     max_flip_rate = max(flip_rates)
 
-    STABLE_RATE_THRESHOLD = 0.02  # average less than 2% of predictions flipping
-    STABLE_MAX_THRESHOLD = 0.05  # no single recent step above 5%
+    STABLE_RATE_THRESHOLD = 0.005  # average less than 0.5% of predictions flipping
+    STABLE_MAX_THRESHOLD = 0.01  # no single recent step above 1%
 
     if avg_flip_rate < STABLE_RATE_THRESHOLD and max_flip_rate < STABLE_MAX_THRESHOLD:
         return {"status": "green", "reason": "Predictions have stabilized.", "avg_flip_rate": round(avg_flip_rate, 4)}


### PR DESCRIPTION
## Summary
This PR significantly tightens the thresholds used to determine when model predictions have stabilized, reducing the acceptable flip rates from 2% average / 5% maximum to 0.5% average / 1% maximum.

## Changes
- **Reduced average flip rate threshold** from 2% to 0.5% (`STABLE_RATE_THRESHOLD`)
- **Reduced maximum single-step flip rate threshold** from 5% to 1% (`STABLE_MAX_THRESHOLD`)
- **Updated test expectations** to reflect the stricter thresholds
- **Added two new test cases**:
  - `test_low_flip_rate_still_yellow`: Validates that a ~1.5% flip rate correctly stays yellow under the new thresholds
  - `test_near_zero_flips_green`: Validates that near-zero flips with only rare single flips on large datasets achieve green status

## Implementation Details
The stricter thresholds ensure that the "green" (stable) status is only granted when predictions are genuinely stable with minimal label flipping. This prevents premature stability declarations and provides more conservative progress tracking. The new test cases confirm that the thresholds work as intended across different flip rate scenarios.

https://claude.ai/code/session_01SnHdbecSqVRqfss6TADGhH