### PR TITLE
Disable auto-detect when no dataset is loaded

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -354,6 +354,7 @@
     leftPanel.style.display = "none";
     if (rightPanel) rightPanel.style.display = "none";
     stripeContainer.innerHTML = "";
+    if (menuFavoritesAutodetect) menuFavoritesAutodetect.classList.add("disabled");
   }
 
   function showMainUI() {
@@ -367,6 +368,7 @@
       center.innerHTML = '<p>Select a media from the left panel</p>';
       announce("Dataset loaded. Select a media from the left panel to begin.");
     }
+    if (menuFavoritesAutodetect) menuFavoritesAutodetect.classList.remove("disabled");
   }
 
   function showProgress() {
@@ -1615,10 +1617,7 @@
 
   if (menuFavoritesAutodetect) {
     menuFavoritesAutodetect.addEventListener("click", async () => {
-      if (medias.length === 0) {
-        await vtAlert("No dataset loaded. Please load a dataset first.", "warning");
-        return;
-      }
+      if (menuFavoritesAutodetect.classList.contains("disabled")) return;
 
       closeBurgerMenu();
 

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,7 @@
         <div class="burger-section-title" id="menu-section-dataset">Dataset</div>
         <div class="burger-item" id="menu-dataset-change" role="menuitem" tabindex="-1">Change Dataset</div>
         <div class="burger-item" id="menu-dataset-export" role="menuitem" tabindex="-1">Export Dataset</div>
+        <div class="burger-item disabled" id="menu-favorites-autodetect" role="menuitem" tabindex="-1">Run Auto-Detect</div>
       </div>
       <div class="burger-section" role="group" aria-label="Labels">
         <div class="burger-section-title" id="menu-section-labels">Labels</div>
@@ -43,7 +44,6 @@
         <div class="burger-item" id="menu-favorites-manage" role="menuitem" tabindex="-1">Manage Favorites</div>
         <div class="burger-item" id="menu-favorites-import" role="menuitem" tabindex="-1">Import Detector</div>
         <div class="burger-item" id="menu-favorites-pregen" role="menuitem" tabindex="-1">Pregen Processors</div>
-        <div class="burger-item" id="menu-favorites-autodetect" role="menuitem" tabindex="-1">Run Auto-Detect</div>
         <div class="burger-status" id="menu-favorites-status" aria-live="polite"></div>
       </div>
       <div class="burger-section">


### PR DESCRIPTION
## Summary
This PR prevents users from running the auto-detect feature when no dataset is loaded by disabling the menu item and moving it to the Dataset section of the menu.

## Key Changes
- **Menu reorganization**: Moved "Run Auto-Detect" menu item from the Favorites section to the Dataset section, making its relationship to dataset loading more intuitive
- **State management**: Added logic to disable/enable the "Run Auto-Detect" menu item based on UI state:
  - Disabled when hiding the main UI (e.g., during dataset loading)
  - Enabled when showing the main UI (after dataset is loaded)
- **Validation simplification**: Replaced the empty dataset check with a disabled state check, providing a cleaner UX by preventing interaction rather than showing an alert

## Implementation Details
- The menu item now starts with the `disabled` class in HTML
- `showMainUI()` removes the `disabled` class when a dataset is ready
- `hideMainUI()` adds the `disabled` class when transitioning away from the main interface
- The click handler now simply returns early if the disabled class is present, preventing execution

https://claude.ai/code/session_01FYejmb2y6hyWjhjozKAiE8