### PR TITLE
Add IMDB dataset support for text media type

### DIFF
--- a/tests/test_imdb_download.py
+++ b/tests/test_imdb_download.py
@@ -1,0 +1,152 @@
+"""Tests for IMDB dataset download and load_demo_source integration."""
+
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_imdb_tar(tmp_path: Path) -> Path:
+    """Create a minimal IMDB tar.gz fixture with 3 reviews per sentiment per split."""
+    tar_path = tmp_path / "aclImdb_v1.tar.gz"
+
+    # Build a temporary directory tree that mirrors the real dataset layout.
+    tree_root = tmp_path / "tar_staging" / "aclImdb"
+    for split in ("train", "test"):
+        for sentiment in ("pos", "neg"):
+            d = tree_root / split / sentiment
+            d.mkdir(parents=True)
+            for i in range(3):
+                (d / f"{i}_{7 + i}.txt").write_text(
+                    f"IMDB {sentiment} review {i} from {split}. This is sample text."
+                )
+
+    with tarfile.open(tar_path, "w:gz") as tf:
+        tf.add(tree_root, arcname="aclImdb")
+
+    return tar_path
+
+
+# ---------------------------------------------------------------------------
+# download_imdb
+# ---------------------------------------------------------------------------
+
+class TestDownloadImdb:
+    def test_returns_reviews_by_category(self, tmp_path):
+        """download_imdb returns a dict of sentiment -> list[str] from a tar.gz."""
+        from vtsearch.datasets import downloader as dl_module
+
+        tar_path = _make_imdb_tar(tmp_path)
+
+        progress_calls = []
+
+        def fake_progress(status, msg, cur, tot):
+            progress_calls.append((status, msg))
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", lambda url, dest, size, cb: tar_path.rename(dest)),
+        ):
+            result = dl_module.download_imdb(on_progress=fake_progress)
+
+        assert set(result.keys()) == {"pos", "neg"}
+        # 3 reviews per split × 2 splits = 6 per sentiment
+        for reviews in result.values():
+            assert len(reviews) == 6
+            assert all(isinstance(r, str) and r for r in reviews)
+
+    def test_cached_extraction_skips_download(self, tmp_path):
+        """If the extract directory already exists, no download is triggered."""
+        from vtsearch.datasets import downloader as dl_module
+
+        # Pre-create the extract directory with one sentiment category.
+        extract_dir = tmp_path / "aclImdb"
+        pos_dir = extract_dir / "train" / "pos"
+        pos_dir.mkdir(parents=True)
+        (pos_dir / "0_7.txt").write_text("A positive review.")
+
+        download_called = []
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = dl_module.download_imdb(on_progress=lambda *a: None)
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert "pos" in result
+
+
+# ---------------------------------------------------------------------------
+# load_demo_source — imdb branch
+# ---------------------------------------------------------------------------
+
+class TestLoadDemoSourceImdb:
+    """TextMediaType.load_demo_source with source='imdb'."""
+
+    def _make_text_media_type(self):
+        from vtsearch.media.text.media_type import TextMediaType
+
+        mt = TextMediaType()
+        # Provide a stub embedding model so we never hit the real network.
+        stub_model = MagicMock()
+        stub_model.encode.return_value = [0.1] * 768
+        mt._model = stub_model
+        return mt
+
+    def test_imdb_source_populates_clips(self):
+        """load_demo_source with source='imdb' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+
+        fake_reviews = {
+            "pos": ["Great movie!", "Loved it!"],
+            "neg": ["Terrible film.", "Hated it."],
+        }
+
+        mt = self._make_text_media_type()
+        clips: dict = {}
+
+        with patch.object(dl_module, "download_imdb", return_value=fake_reviews):
+            mt.load_demo_source(
+                source="imdb",
+                categories=["pos", "neg"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(clips) == 4
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"pos", "neg"}
+
+    def test_imdb_slice_is_applied(self):
+        """slice_start/slice_end limits reviews per category."""
+        from vtsearch.datasets import downloader as dl_module
+
+        fake_reviews = {
+            "pos": [f"Positive review {i}." for i in range(10)],
+        }
+
+        mt = self._make_text_media_type()
+        clips: dict = {}
+
+        with patch.object(dl_module, "download_imdb", return_value=fake_reviews):
+            mt.load_demo_source(
+                source="imdb",
+                categories=["pos"],
+                slice_start=2,
+                slice_end=5,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        # Only reviews[2:5] = 3 reviews.
+        assert len(clips) == 3

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -27,6 +27,7 @@ CALTECH256_URL = "https://data.caltech.edu/records/nyy15-4j048/files/256_ObjectC
 UCF101_SUBSET_URL = "https://huggingface.co/datasets/sayakpaul/ucf101-subset/resolve/main/UCF101_subset.tar.gz"
 BBC_NEWS_URL = "http://mlg.ucd.ie/files/datasets/bbc-fulltext.zip"
 AG_NEWS_URL = "https://raw.githubusercontent.com/mhjabreel/CharCnn_Keras/master/data/ag_news_csv/train.csv"
+IMDB_URL = "https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
 
 # Dataset size estimates
 ESC50_DOWNLOAD_SIZE_MB = 600
@@ -37,6 +38,7 @@ CALTECH256_DOWNLOAD_SIZE_MB = 1200
 UCF101_SUBSET_DOWNLOAD_SIZE_MB = 171
 BBC_NEWS_DOWNLOAD_SIZE_MB = 2
 AG_NEWS_DOWNLOAD_SIZE_MB = 30
+IMDB_DOWNLOAD_SIZE_MB = 84
 MEDIAS_PER_CATEGORY = 40
 MEDIAS_PER_VIDEO_CATEGORY = 150
 IMAGES_PER_CIFAR10_CATEGORY = 100

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -29,6 +29,8 @@ from vtsearch.config import (
     ESC50_DOWNLOAD_SIZE_MB,
     ESC50_URL,
     IMAGE_DIR,
+    IMDB_DOWNLOAD_SIZE_MB,
+    IMDB_URL,
     UCF101_SUBSET_DOWNLOAD_SIZE_MB,
     UCF101_SUBSET_URL,
     VIDEO_DIR,
@@ -577,6 +579,72 @@ def download_ag_news(
                 categories_articles.setdefault(category, []).append(text)
 
     return categories_articles
+
+
+def download_imdb(
+    on_progress: Optional[ProgressCallback] = None,
+) -> dict[str, list[str]]:
+    """Download and prepare the Stanford IMDB Large Movie Review dataset.
+
+    Downloads ``aclImdb_v1.tar.gz`` from the configured ``IMDB_URL`` into
+    ``DATA_DIR`` if it is not already present, then extracts it.  The archive
+    is deleted after extraction to reclaim disk space.
+
+    The dataset contains 50 000 movie reviews split evenly into positive
+    (``pos``) and negative (``neg``) sentiment categories, with 25 000
+    reviews in each of the ``train`` and ``test`` splits.  Both splits are
+    merged so the caller can slice freely.
+
+    Args:
+        on_progress: Optional progress callback. Falls back to the
+            application-wide ``update_progress`` when ``None``.
+
+    Returns:
+        A dict mapping category name to a list of review text strings, e.g.
+        ``{"pos": ["Great film…", …], "neg": ["Terrible…", …]}``.
+    """
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    tar_path = DATA_DIR / "aclImdb_v1.tar.gz"
+    extract_dir = DATA_DIR / "aclImdb"
+    DATA_DIR.mkdir(exist_ok=True)
+
+    if not extract_dir.exists():
+        if not tar_path.exists():
+            on_progress("downloading", "Starting IMDB download...", 0, 0)
+            download_file_with_progress(
+                IMDB_URL,
+                tar_path,
+                IMDB_DOWNLOAD_SIZE_MB * 1024 * 1024,
+                on_progress,
+            )
+
+        on_progress("downloading", "Extracting IMDB dataset...", 0, 0)
+        with tarfile.open(tar_path, "r:gz") as tar_ref:
+            tar_ref.extractall(DATA_DIR, filter="data")
+
+        tar_path.unlink(missing_ok=True)
+
+    # Read reviews grouped by sentiment category, merging train + test splits.
+    categories_reviews: dict[str, list[str]] = {}
+    for sentiment in ("pos", "neg"):
+        reviews: list[str] = []
+        for split in ("train", "test"):
+            split_dir = extract_dir / split / sentiment
+            if not split_dir.is_dir():
+                continue
+            for txt_file in sorted(split_dir.glob("*.txt")):
+                try:
+                    text = txt_file.read_text(encoding="utf-8", errors="replace").strip()
+                except Exception:
+                    continue
+                if text:
+                    reviews.append(text)
+        if reviews:
+            categories_reviews[sentiment] = reviews
+
+    return categories_reviews
 
 
 def _find_bbc_root(directory: Path) -> Optional[Path]:

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -248,6 +248,17 @@ class TextMediaType(MediaType):
                     selected_texts.append(article)
                     selected_categories.append(cat_name)
 
+        elif source == "imdb":
+            from vtsearch.datasets.downloader import download_imdb  # noqa: PLC0415
+
+            categories_reviews = download_imdb(on_progress=on_progress)
+
+            for cat_name in categories:
+                reviews = categories_reviews.get(cat_name, [])
+                for review in reviews[slice_start : (slice_end or len(reviews))]:
+                    selected_texts.append(review)
+                    selected_categories.append(cat_name)
+
         else:
             raise ValueError(f"Unsupported text source: {source!r}")
 


### PR DESCRIPTION
## Summary
This PR adds support for the Stanford IMDB Large Movie Review dataset as a demo source for the text media type. Users can now load movie reviews with sentiment labels (positive/negative) for demonstration and testing purposes.

## Key Changes
- **New `download_imdb()` function** in `vtsearch/datasets/downloader.py`:
  - Downloads and extracts the IMDB dataset from Stanford's official URL
  - Merges train and test splits into unified sentiment categories ("pos" and "neg")
  - Implements caching to skip re-downloading if extraction directory exists
  - Handles file encoding robustly with UTF-8 fallback

- **IMDB source integration** in `vtsearch/media/text/media_type.py`:
  - Added "imdb" branch to `load_demo_source()` method
  - Supports category filtering and slice-based review selection
  - Integrates with existing progress callback mechanism

- **Configuration updates** in `vtsearch/config.py`:
  - Added `IMDB_URL` constant pointing to Stanford's dataset
  - Added `IMDB_DOWNLOAD_SIZE_MB` constant for progress tracking

- **Comprehensive test suite** in `tests/test_imdb_download.py`:
  - Tests for `download_imdb()` function covering normal operation and caching
  - Tests for `load_demo_source()` with IMDB source including category filtering and slicing
  - Fixture helper to create minimal IMDB tar.gz archives for testing

## Implementation Details
- The dataset contains 50,000 reviews (25,000 positive, 25,000 negative) split across train/test sets
- Both splits are merged to allow flexible slicing by the caller
- Archive is automatically deleted after extraction to reclaim disk space
- Uses `tarfile` with `filter="data"` for secure extraction
- Gracefully handles missing or malformed review files during extraction

https://claude.ai/code/session_01Gt8vq5u5iEstfmvJ6PYUsU