### PR TITLE
Reorganize menu: Move Auto-Detect under Autodetect section

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,7 +20,6 @@
         <div class="burger-section-title" id="menu-section-dataset">Dataset</div>
         <div class="burger-item" id="menu-dataset-change" role="menuitem" tabindex="-1">Change Dataset</div>
         <div class="burger-item disabled" id="menu-dataset-export" role="menuitem" tabindex="-1">Export Dataset</div>
-        <div class="burger-item disabled" id="menu-favorites-autodetect" role="menuitem" tabindex="-1">Run Auto-Detect</div>
       </div>
       <div class="burger-section" role="group" aria-label="Labels">
         <div class="burger-section-title" id="menu-section-labels">Labels</div>
@@ -34,9 +33,10 @@
         <div class="burger-item disabled" id="menu-detector-export" role="menuitem" tabindex="-1">Export Detector</div>
         <div class="burger-status" id="menu-detector-status" aria-live="polite"></div>
       </div>
-      <div class="burger-section" role="group" aria-label="Favorite Detectors">
-        <div class="burger-section-title" id="menu-section-favorites">Favorite Detectors</div>
+      <div class="burger-section" role="group" aria-label="Autodetect">
+        <div class="burger-section-title" id="menu-section-favorites">Autodetect</div>
         <div class="burger-item" id="menu-favorites-manage" role="menuitem" tabindex="-1">Manage Favorites</div>
+        <div class="burger-item disabled" id="menu-favorites-autodetect" role="menuitem" tabindex="-1">Run Auto-Detect</div>
         <div class="burger-status" id="menu-favorites-status" aria-live="polite"></div>
       </div>
       <div class="burger-section">


### PR DESCRIPTION
## Summary
Reorganized the burger menu structure by moving the "Run Auto-Detect" menu item from the Dataset section to a renamed "Autodetect" section (previously "Favorite Detectors").

## Key Changes
- Removed "Run Auto-Detect" menu item from the Dataset section
- Renamed the "Favorite Detectors" section to "Autodetect"
- Updated the section's aria-label from "Favorite Detectors" to "Autodetect"
- Moved "Run Auto-Detect" menu item to the Autodetect section, placing it after "Manage Favorites"

## Details
This change improves the menu organization by grouping auto-detection related functionality together in a dedicated section, rather than having it mixed with dataset operations. The "Run Auto-Detect" item remains disabled by default and is now logically grouped with other autodetection features.

https://claude.ai/code/session_01FnPBoSSPVsnPEdB8TRstkN