### PR TITLE
Extract demo datasets documentation to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,7 @@ VTSearch provides several CLI workflows for running detectors, importing labels,
 
 When the app is running, click the hamburger menu in the top-left corner to open the dataset panel. From there you can browse the available demo datasets and load one. Each demo is downloaded and embedded on first use, then cached for instant loading afterward.
 
-Available demos:
-
-| Demo | Media type | Description |
-|------|-----------|-------------|
-| **esc50_s** | Audio | ~350 clips across all 50 ESC-50 sound categories — animals, nature, urban, domestic, and human sounds |
-| **esc50_m** | Audio | ~650 clips across all 50 ESC-50 sound categories |
-| **esc50_l** | Audio | ~1000 clips across all 50 ESC-50 sound categories |
-| **caltech101_s** | Image | ~500 photographs across 25 Caltech-101 categories — animals, vehicles, household objects, and nature |
-| **caltech101_m** | Image | ~1,000 photographs across 25 Caltech-101 categories |
-| **caltech256_l** | Image | ~2,000 photographs across 25 Caltech-256 categories — animals, landmarks, vehicles, and everyday objects |
-| **20newsgroups_s** | Text | ~375 articles across 15 topics from 20 Newsgroups — sports, science, politics, religion, and more |
-| **20newsgroups_m** | Text | ~750 articles across 15 topics from 20 Newsgroups |
-| **20newsgroups_l** | Text | ~1875 articles across 15 topics from 20 Newsgroups |
-| **ucf101_s** | Video | ~150 clips across 10 UCF-101 action categories — personal activities and sports (manual download) |
-| **ucf101_m** | Video | ~250 clips across 10 UCF-101 action categories (manual download) |
-| **ucf101_l** | Video | ~600 clips across 10 UCF-101 action categories (manual download) |
+See [docs/demos.md](docs/demos.md) for the full list of available demo datasets.
 
 You can also load your own data from pickle files or folders via the same menu.
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -1,0 +1,20 @@
+# Demo Datasets
+
+When the app is running, click the hamburger menu in the top-left corner to open the dataset panel. From there you can browse the available demo datasets and load one. Each demo is downloaded and embedded on first use, then cached for instant loading afterward.
+
+| Demo | Media type | Description |
+|------|-----------|-------------|
+| **esc50_s** | Audio | ~350 clips across all 50 ESC-50 sound categories — animals, nature, urban, domestic, and human sounds |
+| **esc50_m** | Audio | ~650 clips across all 50 ESC-50 sound categories |
+| **esc50_l** | Audio | ~1000 clips across all 50 ESC-50 sound categories |
+| **caltech101_s** | Image | ~500 photographs across 25 Caltech-101 categories — animals, vehicles, household objects, and nature |
+| **caltech101_m** | Image | ~1,000 photographs across 25 Caltech-101 categories |
+| **caltech256_l** | Image | ~2,000 photographs across 25 Caltech-256 categories — animals, landmarks, vehicles, and everyday objects |
+| **20newsgroups_s** | Text | ~375 articles across 15 topics from 20 Newsgroups — sports, science, politics, religion, and more |
+| **20newsgroups_m** | Text | ~750 articles across 15 topics from 20 Newsgroups |
+| **20newsgroups_l** | Text | ~1875 articles across 15 topics from 20 Newsgroups |
+| **ucf101_s** | Video | ~150 clips across 10 UCF-101 action categories — personal activities and sports (manual download) |
+| **ucf101_m** | Video | ~250 clips across 10 UCF-101 action categories (manual download) |
+| **ucf101_l** | Video | ~600 clips across 10 UCF-101 action categories (manual download) |
+
+You can also load your own data from pickle files or folders via the same menu.


### PR DESCRIPTION
## Summary
Refactored the demo datasets documentation by extracting it from the README into a dedicated documentation file to improve maintainability and organization.

## Changes
- Created new `docs/demos.md` file containing comprehensive demo datasets documentation
- Moved the complete demo datasets table (11 datasets across audio, image, text, and video categories) from README to the new file
- Updated README to reference the new documentation file with a link instead of duplicating the content
- Preserved all original information about dataset sizes, categories, and download requirements

## Benefits
- Reduces README clutter while maintaining easy access to demo information
- Establishes a dedicated location for dataset documentation that can be expanded independently
- Follows documentation best practices by separating detailed reference material into focused docs

https://claude.ai/code/session_01XTej9rST6WYAks8EqAUCVc