### PR TITLE
Prevent Enter key from submitting in text sort input

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2847,6 +2847,12 @@
   }
 
   textSortInput.addEventListener("input", onTextSortInput);
+  textSortInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      textSortInput.blur();
+    }
+  });
 
   // ---- Learned sort ----
 


### PR DESCRIPTION
## Summary
Added keyboard event handling to the text sort input field to prevent the Enter key from triggering form submission while still allowing the input to lose focus.

## Key Changes
- Added a `keydown` event listener to `textSortInput` that intercepts the Enter key
- When Enter is pressed, the event is prevented from propagating and the input is blurred
- This improves UX by allowing users to dismiss the input field without unintended form submission

## Implementation Details
The handler uses `e.preventDefault()` to stop the default Enter key behavior and `textSortInput.blur()` to remove focus from the input field, providing a clean way to exit the input state.

https://claude.ai/code/session_0133t98FjZvc9QKAgDcFxPzk