### PR TITLE
Change default demo section sort from label to num_files

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -694,7 +694,7 @@
           // Create section (table)
           const section = document.createElement("div");
           section.className = "demo-section";
-          section._demoSort = { key: "label", asc: true };
+          section._demoSort = { key: "num_files", asc: true };
           section.style.display = "none";
 
           const headerRow = sortColumns.map(col =>


### PR DESCRIPTION
## Summary
Updated the default sorting behavior for demo sections to sort by file count instead of label.

## Changes
- Modified the default sort key for demo sections from `"label"` to `"num_files"`
- The sort order remains ascending (`asc: true`)

## Details
This change affects the initial display of demo sections, which will now be ordered by the number of files rather than alphabetically by label. The sorting direction and mechanism remain unchanged.

https://claude.ai/code/session_01GjFc5DrUtnQBZHB3M1tc5x