### PR TITLE
Add submenu support for labels and detector exports

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -257,10 +257,13 @@
   const menuDatasetExport = document.getElementById("menu-dataset-export");
   const menuDatasetChange = document.getElementById("menu-dataset-change");
   const menuLabelsExport = document.getElementById("menu-labels-export");
+  const menuLabelsExportSubmenu = document.getElementById("menu-labels-export-submenu");
   const menuLabelsImport = document.getElementById("menu-labels-import");
   const menuLabelsStatus = document.getElementById("menu-labels-status");
   const menuDetectorImport = document.getElementById("menu-detector-import");
   const menuDetectorExport = document.getElementById("menu-detector-export");
+  const menuDetectorExportSubmenu = document.getElementById("menu-detector-export-submenu");
+  const menuDetectorExportBrowser = document.getElementById("menu-detector-export-browser");
   const menuDetectorExportServer = document.getElementById("menu-detector-export-server");
   const menuDetectorStatus = document.getElementById("menu-detector-status");
   const labelImporterModal = document.getElementById("label-importer-modal");
@@ -1003,6 +1006,12 @@
   function closeBurgerMenu() {
     burgerDropdown.classList.remove("show");
     burgerBtn.setAttribute("aria-expanded", "false");
+    // Collapse any open submenus
+    document.querySelectorAll(".burger-submenu.show").forEach(s => {
+      s.classList.remove("show");
+      const parent = s.previousElementSibling;
+      if (parent) parent.setAttribute("aria-expanded", "false");
+    });
     resumeActiveMedia();
   }
 
@@ -1104,22 +1113,109 @@
     });
   }
 
-  // Labels export
-  if (menuLabelsExport && menuLabelsStatus && burgerDropdown) {
-    menuLabelsExport.addEventListener("click", async () => {
-      menuLabelsStatus.textContent = "";
-      const res = await fetch("/api/labels/export");
-      const data = await res.json();
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "labels.json";
-      a.click();
-      URL.revokeObjectURL(url);
-      menuLabelsStatus.textContent = `Exported ${data.labels.length} labels`;
+  // Labels export submenu toggle
+  let labelsExportersList = [];
+
+  async function loadLabelsExportersList() {
+    try {
+      const res = await fetch("/api/exporters");
+      if (res.ok) {
+        labelsExportersList = await res.json();
+        renderLabelsExportSubmenu();
+      }
+    } catch (_) {}
+  }
+
+  function renderLabelsExportSubmenu() {
+    if (!menuLabelsExportSubmenu) return;
+    menuLabelsExportSubmenu.innerHTML = "";
+    for (const exp of labelsExportersList) {
+      const item = document.createElement("div");
+      item.className = "burger-item burger-subitem";
+      item.setAttribute("role", "menuitem");
+      item.setAttribute("tabindex", "-1");
+      item.dataset.exporterName = exp.name;
+      item.textContent = `${exp.icon} ${exp.display_name}`;
+      item.addEventListener("click", () => runLabelExport(exp));
+      menuLabelsExportSubmenu.appendChild(item);
+    }
+  }
+
+  async function runLabelExport(exp) {
+    menuLabelsStatus.textContent = "";
+    // Collect required field values via prompts
+    const fieldValues = {};
+    for (const field of exp.fields) {
+      if (field.required) {
+        const val = await vtPrompt(field.label + (field.description ? ` (${field.description})` : ""), field.default || "");
+        if (val === null) {
+          menuLabelsStatus.textContent = "Export cancelled";
+          setTimeout(() => { menuLabelsStatus.textContent = ""; }, 2000);
+          return;
+        }
+        fieldValues[field.key] = val;
+      } else {
+        fieldValues[field.key] = field.default || "";
+      }
+    }
+
+    menuLabelsStatus.textContent = "Exporting labels\u2026";
+    try {
+      const labelsRes = await fetch("/api/labels/export");
+      const labelsData = await labelsRes.json();
+
+      const exportRes = await fetch("/api/exporters/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          exporter_name: exp.name,
+          field_values: fieldValues,
+          results: labelsData,
+        }),
+      });
+      const result = await exportRes.json();
+      if (!exportRes.ok) {
+        menuLabelsStatus.textContent = result.error || "Export failed";
+        setTimeout(() => { menuLabelsStatus.textContent = ""; }, 3000);
+        return;
+      }
+      // Handle browser download if the exporter returns download_content
+      if (result.download_content) {
+        const blob = new Blob([result.download_content], { type: result.download_content_type || "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = result.download_filename || "labels.json";
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+      menuLabelsStatus.textContent = result.message || "Labels exported";
+      setTimeout(() => { menuLabelsStatus.textContent = ""; }, 4000);
+    } catch (e) {
+      menuLabelsStatus.textContent = "Export failed";
       setTimeout(() => { menuLabelsStatus.textContent = ""; }, 3000);
-      closeBurgerMenu();
+    }
+    closeBurgerMenu();
+  }
+
+  if (menuLabelsExport && menuLabelsExportSubmenu) {
+    menuLabelsExport.addEventListener("click", (e) => {
+      if (menuLabelsExport.classList.contains("disabled")) return;
+      e.stopPropagation();
+      const isOpen = menuLabelsExportSubmenu.classList.contains("show");
+      // Close any other open submenus
+      document.querySelectorAll(".burger-submenu.show").forEach(s => {
+        s.classList.remove("show");
+        const parent = s.previousElementSibling;
+        if (parent) parent.setAttribute("aria-expanded", "false");
+      });
+      if (!isOpen) {
+        menuLabelsExportSubmenu.classList.add("show");
+        menuLabelsExport.setAttribute("aria-expanded", "true");
+        if (labelsExportersList.length === 0) loadLabelsExportersList();
+      } else {
+        menuLabelsExport.setAttribute("aria-expanded", "false");
+      }
     });
   }
 
@@ -1139,15 +1235,31 @@
     });
   }
 
