### PR TITLE
Add image view controls: zoom, rotate, and reset functionality

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3305,6 +3305,15 @@
         ${playerHTML}
       </div>
       ${mediaType === "audio" ? `<audio controls controlslist="nodownload" loop autoplay src="/api/medias/${c.id}/audio" id="media-audio" aria-label="${escapeHtml(c.filename || 'Audio media')}"></audio>` : ''}
+      ${mediaType === "image" ? `
+      <div class="image-view-controls" id="image-view-controls">
+        <button class="ivc-btn" id="ivc-rotate-left" title="Rotate left" aria-label="Rotate image left">&#x21BA;</button>
+        <button class="ivc-btn" id="ivc-rotate-right" title="Rotate right" aria-label="Rotate image right">&#x21BB;</button>
+        <label for="ivc-zoom" class="sr-only">Zoom</label>
+        <input type="range" id="ivc-zoom" class="ivc-zoom-slider" min="0.25" max="5" step="0.05" value="1" title="Zoom" aria-label="Zoom level">
+        <span class="ivc-zoom-label" id="ivc-zoom-label">1×</span>
+        <button class="ivc-btn" id="ivc-reset" title="Reset view" aria-label="Reset image view">Reset</button>
+      </div>` : ''}
       <div class="metadata-grid">
         ${c.frequency ? `
         <div class="metadata-item">
@@ -3390,6 +3399,40 @@
           if (err.name === "AbortError") return; // expected when selection changes
           console.error("Error loading paragraph:", err);
         });
+    }
+
+    // Image view controls: zoom, rotate, reset
+    if (mediaType === "image") {
+      const img = document.getElementById("media-image");
+      const zoomSlider = document.getElementById("ivc-zoom");
+      const zoomLabel = document.getElementById("ivc-zoom-label");
+      const rotateLeftBtn = document.getElementById("ivc-rotate-left");
+      const rotateRightBtn = document.getElementById("ivc-rotate-right");
+      const resetBtn = document.getElementById("ivc-reset");
+      if (img && zoomSlider) {
+        let ivcZoom = 1, ivcRotation = 0;
+        const applyTransform = () => {
+          img.style.transform = `scale(${ivcZoom}) rotate(${ivcRotation}deg)`;
+          zoomLabel.textContent = ivcZoom.toFixed(1) + '×';
+        };
+        zoomSlider.addEventListener("input", () => {
+          ivcZoom = parseFloat(zoomSlider.value);
+          applyTransform();
+        });
+        rotateLeftBtn.addEventListener("click", () => {
+          ivcRotation -= 90;
+          applyTransform();
+        });
+        rotateRightBtn.addEventListener("click", () => {
+          ivcRotation += 90;
+          applyTransform();
+        });
+        resetBtn.addEventListener("click", () => {
+          ivcZoom = 1; ivcRotation = 0;
+          zoomSlider.value = 1;
+          applyTransform();
+        });
+      }
     }
   }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -581,6 +581,23 @@ video { max-width: 100%; }
 .media-player-text { width: 100%; flex: 1; min-height: 0; overflow-y: auto; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); white-space: pre-wrap; line-height: 1.6; text-align: left; }
 .media-player-embed { width: 100%; height: 100%; object-fit: contain; border: 1px solid var(--border); border-radius: 8px; }
 
+/* Image view controls (zoom, rotate, reset) */
+.image-view-controls {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 4px 0; opacity: 0.5; transition: opacity 0.2s;
+}
+.image-view-controls:hover { opacity: 1; }
+.ivc-btn {
+  background: none; border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text-muted); font-size: 0.75rem; padding: 2px 8px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.ivc-btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.ivc-zoom-slider {
+  width: 100px; accent-color: var(--accent); height: 4px; cursor: pointer;
+}
+.ivc-zoom-label { font-size: 0.7rem; color: var(--text-muted); min-width: 2.5em; text-align: center; }
+
 /* Combine datasets staged items */
 .combine-item { display: flex; align-items: center; padding: 8px 10px; margin-bottom: 4px; background: var(--bg-hover); border-radius: 4px; }
 .combine-item-name { flex: 1; color: var(--text-primary); font-size: 0.9rem; }


### PR DESCRIPTION
## Summary
Added interactive image viewing controls to the media player, allowing users to zoom, rotate, and reset images when viewing image media types.

## Key Changes
- **HTML Controls**: Added a new control panel with zoom slider, rotate left/right buttons, and reset button for image media
- **JavaScript Functionality**: Implemented event listeners for zoom, rotation, and reset operations that apply CSS transforms to the image element
- **Styling**: Added CSS styles for the control panel with hover effects, button styling, and zoom slider appearance

## Implementation Details
- The controls are only rendered when `mediaType === "image"`
- Zoom range: 0.25× to 5× with 0.05 increments, displayed with a visual label
- Rotation: 90-degree increments via left/right buttons
- Reset button restores zoom to 1× and rotation to 0°
- Controls use CSS transforms (`scale` and `rotate`) for smooth transformations
- Control panel has reduced opacity (0.5) by default with full opacity on hover for a clean UI
- All controls include proper ARIA labels for accessibility
- Zoom label dynamically updates to show current zoom level

https://claude.ai/code/session_013JSJ28MrpHKGTiTkcLFe1d