### PR TITLE
Improve server example media UI with disabled state

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4201,7 +4201,7 @@
       <div class="load-sort-option option-card" id="ls-example-local" role="button" tabindex="0">
         <span class="option-card-icon">\uD83D\uDCC1</span>
         <div>
-          <div class="option-card-title">Load Local Media</div>
+          <div class="option-card-title">Local Example</div>
           <div class="option-card-desc">Choose a ${mediaType} file from your computer to sort by similarity.</div>
         </div>
       </div>`;
@@ -4216,16 +4216,17 @@
       }
     } catch (_) { /* ignore */ }
 
-    if (serverMediaFiles.length > 0) {
-      exampleHtml += `
-        <div class="load-sort-option option-card" id="ls-example-server" role="button" tabindex="0">
-          <span class="option-card-icon">\uD83D\uDCBE</span>
-          <div>
-            <div class="option-card-title">Load Server Media</div>
-            <div class="option-card-desc">${serverMediaFiles.length} media file${serverMediaFiles.length !== 1 ? "s" : ""} on the server.</div>
-          </div>
-        </div>`;
-    }
+    const serverExampleDesc = serverMediaFiles.length > 0
+      ? `${serverMediaFiles.length} media file${serverMediaFiles.length !== 1 ? "s" : ""} on the server.`
+      : "No example media files saved on server yet.";
+    exampleHtml += `
+      <div class="load-sort-option option-card${serverMediaFiles.length === 0 ? " option-card-disabled" : ""}" id="ls-example-server" role="button" tabindex="0">
+        <span class="option-card-icon">\uD83D\uDCBE</span>
+        <div>
+          <div class="option-card-title">Server Example</div>
+          <div class="option-card-desc">${serverExampleDesc}</div>
+        </div>
+      </div>`;
 
     loadSortExampleOptions.innerHTML = exampleHtml;
 
@@ -4292,10 +4293,14 @@
       });
     }
 
-    // Server example media — show sub-list
+    // Server example media — show sub-list (always shown; guard empty case)
     const lsExampleServer = document.getElementById("ls-example-server");
-    if (lsExampleServer && serverMediaFiles.length > 0) {
+    if (lsExampleServer) {
       lsExampleServer.addEventListener("click", () => {
+        if (serverMediaFiles.length === 0) {
+          loadSortStatus.textContent = "No example media files on server. Place files in data/example_media/ to use this option.";
+          return;
+        }
         loadSortExampleOptions.innerHTML = serverMediaFiles.map(f => `
           <div class="load-sort-option option-card ls-server-media-item" data-media-filename="${escapeHtml(f.filename)}" data-media-name="${escapeHtml(f.name)}" role="button" tabindex="0">
             <span class="option-card-icon">\uD83C\uDFB5</span>

--- a/static/styles.css
+++ b/static/styles.css
@@ -497,6 +497,8 @@ video { max-width: 100%; }
   display: flex; align-items: center; gap: 12px; transition: background 0.15s;
 }
 .option-card:hover { background: var(--bg-hover); }
+.option-card.option-card-disabled { opacity: 0.45; cursor: default; }
+.option-card.option-card-disabled:hover { background: var(--border); }
 .option-card-icon { font-size: 1.5rem; flex-shrink: 0; }
 .option-card-title { font-weight: bold; color: var(--text-primary); }
 .option-card-desc { font-size: 0.8rem; color: var(--text-muted); margin-top: 2px; }


### PR DESCRIPTION
## Summary
Updated the example media selection UI to always display the server example option, even when no files are available. When disabled, the option shows a helpful message and visual feedback to guide users.

## Key Changes
- **Renamed UI labels** for clarity: "Load Local Media" → "Local Example" and "Load Server Media" → "Server Example"
- **Always render server example card** instead of conditionally hiding it when empty
- **Added disabled state styling** with reduced opacity and default cursor for unavailable options
- **Improved empty state UX** by displaying an informative message ("No example media files on server. Place files in data/example_media/ to use this option.") when users click the disabled server option
- **Enhanced click handler** to guard against empty server media files and provide user guidance

## Implementation Details
- The server example card now includes the `option-card-disabled` class when `serverMediaFiles.length === 0`
- CSS styling for disabled state prevents hover effects and reduces visual prominence
- The click event listener is always attached but checks for empty state and displays status message before attempting to load files
- Dynamic description text updates based on server file availability

https://claude.ai/code/session_01DBfz118TPti9bzkfAvzd5e