### PR TITLE
Add server-side detector file import/export functionality

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1170,7 +1170,7 @@
     });
   }
 
-  // Server-side detector export (ServerFileDetectorExtractor)
+  // Server-side detector export (ServerFileProcessorExporter)
   if (menuDetectorExportServer && menuDetectorStatus && burgerDropdown) {
     menuDetectorExportServer.addEventListener("click", async () => {
       menuDetectorStatus.textContent = "";

--- a/static/app.js
+++ b/static/app.js
@@ -261,6 +261,7 @@
   const menuLabelsStatus = document.getElementById("menu-labels-status");
   const menuDetectorImport = document.getElementById("menu-detector-import");
   const menuDetectorExport = document.getElementById("menu-detector-export");
+  const menuDetectorExportServer = document.getElementById("menu-detector-export-server");
   const menuDetectorStatus = document.getElementById("menu-detector-status");
   const labelImporterModal = document.getElementById("label-importer-modal");
   const labelImporterModalClose = document.getElementById("label-importer-modal-close");
@@ -1163,8 +1164,88 @@
       a.download = "detector.json";
       a.click();
       URL.revokeObjectURL(url);
-      menuDetectorStatus.textContent = "Detector exported";
+      menuDetectorStatus.textContent = "Detector exported (browser)";
       setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+      closeBurgerMenu();
+    });
+  }
+
+  // Server-side detector export (ServerFileDetectorExtractor)
+  if (menuDetectorExportServer && menuDetectorStatus && burgerDropdown) {
+    menuDetectorExportServer.addEventListener("click", async () => {
+      menuDetectorStatus.textContent = "";
+      if (votes.good.length === 0 || votes.bad.length === 0) {
+        menuDetectorStatus.textContent = "Vote good & bad clips first";
+        setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+        return;
+      }
+
+      const name = prompt("Enter a name for the detector file (saved on server):");
+      if (!name || !name.trim()) return;
+
+      menuDetectorStatus.textContent = "Saving detector to server\u2026";
+
+      const res = await fetch("/api/detector/export-server", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+
+      if (res.status === 409) {
+        const info = await res.json();
+        const overwrite = confirm(
+          `A detector file "${info.name}.json" already exists on the server.\n\n` +
+          `Path: ${info.path}\n\nOverwrite it?`
+        );
+        if (overwrite) {
+          menuDetectorStatus.textContent = "Overwriting detector on server\u2026";
+          const res2 = await fetch("/api/detector/export-server", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: name.trim(), overwrite: true }),
+          });
+          if (res2.ok) {
+            const data2 = await res2.json();
+            menuDetectorStatus.textContent = `Saved to server: ${data2.name}.json`;
+            setTimeout(() => { menuDetectorStatus.textContent = ""; }, 4000);
+          } else {
+            const err = await res2.json().catch(() => ({}));
+            menuDetectorStatus.textContent = err.error || "Server export failed";
+            setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+          }
+        } else {
+          // User chose not to overwrite; ask for a new name
+          const newName = prompt("Enter a different name:");
+          if (newName && newName.trim()) {
+            menuDetectorStatus.textContent = "Saving detector to server\u2026";
+            const res3 = await fetch("/api/detector/export-server", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ name: newName.trim() }),
+            });
+            if (res3.ok) {
+              const data3 = await res3.json();
+              menuDetectorStatus.textContent = `Saved to server: ${data3.name}.json`;
+              setTimeout(() => { menuDetectorStatus.textContent = ""; }, 4000);
+            } else {
+              const err = await res3.json().catch(() => ({}));
+              menuDetectorStatus.textContent = err.error || "Server export failed";
+              setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+            }
+          } else {
+            menuDetectorStatus.textContent = "Export cancelled";
+            setTimeout(() => { menuDetectorStatus.textContent = ""; }, 2000);
+          }
+        }
+      } else if (res.ok) {
+        const data = await res.json();
+        menuDetectorStatus.textContent = `Saved to server: ${data.name}.json`;
+        setTimeout(() => { menuDetectorStatus.textContent = ""; }, 4000);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        menuDetectorStatus.textContent = err.error || "Server export failed";
+        setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+      }
       closeBurgerMenu();
     });
   }

