### PR TITLE
Rename "Span" metric to "Diverse" throughout UI and code

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4909,7 +4909,7 @@
     document.getElementById("smart-section").style.display = "none";
     document.getElementById("stable-section").style.display = "none";
     document.getElementById("span-section").style.display = "";
-    document.getElementById("progress-modal-title").textContent = "Span: Diversity Coverage";
+    document.getElementById("progress-modal-title").textContent = "Diverse: Diversity Coverage";
 
     pauseActiveMedia();
     progressModal.classList.add("show");
@@ -4975,7 +4975,7 @@
     } else if (metric === "span") {
       spanSec.style.display = "";
       renderDiversityChart(data.diversity_level_over_time);
-      document.getElementById("progress-modal-title").textContent = "Span: Diversity Coverage";
+      document.getElementById("progress-modal-title").textContent = "Diverse: Diversity Coverage";
       const dvChart = document.getElementById("diversity-chart");
       if (dvChart) {
         dvChart.setAttribute("role", "img");

--- a/static/index.html
+++ b/static/index.html
@@ -146,9 +146,9 @@
         <span class="indicator-label">Stable</span>
         <span class="indicator-subtext" id="stable-subtext"></span>
       </button>
-      <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Span level: diversity tree coverage" title="Do we have good label coverage over the dataset?">
+      <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Diverse level: diversity tree coverage" title="Do we have good label coverage over the dataset?">
         <span class="indicator-dot" aria-hidden="true"></span>
-        <span class="indicator-label">Span</span>
+        <span class="indicator-label">Diverse</span>
         <span class="indicator-subtext" id="span-subtext"></span>
       </button>
     </div>
@@ -176,7 +176,7 @@
   </aside>
 </div>
 
-<!-- Progress Modal — shown per-metric when clicking Smart, Stable, or Span -->
+<!-- Progress Modal — shown per-metric when clicking Smart, Stable, or Diverse -->
 <div id="progress-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="progress-modal-title">
   <div class="modal-content">
     <div class="modal-header">
@@ -210,9 +210,9 @@
         </p>
         <canvas id="stability-chart" width="700" height="250"></canvas>
       </div>
-      <!-- Span: Diversity tree text info + chart -->
+      <!-- Diverse: Diversity tree text info + chart -->
       <div id="span-section" class="progress-chart" style="display:none;">
-        <h3>Span: Diversity Tree Coverage</h3>
+        <h3>Diverse: Diversity Tree Coverage</h3>
         <p class="form-text" style="font-size: 0.8rem; margin-bottom: 8px;">
           Shows how diversity level grows as you label. Higher means broader coverage.
         </p>

--- a/static/styles.css
+++ b/static/styles.css
@@ -207,7 +207,7 @@ header h1 { margin-left: 48px; }
 .theme-btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
 
 /* Left panel – media list */
-.panel-left { width: 170px; border-right: 1px solid var(--border); overflow-y: auto; background: var(--bg-panel); display: flex; flex-direction: column; position: relative; }
+.panel-left { width: 185px; border-right: 1px solid var(--border); overflow-y: auto; background: var(--bg-panel); display: flex; flex-direction: column; position: relative; }
 .sort-bar { padding: 8px 28px 12px 10px; border-bottom: 1px solid var(--border); }
 .sort-mode { display: flex; gap: 10px; margin-bottom: 6px; }
 .sort-mode label { font-size: 0.75rem; color: var(--text-secondary); cursor: pointer; display: flex; align-items: center; gap: 3px; }
@@ -293,7 +293,7 @@ video { max-width: 100%; }
 .btn-bad.voted, .btn-bad.vote-flash { background: var(--color-bad); color: #fff; }
 
 /* Right panel – votes */
-.panel-right { width: 200px; border-left: 1px solid var(--border); overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
+.panel-right { width: 220px; border-left: 1px solid var(--border); overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
 .label-sort-bar { padding: 8px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .vote-section { flex: 1; overflow-y: auto; padding: 12px 16px; }
 .vote-section + .vote-section { border-top: 1px solid var(--border); }


### PR DESCRIPTION
## Summary
This PR renames the "Span" metric to "Diverse" across the application to better reflect its purpose of measuring diversity tree coverage. The change includes updates to UI labels, aria-labels, modal titles, comments, and CSS panel widths for improved layout.

## Key Changes
- **UI Labels**: Updated all user-facing text from "Span" to "Diverse" in buttons, headings, and modal titles
- **Accessibility**: Updated aria-label from "Span level: diversity tree coverage" to "Diverse level: diversity tree coverage"
- **Code Comments**: Updated comments referencing the "Span" metric to use "Diverse" instead
- **JavaScript**: Updated modal title text in `app.js` from "Span: Diversity Coverage" to "Diverse: Diversity Coverage" (2 occurrences)
- **Layout Adjustments**: 
  - Increased left panel width from 170px to 185px
  - Increased right panel width from 200px to 220px

## Notable Details
- The HTML element IDs (`span-indicator`, `span-section`, `span-subtext`) remain unchanged to avoid breaking JavaScript references
- All changes maintain backward compatibility with existing element selectors
- The metric functionality remains identical; this is purely a naming/labeling update

https://claude.ai/code/session_01PrVF7CjueHzw4rYqEaNQmW