### PR TITLE
Add console progress output during embedding model preloading

### DIFF
--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -16,9 +16,10 @@ class TestMakeConsoleProgress:
     def test_forwards_to_original_callback(self):
         """Every call should be forwarded to the original callback."""
         calls = []
-        original = lambda status, message="", current=0, total=0: calls.append(
-            (status, message, current, total)
-        )
+
+        def original(status, message="", current=0, total=0):
+            calls.append((status, message, current, total))
+
         cb = _make_console_progress(original)
 
         cb("loading", "Loading model...", 0, 0)

--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -1,0 +1,172 @@
+"""Tests for console progress output during embedding model preloading.
+
+Verifies that ``preload_favorite_media_types`` prints intermediate status
+messages and download progress bars to stdout so the user can see what is
+happening during the (potentially long) startup phase.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from vtsearch.models.loader import _make_console_progress, preload_favorite_media_types
+
+
+class TestMakeConsoleProgress:
+    """Unit tests for the _make_console_progress wrapper."""
+
+    def test_forwards_to_original_callback(self):
+        """Every call should be forwarded to the original callback."""
+        calls = []
+        original = lambda status, message="", current=0, total=0: calls.append(
+            (status, message, current, total)
+        )
+        cb = _make_console_progress(original)
+
+        cb("loading", "Loading model...", 0, 0)
+        cb("loading", "weights.bin", 50, 100)
+
+        assert len(calls) == 2
+        assert calls[0] == ("loading", "Loading model...", 0, 0)
+        assert calls[1] == ("loading", "weights.bin", 50, 100)
+
+    def test_prints_phase_messages(self, capsys):
+        """Phase messages (total=0) should be printed on their own lines."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "Loading CLAP model weights...", 0, 0)
+        cb("loading", "Loading CLAP processor...", 0, 0)
+
+        captured = capsys.readouterr()
+        assert "Loading CLAP model weights..." in captured.out
+        assert "Loading CLAP processor..." in captured.out
+
+    def test_deduplicates_repeated_phase_messages(self, capsys):
+        """The same phase message repeated should only be printed once."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "Loading model...", 0, 0)
+        cb("loading", "Loading model...", 0, 0)
+        cb("loading", "Loading model...", 0, 0)
+
+        captured = capsys.readouterr()
+        assert captured.out.count("Loading model...") == 1
+
+    def test_prints_progress_bar_for_measurable_progress(self, capsys):
+        """Calls with total > 0 should render an ASCII progress bar."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "model.safetensors", 50, 100)
+
+        captured = capsys.readouterr()
+        assert "model.safetensors" in captured.out
+        assert "50%" in captured.out
+        assert "[" in captured.out
+        assert "]" in captured.out
+
+    def test_progress_bar_completes_with_newline(self, capsys):
+        """When current >= total, a newline should be emitted."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "model.safetensors", 0, 100)
+        cb("loading", "model.safetensors", 100, 100)
+
+        captured = capsys.readouterr()
+        # The completed bar should end with a newline
+        assert "100%" in captured.out
+        # Should end in a newline (not just a \r)
+        lines = captured.out.split("\n")
+        assert len(lines) >= 2  # at least one \n was written after completion
+
+    def test_progress_bar_percentage_capped_at_100(self, capsys):
+        """Overshoot (current > total) should cap at 100%."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        cb("loading", "weights", 150, 100)
+
+        captured = capsys.readouterr()
+        assert "100%" in captured.out
+
+    def test_phase_after_progress_starts_new_line(self, capsys):
+        """A phase message arriving mid-progress-bar should start a new line."""
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        # Start a progress bar (mid-way, not completed)
+        cb("loading", "model.safetensors", 30, 100)
+        # Now a phase message arrives
+        cb("loading", "Warming up pipeline...", 0, 0)
+
+        captured = capsys.readouterr()
+        # The phase message should appear on its own line
+        assert "Warming up pipeline..." in captured.out
+
+
+class TestPreloadConsoleOutput:
+    """Integration-style tests for console output during preload_favorite_media_types."""
+
+    @patch("vtsearch.settings.get_favorite_media_types", return_value=["audio"])
+    @patch("vtsearch.media.get")
+    def test_prints_preloading_banner_and_progress(self, mock_media_get, mock_favs, capsys):
+        """preload_favorite_media_types should print the banner and forward progress to console."""
+        mock_mt = MagicMock()
+        mock_mt.name = "Audio"
+        mock_mt._on_progress = lambda *a, **kw: None
+
+        def fake_load_models():
+            # Simulate what a real load_models does
+            mock_mt._on_progress("loading", "Loading CLAP model weights...", 0, 0)
+            mock_mt._on_progress("loading", "model.safetensors", 50, 100)
+            mock_mt._on_progress("loading", "model.safetensors", 100, 100)
+            mock_mt._on_progress("loading", "Warming up audio pipeline...", 0, 0)
+
+        mock_mt.load_models = fake_load_models
+        mock_media_get.return_value = mock_mt
+
+        result = preload_favorite_media_types()
+
+        captured = capsys.readouterr()
+        assert result == ["audio"]
+        assert "Preloading Audio embedder" in captured.out
+        assert "Loading CLAP model weights..." in captured.out
+        assert "model.safetensors" in captured.out
+        assert "Warming up audio pipeline..." in captured.out
+
+    @patch("vtsearch.settings.get_favorite_media_types", return_value=["audio"])
+    @patch("vtsearch.media.get")
+    def test_restores_original_callback_after_load(self, mock_media_get, mock_favs):
+        """The original _on_progress callback should be restored after load_models."""
+        original_cb = MagicMock()
+        mock_mt = MagicMock()
+        mock_mt.name = "Audio"
+        mock_mt._on_progress = original_cb
+        mock_mt.load_models = MagicMock()
+        mock_media_get.return_value = mock_mt
+
+        preload_favorite_media_types()
+
+        assert mock_mt._on_progress is original_cb
+
+    @patch("vtsearch.settings.get_favorite_media_types", return_value=["audio"])
+    @patch("vtsearch.media.get")
+    def test_restores_callback_on_exception(self, mock_media_get, mock_favs, capsys):
+        """The original callback should be restored even when load_models raises."""
+        original_cb = MagicMock()
+        mock_mt = MagicMock()
+        mock_mt.name = "Audio"
+        mock_mt._on_progress = original_cb
+        mock_mt.load_models.side_effect = RuntimeError("boom")
+        mock_media_get.return_value = mock_mt
+
+        result = preload_favorite_media_types()
+
+        assert mock_mt._on_progress is original_cb
+        assert result == []  # failed, so not in preloaded list
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+
+    @patch("vtsearch.settings.get_favorite_media_types", return_value=[])
+    def test_no_favorites_produces_no_output(self, mock_favs, capsys):
+        """When there are no favorite media types, nothing should be printed."""
+        result = preload_favorite_media_types()
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert captured.out == ""

