### PR TITLE
Fix inclusion bar layout: remove range labels, show value beside slider

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3264,11 +3264,8 @@
         } else {
           html += `<img class="media-thumbnail" src="${thumbnailUrl(c)}" alt="${escapeHtml(mediaLabel)}" loading="lazy">`;
         }
-        html += `<div class="media-thumb-info">`;
-      }
-      html += `<div style="font-weight: 500;">${escapeHtml(mediaLabel)}</div>`;
-      if (useThumbnail) {
-        html += `</div>`;
+      } else {
+        html += `<div style="font-weight: 500;">${escapeHtml(mediaLabel)}</div>`;
       }
       div.innerHTML = html;
       div.onclick = () => selectMedia(c.id);

--- a/static/index.html
+++ b/static/index.html
@@ -74,14 +74,10 @@
         <label><input type="radio" name="select-mode" value="new"> New</label>
       </div>
       <span class="sort-label" style="margin-top:8px">Inclusion</span>
-      <div style="display:flex; align-items:center; gap:8px; margin-top:4px">
-        <span style="font-size:0.7rem; color:var(--text-muted)">-10</span>
+      <div style="display:flex; align-items:center; gap:6px; margin-top:4px">
         <label for="inclusion-slider" class="sr-only">Inclusion</label>
-        <input type="range" id="inclusion-slider" min="-10" max="10" value="0" step="1" aria-valuetext="0" style="flex:1; accent-color:var(--accent)">
-        <span style="font-size:0.7rem; color:var(--text-muted)">+10</span>
-      </div>
-      <div style="text-align:center; font-size:0.75rem; color:var(--text-secondary); margin-top:2px">
-        <span id="inclusion-value">0</span>
+        <input type="range" id="inclusion-slider" min="-10" max="10" value="0" step="1" aria-valuetext="0" style="width:80%; accent-color:var(--accent)">
+        <span id="inclusion-value" style="font-size:0.75rem; color:var(--text-secondary); min-width:1.5em; text-align:right">0</span>
       </div>
       <div id="sort-status" class="sort-status" aria-live="polite"></div>
       <div id="sort-progress" class="sort-progress" role="status" aria-live="polite">

--- a/static/styles.css
+++ b/static/styles.css
@@ -236,9 +236,8 @@ header h1 { margin-left: 48px; }
 .media-threshold-line::after { content: ''; position: absolute; right: 20px; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent; border-right: 6px solid var(--accent); }
 
 /* Thumbnail mode — media list */
-.media-item.media-item-thumb { display: flex; align-items: center; gap: 8px; padding: 4px 12px; }
+.media-item.media-item-thumb { display: flex; align-items: center; justify-content: center; padding: 4px 12px; }
 .media-item.media-item-thumb .media-thumbnail { width: 60px; height: 45px; object-fit: cover; border-radius: 3px; flex-shrink: 0; background: var(--bg-surface); }
-.media-item.media-item-thumb .media-thumb-info { min-width: 0; flex: 1; overflow: hidden; }
 /* Thumbnail mode — vote entries */
 .vote-entry.vote-entry-thumb { display: flex; align-items: center; gap: 8px; padding: 4px 0; }
 .vote-entry.vote-entry-thumb .vote-thumbnail { width: 48px; height: 36px; object-fit: cover; border-radius: 3px; flex-shrink: 0; background: var(--bg-surface); }

