### PR TITLE
Add dashboard UI for managing datasets and models

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -449,6 +449,32 @@
 
       await checkDatasetStatus();
       if (datasetLoaded) {
+        // Dashboard add-dataset mode: capture info and return to dashboard
+        if (_dashboardAddDatasetMode) {
+          _dashboardAddDatasetMode = false;
+          try {
+            const infoRes = await fetch("/api/dashboard/dataset-info");
+            if (infoRes.ok) {
+              const info = await infoRes.json();
+              dashboardDatasets.push({
+                id: _dashboardNextId++,
+                name: info.name,
+                num_medias: info.num_medias,
+                media_type: info.media_type,
+                origin: info.origin,
+              });
+            }
+          } catch (_) { /* ignore */ }
+          // Clear the dataset from the backend
+          await fetch("/api/dataset/clear", { method: "POST" });
+          medias = [];
+          votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
+          selected = null;
+          datasetLoaded = false;
+          showDashboard();
+          return;
+        }
+
         await fetchMedias();
         await fetchVotes();
 
@@ -1207,6 +1233,12 @@
     if (_combineState) {
       fetch("/api/dataset/staging", { method: "DELETE" }).catch(() => {});
       _combineState = null;
+    }
+    // If we came from the dashboard, go back to dashboard
+    if (_dashboardAddDatasetMode) {
+      _dashboardAddDatasetMode = false;
+      showDashboard();
+      return;
     }
     showWelcomeScreen();
   });
@@ -5334,6 +5366,408 @@
     } catch (_) {
       // Fallback: leave empty, the UI will degrade gracefully.
     }
