### PR TITLE
Reduce spacing and font sizes in player center panel

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -263,10 +263,10 @@ header h1 { margin-left: 48px; }
 .stripe-highlight { position: absolute; left: 0; right: 0; background: var(--accent-highlight-bg); border-top: 1px solid var(--accent-highlight-border); border-bottom: 1px solid var(--accent-highlight-border); pointer-events: none; transition: top 0.05s, height 0.05s; z-index: 0; }
 
 /* Center panel – player */
-.panel-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; padding: 32px; overflow-y: auto; }
+.panel-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 16px; overflow-y: auto; }
 .panel-center.empty { color: var(--text-placeholder); font-size: 1rem; }
 .meta { text-align: center; }
-.meta h2 { font-size: 1.5rem; color: var(--accent); margin-bottom: 8px; }
+.meta h2 { font-size: 1.25rem; color: var(--accent); margin-bottom: 4px; }
 .meta p { font-size: 0.85rem; color: var(--text-muted); margin: 2px 0; }
 
 /* Waveform canvas */
@@ -279,10 +279,10 @@ video { max-width: 600px; max-height: 400px; }
 .metadata-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 12px 24px;
+  gap: 6px 24px;
   width: 600px;
   background: var(--bg-surface);
-  padding: 16px 20px;
+  padding: 10px 20px;
   border-radius: 8px;
   border: 1px solid var(--border);
 }


### PR DESCRIPTION
## Summary
This PR reduces the vertical and horizontal spacing throughout the center player panel to create a more compact layout. Font sizes for metadata headings are also slightly reduced for better visual hierarchy.

## Key Changes
- **Panel center container**: Reduced gap from 20px to 10px and padding from 32px to 16px
- **Metadata heading (h2)**: Reduced font size from 1.5rem to 1.25rem and margin-bottom from 8px to 4px
- **Metadata grid**: Reduced vertical gap from 12px to 6px and padding from 16px to 10px

## Details
These changes create a tighter, more space-efficient layout for the player interface while maintaining visual clarity. The adjustments are proportional across different spacing values to ensure consistent visual balance.

https://claude.ai/code/session_01E8xQwSJNHBzkPi7GDvyDqR