### PR TITLE
Move audio player outside swipe wrapper for fixed positioning

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3084,10 +3084,10 @@
           Loading...
         </div>`;
     } else if (mediaType === "audio") {
-      // Audio/Sound
+      // Audio/Sound – only the waveform canvas goes inside the swipe wrapper;
+      // the <audio> player is placed outside so it stays fixed during the animation.
       playerHTML = `
-        <canvas id="waveform-canvas" width="600" height="120" role="img" aria-label="Audio waveform visualization"></canvas>
-        <audio controls controlslist="nodownload" loop autoplay src="/api/medias/${c.id}/audio" id="media-audio" aria-label="${escapeHtml(c.filename || 'Audio media')}"></audio>`;
+        <canvas id="waveform-canvas" width="600" height="120" role="img" aria-label="Audio waveform visualization"></canvas>`;
     } else {
       // Unknown/new media type: try to render via generic endpoint.
       // If it loops, use a video element; otherwise use a generic embed.
@@ -3107,6 +3107,7 @@
       <div class="media-swipe-wrapper" id="media-swipe-wrapper">
         ${playerHTML}
       </div>
+      ${mediaType === "audio" ? `<audio controls controlslist="nodownload" loop autoplay src="/api/medias/${c.id}/audio" id="media-audio" aria-label="${escapeHtml(c.filename || 'Audio media')}"></audio>` : ''}
       <div class="metadata-grid">
         ${c.frequency ? `
         <div class="metadata-item">


### PR DESCRIPTION
## Summary
Refactored the audio player layout to fix positioning issues during media swiping animations. The audio `<audio>` element is now rendered outside the swipe wrapper container, while the waveform canvas remains inside.

## Key Changes
- Removed the `<audio>` element from inside the `media-swipe-wrapper` div
- Moved the `<audio>` element to render outside the swipe wrapper, positioned after it
- Updated the audio player rendering to be conditionally placed based on `mediaType === "audio"`
- Enhanced code comments to clarify the layout structure and reasoning

## Implementation Details
- The waveform canvas (`#waveform-canvas`) remains inside the swipe wrapper to participate in swiping animations
- The audio player is now conditionally rendered outside the wrapper using a ternary operator
- This separation allows the audio controls to remain fixed/stable while the waveform animates during swipe gestures
- Maintains all existing audio player attributes: `controls`, `controlslist="nodownload"`, `loop`, `autoplay`, and accessibility labels

https://claude.ai/code/session_013s9B3ZPu5rXoghCm7c2BGV