+  }
+
+  // ---- Dashboard ----
+
+  const dashboardView = document.getElementById("dashboard-view");
+  const dashboardDatasetsTbody = document.getElementById("dashboard-datasets-tbody");
+  const dashboardDatasetsTable = document.getElementById("dashboard-datasets-table");
+  const dashboardDatasetsEmpty = document.getElementById("dashboard-datasets-empty");
+  const dashboardModelsTbody = document.getElementById("dashboard-models-tbody");
+  const dashboardModelsTable = document.getElementById("dashboard-models-table");
+  const dashboardModelsEmpty = document.getElementById("dashboard-models-empty");
+  const dashboardTrainBtn = document.getElementById("dashboard-train-btn");
+  const dashboardRunBtn = document.getElementById("dashboard-run-btn");
+  const dashboardDatasetAdd = document.getElementById("dashboard-dataset-add");
+  const dashboardModelAdd = document.getElementById("dashboard-model-add");
+  const menuDashboard = document.getElementById("menu-dashboard");
+
+  let dashboardDatasets = [];
+  let dashboardModels = [];
+  let dashboardDatasetSort = { key: "name", asc: true };
+  let dashboardModelSort = { key: "name", asc: true };
+  let dashboardSelectedDatasets = {};  // id -> true
+  let dashboardSelectedModels = {};    // id -> true
+  let _dashboardAddDatasetMode = false;
+  let _dashboardNextId = 1;
+
+  function showDashboard() {
+    // Hide left/right panels and welcome screen
+    leftPanel.style.display = "none";
+    if (rightPanel) rightPanel.style.display = "none";
+    sortBar.style.display = "none";
+    datasetBar.style.display = "none";
+    datasetWelcome.style.display = "none";
+    center.className = "panel-center";
+    center.innerHTML = "";
+    center.appendChild(dashboardView);
+    dashboardView.style.display = "flex";
+    renderDashboardDatasets();
+    renderDashboardModels();
+    updateDashboardButtons();
+  }
+
+  function hideDashboard() {
+    dashboardView.style.display = "none";
+  }
+
+  // Sort helper
+  function dashboardSortRows(rows, sortState) {
+    const { key, asc } = sortState;
+    return rows.slice().sort((a, b) => {
+      let va = a[key], vb = b[key];
+      if (typeof va === "number" && typeof vb === "number") {
+        return asc ? va - vb : vb - va;
+      }
+      va = String(va || "").toLowerCase();
+      vb = String(vb || "").toLowerCase();
+      if (va < vb) return asc ? -1 : 1;
+      if (va > vb) return asc ? 1 : -1;
+      return 0;
+    });
+  }
+
+  function renderDashboardDatasets() {
+    if (dashboardDatasets.length === 0) {
+      dashboardDatasetsTable.style.display = "none";
+      dashboardDatasetsEmpty.style.display = "";
+      return;
+    }
+    dashboardDatasetsEmpty.style.display = "none";
+    dashboardDatasetsTable.style.display = "";
+
+    // Update sort arrows
+    dashboardDatasetsTable.querySelectorAll("th[data-col]").forEach(th => {
+      const arrow = th.querySelector(".sort-arrow");
+      arrow.textContent = th.dataset.col === dashboardDatasetSort.key
+        ? (dashboardDatasetSort.asc ? " \u25B2" : " \u25BC") : "";
+    });
+
+    const sorted = dashboardSortRows(dashboardDatasets, dashboardDatasetSort);
+    dashboardDatasetsTbody.innerHTML = sorted.map(ds => {
+      const sel = dashboardSelectedDatasets[ds.id] ? " selected" : "";
+      return `<tr data-id="${ds.id}" class="${sel}">
+        <td title="${escapeHtml(ds.name)}">${escapeHtml(ds.name)}</td>
+        <td>${ds.num_medias}</td>
+        <td>${escapeHtml(ds.media_type)}</td>
+        <td title="${escapeHtml(ds.origin)}">${escapeHtml(ds.origin)}</td>
+        <td><div class="dashboard-row-actions">
+          <button class="btn-sm" data-action="rename" data-id="${ds.id}">Rename</button>
+          <button class="btn-sm-danger" data-action="remove" data-id="${ds.id}">Remove</button>
+        </div></td>
+      </tr>`;
+    }).join("");
+
+    // Wire row click for selection
+    dashboardDatasetsTbody.querySelectorAll("tr").forEach(tr => {
+      tr.addEventListener("click", (e) => {
+        if (e.target.closest("button")) return;
+        const id = parseInt(tr.dataset.id);
+        if (dashboardSelectedDatasets[id]) {
+          delete dashboardSelectedDatasets[id];
+        } else {
+          dashboardSelectedDatasets[id] = true;
+        }
+        renderDashboardDatasets();
+        updateDashboardButtons();
+      });
+    });
+
+    // Wire action buttons
+    dashboardDatasetsTbody.querySelectorAll("button[data-action]").forEach(btn => {
+      btn.addEventListener("click", async () => {
+        const id = parseInt(btn.dataset.id);
+        if (btn.dataset.action === "remove") {
+          dashboardDatasets = dashboardDatasets.filter(d => d.id !== id);
+          delete dashboardSelectedDatasets[id];
+          renderDashboardDatasets();
+          updateDashboardButtons();
+        } else if (btn.dataset.action === "rename") {
+          const ds = dashboardDatasets.find(d => d.id === id);
+          if (!ds) return;
+          const newName = await vtPrompt(`Rename dataset "${ds.name}" to:`, ds.name);
+          if (newName && newName !== ds.name) {
+            ds.name = newName;
+            renderDashboardDatasets();
+          }
+        }
+      });
+    });
+  }
+
+  function renderDashboardModels() {
+    if (dashboardModels.length === 0) {
+      dashboardModelsTable.style.display = "none";
+      dashboardModelsEmpty.style.display = "";
+      return;
+    }
+    dashboardModelsEmpty.style.display = "none";
+    dashboardModelsTable.style.display = "";
+
+    // Update sort arrows
+    dashboardModelsTable.querySelectorAll("th[data-col]").forEach(th => {
+      const arrow = th.querySelector(".sort-arrow");
+      arrow.textContent = th.dataset.col === dashboardModelSort.key
+        ? (dashboardModelSort.asc ? " \u25B2" : " \u25BC") : "";
+    });
+
+    const sorted = dashboardSortRows(dashboardModels, dashboardModelSort);
+    dashboardModelsTbody.innerHTML = sorted.map(m => {
+      const sel = dashboardSelectedModels[m.id] ? " selected" : "";
+      return `<tr data-id="${m.id}" class="${sel}">
+        <td title="${escapeHtml(m.name)}">${escapeHtml(m.name)}</td>
+        <td>${m.num_labels}</td>
+        <td>${escapeHtml(m.media_type)}</td>
+        <td title="${escapeHtml(m.text_examples)}">${escapeHtml(m.text_examples)}</td>
+        <td title="${escapeHtml(m.media_examples)}">${escapeHtml(m.media_examples)}</td>
+        <td title="${escapeHtml(m.origin)}">${escapeHtml(m.origin)}</td>
+        <td><div class="dashboard-row-actions">
+          <button class="btn-sm" data-action="rename" data-id="${m.id}">Rename</button>
+          <button class="btn-sm-danger" data-action="remove" data-id="${m.id}">Remove</button>
+        </div></td>
+      </tr>`;
+    }).join("");
+
+    // Wire row click for selection
+    dashboardModelsTbody.querySelectorAll("tr").forEach(tr => {
+      tr.addEventListener("click", (e) => {
+        if (e.target.closest("button")) return;
+        const id = parseInt(tr.dataset.id);
+        if (dashboardSelectedModels[id]) {
+          delete dashboardSelectedModels[id];
+        } else {
+          dashboardSelectedModels[id] = true;
+        }
+        renderDashboardModels();
+        updateDashboardButtons();
+      });
+    });
+
+    // Wire action buttons
+    dashboardModelsTbody.querySelectorAll("button[data-action]").forEach(btn => {
+      btn.addEventListener("click", async () => {
+        const id = parseInt(btn.dataset.id);
+        if (btn.dataset.action === "remove") {
+          dashboardModels = dashboardModels.filter(m => m.id !== id);
+          delete dashboardSelectedModels[id];
+          renderDashboardModels();
+          updateDashboardButtons();
+        } else if (btn.dataset.action === "rename") {
+          const m = dashboardModels.find(m => m.id === id);
+          if (!m) return;
+          const newName = await vtPrompt(`Rename model "${m.name}" to:`, m.name);
+          if (newName && newName !== m.name) {
+            m.name = newName;
+            renderDashboardModels();
+          }
+        }
+      });
+    });
+  }
+
+  function updateDashboardButtons() {
+    const numDS = Object.keys(dashboardSelectedDatasets).length;
+    const numMD = Object.keys(dashboardSelectedModels).length;
+    // Train: exactly 1 dataset + exactly 1 model
+    dashboardTrainBtn.disabled = !(numDS === 1 && numMD === 1);
+    // Run: at least 1 dataset + at least 1 model
+    dashboardRunBtn.disabled = !(numDS >= 1 && numMD >= 1);
+  }
+
+  // Wire sortable headers for datasets table
+  if (dashboardDatasetsTable) {
+    dashboardDatasetsTable.querySelectorAll("th[data-col]").forEach(th => {
+      th.addEventListener("click", () => {
+        const col = th.dataset.col;
+        if (dashboardDatasetSort.key === col) {
+          dashboardDatasetSort.asc = !dashboardDatasetSort.asc;
+        } else {
+          dashboardDatasetSort = { key: col, asc: true };
+        }
+        renderDashboardDatasets();
+      });
+    });
+  }
+
+  // Wire sortable headers for models table
+  if (dashboardModelsTable) {
+    dashboardModelsTable.querySelectorAll("th[data-col]").forEach(th => {
+      th.addEventListener("click", () => {
+        const col = th.dataset.col;
+        if (dashboardModelSort.key === col) {
+          dashboardModelSort.asc = !dashboardModelSort.asc;
+        } else {
+          dashboardModelSort = { key: col, asc: true };
+        }
+        renderDashboardModels();
+      });
+    });
+  }
+
+  // Dashboard "Add Dataset" — enters the welcome screen in dashboard mode
+  if (dashboardDatasetAdd) {
+    dashboardDatasetAdd.addEventListener("click", () => {
+      _dashboardAddDatasetMode = true;
+      hideDashboard();
+      // Clear any existing dataset so we can load a fresh one
+      fetch("/api/dataset/clear", { method: "POST" }).then(() => {
+        medias = [];
+        votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
+        selected = null;
+        datasetLoaded = false;
+        showWelcomeScreen();
+      });
+    });
+  }
+
+  // Dashboard "Add Model" — opens the processor importer modal in dashboard mode
+  if (dashboardModelAdd) {
+    dashboardModelAdd.addEventListener("click", () => {
+      openProcessorImporterModalForDashboard();
+    });
+  }
+
+  async function openProcessorImporterModalForDashboard() {
+    let importers = [];
+    try {
+      const res = await fetch("/api/processor-importers");
+      if (res.ok) importers = await res.json();
+    } catch (_) { /* ignore */ }
+
+    processorImporterFormDiv.style.display = "none";
+    processorImporterFormDiv.innerHTML = "";
+    processorImporterBack.style.display = "none";
+    processorImporterList.style.display = "";
+
+    if (importers.length === 0) {
+      processorImporterList.innerHTML = '<p style="color:var(--text-muted);">No processor importers available.</p>';
+    } else {
+      processorImporterList.innerHTML = importers.map(imp => `
+        <div class="processor-importer-option option-card" data-name="${escapeHtml(imp.name)}">
+          <span class="option-card-icon">${escapeHtml(imp.icon || '\u{1F9E9}')}</span>
+          <div>
+            <div class="option-card-title">${escapeHtml(imp.display_name)}</div>
+            <div class="option-card-desc">${escapeHtml(imp.description)}</div>
+          </div>
+        </div>
+      `).join("");
+
+      processorImporterList.querySelectorAll(".processor-importer-option").forEach(el => {
+        el.setAttribute("role", "button");
+        el.setAttribute("tabindex", "0");
+        const name = el.dataset.name;
+        const imp = importers.find(i => i.name === name);
+        el.addEventListener("click", () => showProcessorImporterFormForDashboard(imp));
+        el.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); showProcessorImporterFormForDashboard(imp); }
+        });
+      });
+    }
+
+    processorImporterModal.classList.add("show");
+  }
+
+  function showProcessorImporterFormForDashboard(importer) {
+    processorImporterList.style.display = "none";
+    processorImporterBack.style.display = "inline-block";
+
+    let html = `<h3 class="form-heading">${escapeHtml(importer.display_name)}</h3>`;
+    html += `<form id="proc-imp-form">`;
+    html += `<div class="form-group">`;
+    html += `<label class="form-label">Detector Name *</label>`;
+    html += `<input type="text" name="name" placeholder="e.g. Dog Barks" class="form-input" required>`;
+    html += `<div class="form-hint">Name for the imported detector.</div>`;
+    html += `</div>`;
+    for (const field of importer.fields) {
+      html += `<div class="form-group">`;
+      html += `<label class="form-label">${escapeHtml(field.label)}${field.required ? " *" : ""}</label>`;
+      if (field.field_type === "file") {
+        html += `<input type="file" name="${escapeHtml(field.key)}" accept="${escapeHtml(field.accept)}" class="form-input" ${field.required ? "required" : ""}>`;
+      } else if (field.field_type === "select") {
+        html += `<select name="${escapeHtml(field.key)}" class="form-input">`;
+        for (const opt of field.options) {
+          html += `<option value="${escapeHtml(opt)}"${opt === field.default ? " selected" : ""}>${escapeHtml(opt || "(auto-detect)")}</option>`;
+        }
+        html += `</select>`;
+      } else {
+        const itype = field.field_type === "password" ? "password" : "text";
+        const placeholder = escapeHtml(field.placeholder || field.description);
+        html += `<input type="${itype}" name="${escapeHtml(field.key)}" value="${escapeHtml(field.default)}" placeholder="${placeholder}" class="form-input" ${field.required ? "required" : ""}>`;
+      }
+      if (field.description) {
+        html += `<div class="form-hint">${escapeHtml(field.description)}</div>`;
+      }
+      html += `</div>`;
+    }
+    html += `<div id="proc-imp-status" class="status-text compact"></div>`;
+    html += `<button type="submit" class="btn-block-primary">Import</button>`;
+    html += `</form>`;
+
+    processorImporterFormDiv.innerHTML = html;
+    processorImporterFormDiv.style.display = "block";
+
+    const statusEl = processorImporterFormDiv.querySelector("#proc-imp-status");
+
+    processorImporterFormDiv.querySelector("#proc-imp-form").addEventListener("submit", async (e) => {
+      e.preventDefault();
+      statusEl.textContent = "Importing\u2026";
+      statusEl.style.color = "var(--text-muted)";
+
+      const formEl = e.target;
+      const hasFiles = importer.fields.some(f => f.field_type === "file");
+      let body, headers = {};
+
+      if (hasFiles) {
+        body = new FormData(formEl);
+      } else {
+        const obj = { name: formEl.elements["name"].value };
+        for (const field of importer.fields) {
+          obj[field.key] = formEl.elements[field.key].value;
+        }
+        body = JSON.stringify(obj);
+        headers["Content-Type"] = "application/json";
+      }
+
+      try {
+        const res = await fetch(`/api/processor-importers/import/${encodeURIComponent(importer.name)}`, {
+          method: "POST", headers, body,
+        });
+        const result = await res.json();
+        if (res.ok) {
+          const modelEntry = {
+            id: _dashboardNextId++,
+            name: result.name,
+            num_labels: result.loaded || 0,
+            media_type: result.media_type || "unknown",
+            text_examples: "-",
+            media_examples: "-",
+            origin: importer.display_name,
+          };
+          dashboardModels.push(modelEntry);
+          statusEl.textContent = `Imported "${result.name}"`;
+          statusEl.style.color = "var(--color-good)";
+          setTimeout(() => {
+            processorImporterModal.classList.remove("show");
+            showDashboard();
+          }, 1000);
+        } else {
+          statusEl.textContent = result.error || "Import failed";
+          statusEl.style.color = "var(--color-bad)";
+        }
+      } catch (err) {
+        statusEl.textContent = `Error: ${err.message}`;
+        statusEl.style.color = "var(--color-bad)";
+      }
+    });
+  }
+
+  // Burger menu handler for Dashboard
+  if (menuDashboard) {
+    menuDashboard.addEventListener("click", () => {
+      closeBurgerMenu();
+      showDashboard();
+    });
   }
 
   // Initialize

