### PR TITLE
Improve progress indicator bar layout and add label

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -139,6 +139,7 @@
   <aside class="panel-right" aria-label="Labels">
     <!-- import-file removed: label import now uses the label importer modal -->
     <div class="progress-check-bar">
+      <span class="progress-check-label">Progress</span>
       <button id="smart-indicator" class="labeling-indicator" data-status="" aria-label="Smart level: error cost flatness" title="Has the model stopped learning over time?">
         <span class="indicator-dot" aria-hidden="true"></span>
         <span class="indicator-label">Smart</span>

--- a/static/styles.css
+++ b/static/styles.css
@@ -374,7 +374,8 @@ video { max-width: 100%; }
 .dataset-bar button:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* Progress indicator buttons */
-.progress-check-bar { padding: 10px 8px; border-bottom: 1px solid var(--border); display: flex; gap: 4px; }
+.progress-check-bar { padding: 8px 16px; border-bottom: 1px solid var(--border); display: flex; gap: 4px; flex-wrap: wrap; align-items: center; }
+.progress-check-label { font-size: 0.7rem; color: var(--text-dim); width: 100%; }
 .labeling-indicator {
   flex: 1; padding: 5px 6px; border-radius: 4px; background: transparent;
   font-size: 0.7rem; cursor: pointer; transition: border-color 0.4s, opacity 0.2s;


### PR DESCRIPTION
## Summary
Enhanced the progress indicator bar styling and added a descriptive label to improve UI clarity and responsiveness.

## Key Changes
- Updated `.progress-check-bar` styling:
  - Adjusted padding from `10px 8px` to `8px 16px` for better spacing
  - Added `flex-wrap: wrap` to allow indicators to wrap on smaller screens
  - Added `align-items: center` for vertical alignment of wrapped items
- Added new `.progress-check-label` style class:
  - Displays "Progress" label with reduced font size (0.7rem)
  - Uses dimmed text color for visual hierarchy
  - Set to full width to ensure label appears on its own line
- Added `<span class="progress-check-label">Progress</span>` to the progress indicator bar in the HTML

## Implementation Details
The label is positioned as the first child of the flex container and spans the full width, causing subsequent indicator buttons to wrap below it. This creates a clear visual hierarchy while maintaining responsive behavior on smaller viewports.

https://claude.ai/code/session_014BHWaquWgkw9whQQYY6St2