### PR TITLE
Refactor inclusion slider layout for improved UX

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -74,14 +74,10 @@
         <label><input type="radio" name="select-mode" value="new"> New</label>
       </div>
       <span class="sort-label" style="margin-top:8px">Inclusion</span>
-      <div style="display:flex; align-items:center; gap:8px; margin-top:4px">
-        <span style="font-size:0.7rem; color:var(--text-muted)">-10</span>
+      <div style="display:flex; align-items:center; gap:6px; margin-top:4px">
         <label for="inclusion-slider" class="sr-only">Inclusion</label>
-        <input type="range" id="inclusion-slider" min="-10" max="10" value="0" step="1" aria-valuetext="0" style="flex:1; accent-color:var(--accent)">
-        <span style="font-size:0.7rem; color:var(--text-muted)">+10</span>
-      </div>
-      <div style="text-align:center; font-size:0.75rem; color:var(--text-secondary); margin-top:2px">
-        <span id="inclusion-value">0</span>
+        <input type="range" id="inclusion-slider" min="-10" max="10" value="0" step="1" aria-valuetext="0" style="width:80%; accent-color:var(--accent)">
+        <span id="inclusion-value" style="font-size:0.75rem; color:var(--text-secondary); min-width:1.5em; text-align:right">0</span>
       </div>
       <div id="sort-status" class="sort-status" aria-live="polite"></div>
       <div id="sort-progress" class="sort-progress" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
Redesigned the inclusion slider UI to display the current value inline with the slider control, improving space efficiency and visual clarity.

## Key Changes
- Removed the `-10` and `+10` label endpoints from the slider
- Consolidated the value display from a separate centered row into an inline element positioned to the right of the slider
- Adjusted gap spacing from `8px` to `6px` for tighter layout
- Changed slider width from `flex:1` to `width:80%` to accommodate the inline value display
- Updated value display styling to use `min-width`, `text-align:right`, and appropriate font sizing for better alignment

## Implementation Details
- The inclusion value now displays in real-time next to the slider rather than below it, reducing vertical space usage
- The slider takes up 80% of the available width with the value indicator taking the remaining space
- Maintained all accessibility features including the `aria-valuetext` attribute and screen reader label

https://claude.ai/code/session_01PZqzMJapaSdBQa7BSw1Qmm