--- a/static/index.html
+++ b/static/index.html
@@ -40,6 +40,9 @@
         <div class="burger-status" id="menu-favorites-status" aria-live="polite"></div>
       </div>
       <div class="burger-section">
+        <div class="burger-item" id="menu-dashboard">Dashboard</div>
+      </div>
+      <div class="burger-section">
         <div class="burger-item" id="menu-settings">Settings</div>
       </div>
     </div>
@@ -127,6 +130,65 @@
       <div class="demo-datasets" id="demo-datasets" style="display:none"></div>
       <div id="extended-importer-form" style="display:none"></div>
       <button class="back-button" id="back-button" style="display:none" aria-label="Back to dataset options">Back</button>
+    </div>
+    <!-- Dashboard view -->
+    <div id="dashboard-view" style="display:none">
+      <h2>VTSearch Dashboard</h2>
+      <p class="dashboard-subtitle">Manage your datasets and models</p>
+
+      <!-- My Datasets section -->
+      <div class="dashboard-section">
+        <div class="dashboard-section-header">
+          <h3>My Datasets</h3>
+          <div class="dashboard-section-actions">
+            <button id="dashboard-dataset-add" class="btn-sm">Add</button>
+          </div>
+        </div>
+        <div id="dashboard-datasets-empty" class="dashboard-empty">No datasets added yet.</div>
+        <table id="dashboard-datasets-table" class="dashboard-table" style="display:none">
+          <thead>
+            <tr>
+              <th data-col="name">Name<span class="sort-arrow"></span></th>
+              <th data-col="num_medias">#Media<span class="sort-arrow"></span></th>
+              <th data-col="media_type">MediaType<span class="sort-arrow"></span></th>
+              <th data-col="origin">Origin<span class="sort-arrow"></span></th>
+              <th class="col-actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="dashboard-datasets-tbody"></tbody>
+        </table>
+      </div>
+
+      <!-- My Models section -->
+      <div class="dashboard-section">
+        <div class="dashboard-section-header">
+          <h3>My Models</h3>
+          <div class="dashboard-section-actions">
+            <button id="dashboard-model-add" class="btn-sm">Add</button>
+          </div>
+        </div>
+        <div id="dashboard-models-empty" class="dashboard-empty">No models added yet.</div>
+        <table id="dashboard-models-table" class="dashboard-table" style="display:none">
+          <thead>
+            <tr>
+              <th data-col="name">Name<span class="sort-arrow"></span></th>
+              <th data-col="num_labels">#Labels<span class="sort-arrow"></span></th>
+              <th data-col="media_type">MediaType<span class="sort-arrow"></span></th>
+              <th data-col="text_examples">Text Examples<span class="sort-arrow"></span></th>
+              <th data-col="media_examples">Media Examples<span class="sort-arrow"></span></th>
+              <th data-col="origin">Origin<span class="sort-arrow"></span></th>
+              <th class="col-actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="dashboard-models-tbody"></tbody>
+        </table>
+      </div>
+
+      <!-- Action buttons -->
+      <div class="dashboard-actions">
+        <button id="dashboard-train-btn" class="btn-block-primary" disabled>Train</button>
+        <button id="dashboard-run-btn" class="btn-block-primary" disabled>Run</button>
+      </div>
     </div>
   </main>
   <input type="file" id="file-input" accept=".pkl" style="display:none" aria-label="Dataset file">

