### PR TITLE
Fix flaky tests by centralizing state cleanup in conftest.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
 - `static/` — Frontend (index.html, app.js, styles.css) and assets (favicons, logo.svg, logo.png)
 - `docs/` — Extended docs (ARCHITECTURE.md, CLI.md, DEPLOYMENT.md, EVAL.md, EXTENDING.md, FEATURE_IDEAS.md, HANDOFF.md, ML.md, SETUP.md, demos.md)
 - `tests/` — Test suite split by module:
-  - `conftest.py` — Shared fixtures (client, vote reset, model init)
+  - `conftest.py` — Shared fixtures: `reset_state` (autouse, clears all mutable global state), `isolated_settings` (autouse, redirects settings to tmp_path), `client` (Flask test client)
   - `test_audio.py` — WAV generation
   - `test_medias.py` — Media init, listing, audio endpoint, MD5
   - `test_votes.py` — Voting and vote retrieval
@@ -92,6 +92,32 @@ Testing can crash the session. To avoid losing work, follow this workflow:
 4. **Repeat** until tests pass. Every cycle of fixes should be committed and pushed before the next test run.
 
 This ensures work is recoverable if the session crashes during a test run.
+
+## Test Isolation (IMPORTANT)
+
+All mutable global state is reset automatically before each test via two autouse fixtures in `conftest.py`:
+
+1. **`reset_state`** — Clears all mutable state in `vtsearch/utils/state.py`:
+   - `good_votes`, `bad_votes`, `label_history`, `textsort_suggestions`, `vote_click_times`, `last_learned_scores`
+   - `favorite_detectors`, `favorite_extractors`, `favorite_localizers`
+   - `_click_counter`, `inclusion`, `_diversity_tree`
+   - Progress cache
+
+2. **`isolated_settings`** — Redirects `SETTINGS_PATH` to a per-test temp file so settings writes never touch `data/settings.json`. Yields the temp path for tests that need to inspect the file.
+
+**When writing new tests:**
+- Do NOT add per-file or per-class autouse fixtures to clear favorites, reset settings, or reset votes — `conftest.py` handles all of this automatically.
+- Do NOT add inline `.pop()` or `.clear()` cleanup at the end of tests — the conftest fixtures run before each test regardless of whether the previous test passed or failed.
+- If a test needs to temporarily empty `medias`, use the save/restore pattern with try/finally (since `medias` is intentionally NOT reset between tests to avoid expensive re-generation):
+  ```python
+  saved = dict(medias)
+  medias.clear()
+  try:
+      # ... test logic ...
+  finally:
+      medias.update(saved)
+  ```
+- If a test needs to read the settings file path (e.g. to verify persistence), use `isolated_settings` as a parameter: `def test_foo(self, isolated_settings): ...`
 
 ## Key Details
 - Global state lives in `vtsearch/utils/state.py`: `medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `last_learned_scores`, `inclusion`, `textsort_suggestions`, `favorite_detectors`, `favorite_extractors`, `favorite_localizers` are module-level dicts/lists

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,13 @@ app_module.init_medias()
 
 
 @pytest.fixture(autouse=True)
-def reset_votes():
-    """Reset vote state and progress cache before each test."""
+def reset_state():
+    """Reset all mutable global state before each test.
+
+    This fixture prevents cross-test contamination by clearing votes,
+    favorites, and all other mutable state that lives in
+    ``vtsearch.utils.state``.  It runs automatically before every test.
+    """
     import vtsearch.utils.state as _state
 
     good_votes.clear()
@@ -43,7 +48,27 @@ def reset_votes():
     _state._click_counter = 0
     _state.inclusion = None  # reset to "not loaded" so it re-reads from settings
     _state._diversity_tree = None
+    _state.favorite_detectors.clear()
+    _state.favorite_extractors.clear()
+    _state.favorite_localizers.clear()
     clear_progress_cache()
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(tmp_path, monkeypatch):
+    """Redirect the settings file to a temp directory for each test.
+
+    Without this, tests that write settings (inclusion, safe_thresholds,
+    volume, etc.) would mutate the shared ``data/settings.json`` on disk,
+    leaking values into subsequent tests that lazy-load from that file.
+    """
+    from vtsearch import settings as settings_mod
+
+    test_settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
+    settings_mod.reset()
+    yield test_settings_path
+    settings_mod.reset()
 
 
 @pytest.fixture

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -76,20 +76,6 @@ def _make_settings_file(tmp_path, detector_paths, name="settings.json"):
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 
 
-@pytest.fixture(autouse=True)
-def _reset_processors():
-    """Clean up global favorite detectors and settings cache after each test."""
-    import vtsearch.settings as settings_mod
-
-    original_path = settings_mod.SETTINGS_PATH
-    yield
-    from vtsearch.utils.state import favorite_detectors
-
-    favorite_detectors.clear()
-    settings_mod.SETTINGS_PATH = original_path
-    settings_mod.reset()
-
-
 # ---------------------------------------------------------------------------
 # Tests for run_autodetect()
 # ---------------------------------------------------------------------------

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -114,14 +114,6 @@ class TestDetectorSort:
 class TestFavoriteDetectors:
     """Tests for the favorite-detectors management endpoints."""
 
-    @pytest.fixture(autouse=True)
-    def clear_favorites(self):
-        from vtsearch.utils.state import favorite_detectors
-
-        favorite_detectors.clear()
-        yield
-        favorite_detectors.clear()
-
     def _export_detector(self, client):
         """Helper: vote on some medias and export a valid detector payload."""
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
@@ -354,14 +346,6 @@ class TestFavoriteDetectors:
 
 class TestAutoDetect:
     """Tests for POST /api/auto-detect."""
-
-    @pytest.fixture(autouse=True)
-    def clear_favorites(self):
-        from vtsearch.utils.state import favorite_detectors
-
-        favorite_detectors.clear()
-        yield
-        favorite_detectors.clear()
 
     def _add_audio_detector(self, client, name="test-detector"):
         """Helper: create and save an audio detector."""

--- a/tests/test_enrich_descriptions.py
+++ b/tests/test_enrich_descriptions.py
@@ -266,16 +266,6 @@ class TestEmbedTextQueryEnrich:
 
 
 class TestEnrichDescriptionsSetting:
-    @pytest.fixture(autouse=True)
-    def isolated_settings(self, tmp_path, monkeypatch):
-        from vtsearch import settings as settings_mod
-
-        test_settings_path = tmp_path / "settings.json"
-        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
-        settings_mod.reset()
-        yield test_settings_path
-        settings_mod.reset()
-
     def test_default_is_false(self):
         from vtsearch import settings as settings_mod
 
@@ -313,16 +303,6 @@ class TestEnrichDescriptionsSetting:
 
 
 class TestEnrichDescriptionsAPI:
-    @pytest.fixture(autouse=True)
-    def isolated_settings(self, tmp_path, monkeypatch):
-        from vtsearch import settings as settings_mod
-
-        test_settings_path = tmp_path / "settings.json"
-        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
-        settings_mod.reset()
-        yield
-        settings_mod.reset()
-
     @pytest.fixture
     def client(self):
         import app as app_module

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -184,14 +184,6 @@ class TestImageClassExtractor:
 
 
 class TestFavoriteExtractors:
-    @pytest.fixture(autouse=True)
-    def clear_favorites(self):
-        from vtsearch.utils.state import favorite_extractors
-
-        favorite_extractors.clear()
-        yield
-        favorite_extractors.clear()
-
     def _post_extractor(self, client, name="test-ext"):
         return client.post(
             "/api/favorite-extractors",
@@ -396,14 +388,6 @@ class TestExtractEndpoint:
 
 
 class TestAutoExtract:
-    @pytest.fixture(autouse=True)
-    def clear_favorites(self):
-        from vtsearch.utils.state import favorite_extractors
-
-        favorite_extractors.clear()
-        yield
-        favorite_extractors.clear()
-
     def test_no_clips_returns_400(self, client):
         from vtsearch.utils.state import medias
 

--- a/tests/test_inclusion.py
+++ b/tests/test_inclusion.py
@@ -1,18 +1,3 @@
-import pytest
-
-from vtsearch import settings as settings_mod
-
-
-@pytest.fixture(autouse=True)
-def isolated_settings(tmp_path, monkeypatch):
-    """Use a temp file so inclusion persistence doesn't affect other tests."""
-    test_settings_path = tmp_path / "settings.json"
-    monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
-    settings_mod.reset()
-    yield test_settings_path
-    settings_mod.reset()
-
-
 class TestInclusionEndpoints:
     def test_get_default_inclusion(self, client):
         resp = client.get("/api/inclusion")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,28 +17,6 @@ import numpy as np
 import pytest
 
 import app as app_module
-from vtsearch import settings as settings_mod
-
-
-@pytest.fixture(autouse=True)
-def isolated_settings(tmp_path, monkeypatch):
-    """Use a temp file so settings don't leak between tests."""
-    test_settings_path = tmp_path / "settings.json"
-    monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
-    settings_mod.reset()
-    yield test_settings_path
-    settings_mod.reset()
-
-
-@pytest.fixture(autouse=True)
-def clear_favorites():
-    from vtsearch.utils.state import favorite_detectors, favorite_extractors
-
-    favorite_detectors.clear()
-    favorite_extractors.clear()
-    yield
-    favorite_detectors.clear()
-    favorite_extractors.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_errors.py
+++ b/tests/test_memory_errors.py
@@ -1,10 +1,6 @@
 """Tests for graceful MemoryError handling during dataset loading."""
 
-import gc
 import pickle
-import threading
-import time
-from pathlib import Path
 from unittest import mock
 
 import numpy as np
@@ -12,7 +8,7 @@ import pytest
 
 import app as app_module
 from vtsearch.datasets.config import DEMO_DATASETS
-from vtsearch.utils import medias, clear_all, get_progress, update_progress
+from vtsearch.utils import medias, get_progress, update_progress
 from vtsearch.utils.state import clear_medias
 
 
@@ -177,7 +173,6 @@ class TestCombineMemoryError:
 
         # Make the second _load_clips_from_pickle call OOM
         call_count = 0
-        real_load = None
 
         def oom_second_load(path):
             nonlocal call_count
@@ -216,16 +211,20 @@ class TestBackgroundImportMemoryError:
         # Reset progress
         update_progress("idle", "")
 
-        _run_importer_in_background(mock_importer, {})
+        # Patch threading.Thread to run synchronously so we don't race
+        with mock.patch("vtsearch.routes.datasets.threading") as mock_threading:
+            captured_target = {}
 
-        # Poll for the background thread to report the error (up to 5s)
-        deadline = time.monotonic() + 5
-        while time.monotonic() < deadline:
-            progress = get_progress()
-            if progress["error"] is not None:
-                break
-            time.sleep(0.1)
+            def fake_thread(target, daemon=True):
+                captured_target["fn"] = target
+                thread = mock.MagicMock()
+                thread.start = lambda: target()
+                return thread
 
+            mock_threading.Thread.side_effect = fake_thread
+            _run_importer_in_background(mock_importer, {})
+
+        progress = get_progress()
         assert progress["error"] is not None
         assert "Out of memory" in progress["error"]
         assert progress["status"] == "idle"
@@ -237,9 +236,17 @@ class TestBackgroundImportMemoryError:
         """When loading a demo dataset OOMs, the progress shows the error."""
         update_progress("idle", "")
 
+        def sync_thread(target, daemon=True):
+            thread = mock.MagicMock()
+            thread.start = lambda: target()
+            return thread
+
         with mock.patch(
             "vtsearch.routes.datasets.load_demo_dataset",
             side_effect=MemoryError("simulated"),
+        ), mock.patch(
+            "vtsearch.routes.datasets.threading.Thread",
+            side_effect=sync_thread,
         ):
             resp = client.post(
                 "/api/dataset/load-demo",
@@ -247,14 +254,7 @@ class TestBackgroundImportMemoryError:
             )
             assert resp.status_code == 200
 
-            # Poll for the background thread to report the error (up to 5s)
-            deadline = time.monotonic() + 5
-            while time.monotonic() < deadline:
-                progress = get_progress()
-                if progress["error"] is not None:
-                    break
-                time.sleep(0.1)
-
+            progress = get_progress()
             assert progress["error"] is not None
             assert "Out of memory" in progress["error"]
 

--- a/tests/test_memory_errors.py
+++ b/tests/test_memory_errors.py
@@ -218,10 +218,14 @@ class TestBackgroundImportMemoryError:
 
         _run_importer_in_background(mock_importer, {})
 
-        # Wait for the background thread to finish
-        time.sleep(0.5)
+        # Poll for the background thread to report the error (up to 5s)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            progress = get_progress()
+            if progress["error"] is not None:
+                break
+            time.sleep(0.1)
 
-        progress = get_progress()
         assert progress["error"] is not None
         assert "Out of memory" in progress["error"]
         assert progress["status"] == "idle"
@@ -243,10 +247,14 @@ class TestBackgroundImportMemoryError:
             )
             assert resp.status_code == 200
 
-            # Wait for background thread
-            time.sleep(0.5)
+            # Poll for the background thread to report the error (up to 5s)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                progress = get_progress()
+                if progress["error"] is not None:
+                    break
+                time.sleep(0.1)
 
-            progress = get_progress()
             assert progress["error"] is not None
             assert "Out of memory" in progress["error"]
 

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -469,9 +469,6 @@ class TestServerFileProcessorImporter:
         assert result["media_type"] == "image"
         assert "server_test_det" in favorite_detectors
 
-        # Clean up
-        favorite_detectors.pop("server_test_det", None)
-
 
 # ---------------------------------------------------------------------------
 # Label file importer (mocked embedding/training)
@@ -623,12 +620,7 @@ class TestProcessorImportEndpoint:
         assert result["media_type"] == "image"
         assert "test_detector" in favorite_detectors
 
-        # Clean up
-        favorite_detectors.pop("test_detector", None)
-
     def test_detector_file_defaults_to_audio(self, client):
-        from vtsearch.utils import favorite_detectors
-
         payload = {"weights": {"0.weight": [[1.0]]}, "threshold": 0.5}
         raw = json.dumps(payload).encode()
         data = {
@@ -642,9 +634,6 @@ class TestProcessorImportEndpoint:
         )
         assert res.status_code == 200
         assert res.get_json()["media_type"] == "audio"
-
-        # Clean up
-        favorite_detectors.pop("audio_det", None)
 
     def test_detector_file_invalid_json_returns_400(self, client):
         data = {
@@ -848,9 +837,6 @@ class TestFromLabelImportEndpoint:
         assert result["name"] == "from_label_import_test"
         assert result["loaded"] >= 2
         assert "from_label_import_test" in favorite_detectors
-
-        # Clean up
-        favorite_detectors.pop("from_label_import_test", None)
 
     def test_no_clips_returns_400(self, client):
         from vtsearch.utils import medias

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -365,11 +365,6 @@ class TestFaceLocalizer:
 
 
 class TestFavoriteLocalizerState:
-    def setup_method(self):
-        from vtsearch.utils.state import favorite_localizers
-
-        favorite_localizers.clear()
-
     def test_add_and_get(self):
         from vtsearch.utils.state import add_favorite_localizer, get_favorite_localizers
 
@@ -412,18 +407,6 @@ class TestFavoriteLocalizerState:
 
 
 class TestPregenProcessorsRoute:
-    def setup_method(self):
-        from vtsearch.utils.state import favorite_extractors, favorite_localizers
-
-        favorite_extractors.clear()
-        favorite_localizers.clear()
-
-    def teardown_method(self):
-        from vtsearch.utils.state import favorite_extractors, favorite_localizers
-
-        favorite_extractors.clear()
-        favorite_localizers.clear()
-
     def test_list_pregen_processors(self, client):
         res = client.get("/api/pregen-processors")
         assert res.status_code == 200

--- a/tests/test_safe_thresholds.py
+++ b/tests/test_safe_thresholds.py
@@ -119,14 +119,6 @@ class TestTrainAndScoreWithSafeThresholds:
 class TestSafeThresholdsSetting:
     """Tests for the safe_thresholds setting persistence."""
 
-    @pytest.fixture(autouse=True)
-    def reset_setting(self):
-        from vtsearch import settings
-
-        original = settings.get_safe_thresholds()
-        yield
-        settings.set_safe_thresholds(original)
-
     def test_default_is_false(self):
         from vtsearch import settings
 
@@ -159,14 +151,6 @@ class TestSafeThresholdsSetting:
 
 class TestSafeThresholdsAPI:
     """Tests for GET/POST /api/safe-thresholds."""
-
-    @pytest.fixture(autouse=True)
-    def reset_setting(self):
-        from vtsearch import settings
-
-        original = settings.get_safe_thresholds()
-        yield
-        settings.set_safe_thresholds(original)
 
     def test_get_returns_current_value(self, client):
         resp = client.get("/api/safe-thresholds")
@@ -359,14 +343,6 @@ class TestCalibrationFractionTrainAndScore:
 class TestCalibrationFractionSetting:
     """Tests for calibration_fraction setting persistence."""
 
-    @pytest.fixture(autouse=True)
-    def reset_setting(self):
-        from vtsearch import settings
-
-        original = settings.get_calibration_fraction()
-        yield
-        settings.set_calibration_fraction(original)
-
     def test_default_is_half(self):
         from vtsearch import settings
 
@@ -401,14 +377,6 @@ class TestCalibrationFractionSetting:
 
 class TestCalibrationFractionAPI:
     """Tests for calibration_fraction via the settings API."""
-
-    @pytest.fixture(autouse=True)
-    def reset_setting(self):
-        from vtsearch import settings
-
-        original = settings.get_calibration_fraction()
-        yield
-        settings.set_calibration_fraction(original)
 
     def test_get_settings_includes_calibration_fraction(self, client):
         resp = client.get("/api/settings")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,16 +19,6 @@ import app as app_module  # noqa: F401 — triggers conftest media init
 from vtsearch import settings as settings_mod
 
 
-@pytest.fixture(autouse=True)
-def isolated_settings(tmp_path, monkeypatch):
-    """Use a temp file for each test so tests don't interfere."""
-    test_settings_path = tmp_path / "settings.json"
-    monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
-    settings_mod.reset()
-    yield test_settings_path
-    settings_mod.reset()
-
-
 @pytest.fixture
 def client():
     app_module.app.config["TESTING"] = True
@@ -311,9 +301,6 @@ class TestEnsureFavoriteProcessorsImported:
             "threshold": 0.5,
         }))
 
-        # Clear any existing detectors with this name
-        favorite_detectors.pop("settings_test_det", None)
-
         settings_mod.add_favorite_processor(
             "settings_test_det", "detector_file", {"file": str(det_path)}
         )
@@ -322,12 +309,9 @@ class TestEnsureFavoriteProcessorsImported:
         assert "settings_test_det" in imported
         assert "settings_test_det" in favorite_detectors
 
-        # Clean up
-        favorite_detectors.pop("settings_test_det", None)
-
     def test_skips_already_imported(self, tmp_path):
         """If a detector with the same name already exists, skip it."""
-        from vtsearch.utils import add_favorite_detector, favorite_detectors
+        from vtsearch.utils import add_favorite_detector
 
         add_favorite_detector("existing", "audio", {"0.weight": [[0.1]], "0.bias": [0.0]}, 0.5)
 
@@ -337,9 +321,6 @@ class TestEnsureFavoriteProcessorsImported:
 
         imported = settings_mod.ensure_favorite_processors_imported()
         assert imported == []
-
-        # Clean up
-        favorite_detectors.pop("existing", None)
 
     def test_handles_bad_importer_gracefully(self):
         """Unknown importer name should not crash."""


### PR DESCRIPTION
Tests were flaky when run together because mutable global state
(favorite_detectors, favorite_extractors, favorite_localizers, and
settings persistence) was not consistently reset between tests.
Individual test files had fragile ad-hoc cleanup patterns (inline .pop()
calls, per-class autouse fixtures, setup_method/teardown_method) that
would leak state if assertions failed before the cleanup ran.

Changes:
- Rename reset_votes -> reset_state in conftest.py; add clearing of
  favorite_detectors, favorite_extractors, and favorite_localizers
- Add isolated_settings autouse fixture in conftest.py that redirects
  SETTINGS_PATH to a per-test tmp_path, preventing settings writes from
  leaking between tests via data/settings.json
- Remove 18 redundant per-file cleanup fixtures across 10 test files
  (clear_favorites, isolated_settings, reset_setting, setup/teardown)
- Remove fragile inline favorite_detectors.pop() calls (7 occurrences)
- Update CLAUDE.md with Test Isolation section documenting the pattern

https://claude.ai/code/session_0155pQMarvTsJSBJyU1aEcxa