--- a/static/index.html
+++ b/static/index.html
@@ -30,7 +30,8 @@
       <div class="burger-section" role="group" aria-label="Detector">
         <div class="burger-section-title" id="menu-section-detector">Detector</div>
         <div class="burger-item" id="menu-detector-import" role="menuitem" tabindex="-1">Load Sort</div>
-        <div class="burger-item" id="menu-detector-export" role="menuitem" tabindex="-1">Export Detector</div>
+        <div class="burger-item" id="menu-detector-export" role="menuitem" tabindex="-1">Export Detector (Browser)</div>
+        <div class="burger-item" id="menu-detector-export-server" role="menuitem" tabindex="-1">Export Detector (Server)</div>
         <div class="burger-status" id="menu-detector-status" aria-live="polite"></div>
       </div>
       <div class="burger-section" role="group" aria-label="Favorite Detectors">

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -544,3 +544,125 @@ class TestAutoDetect:
         for result in data["results"].values():
             scores = [h["score"] for h in result["negative_hits"]]
             assert scores == sorted(scores, reverse=True)
+
+
+class TestServerDetectorExport:
+    """Tests for the ServerFileDetectorExtractor endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_server_dir(self, tmp_path, monkeypatch):
+        """Point SERVER_DETECTOR_DIR at a temp directory for each test."""
+        from vtsearch.routes import detectors as det_module
+
+        monkeypatch.setattr(det_module, "SERVER_DETECTOR_DIR", tmp_path / "detectors")
+        self._det_dir = tmp_path / "detectors"
+        yield
+
+    def _vote(self):
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+
+    # -- basic success --
+
+    def test_export_server_creates_file(self, client):
+        self._vote()
+        resp = client.post("/api/detector/export-server", json={"name": "my_detector"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["name"] == "my_detector"
+        assert (self._det_dir / "my_detector.json").exists()
+
+    def test_export_server_file_contains_valid_json(self, client):
+        self._vote()
+        client.post("/api/detector/export-server", json={"name": "valid_json"})
+        content = json.loads((self._det_dir / "valid_json.json").read_text())
+        assert "weights" in content
+        assert "threshold" in content
+        assert "media_type" in content
+        assert "name" in content
+
+    def test_export_server_returns_path(self, client):
+        self._vote()
+        resp = client.post("/api/detector/export-server", json={"name": "path_check"})
+        data = resp.get_json()
+        assert "path" in data
+        assert "path_check.json" in data["path"]
+
+    # -- name validation --
+
+    def test_export_server_missing_name_returns_400(self, client):
+        self._vote()
+        resp = client.post("/api/detector/export-server", json={})
+        assert resp.status_code == 400
+        assert "name" in resp.get_json()["error"].lower()
+
+    def test_export_server_empty_name_returns_400(self, client):
+        self._vote()
+        resp = client.post("/api/detector/export-server", json={"name": "  "})
+        assert resp.status_code == 400
+
+    # -- vote validation --
+
+    def test_export_server_no_votes_returns_400(self, client):
+        resp = client.post("/api/detector/export-server", json={"name": "no_votes"})
+        assert resp.status_code == 400
+        assert "vote" in resp.get_json()["error"].lower()
+
+    # -- overwrite logic --
+
+    def test_export_server_returns_409_when_exists(self, client):
+        self._vote()
+        client.post("/api/detector/export-server", json={"name": "dup"})
+        # Second export without overwrite
+        resp = client.post("/api/detector/export-server", json={"name": "dup"})
+        assert resp.status_code == 409
+        data = resp.get_json()
+        assert data["exists"] is True
+        assert "dup" in data["name"]
+
+    def test_export_server_overwrite_succeeds(self, client):
+        self._vote()
+        client.post("/api/detector/export-server", json={"name": "overwrite_me"})
+        resp = client.post(
+            "/api/detector/export-server",
+            json={"name": "overwrite_me", "overwrite": True},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+
+    # -- list server files --
+
+    def test_list_server_files_empty(self, client):
+        resp = client.get("/api/detector/server-files")
+        assert resp.status_code == 200
+        assert resp.get_json()["files"] == []
+
+    def test_list_server_files_after_export(self, client):
+        self._vote()
+        client.post("/api/detector/export-server", json={"name": "listed"})
+        resp = client.get("/api/detector/server-files")
+        data = resp.get_json()
+        names = [f["name"] for f in data["files"]]
+        assert "listed" in names
+
+    def test_list_server_files_has_path_and_size(self, client):
+        self._vote()
+        client.post("/api/detector/export-server", json={"name": "sized"})
+        resp = client.get("/api/detector/server-files")
+        entry = resp.get_json()["files"][0]
+        assert "path" in entry
+        assert "size_bytes" in entry
+        assert entry["size_bytes"] > 0
+
+    # -- name sanitisation --
+
+    def test_export_server_sanitises_name(self, client):
+        self._vote()
+        resp = client.post("/api/detector/export-server", json={"name": "a/b\\c:d"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Special characters should be stripped
+        assert "/" not in data["name"]
+        assert "\\" not in data["name"]
+        assert ":" not in data["name"]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -547,7 +547,7 @@ class TestAutoDetect:
 
 
 class TestServerDetectorExport:
-    """Tests for the ServerFileDetectorExtractor endpoints."""
+    """Tests for the ServerFileProcessorExporter endpoints."""
 
     @pytest.fixture(autouse=True)
     def _setup_server_dir(self, tmp_path, monkeypatch):

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -460,8 +460,7 @@ class TestServerFileDetectorImporter:
 
         res = client.post(
             "/api/processor-importers/import/server_detector_file",
-            data={"filepath": str(p), "name": "server_test_det"},
-            content_type="multipart/form-data",
+            json={"filepath": str(p), "name": "server_test_det"},
         )
         assert res.status_code == 200
         result = res.get_json()

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -257,8 +257,8 @@ class TestProcessorImporterRegistry:
 # ---------------------------------------------------------------------------
 
 
-class TestLocalFileDetectorImporter:
-    """Tests for the LocalFileDetectorImporter (formerly DetectorFileProcessorImporter)."""
+class TestLocalFileProcessorImporter:
+    """Tests for the LocalFileProcessorImporter (formerly DetectorFileProcessorImporter)."""
 
     def _get_importer(self):
         from vtsearch.processors.importers.detector_file import PROCESSOR_IMPORTER
@@ -269,9 +269,9 @@ class TestLocalFileDetectorImporter:
         assert self._get_importer().name == "detector_file"
 
     def test_class_name(self):
-        from vtsearch.processors.importers.detector_file import LocalFileDetectorImporter
+        from vtsearch.processors.importers.detector_file import LocalFileProcessorImporter
 
-        assert isinstance(self._get_importer(), LocalFileDetectorImporter)
+        assert isinstance(self._get_importer(), LocalFileProcessorImporter)
 
     def test_display_name(self):
         assert "detector" in self._get_importer().display_name.lower()
@@ -355,7 +355,7 @@ class TestLocalFileDetectorImporter:
 # ---------------------------------------------------------------------------
 
 
-class TestServerFileDetectorImporter:
+class TestServerFileProcessorImporter:
     def _get_importer(self):
         from vtsearch.processors.importers.server_detector_file import PROCESSOR_IMPORTER
 
@@ -365,9 +365,9 @@ class TestServerFileDetectorImporter:
         assert self._get_importer().name == "server_detector_file"
 
     def test_class_name(self):
-        from vtsearch.processors.importers.server_detector_file import ServerFileDetectorImporter
+        from vtsearch.processors.importers.server_detector_file import ServerFileProcessorImporter
 
-        assert isinstance(self._get_importer(), ServerFileDetectorImporter)
+        assert isinstance(self._get_importer(), ServerFileProcessorImporter)
 
     def test_display_name(self):
         assert "server" in self._get_importer().display_name.lower()

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -214,13 +214,14 @@ class TestProcessorImporterRegistry:
 
         names = {imp.name for imp in list_processor_importers()}
         assert "detector_file" in names
+        assert "server_detector_file" in names
         assert "label_file" in names
         assert "csv_label_file" in names
 
     def test_get_processor_importer_known(self):
         from vtsearch.processors.importers import get_processor_importer
 
-        for name in ("detector_file", "label_file", "csv_label_file"):
+        for name in ("detector_file", "server_detector_file", "label_file", "csv_label_file"):
             imp = get_processor_importer(name)
             assert imp is not None, f"Processor importer '{name}' not found"
             assert imp.name == name
@@ -256,7 +257,9 @@ class TestProcessorImporterRegistry:
 # ---------------------------------------------------------------------------
 
 
-class TestDetectorFileImporter:
+class TestLocalFileDetectorImporter:
+    """Tests for the LocalFileDetectorImporter (formerly DetectorFileProcessorImporter)."""
+
     def _get_importer(self):
         from vtsearch.processors.importers.detector_file import PROCESSOR_IMPORTER
 
@@ -265,8 +268,14 @@ class TestDetectorFileImporter:
     def test_name(self):
         assert self._get_importer().name == "detector_file"
 
+    def test_class_name(self):
+        from vtsearch.processors.importers.detector_file import LocalFileDetectorImporter
+
+        assert isinstance(self._get_importer(), LocalFileDetectorImporter)
+
     def test_display_name(self):
         assert "detector" in self._get_importer().display_name.lower()
+        assert "local" in self._get_importer().display_name.lower()
 
     def test_icon(self):
         assert self._get_importer().icon
@@ -339,6 +348,130 @@ class TestDetectorFileImporter:
     def test_run_cli_raises_on_empty_path(self):
         with pytest.raises(ValueError, match="--file"):
             self._get_importer().run_cli({"file": ""})
+
+
+# ---------------------------------------------------------------------------
+# Server detector file importer
+# ---------------------------------------------------------------------------
+
+
+class TestServerFileDetectorImporter:
+    def _get_importer(self):
+        from vtsearch.processors.importers.server_detector_file import PROCESSOR_IMPORTER
+
+        return PROCESSOR_IMPORTER
+
+    def test_name(self):
+        assert self._get_importer().name == "server_detector_file"
+
+    def test_class_name(self):
+        from vtsearch.processors.importers.server_detector_file import ServerFileDetectorImporter
+
+        assert isinstance(self._get_importer(), ServerFileDetectorImporter)
+
+    def test_display_name(self):
+        assert "server" in self._get_importer().display_name.lower()
+
+    def test_icon(self):
+        assert self._get_importer().icon
+
+    def test_has_filepath_field(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "filepath" in fields
+        assert fields["filepath"].field_type == "text"
+
+    def test_run_with_valid_file(self, tmp_path):
+        payload = {
+            "weights": {"0.weight": [[1.0, 2.0]], "0.bias": [0.5]},
+            "threshold": 0.75,
+            "media_type": "image",
+        }
+        p = tmp_path / "detector.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run({"filepath": str(p)})
+        assert result["media_type"] == "image"
+        assert result["weights"] == payload["weights"]
+        assert result["threshold"] == 0.75
+
+    def test_run_defaults_media_type_to_audio(self, tmp_path):
+        payload = {"weights": {"0.weight": [[1.0]]}, "threshold": 0.5}
+        p = tmp_path / "detector.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run({"filepath": str(p)})
+        assert result["media_type"] == "audio"
+
+    def test_run_includes_suggested_name(self, tmp_path):
+        payload = {"weights": {"0.weight": [[1.0]]}, "threshold": 0.5, "name": "my detector"}
+        p = tmp_path / "detector.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run({"filepath": str(p)})
+        assert result["name"] == "my detector"
+
+    def test_run_raises_on_invalid_json(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("not json")
+        with pytest.raises(ValueError, match="JSON"):
+            self._get_importer().run({"filepath": str(p)})
+
+    def test_run_raises_on_missing_weights(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text(json.dumps({"threshold": 0.5}))
+        with pytest.raises(ValueError, match="weights"):
+            self._get_importer().run({"filepath": str(p)})
+
+    def test_run_raises_when_no_filepath(self):
+        with pytest.raises(ValueError, match="path"):
+            self._get_importer().run({"filepath": ""})
+
+    def test_run_raises_when_file_not_found(self, tmp_path):
+        with pytest.raises(ValueError, match="not found"):
+            self._get_importer().run({"filepath": str(tmp_path / "nonexistent.json")})
+
+    def test_run_cli_delegates_to_run(self, tmp_path):
+        payload = {"weights": {"0.weight": [[1.0]], "0.bias": [0.1]}, "threshold": 0.6}
+        p = tmp_path / "detector.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run_cli({"filepath": str(p)})
+        assert result["threshold"] == 0.6
+        assert result["weights"] == payload["weights"]
+
+    def test_registry_contains_server_detector_file(self):
+        from vtsearch.processors.importers import list_processor_importers
+
+        names = {imp.name for imp in list_processor_importers()}
+        assert "server_detector_file" in names
+
+    def test_api_lists_server_detector_file(self, client):
+        res = client.get("/api/processor-importers")
+        assert res.status_code == 200
+        names = {entry["name"] for entry in res.get_json()}
+        assert "server_detector_file" in names
+
+    def test_api_import_from_server_path(self, client, tmp_path):
+        from vtsearch.utils import favorite_detectors
+
+        payload = {
+            "weights": {"0.weight": [[1.0, 2.0]], "0.bias": [0.5]},
+            "threshold": 0.75,
+            "media_type": "image",
+        }
+        p = tmp_path / "detector.json"
+        p.write_text(json.dumps(payload))
+
+        res = client.post(
+            "/api/processor-importers/import/server_detector_file",
+            data={"filepath": str(p), "name": "server_test_det"},
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["success"] is True
+        assert result["name"] == "server_test_det"
+        assert result["media_type"] == "image"
+        assert "server_test_det" in favorite_detectors
+
+        # Clean up
+        favorite_detectors.pop("server_test_det", None)
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +559,7 @@ class TestGetProcessorImportersEndpoint:
         res = client.get("/api/processor-importers")
         names = {entry["name"] for entry in res.get_json()}
         assert "detector_file" in names
+        assert "server_detector_file" in names
         assert "label_file" in names
         assert "csv_label_file" in names
 

--- a/vtsearch/processors/importers/detector_file/__init__.py
+++ b/vtsearch/processors/importers/detector_file/__init__.py
@@ -23,7 +23,7 @@ from typing import Any
 from vtsearch.processors.importers.base import ProcessorImporter, ProcessorImporterField
 
 
-class LocalFileDetectorImporter(ProcessorImporter):
+class LocalFileProcessorImporter(ProcessorImporter):
     """Import a processor (detector) from a local JSON file uploaded via the browser.
 
     The file must contain ``"weights"`` (serialised MLP state dict) and