--- a/static/styles.css
+++ b/static/styles.css
@@ -603,3 +603,42 @@ video { max-width: 100%; }
 
 /* Missing elements prompt */
 .missing-prompt { margin-top: 14px; padding: 14px; background: var(--border); border: 1px solid var(--bg-secondary-btn); border-radius: 6px; }
+
+/* ---- Dashboard ---- */
+#dashboard-view {
+  width: 100%; max-width: 900px; margin: 0 auto; padding: 32px 24px;
+  display: flex; flex-direction: column; gap: 24px;
+}
+#dashboard-view h2 { font-size: 1.6rem; color: var(--accent); margin: 0; }
+.dashboard-subtitle { font-size: 0.9rem; color: var(--text-secondary); margin: 0; }
+.dashboard-section {
+  background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px;
+  padding: 16px; display: flex; flex-direction: column; gap: 10px;
+}
+.dashboard-section-header {
+  display: flex; justify-content: space-between; align-items: center;
+}
+.dashboard-section-header h3 { font-size: 1rem; color: var(--text-primary); margin: 0; }
+.dashboard-section-actions { display: flex; gap: 6px; }
+.dashboard-empty { font-size: 0.85rem; color: var(--text-muted); text-align: center; padding: 16px 0; }
+.dashboard-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.dashboard-table thead th {
+  text-align: left; padding: 6px 8px; color: var(--accent); font-size: 0.72rem;
+  font-weight: 600; cursor: pointer; user-select: none; white-space: nowrap;
+  border-bottom: 1px solid var(--border);
+}
+.dashboard-table thead th:hover { color: var(--accent-light); }
+.dashboard-table thead th .sort-arrow { font-size: 0.6rem; display: inline-block; width: 1em; text-align: left; }
+.dashboard-table thead th.col-actions { cursor: default; width: 100px; }
+.dashboard-table tbody td {
+  padding: 6px 8px; border-bottom: 1px solid var(--border); color: var(--text-primary);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px;
+}
+.dashboard-table tbody tr { transition: background 0.15s; }
+.dashboard-table tbody tr:hover { background: var(--bg-subtle); }
+.dashboard-table tbody tr.selected { background: var(--accent-highlight-bg); }
+.dashboard-row-actions { display: flex; gap: 4px; }
+.dashboard-actions {
+  display: flex; gap: 12px; justify-content: flex-end; padding-top: 8px;
+}
+.dashboard-actions .btn-block-primary { width: auto; padding: 10px 32px; }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,6 @@
 """Tests for the VTSearch dashboard API endpoint."""
 
