### PR TITLE
Refactor importers and exporters to distinguish local vs server sources

### DIFF
--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -1043,7 +1043,7 @@ class TestRunExporter:
         results = _build_results_dict(hits, str(detector_path), "audio")
 
         output_file = tmp_path / "export_output.json"
-        _run_exporter("file", {"filepath": str(output_file)}, results)
+        _run_exporter("server_json_file", {"filepath": str(output_file)}, results)
 
         assert output_file.exists()
         saved = json.loads(output_file.read_text())
@@ -1096,7 +1096,7 @@ class TestAutodetectMainWithExporter:
         autodetect_main(
             str(dataset_path),
             settings_path=str(settings_path),
-            exporter_name="file",
+            exporter_name="server_json_file",
             exporter_field_values={"filepath": str(output_file)},
         )
 
@@ -1132,7 +1132,7 @@ class TestAutodetectMainWithExporter:
         autodetect_main(
             str(dataset_path),
             settings_path=str(settings_path),
-            exporter_name="file",
+            exporter_name="server_json_file",
             exporter_field_values={"filepath": str(output_file)},
         )
 
@@ -1157,7 +1157,7 @@ class TestAutodetectImporterMainWithExporter:
             "pickle",
             {"file": str(dataset_path)},
             settings_path=str(settings_path),
-            exporter_name="file",
+            exporter_name="server_json_file",
             exporter_field_values={"filepath": str(output_file)},
         )
 

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -831,20 +831,20 @@ class TestAutodetectImporterCLI:
 class TestExporterCLIArguments:
     """Tests for add_cli_arguments and validate_cli_field_values on exporters."""
 
-    def test_file_exporter_adds_filepath_arg(self):
-        from vtsearch.exporters.file import FileLabelsetExporter
+    def test_server_json_exporter_adds_filepath_arg(self):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
 
-        exp = FileLabelsetExporter()
+        exp = ServerJsonLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
         args = parser.parse_args(["--filepath", "/tmp/results.json"])
         assert args.filepath == "/tmp/results.json"
 
-    def test_file_exporter_filepath_default(self):
-        from vtsearch.exporters.file import FileLabelsetExporter
+    def test_server_json_exporter_filepath_default(self):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
 
-        exp = FileLabelsetExporter()
+        exp = ServerJsonLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -931,10 +931,10 @@ class TestExporterCLIArguments:
             }
         )
 
-    def test_file_exporter_validate_passes(self):
-        from vtsearch.exporters.file import FileLabelsetExporter
+    def test_server_json_exporter_validate_passes(self):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
 
