### PR TITLE
Make MLP hidden layer width configurable for consistent cross-calibration

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -7,11 +7,11 @@ VTSearch uses a small MLP (multi-layer perceptron) neural network to learn a bin
 The MLP is defined in `vtsearch/models/training.py` via `build_model()`:
 
 ```
-Linear(input_dim, 64) -> ReLU -> Linear(64, 1)
+Linear(input_dim, hidden_dim) -> ReLU -> Dropout(p) -> Linear(hidden_dim, 1)
 ```
 
 - **Input dimension**: Dynamic, depends on the embedding model for the current media type (see [Embedding Models](#embedding-models) below).
-- **Hidden layer**: 64 neurons with ReLU activation.
+- **Hidden layer**: Width chosen automatically by `_auto_hidden_dim(n_labels)` — `max(MLP_HIDDEN_MIN, min(MLP_HIDDEN_MAX, n_labels // 3))`, i.e. 4–32 neurons depending on label count. Dropout (`MLP_DROPOUT=0.5`) is applied after ReLU during training.
 - **Output**: A single logit. `torch.sigmoid` is applied at inference time to produce a probability in [0, 1].
 
 The model outputs raw logits (not probabilities) during training. This allows the use of `BCEWithLogitsLoss`, which fuses the sigmoid and binary cross-entropy computation using the log-sum-exp trick for better numerical stability. At inference time, `torch.sigmoid()` is applied explicitly to convert logits to probabilities.
@@ -23,8 +23,10 @@ The model outputs raw logits (not probabilities) during training. This allows th
 | **Loss function** | `BCEWithLogitsLoss` | Per-sample (unreduced), with manual class weighting |
 | **Optimizer** | Adam | `lr=0.001`, `weight_decay=1e-4` |
 | **Epochs** | 200 | Configurable via `TRAIN_EPOCHS` in `config.py` |
+| **Hidden layer** | 4–32 neurons | `max(4, min(32, n_labels // 3))` via `_auto_hidden_dim()` |
+| **Dropout** | 0.5 | Applied after ReLU, active only during training |
 | **Batching** | Full-batch | All labeled data in every forward pass |
-| **Reproducibility** | `torch.manual_seed(42)` | Set before model construction for deterministic weight init |
+| **Reproducibility** | Local `torch.Generator` | Per-model seed (default 42) for thread-safe deterministic init |
 | **Gradient scoping** | `torch.enable_grad()` | Explicitly enabled during training loop |
 
 ### Class Weighting
@@ -39,10 +41,13 @@ Training uses inverse-frequency weighting to balance classes, with an additional
 
 A decision threshold separating "good" from "bad" predictions is computed via **cross-calibration**:
 
-1. Split labeled data into Train (1 − `calibration_fraction`) and Calibrate (`calibration_fraction`).
-2. Train a model on Train, find the optimal threshold by evaluating on Calibrate.
-3. Repeat for `calibrate_count` independent random splits.
-4. Return the mean of all thresholds.
+1. Compute `hidden_dim` once from the **full** label count.
+2. Split labeled data into Train (1 − `calibration_fraction`) and Calibrate (`calibration_fraction`).
+3. Train a fold model on Train **using the full-data `hidden_dim`**, find the optimal threshold by evaluating on Calibrate.
+4. Repeat for `calibrate_count` independent random splits.
+5. Return the mean of all thresholds.
+
+**Why fold models use the full-data hidden_dim:** The hidden-layer width is normally auto-sized from the training-set size (`n_labels // 3`, clamped to 4–32). Without intervention, each fold model would train on fewer examples and therefore get a smaller hidden layer than the final model. A smaller architecture produces a different score distribution, so thresholds found on fold models would not transfer faithfully to the final model. By forcing fold models to use the same `hidden_dim` as the final model, the architectures match: same capacity, same score distribution shape. The only difference is the fold models see less data, which is the whole point — you want held-out calibration data. Existing regularization (dropout 0.5, weight decay 1e-4) and the small max width (32) prevent the slightly "oversized" fold models from overfitting meaningfully.
 
 The **Calibration Fraction** setting (0–1, default 0.5) controls how much data is reserved for threshold calibration vs. model training in each split. For example, a value of 0.2 means 80% Train / 20% Calibrate. If the fraction is so extreme that a valid Train/Calibrate split cannot be formed (fewer than 2 training examples or fewer than 1 calibration example), the system returns a maximum threshold so that nothing is predicted as Good.
 

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -150,12 +150,14 @@ def train_model(
     input_dim: int,
     inclusion_value: int = 0,
     seed: int = 42,
+    hidden_dim: int | None = None,
 ) -> nn.Sequential:
     """Train a small MLP classifier and return the trained model.
 
     The hidden-layer width is chosen automatically based on the number of
-    training examples (see :func:`_auto_hidden_dim`) and dropout is applied
-    during training to reduce overfitting.
+    training examples (see :func:`_auto_hidden_dim`) unless explicitly
+    provided via ``hidden_dim``.  Dropout is applied during training to
+    reduce overfitting.
 
     Trains using weighted binary cross-entropy loss with logits
     (``BCEWithLogitsLoss``).  Class weights are adjusted based on
@@ -178,6 +180,9 @@ def train_model(
             - Negative: increase weight for False samples by ``2 ** (-inclusion_value)``,
               causing the model to exclude more items.
         seed: Seed for the local RNG used for weight initialisation (default 42).
+        hidden_dim: Number of neurons in the hidden layer.  When ``None``
+            (default) the width is chosen automatically via
+            :func:`_auto_hidden_dim` based on the training-set size.
 
     Returns:
         A trained ``nn.Sequential`` model in eval mode.
@@ -187,7 +192,8 @@ def train_model(
     import torch.nn as nn  # noqa: PLC0415
 
     n_train = len(X_train)
-    hidden_dim = _auto_hidden_dim(n_train)
+    if hidden_dim is None:
+        hidden_dim = _auto_hidden_dim(n_train)
 
     # Seed both a local Generator (for weight init) and the global RNG
     # (for nn.Dropout during training) so results are reproducible.
@@ -316,6 +322,7 @@ def calculate_cross_calibration_threshold(
     rng: np.random.RandomState | None = None,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    hidden_dim: int | None = None,
 ) -> float:
     """Estimate a decision threshold using k-fold calibration.
 
@@ -348,6 +355,10 @@ def calculate_cross_calibration_threshold(
             cannot be formed (fewer than 2 training or 1 calibration
             examples), returns ``float('inf')`` so that nothing is
             predicted as Good.
+        hidden_dim: Force a specific hidden-layer width for the fold models.
+            When ``None`` (default), each fold model auto-sizes based on its
+            own training-set size.  Pass the full-data hidden dim to ensure
+            fold models match the final model's architecture.
 
     Returns:
         A float threshold. Returns 0.5 if fewer than 4 examples are provided
@@ -382,7 +393,7 @@ def calculate_cross_calibration_threshold(
         y_train = torch.tensor(y_np[train_idx], dtype=torch.float32).unsqueeze(1)
         X_cal = torch.tensor(X_np[cal_idx], dtype=torch.float32)
 
-        model = train_model(X_train, y_train, input_dim, inclusion_value)
+        model = train_model(X_train, y_train, input_dim, inclusion_value, hidden_dim=hidden_dim)
 
         with torch.no_grad():
             scores = torch.sigmoid(model(X_cal)).squeeze(1).tolist()
@@ -483,6 +494,12 @@ def train_and_score(
 
     input_dim = X.shape[1]
 
+    # Compute hidden_dim once from the *full* label count so that fold
+    # models use the same architecture as the final model.  This makes
+    # cross-calibration thresholds directly comparable to final-model
+    # scores (same capacity, same score distribution shape).
+    hidden_dim = _auto_hidden_dim(len(X_list))
+
     # Calculate threshold using k-fold calibration
     threshold = calculate_cross_calibration_threshold(
         X_list,
@@ -491,10 +508,11 @@ def train_and_score(
         inclusion_value,
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
+        hidden_dim=hidden_dim,
     )
 
     # Train final model on all data
-    model = train_model(X, y, input_dim, inclusion_value)
+    model = train_model(X, y, input_dim, inclusion_value, hidden_dim=hidden_dim)
 
     # Score every media
     all_ids = sorted(clips_dict.keys())


### PR DESCRIPTION
## Summary
This PR makes the MLP hidden layer width configurable by adding an optional `hidden_dim` parameter to `train_model()` and `calculate_cross_calibration_threshold()`. This ensures fold models used during cross-calibration use the same architecture as the final model, making threshold estimates directly comparable to final model scores.

## Key Changes

- **Added `hidden_dim` parameter to `train_model()`**: When `None` (default), automatically sizes via `_auto_hidden_dim()`. When provided, uses the explicit value. This allows callers to control architecture.

- **Added `hidden_dim` parameter to `calculate_cross_calibration_threshold()`**: Passes through to fold model training so all fold models use consistent architecture.

- **Updated `train_and_score()` workflow**: Now computes `hidden_dim` once from the full label count and passes it to both cross-calibration and final model training. This ensures fold models and the final model have identical architectures.

- **Updated documentation**: 
  - Clarified that hidden layer width is auto-sized based on training-set size unless explicitly provided
  - Updated ML.md to document the auto-sizing formula and explain why fold models use full-data `hidden_dim`
  - Added detailed explanation of the cross-calibration process and the rationale for architecture consistency

## Implementation Details

The core issue addressed: Previously, fold models in cross-calibration would auto-size their hidden layers based on their smaller training-set size (fewer examples per fold), resulting in different architectures than the final model trained on all data. This caused score distributions to differ, making thresholds found on fold data not transfer faithfully to final model predictions.

The solution: Compute `hidden_dim = _auto_hidden_dim(len(X_list))` once from the full dataset, then pass this value to all fold models and the final model. This ensures:
- Same capacity across all models
- Same score distribution shape
- Thresholds found during calibration are directly comparable to final model scores
- Existing regularization (dropout 0.5, weight decay 1e-4) prevents overfitting of slightly "oversized" fold models

https://claude.ai/code/session_01CmCy8oXHRrkaRRaQdQripg