### PR TITLE
Dynamically update media type label based on current media

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4945,6 +4945,9 @@
     if (_lastStatusData) {
       document.getElementById("stat-total-labels").textContent = _lastStatusData.total_count || 0;
       document.getElementById("stat-total-medias").textContent = "—";
+      const currentType = medias.length > 0 ? medias[0].type : null;
+      const mtInfo = currentType ? mediaTypesMap[currentType] : null;
+      document.getElementById("stat-total-medias-label").textContent = mtInfo ? `Total ${mtInfo.tab_title}` : "Total Medias";
     }
 
     document.getElementById("smart-section").style.display = "none";
@@ -4976,6 +4979,9 @@
     // Update summary stats
     document.getElementById("stat-total-labels").textContent = data.total_labels;
     document.getElementById("stat-total-medias").textContent = data.total_medias;
+    const currentType = medias.length > 0 ? medias[0].type : null;
+    const mtInfo = currentType ? mediaTypesMap[currentType] : null;
+    document.getElementById("stat-total-medias-label").textContent = mtInfo ? `Total ${mtInfo.tab_title}` : "Total Medias";
 
     const ecChart = document.getElementById("error-cost-chart");
     if (ecChart) ecChart.setAttribute("role", "img");


### PR DESCRIPTION
## Summary
Updated the statistics panel to dynamically display the appropriate media type label based on the currently viewed media, rather than using a static "Total Medias" label.

## Key Changes
- Added logic to determine the current media type from the first item in the medias array
- Look up the media type's display information from the `mediaTypesMap`
- Dynamically set the "stat-total-medias-label" text to show `Total {media_type}` (e.g., "Total Images", "Total Videos") when a specific media type is available
- Falls back to "Total Medias" when no media type information is available
- Applied this logic in two locations where statistics are updated

## Implementation Details
The change uses the existing `mediaTypesMap` to retrieve the `tab_title` property for each media type, providing a consistent and localized label that matches the media type naming convention already used elsewhere in the application.

https://claude.ai/code/session_01BCaoP7fqcTMdC1JXQyeEhP