### PR TITLE
Add pre-tool hooks for pytest and install additional dependencies

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -41,6 +41,11 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu \
   ultralytics \
   sentence-transformers \
   pandas \
+  PyMuPDF \
+  scipy \
+  soundfile \
+  feedparser \
+  yt-dlp \
   --ignore-installed blinker \
   -q
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'pytest'; then bash $CLAUDE_PROJECT_DIR/.claude/hooks/ensure-test-deps.sh; fi"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
This PR adds a pre-tool execution hook for Bash commands and expands the test environment dependencies to support additional functionality.

## Key Changes
- **Pre-tool hook configuration**: Added a `PreToolUse` hook in `.claude/settings.json` that automatically runs `ensure-test-deps.sh` when pytest commands are detected in Bash tool input
- **Extended dependencies**: Added five new packages to the test environment setup:
  - `PyMuPDF` - PDF document processing
  - `scipy` - Scientific computing utilities
  - `soundfile` - Audio file I/O
  - `feedparser` - RSS/Atom feed parsing
  - `yt-dlp` - YouTube content downloading

## Implementation Details
The pre-tool hook uses a conditional grep pattern to detect pytest invocations and ensures all required dependencies are installed before test execution. This prevents test failures due to missing optional dependencies while keeping the dependency installation automatic and transparent.

https://claude.ai/code/session_01UAAo2sZXnMcfjD1L3ERws3