--- a/vtsearch/models/loader.py
+++ b/vtsearch/models/loader.py
@@ -11,6 +11,7 @@ to work unchanged.
 """
 
 import gc
+import sys
 
 from vtsearch.config import MODELS_CACHE_DIR
 
@@ -32,12 +33,55 @@ def initialize_models() -> None:
     gc.collect()
 
 
+def _make_console_progress(original_callback):
+    """Wrap *original_callback* to also print status to the terminal.
+
+    Used during startup preloading so the user sees intermediate status
+    messages and download progress bars in the console while models are
+    being loaded.
+    """
+    _last_msg: list[str | None] = [None]
+    _on_progress_line: list[bool] = [False]
+
+    def _callback(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        original_callback(status, message, current, total)
+
+        if total > 0:
+            # Measurable progress (download / weight loading) — overwrite same line
+            pct = min(100, current * 100 // total)
+            filled = pct * 30 // 100
+            bar = "#" * filled + "." * (30 - filled)
+            line = f"\r    {message} [{bar}] {pct:>3}%"
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            _on_progress_line[0] = True
+            if current >= total:
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+                _on_progress_line[0] = False
+                _last_msg[0] = None
+        elif message and message != _last_msg[0]:
+            # New phase message — print on its own line
+            if _on_progress_line[0]:
+                sys.stdout.write("\n")
+                _on_progress_line[0] = False
+            sys.stdout.write(f"    {message}\n")
+            sys.stdout.flush()
+            _last_msg[0] = message
+
+    return _callback
+
+
 def preload_favorite_media_types() -> list[str]:
     """Eagerly load embedding models for all favorite media types.
 
     Reads ``favorite_media_types`` from persisted settings and calls
     :meth:`~vtsearch.media.base.MediaType.load_models` on each one so
     that models are warm before the user opens the GUI.
+
+    Prints intermediate status messages and download progress bars to
+    the console so that the user can see what is happening during the
+    (potentially long) model loading phase.
 
     Returns the list of type IDs that were preloaded.
     """
@@ -49,7 +93,14 @@ def preload_favorite_media_types() -> list[str]:
         try:
             mt = media_get(type_id)
             print(f"  Preloading {mt.name} embedder...", flush=True)
-            mt.load_models()
+            # Temporarily wrap the media type's progress callback so
+            # that status updates are also printed to the console.
+            original_cb = mt._on_progress
+            mt._on_progress = _make_console_progress(original_cb)
+            try:
+                mt.load_models()
+            finally:
+                mt._on_progress = original_cb
             preloaded.append(type_id)
         except Exception as exc:
             print(f"  Warning: failed to preload {type_id}: {exc}", flush=True)


### PR DESCRIPTION
## Summary
This PR adds console progress output during the model preloading phase, allowing users to see what's happening during the (potentially long) startup sequence. Previously, the preloading process ran silently except for a single status line per media type.

## Changes
- **New `_make_console_progress()` function**: Wraps the media type's progress callback to print intermediate status messages and ASCII progress bars to stdout
  - Phase messages (e.g., "Loading CLAP model weights...") are printed on their own lines with deduplication to avoid spam
  - Download/weight loading progress (when `total > 0`) displays an ASCII progress bar with percentage, updated in-place using carriage returns
  - Properly handles transitions between progress bars and phase messages with newline management
  - Caps percentage display at 100% to handle overshoot scenarios

- **Updated `preload_favorite_media_types()`**: Temporarily wraps each media type's `_on_progress` callback during model loading
  - Restores the original callback after loading completes
  - Ensures callback is restored even if `load_models()` raises an exception

- **Comprehensive test coverage**: Added 173 lines of tests covering:
  - Unit tests for `_make_console_progress()` behavior (deduplication, progress bar rendering, line management)
  - Integration tests for the full preloading flow with console output verification
  - Edge cases like callback restoration on exceptions and empty favorite lists

## Implementation Details
- Uses `sys.stdout.write()` and `sys.stdout.flush()` for direct console control
- Progress bar uses `\r` (carriage return) for in-place updates and `\n` for completion
- Tracks last printed message to deduplicate repeated phase messages
- Tracks whether a progress bar is currently being displayed to manage newlines correctly

https://claude.ai/code/session_012uncvQgj3eCMTKRktDpUyR