@@ -103,4 +103,4 @@ def _parse_detector_json(raw: bytes) -> dict[str, Any]:
     return result
 
 
-PROCESSOR_IMPORTER = LocalFileDetectorImporter()
+PROCESSOR_IMPORTER = LocalFileProcessorImporter()

--- a/vtsearch/processors/importers/detector_file/__init__.py
+++ b/vtsearch/processors/importers/detector_file/__init__.py
@@ -23,8 +23,8 @@ from typing import Any
 from vtsearch.processors.importers.base import ProcessorImporter, ProcessorImporterField
 
 
-class DetectorFileProcessorImporter(ProcessorImporter):
-    """Import a processor (detector) from a JSON file.
+class LocalFileDetectorImporter(ProcessorImporter):
+    """Import a processor (detector) from a local JSON file uploaded via the browser.
 
     The file must contain ``"weights"`` (serialised MLP state dict) and
     ``"threshold"`` (float).  An optional ``"media_type"`` key specifies the
@@ -32,8 +32,8 @@ class DetectorFileProcessorImporter(ProcessorImporter):
     """
 
     name = "detector_file"
-    display_name = "Detector File (.json)"
-    description = "Import a pre-trained detector from a VTSearch detector JSON file."
+    display_name = "Local Detector File (.json)"
+    description = "Import a pre-trained detector from a JSON file uploaded from your local machine."
     icon = "\U0001f4c4"  # page facing up
     fields = [
         ProcessorImporterField(
@@ -103,4 +103,4 @@ def _parse_detector_json(raw: bytes) -> dict[str, Any]:
     return result
 
 
-PROCESSOR_IMPORTER = DetectorFileProcessorImporter()
+PROCESSOR_IMPORTER = LocalFileDetectorImporter()

--- a/vtsearch/processors/importers/server_detector_file/__init__.py
+++ b/vtsearch/processors/importers/server_detector_file/__init__.py
@@ -25,7 +25,7 @@ from typing import Any
 from vtsearch.processors.importers.base import ProcessorImporter, ProcessorImporterField
 
 
-class ServerFileDetectorImporter(ProcessorImporter):
+class ServerFileProcessorImporter(ProcessorImporter):
     """Import a processor (detector) from a JSON file on the server filesystem.
 
     The user provides a file path on the server (the machine running the
@@ -104,4 +104,4 @@ def _parse_detector_json(raw: bytes) -> dict[str, Any]:
     return result
 
 
-PROCESSOR_IMPORTER = ServerFileDetectorImporter()
+PROCESSOR_IMPORTER = ServerFileProcessorImporter()

--- a/vtsearch/processors/importers/server_detector_file/__init__.py
+++ b/vtsearch/processors/importers/server_detector_file/__init__.py
@@ -1,0 +1,107 @@
+"""Server-file detector importer -- loads a detector from a ``.json`` file on the server.
+
+This importer reads a VTSearch detector JSON file from the server filesystem
+(the machine where the Python process is running), as opposed to the local
+(browser-upload) importer which receives files uploaded from the user's
+browser.  The file format is identical::
+
+    {
+        "weights": {"0.weight": [...], "0.bias": [...], "2.weight": [...], "2.bias": [...]},
+        "threshold": 0.5,
+        "media_type": "audio",
+        "name": "my detector"
+    }
+
+No additional pip packages are required; uses only Python's ``json`` and
+``pathlib`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vtsearch.processors.importers.base import ProcessorImporter, ProcessorImporterField
+
+
+class ServerFileDetectorImporter(ProcessorImporter):
+    """Import a processor (detector) from a JSON file on the server filesystem.
+
+    The user provides a file path on the server (the machine running the
+    Python process).  The file must contain ``"weights"`` (serialised MLP
+    state dict) and ``"threshold"`` (float).  An optional ``"media_type"``
+    key specifies the media type; when absent it defaults to ``"audio"``.
+    """
+
+    name = "server_detector_file"
+    display_name = "Server Detector File (.json)"
+    description = "Import a pre-trained detector from a JSON file on the server filesystem."
+    icon = "\U0001f5a5"  # desktop computer
+    fields = [
+        ProcessorImporterField(
+            key="filepath",
+            label="Server File Path",
+            field_type="text",
+            description=(
+                "Absolute or relative path to a VTSearch detector JSON file "
+                "on the server filesystem."
+            ),
+            placeholder="data/detectors/my_detector.json",
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any]) -> dict[str, Any]:
+        """Read and parse the JSON detector file from the server filesystem."""
+        filepath = (field_values.get("filepath") or "").strip()
+        if not filepath:
+            raise ValueError("A file path is required.")
+
+        path = Path(filepath)
+        if not path.exists():
+            raise ValueError(f"File not found: {path}")
+        if not path.is_file():
+            raise ValueError(f"Not a file: {path}")
+
+        raw = path.read_bytes()
+        return _parse_detector_json(raw)
+
+    def run_cli(self, field_values: dict[str, Any]) -> dict[str, Any]:
+        """Load a detector from a file-path string (CLI usage)."""
+        return self.run(field_values)
+
+    def add_cli_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--filepath",
+            dest="filepath",
+            help="Path to a VTSearch detector JSON file on the server.",
+            required=False,
+        )
+
+
+def _parse_detector_json(raw: bytes) -> dict[str, Any]:
+    """Decode *raw* bytes as JSON and extract detector data."""
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    weights = data.get("weights")
+    if not weights:
+        raise ValueError("Detector file missing 'weights' field.")
+
+    threshold = data.get("threshold", 0.5)
+    media_type = data.get("media_type", "audio")
+    suggested_name = data.get("name", "")
+
+    result: dict[str, Any] = {
+        "media_type": media_type,
+        "weights": weights,
+        "threshold": threshold,
+    }
+    if suggested_name:
+        result["name"] = suggested_name
+    return result
+
+
+PROCESSOR_IMPORTER = ServerFileDetectorImporter()

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -98,7 +98,7 @@ def export_detector():
 
 
 # ---------------------------------------------------------------------------
-# Server-side detector file export (ServerFileDetectorExtractor)
+# Server-side detector file export (ServerFileProcessorExporter)
 # ---------------------------------------------------------------------------
 
 #: Default directory for server-side detector files.

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -97,6 +97,131 @@ def export_detector():
     return jsonify({"weights": weights, "threshold": round(threshold, 4)})
 
 
+# ---------------------------------------------------------------------------
+# Server-side detector file export (ServerFileDetectorExtractor)
+# ---------------------------------------------------------------------------
+
+#: Default directory for server-side detector files.
+SERVER_DETECTOR_DIR = Path("data/detectors")
+
+
+@detectors_bp.route("/api/detector/export-server", methods=["POST"])
+def export_detector_server():
+    """Train MLP on current votes and save to a file on the server filesystem.
+
+    Expects JSON body with ``name`` (required) and optionally ``overwrite``
+    (bool, default false).  The detector is saved as
+    ``data/detectors/<name>.json``.  If the file already exists and
+    ``overwrite`` is false, returns ``{"exists": true, "path": ...}`` with
+    status 409 so the client can ask the user whether to overwrite.
+    """
+    import torch  # noqa: PLC0415
+
+    from vtsearch.utils import bad_votes, good_votes
+
+    data = request.get_json(force=True)
+    if data is None:
+        return jsonify({"error": "Invalid request body"}), 400
+
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify({"error": "name is required"}), 400
+
+    overwrite = data.get("overwrite", False)
+
+    # Sanitise the filename: only allow alphanumeric, hyphen, underscore, space
+    safe_name = "".join(c for c in name if c.isalnum() or c in "-_ ")
+    if not safe_name:
+        return jsonify({"error": "name contains no valid characters"}), 400
+
+    SERVER_DETECTOR_DIR.mkdir(parents=True, exist_ok=True)
+    filepath = SERVER_DETECTOR_DIR / f"{safe_name}.json"
+
+    # Check for existing file before doing expensive training
+    if filepath.exists() and not overwrite:
+        return jsonify({"exists": True, "path": str(filepath.resolve()), "name": safe_name}), 409
+
+    if not good_votes or not bad_votes:
+        return jsonify({"error": "need at least one good and one bad vote"}), 400
+
+    # Train the model (same logic as export_detector)
+    X_list = []
+    y_list = []
+    for cid in good_votes:
+        if cid in clips:
+            X_list.append(clips[cid]["embedding"])
+            y_list.append(1.0)
+    for cid in bad_votes:
+        if cid in clips:
+            X_list.append(clips[cid]["embedding"])
+            y_list.append(0.0)
+
+    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+    input_dim = X.shape[1]
+
+    threshold = calculate_cross_calibration_threshold(
+        X_list,
+        y_list,
+        input_dim,
+        get_inclusion(),
+        calibrate_count=get_calibrate_count(),
+        calibration_fraction=get_calibration_fraction(),
+    )
+    model = train_model(X, y, input_dim, get_inclusion())
+
+    if get_safe_thresholds():
+        all_ids = sorted(clips.keys())
+        all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
+        X_all = torch.tensor(all_embs, dtype=torch.float32)
+        with torch.no_grad():
+            all_scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
+        threshold = calculate_safe_threshold(threshold, all_scores, len(X_list))
+
+    state_dict = model.state_dict()
+    weights = {}
+    for key, value in state_dict.items():
+        weights[key] = value.tolist()
+
+    # Determine media type from current clips
+    media_type = "audio"
+    if clips:
+        media_type = next(iter(clips.values())).get("type", "audio")
+
+    detector_data = {
+        "weights": weights,
+        "threshold": round(threshold, 4),
+        "media_type": media_type,
+        "name": safe_name,
+    }
+
+    filepath.write_text(json.dumps(detector_data, indent=2), encoding="utf-8")
+
+    return jsonify({
+        "success": True,
+        "name": safe_name,
+        "path": str(filepath.resolve()),
+        "threshold": round(threshold, 4),
+        "media_type": media_type,
+    })
+
+
+@detectors_bp.route("/api/detector/server-files", methods=["GET"])
+def list_server_detector_files():
+    """List detector JSON files saved on the server in data/detectors/."""
+    if not SERVER_DETECTOR_DIR.is_dir():
+        return jsonify({"files": []})
+
+    files = []
+    for p in sorted(SERVER_DETECTOR_DIR.glob("*.json")):
+        files.append({
+            "name": p.stem,
+            "path": str(p.resolve()),
+            "size_bytes": p.stat().st_size,
+        })
+    return jsonify({"files": files})
+
+
 @detectors_bp.route("/api/detector-sort", methods=["POST"])
 def detector_sort():
     """Score all clips using a loaded detector model."""


### PR DESCRIPTION
## Summary
This PR adds server-side detector file import and export capabilities to complement the existing browser-based detector file handling. Users can now save trained detectors to the server filesystem and import detectors from server-stored JSON files.

## Key Changes

### Backend
- **New Server Detector Exporter** (`vtsearch/routes/detectors.py`):
  - Added `/api/detector/export-server` endpoint to train and save detectors as JSON files to `data/detectors/` directory
  - Added `/api/detector/server-files` endpoint to list available server-stored detector files
  - Implements file existence checking with 409 conflict response and overwrite support
  - Includes filename sanitization to prevent path traversal attacks
  - Validates that at least one good and one bad vote exist before training

- **New Server Detector Importer** (`vtsearch/processors/importers/server_detector_file/`):
  - Created `ServerFileProcessorImporter` class to load detectors from server filesystem paths
  - Parses JSON detector files with validation for required `weights` field
  - Defaults `media_type` to "audio" when not specified
  - Supports optional `name` field from detector metadata

- **Refactored Local Detector Importer** (`vtsearch/processors/importers/detector_file/`):
  - Renamed `DetectorFileProcessorImporter` to `LocalFileProcessorImporter` for clarity
  - Updated display name to indicate "Local" file source
  - Maintains backward compatibility with existing `detector_file` importer name

### Frontend
- **UI Updates** (`static/app.js`, `static/index.html`):
  - Added "Export to Server" menu item in detector section
  - Implements prompt-based workflow for naming server-stored detectors
  - Handles 409 conflict responses with user confirmation for overwrite
  - Provides fallback to rename detector if file already exists
  - Updated browser export status message to clarify "(browser)" source

### Tests
- **Comprehensive test coverage** (`tests/test_processor_importers.py`, `tests/test_detectors.py`):
  - Added `TestServerFileProcessorImporter` class with 13 test cases covering:
    - File I/O operations and JSON parsing
    - Error handling (missing weights, invalid JSON, file not found)
    - API integration and registry inclusion
    - Media type defaulting and name suggestions
  - Renamed `TestDetectorFileImporter` to `TestLocalFileProcessorImporter`
  - Added tests for server export endpoint with vote validation, overwrite logic, and name sanitization
  - Updated existing tests to include new `server_detector_file` importer in registry checks

## Implementation Details
- Server detector files are stored in `data/detectors/` with `.json` extension
- File paths are resolved to absolute paths in API responses for clarity
- Detector JSON format is consistent between browser and server importers: `{weights, threshold, media_type, name}`
- Name sanitization strips special characters but preserves alphanumeric, hyphen, underscore, and space
- Uses temporary directory fixtures in tests to avoid filesystem pollution

https://claude.ai/code/session_01HMomz2x1vrMhVszNC4V7fV