-  // Detector export
-  if (menuDetectorExport && menuDetectorStatus && burgerDropdown) {
-    menuDetectorExport.addEventListener("click", async () => {
-      menuDetectorStatus.textContent = "";
-      if (votes.good.length === 0 || votes.bad.length === 0) {
-        menuDetectorStatus.textContent = "Vote good & bad medias first";
-        setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
-        return;
+  // Detector export submenu toggle
+  if (menuDetectorExport && menuDetectorExportSubmenu) {
+    menuDetectorExport.addEventListener("click", (e) => {
+      if (menuDetectorExport.classList.contains("disabled")) return;
+      e.stopPropagation();
+      const isOpen = menuDetectorExportSubmenu.classList.contains("show");
+      // Close any other open submenus
+      document.querySelectorAll(".burger-submenu.show").forEach(s => {
+        s.classList.remove("show");
+        const parent = s.previousElementSibling;
+        if (parent) parent.setAttribute("aria-expanded", "false");
+      });
+      if (!isOpen) {
+        menuDetectorExportSubmenu.classList.add("show");
+        menuDetectorExport.setAttribute("aria-expanded", "true");
+      } else {
+        menuDetectorExport.setAttribute("aria-expanded", "false");
       }
+    });
+  }
+
+  // Detector export – browser download
+  if (menuDetectorExportBrowser && menuDetectorStatus && burgerDropdown) {
+    menuDetectorExportBrowser.addEventListener("click", async () => {
+      menuDetectorStatus.textContent = "";
       menuDetectorStatus.textContent = "Exporting detector\u2026";
       const res = await fetch("/api/detector/export", {
         method: "POST",
@@ -1172,17 +1284,12 @@
     });
   }
 
-  // Server-side detector export (ServerFileProcessorExporter)
+  // Detector export – save to server
   if (menuDetectorExportServer && menuDetectorStatus && burgerDropdown) {
     menuDetectorExportServer.addEventListener("click", async () => {
       menuDetectorStatus.textContent = "";
-      if (votes.good.length === 0 || votes.bad.length === 0) {
-        menuDetectorStatus.textContent = "Vote good & bad clips first";
-        setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
-        return;
-      }
 
-      const name = prompt("Enter a name for the detector file (saved on server):");
+      const name = await vtPrompt("Enter a name for the detector file (saved on server):");
       if (!name || !name.trim()) return;
 
       menuDetectorStatus.textContent = "Saving detector to server\u2026";
@@ -1195,9 +1302,8 @@
 
       if (res.status === 409) {
         const info = await res.json();
-        const overwrite = confirm(
-          `A detector file "${info.name}.json" already exists on the server.\n\n` +
-          `Path: ${info.path}\n\nOverwrite it?`
+        const overwrite = await vtConfirm(
+          `A detector file "${info.name}.json" already exists on the server.\n\nPath: ${info.path}\n\nOverwrite it?`
         );
         if (overwrite) {
           menuDetectorStatus.textContent = "Overwriting detector on server\u2026";
@@ -1216,8 +1322,7 @@
             setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
           }
         } else {
-          // User chose not to overwrite; ask for a new name
-          const newName = prompt("Enter a different name:");
+          const newName = await vtPrompt("Enter a different name:");
           if (newName && newName.trim()) {
             menuDetectorStatus.textContent = "Saving detector to server\u2026";
             const res3 = await fetch("/api/detector/export-server", {
@@ -2217,6 +2322,31 @@
     loadRadio.disabled = false;
     loadRadio.parentElement.style.opacity = "1";
     loadRadio.parentElement.style.cursor = "pointer";
+
+    // Disable Export Detector when no detector can be trained (need good AND bad)
+    if (menuDetectorExport) {
+      if (hasGoodAndBad) {
+        menuDetectorExport.classList.remove("disabled");
+      } else {
+        menuDetectorExport.classList.add("disabled");
+        // Collapse submenu if open
+        if (menuDetectorExportSubmenu) menuDetectorExportSubmenu.classList.remove("show");
+        menuDetectorExport.setAttribute("aria-expanded", "false");
+      }
+    }
+
+    // Disable Export Labels when no labels exist (need any votes)
+    const hasAnyVotes = votes.good.length > 0 || votes.bad.length > 0;
+    if (menuLabelsExport) {
+      if (hasAnyVotes) {
+        menuLabelsExport.classList.remove("disabled");
+      } else {
+        menuLabelsExport.classList.add("disabled");
+        // Collapse submenu if open
+        if (menuLabelsExportSubmenu) menuLabelsExportSubmenu.classList.remove("show");
+        menuLabelsExport.setAttribute("aria-expanded", "false");
+      }
+    }
   }
 
   document.querySelectorAll('input[name="sort-mode"]').forEach(radio => {

--- a/static/index.html
+++ b/static/index.html
@@ -24,14 +24,18 @@
       <div class="burger-section" role="group" aria-label="Labels">
         <div class="burger-section-title" id="menu-section-labels">Labels</div>
         <div class="burger-item" id="menu-labels-import" role="menuitem" tabindex="-1">Import Labels</div>
-        <div class="burger-item" id="menu-labels-export" role="menuitem" tabindex="-1">Export Labels</div>
+        <div class="burger-item burger-item-parent" id="menu-labels-export" role="menuitem" tabindex="-1" aria-expanded="false">Export Labels <span class="burger-arrow" aria-hidden="true">&#9656;</span></div>
+        <div class="burger-submenu" id="menu-labels-export-submenu" role="group" aria-label="Export Labels options"></div>
         <div class="burger-status" id="menu-labels-status" aria-live="polite"></div>
       </div>
       <div class="burger-section" role="group" aria-label="Detector">
         <div class="burger-section-title" id="menu-section-detector">Detector</div>
         <div class="burger-item" id="menu-detector-import" role="menuitem" tabindex="-1">Load Sort</div>
-        <div class="burger-item" id="menu-detector-export" role="menuitem" tabindex="-1">Export Detector (Browser)</div>
-        <div class="burger-item" id="menu-detector-export-server" role="menuitem" tabindex="-1">Export Detector (Server)</div>
+        <div class="burger-item burger-item-parent" id="menu-detector-export" role="menuitem" tabindex="-1" aria-expanded="false">Export Detector <span class="burger-arrow" aria-hidden="true">&#9656;</span></div>
+        <div class="burger-submenu" id="menu-detector-export-submenu" role="group" aria-label="Export Detector options">
+          <div class="burger-item burger-subitem" id="menu-detector-export-browser" role="menuitem" tabindex="-1">Download (Browser)</div>
+          <div class="burger-item burger-subitem" id="menu-detector-export-server" role="menuitem" tabindex="-1">Save to Server</div>
+        </div>
         <div class="burger-status" id="menu-detector-status" aria-live="polite"></div>
       </div>
       <div class="burger-section" role="group" aria-label="Favorite Detectors">

--- a/static/styles.css
+++ b/static/styles.css
@@ -187,6 +187,14 @@ header h1 { font-size: 1.3rem; color: var(--accent); }
 .burger-item { padding: 10px 16px; cursor: pointer; font-size: 0.85rem; color: var(--text-secondary); transition: all 0.15s; display: flex; align-items: center; gap: 8px; }
 .burger-item:hover { background: var(--bg-hover); color: var(--text-primary); }
 .burger-status { font-size: 0.7rem; color: var(--text-dim); padding: 4px 16px 8px; }
+.burger-item-parent { justify-content: space-between; }
+.burger-arrow { font-size: 0.7rem; transition: transform 0.15s; }
+.burger-item-parent[aria-expanded="true"] .burger-arrow { transform: rotate(90deg); }
+.burger-submenu { display: none; }
+.burger-submenu.show { display: block; }
+.burger-subitem { padding-left: 28px; font-size: 0.8rem; }
+.burger-item.disabled { opacity: 0.4; cursor: not-allowed; }
+.burger-item.disabled:hover { background: transparent; color: var(--text-secondary); }
 header h1 { margin-left: 48px; }
 
 /* Theme selector */


### PR DESCRIPTION
## Summary
Refactored the export functionality for labels and detector to use expandable submenus instead of direct actions. This allows for multiple export options and better organization of export features.

## Key Changes

- **Labels Export**: Converted to a submenu that dynamically loads available exporters from `/api/exporters` endpoint. Each exporter can define custom fields that are collected via prompts before export.

- **Detector Export**: Reorganized into a submenu with two options:
  - "Download (Browser)" - exports detector for browser download
  - "Save to Server" - exports detector to server storage

- **Submenu UI/UX**:
  - Added visual indicators (arrow icons) that rotate when submenus are expanded
  - Implemented proper menu state management with `aria-expanded` attributes
  - Submenus automatically close when opening another submenu
  - All open submenus collapse when closing the burger menu

- **Export Validation**:
  - Labels export is disabled when no votes exist (good or bad)
  - Detector export is disabled when insufficient votes exist (need both good AND bad)
  - Disabled state is visually indicated with reduced opacity and disabled cursor

- **Dialog Improvements**: Replaced native `prompt()` and `confirm()` with custom `vtPrompt()` and `vtConfirm()` functions for better UX consistency

- **HTML Structure**: Updated menu items to support parent-child relationships with proper ARIA roles and attributes for accessibility

## Implementation Details

- Submenu toggle logic prevents event propagation and manages mutual exclusivity between open submenus
- Labels exporter list is lazy-loaded on first submenu open
- Export field collection supports both required and optional fields with descriptions and defaults
- Server-side detector export now uses custom prompt instead of native browser prompt
- Proper cleanup of object URLs and status message timeouts to prevent memory leaks

https://claude.ai/code/session_017AfwvUZUdboB9uNduXajdD