-import app as app_module
+import app as app_module  # noqa: F401 — triggers conftest side effects
 from vtsearch.utils import medias
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,124 @@
+"""Tests for the VTSearch dashboard API endpoint."""
+
+import app as app_module
+from vtsearch.utils import medias
+
+
+class TestDashboardDatasetInfo:
+    """Tests for GET /api/dashboard/dataset-info."""
+
+    def test_returns_404_when_no_dataset(self, client):
+        """Endpoint returns 404 when no dataset is loaded."""
+        saved = dict(medias)
+        medias.clear()
+        try:
+            resp = client.get("/api/dashboard/dataset-info")
+            assert resp.status_code == 404
+            data = resp.get_json()
+            assert "error" in data
+        finally:
+            medias.update(saved)
+
+    def test_returns_info_with_loaded_medias(self, client):
+        """Endpoint returns dataset metadata when medias are loaded."""
+        resp = client.get("/api/dashboard/dataset-info")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "name" in data
+        assert "num_medias" in data
+        assert "media_type" in data
+        assert "origin" in data
+        assert data["num_medias"] == len(medias)
+
+    def test_returns_correct_media_type(self, client):
+        """Endpoint returns the media type of the first media."""
+        resp = client.get("/api/dashboard/dataset-info")
+        data = resp.get_json()
+        first_media = next(iter(medias.values()))
+        assert data["media_type"] == first_media.get("type", "audio")
+
+    def test_returns_origin_from_media(self, client):
+        """Endpoint extracts origin info when medias have origin set."""
+        first_key = next(iter(medias))
+        saved_origin = medias[first_key].get("origin")
+        try:
+            medias[first_key]["origin"] = {"importer": "demo", "params": {"name": "test_dataset"}}
+            resp = client.get("/api/dashboard/dataset-info")
+            data = resp.get_json()
+            assert data["origin"] == "demo:test_dataset"
+            assert data["name"] == "test_dataset"
+        finally:
+            if saved_origin is not None:
+                medias[first_key]["origin"] = saved_origin
+            else:
+                medias[first_key].pop("origin", None)
+
+    def test_returns_origin_folder(self, client):
+        """Endpoint formats folder origin correctly."""
+        first_key = next(iter(medias))
+        saved_origin = medias[first_key].get("origin")
+        try:
+            medias[first_key]["origin"] = {"importer": "folder", "params": {"path": "/data/sounds"}}
+            resp = client.get("/api/dashboard/dataset-info")
+            data = resp.get_json()
+            assert data["origin"] == "folder:/data/sounds"
+        finally:
+            if saved_origin is not None:
+                medias[first_key]["origin"] = saved_origin
+            else:
+                medias[first_key].pop("origin", None)
+
+    def test_returns_origin_pickle(self, client):
+        """Endpoint formats pickle origin correctly."""
+        first_key = next(iter(medias))
+        saved_origin = medias[first_key].get("origin")
+        try:
+            medias[first_key]["origin"] = {"importer": "pickle", "params": {"filename": "esc50.pkl"}}
+            resp = client.get("/api/dashboard/dataset-info")
+            data = resp.get_json()
+            assert data["origin"] == "file:esc50.pkl"
+            assert data["name"] == "esc50.pkl"
+        finally:
+            if saved_origin is not None:
+                medias[first_key]["origin"] = saved_origin
+            else:
+                medias[first_key].pop("origin", None)
+
+    def test_returns_unknown_origin_when_none(self, client):
+        """Endpoint returns 'unknown' origin when medias have no origin."""
+        # Default test medias don't have origin set
+        saved_origins = {}
+        for k, v in medias.items():
+            saved_origins[k] = v.get("origin")
+            v.pop("origin", None)
+        try:
+            resp = client.get("/api/dashboard/dataset-info")
+            data = resp.get_json()
+            assert data["origin"] == "unknown"
+        finally:
+            for k, v in medias.items():
+                if saved_origins.get(k) is not None:
+                    v["origin"] = saved_origins[k]
+
+
+class TestDashboardHtmlPresent:
+    """Test that the dashboard HTML is present in the index page."""
+
+    def test_dashboard_view_in_html(self, client):
+        """The dashboard view div should be in the index HTML."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert b"dashboard-view" in resp.data
+        assert b"My Datasets" in resp.data
+        assert b"My Models" in resp.data
+
+    def test_dashboard_menu_item(self, client):
+        """The burger menu should have a Dashboard entry."""
+        resp = client.get("/")
+        assert b"menu-dashboard" in resp.data
+
+    def test_train_and_run_buttons(self, client):
+        """Train and Run buttons should be present and disabled by default."""
+        resp = client.get("/")
+        assert b"dashboard-train-btn" in resp.data
+        assert b"dashboard-run-btn" in resp.data

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -725,3 +725,48 @@ def clear_dataset_route():
     """Clear the current dataset."""
     clear_dataset()
     return jsonify({"ok": True})
+
+
+@datasets_bp.route("/api/dashboard/dataset-info")
+def dashboard_dataset_info():
+    """Return metadata about the currently loaded dataset for the dashboard.
+
+    Returns a JSON object with ``name``, ``num_medias``, ``media_type``, and
+    ``origin`` extracted from the first media that has origin info.
+    """
+    if not medias:
+        return jsonify({"error": "No dataset loaded"}), 404
+
+    first = next(iter(medias.values()))
+    media_type = first.get("type", "audio")
+    num_medias = len(medias)
+
+    # Determine origin from the first media that has one
+    origin = None
+    for m in medias.values():
+        o = m.get("origin")
+        if o:
+            importer = o.get("importer", "")
+            params = o.get("params", {})
+            # Build a human-readable origin string
+            if importer == "demo":
+                origin = f"demo:{params.get('name', '')}"
+            elif importer == "pickle":
+                origin = f"file:{params.get('filename', '')}"
+            elif importer == "folder":
+                origin = f"folder:{params.get('path', '')}"
+            elif importer:
+                origin = importer
+            break
+
+    # Determine a sensible name from origin or filenames
+    name = origin or "Untitled"
+    if origin and ":" in origin:
+        name = origin.split(":", 1)[1] or origin
+
+    return jsonify({
+        "name": name,
+        "num_medias": num_medias,
+        "media_type": media_type,
+        "origin": origin or "unknown",
+    })


### PR DESCRIPTION
## Summary
This PR introduces a new dashboard interface to VTSearch that allows users to manage their datasets and models in a centralized location. The dashboard provides a tabular view of loaded datasets and models with sorting, selection, and basic CRUD operations.

## Key Changes

### Frontend (JavaScript & HTML)
- **Dashboard View**: Added a new dashboard panel (`#dashboard-view`) with two main sections:
  - "My Datasets" table with columns for name, media count, media type, and origin
  - "My Models" table with columns for name, label count, media type, examples, and origin
  
- **Dashboard Functionality**:
  - Sortable table headers (click to sort by column, toggle ascending/descending)
  - Row selection with visual highlighting
  - Rename and remove actions for both datasets and models
  - "Add Dataset" button that enters a special mode to load a new dataset and return to dashboard
  - "Add Model" button that opens the processor importer modal
  - Train and Run buttons that enable based on selection (Train: 1 dataset + 1 model; Run: ≥1 dataset + ≥1 model)
  
- **Navigation**: Added "Dashboard" menu item to the burger menu for quick access

- **Dataset Add Mode**: Implemented `_dashboardAddDatasetMode` flag to handle the workflow of adding a dataset from the dashboard, capturing its metadata via the new API endpoint, and returning to the dashboard

### Backend (Python)
- **New API Endpoint** (`/api/dashboard/dataset-info`):
  - Returns 404 if no dataset is loaded
  - Extracts and returns dataset metadata: name, number of medias, media type, and origin
  - Intelligently formats origin information based on importer type (demo, pickle, folder, etc.)
  - Derives a sensible dataset name from origin information when available

### Styling
- Added comprehensive CSS for the dashboard layout including:
  - Responsive table styling with hover and selection states
  - Sort arrow indicators on table headers
  - Empty state messaging
  - Action button styling
  - Dashboard section containers and headers

### Testing
- Added comprehensive test suite (`test_dashboard.py`) covering:
  - 404 response when no dataset is loaded
  - Correct metadata extraction from loaded medias
  - Origin formatting for different importer types (demo, folder, pickle)
  - Fallback to "unknown" origin when not available
  - HTML presence verification for dashboard elements

## Implementation Details
- Dashboard state is maintained in separate variables (`dashboardDatasets`, `dashboardModels`, `dashboardSelectedDatasets`, `dashboardSelectedModels`)
- Sorting is implemented with a generic `dashboardSortRows()` helper that handles both numeric and string comparisons
- The processor importer modal is reused for adding models, with results automatically added to the dashboard
- Dataset and model IDs are auto-incremented using `_dashboardNextId` counter

https://claude.ai/code/session_01FcSdhPBxgY7g8aE97foPAc