### PR TITLE
Refactor metadata display from header to grid layout

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3324,25 +3324,7 @@
     center.className = "panel-center";
 
     const mediaType = c.type || "audio";
-    let metaInfo = [];
-    if (c.frequency) {
-      metaInfo.push(`${c.frequency} Hz`);
-    }
-    if (c.category && c.category !== "unknown") {
-      metaInfo.push(c.category);
-    }
-    // Use media type metadata from the registry for duration/details display
     const mtInfo = mediaTypesMap[mediaType];
-    if (c.duration && c.duration > 0) {
-      metaInfo.push(`${c.duration.toFixed(1)}s`);
-    }
-    if (c.width && c.height) {
-      metaInfo.push(`${c.width}×${c.height}`);
-    }
-    if (c.word_count) {
-      metaInfo.push(`${c.word_count} words`);
-    }
-    metaInfo.push(`${(c.file_size / 1024).toFixed(1)} KB`);
 
     // Render media player based on media type.
     // Known types get specialised players; new/unknown types fall back to
@@ -3374,10 +3356,6 @@
     }
 
     center.innerHTML = `
-      <div class="meta">
-        <h2>${escapeHtml(c.filename || 'Media #' + c.id)}</h2>
-        <p>${metaInfo.map(s => escapeHtml(s)).join(' &middot; ')}</p>
-      </div>
       <div class="media-swipe-wrapper" id="media-swipe-wrapper">
         ${playerHTML}
       </div>
@@ -3392,6 +3370,10 @@
         <button class="ivc-btn" id="ivc-reset" title="Reset view" aria-label="Reset image view">Reset</button>
       </div>` : ''}
       <div class="metadata-grid">
+        <div class="metadata-item">
+          <span class="metadata-label">Name</span>
+          <span class="metadata-value">${escapeHtml(c.filename || 'Media #' + c.id)}</span>
+        </div>
         ${c.frequency ? `
         <div class="metadata-item">
           <span class="metadata-label">Frequency</span>
@@ -3428,10 +3410,6 @@
         <div class="metadata-item">
           <span class="metadata-label">File Size</span>
           <span class="metadata-value">${(c.file_size / 1024).toFixed(1)} KB</span>
-        </div>
-        <div class="metadata-item">
-          <span class="metadata-label">Filename</span>
-          <span class="metadata-value">${escapeHtml(c.filename || 'media_' + c.id + '.wav')}</span>
         </div>
         <div class="metadata-item">
           <span class="metadata-label">MD5</span>

--- a/static/styles.css
+++ b/static/styles.css
@@ -263,9 +263,6 @@ header h1 { margin-left: 48px; }
 /* Center panel – player */
 .panel-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; padding: 16px; overflow-y: auto; }
 .panel-center.empty { color: var(--text-placeholder); font-size: 1rem; }
-.meta { text-align: center; }
-.meta h2 { font-size: 1.25rem; color: var(--accent); margin-bottom: 4px; }
-.meta p { font-size: 0.85rem; color: var(--text-muted); margin: 2px 0; }
 
 /* Waveform canvas */
 #waveform-canvas { width: 100%; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-surface); }


### PR DESCRIPTION
## Summary
Restructured the metadata display in the media player panel by moving filename and metadata information from a centered header section to the metadata grid below the player. This improves visual hierarchy and consistency with the overall layout design.

## Key Changes
- Removed the `.meta` header section that displayed filename and comma-separated metadata above the media player
- Moved filename display to the metadata grid as the first item with "Name" label
- Removed duplicate "Filename" entry from the metadata grid (which had different fallback text)
- Deleted associated CSS styles for `.meta`, `.meta h2`, and `.meta p` classes
- Consolidated metadata presentation into a single grid-based layout below the player

## Implementation Details
- The filename now appears in the metadata grid with consistent styling and labeling
- Metadata items (frequency, category, duration, dimensions, word count, file size) remain in the grid with conditional rendering
- The media player now has more vertical space without the header section above it
- All metadata is now presented in a uniform grid format rather than mixed header/grid layouts

https://claude.ai/code/session_01JXVripcgDV2UQxuxneJ7JU