### PR TITLE
Fix overflow clipping for swiped media animations

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -486,6 +486,7 @@ video { max-width: 100%; }
 }
 .media-swipe-wrapper.swipe-right { animation: swipe-right 0.18s cubic-bezier(0.4, 0, 1, 1) forwards; }
 .media-swipe-wrapper.swipe-left  { animation: swipe-left  0.18s cubic-bezier(0.4, 0, 1, 1) forwards; }
+.panel-center:has(.swipe-right, .swipe-left) { overflow: hidden; }
 
 /* ---- Shared component classes ---- */
 


### PR DESCRIPTION
## Summary
Added overflow hidden styling to the panel-center container when media swipe animations are active to prevent content from visually extending beyond the container boundaries during swipe transitions.

## Changes
- Added CSS rule to hide overflow on `.panel-center` when it contains elements with `.swipe-right` or `.swipe-left` classes
- Uses the `:has()` selector to apply the overflow constraint only during active swipe animations

## Details
This prevents animated media elements from visually overflowing the container during the 0.18s swipe animation, ensuring a cleaner visual presentation of the swipe transition effect.

https://claude.ai/code/session_017HW5Mvf81PJC8GJWbRFqbX