### PR TITLE
Disable import/export menu items until dataset is loaded

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -361,6 +361,10 @@
     if (rightPanel) rightPanel.style.display = "none";
     stripeContainer.innerHTML = "";
     if (menuFavoritesAutodetect) menuFavoritesAutodetect.classList.add("disabled");
+    if (menuLabelsImport) menuLabelsImport.classList.add("disabled");
+    if (menuLabelsExport) menuLabelsExport.classList.add("disabled");
+    if (menuDetectorImport) menuDetectorImport.classList.add("disabled");
+    if (menuDetectorExport) menuDetectorExport.classList.add("disabled");
   }
 
   function showMainUI() {
@@ -375,6 +379,9 @@
       announce("Dataset loaded. Select a media from the left panel to begin.");
     }
     if (menuFavoritesAutodetect) menuFavoritesAutodetect.classList.remove("disabled");
+    if (menuLabelsImport) menuLabelsImport.classList.remove("disabled");
+    if (menuDetectorImport) menuDetectorImport.classList.remove("disabled");
+    // menuLabelsExport and menuDetectorExport stay disabled until votes are loaded (updateSortModeAvailability)
   }
 
   function showProgress() {
@@ -1247,6 +1254,7 @@
   // Labels import – open the label importer picker modal
   if (menuLabelsImport && burgerDropdown) {
     menuLabelsImport.addEventListener("click", async () => {
+      if (menuLabelsImport.classList.contains("disabled")) return;
       closeBurgerMenu();
       await openLabelImporterModal();
     });
@@ -1255,6 +1263,7 @@
   // Detector import
   if (menuDetectorImport && loadDetectorFile && burgerDropdown) {
     menuDetectorImport.addEventListener("click", () => {
+      if (menuDetectorImport.classList.contains("disabled")) return;
       loadDetectorFile.click();
       closeBurgerMenu();
     });

--- a/static/index.html
+++ b/static/index.html
@@ -24,14 +24,14 @@
       </div>
       <div class="burger-section" role="group" aria-label="Labels">
         <div class="burger-section-title" id="menu-section-labels">Labels</div>
-        <div class="burger-item" id="menu-labels-import" role="menuitem" tabindex="-1">Import Labels</div>
-        <div class="burger-item" id="menu-labels-export" role="menuitem" tabindex="-1">Export Labels</div>
+        <div class="burger-item disabled" id="menu-labels-import" role="menuitem" tabindex="-1">Import Labels</div>
+        <div class="burger-item disabled" id="menu-labels-export" role="menuitem" tabindex="-1">Export Labels</div>
         <div class="burger-status" id="menu-labels-status" aria-live="polite"></div>
       </div>
       <div class="burger-section" role="group" aria-label="Detector">
         <div class="burger-section-title" id="menu-section-detector">Detector</div>
-        <div class="burger-item" id="menu-detector-import" role="menuitem" tabindex="-1">Load Sort</div>
-        <div class="burger-item" id="menu-detector-export" role="menuitem" tabindex="-1">Export Detector</div>
+        <div class="burger-item disabled" id="menu-detector-import" role="menuitem" tabindex="-1">Load Sort</div>
+        <div class="burger-item disabled" id="menu-detector-export" role="menuitem" tabindex="-1">Export Detector</div>
         <div class="burger-status" id="menu-detector-status" aria-live="polite"></div>
       </div>
       <div class="burger-section" role="group" aria-label="Favorite Detectors">


### PR DESCRIPTION
## Summary
This PR disables the Labels and Detector import/export menu items until a dataset is loaded, improving UX by preventing users from attempting these operations when no data is available.

## Key Changes
- **HTML**: Added `disabled` class to Labels Import/Export and Detector Import/Export menu items in the burger menu, making them visually disabled on initial load
- **JavaScript**: 
  - Updated `hideMainUI()` to disable all four import/export menu items when hiding the main interface
  - Updated `showMainUI()` to re-enable Labels Import and Detector Import when showing the main interface (Export items remain disabled until votes are loaded)
  - Added guard clauses in click handlers for Labels Import and Detector Import to prevent action if the menu item is disabled
  
## Implementation Details
- The export menu items (`menuLabelsExport` and `menuDetectorExport`) are intentionally kept disabled in `showMainUI()` with a comment indicating they stay disabled until `updateSortModeAvailability()` is called (when votes are loaded)
- Guard clauses in event listeners provide an additional safety check to prevent disabled menu items from triggering their associated actions
- This follows the existing pattern used for `menuFavoritesAutodetect`

https://claude.ai/code/session_01Je3TD1U7NR4rLK5Jy6N1KK