### PR TITLE
Fix vote button layout shift on hover with ::after pseudo-element

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -295,9 +295,11 @@ video { max-width: 600px; max-height: 400px; }
 .vote-buttons button { padding: 10px 28px; border: 2px solid; border-radius: 8px; font-size: 1rem; cursor: pointer; background: transparent; transition: all 0.15s; }
 .btn-good { color: var(--color-good); border-color: var(--color-good); }
 .btn-good:hover { font-weight: 700; }
+.btn-good::after { content: "Good"; font-weight: 700; display: block; height: 0; overflow: hidden; visibility: hidden; pointer-events: none; }
 .btn-good.voted, .btn-good.vote-flash { background: var(--color-good); color: #fff; }
 .btn-bad { color: var(--color-bad); border-color: var(--color-bad); }
 .btn-bad:hover { font-weight: 700; }
+.btn-bad::after { content: "Bad"; font-weight: 700; display: block; height: 0; overflow: hidden; visibility: hidden; pointer-events: none; }
 .btn-bad.voted, .btn-bad.vote-flash { background: var(--color-bad); color: #fff; }
 
 /* Right panel – votes */


### PR DESCRIPTION
## Summary
This change prevents layout shift that occurs when vote buttons transition to bold font weight on hover by using a `::after` pseudo-element technique.

## Key Changes
- Added `::after` pseudo-element to `.btn-good` button with hidden "Good" text in bold font weight
- Added `::after` pseudo-element to `.btn-bad` button with hidden "Bad" text in bold font weight
- Both pseudo-elements use `height: 0`, `overflow: hidden`, and `visibility: hidden` to remain invisible while reserving space

## Implementation Details
The `::after` pseudo-elements are rendered with `font-weight: 700` (bold) but kept invisible through CSS properties. This reserves the additional space that would be needed when the button text becomes bold on hover, eliminating the visual layout shift that would otherwise occur. The `pointer-events: none` ensures the pseudo-element doesn't interfere with button interactions.

https://claude.ai/code/session_019iagJ5eXw5ASZPxDdyLi2Y