### PR TITLE
Fix CLIP model ID typo in config and documentation

### DIFF
--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -47,5 +47,5 @@ MLP_DROPOUT = 0.5
 # Model IDs
 CLAP_MODEL_ID = "laion/clap-htsat-unfused"
 XCLIP_MODEL_ID = "microsoft/xclip-base-patch32"
-CLIP_MODEL_ID = "openai/media-vit-base-patch32"
+CLIP_MODEL_ID = "openai/clip-vit-base-patch32"
 E5_MODEL_ID = "intfloat/e5-base-v2"

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -57,7 +57,7 @@ _IMAGE_MIME_TYPES: dict[str, str] = {
 
 
 class ImageMediaType(MediaType):
-    """Handles image medias using the CLIP model (openai/media-vit-base-patch32).
+    """Handles image medias using the CLIP model (openai/clip-vit-base-patch32).
 
     * Embeds images via CLIP's vision encoder (768-dim vectors).
     * Embeds text queries via CLIP's text encoder (same 768-dim space).


### PR DESCRIPTION
## Summary
Corrected the CLIP model ID from an incorrect identifier to the proper HuggingFace model name.

## Changes
- Updated `CLIP_MODEL_ID` in `vtsearch/config.py` from `"openai/media-vit-base-patch32"` to `"openai/clip-vit-base-patch32"`
- Updated the docstring in `ImageMediaType` class to reflect the correct model ID

## Details
The model ID contained a typo where "media-vit" was used instead of "clip-vit". This fix ensures the correct OpenAI CLIP model is referenced, which is essential for proper model loading and image embedding functionality.

https://claude.ai/code/session_01YSuAuKBqSkiNzuEoX6bhsp