### PR TITLE
Fix image viewer pan constraints and cursor feedback

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3412,15 +3412,44 @@
       const resetBtn = document.getElementById("ivc-reset");
       if (img && zoomSlider && wrap) {
         let ivcZoom = 1, ivcRotation = 0, ivcPanX = 0, ivcPanY = 0;
+        // Compute how far the image can be panned before showing empty space
+        const getMaxPan = () => {
+          const natW = img.naturalWidth;
+          const natH = img.naturalHeight;
+          if (!natW || !natH) return { x: 0, y: 0 };
+          const wrapW = wrap.clientWidth;
+          const wrapH = wrap.clientHeight;
+          if (!wrapW || !wrapH) return { x: 0, y: 0 };
+          const imgAspect = natW / natH;
+          const wrapAspect = wrapW / wrapH;
+          let rendW, rendH;
+          if (imgAspect > wrapAspect) {
+            rendW = wrapW;
+            rendH = wrapW / imgAspect;
+          } else {
+            rendH = wrapH;
+            rendW = wrapH * imgAspect;
+          }
+          const rot = ((ivcRotation % 360) + 360) % 360;
+          const swapped = (rot === 90 || rot === 270);
+          const effW = swapped ? rendH : rendW;
+          const effH = swapped ? rendW : rendH;
+          return {
+            x: Math.max(0, (effW * ivcZoom - wrapW) / 2),
+            y: Math.max(0, (effH * ivcZoom - wrapH) / 2),
+          };
+        };
         const applyTransform = () => {
+          const max = getMaxPan();
+          ivcPanX = Math.max(-max.x, Math.min(max.x, ivcPanX));
+          ivcPanY = Math.max(-max.y, Math.min(max.y, ivcPanY));
           img.style.transform = `translate(${ivcPanX}px, ${ivcPanY}px) scale(${ivcZoom}) rotate(${ivcRotation}deg)`;
           zoomLabel.textContent = ivcZoom.toFixed(1) + '×';
-          wrap.style.cursor = ivcZoom > 1 ? 'grab' : '';
+          wrap.style.cursor = (max.x > 0 || max.y > 0) ? 'grab' : '';
         };
         const clampZoom = (val) => Math.min(parseFloat(zoomSlider.max), Math.max(parseFloat(zoomSlider.min), val));
         zoomSlider.addEventListener("input", () => {
           ivcZoom = parseFloat(zoomSlider.value);
-          if (ivcZoom <= 1) { ivcPanX = 0; ivcPanY = 0; }
           applyTransform();
         });
         rotateLeftBtn.addEventListener("click", () => {
@@ -3451,14 +3480,14 @@
           const ratio = ivcZoom / oldZoom;
           ivcPanX = cx - ratio * (cx - ivcPanX);
           ivcPanY = cy - ratio * (cy - ivcPanY);
-          if (ivcZoom <= 1) { ivcPanX = 0; ivcPanY = 0; }
           applyTransform();
         }, { passive: false });
 
         // Mouse drag panning
         let isPanning = false, panStartX = 0, panStartY = 0, panOriginX = 0, panOriginY = 0;
         wrap.addEventListener("mousedown", (e) => {
-          if (ivcZoom <= 1 || e.button !== 0) return;
+          const max = getMaxPan();
+          if ((max.x <= 0 && max.y <= 0) || e.button !== 0) return;
           isPanning = true;
           panStartX = e.clientX; panStartY = e.clientY;
           panOriginX = ivcPanX; panOriginY = ivcPanY;
@@ -3475,7 +3504,8 @@
         window.addEventListener("mouseup", () => {
           if (!isPanning) return;
           isPanning = false;
-          wrap.style.cursor = ivcZoom > 1 ? 'grab' : '';
+          const max = getMaxPan();
+          wrap.style.cursor = (max.x > 0 || max.y > 0) ? 'grab' : '';
         });
       }
     }


### PR DESCRIPTION
## Summary
Improved the image viewer pan behavior to properly constrain panning based on the actual rendered image dimensions after zoom and rotation, rather than just checking if zoom > 1. This prevents users from panning to show empty space and provides more accurate cursor feedback.

## Key Changes
- Added `getMaxPan()` function that calculates the maximum pan distance in each direction based on:
  - Natural image dimensions
  - Current zoom level
  - Current rotation (accounting for 90°/270° rotation which swaps dimensions)
  - Container dimensions
- Updated `applyTransform()` to clamp pan values within calculated limits before applying the transform
- Changed pan enablement logic from `ivcZoom > 1` to checking if `max.x > 0 || max.y > 0`, which correctly handles cases where:
  - Image is zoomed but still fits within container in one dimension
  - Image is rotated, changing which dimensions allow panning
- Removed manual pan reset when `ivcZoom <= 1` since clamping now handles this automatically
- Updated cursor feedback to reflect actual pan capability rather than just zoom state

## Implementation Details
- The `getMaxPan()` function accounts for image aspect ratio and container aspect ratio to determine rendered dimensions
- Rotation handling correctly identifies when dimensions are swapped (90° or 270°)
- Pan clamping uses symmetric bounds: `[-max, +max]` for both X and Y axes
- Cursor changes from 'grab' to default based on whether panning is actually possible in any direction

https://claude.ai/code/session_01Wmb5B9UrDYrJEYqqJXnYYR