### PR TITLE
Simplify media thumbnail label layout

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3264,11 +3264,8 @@
         } else {
           html += `<img class="media-thumbnail" src="${thumbnailUrl(c)}" alt="${escapeHtml(mediaLabel)}" loading="lazy">`;
         }
-        html += `<div class="media-thumb-info">`;
-      }
-      html += `<div style="font-weight: 500;">${escapeHtml(mediaLabel)}</div>`;
-      if (useThumbnail) {
-        html += `</div>`;
+      } else {
+        html += `<div style="font-weight: 500;">${escapeHtml(mediaLabel)}</div>`;
       }
       div.innerHTML = html;
       div.onclick = () => selectMedia(c.id);

--- a/static/styles.css
+++ b/static/styles.css
@@ -236,9 +236,8 @@ header h1 { margin-left: 48px; }
 .media-threshold-line::after { content: ''; position: absolute; right: 20px; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent; border-right: 6px solid var(--accent); }
 
 /* Thumbnail mode — media list */
-.media-item.media-item-thumb { display: flex; align-items: center; gap: 8px; padding: 4px 12px; }
+.media-item.media-item-thumb { display: flex; align-items: center; justify-content: center; padding: 4px 12px; }
 .media-item.media-item-thumb .media-thumbnail { width: 60px; height: 45px; object-fit: cover; border-radius: 3px; flex-shrink: 0; background: var(--bg-surface); }
-.media-item.media-item-thumb .media-thumb-info { min-width: 0; flex: 1; overflow: hidden; }
 /* Thumbnail mode — vote entries */
 .vote-entry.vote-entry-thumb { display: flex; align-items: center; gap: 8px; padding: 4px 0; }
 .vote-entry.vote-entry-thumb .vote-thumbnail { width: 48px; height: 36px; object-fit: cover; border-radius: 3px; flex-shrink: 0; background: var(--bg-surface); }


### PR DESCRIPTION
## Summary
Refactored the media thumbnail label rendering to simplify the HTML structure and CSS styling. The label is now rendered conditionally based on whether thumbnails are used, eliminating unnecessary wrapper divs and CSS rules.

## Key Changes
- **HTML Structure**: Removed the `.media-thumb-info` wrapper div that was only used in thumbnail mode. The media label is now rendered directly with conditional logic instead of being wrapped in an extra container.
- **CSS Cleanup**: 
  - Removed the `gap: 8px` property from `.media-item.media-item-thumb` and replaced it with `justify-content: center` for better alignment
  - Removed the `.media-item.media-item-thumb .media-thumb-info` CSS rule entirely as the wrapper div is no longer needed

## Implementation Details
The change consolidates the label rendering logic by using an `else` block to render the label only when thumbnails are not being used, rather than always rendering it and wrapping it conditionally. This reduces DOM complexity and makes the code more maintainable.

https://claude.ai/code/session_01D6qKc6M96NTNGt5WHzekKq