### PR TITLE
Disable dataset export when no dataset is loaded

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -321,6 +321,10 @@
     const status = await res.json();
     datasetLoaded = status.loaded;
 
+    if (menuDatasetExport) {
+      menuDatasetExport.classList.toggle("disabled", !datasetLoaded);
+    }
+
     if (datasetLoaded) {
       showMainUI();
       const mtInfo = mediaTypesMap[status.media_type];
@@ -1088,6 +1092,7 @@
   // Dataset export
   if (menuDatasetExport && burgerDropdown) {
     menuDatasetExport.addEventListener("click", () => {
+      if (menuDatasetExport.classList.contains("disabled")) return;
       window.location.href = "/api/dataset/export";
       closeBurgerMenu();
     });
@@ -1103,6 +1108,7 @@
             votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
             selected = null;
             datasetLoaded = false;
+            if (menuDatasetExport) menuDatasetExport.classList.add("disabled");
             updateMediaHeading();
             showWelcomeScreen();
             renderVotes();

--- a/static/index.html
+++ b/static/index.html
@@ -19,7 +19,7 @@
       <div class="burger-section" role="group" aria-label="Dataset">
         <div class="burger-section-title" id="menu-section-dataset">Dataset</div>
         <div class="burger-item" id="menu-dataset-change" role="menuitem" tabindex="-1">Change Dataset</div>
-        <div class="burger-item" id="menu-dataset-export" role="menuitem" tabindex="-1">Export Dataset</div>
+        <div class="burger-item disabled" id="menu-dataset-export" role="menuitem" tabindex="-1">Export Dataset</div>
         <div class="burger-item disabled" id="menu-favorites-autodetect" role="menuitem" tabindex="-1">Run Auto-Detect</div>
       </div>
       <div class="burger-section" role="group" aria-label="Labels">


### PR DESCRIPTION
## Summary
This PR prevents users from attempting to export a dataset when none is currently loaded by disabling the "Export Dataset" menu item in the UI.

## Key Changes
- Initialize the "Export Dataset" menu item with the `disabled` class in HTML
- Toggle the `disabled` class on the export menu item based on the `datasetLoaded` state when checking dataset status
- Add a guard clause to prevent export requests when the menu item is disabled
- Re-disable the export menu item when resetting the dataset state

## Implementation Details
The changes ensure that:
1. The export button starts in a disabled state (no dataset loaded on page load)
2. The button is enabled/disabled dynamically as datasets are loaded or cleared
3. Even if the disabled state is somehow bypassed in the UI, the click handler will prevent the export action from executing
4. The disabled state is properly reset when the user changes datasets

https://claude.ai/code/session_0186Npc95NVyMpP6YbbQSjTN