-        exp = FileLabelsetExporter()
+        exp = ServerJsonLabelsetExporter()
         exp.validate_cli_field_values({"filepath": "/tmp/out.json"})
 
     def test_gui_exporter_validate_passes_empty(self):

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -75,34 +75,34 @@ class TestCsvExporterMetadata:
     def test_csv_exporter_registered(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("csv")
+        exp = get_exporter("server_csv_file")
         assert exp is not None
 
     def test_csv_exporter_display_name(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("csv")
-        assert exp.display_name == "Save to CSV"
+        exp = get_exporter("server_csv_file")
+        assert exp.display_name == "Server CSV File"
 
     def test_csv_exporter_icon(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("csv")
+        exp = get_exporter("server_csv_file")
         assert exp.icon == "\U0001f4ca"
 
     def test_csv_exporter_has_filepath_field(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("csv")
+        exp = get_exporter("server_csv_file")
         keys = [f.key for f in exp.fields]
         assert "filepath" in keys
 
     def test_csv_exporter_to_dict(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("csv")
+        exp = get_exporter("server_csv_file")
         d = exp.to_dict()
-        assert d["name"] == "csv"
+        assert d["name"] == "server_csv_file"
         assert "fields" in d
         assert len(d["fields"]) >= 1
 
@@ -116,9 +116,9 @@ class TestCsvExporterCLI:
     """CLI argument parsing for the CSV exporter."""
 
     def test_adds_filepath_arg(self):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -126,9 +126,9 @@ class TestCsvExporterCLI:
         assert args.filepath == "/tmp/results.csv"
 
     def test_filepath_default(self):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -136,15 +136,15 @@ class TestCsvExporterCLI:
         assert args.filepath == "autodetect_results.csv"
 
     def test_validate_passes(self):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         exp.validate_cli_field_values({"filepath": "/tmp/out.csv"})
 
     def test_validate_missing_filepath(self):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         with pytest.raises(ValueError, match="Missing required argument: --filepath"):
             exp.validate_cli_field_values({})
 
@@ -158,9 +158,9 @@ class TestCsvExporterExport:
     """Tests for the CSV export() method."""
 
     def test_creates_csv_file(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -170,9 +170,9 @@ class TestCsvExporterExport:
         assert "Saved" in result["message"]
 
     def test_csv_has_correct_header(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -183,9 +183,9 @@ class TestCsvExporterExport:
         assert header == ["detector", "threshold", "filename", "category", "score", "origin", "origin_name"]
 
     def test_csv_has_correct_row_count(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -197,9 +197,9 @@ class TestCsvExporterExport:
         assert len(rows) == 4
 
     def test_csv_row_values(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
@@ -214,9 +214,9 @@ class TestCsvExporterExport:
         assert first_row[4] == "0.95"
 
     def test_csv_empty_results(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = {"media_type": "audio", "detectors_run": 0, "results": {}}
         filepath = tmp_path / "empty.csv"
 
@@ -225,9 +225,9 @@ class TestCsvExporterExport:
         assert "0 hit(s)" in result["message"]
 
     def test_csv_creates_parent_dirs(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = _make_sample_results()
         filepath = tmp_path / "sub" / "dir" / "output.csv"
 
@@ -235,16 +235,16 @@ class TestCsvExporterExport:
         assert filepath.exists()
 
     def test_csv_empty_filepath_raises(self):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         with pytest.raises(ValueError, match="file path is required"):
             exp.export({}, {"filepath": ""})
 
     def test_csv_multiple_detectors(self, tmp_path):
-        from vtsearch.exporters.csv_file import CsvLabelsetExporter
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
 
-        exp = CsvLabelsetExporter()
+        exp = ServerCsvLabelsetExporter()
         results = {
             "media_type": "audio",
             "detectors_run": 2,
@@ -289,7 +289,7 @@ class TestCsvExporterIntegration:
         results = _build_results_dict(hits, str(detector_path), "audio")
 
         output_file = tmp_path / "integrated.csv"
-        _run_exporter("csv", {"filepath": str(output_file)}, results)
+        _run_exporter("server_csv_file", {"filepath": str(output_file)}, results)
 
         assert output_file.exists()
         with open(output_file, newline="", encoding="utf-8") as f:

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -88,7 +88,7 @@ class TestCsvExporterMetadata:
         from vtsearch.exporters import get_exporter
 
         exp = get_exporter("server_csv_file")
-        assert exp.icon == "\U0001f4ca"
+        assert exp.icon == "\U0001f5a5"
 
     def test_csv_exporter_has_filepath_field(self):
         from vtsearch.exporters import get_exporter

--- a/tests/test_diversity_tree_integration.py
+++ b/tests/test_diversity_tree_integration.py
@@ -301,12 +301,12 @@ class TestLabelImporterUpdatesTree:
         cid = 1
         md5 = medias[cid]["md5"]
 
-        # Import a label via the json_file label importer
+        # Import a label via the local_json_file label importer
         labels_data = {"labels": [{"md5": md5, "label": "good"}]}
         file_content = json.dumps(labels_data).encode()
 
         resp = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data={"file": (io.BytesIO(file_content), "labels.json")},
             content_type="multipart/form-data",
         )

--- a/tests/test_export_options.py
+++ b/tests/test_export_options.py
@@ -295,7 +295,7 @@ class TestExportWithFilteredResults:
             resp = client.post(
                 "/api/exporters/export",
                 json={
-                    "exporter_name": "file",
+                    "exporter_name": "server_json_file",
                     "field_values": {"filepath": str(fpath)},
                     "results": {
                         "media_type": "audio",
@@ -325,7 +325,7 @@ class TestExportWithFilteredResults:
             resp = client.post(
                 "/api/exporters/export",
                 json={
-                    "exporter_name": "file",
+                    "exporter_name": "server_json_file",
                     "field_values": {"filepath": str(fpath)},
                     "results": {
                         "media_type": "audio",
@@ -358,7 +358,7 @@ class TestExportWithFilteredResults:
             resp = client.post(
                 "/api/exporters/export",
                 json={
-                    "exporter_name": "file",
+                    "exporter_name": "server_json_file",
                     "field_values": {"filepath": str(fpath)},
                     "results": {
                         "media_type": "audio",
@@ -405,7 +405,7 @@ class TestExportWithFilteredResults:
             export_resp = client.post(
                 "/api/exporters/export",
                 json={
-                    "exporter_name": "file",
+                    "exporter_name": "server_json_file",
                     "field_values": {"filepath": str(fpath)},
                     "results": fill_data["results"],
                 },

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -3,7 +3,7 @@
 Covers:
 - ExporterField and LabelsetExporter base classes
 - Auto-discovery registry
-- Built-in exporters: gui, file, email_smtp
+- Built-in exporters: gui, local_json_file, server_json_file, email_smtp
 - Flask API routes: GET /api/exporters, POST /api/exporters/export
 """
 
@@ -143,13 +143,16 @@ class TestExporterRegistry:
 
         names = {e.name for e in list_exporters()}
         assert "gui" in names
-        assert "file" in names
+        assert "local_json_file" in names
+        assert "server_json_file" in names
+        assert "local_csv_file" in names
+        assert "server_csv_file" in names
         assert "email_smtp" in names
 
     def test_get_exporter_known(self):
         from vtsearch.exporters import get_exporter
 
-        for name in ("gui", "file", "email_smtp"):
+        for name in ("gui", "local_json_file", "server_json_file", "local_csv_file", "server_csv_file", "email_smtp"):
             exp = get_exporter(name)
             assert exp is not None, f"Exporter '{name}' not found"
             assert exp.name == name
@@ -271,22 +274,22 @@ class TestDisplayLabelsetExporter:
 
 
 # ---------------------------------------------------------------------------
-# File exporter
+# Server JSON file exporter
 # ---------------------------------------------------------------------------
 
 
-class TestFileLabelsetExporter:
+class TestServerJsonLabelsetExporter:
     def test_has_filepath_field(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("file")
+        exp = get_exporter("server_json_file")
         keys = [f.key for f in exp.fields]
         assert "filepath" in keys
 
     def test_export_writes_json(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("file")
+        exp = get_exporter("server_json_file")
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "results.json"
             result = exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
@@ -299,7 +302,7 @@ class TestFileLabelsetExporter:
     def test_export_creates_parent_dirs(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("file")
+        exp = get_exporter("server_json_file")
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "sub" / "dir" / "results.json"
             exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
@@ -308,14 +311,14 @@ class TestFileLabelsetExporter:
     def test_export_raises_on_empty_filepath(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("file")
+        exp = get_exporter("server_json_file")
         with pytest.raises(ValueError, match="file path"):
             exp.export(SAMPLE_RESULTS, {"filepath": ""})
 
     def test_export_message_contains_hit_count(self):
         from vtsearch.exporters import get_exporter
 
-        exp = get_exporter("file")
+        exp = get_exporter("server_json_file")
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "out.json"
             result = exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
@@ -324,10 +327,63 @@ class TestFileLabelsetExporter:
     def test_to_dict_has_all_keys(self):
         from vtsearch.exporters import get_exporter
 
-        d = get_exporter("file").to_dict()
-        assert d["name"] == "file"
+        d = get_exporter("server_json_file").to_dict()
+        assert d["name"] == "server_json_file"
         assert "fields" in d
         assert len(d["fields"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Local JSON file exporter
+# ---------------------------------------------------------------------------
+
+
+class TestLocalJsonLabelsetExporter:
+    def test_export_returns_download_content(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("local_json_file")
+        result = exp.export(SAMPLE_RESULTS, {})
+        assert "message" in result
+        assert "download_content" in result
+        assert "download_filename" in result
+        assert "download_content_type" in result
+        assert result["download_content_type"] == "application/json"
+        parsed = json.loads(result["download_content"])
+        assert parsed["media_type"] == "audio"
+        assert parsed["detectors_run"] == 2
+
+    def test_export_uses_custom_filename(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("local_json_file")
+        result = exp.export(SAMPLE_RESULTS, {"filepath": "custom.json"})
+        assert result["download_filename"] == "custom.json"
+
+    def test_export_default_filename(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("local_json_file")
+        result = exp.export(SAMPLE_RESULTS, {})
+        assert result["download_filename"] == "autodetect_results.json"
+
+    def test_export_cli_writes_file(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("local_json_file")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "out.json"
+            result = exp.export_cli(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            assert fpath.exists()
+            assert "message" in result
+            written = json.loads(fpath.read_text())
+            assert written["media_type"] == "audio"
+
+    def test_to_dict(self):
+        from vtsearch.exporters import get_exporter
+
+        d = get_exporter("local_json_file").to_dict()
+        assert d["name"] == "local_json_file"
 
 
 # ---------------------------------------------------------------------------
@@ -483,7 +539,10 @@ class TestGetExportersEndpoint:
         res = client.get("/api/exporters")
         names = {e["name"] for e in res.get_json()}
         assert "gui" in names
-        assert "file" in names
+        assert "local_json_file" in names
+        assert "server_json_file" in names
+        assert "local_csv_file" in names
+        assert "server_csv_file" in names
         assert "email_smtp" in names
 
     def test_each_entry_has_required_keys(self, client):
@@ -533,13 +592,13 @@ class TestExportEndpoint:
         assert "message" in data
         assert "display_results" in data
 
-    def test_file_exporter_creates_file(self, client):
+    def test_server_json_exporter_creates_file(self, client):
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "export.json"
             res = client.post(
                 "/api/exporters/export",
                 json={
-                    "exporter_name": "file",
+                    "exporter_name": "server_json_file",
                     "field_values": {"filepath": str(fpath)},
                     "results": SAMPLE_RESULTS,
                 },
@@ -551,23 +610,23 @@ class TestExportEndpoint:
             written = json.loads(fpath.read_text())
             assert written["detectors_run"] == 2
 
-    def test_file_exporter_missing_filepath_returns_400(self, client):
+    def test_server_json_exporter_missing_filepath_returns_400(self, client):
         res = client.post(
             "/api/exporters/export",
             json={
-                "exporter_name": "file",
+                "exporter_name": "server_json_file",
                 "field_values": {"filepath": ""},
                 "results": SAMPLE_RESULTS,
             },
         )
         assert res.status_code == 400
 
-    def test_file_exporter_missing_field_returns_400(self, client):
+    def test_server_json_exporter_missing_field_returns_400(self, client):
         """The route should reject the request before calling export()."""
         res = client.post(
             "/api/exporters/export",
             json={
-                "exporter_name": "file",
+                "exporter_name": "server_json_file",
                 "field_values": {},  # 'filepath' is required but absent
                 "results": SAMPLE_RESULTS,
             },
@@ -576,6 +635,20 @@ class TestExportEndpoint:
         data = res.get_json()
         assert "missing_fields" in data
         assert "filepath" in data["missing_fields"]
+
+    def test_local_json_exporter_returns_download(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "local_json_file",
+                "field_values": {},
+                "results": SAMPLE_RESULTS,
+            },
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert "download_content" in data
 
     def test_email_exporter_sends_via_smtp(self, client):
         mock_server = MagicMock()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -387,7 +387,7 @@ class TestAutoDetectExportPipeline:
             resp = client.post(
                 "/api/exporters/export",
                 json={
-                    "exporter_name": "file",
+                    "exporter_name": "server_json_file",
                     "field_values": {"filepath": str(fpath)},
                     "results": auto_results,
                 },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -738,7 +738,7 @@ class TestGuiExporterWorkflow:
         assert resp.status_code == 200
         exporter_names = {e["name"] for e in resp.get_json()}
         assert "gui" in exporter_names
-        assert "file" in exporter_names
+        assert "server_json_file" in exporter_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -3,7 +3,7 @@
 Covers:
 - LabelImporterField and LabelImporter base classes
 - Auto-discovery registry (list_label_importers, get_label_importer)
-- Built-in importers: json_file, csv_file
+- Built-in importers: local_json_file, server_json_file, local_csv_file, server_csv_file
 - Flask API routes: GET /api/label-importers, POST /api/label-importers/import/<name>
 """
 
@@ -222,13 +222,15 @@ class TestLabelImporterRegistry:
         from vtsearch.labels.importers import list_label_importers
 
         names = {imp.name for imp in list_label_importers()}
-        assert "json_file" in names
-        assert "csv_file" in names
+        assert "local_json_file" in names
+        assert "server_json_file" in names
+        assert "local_csv_file" in names
+        assert "server_csv_file" in names
 
     def test_get_label_importer_known(self):
         from vtsearch.labels.importers import get_label_importer
 
-        for name in ("json_file", "csv_file"):
+        for name in ("local_json_file", "server_json_file", "local_csv_file", "server_csv_file"):
             imp = get_label_importer(name)
             assert imp is not None, f"Label importer '{name}' not found"
             assert imp.name == name
@@ -260,18 +262,18 @@ class TestLabelImporterRegistry:
 
 
 # ---------------------------------------------------------------------------
-# JSON file importer
+# Local JSON file importer
 # ---------------------------------------------------------------------------
 
 
-class TestJsonLabelImporter:
+class TestLocalJsonLabelImporter:
     def _get_importer(self):
-        from vtsearch.labels.importers.json_file import LABEL_IMPORTER
+        from vtsearch.labels.importers.local_json_file import LABEL_IMPORTER
 
         return LABEL_IMPORTER
 
     def test_name(self):
-        assert self._get_importer().name == "json_file"
+        assert self._get_importer().name == "local_json_file"
 
     def test_display_name(self):
         assert "json" in self._get_importer().display_name.lower()
@@ -343,18 +345,18 @@ class TestJsonLabelImporter:
 
 
 # ---------------------------------------------------------------------------
-# CSV file importer
+# Local CSV file importer
 # ---------------------------------------------------------------------------
 
 
-class TestCsvLabelImporter:
+class TestLocalCsvLabelImporter:
     def _get_importer(self):
-        from vtsearch.labels.importers.csv_file import LABEL_IMPORTER
+        from vtsearch.labels.importers.local_csv_file import LABEL_IMPORTER
 
         return LABEL_IMPORTER
 
     def test_name(self):
-        assert self._get_importer().name == "csv_file"
+        assert self._get_importer().name == "local_csv_file"
 
     def test_display_name(self):
         assert "csv" in self._get_importer().display_name.lower()
@@ -442,35 +444,35 @@ class TestCsvLabelImporter:
 
 class TestParseHelpers:
     def test_parse_json_bytes_valid(self):
-        from vtsearch.labels.importers.json_file import _parse_json_bytes
+        from vtsearch.labels.importers.local_json_file import _parse_json_bytes
 
         raw = json.dumps({"labels": [{"md5": "a", "label": "good"}]}).encode()
         result = _parse_json_bytes(raw)
         assert result == [{"md5": "a", "label": "good"}]
 
     def test_parse_json_bytes_empty_labels(self):
-        from vtsearch.labels.importers.json_file import _parse_json_bytes
+        from vtsearch.labels.importers.local_json_file import _parse_json_bytes
 
         raw = json.dumps({"labels": []}).encode()
         result = _parse_json_bytes(raw)
         assert result == []
 
     def test_parse_json_bytes_non_dict_entries_filtered(self):
-        from vtsearch.labels.importers.json_file import _parse_json_bytes
+        from vtsearch.labels.importers.local_json_file import _parse_json_bytes
 
         raw = json.dumps({"labels": [{"md5": "a", "label": "good"}, "bad_entry", 42]}).encode()
         result = _parse_json_bytes(raw)
         assert len(result) == 1
 
     def test_parse_csv_bytes_valid(self):
-        from vtsearch.labels.importers.csv_file import _parse_csv_bytes
+        from vtsearch.labels.importers.local_csv_file import _parse_csv_bytes
 
         raw = b"md5,label\nabc,good\ndef,bad\n"
         result = _parse_csv_bytes(raw)
         assert len(result) == 2
 
     def test_parse_csv_bytes_case_insensitive_headers(self):
-        from vtsearch.labels.importers.csv_file import _parse_csv_bytes
+        from vtsearch.labels.importers.local_csv_file import _parse_csv_bytes
 
         raw = b"MD5,LABEL\nabc,good\n"
         result = _parse_csv_bytes(raw)
@@ -478,7 +480,7 @@ class TestParseHelpers:
         assert result[0]["md5"] == "abc"
 
     def test_parse_csv_bytes_skips_empty_md5(self):
-        from vtsearch.labels.importers.csv_file import _parse_csv_bytes
+        from vtsearch.labels.importers.local_csv_file import _parse_csv_bytes
 
         raw = b"md5,label\n,good\nabc,bad\n"
         result = _parse_csv_bytes(raw)
@@ -505,8 +507,10 @@ class TestGetLabelImportersEndpoint:
     def test_contains_builtin_importers(self, client):
         res = client.get("/api/label-importers")
         names = {entry["name"] for entry in res.get_json()}
-        assert "json_file" in names
-        assert "csv_file" in names
+        assert "local_json_file" in names
+        assert "server_json_file" in names
+        assert "local_csv_file" in names
+        assert "server_csv_file" in names
 
     def test_each_entry_has_required_keys(self, client):
         res = client.get("/api/label-importers")
@@ -534,7 +538,7 @@ class TestLabelImportEndpoint:
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -550,7 +554,7 @@ class TestLabelImportEndpoint:
         payload = json.dumps({"labels": [{"md5": md5, "label": "bad"}]}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -561,7 +565,7 @@ class TestLabelImportEndpoint:
         payload = json.dumps({"labels": [{"md5": "no_such_md5", "label": "good"}]}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -576,7 +580,7 @@ class TestLabelImportEndpoint:
         payload = json.dumps({"labels": [{"md5": md5, "label": "meh"}]}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -591,7 +595,7 @@ class TestLabelImportEndpoint:
         csv_bytes = f"md5,label\n{md5_1},good\n{md5_2},bad\n".encode()
         data = {"file": (io.BytesIO(csv_bytes), "labels.csv")}
         res = client.post(
-            "/api/label-importers/import/csv_file",
+            "/api/label-importers/import/local_csv_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -605,7 +609,7 @@ class TestLabelImportEndpoint:
         csv_bytes = b"md5,label\nunknown_hash,good\n"
         data = {"file": (io.BytesIO(csv_bytes), "labels.csv")}
         res = client.post(
-            "/api/label-importers/import/csv_file",
+            "/api/label-importers/import/local_csv_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -620,7 +624,7 @@ class TestLabelImportEndpoint:
         payload = json.dumps({"labels": [{"md5": md5, "label": "bad"}]}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -631,7 +635,7 @@ class TestLabelImportEndpoint:
         payload = json.dumps({"labels": []}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -652,7 +656,7 @@ class TestLabelImportEndpoint:
         raw = json.dumps(exported).encode()
         data = {"file": (io.BytesIO(raw), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -662,7 +666,7 @@ class TestLabelImportEndpoint:
         assert set(app_module.bad_votes) == {2, 4}
 
     def test_json_roundtrip(self, client):
-        """Export labels, re-import via json_file importer."""
+        """Export labels, re-import via local_json_file importer."""
         app_module.good_votes.update({k: None for k in [1, 3]})
         app_module.bad_votes.update({k: None for k in [2]})
 
@@ -675,7 +679,7 @@ class TestLabelImportEndpoint:
         raw = json.dumps(exported).encode()
         data = {"file": (io.BytesIO(raw), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -695,7 +699,7 @@ class TestLabelImportEndpoint:
         csv_bytes = "\n".join(lines).encode()
         data = {"file": (io.BytesIO(csv_bytes), "labels.csv")}
         res = client.post(
-            "/api/label-importers/import/csv_file",
+            "/api/label-importers/import/local_csv_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -843,7 +847,7 @@ class TestLabelImportMissingElements:
         ).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -859,7 +863,7 @@ class TestLabelImportMissingElements:
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]}).encode()
         data = {"file": (io.BytesIO(payload), "labels.json")}
         res = client.post(
-            "/api/label-importers/import/json_file",
+            "/api/label-importers/import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -997,3 +1001,147 @@ class TestIngestMissingClips:
         assert 2 in existing_clips
         assert existing_clips[2]["origin_name"] == "hello.txt"
         assert existing_clips[2]["embedding"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Server JSON file importer
+# ---------------------------------------------------------------------------
+
+
+class TestServerJsonLabelImporter:
+    def _get_importer(self):
+        from vtsearch.labels.importers.server_json_file import LABEL_IMPORTER
+
+        return LABEL_IMPORTER
+
+    def test_name(self):
+        assert self._get_importer().name == "server_json_file"
+
+    def test_display_name(self):
+        assert "server" in self._get_importer().display_name.lower()
+
+    def test_icon(self):
+        assert self._get_importer().icon
+
+    def test_has_filepath_field(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "filepath" in fields
+        assert fields["filepath"].field_type == "text"
+
+    def test_run_reads_server_file(self, tmp_path):
+        payload = {"labels": [{"md5": "abc", "label": "good"}, {"md5": "def", "label": "bad"}]}
+        p = tmp_path / "labels.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run({"filepath": str(p)})
+        assert len(result) == 2
+        assert result[0]["md5"] == "abc"
+
+    def test_run_raises_on_missing_file(self):
+        with pytest.raises(ValueError, match="not found"):
+            self._get_importer().run({"filepath": "/nonexistent/path.json"})
+
+    def test_run_raises_on_empty_filepath(self):
+        with pytest.raises(ValueError, match="file path"):
+            self._get_importer().run({"filepath": ""})
+
+    def test_run_raises_on_invalid_json(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("not json at all")
+        with pytest.raises(ValueError, match="JSON"):
+            self._get_importer().run({"filepath": str(p)})
+
+    def test_run_raises_on_missing_labels_key(self, tmp_path):
+        p = tmp_path / "no_labels.json"
+        p.write_text(json.dumps({"data": []}))
+        with pytest.raises(ValueError, match="labels"):
+            self._get_importer().run({"filepath": str(p)})
+
+    def test_run_cli_delegates_to_run(self, tmp_path):
+        payload = {"labels": [{"md5": "xyz", "label": "bad"}]}
+        p = tmp_path / "labels.json"
+        p.write_text(json.dumps(payload))
+        result = self._get_importer().run_cli({"filepath": str(p)})
+        assert len(result) == 1
+        assert result[0]["md5"] == "xyz"
+
+    def test_api_route(self, client, tmp_path):
+        md5 = app_module.medias[1]["md5"]
+        payload = {"labels": [{"md5": md5, "label": "good"}]}
+        p = tmp_path / "server_labels.json"
+        p.write_text(json.dumps(payload))
+        res = client.post(
+            "/api/label-importers/import/server_json_file",
+            json={"filepath": str(p)},
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 1
+        assert 1 in app_module.good_votes
+
+
+# ---------------------------------------------------------------------------
+# Server CSV file importer
+# ---------------------------------------------------------------------------
+
+
+class TestServerCsvLabelImporter:
+    def _get_importer(self):
+        from vtsearch.labels.importers.server_csv_file import LABEL_IMPORTER
+
+        return LABEL_IMPORTER
+
+    def test_name(self):
+        assert self._get_importer().name == "server_csv_file"
+
+    def test_display_name(self):
+        assert "server" in self._get_importer().display_name.lower()
+
+    def test_has_filepath_field(self):
+        fields = {f.key: f for f in self._get_importer().fields}
+        assert "filepath" in fields
+        assert fields["filepath"].field_type == "text"
+
+    def test_run_reads_server_file(self, tmp_path):
+        p = tmp_path / "labels.csv"
+        p.write_text("md5,label\nabc123,good\ndef456,bad\n")
+        result = self._get_importer().run({"filepath": str(p)})
+        assert len(result) == 2
+        labels = {r["md5"]: r["label"] for r in result}
+        assert labels["abc123"] == "good"
+        assert labels["def456"] == "bad"
+
+    def test_run_raises_on_missing_file(self):
+        with pytest.raises(ValueError, match="not found"):
+            self._get_importer().run({"filepath": "/nonexistent/path.csv"})
+
+    def test_run_raises_on_empty_filepath(self):
+        with pytest.raises(ValueError, match="file path"):
+            self._get_importer().run({"filepath": ""})
+
+    def test_run_raises_on_missing_columns(self, tmp_path):
+        p = tmp_path / "bad.csv"
+        p.write_text("hash,category\nabc,good\n")
+        with pytest.raises(ValueError, match="md5"):
+            self._get_importer().run({"filepath": str(p)})
+
+    def test_run_cli_delegates_to_run(self, tmp_path):
+        p = tmp_path / "labels.csv"
+        p.write_text("md5,label\nxyz789,bad\n")
+        result = self._get_importer().run_cli({"filepath": str(p)})
+        assert len(result) == 1
+        assert result[0]["md5"] == "xyz789"
+
+    def test_api_route(self, client, tmp_path):
+        md5_1 = app_module.medias[1]["md5"]
+        md5_2 = app_module.medias[2]["md5"]
+        p = tmp_path / "server_labels.csv"
+        p.write_text(f"md5,label\n{md5_1},good\n{md5_2},bad\n")
+        res = client.post(
+            "/api/label-importers/import/server_csv_file",
+            json={"filepath": str(p)},
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 2
+        assert 1 in app_module.good_votes
+        assert 2 in app_module.bad_votes

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -797,7 +797,7 @@ class TestFromLabelImportEndpoint:
         raw = json.dumps({"labels": [{"md5": "abc", "label": "good"}]}).encode()
         data = {"file": (io.BytesIO(raw), "labels.json")}
         res = client.post(
-            "/api/favorite-detectors/from-label-import/json_file",
+            "/api/favorite-detectors/from-label-import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -838,7 +838,7 @@ class TestFromLabelImportEndpoint:
             "name": "from_label_import_test",
         }
         res = client.post(
-            "/api/favorite-detectors/from-label-import/json_file",
+            "/api/favorite-detectors/from-label-import/local_json_file",
             data=data,
             content_type="multipart/form-data",
         )
@@ -864,7 +864,7 @@ class TestFromLabelImportEndpoint:
                 "name": "test",
             }
             res = client.post(
-                "/api/favorite-detectors/from-label-import/json_file",
+                "/api/favorite-detectors/from-label-import/local_json_file",
                 data=data,
                 content_type="multipart/form-data",
             )

--- a/vtsearch/exporters/__init__.py
+++ b/vtsearch/exporters/__init__.py
@@ -8,7 +8,7 @@ Usage::
 
     from vtsearch.exporters import get_exporter, list_exporters
 
-    exporter = get_exporter("file")
+    exporter = get_exporter("server_json_file")
     for exp in list_exporters():
         print(exp.name, exp.display_name)
 """

--- a/vtsearch/exporters/csv_file/requirements.txt
+++ b/vtsearch/exporters/csv_file/requirements.txt
@@ -1,1 +1,0 @@
-# csv_file exporter — no additional dependencies beyond core deps.

--- a/vtsearch/exporters/file/requirements.txt
+++ b/vtsearch/exporters/file/requirements.txt
@@ -1,1 +1,0 @@
-# No additional packages required – uses only Python stdlib (json, pathlib).

--- a/vtsearch/exporters/local_csv_file/__init__.py
+++ b/vtsearch/exporters/local_csv_file/__init__.py
@@ -1,0 +1,114 @@
+"""Local CSV exporter – returns auto-detect results as CSV for browser download.
+
+In the GUI the CSV data is returned inline so the frontend can trigger
+a file download on the user's local machine.  In the CLI the CSV is written
+to a local file path.
+
+No additional pip packages are required; uses only Python's ``csv`` and
+``io`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+from typing import Any
+
+from vtsearch.exporters.base import ExporterField, LabelsetExporter
+
+
+class LocalCsvLabelsetExporter(LabelsetExporter):
+    """Return auto-detect results as CSV for download to the user's local machine.
+
+    In the GUI this exporter returns the CSV data inline in the API
+    response (via ``download_content``).  The frontend is expected to
+    create a Blob and trigger a browser download.
+
+    In the CLI (via ``export_cli``) the CSV is written to a file path.
+    """
+
+    name = "local_csv_file"
+    display_name = "Local CSV File"
+    description = "Download the results as a CSV file to your local machine."
+    icon = "\U0001f4ca"  # bar chart
+    fields = [
+        ExporterField(
+            key="filepath",
+            label="File Path",
+            field_type="text",
+            description=(
+                "Filename for the downloaded CSV file (used by the CLI; "
+                "the browser uses its own save-as dialog)."
+            ),
+            placeholder="autodetect_results.csv",
+            default="autodetect_results.csv",
+            required=False,
+        ),
+    ]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        csv_content, total_hits = _build_csv_string(results)
+        return {
+            "message": (
+                f"Prepared {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) for download."
+            ),
+            "download_content": csv_content,
+            "download_filename": field_values.get("filepath", "").strip() or "autodetect_results.csv",
+            "download_content_type": "text/csv",
+        }
+
+    def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Write CSV to a local file path (CLI usage)."""
+        filepath_str = (field_values.get("filepath") or "").strip() or "autodetect_results.csv"
+        filepath = Path(filepath_str)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        csv_content, total_hits = _build_csv_string(results)
+        filepath.write_text(csv_content, encoding="utf-8")
+
+        return {
+            "message": (
+                f"Saved {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) "
+                f"to {filepath.resolve()}."
+            ),
+            "filepath": str(filepath.resolve()),
+        }
+
+
+def _build_csv_string(results: dict[str, Any]) -> tuple[str, int]:
+    """Build a CSV string from results and return ``(csv_text, total_hits)``."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["detector", "threshold", "filename", "category", "score", "origin", "origin_name"])
+
+    total_hits = 0
+    for det_result in results.get("results", {}).values():
+        detector_name = det_result.get("detector_name", "unknown")
+        threshold = det_result.get("threshold", "")
+        for hit in det_result.get("hits", []):
+            origin = hit.get("origin")
+            origin_str = ""
+            if origin:
+                from vtsearch.datasets.origin import Origin
+
+                origin_str = Origin.from_dict(origin).display()
+            writer.writerow(
+                [
+                    detector_name,
+                    threshold,
+                    hit.get("filename", ""),
+                    hit.get("category", ""),
+                    hit.get("score", ""),
+                    origin_str,
+                    hit.get("origin_name", ""),
+                ]
+            )
+            total_hits += 1
+
+    return buf.getvalue(), total_hits
+
+
+EXPORTER = LocalCsvLabelsetExporter()

--- a/vtsearch/exporters/local_json_file/__init__.py
+++ b/vtsearch/exporters/local_json_file/__init__.py
@@ -1,0 +1,79 @@
+"""Local JSON exporter – returns auto-detect results as JSON for browser download.
+
+In the GUI the results JSON is returned inline so the frontend can trigger
+a file download on the user's local machine.  In the CLI the JSON is written
+to a local file path.
+
+No additional pip packages are required; uses only Python's ``json`` stdlib
+module.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vtsearch.exporters.base import ExporterField, LabelsetExporter
+
+
+class LocalJsonLabelsetExporter(LabelsetExporter):
+    """Return auto-detect results as JSON for download to the user's local machine.
+
+    In the GUI this exporter returns the JSON data inline in the API
+    response (via ``download_content``).  The frontend is expected to
+    create a Blob and trigger a browser download.
+
+    In the CLI (via ``export_cli``) the JSON is written to a file path.
+    """
+
+    name = "local_json_file"
+    display_name = "Local JSON File"
+    description = "Download the results as a JSON file to your local machine."
+    icon = "\U0001f4be"  # floppy disk
+    fields = [
+        ExporterField(
+            key="filepath",
+            label="File Path",
+            field_type="text",
+            description=(
+                "Filename for the downloaded JSON file (used by the CLI; "
+                "the browser uses its own save-as dialog)."
+            ),
+            placeholder="autodetect_results.json",
+            default="autodetect_results.json",
+            required=False,
+        ),
+    ]
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
+        return {
+            "message": (
+                f"Prepared {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) for download."
+            ),
+            "download_content": json.dumps(results, indent=2),
+            "download_filename": field_values.get("filepath", "").strip() or "autodetect_results.json",
+            "download_content_type": "application/json",
+        }
+
+    def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Write JSON to a local file path (CLI usage)."""
+        filepath_str = (field_values.get("filepath") or "").strip() or "autodetect_results.json"
+        filepath = Path(filepath_str)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
+        return {
+            "message": (
+                f"Saved {total_hits} hit(s) across "
+                f"{results.get('detectors_run', 0)} detector(s) "
+                f"to {filepath.resolve()}."
+            ),
+            "filepath": str(filepath.resolve()),
+        }
+
+
+EXPORTER = LocalJsonLabelsetExporter()

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -1,4 +1,8 @@
-"""CSV exporter – saves auto-detect results to a CSV file on disk.
+"""Server CSV exporter – saves auto-detect results to a CSV file on the server.
+
+Writes a CSV file to the server filesystem (the machine where the Python
+process is running).  The user supplies a path (absolute or relative) as a
+text field.
 
 No additional pip packages are required; uses only Python's ``csv`` and
 ``pathlib`` stdlib modules.
@@ -13,26 +17,27 @@ from typing import Any
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
-class CsvLabelsetExporter(LabelsetExporter):
-    """Save auto-detect results as a CSV file.
+class ServerCsvLabelsetExporter(LabelsetExporter):
+    """Save auto-detect results as a CSV file on the server filesystem.
 
     Produces one row per hit across all detectors, with columns for the
     detector name, filename, category, and score.  Opens directly in
     Excel, Google Sheets, or any spreadsheet application.
     """
 
-    name = "csv"
-    display_name = "Save to CSV"
-    description = "Write the results to a CSV file for spreadsheet analysis."
-    icon = "\U0001f4ca"
+    name = "server_csv_file"
+    display_name = "Server CSV File"
+    description = "Write the results to a CSV file on the server filesystem."
+    icon = "\U0001f5a5"  # desktop computer
     fields = [
         ExporterField(
             key="filepath",
-            label="File Path",
+            label="Server File Path",
             field_type="text",
             description=(
-                "Absolute or relative path where the CSV results file will be "
-                "written.  Parent directories are created automatically."
+                "Absolute or relative path on the server where the CSV "
+                "results file will be written.  Parent directories are "
+                "created automatically."
             ),
             placeholder="/home/user/autodetect_results.csv",
             default="autodetect_results.csv",
@@ -85,4 +90,4 @@ class CsvLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = CsvLabelsetExporter()
+EXPORTER = ServerCsvLabelsetExporter()

--- a/vtsearch/exporters/server_json_file/__init__.py
+++ b/vtsearch/exporters/server_json_file/__init__.py
@@ -1,4 +1,8 @@
-"""File exporter – saves auto-detect results to a JSON file on disk.
+"""Server JSON exporter – saves auto-detect results to a JSON file on the server.
+
+Writes a JSON file to the server filesystem (the machine where the Python
+process is running).  The user supplies a path (absolute or relative) as a
+text field rather than a browser file picker.
 
 No additional pip packages are required; uses only Python's ``json`` and
 ``pathlib`` stdlib modules.
@@ -13,25 +17,27 @@ from typing import Any
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
-class FileLabelsetExporter(LabelsetExporter):
-    """Save auto-detect results as a JSON file at a path chosen by the user.
+class ServerJsonLabelsetExporter(LabelsetExporter):
+    """Save auto-detect results as a JSON file on the server filesystem.
 
     The user supplies the destination path (absolute or relative to the
-    current working directory).  Parent directories are created automatically.
+    server's current working directory).  Parent directories are created
+    automatically.
     """
 
-    name = "file"
-    display_name = "Save to File"
-    description = "Write the results to a JSON file on the local filesystem."
-    icon = "💾"
+    name = "server_json_file"
+    display_name = "Server JSON File"
+    description = "Write the results to a JSON file on the server filesystem."
+    icon = "\U0001f5a5"  # desktop computer
     fields = [
         ExporterField(
             key="filepath",
-            label="File Path",
+            label="Server File Path",
             field_type="text",
             description=(
-                "Absolute or relative path where the JSON results file will be "
-                "written.  Parent directories are created automatically."
+                "Absolute or relative path on the server where the JSON "
+                "results file will be written.  Parent directories are "
+                "created automatically."
             ),
             placeholder="/home/user/autodetect_results.json",
             default="autodetect_results.json",
@@ -58,4 +64,4 @@ class FileLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = FileLabelsetExporter()
+EXPORTER = ServerJsonLabelsetExporter()

--- a/vtsearch/labels/importers/local_csv_file/__init__.py
+++ b/vtsearch/labels/importers/local_csv_file/__init__.py
@@ -1,4 +1,4 @@
-"""CSV label importer – loads labels from a ``.csv`` file on disk.
+"""Local CSV label importer – loads labels from a ``.csv`` file uploaded via the browser.
 
 The CSV file must have at least two columns: ``md5`` and ``label``.  A header
 row is required.  Any additional columns are silently ignored.
@@ -23,18 +23,18 @@ from typing import Any
 from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
 
 
-class CsvLabelImporter(LabelImporter):
-    """Import labels from a CSV file with ``md5`` and ``label`` columns.
+class LocalCsvLabelImporter(LabelImporter):
+    """Import labels from a CSV file uploaded from the user's local machine.
 
     The file must have a header row.  Any row missing the ``md5`` or
     ``label`` column, or with a label that is not ``"good"`` or ``"bad"``,
     is silently skipped by the route handler.
     """
 
-    name = "csv_file"
-    display_name = "CSV File"
-    description = "Import labels from a CSV file with md5 and label columns."
-    icon = "📊"
+    name = "local_csv_file"
+    display_name = "Local CSV File"
+    description = "Import labels from a CSV file uploaded from your local machine."
+    icon = "\U0001f4ca"  # bar chart
     fields = [
         LabelImporterField(
             key="file",
@@ -102,4 +102,4 @@ def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
     return results
 
 
-LABEL_IMPORTER = CsvLabelImporter()
+LABEL_IMPORTER = LocalCsvLabelImporter()

--- a/vtsearch/labels/importers/local_json_file/__init__.py
+++ b/vtsearch/labels/importers/local_json_file/__init__.py
@@ -1,8 +1,10 @@
-"""JSON label importer – loads labels from a ``.json`` file on disk.
+"""Local JSON label importer – loads labels from a ``.json`` file uploaded via the browser.
 
 This importer reads the standard VTSearch label format::
 
     {"labels": [{"md5": "...", "label": "good"}, ...]}
+
+The file is uploaded from the user's local machine through the browser.
 
 No additional pip packages are required; uses only Python's ``json`` and
 ``pathlib`` stdlib modules.
@@ -17,18 +19,18 @@ from typing import Any
 from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
 
 
-class JsonLabelImporter(LabelImporter):
-    """Import labels from a JSON file in the standard VTSearch label format.
+class LocalJsonLabelImporter(LabelImporter):
+    """Import labels from a JSON file uploaded from the user's local machine.
 
     The file must be a JSON object with a top-level ``"labels"`` key whose
     value is a list of ``{"md5": "...", "label": "good"|"bad"}`` dicts.
     This is the same format produced by ``GET /api/labels/export``.
     """
 
-    name = "json_file"
-    display_name = "JSON File"
-    description = "Import labels from a VTSearch-format JSON file (.json)."
-    icon = "📄"
+    name = "local_json_file"
+    display_name = "Local JSON File"
+    description = "Import labels from a VTSearch-format JSON file uploaded from your local machine."
+    icon = "\U0001f4c4"  # page facing up
     fields = [
         LabelImporterField(
             key="file",
@@ -84,4 +86,4 @@ def _parse_json_bytes(raw: bytes) -> list[dict[str, str]]:
     return [entry for entry in labels if isinstance(entry, dict)]
 
 
-LABEL_IMPORTER = JsonLabelImporter()
+LABEL_IMPORTER = LocalJsonLabelImporter()

--- a/vtsearch/labels/importers/server_csv_file/__init__.py
+++ b/vtsearch/labels/importers/server_csv_file/__init__.py
@@ -1,0 +1,101 @@
+"""Server CSV label importer – loads labels from a ``.csv`` file on the server.
+
+This importer reads a CSV file from the server filesystem (the machine
+where the Python process is running), as opposed to the local
+(browser-upload) importer which receives files uploaded from the user's
+browser.  The file format is identical: a header row with ``md5`` and
+``label`` columns.
+
+No additional pip packages are required; uses only Python's ``csv``,
+``io``, and ``pathlib`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+from typing import Any
+
+from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+
+class ServerCsvLabelImporter(LabelImporter):
+    """Import labels from a CSV file on the server filesystem.
+
+    The user provides a file path on the server (the machine running the
+    Python process).  The file must have a header row with ``md5`` and
+    ``label`` columns.
+    """
+
+    name = "server_csv_file"
+    display_name = "Server CSV File"
+    description = "Import labels from a CSV file on the server filesystem."
+    icon = "\U0001f5a5"  # desktop computer
+    fields = [
+        LabelImporterField(
+            key="filepath",
+            label="Server File Path",
+            field_type="text",
+            description=(
+                "Absolute or relative path to a CSV file with md5 and "
+                "label columns on the server filesystem."
+            ),
+            placeholder="data/labels/my_labels.csv",
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Read and parse the CSV labels file from the server filesystem."""
+        filepath = (field_values.get("filepath") or "").strip()
+        if not filepath:
+            raise ValueError("A file path is required.")
+
+        path = Path(filepath)
+        if not path.exists():
+            raise ValueError(f"File not found: {path}")
+        if not path.is_file():
+            raise ValueError(f"Not a file: {path}")
+
+        raw = path.read_bytes()
+        return _parse_csv_bytes(raw)
+
+    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Load labels from a file-path string (CLI usage)."""
+        return self.run(field_values)
+
+    def add_cli_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--filepath",
+            dest="filepath",
+            help="Path to a CSV file with md5 and label columns on the server.",
+            required=False,
+        )
+
+
+def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
+    """Decode *raw* bytes as CSV and extract ``md5``/``label`` pairs."""
+    try:
+        text = raw.decode("utf-8-sig")  # strip BOM if present
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1")
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise ValueError("CSV file appears to be empty.")
+
+    # Normalise header names to lower-case and strip whitespace
+    normalised = {k.strip().lower(): k for k in reader.fieldnames if k}
+    if "md5" not in normalised or "label" not in normalised:
+        raise ValueError("CSV must have 'md5' and 'label' column headers.")
+
+    results = []
+    for row in reader:
+        md5 = row.get(normalised["md5"], "").strip()
+        label = row.get(normalised["label"], "").strip().lower()
+        if md5 and label:
+            results.append({"md5": md5, "label": label})
+    return results
+
+
+LABEL_IMPORTER = ServerCsvLabelImporter()

--- a/vtsearch/labels/importers/server_json_file/__init__.py
+++ b/vtsearch/labels/importers/server_json_file/__init__.py
@@ -1,0 +1,89 @@
+"""Server JSON label importer – loads labels from a ``.json`` file on the server.
+
+This importer reads a VTSearch label-format JSON file from the server
+filesystem (the machine where the Python process is running), as opposed
+to the local (browser-upload) importer which receives files uploaded from
+the user's browser.  The file format is identical::
+
+    {"labels": [{"md5": "...", "label": "good"}, ...]}
+
+No additional pip packages are required; uses only Python's ``json`` and
+``pathlib`` stdlib modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vtsearch.labels.importers.base import LabelImporter, LabelImporterField
+
+
+class ServerJsonLabelImporter(LabelImporter):
+    """Import labels from a JSON file on the server filesystem.
+
+    The user provides a file path on the server (the machine running the
+    Python process).  The file must be a JSON object with a top-level
+    ``"labels"`` key whose value is a list of ``{"md5": "...", "label":
+    "good"|"bad"}`` dicts.
+    """
+
+    name = "server_json_file"
+    display_name = "Server JSON File"
+    description = "Import labels from a VTSearch-format JSON file on the server filesystem."
+    icon = "\U0001f5a5"  # desktop computer
+    fields = [
+        LabelImporterField(
+            key="filepath",
+            label="Server File Path",
+            field_type="text",
+            description=(
+                "Absolute or relative path to a VTSearch labels JSON file "
+                "on the server filesystem."
+            ),
+            placeholder="data/labels/my_labels.json",
+        ),
+    ]
+
+    def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Read and parse the JSON labels file from the server filesystem."""
+        filepath = (field_values.get("filepath") or "").strip()
+        if not filepath:
+            raise ValueError("A file path is required.")
+
+        path = Path(filepath)
+        if not path.exists():
+            raise ValueError(f"File not found: {path}")
+        if not path.is_file():
+            raise ValueError(f"Not a file: {path}")
+
+        raw = path.read_bytes()
+        return _parse_json_bytes(raw)
+
+    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+        """Load labels from a file-path string (CLI usage)."""
+        return self.run(field_values)
+
+    def add_cli_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--filepath",
+            dest="filepath",
+            help="Path to a VTSearch labels JSON file on the server.",
+            required=False,
+        )
+
+
+def _parse_json_bytes(raw: bytes) -> list[dict[str, str]]:
+    """Decode *raw* bytes as JSON and extract the labels list."""
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+    labels = data.get("labels")
+    if not isinstance(labels, list):
+        raise ValueError("JSON must contain a top-level 'labels' list.")
+    return [entry for entry in labels if isinstance(entry, dict)]
+
+
+LABEL_IMPORTER = ServerJsonLabelImporter()

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -176,8 +176,8 @@ def export_detector_server():
     model = train_model(X, y, input_dim, get_inclusion())
 
     if get_safe_thresholds():
-        all_ids = sorted(clips.keys())
-        all_embs = np.array([clips[cid]["embedding"] for cid in all_ids])
+        all_ids = sorted(medias.keys())
+        all_embs = np.array([medias[cid]["embedding"] for cid in all_ids])
         X_all = torch.tensor(all_embs, dtype=torch.float32)
         with torch.no_grad():
             all_scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
@@ -188,10 +188,10 @@ def export_detector_server():
     for key, value in state_dict.items():
         weights[key] = value.tolist()
 
-    # Determine media type from current clips
+    # Determine media type from current medias
     media_type = "audio"
-    if clips:
-        media_type = next(iter(clips.values())).get("type", "audio")
+    if medias:
+        media_type = next(iter(medias.values())).get("type", "audio")
 
     detector_data = {
         "weights": weights,

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -153,12 +153,12 @@ def export_detector_server():
     X_list = []
     y_list = []
     for cid in good_votes:
-        if cid in clips:
-            X_list.append(clips[cid]["embedding"])
+        if cid in medias:
+            X_list.append(medias[cid]["embedding"])
             y_list.append(1.0)
     for cid in bad_votes:
-        if cid in clips:
-            X_list.append(clips[cid]["embedding"])
+        if cid in medias:
+            X_list.append(medias[cid]["embedding"])
             y_list.append(0.0)
 
     X = torch.tensor(np.array(X_list), dtype=torch.float32)

--- a/vtsearch/routes/exporters.py
+++ b/vtsearch/routes/exporters.py
@@ -10,7 +10,7 @@ POST /api/exporters/export
     body.  Body (JSON)::
 
         {
-            "exporter_name": "file",
+            "exporter_name": "server_json_file",
             "field_values":  {"filepath": "/home/user/results.json"},
             "results":       { ...auto-detect results dict... }
         }
@@ -54,7 +54,7 @@ def run_export():
     .. code-block:: json
 
         {
-            "exporter_name": "file",
+            "exporter_name": "server_json_file",
             "field_values":  {"filepath": "/home/user/results.json"},
             "results":       {}
         }


### PR DESCRIPTION
## Summary
This PR refactors the label importers and exporters to explicitly distinguish between local (browser-uploaded) and server (filesystem-based) sources. This improves clarity about where files are being read from and written to, and enables users to choose the appropriate method for their workflow.

## Key Changes

### Label Importers
- **Renamed `json_file` → `local_json_file`**: Handles JSON files uploaded from the user's browser
- **Renamed `csv_file` → `local_csv_file`**: Handles CSV files uploaded from the user's browser
- **Added `server_json_file`**: New importer for reading JSON label files from the server filesystem
- **Added `server_csv_file`**: New importer for reading CSV label files from the server filesystem

### Exporters
- **Renamed `file` → `server_json_file`**: Writes JSON results to the server filesystem
- **Renamed `csv` → `server_csv_file`**: Writes CSV results to the server filesystem
- **Added `local_json_file`**: New exporter that returns JSON results as downloadable content for browser download
- **Added `local_csv_file`**: New exporter that returns CSV results as downloadable content for browser download

### Implementation Details
- Server-based importers accept a `filepath` field for absolute or relative paths on the server
- Local exporters return `download_content`, `download_filename`, and `download_content_type` in the API response, allowing the frontend to trigger browser downloads
- Both local and server variants support CLI usage via `export_cli()` and `run_cli()` methods
- Updated all tests and documentation to reflect the new naming scheme
- Updated API route examples and docstrings to use the new importer/exporter names

## Benefits
- **Clarity**: Users immediately understand whether they're uploading from their machine or reading from the server
- **Flexibility**: Supports both browser-based workflows (local) and server-based automation (server)
- **Consistency**: Naming convention is now consistent across all importers and exporters

https://claude.ai/code/session_01DWxhFNohxSCUigscMycjNB