### PR TITLE
Make media players responsive and improve canvas rendering

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3490,6 +3490,9 @@
     if (!canvas) return;
 
     const ctx = canvas.getContext("2d");
+    // Size the canvas bitmap to match its CSS-displayed size for sharp rendering
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width > 0) canvas.width = Math.round(rect.width);
     const width = canvas.width;
     const height = canvas.height;
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -270,10 +270,10 @@ header h1 { margin-left: 48px; }
 .meta p { font-size: 0.85rem; color: var(--text-muted); margin: 2px 0; }
 
 /* Waveform canvas */
-#waveform-canvas { border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }
+#waveform-canvas { width: 100%; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }
 
-audio { width: 320px; }
-video { max-width: 600px; max-height: 400px; }
+audio { width: 100%; max-width: 480px; }
+video { max-width: 100%; }
 
 /* Metadata grid */
 .metadata-grid {
@@ -567,11 +567,11 @@ video { max-width: 600px; max-height: 400px; }
 .fav-btn-row { display: flex; gap: 8px; flex-wrap: wrap; }
 
 /* Media players */
-.media-player-video { width: 600px; max-height: 400px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }
-.media-player-image-wrap { flex: 1; min-height: 0; width: 100%; display: flex; align-items: center; justify-content: center; }
-.media-player-image { max-width: 100%; max-height: 100%; object-fit: contain; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }
-.media-player-text { max-width: 600px; max-height: 400px; overflow-y: auto; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); white-space: pre-wrap; line-height: 1.6; text-align: left; }
-.media-player-embed { max-width: 100%; max-height: 100%; border: 1px solid var(--border); border-radius: 8px; }
+.media-player-video { max-width: 100%; max-height: 100%; flex: 1; min-height: 0; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }
+.media-player-image-wrap { flex: 1; min-height: 0; width: 100%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.media-player-image { width: 100%; height: 100%; object-fit: contain; border-radius: 8px; }
+.media-player-text { width: 100%; flex: 1; min-height: 0; overflow-y: auto; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); white-space: pre-wrap; line-height: 1.6; text-align: left; }
+.media-player-embed { width: 100%; height: 100%; object-fit: contain; border: 1px solid var(--border); border-radius: 8px; }
 
 /* Combine datasets staged items */
 .combine-item { display: flex; align-items: center; padding: 8px 10px; margin-bottom: 4px; background: var(--bg-hover); border-radius: 4px; }


### PR DESCRIPTION
## Summary
This PR improves the responsiveness of media players and enhances canvas rendering quality by making them adapt to their container sizes rather than using fixed dimensions.

## Key Changes
- **Responsive media players**: Updated `.media-player-video`, `.media-player-text`, and `.media-player-embed` to use flexible sizing (`width: 100%`, `flex: 1`) instead of fixed pixel dimensions (600px/400px)
- **Audio/video element sizing**: Changed `<audio>` from fixed 320px width to responsive `width: 100%; max-width: 480px`, and `<video>` from fixed max dimensions to `max-width: 100%`
- **Waveform canvas**: Added `width: 100%` to make the canvas container responsive
- **Canvas bitmap scaling**: Added JavaScript logic to size the canvas bitmap to match its CSS-displayed size, ensuring sharp rendering at any resolution
- **Image player improvements**: Added `overflow: hidden` to `.media-player-image-wrap` and adjusted `.media-player-image` sizing for better containment
- **Removed redundant borders**: Simplified `.media-player-image` styling by removing duplicate border properties

## Implementation Details
The canvas rendering fix addresses a common issue where canvas elements render blurry when their bitmap size doesn't match their display size. The code now reads the canvas's bounding client rectangle and sets the canvas width property to match, ensuring crisp rendering at any viewport size.

https://claude.ai/code/session_01EYkNto8vQsF5ra1EZNjsBa