### PR TITLE
Update download status badge text to "Needs Download"

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -619,7 +619,7 @@
         function buildStatusBadge(st) {
           if (st === "ready") return '<span class="ready-badge">Ready</span>';
           if (st === "needs_embedding") return '<span class="embedding-badge">Needs Embed</span>';
-          return '<span class="download-badge">Download</span>';
+          return '<span class="download-badge">Needs Download</span>';
         }
 
         function renderTable(items, section) {


### PR DESCRIPTION
## Summary
Updated the status badge text for the download state to be more descriptive and consistent with other status labels in the UI.

## Changes
- Changed the download status badge text from "Download" to "Needs Download" in the `buildStatusBadge()` function
- This provides clearer indication that the item requires downloading, matching the pattern used by the "Needs Embed" status

## Details
The status badge now uses more explicit language ("Needs Download") to better communicate the required action to users, improving consistency with other status indicators like "Needs Embed".

https://claude.ai/code/session_01ShYXdgKB2cx72KH6qJEYTM