### PR TITLE
Reorder dataset bar below search filters in left panel

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -50,9 +50,6 @@
 <div class="layout" role="presentation">
   <!-- Left panel -->
   <div class="panel-left" id="left-panel" role="region" aria-label="Media list">
-    <div class="dataset-bar" id="dataset-bar" style="display:none">
-      <span class="dataset-info" id="dataset-info">No dataset loaded</span>
-    </div>
     <div class="sort-bar" id="sort-bar">
       <span class="sort-label">Sort</span>
       <div class="sort-mode">
@@ -92,6 +89,9 @@
           <div class="sort-progress-fill"></div>
         </div>
       </div>
+    </div>
+    <div class="dataset-bar" id="dataset-bar" style="display:none">
+      <span class="dataset-info" id="dataset-info">No dataset loaded</span>
     </div>
     <div id="media-list" role="listbox" aria-label="Medias"></div>
     <div class="stripe-overview" id="stripe-overview" role="img" aria-label="Media overview showing labeled medias and current position">


### PR DESCRIPTION
## Summary
Reorganized the DOM structure of the left panel by moving the dataset bar element to appear after the search/filter controls instead of before them.

## Changes
- Moved the `dataset-bar` div from the top of the left panel (before sort controls) to below the search filter section
- This change affects the visual hierarchy and layout flow of the media list panel without modifying any functionality

## Details
The dataset bar, which displays dataset loading status, now appears lower in the left panel layout. This repositioning likely improves the UI/UX by placing primary search and filter controls at the top where users expect them, with secondary status information (dataset info) positioned below the main interaction elements.

https://claude.ai/code/session_01SwDtjLcjBb5DiLLtsWW2eG