### PR TITLE
Add AG News dataset support for text media type

### DIFF
--- a/tests/test_ag_news_download.py
+++ b/tests/test_ag_news_download.py
@@ -1,0 +1,177 @@
+"""Tests for AG News dataset download and load_demo_source integration."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ag_news_csv(tmp_path: Path) -> Path:
+    """Create a minimal AG News CSV fixture with 3 articles per category."""
+    csv_path = tmp_path / "ag_news_train.csv"
+    # AG News CSV format: "class_index","title","description"
+    # 1=World, 2=Sports, 3=Business, 4=Sci/Tech
+    lines = []
+    for class_idx in range(1, 5):
+        for i in range(1, 4):
+            title = f"Title {class_idx}-{i}"
+            desc = f"Description for class {class_idx} article {i}. This is sample text."
+            lines.append(f'"{class_idx}","{title}","{desc}"')
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return csv_path
+
+
+# ---------------------------------------------------------------------------
+# download_ag_news
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadAgNews:
+    def test_returns_articles_by_category(self, tmp_path):
+        """download_ag_news returns a dict of category -> list[str] from a CSV."""
+        from vtsearch.datasets import downloader as dl_module
+
+        csv_path = _make_ag_news_csv(tmp_path)
+
+        progress_calls = []
+
+        def fake_progress(status, msg, cur, tot):
+            progress_calls.append((status, msg))
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: csv_path.rename(dest) if dest != csv_path else None,
+            ),
+        ):
+            # Ensure the CSV is at the expected location.
+            if not (tmp_path / "ag_news_train.csv").exists():
+                _make_ag_news_csv(tmp_path)
+            result = dl_module.download_ag_news(on_progress=fake_progress)
+
+        assert set(result.keys()) == {"World", "Sports", "Business", "Sci/Tech"}
+        for articles in result.values():
+            assert len(articles) == 3
+            assert all(isinstance(a, str) and a for a in articles)
+
+    def test_articles_combine_title_and_description(self, tmp_path):
+        """Each article text should contain both the title and description."""
+        from vtsearch.datasets import downloader as dl_module
+
+        _make_ag_news_csv(tmp_path)
+
+        with patch.object(dl_module, "DATA_DIR", tmp_path):
+            result = dl_module.download_ag_news(on_progress=lambda *a: None)
+
+        # Check that the first World article has both title and description.
+        first_article = result["World"][0]
+        assert "Title 1-1" in first_article
+        assert "Description for class 1 article 1" in first_article
+
+    def test_cached_csv_skips_download(self, tmp_path):
+        """If the CSV already exists, no download is triggered."""
+        from vtsearch.datasets import downloader as dl_module
+
+        _make_ag_news_csv(tmp_path)
+        download_called = []
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = dl_module.download_ag_news(on_progress=lambda *a: None)
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert "World" in result
+
+    def test_skips_malformed_rows(self, tmp_path):
+        """Rows with fewer than 3 columns are silently skipped."""
+        from vtsearch.datasets import downloader as dl_module
+
+        csv_path = tmp_path / "ag_news_train.csv"
+        csv_path.write_text(
+            '"1","Good title","Good description"\n"bad row"\n"2","Another","Article"\n', encoding="utf-8"
+        )
+
+        with patch.object(dl_module, "DATA_DIR", tmp_path):
+            result = dl_module.download_ag_news(on_progress=lambda *a: None)
+
+        total = sum(len(v) for v in result.values())
+        assert total == 2
+
+
+# ---------------------------------------------------------------------------
+# load_demo_source — ag_news branch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDemoSourceAgNews:
+    """TextMediaType.load_demo_source with source='ag_news'."""
+
+    def _make_text_media_type(self):
+        from vtsearch.media.text.media_type import TextMediaType
+
+        mt = TextMediaType()
+        stub_model = MagicMock()
+        stub_model.encode.return_value = [0.1] * 768
+        mt._model = stub_model
+        return mt
+
+    def test_ag_news_source_populates_clips(self):
+        """load_demo_source with source='ag_news' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+
+        fake_articles = {
+            "World": ["World article one.", "World article two."],
+            "Sports": ["Sports article one.", "Sports article two."],
+        }
+
+        mt = self._make_text_media_type()
+        clips: dict = {}
+
+        with patch.object(dl_module, "download_ag_news", return_value=fake_articles):
+            mt.load_demo_source(
+                source="ag_news",
+                categories=["World", "Sports"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(clips) == 4
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"World", "Sports"}
+
+    def test_ag_news_slice_is_applied(self):
+        """slice_start/slice_end limits articles per category."""
+        from vtsearch.datasets import downloader as dl_module
+
+        fake_articles = {
+            "Business": [f"Business article {i}." for i in range(10)],
+        }
+
+        mt = self._make_text_media_type()
+        clips: dict = {}
+
+        with patch.object(dl_module, "download_ag_news", return_value=fake_articles):
+            mt.load_demo_source(
+                source="ag_news",
+                categories=["Business"],
+                slice_start=2,
+                slice_end=5,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        # Only articles[2:5] = 3 articles.
+        assert len(clips) == 3

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -14,7 +14,9 @@ VIDEO_DIR = DATA_DIR / "video"
 IMAGE_DIR = DATA_DIR / "images"
 PARAGRAPH_DIR = DATA_DIR / "paragraphs"
 EMBEDDINGS_DIR = DATA_DIR / "embeddings"
-MODELS_CACHE_DIR = Path(os.environ["VTSEARCH_MODELS_DIR"]) if "VTSEARCH_MODELS_DIR" in os.environ else DATA_DIR / "models"
+MODELS_CACHE_DIR = (
+    Path(os.environ["VTSEARCH_MODELS_DIR"]) if "VTSEARCH_MODELS_DIR" in os.environ else DATA_DIR / "models"
+)
 
 # Dataset URLs
 ESC50_URL = "https://github.com/karolpiczak/ESC-50/archive/master.zip"
@@ -24,6 +26,7 @@ CALTECH101_URL = "https://data.caltech.edu/records/mzrjq-6wc02/files/caltech-101
 CALTECH256_URL = "https://data.caltech.edu/records/nyy15-4j048/files/256_ObjectCategories.tar?download=1"
 UCF101_SUBSET_URL = "https://huggingface.co/datasets/sayakpaul/ucf101-subset/resolve/main/UCF101_subset.tar.gz"
 BBC_NEWS_URL = "http://mlg.ucd.ie/files/datasets/bbc-fulltext.zip"
+AG_NEWS_URL = "https://raw.githubusercontent.com/mhjabreel/CharCnn_Keras/master/data/ag_news_csv/train.csv"
 
 # Dataset size estimates
 ESC50_DOWNLOAD_SIZE_MB = 600
@@ -33,6 +36,7 @@ CALTECH101_DOWNLOAD_SIZE_MB = 131
 CALTECH256_DOWNLOAD_SIZE_MB = 1200
 UCF101_SUBSET_DOWNLOAD_SIZE_MB = 171
 BBC_NEWS_DOWNLOAD_SIZE_MB = 2
+AG_NEWS_DOWNLOAD_SIZE_MB = 30
 MEDIAS_PER_CATEGORY = 40
 MEDIAS_PER_VIDEO_CATEGORY = 150
 IMAGES_PER_CIFAR10_CATEGORY = 100

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -15,6 +15,8 @@ from typing import Callable, Optional
 import requests
 
 from vtsearch.config import (
+    AG_NEWS_DOWNLOAD_SIZE_MB,
+    AG_NEWS_URL,
     BBC_NEWS_DOWNLOAD_SIZE_MB,
     BBC_NEWS_URL,
     CALTECH101_DOWNLOAD_SIZE_MB,
@@ -510,6 +512,69 @@ def download_bbc_news(
                 articles.append(text)
         if articles:
             categories_articles[category_dir.name] = articles
+
+    return categories_articles
+
+
+def download_ag_news(
+    on_progress: Optional[ProgressCallback] = None,
+) -> dict[str, list[str]]:
+    """Download and prepare the AG News text classification dataset.
+
+    Downloads the AG News training CSV into ``DATA_DIR`` if it is not already
+    present.  The CSV has no header row; each line is
+    ``"class_index","title","description"`` where class_index is 1-4:
+
+    1 = World, 2 = Sports, 3 = Business, 4 = Sci/Tech.
+
+    Title and description are concatenated into a single article string.
+
+    Args:
+        on_progress: Optional progress callback. Falls back to the
+            application-wide ``update_progress`` when ``None``.
+
+    Returns:
+        A dict mapping category name to a list of article text strings, e.g.
+        ``{"World": ["Article text…", …], "Sports": […], …}``.
+    """
+    import csv  # noqa: PLC0415
+
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    csv_path = DATA_DIR / "ag_news_train.csv"
+    DATA_DIR.mkdir(exist_ok=True)
+
+    if not csv_path.exists():
+        on_progress("downloading", "Starting AG News download...", 0, 0)
+        download_file_with_progress(
+            AG_NEWS_URL,
+            csv_path,
+            AG_NEWS_DOWNLOAD_SIZE_MB * 1024 * 1024,
+            on_progress,
+        )
+
+    label_to_category = {
+        "1": "World",
+        "2": "Sports",
+        "3": "Business",
+        "4": "Sci/Tech",
+    }
+
+    categories_articles: dict[str, list[str]] = {}
+    with open(csv_path, "r", encoding="utf-8", errors="replace") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 3:
+                continue
+            class_idx, title, description = row[0], row[1], row[2]
+            category = label_to_category.get(class_idx)
+            if category is None:
+                continue
+            # Combine title and description into one article string.
+            text = f"{title.strip()} {description.strip()}".strip()
+            if text:
+                categories_articles.setdefault(category, []).append(text)
 
     return categories_articles
 

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -226,6 +226,17 @@ class TextMediaType(MediaType):
                         selected_texts.append(text)
                         selected_categories.append(cat_name)
 
+        elif source == "ag_news":
+            from vtsearch.datasets.downloader import download_ag_news  # noqa: PLC0415
+
+            categories_articles = download_ag_news(on_progress=on_progress)
+
+            for cat_name in categories:
+                articles = categories_articles.get(cat_name, [])
+                for article in articles[slice_start : (slice_end or len(articles))]:
+                    selected_texts.append(article)
+                    selected_categories.append(cat_name)
+
         elif source == "bbc_news":
             from vtsearch.datasets.downloader import download_bbc_news  # noqa: PLC0415
 


### PR DESCRIPTION
## Summary
This PR adds support for the AG News text classification dataset as a demo source for the TextMediaType class, enabling users to load and embed news articles from four categories (World, Sports, Business, Sci/Tech).

## Key Changes
- **New `download_ag_news()` function** in `vtsearch/datasets/downloader.py`:
  - Downloads the AG News training CSV from the official repository
  - Parses CSV rows and maps class indices (1-4) to category names
  - Combines title and description fields into single article strings
  - Implements caching to skip re-downloading if the CSV already exists
  - Gracefully handles malformed rows by skipping them

- **AG News support in `TextMediaType.load_demo_source()`**:
  - Added `ag_news` branch to handle the new dataset source
  - Applies `slice_start` and `slice_end` parameters to limit articles per category
  - Integrates with existing demo source loading pipeline

- **Configuration updates** in `vtsearch/config.py`:
  - Added `AG_NEWS_URL` pointing to the official dataset CSV
  - Added `AG_NEWS_DOWNLOAD_SIZE_MB` constant (30 MB estimate)
  - Minor formatting fix for `MODELS_CACHE_DIR` definition

- **Comprehensive test suite** in `tests/test_ag_news_download.py`:
  - Tests for CSV parsing and category mapping
  - Tests for caching behavior (skips download when file exists)
  - Tests for malformed row handling
  - Tests for `load_demo_source()` integration with slicing
  - Uses fixtures and mocking to avoid actual network calls

## Implementation Details
- The AG News CSV format is: `"class_index","title","description"` with no header row
- Articles are created by concatenating title and description with a space separator
- The implementation follows the same pattern as the existing BBC News dataset support
- Progress callbacks are properly integrated for download status reporting

https://claude.ai/code/session_01QqDqvdprL7fxqaAJa34A7x