--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -1,0 +1,429 @@
+"""Tests for the MediaClipper base class and all built-in clippers."""
+
+import io
+import wave
+
+import pytest
+
+from vtsearch.audio import generate_wav
+from vtsearch.media.base import MediaClipper
+
+
+# ---------------------------------------------------------------------------
+# MediaClipper ABC
+# ---------------------------------------------------------------------------
+
+
+class TestMediaClipperABC:
+    def test_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            MediaClipper()
+
+    def test_to_dict_on_concrete(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        d = c.to_dict()
+        assert d == {"name": "sound_default", "media_type": "audio"}
+
+
+# ---------------------------------------------------------------------------
+# SoundDefaultClipper
+# ---------------------------------------------------------------------------
+
+
+class TestSoundDefaultClipper:
+    def test_returns_media_unchanged(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        media = {"id": 1, "type": "audio", "media_bytes": b"fake", "duration": 3.0}
+        result = SoundDefaultClipper().clip(media)
+        assert result == [media]
+
+    def test_identity(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        assert c.name == "sound_default"
+        assert c.media_type == "audio"
+        assert isinstance(c, MediaClipper)
+
+
+# ---------------------------------------------------------------------------
+# SoundTilingClipper
+# ---------------------------------------------------------------------------
+
+
+class TestSoundTilingClipper:
+    def test_identity(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        assert c.name == "sound_tiling_2.0s"
+        assert c.media_type == "audio"
+        assert c.duration == 2.0
+        assert isinstance(c, MediaClipper)
+
+    def test_rejects_non_positive_duration(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        with pytest.raises(ValueError):
+            SoundTilingClipper(0)
+        with pytest.raises(ValueError):
+            SoundTilingClipper(-1)
+
+    def test_short_audio_returned_unchanged(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        wav = generate_wav(440, 1.5)
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.5}
+        result = SoundTilingClipper(2.0).clip(media)
+        assert len(result) == 1
+        assert result[0] is media
+
+    def test_tiles_longer_audio(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        wav = generate_wav(440, 5.0)
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 5.0}
+        result = SoundTilingClipper(2.0).clip(media)
+        # 5.0 / 2.0 = 2.5 → ceil → 3 tiles
+        assert len(result) == 3
+        for idx, tile in enumerate(result):
+            assert tile["clip_index"] == idx
+            assert "clip_start" in tile
+            assert "clip_end" in tile
+            assert tile["duration"] == pytest.approx(2.0, abs=0.01)
+            # Each tile should be valid WAV bytes
+            with wave.open(io.BytesIO(tile["media_bytes"]), "rb") as wf:
+                assert wf.getframerate() == 48000
+
+    def test_9_5s_produces_five_2s_tiles(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        wav = generate_wav(440, 9.5)
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 9.5}
+        result = SoundTilingClipper(2.0).clip(media)
+        # 9.5 / 2.0 = 4.75 → round → 5 tiles
+        assert len(result) == 5
+        # First tile starts at 0
+        assert result[0]["clip_start"] == pytest.approx(0.0)
+        # Last tile ends at 9.5
+        assert result[-1]["clip_end"] == pytest.approx(9.5, abs=0.01)
+
+    def test_no_media_bytes_returns_unchanged(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        media = {"id": 1, "type": "audio", "duration": 10.0}
+        result = SoundTilingClipper(2.0).clip(media)
+        assert result == [media]
+
+    def test_to_dict_includes_duration(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(3.5)
+        d = c.to_dict()
+        assert d["name"] == "sound_tiling_3.5s"
+        assert d["media_type"] == "audio"
+        assert d["duration"] == 3.5
+
+
+# ---------------------------------------------------------------------------
+# VideoDefaultClipper
+# ---------------------------------------------------------------------------
+
+
+class TestVideoDefaultClipper:
+    def test_returns_media_unchanged(self):
+        from vtsearch.media.video.clipper import VideoDefaultClipper
+
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        result = VideoDefaultClipper().clip(media)
+        assert result == [media]
+
+    def test_identity(self):
+        from vtsearch.media.video.clipper import VideoDefaultClipper
+
+        c = VideoDefaultClipper()
+        assert c.name == "video_default"
+        assert c.media_type == "video"
+        assert isinstance(c, MediaClipper)
+
+
+# ---------------------------------------------------------------------------
+# VideoTilingClipper
+# ---------------------------------------------------------------------------
+
+
+class TestVideoTilingClipper:
+    def test_identity(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        c = VideoTilingClipper(2.0)
+        assert c.name == "video_tiling_2.0s"
+        assert c.media_type == "video"
+        assert c.duration == 2.0
+        assert isinstance(c, MediaClipper)
+
+    def test_rejects_non_positive_duration(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        with pytest.raises(ValueError):
+            VideoTilingClipper(0)
+        with pytest.raises(ValueError):
+            VideoTilingClipper(-1)
+
+    def test_short_video_returned_unchanged(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 1.5}
+        result = VideoTilingClipper(2.0).clip(media)
+        assert len(result) == 1
+        assert result[0] is media
+
+    def test_9_5s_produces_five_2s_tiles(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 9.5}
+        result = VideoTilingClipper(2.0).clip(media)
+        assert len(result) == 5
+        assert result[0]["clip_start"] == pytest.approx(0.0)
+        assert result[-1]["clip_end"] == pytest.approx(9.5, abs=0.01)
+        for idx, tile in enumerate(result):
+            assert tile["clip_index"] == idx
+            assert tile["duration"] == pytest.approx(2.0)
+
+    def test_exact_multiple_duration(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        result = VideoTilingClipper(2.0).clip(media)
+        assert len(result) == 5
+        # No overlap when duration is exact multiple
+        assert result[0]["clip_start"] == pytest.approx(0.0)
+        assert result[-1]["clip_end"] == pytest.approx(10.0)
+
+    def test_to_dict_includes_duration(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        c = VideoTilingClipper(3.5)
+        d = c.to_dict()
+        assert d["name"] == "video_tiling_3.5s"
+        assert d["media_type"] == "video"
+        assert d["duration"] == 3.5
+
+    def test_zero_duration_video_returned_unchanged(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 0}
+        result = VideoTilingClipper(2.0).clip(media)
+        assert result == [media]
+
+
+# ---------------------------------------------------------------------------
+# ImageDefaultClipper
+# ---------------------------------------------------------------------------
+
+
+class TestImageDefaultClipper:
+    def test_returns_media_unchanged(self):
+        from vtsearch.media.image.clipper import ImageDefaultClipper
+
+        media = {"id": 1, "type": "image", "media_bytes": b"fake", "width": 100, "height": 100}
+        result = ImageDefaultClipper().clip(media)
+        assert result == [media]
+
+    def test_identity(self):
+        from vtsearch.media.image.clipper import ImageDefaultClipper
+
+        c = ImageDefaultClipper()
+        assert c.name == "image_default"
+        assert c.media_type == "image"
+        assert isinstance(c, MediaClipper)
+
+
+# ---------------------------------------------------------------------------
+# ImageTilingClipper
+# ---------------------------------------------------------------------------
+
+
+def _make_image_bytes(width, height, fmt="PNG"):
+    """Helper to create a simple solid-colour image as bytes."""
+    from PIL import Image
+
+    img = Image.new("RGB", (width, height), color=(128, 64, 32))
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestImageTilingClipper:
+    def test_identity(self):
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        c = ImageTilingClipper()
+        assert c.name == "image_tiling"
+        assert c.media_type == "image"
+        assert isinstance(c, MediaClipper)
+
+    def test_square_image_returned_unchanged(self):
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        img_bytes = _make_image_bytes(100, 100)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 100, "height": 100}
+        result = ImageTilingClipper().clip(media)
+        assert len(result) == 1
+        assert result[0] is media
+
+    def test_portrait_image_tiled_vertically(self):
+        from PIL import Image
+
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        # 100 x 250 image → tile_size = 100, ceil(250/100) = 3 tiles
+        img_bytes = _make_image_bytes(100, 250)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 100, "height": 250}
+        result = ImageTilingClipper().clip(media)
+        assert len(result) == 3
+        for tile in result:
+            assert tile["width"] == 100
+            assert tile["height"] == 100
+            img = Image.open(io.BytesIO(tile["media_bytes"]))
+            assert img.size == (100, 100)
+            assert "clip_index" in tile
+            assert "clip_box" in tile
+
+    def test_landscape_image_tiled_horizontally(self):
+        from PIL import Image
+
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        # 300 x 100 image → tile_size = 100, 300/100 = 3 → 3 tiles
+        img_bytes = _make_image_bytes(300, 100)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 300, "height": 100}
+        result = ImageTilingClipper().clip(media)
+        assert len(result) == 3
+        for tile in result:
+            assert tile["width"] == 100
+            assert tile["height"] == 100
+            img = Image.open(io.BytesIO(tile["media_bytes"]))
+            assert img.size == (100, 100)
+
+    def test_8_5_by_11_produces_two_tiles(self):
+        """An 8.5x11 (scaled to 85x110) yields two 85x85 tiles."""
+        from PIL import Image
+
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        # 85 x 110 portrait: tile_size = 85, ceil(110/85) = 2 tiles
+        img_bytes = _make_image_bytes(85, 110)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 85, "height": 110}
+        result = ImageTilingClipper().clip(media)
+        assert len(result) == 2
+        # First tile at top, second at bottom
+        assert result[0]["clip_box"][1] == 0  # y=0
+        assert result[1]["clip_box"][3] == 110  # y2 = height
+        for tile in result:
+            assert tile["width"] == 85
+            assert tile["height"] == 85
+            img = Image.open(io.BytesIO(tile["media_bytes"]))
+            assert img.size == (85, 85)
+
+    def test_no_media_bytes_returns_unchanged(self):
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        media = {"id": 1, "type": "image", "width": 100, "height": 200}
+        result = ImageTilingClipper().clip(media)
+        assert result == [media]
+
+    def test_missing_dimensions_returns_unchanged(self):
+        from vtsearch.media.image.clipper import ImageTilingClipper
+
+        media = {"id": 1, "type": "image", "media_bytes": b"fake"}
+        result = ImageTilingClipper().clip(media)
+        assert result == [media]
+
+
+# ---------------------------------------------------------------------------
+# TextDefaultClipper
+# ---------------------------------------------------------------------------
+
+
+class TestTextDefaultClipper:
+    def test_returns_media_unchanged(self):
+        from vtsearch.media.text.clipper import TextDefaultClipper
+
+        media = {"id": 1, "type": "paragraph", "media_string": "Hello world."}
+        result = TextDefaultClipper().clip(media)
+        assert result == [media]
+
+    def test_identity(self):
+        from vtsearch.media.text.clipper import TextDefaultClipper
+
+        c = TextDefaultClipper()
+        assert c.name == "text_default"
+        assert c.media_type == "paragraph"
+        assert isinstance(c, MediaClipper)
+
+
+# ---------------------------------------------------------------------------
+# TextSentenceClipper
+# ---------------------------------------------------------------------------
+
+
+class TestTextSentenceClipper:
+    def test_identity(self):
+        from vtsearch.media.text.clipper import TextSentenceClipper
+
+        c = TextSentenceClipper()
+        assert c.name == "text_sentence"
+        assert c.media_type == "paragraph"
+        assert isinstance(c, MediaClipper)
+
+    def test_single_sentence_unchanged(self):
+        from vtsearch.media.text.clipper import TextSentenceClipper
+
+        media = {"id": 1, "type": "paragraph", "media_string": "Hello world."}
+        result = TextSentenceClipper().clip(media)
+        assert len(result) == 1
+        assert result[0] is media
+
+    def test_splits_multiple_sentences(self):
+        from vtsearch.media.text.clipper import TextSentenceClipper
+
+        text = "First sentence. Second sentence. Third one!"
+        media = {"id": 1, "type": "paragraph", "media_string": text, "word_count": 7, "character_count": len(text)}
+        result = TextSentenceClipper().clip(media)
+        assert len(result) == 3
+        assert result[0]["media_string"] == "First sentence."
+        assert result[1]["media_string"] == "Second sentence."
+        assert result[2]["media_string"] == "Third one!"
+        for idx, tile in enumerate(result):
+            assert tile["clip_index"] == idx
+            assert tile["word_count"] == len(tile["media_string"].split())
+            assert tile["character_count"] == len(tile["media_string"])
+
+    def test_question_and_exclamation(self):
+        from vtsearch.media.text.clipper import TextSentenceClipper
+
+        text = "Is this a test? Yes it is! Great."
+        media = {"id": 1, "type": "paragraph", "media_string": text}
+        result = TextSentenceClipper().clip(media)
+        assert len(result) == 3
+        assert result[0]["media_string"] == "Is this a test?"
+        assert result[1]["media_string"] == "Yes it is!"
+        assert result[2]["media_string"] == "Great."
+
+    def test_empty_string_returns_unchanged(self):
+        from vtsearch.media.text.clipper import TextSentenceClipper
+
+        media = {"id": 1, "type": "paragraph", "media_string": ""}
+        result = TextSentenceClipper().clip(media)
+        assert result == [media]
+
+    def test_no_media_string_returns_unchanged(self):
+        from vtsearch.media.text.clipper import TextSentenceClipper
+
+        media = {"id": 1, "type": "paragraph"}
+        result = TextSentenceClipper().clip(media)
+        assert result == [media]

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -20,6 +20,7 @@ from vtsearch.media.base import (
     Detector,
     Extractor,
     Localizer,
+    MediaClipper,
     MediaResponse,
     MediaType,
     Processor,
@@ -144,6 +145,7 @@ def set_progress_callback(callback: "ProgressCallback") -> None:
 
 __all__ = [
     "MediaType",
+    "MediaClipper",
     "MediaResponse",
     "DemoDataset",
     "Processor",

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -1,0 +1,125 @@
+"""Audio clippers — tile or pass-through audio media."""
+
+from __future__ import annotations
+
+import io
+import math
+import wave
+from typing import Any
+
+from vtsearch.media.base import MediaClipper
+
+
+def _wav_duration(wav_bytes: bytes) -> float:
+    """Return the duration in seconds of a WAV byte string."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        return wf.getnframes() / wf.getframerate()
+
+
+def _wav_slice(wav_bytes: bytes, start: float, end: float) -> bytes:
+    """Extract a [start, end) slice from a WAV byte string.
+
+    Returns a new WAV byte string containing only the requested segment.
+    """
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        sr = wf.getframerate()
+        n_channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        start_frame = int(start * sr)
+        end_frame = int(end * sr)
+        total_frames = wf.getnframes()
+        start_frame = max(0, min(start_frame, total_frames))
+        end_frame = max(start_frame, min(end_frame, total_frames))
+        wf.setpos(start_frame)
+        frames = wf.readframes(end_frame - start_frame)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as out:
+        out.setnchannels(n_channels)
+        out.setsampwidth(sampwidth)
+        out.setframerate(sr)
+        out.writeframes(frames)
+    return buf.getvalue()
+
+
+class SoundDefaultClipper(MediaClipper):
+    """Returns the audio media unchanged."""
+
+    @property
+    def name(self) -> str:
+        return "sound_default"
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        return [media]
+
+
+class SoundTilingClipper(MediaClipper):
+    """Tile audio into equally-spaced segments of a given duration.
+
+    ``SoundTilingClipper(2)`` tiles a 9.5 s clip into five 2 s segments
+    whose start times are equally spaced so the first starts at 0 and the
+    last ends at 9.5 s (with a little overlap between neighbours when the
+    total duration is not an exact multiple of the segment size).
+
+    If the audio is shorter than or equal to *duration*, a single segment
+    covering the full audio is returned.
+    """
+
+    def __init__(self, duration: float) -> None:
+        if duration <= 0:
+            raise ValueError("duration must be positive")
+        self._duration = duration
+
+    @property
+    def name(self) -> str:
+        return f"sound_tiling_{self._duration}s"
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    @property
+    def duration(self) -> float:
+        return self._duration
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        wav_bytes = media.get("media_bytes")
+        if wav_bytes is None:
+            return [media]
+
+        total = _wav_duration(wav_bytes)
+        seg = self._duration
+
+        if total <= seg:
+            return [media]
+
+        n_tiles = max(1, math.ceil(total / seg))
+        # Space n_tiles segments so that the first starts at 0 and the last
+        # ends at *total*.  When n_tiles == 1 this degenerates to [0, seg).
+        if n_tiles == 1:
+            starts = [0.0]
+        else:
+            starts = [i * (total - seg) / (n_tiles - 1) for i in range(n_tiles)]
+
+        results: list[dict[str, Any]] = []
+        for idx, t0 in enumerate(starts):
+            t1 = t0 + seg
+            sliced = _wav_slice(wav_bytes, t0, t1)
+            tile = dict(media)
+            tile["media_bytes"] = sliced
+            tile["duration"] = round(t1 - t0, 6)
+            tile["file_size"] = len(sliced)
+            tile["clip_index"] = idx
+            tile["clip_start"] = round(t0, 6)
+            tile["clip_end"] = round(t1, 6)
+            results.append(tile)
+        return results
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["duration"] = self._duration
+        return d

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -34,6 +34,7 @@ __all__ = [
     "DemoDataset",
     "Detector",
     "Extractor",
+    "MediaClipper",
     "MediaResponse",
     "MediaType",
     "Processor",
@@ -749,3 +750,75 @@ class Extractor(Processor):
     def process(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         """Run extraction on *media* (delegates to :meth:`extract`)."""
         return self.extract(media)
+
+
+class MediaClipper(ABC):
+    """Abstract base class for media clippers.
+
+    A *MediaClipper* takes a single media item and returns one or more media
+    items of the **same** type.  Each concrete clipper operates on exactly one
+    media type (declared via :attr:`media_type`).
+
+    Unlike :class:`Processor` subclasses which return metadata *about* a media
+    (booleans, bounding boxes, labels), a ``MediaClipper`` returns **new media
+    dicts** that can be used directly in place of the original.
+
+    Examples:
+
+    * ``SoundTilingClipper(2)`` — tiles a 9.5 s audio clip into five 2 s
+      clips equally spaced across the original duration.
+    * ``ImageTilingClipper()`` — covers a tall image with equidistant square
+      tiles using the shorter dimension as the tile size.
+    * ``TextSentenceClipper()`` — splits a paragraph into individual sentences.
+    * Any ``*DefaultClipper`` — returns the media unchanged (single-element
+      list).
+
+    Subclasses must implement:
+
+    * :attr:`name` — unique identifier for this clipper.
+    * :attr:`media_type` — which media ``type_id`` it works on.
+    * :meth:`clip` — split a single media dict into a list of media dicts.
+    """
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique identifier for this clipper, e.g. ``"video_tiling_2s"``."""
+
+    @property
+    @abstractmethod
+    def media_type(self) -> str:
+        """The media ``type_id`` this clipper operates on (e.g. ``"audio"``)."""
+
+    # ------------------------------------------------------------------
+    # Clipping
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        """Split *media* into one or more media dicts of the same type.
+
+        Each dict in the returned list is a **new** media dict that preserves
+        the structure of the original (``id``, ``type``, ``category``,
+        ``origin``, ``origin_name``, etc.) but contains the clipped content
+        (updated ``media_bytes`` / ``media_string``, ``duration``, and any
+        type-specific fields).
+
+        Returns a list with at least one element.  Default clippers return
+        ``[media]`` unchanged.
+        """
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable summary of this clipper's metadata."""
+        return {
+            "name": self.name,
+            "media_type": self.media_type,
+        }

--- a/vtsearch/media/image/clipper.py
+++ b/vtsearch/media/image/clipper.py
@@ -1,0 +1,99 @@
+"""Image clippers — tile or pass-through image media."""
+
+from __future__ import annotations
+
+import io
+import math
+from typing import Any
+
+from vtsearch.media.base import MediaClipper
+
+
+class ImageDefaultClipper(MediaClipper):
+    """Returns the image media unchanged."""
+
+    @property
+    def name(self) -> str:
+        return "image_default"
+
+    @property
+    def media_type(self) -> str:
+        return "image"
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        return [media]
+
+
+class ImageTilingClipper(MediaClipper):
+    """Tile an image into equidistant square crops.
+
+    The tile size is the shorter dimension of the image (so an already-square
+    image is returned unchanged).  Tiles are placed equidistantly along the
+    longer axis so that the first tile is flush with one edge and the last
+    tile is flush with the other.
+
+    For example an 8.5 x 11 image (w < h) would yield two 8.5 x 8.5 tiles
+    spaced to cover the full height.
+    """
+
+    @property
+    def name(self) -> str:
+        return "image_tiling"
+
+    @property
+    def media_type(self) -> str:
+        return "image"
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        from PIL import Image  # noqa: PLC0415
+
+        width = media.get("width")
+        height = media.get("height")
+        media_bytes = media.get("media_bytes")
+
+        if width is None or height is None or media_bytes is None:
+            return [media]
+
+        tile_size = min(width, height)
+
+        # Already square — return unchanged.
+        if width == tile_size and height == tile_size:
+            return [media]
+
+        img = Image.open(io.BytesIO(media_bytes))
+
+        if width >= height:
+            # Landscape: tile along the x-axis.
+            long_axis = width
+            n_tiles = max(1, math.ceil(long_axis / tile_size))
+            if n_tiles == 1:
+                offsets = [0]
+            else:
+                offsets = [round(i * (long_axis - tile_size) / (n_tiles - 1)) for i in range(n_tiles)]
+            boxes = [(x, 0, x + tile_size, tile_size) for x in offsets]
+        else:
+            # Portrait: tile along the y-axis.
+            long_axis = height
+            n_tiles = max(1, math.ceil(long_axis / tile_size))
+            if n_tiles == 1:
+                offsets = [0]
+            else:
+                offsets = [round(i * (long_axis - tile_size) / (n_tiles - 1)) for i in range(n_tiles)]
+            boxes = [(0, y, tile_size, y + tile_size) for y in offsets]
+
+        results: list[dict[str, Any]] = []
+        fmt = img.format or "PNG"
+        for idx, box in enumerate(boxes):
+            cropped = img.crop(box)
+            buf = io.BytesIO()
+            cropped.save(buf, format=fmt)
+            crop_bytes = buf.getvalue()
+            tile = dict(media)
+            tile["media_bytes"] = crop_bytes
+            tile["width"] = tile_size
+            tile["height"] = tile_size
+            tile["file_size"] = len(crop_bytes)
+            tile["clip_index"] = idx
+            tile["clip_box"] = list(box)
+            results.append(tile)
+        return results

--- a/vtsearch/media/text/clipper.py
+++ b/vtsearch/media/text/clipper.py
@@ -1,0 +1,63 @@
+"""Text clippers — split into sentences or pass-through text media."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from vtsearch.media.base import MediaClipper
+
+
+class TextDefaultClipper(MediaClipper):
+    """Returns the text media unchanged."""
+
+    @property
+    def name(self) -> str:
+        return "text_default"
+
+    @property
+    def media_type(self) -> str:
+        return "paragraph"
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        return [media]
+
+
+class TextSentenceClipper(MediaClipper):
+    """Split a text media into one media per sentence.
+
+    Sentences are detected by splitting on common sentence-ending
+    punctuation (``.``, ``!``, ``?``) followed by whitespace or end-of-string.
+    If the text contains no sentence boundaries (i.e. is a single sentence),
+    it is returned unchanged.
+    """
+
+    # Match sentence-ending punctuation followed by whitespace or end.
+    _SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+
+    @property
+    def name(self) -> str:
+        return "text_sentence"
+
+    @property
+    def media_type(self) -> str:
+        return "paragraph"
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        text = media.get("media_string") or ""
+        if not text:
+            return [media]
+
+        sentences = [s.strip() for s in self._SENTENCE_RE.split(text) if s.strip()]
+        if len(sentences) <= 1:
+            return [media]
+
+        results: list[dict[str, Any]] = []
+        for idx, sentence in enumerate(sentences):
+            tile = dict(media)
+            tile["media_string"] = sentence
+            tile["word_count"] = len(sentence.split())
+            tile["character_count"] = len(sentence)
+            tile["clip_index"] = idx
+            results.append(tile)
+        return results

--- a/vtsearch/media/video/clipper.py
+++ b/vtsearch/media/video/clipper.py
@@ -1,0 +1,88 @@
+"""Video clippers — tile or pass-through video media."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from vtsearch.media.base import MediaClipper
+
+
+class VideoDefaultClipper(MediaClipper):
+    """Returns the video media unchanged."""
+
+    @property
+    def name(self) -> str:
+        return "video_default"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        return [media]
+
+
+class VideoTilingClipper(MediaClipper):
+    """Tile a video into equally-spaced segments of a given duration.
+
+    ``VideoTilingClipper(2)`` tiles a 9.5 s video into five 2 s segments
+    whose start times are equally spaced so the first starts at 0 and the
+    last ends at 9.5 s (with a little overlap between neighbours when the
+    total duration is not an exact multiple of the segment size).
+
+    If the video is shorter than or equal to *duration*, a single segment
+    covering the full video is returned.
+
+    Because video transcoding requires heavy dependencies (ffmpeg / moviepy),
+    this clipper records the clip boundaries as metadata on the media dict
+    (``clip_start``, ``clip_end``, ``clip_index``) without slicing the
+    underlying bytes.  Downstream consumers can use these fields to seek or
+    trim on playback.
+    """
+
+    def __init__(self, duration: float) -> None:
+        if duration <= 0:
+            raise ValueError("duration must be positive")
+        self._duration = duration
+
+    @property
+    def name(self) -> str:
+        return f"video_tiling_{self._duration}s"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    @property
+    def duration(self) -> float:
+        return self._duration
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        total = media.get("duration", 0)
+        seg = self._duration
+
+        if total <= seg:
+            return [media]
+
+        n_tiles = max(1, math.ceil(total / seg))
+        if n_tiles == 1:
+            starts = [0.0]
+        else:
+            starts = [i * (total - seg) / (n_tiles - 1) for i in range(n_tiles)]
+
+        results: list[dict[str, Any]] = []
+        for idx, t0 in enumerate(starts):
+            t1 = t0 + seg
+            tile = dict(media)
+            tile["duration"] = round(t1 - t0, 6)
+            tile["clip_index"] = idx
+            tile["clip_start"] = round(t0, 6)
+            tile["clip_end"] = round(t1, 6)
+            results.append(tile)
+        return results
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["duration"] = self._duration
+        return d


### PR DESCRIPTION
Remove the "-10" and "+10" range labels that were causing the slider to
overflow its panel. Display the current inclusion value to the right of
the slider instead of centered below it, and shrink the slider width to
80% so it fits comfortably within the sort panel.

https://claude.ai/code/session_01PZqzMJapaSdBQa7BSw1Qmm