### PR TITLE
Add UCSF Industry Documents imagery demo dataset

### DIFF
--- a/tests/test_ucsf_documents_download.py
+++ b/tests/test_ucsf_documents_download.py
@@ -1,12 +1,9 @@
 """Tests for UCSF Industry Documents demo dataset download and load_demo_source integration."""
 
-import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
-
 from PIL import Image
 
 

--- a/tests/test_ucsf_documents_download.py
+++ b/tests/test_ucsf_documents_download.py
@@ -1,0 +1,397 @@
+"""Tests for UCSF Industry Documents demo dataset download and load_demo_source integration."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ucsf_fixture(tmp_path: Path, categories: list[str] | None = None, docs_per_cat: int = 3) -> Path:
+    """Pre-populate a ucsf_documents/ directory with tiny PDFs per category."""
+    if categories is None:
+        categories = ["Tobacco", "Food"]
+    extract_dir = tmp_path / "ucsf_documents"
+    for cat in categories:
+        cat_dir = extract_dir / cat
+        cat_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(docs_per_cat):
+            # Write minimal non-empty files (real PDFs are not needed;
+            # tests mock render_pdf_pages).
+            (cat_dir / f"doc{i:04d}.pdf").write_bytes(b"%PDF-1.0 stub")
+    return extract_dir
+
+
+def _fake_solr_response(doc_ids: list[str]) -> dict:
+    """Return a dict mimicking a Solr JSON response."""
+    return {
+        "response": {
+            "numFound": len(doc_ids),
+            "docs": [{"id": did} for did in doc_ids],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# download_ucsf_documents
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadUcsfDocuments:
+    def test_returns_extract_directory(self, tmp_path):
+        """download_ucsf_documents returns the ucsf_documents/ directory."""
+        from vtsearch.datasets import downloader as dl_module
+
+        solr_resp = _fake_solr_response(["abcd0001", "abcd0002"])
+        mock_response = MagicMock()
+        mock_response.json.return_value = solr_resp
+        mock_response.raise_for_status = MagicMock()
+
+        downloads = []
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"%PDF-1.0 stub")
+            downloads.append(dest.name)
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", fake_download),
+            patch("requests.get", return_value=mock_response),
+        ):
+            result = dl_module.download_ucsf_documents(
+                categories=["Tobacco"],
+                docs_per_category=2,
+                on_progress=lambda *a: None,
+            )
+
+        assert result.name == "ucsf_documents"
+        assert result.exists()
+        assert (result / "Tobacco").is_dir()
+        assert len(list((result / "Tobacco").glob("*.pdf"))) == 2
+
+    def test_constructs_correct_download_url(self, tmp_path):
+        """PDF download URLs follow the UCSF split-character scheme."""
+        from vtsearch.datasets import downloader as dl_module
+
+        solr_resp = _fake_solr_response(["xyzw1234"])
+        mock_response = MagicMock()
+        mock_response.json.return_value = solr_resp
+        mock_response.raise_for_status = MagicMock()
+
+        captured_urls = []
+
+        def fake_download(url, dest, size, cb):
+            captured_urls.append(url)
+            dest.write_bytes(b"%PDF-1.0 stub")
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", fake_download),
+            patch("requests.get", return_value=mock_response),
+        ):
+            dl_module.download_ucsf_documents(
+                categories=["Drug"],
+                docs_per_category=1,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(captured_urls) == 1
+        assert "/x/y/z/w/xyzw1234/xyzw1234.pdf" in captured_urls[0]
+
+    def test_cached_pdfs_skip_download(self, tmp_path):
+        """If category directories already contain PDFs, no download occurs."""
+        from vtsearch.datasets import downloader as dl_module
+
+        _make_ucsf_fixture(tmp_path, ["Tobacco", "Food"], docs_per_cat=3)
+
+        download_called = []
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = dl_module.download_ucsf_documents(
+                categories=["Tobacco", "Food"],
+                on_progress=lambda *a: None,
+            )
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert result.exists()
+
+    def test_quotes_multi_word_industry(self, tmp_path):
+        """Multi-word industry names are quoted in the Solr query."""
+        from vtsearch.datasets import downloader as dl_module
+
+        solr_resp = _fake_solr_response(["ffff0001"])
+        mock_response = MagicMock()
+        mock_response.json.return_value = solr_resp
+        mock_response.raise_for_status = MagicMock()
+
+        captured_params = []
+
+        def fake_get(url, params=None, timeout=None):
+            captured_params.append(params)
+            return mock_response
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"%PDF-1.0 stub")
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", fake_download),
+            patch("requests.get", fake_get),
+        ):
+            dl_module.download_ucsf_documents(
+                categories=["Fossil Fuel"],
+                docs_per_category=1,
+                on_progress=lambda *a: None,
+            )
+
+        assert captured_params
+        query = captured_params[0]["q"]
+        assert '"Fossil Fuel"' in query
+
+    def test_skips_short_document_ids(self, tmp_path):
+        """Document IDs shorter than 4 characters are skipped."""
+        from vtsearch.datasets import downloader as dl_module
+
+        solr_resp = _fake_solr_response(["ab", "abcd0001"])
+        mock_response = MagicMock()
+        mock_response.json.return_value = solr_resp
+        mock_response.raise_for_status = MagicMock()
+
+        downloads = []
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"%PDF-1.0 stub")
+            downloads.append(dest.name)
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch.object(dl_module, "download_file_with_progress", fake_download),
+            patch("requests.get", return_value=mock_response),
+        ):
+            dl_module.download_ucsf_documents(
+                categories=["Tobacco"],
+                docs_per_category=5,
+                on_progress=lambda *a: None,
+            )
+
+        # Only the valid 4+ char ID should be downloaded.
+        assert len(downloads) == 1
+        assert "abcd0001.pdf" in downloads
+
+    def test_handles_api_failure_gracefully(self, tmp_path):
+        """If the Solr API request fails, the category is skipped."""
+        from vtsearch.datasets import downloader as dl_module
+
+        def fail_get(*a, **kw):
+            raise ConnectionError("network down")
+
+        with (
+            patch.object(dl_module, "DATA_DIR", tmp_path),
+            patch("requests.get", fail_get),
+        ):
+            result = dl_module.download_ucsf_documents(
+                categories=["Tobacco"],
+                docs_per_category=5,
+                on_progress=lambda *a: None,
+            )
+
+        # Should still return the directory (possibly empty).
+        assert result.name == "ucsf_documents"
+
+
+# ---------------------------------------------------------------------------
+# load_demo_source — ucsf_documents branch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDemoSourceUcsfDocuments:
+    """ImageMediaType.load_demo_source with source='ucsf_documents'."""
+
+    def _make_image_media_type(self):
+        from vtsearch.media.image.media_type import ImageMediaType
+
+        mt = ImageMediaType()
+        mt._model = MagicMock()
+        mt._processor = MagicMock()
+        return mt
+
+    def _fake_render(self, page_count: int = 1, width: int = 100, height: int = 80):
+        """Return a render_pdf_pages replacement that yields tiny PIL images."""
+
+        def render(pdf_path, dpi=150):
+            pages = []
+            for i in range(page_count):
+                img = Image.new("RGB", (width, height), color=(200, 200, 200))
+                page_name = f"{pdf_path.name}-{i + 1}"
+                pages.append((page_name, img))
+            return pages
+
+        return render
+
+    def test_ucsf_documents_populates_clips(self, tmp_path):
+        """load_demo_source with source='ucsf_documents' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import pdf as pdf_module
+
+        docs_dir = _make_ucsf_fixture(tmp_path, ["Tobacco", "Food"], docs_per_cat=2)
+
+        mt = self._make_image_media_type()
+        mt.embed_pil_image = MagicMock(return_value=np.zeros(768))
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_ucsf_documents", return_value=docs_dir),
+            patch.object(pdf_module, "render_pdf_pages", self._fake_render()),
+        ):
+            mt.load_demo_source(
+                source="ucsf_documents",
+                categories=["Tobacco", "Food"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(clips) == 4  # 2 docs × 2 categories
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"Tobacco", "Food"}
+
+    def test_clips_have_expected_fields(self, tmp_path):
+        """Each clip dict contains all required image media fields."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import pdf as pdf_module
+
+        docs_dir = _make_ucsf_fixture(tmp_path, ["Drug"], docs_per_cat=1)
+
+        mt = self._make_image_media_type()
+        mt.embed_pil_image = MagicMock(return_value=np.zeros(768))
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_ucsf_documents", return_value=docs_dir),
+            patch.object(pdf_module, "render_pdf_pages", self._fake_render()),
+        ):
+            mt.load_demo_source(
+                source="ucsf_documents",
+                categories=["Drug"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(clips) == 1
+        clip = clips[1]
+        assert clip["type"] == "image"
+        assert clip["category"] == "Drug"
+        assert clip["media_bytes"] is not None
+        assert clip["width"] == 100
+        assert clip["height"] == 80
+        assert clip["filename"].endswith(".png")
+        assert clip["origin"] == {"importer": "demo", "params": {}}
+
+    def test_slice_is_applied(self, tmp_path):
+        """slice_start/slice_end limits pages per category."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import pdf as pdf_module
+
+        docs_dir = _make_ucsf_fixture(tmp_path, ["Tobacco"], docs_per_cat=10)
+
+        mt = self._make_image_media_type()
+        mt.embed_pil_image = MagicMock(return_value=np.zeros(768))
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_ucsf_documents", return_value=docs_dir),
+            patch.object(pdf_module, "render_pdf_pages", self._fake_render()),
+        ):
+            mt.load_demo_source(
+                source="ucsf_documents",
+                categories=["Tobacco"],
+                slice_start=2,
+                slice_end=5,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        # Only docs[2:5] = 3 pages.
+        assert len(clips) == 3
+
+    def test_uses_first_page_only(self, tmp_path):
+        """Only the first page of multi-page PDFs is used."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import pdf as pdf_module
+
+        docs_dir = _make_ucsf_fixture(tmp_path, ["Chemical"], docs_per_cat=2)
+
+        mt = self._make_image_media_type()
+        mt.embed_pil_image = MagicMock(return_value=np.zeros(768))
+        clips: dict = {}
+
+        # Each PDF has 5 pages, but only page 1 should be used per doc.
+        with (
+            patch.object(dl_module, "download_ucsf_documents", return_value=docs_dir),
+            patch.object(pdf_module, "render_pdf_pages", self._fake_render(page_count=5)),
+        ):
+            mt.load_demo_source(
+                source="ucsf_documents",
+                categories=["Chemical"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        # 2 docs × 1 page each = 2 clips.
+        assert len(clips) == 2
+
+    def test_skips_failed_pdf_renders(self, tmp_path):
+        """PDFs that fail to render are silently skipped."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import pdf as pdf_module
+
+        docs_dir = _make_ucsf_fixture(tmp_path, ["Opioids"], docs_per_cat=3)
+
+        mt = self._make_image_media_type()
+        mt.embed_pil_image = MagicMock(return_value=np.zeros(768))
+        clips: dict = {}
+
+        call_count = [0]
+
+        def flaky_render(pdf_path, dpi=150):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise RuntimeError("corrupt PDF")
+            img = Image.new("RGB", (100, 80), color=(200, 200, 200))
+            return [(f"{pdf_path.name}-1", img)]
+
+        with (
+            patch.object(dl_module, "download_ucsf_documents", return_value=docs_dir),
+            patch.object(pdf_module, "render_pdf_pages", flaky_render),
+        ):
+            mt.load_demo_source(
+                source="ucsf_documents",
+                categories=["Opioids"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+            )
+
+        # 3 docs, 1 fails → 2 clips.
+        assert len(clips) == 2

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -36,6 +36,8 @@ OXFORD_FLOWERS_LABELS_URL = "https://www.robots.ox.ac.uk/~vgg/data/flowers/102/i
 FOOD101_URL = "http://data.vision.ee.ethz.ch/cvl/food-101.tar.gz"
 EUROSAT_URL = "https://huggingface.co/datasets/blanchon/EuroSAT_RGB/resolve/main/EuroSAT_RGB.zip"
 STANFORD_DOGS_URL = "http://vision.stanford.edu/aditya86/ImageNetDogDataset/images.tar"
+UCSF_IDL_API_URL = "https://metadata.idl.ucsf.edu/solr/ltdl3/query"
+UCSF_IDL_DOWNLOAD_URL = "https://download.industrydocuments.ucsf.edu"
 
 # Dataset size estimates
 ESC50_DOWNLOAD_SIZE_MB = 600
@@ -54,6 +56,7 @@ OXFORD_FLOWERS_DOWNLOAD_SIZE_MB = 330
 FOOD101_DOWNLOAD_SIZE_MB = 5000
 EUROSAT_DOWNLOAD_SIZE_MB = 90
 STANFORD_DOGS_DOWNLOAD_SIZE_MB = 750
+UCSF_IDL_DOWNLOAD_SIZE_MB = 50
 MEDIAS_PER_CATEGORY = 40
 MEDIAS_PER_VIDEO_CATEGORY = 150
 IMAGES_PER_CIFAR10_CATEGORY = 100

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -46,6 +46,8 @@ from vtsearch.config import (
     STANFORD_DOGS_URL,
     UCF101_SUBSET_DOWNLOAD_SIZE_MB,
     UCF101_SUBSET_URL,
+    UCSF_IDL_API_URL,
+    UCSF_IDL_DOWNLOAD_URL,
     URBANSOUND8K_DOWNLOAD_SIZE_MB,
     URBANSOUND8K_URL,
     VIDEO_DIR,
@@ -982,6 +984,117 @@ def download_imdb(
             categories_reviews[sentiment] = reviews
 
     return categories_reviews
+
+
+def download_ucsf_documents(
+    categories: list[str],
+    docs_per_category: int = 25,
+    on_progress: Optional[ProgressCallback] = None,
+) -> Path:
+    """Download UCSF Industry Documents Library PDFs by industry category.
+
+    Queries the UCSF Industry Documents Library Solr API for short documents
+    (1–3 pages) within each *category* (industry name), downloads individual
+    PDFs, and organises them into category subdirectories under
+    ``DATA_DIR / "ucsf_documents"``.
+
+    Each PDF can later be rendered to page images with
+    :func:`~vtsearch.datasets.pdf.render_pdf_pages` for use as an image demo
+    dataset.
+
+    Args:
+        categories: Industry names recognised by the UCSF IDL Solr index
+            (e.g. ``["Tobacco", "Food", "Drug"]``).
+        docs_per_category: Maximum number of PDFs to download per category.
+        on_progress: Optional progress callback.  Falls back to the
+            application-wide ``update_progress`` when ``None``.
+
+    Returns:
+        Path to the ``ucsf_documents/`` directory containing category
+        subdirectories with ``.pdf`` files (e.g. ``data/ucsf_documents``).
+    """
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    extract_dir = DATA_DIR / "ucsf_documents"
+    DATA_DIR.mkdir(exist_ok=True)
+
+    # Fast-path: if every category already has PDFs, skip the download.
+    all_present = True
+    for cat in categories:
+        cat_dir = extract_dir / cat
+        if not cat_dir.exists() or not any(cat_dir.glob("*.pdf")):
+            all_present = False
+            break
+
+    if all_present:
+        return extract_dir
+
+    extract_dir.mkdir(parents=True, exist_ok=True)
+
+    total_docs = len(categories) * docs_per_category
+    downloaded = 0
+
+    for cat in categories:
+        cat_dir = extract_dir / cat
+        cat_dir.mkdir(exist_ok=True)
+
+        # Skip if this category already has enough PDFs.
+        existing_pdfs = list(cat_dir.glob("*.pdf"))
+        if len(existing_pdfs) >= docs_per_category:
+            downloaded += docs_per_category
+            continue
+
+        # Query the Solr API for short document IDs in this industry.
+        on_progress("downloading", f"Querying UCSF API for {cat} documents...", downloaded, total_docs)
+
+        # Quote multi-word industry names for the Solr query.
+        solr_cat = f'"{cat}"' if " " in cat else cat
+        params = {
+            "q": f"industry:{solr_cat} AND pages:[1 TO 3]",
+            "rows": str(docs_per_category),
+            "wt": "json",
+            "fl": "id",
+            "sort": "id asc",
+        }
+
+        try:
+            resp = requests.get(UCSF_IDL_API_URL, params=params, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            docs = data.get("response", {}).get("docs", [])
+        except Exception:
+            docs = []
+
+        # Download each PDF using the UCSF split-character URL scheme.
+        for doc in docs:
+            doc_id = doc.get("id", "")
+            if not doc_id or len(doc_id) < 4:
+                continue
+
+            pdf_path = cat_dir / f"{doc_id}.pdf"
+            if pdf_path.exists():
+                downloaded += 1
+                on_progress("downloading", f"Cached {doc_id}.pdf ({downloaded}/{total_docs})", downloaded, total_docs)
+                continue
+
+            url = (
+                f"{UCSF_IDL_DOWNLOAD_URL}/"
+                f"{doc_id[0]}/{doc_id[1]}/{doc_id[2]}/{doc_id[3]}/"
+                f"{doc_id}/{doc_id}.pdf"
+            )
+
+            try:
+                download_file_with_progress(url, pdf_path, 0, on_progress)
+                downloaded += 1
+                on_progress(
+                    "downloading", f"Downloaded {doc_id}.pdf ({downloaded}/{total_docs})", downloaded, total_docs
+                )
+            except Exception:
+                # Skip failed downloads silently.
+                pdf_path.unlink(missing_ok=True)
+
+    return extract_dir
 
 
 def _find_bbc_root(directory: Path) -> Optional[Path]:

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -13,6 +13,7 @@ from vtsearch.config import (
     CIFAR10_DOWNLOAD_SIZE_MB,
     CLIP_MODEL_ID,
     MODELS_CACHE_DIR,
+    UCSF_IDL_DOWNLOAD_SIZE_MB,
 )
 
 if TYPE_CHECKING:
@@ -533,6 +534,16 @@ class ImageMediaType(MediaType):
         "African_hunting_dog",
     ]
 
+    # Categories for UCSF Industry Documents (6 industry types).
+    _UCSF_DOCUMENTS_CATEGORIES = [
+        "Tobacco",
+        "Food",
+        "Drug",
+        "Chemical",
+        "Fossil Fuel",
+        "Opioids",
+    ]
+
     @property
     def demo_datasets(self) -> list:
         cats101 = self._DEMO_CATEGORIES_CALTECH101
@@ -607,6 +618,16 @@ class ImageMediaType(MediaType):
                 slice_start=0,
                 slice_end=171,
                 download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="ucsf_documents_a",
+                label="UCSF Documents (A)",
+                description="Scanned industry document pages from the UCSF Industry Documents Library.",
+                categories=self._UCSF_DOCUMENTS_CATEGORIES,
+                source="ucsf_documents",
+                slice_start=0,
+                slice_end=25,
+                download_size_mb=UCSF_IDL_DOWNLOAD_SIZE_MB,
             ),
         ]
 
@@ -865,6 +886,66 @@ class ImageMediaType(MediaType):
                     "height": height,
                     "origin": demo_origin,
                     "origin_name": img_path.name,
+                }
+                clip_id += 1
+            return None  # bytes are inline
+
+        elif source == "ucsf_documents":
+            from vtsearch.datasets.downloader import download_ucsf_documents  # noqa: PLC0415
+            from vtsearch.datasets.pdf import render_pdf_pages  # noqa: PLC0415
+
+            docs_dir = download_ucsf_documents(categories, on_progress=on_progress)
+
+            # Render the first page of each PDF, grouped by category.
+            by_cat: dict[str, list[tuple[str, "Image.Image"]]] = {}
+            for cat in categories:
+                cat_dir = docs_dir / cat
+                if not cat_dir.is_dir():
+                    continue
+                for pdf_path in sorted(cat_dir.glob("*.pdf")):
+                    try:
+                        pages = render_pdf_pages(pdf_path, dpi=150)
+                        if pages:
+                            by_cat.setdefault(cat, []).append(pages[0])
+                    except Exception:
+                        continue
+
+            selected: list[tuple[str, "Image.Image", str]] = []
+            for cat in categories:
+                for page_name, pil_image in by_cat.get(cat, [])[slice_start:slice_end]:
+                    selected.append((page_name, pil_image, cat))
+
+            if getattr(self, "_model", None) is None:
+                on_progress("loading", "Loading image embedding model…", 0, 0)
+                self.load_models()
+
+            clip_id = 1
+            total = len(selected)
+            on_progress("embedding", f"Starting embedding for {total} document pages...", 0, total)
+
+            for i, (page_name, pil_image, category) in enumerate(selected):
+                on_progress("embedding", f"Embedding {page_name} ({i + 1}/{total})", i + 1, total)
+                embedding = self.embed_pil_image(pil_image)
+                if embedding is None:
+                    continue
+                img_buffer = _io.BytesIO()
+                pil_image.save(img_buffer, format="PNG")
+                image_bytes = img_buffer.getvalue()
+                clips[clip_id] = {
+                    "id": clip_id,
+                    "type": self.type_id,
+                    "duration": 0,
+                    "file_size": len(image_bytes),
+                    "md5": hashlib.md5(image_bytes).hexdigest(),
+                    "embedding": embedding,
+                    "media_bytes": image_bytes,
+                    "media_string": None,
+                    "filename": f"{page_name}.png",
+                    "category": category,
+                    "width": pil_image.width,
+                    "height": pil_image.height,
+                    "origin": demo_origin,
+                    "origin_name": page_name,
                 }
                 clip_id += 1
             return None  # bytes are inline


### PR DESCRIPTION
Adds a new image demo dataset that downloads PDFs from the UCSF Industry
Documents Library (by industry category), converts them to page images via
render_pdf_pages(), and embeds with CLIP.

- config.py: UCSF_IDL_API_URL, UCSF_IDL_DOWNLOAD_URL, UCSF_IDL_DOWNLOAD_SIZE_MB
- downloader.py: download_ucsf_documents() queries Solr API, downloads PDFs
- image/media_type.py: ucsf_documents demo dataset + load_demo_source handler
- tests/test_ucsf_documents_download.py: download + load_demo_source tests

https://claude.ai/code/session_01H53H3jshxgj5NyBNszAzmy