### PR TITLE
Fix ETA calculation to exclude warmup phase timing

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -435,18 +435,29 @@
       progressFill.style.width = `${percentage}%`;
       progressText.textContent = `${percentage}%`;
 
-      // Calculate ETA
+      // Only calculate ETA during the "embedding" phase.  Earlier phases like
+      // warmup also report a known total (e.g. 1/3, 2/3, 3/3) to drive their
+      // own determinate bar, but their per-step timing must not seed the ETA
+      // for the subsequent, much longer embedding loop.
       const now = Date.now();
-      if (!progressEtaState || progressEtaState.total !== progress.total) {
-        progressEtaState = { startTime: now, startCurrent: progress.current, total: progress.total };
-      }
-      const elapsed = (now - progressEtaState.startTime) / 1000;
-      const done = progress.current - progressEtaState.startCurrent;
-      if (done > 0 && elapsed > 1 && progress.current < progress.total) {
-        const rate = done / elapsed;
-        const remaining = (progress.total - progress.current) / rate;
-        progressEta.textContent = formatETA(remaining);
-      } else if (progress.current >= progress.total) {
+      if (progress.status === "embedding") {
+        if (!progressEtaState || progressEtaState.total !== progress.total) {
+          progressEtaState = { startTime: now, startCurrent: progress.current, total: progress.total };
+        }
+        const elapsed = (now - progressEtaState.startTime) / 1000;
+        const done = progress.current - progressEtaState.startCurrent;
+        if (done > 0 && elapsed > 1 && progress.current < progress.total) {
+          const rate = done / elapsed;
+          const remaining = (progress.total - progress.current) / rate;
+          progressEta.textContent = formatETA(remaining);
+        } else if (progress.current >= progress.total) {
+          progressEta.textContent = "";
+        }
+      } else {
+        // Non-embedding phase with a known total (e.g. warmup): show the
+        // determinate bar but suppress ETA and clear any stale ETA state so
+        // embedding always starts with a fresh timer.
+        progressEtaState = null;
         progressEta.textContent = "";
       }
     } else {

--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -116,7 +116,9 @@ class TestPreloadConsoleOutput:
             mock_mt._on_progress("loading", "Loading CLAP model weights...", 0, 0)
             mock_mt._on_progress("loading", "model.safetensors", 50, 100)
             mock_mt._on_progress("loading", "model.safetensors", 100, 100)
-            mock_mt._on_progress("loading", "Warming up audio pipeline...", 0, 0)
+            mock_mt._on_progress("loading", "Warming up audio pipeline: importing libraries...", 1, 3)
+            mock_mt._on_progress("loading", "Warming up audio pipeline: preprocessing...", 2, 3)
+            mock_mt._on_progress("loading", "Warming up audio pipeline: running model...", 3, 3)
 
         mock_mt.load_models = fake_load_models
         mock_media_get.return_value = mock_mt
@@ -128,7 +130,7 @@ class TestPreloadConsoleOutput:
         assert "Preloading Audio embedder" in captured.out
         assert "Loading CLAP model weights..." in captured.out
         assert "model.safetensors" in captured.out
-        assert "Warming up audio pipeline..." in captured.out
+        assert "Warming up audio pipeline: importing libraries..." in captured.out
 
     @patch("vtsearch.settings.get_favorite_media_types", return_value=["audio"])
     @patch("vtsearch.media.get")

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -395,9 +395,16 @@ class AudioMediaType(MediaType):
         # call runs at the same speed as every subsequent one.  Without this
         # the first embedding stalls inside the progress-bar loop and skews
         # the ETA estimate for all remaining items.
-        self._on_progress("loading", "Warming up audio pipeline…", 0, 0)
+        #
+        # Three explicit steps are reported (1/3, 2/3, 3/3) so the frontend
+        # can show a determinate progress bar for the warmup phase.  The
+        # status remains "loading" so the frontend knows not to include this
+        # phase in its ETA calculation for the subsequent "embedding" phase.
+        self._on_progress("loading", "Warming up audio pipeline: importing libraries…", 1, 3)
+        import librosa  # noqa: PLC0415 — lazy import; pulls in numba, scipy, etc.
         import torch  # noqa: PLC0415
 
+        self._on_progress("loading", "Warming up audio pipeline: preprocessing…", 2, 3)
         dummy_audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
@@ -407,6 +414,7 @@ class AudioMediaType(MediaType):
             max_length=480000,
             truncation=True,
         )
+        self._on_progress("loading", "Warming up audio pipeline: running model…", 3, 3)
         with torch.no_grad():
             outputs = self._model.audio_model(**inputs)
             self._model.audio_projection(outputs.pooler_output)


### PR DESCRIPTION
## Summary
This PR fixes the ETA (estimated time to arrival) calculation for the embedding process by excluding timing data from the warmup phase. Previously, the fast warmup steps would skew the ETA estimate for the much longer embedding phase that follows.

## Key Changes

- **Frontend (app.js)**: Modified ETA calculation to only run during the "embedding" phase. Non-embedding phases (like warmup) now show a determinate progress bar without ETA, and the ETA state is reset when entering the embedding phase to ensure a fresh timer.

- **Backend (media_type.py)**: Enhanced the warmup phase to report three explicit progress steps (1/3, 2/3, 3/3) instead of a single indeterminate step (0/0). This allows the frontend to display a determinate progress bar during warmup while keeping the status as "loading" so the frontend knows not to include this phase in ETA calculations.

- **Tests (test_preload_progress.py)**: Updated test expectations to match the new three-step warmup progress reporting.

## Implementation Details

The warmup phase now reports progress at three distinct points:
1. Importing libraries (librosa, torch)
2. Preprocessing audio
3. Running the model

This provides better user feedback during the warmup phase while ensuring that the ETA calculation for the subsequent embedding phase starts with a clean slate and accurate timing data.

https://claude.ai/code/session_0111X1MKQW7bMxzi3RaGsQ8M