### PR TITLE
Move pregen processors feature into favorites modal

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -278,9 +278,8 @@
   const processorImporterList = document.getElementById("processor-importer-list");
   const processorImporterFormDiv = document.getElementById("processor-importer-form");
   const processorImporterBack = document.getElementById("processor-importer-back");
-  const menuFavoritesImport = document.getElementById("menu-favorites-import");
-  const menuFavoritesPregen = document.getElementById("menu-favorites-pregen");
   const menuFavoritesStatus = document.getElementById("menu-favorites-status");
+  const favPregenBtn = document.getElementById("fav-pregen-btn");
   const menuFavoritesManage = document.getElementById("menu-favorites-manage");
   const menuFavoritesAutodetect = document.getElementById("menu-favorites-autodetect");
   const favoritesModal = document.getElementById("favorites-modal");
@@ -3780,50 +3779,44 @@
     });
   }
 
-  // ---- Pregen processors ----
+  // ---- Pregen processors (in favorites modal) ----
 
-  if (menuFavoritesPregen && burgerDropdown) {
-    menuFavoritesPregen.addEventListener("click", async () => {
-      closeBurgerMenu();
-      if (menuFavoritesStatus) {
-        menuFavoritesStatus.textContent = "Adding pregen processors\u2026";
-        menuFavoritesStatus.style.color = "var(--text-muted)";
+  if (favPregenBtn) {
+    favPregenBtn.addEventListener("click", async () => {
+      favPregenBtn.disabled = true;
+      if (favAddStatus) {
+        favAddStatus.textContent = "Adding pregen processors\u2026";
+        favAddStatus.style.color = "var(--text-muted)";
       }
       try {
         const res = await fetch("/api/pregen-processors/add", { method: "POST" });
         const result = await res.json();
         if (res.ok && result.success) {
-          const msg = `Added ${result.added.length} pregen processor(s)`;
-          if (menuFavoritesStatus) {
-            menuFavoritesStatus.textContent = msg;
-            menuFavoritesStatus.style.color = "var(--color-good)";
-            setTimeout(() => { menuFavoritesStatus.textContent = ""; }, 3000);
+          if (favAddStatus) {
+            favAddStatus.textContent = `Added ${result.added.length} pregen processor(s)`;
+            favAddStatus.style.color = "var(--color-good)";
+            setTimeout(() => { favAddStatus.textContent = ""; }, 3000);
           }
         } else {
-          if (menuFavoritesStatus) {
-            menuFavoritesStatus.textContent = result.error || "Failed to add pregen processors";
-            menuFavoritesStatus.style.color = "var(--color-bad)";
-            setTimeout(() => { menuFavoritesStatus.textContent = ""; }, 3000);
+          if (favAddStatus) {
+            favAddStatus.textContent = result.error || "Failed to add pregen processors";
+            favAddStatus.style.color = "var(--color-bad)";
+            setTimeout(() => { favAddStatus.textContent = ""; }, 3000);
           }
         }
       } catch (err) {
-        if (menuFavoritesStatus) {
-          menuFavoritesStatus.textContent = `Error: ${err.message}`;
-          menuFavoritesStatus.style.color = "var(--color-bad)";
-          setTimeout(() => { menuFavoritesStatus.textContent = ""; }, 3000);
+        if (favAddStatus) {
+          favAddStatus.textContent = `Error: ${err.message}`;
+          favAddStatus.style.color = "var(--color-bad)";
+          setTimeout(() => { favAddStatus.textContent = ""; }, 3000);
         }
+      } finally {
+        favPregenBtn.disabled = false;
       }
     });
   }
 
   // ---- Processor importer modal ----
-
-  if (menuFavoritesImport && burgerDropdown) {
-    menuFavoritesImport.addEventListener("click", async () => {
-      closeBurgerMenu();
-      await openProcessorImporterModal();
-    });
-  }
 
   async function openProcessorImporterModal() {
     let importers = [];

--- a/static/index.html
+++ b/static/index.html
@@ -37,8 +37,6 @@
       <div class="burger-section" role="group" aria-label="Favorite Detectors">
         <div class="burger-section-title" id="menu-section-favorites">Favorite Detectors</div>
         <div class="burger-item" id="menu-favorites-manage" role="menuitem" tabindex="-1">Manage Favorites</div>
-        <div class="burger-item" id="menu-favorites-import" role="menuitem" tabindex="-1">Import Detector</div>
-        <div class="burger-item" id="menu-favorites-pregen" role="menuitem" tabindex="-1">Pregen Processors</div>
         <div class="burger-status" id="menu-favorites-status" aria-live="polite"></div>
       </div>
       <div class="burger-section">
@@ -247,6 +245,7 @@
         </div>
         <div style="display: flex; gap: 8px; flex-wrap: wrap;">
           <button id="fav-add-from-votes-btn" style="flex: 1; padding: 8px 12px; background: var(--accent); color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">From Current Labels</button>
+          <button id="fav-pregen-btn" style="padding: 8px 12px; background: var(--bg-secondary-btn); color: var(--text-primary); border: 1px solid var(--border); border-radius: 4px; cursor: pointer; font-size: 0.8rem;">Pregen Processors</button>
         </div>
         <div id="fav-importer-buttons" style="margin-top: 4px;"></div>
         <div id="fav-add-status" style="font-size: 0.78rem; color: var(--text-muted); margin-top: 8px; min-height: 1.2em;"></div>


### PR DESCRIPTION
## Summary
Refactored the "Pregen Processors" feature from a burger menu item to a button within the favorites modal, improving UI organization and user experience.

## Key Changes
- **Removed burger menu items**: Deleted `menu-favorites-import` and `menu-favorites-pregen` from the burger dropdown menu in the HTML
- **Moved pregen button to modal**: Added `fav-pregen-btn` button inside the favorites modal alongside other favorite management controls
- **Updated JavaScript references**: 
  - Removed references to `menuFavoritesImport` and `menuFavoritesPregen` elements
  - Added reference to new `favPregenBtn` element
  - Updated event listener to use `favPregenBtn` instead of `menuFavoritesPregen`
  - Changed status message references from `menuFavoritesStatus` to `favAddStatus` for consistency with modal context
- **Improved UX**: Added button disable state during processing and proper re-enabling in finally block to prevent duplicate submissions
- **Removed burger menu closure**: Eliminated `closeBurgerMenu()` call since the button now lives in a modal rather than the burger menu

## Implementation Details
- The pregen processors functionality remains unchanged; only its UI location and triggering mechanism were modified
- Status messages now use the modal's dedicated status element (`favAddStatus`) instead of the burger menu status
- Button styling uses modal-appropriate colors (`--bg-secondary-btn`, `--border`) instead of burger menu styling
- The feature is now more discoverable within the favorites management workflow

https://claude.ai/code/session_016k8yDMXzisLS5J7Mz5gab3