### PR TITLE
Add pan and mouse wheel zoom to image viewer

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3401,22 +3401,26 @@
         });
     }
 
-    // Image view controls: zoom, rotate, reset
+    // Image view controls: zoom, rotate, pan, reset
     if (mediaType === "image") {
       const img = document.getElementById("media-image");
+      const wrap = img ? img.closest(".media-player-image-wrap") : null;
       const zoomSlider = document.getElementById("ivc-zoom");
       const zoomLabel = document.getElementById("ivc-zoom-label");
       const rotateLeftBtn = document.getElementById("ivc-rotate-left");
       const rotateRightBtn = document.getElementById("ivc-rotate-right");
       const resetBtn = document.getElementById("ivc-reset");
-      if (img && zoomSlider) {
-        let ivcZoom = 1, ivcRotation = 0;
+      if (img && zoomSlider && wrap) {
+        let ivcZoom = 1, ivcRotation = 0, ivcPanX = 0, ivcPanY = 0;
         const applyTransform = () => {
-          img.style.transform = `scale(${ivcZoom}) rotate(${ivcRotation}deg)`;
+          img.style.transform = `translate(${ivcPanX}px, ${ivcPanY}px) scale(${ivcZoom}) rotate(${ivcRotation}deg)`;
           zoomLabel.textContent = ivcZoom.toFixed(1) + '×';
+          wrap.style.cursor = ivcZoom > 1 ? 'grab' : '';
         };
+        const clampZoom = (val) => Math.min(parseFloat(zoomSlider.max), Math.max(parseFloat(zoomSlider.min), val));
         zoomSlider.addEventListener("input", () => {
           ivcZoom = parseFloat(zoomSlider.value);
+          if (ivcZoom <= 1) { ivcPanX = 0; ivcPanY = 0; }
           applyTransform();
         });
         rotateLeftBtn.addEventListener("click", () => {
@@ -3428,9 +3432,50 @@
           applyTransform();
         });
         resetBtn.addEventListener("click", () => {
-          ivcZoom = 1; ivcRotation = 0;
+          ivcZoom = 1; ivcRotation = 0; ivcPanX = 0; ivcPanY = 0;
           zoomSlider.value = 1;
           applyTransform();
+        });
+
+        // Mouse wheel zoom — zooms toward cursor position
+        wrap.addEventListener("wheel", (e) => {
+          e.preventDefault();
+          const oldZoom = ivcZoom;
+          const delta = e.deltaY > 0 ? -0.15 : 0.15;
+          ivcZoom = clampZoom(ivcZoom + delta * ivcZoom);
+          zoomSlider.value = ivcZoom;
+          // Adjust pan so the point under the cursor stays fixed
+          const rect = wrap.getBoundingClientRect();
+          const cx = e.clientX - rect.left - rect.width / 2;
+          const cy = e.clientY - rect.top - rect.height / 2;
+          const ratio = ivcZoom / oldZoom;
+          ivcPanX = cx - ratio * (cx - ivcPanX);
+          ivcPanY = cy - ratio * (cy - ivcPanY);
+          if (ivcZoom <= 1) { ivcPanX = 0; ivcPanY = 0; }
+          applyTransform();
+        }, { passive: false });
+
+        // Mouse drag panning
+        let isPanning = false, panStartX = 0, panStartY = 0, panOriginX = 0, panOriginY = 0;
+        wrap.addEventListener("mousedown", (e) => {
+          if (ivcZoom <= 1 || e.button !== 0) return;
+          isPanning = true;
+          panStartX = e.clientX; panStartY = e.clientY;
+          panOriginX = ivcPanX; panOriginY = ivcPanY;
+          wrap.style.cursor = 'grabbing';
+          e.preventDefault();
+        });
+        window.addEventListener("mousemove", (e) => {
+          if (!isPanning) return;
+          ivcPanX = panOriginX + (e.clientX - panStartX);
+          ivcPanY = panOriginY + (e.clientY - panStartY);
+          applyTransform();
+          wrap.style.cursor = 'grabbing';
+        });
+        window.addEventListener("mouseup", () => {
+          if (!isPanning) return;
+          isPanning = false;
+          wrap.style.cursor = ivcZoom > 1 ? 'grab' : '';
         });
       }
     }

--- a/static/styles.css
+++ b/static/styles.css
@@ -578,7 +578,7 @@ video { max-width: 100%; }
 /* Media players */
 .media-player-video { max-width: 100%; max-height: 100%; flex: 1; min-height: 0; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }
 .media-player-image-wrap { flex: 1; min-height: 0; width: 100%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
-.media-player-image { width: 100%; height: 100%; object-fit: contain; border-radius: 8px; }
+.media-player-image { width: 100%; height: 100%; object-fit: contain; border-radius: 8px; user-select: none; -webkit-user-drag: none; }
 .media-player-text { width: 100%; flex: 1; min-height: 0; overflow-y: auto; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); white-space: pre-wrap; line-height: 1.6; text-align: left; }
 .media-player-embed { width: 100%; height: 100%; object-fit: contain; border: 1px solid var(--border); border-radius: 8px; }
 


### PR DESCRIPTION
## Summary
Enhanced the image viewer with mouse wheel zoom and drag-to-pan functionality, improving the user experience when viewing zoomed images.

## Key Changes
- **Mouse wheel zoom**: Scroll to zoom in/out with the zoom level clamped to valid range; zoom is centered on cursor position to keep the viewed area stable
- **Drag-to-pan**: Click and drag to pan around zoomed images; panning is only enabled when zoom > 1
- **Cursor feedback**: Cursor changes to "grab" when hoverable over zoomed images and "grabbing" while actively panning
- **Pan reset**: Pan values reset to (0, 0) when zoom returns to 1.0 or when reset button is clicked
- **CSS improvements**: Added `user-select: none` and `-webkit-user-drag: none` to prevent unwanted text selection and image dragging during interactions
- **Transform order**: Updated transform to apply translate before scale/rotate for correct pan behavior

## Implementation Details
- Pan state tracked with `ivcPanX` and `ivcPanY` variables
- Mouse wheel handler uses `preventDefault()` with `{ passive: false }` to enable smooth zoom control
- Pan drag uses mousedown/mousemove/mouseup event listeners on window to handle drags outside the image container
- Zoom clamping utility function ensures values stay within slider bounds
- Pan automatically disabled when zoom ≤ 1 to prevent confusion when image fits in viewport

https://claude.ai/code/session_01DsEAGfDfbDv5uoyZC5CMPD