### PR TITLE
Add BBC News dataset support to text media type

### DIFF
--- a/tests/test_bbc_news_download.py
+++ b/tests/test_bbc_news_download.py
@@ -1,0 +1,213 @@
+"""Tests for BBC News dataset download and load_demo_source integration."""
+
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bbc_zip(tmp_path: Path, top_folder: str = "") -> Path:
+    """Create a minimal BBC News zip fixture with 3 articles per category."""
+    categories = ["business", "entertainment", "politics", "sport", "tech"]
+    zip_path = tmp_path / "bbc-fulltext.zip"
+
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for cat in categories:
+            for i in range(1, 4):
+                article_text = f"BBC {cat} article number {i}. This is sample text."
+                # Optionally nest inside a top-level folder.
+                arc_name = f"{top_folder}/{cat}/{i:03d}.txt" if top_folder else f"{cat}/{i:03d}.txt"
+                zf.writestr(arc_name, article_text)
+
+    return zip_path
+
+
+# ---------------------------------------------------------------------------
+# _find_bbc_root
+# ---------------------------------------------------------------------------
+
+class TestFindBbcRoot:
+    def test_flat_structure(self, tmp_path):
+        """Category directories sit directly inside the root."""
+        from vtsearch.datasets.downloader import _find_bbc_root
+
+        for cat in ("business", "sport", "tech"):
+            (tmp_path / cat).mkdir()
+
+        result = _find_bbc_root(tmp_path)
+        assert result == tmp_path
+
+    def test_nested_structure(self, tmp_path):
+        """Category directories are one level deeper (zip has a top-level folder)."""
+        from vtsearch.datasets.downloader import _find_bbc_root
+
+        inner = tmp_path / "bbc"
+        inner.mkdir()
+        for cat in ("business", "sport", "tech"):
+            (inner / cat).mkdir()
+
+        result = _find_bbc_root(tmp_path)
+        assert result == inner
+
+    def test_no_match_returns_none(self, tmp_path):
+        from vtsearch.datasets.downloader import _find_bbc_root
+
+        (tmp_path / "unrelated").mkdir()
+        assert _find_bbc_root(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# download_bbc_news
+# ---------------------------------------------------------------------------
+
+class TestDownloadBbcNews:
+    def test_returns_articles_by_category(self, tmp_path):
+        """download_bbc_news returns a dict of category -> list[str] from a zip."""
+        from vtsearch.datasets import downloader as dl_module
+
+        zip_path = _make_bbc_zip(tmp_path)
+
+        progress_calls = []
+
+        def fake_progress(status, msg, cur, tot):
+            progress_calls.append((status, msg))
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", lambda url, dest, size, cb: zip_path.rename(dest)),
+        ):
+            result = dl_module.download_bbc_news(on_progress=fake_progress)
+
+        assert set(result.keys()) == {"business", "entertainment", "politics", "sport", "tech"}
+        for articles in result.values():
+            assert len(articles) == 3
+            assert all(isinstance(a, str) and a for a in articles)
+
+    def test_nested_zip_structure(self, tmp_path):
+        """download_bbc_news handles a zip with a top-level 'bbc/' folder."""
+        from vtsearch.datasets import downloader as dl_module
+
+        zip_path = _make_bbc_zip(tmp_path, top_folder="bbc")
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", lambda url, dest, size, cb: zip_path.rename(dest)),
+        ):
+            result = dl_module.download_bbc_news(on_progress=lambda *a: None)
+
+        assert "business" in result
+        assert len(result["business"]) == 3
+
+    def test_cached_extraction_skips_download(self, tmp_path):
+        """If the extract directory already exists, no download is triggered."""
+        from vtsearch.datasets import downloader as dl_module
+
+        # Pre-create the extract directory with one category.
+        extract_dir = tmp_path / "bbc-fulltext"
+        sport_dir = extract_dir / "sport"
+        sport_dir.mkdir(parents=True)
+        (sport_dir / "001.txt").write_text("A sport article.")
+
+        download_called = []
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = dl_module.download_bbc_news(on_progress=lambda *a: None)
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert "sport" in result
+
+
+# ---------------------------------------------------------------------------
+# load_demo_source — bbc_news branch
+# ---------------------------------------------------------------------------
+
+class TestLoadDemoSourceBbcNews:
+    """TextMediaType.load_demo_source with source='bbc_news'."""
+
+    def _make_text_media_type(self):
+        from vtsearch.media.text.media_type import TextMediaType
+
+        mt = TextMediaType()
+        # Provide a stub embedding model so we never hit the real network.
+        stub_model = MagicMock()
+        stub_model.encode.return_value = [0.1] * 768
+        mt._model = stub_model
+        return mt
+
+    def test_bbc_news_source_populates_clips(self, tmp_path):
+        """load_demo_source with source='bbc_news' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+
+        # Provide fake categories_articles directly.
+        fake_articles = {
+            "business": ["Business article one.", "Business article two."],
+            "sport": ["Sport article one.", "Sport article two."],
+        }
+
+        mt = self._make_text_media_type()
+        clips: dict = {}
+
+        with patch.object(dl_module, "download_bbc_news", return_value=fake_articles):
+            mt.load_demo_source(
+                source="bbc_news",
+                categories=["business", "sport"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(clips) == 4
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"business", "sport"}
+
+    def test_bbc_news_slice_is_applied(self, tmp_path):
+        """slice_start/slice_end limits articles per category."""
+        from vtsearch.datasets import downloader as dl_module
+
+        fake_articles = {
+            "tech": [f"Tech article {i}." for i in range(10)],
+        }
+
+        mt = self._make_text_media_type()
+        clips: dict = {}
+
+        with patch.object(dl_module, "download_bbc_news", return_value=fake_articles):
+            mt.load_demo_source(
+                source="bbc_news",
+                categories=["tech"],
+                slice_start=2,
+                slice_end=5,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        # Only articles[2:5] = 3 articles.
+        assert len(clips) == 3
+
+    def test_unsupported_source_still_raises(self):
+        """Non-existent sources still raise ValueError."""
+        from vtsearch.media.text.media_type import TextMediaType
+
+        mt = TextMediaType()
+        with pytest.raises(ValueError, match="Unsupported text source"):
+            mt.load_demo_source(
+                source="unknown_source",
+                categories=[],
+                slice_start=0,
+                slice_end=10,
+                clips={},
+                on_progress=lambda *a: None,
+            )

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -23,6 +23,7 @@ CIFAR10_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
 CALTECH101_URL = "https://data.caltech.edu/records/mzrjq-6wc02/files/caltech-101.zip"
 CALTECH256_URL = "https://data.caltech.edu/records/nyy15-4j048/files/256_ObjectCategories.tar?download=1"
 UCF101_SUBSET_URL = "https://huggingface.co/datasets/sayakpaul/ucf101-subset/resolve/main/UCF101_subset.tar.gz"
+BBC_NEWS_URL = "http://mlg.ucd.ie/files/datasets/bbc-fulltext.zip"
 
 # Dataset size estimates
 ESC50_DOWNLOAD_SIZE_MB = 600
@@ -31,6 +32,7 @@ CIFAR10_DOWNLOAD_SIZE_MB = 170
 CALTECH101_DOWNLOAD_SIZE_MB = 131
 CALTECH256_DOWNLOAD_SIZE_MB = 1200
 UCF101_SUBSET_DOWNLOAD_SIZE_MB = 171
+BBC_NEWS_DOWNLOAD_SIZE_MB = 2
 MEDIAS_PER_CATEGORY = 40
 MEDIAS_PER_VIDEO_CATEGORY = 150
 IMAGES_PER_CIFAR10_CATEGORY = 100

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -15,6 +15,8 @@ from typing import Callable, Optional
 import requests
 
 from vtsearch.config import (
+    BBC_NEWS_DOWNLOAD_SIZE_MB,
+    BBC_NEWS_URL,
     CALTECH101_DOWNLOAD_SIZE_MB,
     CALTECH101_URL,
     CALTECH256_DOWNLOAD_SIZE_MB,
@@ -436,3 +438,93 @@ def download_20newsgroups(
     ]
 
     return texts, labels, target_names
+
+
+def download_bbc_news(
+    on_progress: Optional[ProgressCallback] = None,
+) -> dict[str, list[str]]:
+    """Download and prepare the BBC News full-text dataset.
+
+    Downloads ``bbc-fulltext.zip`` from the configured ``BBC_NEWS_URL`` into
+    ``DATA_DIR`` if it is not already present, then extracts it.  The zip is
+    deleted after extraction to reclaim disk space.
+
+    The dataset contains ~2225 articles across five topic categories:
+    ``business``, ``entertainment``, ``politics``, ``sport``, and ``tech``.
+
+    Args:
+        on_progress: Optional progress callback. Falls back to the
+            application-wide ``update_progress`` when ``None``.
+
+    Returns:
+        A dict mapping category name to a list of article text strings, e.g.
+        ``{"business": ["Article text…", …], "sport": […], …}``.
+    """
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    zip_path = DATA_DIR / "bbc-fulltext.zip"
+    extract_dir = DATA_DIR / "bbc-fulltext"
+    DATA_DIR.mkdir(exist_ok=True)
+
+    if not extract_dir.exists():
+        if not zip_path.exists():
+            on_progress("downloading", "Starting BBC News download...", 0, 0)
+            download_file_with_progress(
+                BBC_NEWS_URL,
+                zip_path,
+                BBC_NEWS_DOWNLOAD_SIZE_MB * 1024 * 1024,
+                on_progress,
+            )
+
+        on_progress("downloading", "Extracting BBC News dataset...", 0, 0)
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            # The zip may contain a top-level folder (e.g. "bbc/"); extract
+            # all members and then locate category directories below.
+            zip_ref.extractall(DATA_DIR / "bbc-fulltext-raw")
+
+        # Find the directory that contains the category subfolders.
+        raw_root = DATA_DIR / "bbc-fulltext-raw"
+        _bbc_root = _find_bbc_root(raw_root)
+        if _bbc_root is None:
+            raise RuntimeError(f"Could not locate BBC News category directories inside {raw_root}")
+
+        import shutil
+
+        shutil.copytree(_bbc_root, extract_dir)
+        shutil.rmtree(raw_root, ignore_errors=True)
+        zip_path.unlink(missing_ok=True)
+
+    # Read articles grouped by category directory name.
+    categories_articles: dict[str, list[str]] = {}
+    for category_dir in sorted(extract_dir.iterdir()):
+        if not category_dir.is_dir():
+            continue
+        articles: list[str] = []
+        for txt_file in sorted(category_dir.glob("*.txt")):
+            try:
+                text = txt_file.read_text(encoding="utf-8", errors="replace").strip()
+            except Exception:
+                continue
+            if text:
+                articles.append(text)
+        if articles:
+            categories_articles[category_dir.name] = articles
+
+    return categories_articles
+
+
+def _find_bbc_root(directory: Path) -> Optional[Path]:
+    """Return the first directory under *directory* that contains BBC category subfolders."""
+    _BBC_CATEGORIES = {"business", "entertainment", "politics", "sport", "tech"}
+    # Check the directory itself first.
+    subdirs = {p.name for p in directory.iterdir() if p.is_dir()}
+    if subdirs & _BBC_CATEGORIES:
+        return directory
+    # One level of nesting (common when the zip has a top-level folder).
+    for child in directory.iterdir():
+        if child.is_dir():
+            grandchildren = {p.name for p in child.iterdir() if p.is_dir()}
+            if grandchildren & _BBC_CATEGORIES:
+                return child
+    return None

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -210,22 +210,35 @@ class TextMediaType(MediaType):
 
             on_progress = update_progress
 
-        if source != "ag_news_sample":
-            raise ValueError(f"Unsupported text source: {source!r}")
-
-        from vtsearch.datasets.downloader import download_20newsgroups  # noqa: PLC0415
-
-        texts, labels, category_names = download_20newsgroups(categories, on_progress=on_progress)
-
         selected_texts = []
         selected_categories = []
-        for cat_name in categories:
-            if cat_name in category_names:
-                cat_idx = category_names.index(cat_name)
-                cat_texts = [texts[i] for i, lbl in enumerate(labels) if lbl == cat_idx]
-                for text in cat_texts[slice_start : (slice_end or len(cat_texts))]:
-                    selected_texts.append(text)
+
+        if source == "ag_news_sample":
+            from vtsearch.datasets.downloader import download_20newsgroups  # noqa: PLC0415
+
+            texts, labels, category_names = download_20newsgroups(categories, on_progress=on_progress)
+
+            for cat_name in categories:
+                if cat_name in category_names:
+                    cat_idx = category_names.index(cat_name)
+                    cat_texts = [texts[i] for i, lbl in enumerate(labels) if lbl == cat_idx]
+                    for text in cat_texts[slice_start : (slice_end or len(cat_texts))]:
+                        selected_texts.append(text)
+                        selected_categories.append(cat_name)
+
+        elif source == "bbc_news":
+            from vtsearch.datasets.downloader import download_bbc_news  # noqa: PLC0415
+
+            categories_articles = download_bbc_news(on_progress=on_progress)
+
+            for cat_name in categories:
+                articles = categories_articles.get(cat_name, [])
+                for article in articles[slice_start : (slice_end or len(articles))]:
+                    selected_texts.append(article)
                     selected_categories.append(cat_name)
+
+        else:
+            raise ValueError(f"Unsupported text source: {source!r}")
 
         if getattr(self, "_model", None) is None:
             on_progress("loading", "Loading text embedding model…", 0, 0)


### PR DESCRIPTION
## Summary
This PR adds support for the BBC News full-text dataset as a demo source for the text media type, alongside the existing AG News support.

## Key Changes

- **New `download_bbc_news()` function** in `vtsearch/datasets/downloader.py`:
  - Downloads the BBC News dataset (~2225 articles across 5 categories: business, entertainment, politics, sport, tech)
  - Handles both flat and nested zip structures (with optional top-level folder)
  - Extracts to `DATA_DIR/bbc-fulltext` and cleans up the zip file after extraction
  - Implements caching to skip re-downloading if extraction directory already exists
  - Returns a dict mapping category names to lists of article text strings

- **New `_find_bbc_root()` helper function**:
  - Locates the directory containing BBC category subdirectories
  - Handles both direct nesting and one level of indirection (common when zips contain a top-level folder)

- **Extended `load_demo_source()` in `vtsearch/media/text/media_type.py`**:
  - Added support for `source="bbc_news"` alongside existing `"ag_news_sample"`
  - Applies `slice_start`/`slice_end` filtering per category
  - Refactored to use if/elif/else structure for cleaner source handling

- **Configuration updates** in `vtsearch/config.py`:
  - Added `BBC_NEWS_URL` and `BBC_NEWS_DOWNLOAD_SIZE_MB` constants

- **Comprehensive test suite** in `tests/test_bbc_news_download.py`:
  - Tests for `_find_bbc_root()` with flat and nested structures
  - Tests for `download_bbc_news()` including zip extraction, caching, and progress callbacks
  - Integration tests for `load_demo_source()` with BBC News source, category filtering, and slicing

## Implementation Details

- The BBC News downloader gracefully handles zip files with or without a top-level folder by extracting to a temporary directory and then locating the actual category root
- Progress callbacks are properly integrated throughout the download and extraction process
- The implementation follows the same patterns as existing dataset downloaders (e.g., 20 Newsgroups)
- All file I/O uses UTF-8 encoding with error replacement for robustness

https://claude.ai/code/session_0198LtX8gh2kUoWsmDmYMSn5