### PR TITLE
Add labelset export functionality to detector export modal

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1463,15 +1463,24 @@
 
   // Detector export – open modal
   if (menuDetectorExport) {
-    menuDetectorExport.addEventListener("click", () => {
+    menuDetectorExport.addEventListener("click", async () => {
       if (menuDetectorExport.classList.contains("disabled")) return;
       closeBurgerMenu();
-      openDetectorExportModal();
+      await openDetectorExportModal();
     });
   }
 
-  function openDetectorExportModal() {
-    detectorExportList.innerHTML = `
+  async function openDetectorExportModal() {
+    // Fetch labelset exporters in parallel with building the modal
+    let labelsetExporters = [];
+    try {
+      const res = await fetch("/api/exporters");
+      if (res.ok) labelsetExporters = await res.json();
+    } catch (_) { /* ignore */ }
+    // Filter out the GUI exporter (not useful for file-based export)
+    labelsetExporters = labelsetExporters.filter(e => e.name !== "gui");
+
+    let html = `
       <div id="detector-export-browser-btn" class="option-card" role="button" tabindex="0">
         <span class="option-card-icon">\u2B07\uFE0F</span>
         <div>
@@ -1488,6 +1497,22 @@
       </div>
     `;
 
+    if (labelsetExporters.length > 0) {
+      html += `<h3 style="margin:1.2em 0 0.3em;font-size:1em;color:var(--text-muted);">Export Labels</h3>
+        <p style="margin:0 0 0.6em;font-size:0.85em;color:var(--text-muted);">Export votes as a label set (sufficient to retrain the detector later).</p>`;
+      html += labelsetExporters.map(exp => `
+        <div class="detector-labelset-export-option option-card" data-name="${escapeHtml(exp.name)}" role="button" tabindex="0">
+          <span class="option-card-icon">${escapeHtml(exp.icon || '\uD83D\uDCE4')}</span>
+          <div>
+            <div class="option-card-title">${escapeHtml(exp.display_name)}</div>
+            <div class="option-card-desc">${escapeHtml(exp.description)}</div>
+          </div>
+        </div>
+      `).join("");
+    }
+
+    detectorExportList.innerHTML = html;
+
     const browserBtn = detectorExportList.querySelector("#detector-export-browser-btn");
     const serverBtn = detectorExportList.querySelector("#detector-export-server-btn");
 
@@ -1500,7 +1525,80 @@
       if (e.key === "Enter" || e.key === " ") { e.preventDefault(); detectorExportModal.classList.remove("show"); runDetectorExportServer(); }
     });
 
+    // Wire up labelset exporter options
+    detectorExportList.querySelectorAll(".detector-labelset-export-option").forEach(el => {
+      const name = el.dataset.name;
+      const exp = labelsetExporters.find(e => e.name === name);
+      el.addEventListener("click", () => {
+        detectorExportModal.classList.remove("show");
+        runDetectorLabelExport(exp);
+      });
+      el.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          detectorExportModal.classList.remove("show");
+          runDetectorLabelExport(exp);
+        }
+      });
+    });
+
     detectorExportModal.classList.add("show");
+  }
+
+  async function runDetectorLabelExport(exp) {
+    menuDetectorStatus.textContent = "";
+    // Collect required field values via prompts
+    const fieldValues = {};
+    for (const field of exp.fields) {
+      if (field.required) {
+        const val = await vtPrompt(field.label + (field.description ? ` (${field.description})` : ""), field.default || "");
+        if (val === null) {
+          menuDetectorStatus.textContent = "Export cancelled";
+          setTimeout(() => { menuDetectorStatus.textContent = ""; }, 2000);
+          return;
+        }
+        fieldValues[field.key] = val;
+      } else {
+        fieldValues[field.key] = field.default || "";
+      }
+    }
+
+    menuDetectorStatus.textContent = "Exporting labels\u2026";
+    try {
+      const labelsRes = await fetch("/api/labels/export");
+      const labelsData = await labelsRes.json();
+
+      const exportRes = await fetch("/api/exporters/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          exporter_name: exp.name,
+          field_values: fieldValues,
+          results: labelsData,
+        }),
+      });
+      const result = await exportRes.json();
+      if (!exportRes.ok) {
+        menuDetectorStatus.textContent = result.error || "Export failed";
+        setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+        return;
+      }
+      // Handle browser download if the exporter returns download_content
+      if (result.download_content) {
+        const blob = new Blob([result.download_content], { type: result.download_content_type || "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = result.download_filename || "labels.json";
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+      menuDetectorStatus.textContent = result.message || "Labels exported";
+      setTimeout(() => { menuDetectorStatus.textContent = ""; }, 4000);
+    } catch (e) {
+      menuDetectorStatus.textContent = "Export failed";
+      setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000);
+    }
   }
 
   async function runDetectorExportBrowser() {

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -650,3 +650,110 @@ class TestServerDetectorExport:
         assert "/" not in data["name"]
         assert "\\" not in data["name"]
         assert ":" not in data["name"]
+
+
+class TestDetectorLabelsetExport:
+    """Test the labelset export flow from the detector export context.
+
+    The frontend Export Detector modal offers labelset exporters alongside
+    the traditional detector weight export.  The flow is:
+      1. GET /api/exporters  (list available exporters)
+      2. GET /api/labels/export  (build labelset from current votes)
+      3. POST /api/exporters/export  (run the chosen exporter on the labelset)
+    """
+
+    def test_exporters_list_available(self, client):
+        """GET /api/exporters returns labelset exporters usable from the detector modal."""
+        resp = client.get("/api/exporters")
+        assert resp.status_code == 200
+        names = {e["name"] for e in resp.get_json()}
+        # At least the JSON-based exporters should be present
+        assert "local_json_file" in names
+        assert "server_json_file" in names
+
+    def test_labelset_export_local_json(self, client):
+        """Full flow: votes -> labelset -> local_json_file exporter -> download content."""
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19]})
+
+        # Step 1: get the labelset
+        labels_resp = client.get("/api/labels/export")
+        assert labels_resp.status_code == 200
+        labels_data = labels_resp.get_json()
+        assert "labels" in labels_data
+        assert len(labels_data["labels"]) == 5
+
+        # Step 2: export through local_json_file exporter
+        export_resp = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "local_json_file",
+                "field_values": {},
+                "results": labels_data,
+            },
+        )
+        assert export_resp.status_code == 200
+        data = export_resp.get_json()
+        assert data["success"] is True
+        assert "download_content" in data
+
+        # The download should contain valid JSON with the labels
+        downloaded = json.loads(data["download_content"])
+        assert "labels" in downloaded
+        assert len(downloaded["labels"]) == 5
+
+    def test_labelset_export_server_json(self, client, tmp_path):
+        """Full flow: votes -> labelset -> server_json_file exporter -> file on disk."""
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3]})
+
+        labels_resp = client.get("/api/labels/export")
+        labels_data = labels_resp.get_json()
+
+        fpath = tmp_path / "detector_labels.json"
+        export_resp = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "server_json_file",
+                "field_values": {"filepath": str(fpath)},
+                "results": labels_data,
+            },
+        )
+        assert export_resp.status_code == 200
+        assert export_resp.get_json()["success"] is True
+        assert fpath.exists()
+
+        written = json.loads(fpath.read_text())
+        assert "labels" in written
+        assert len(written["labels"]) == 3
+
+    def test_labelset_roundtrip_via_exporter(self, client, tmp_path):
+        """Labels exported through an exporter can be re-imported to restore votes."""
+        app_module.good_votes.update({k: None for k in [1, 3]})
+        app_module.bad_votes.update({k: None for k in [2]})
+
+        # Export labelset
+        labels_resp = client.get("/api/labels/export")
+        labels_data = labels_resp.get_json()
+
+        # Save via server_json_file exporter
+        fpath = tmp_path / "labels_roundtrip.json"
+        client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "server_json_file",
+                "field_values": {"filepath": str(fpath)},
+                "results": labels_data,
+            },
+        )
+
+        # Clear votes and re-import
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+
+        saved = json.loads(fpath.read_text())
+        resp = client.post("/api/labels/import", json=saved)
+        data = resp.get_json()
+        assert data["applied"] == 3
+        assert set(app_module.good_votes) == {1, 3}
+        assert set(app_module.bad_votes) == {2}


### PR DESCRIPTION
## Summary
This PR adds the ability to export detector votes as a labelset through various exporters (JSON file, etc.) directly from the detector export modal. This complements the existing detector weight export and allows users to save their labeled data for retraining purposes.

## Key Changes
- **Backend Tests**: Added comprehensive test suite (`TestDetectorLabelsetExport`) covering:
  - Listing available labelset exporters via `/api/exporters`
  - Exporting votes as a labelset via `/api/labels/export`
  - Running exporters on labelsets via `/api/exporters/export`
  - Full roundtrip export/import workflow to verify data integrity

- **Frontend Modal Enhancement**: Updated the detector export modal to:
  - Fetch available labelset exporters asynchronously when opening the modal
  - Filter out the GUI exporter (not applicable for file-based export)
  - Display labelset exporters as additional export options alongside the existing detector weight exports
  - Add descriptive section header and explanation for the labelset export options

- **Frontend Export Flow**: Implemented `runDetectorLabelExport()` function to:
  - Collect required field values from users via prompts (e.g., filepath for file-based exporters)
  - Fetch the current labelset from `/api/labels/export`
  - POST the labelset to `/api/exporters/export` with the selected exporter
  - Handle browser downloads for exporters that return `download_content`
  - Provide user feedback via status messages

## Implementation Details
- The modal opening is now async to support parallel fetching of exporters
- Labelset exporters are dynamically loaded and rendered, making the feature extensible
- The export flow mirrors the existing detector export pattern for consistency
- User prompts are used for required exporter fields (e.g., filepath), with optional fields defaulting to empty strings
- Error handling and user feedback are provided throughout the export process

https://claude.ai/code/session_01HC5nWtVosKHQhdRqBQ1aB9