### PR TITLE
Refactor dashboard table actions to use compact icon buttons

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5503,14 +5503,11 @@
     dashboardDatasetsTbody.innerHTML = sorted.map(ds => {
       const sel = dashboardSelectedDatasets[ds.id] ? " selected" : "";
       return `<tr data-id="${ds.id}" class="${sel}">
-        <td title="${escapeHtml(ds.name)}">${escapeHtml(ds.name)}</td>
+        <td title="${escapeHtml(ds.name)}">${escapeHtml(ds.name)} <button class="btn-icon" data-action="rename" data-id="${ds.id}" title="Rename">&#9998;</button></td>
         <td>${ds.num_medias}</td>
         <td>${escapeHtml(ds.media_type)}</td>
         <td title="${escapeHtml(ds.origin)}">${escapeHtml(ds.origin)}</td>
-        <td><div class="dashboard-row-actions">
-          <button class="btn-sm" data-action="rename" data-id="${ds.id}">Rename</button>
-          <button class="btn-sm-danger" data-action="remove" data-id="${ds.id}">Remove</button>
-        </div></td>
+        <td><button class="btn-icon btn-icon-danger" data-action="remove" data-id="${ds.id}" title="Remove">&#128465;</button></td>
       </tr>`;
     }).join("");
 
@@ -5571,16 +5568,13 @@
     dashboardModelsTbody.innerHTML = sorted.map(m => {
       const sel = dashboardSelectedModels[m.id] ? " selected" : "";
       return `<tr data-id="${m.id}" class="${sel}">
-        <td title="${escapeHtml(m.name)}">${escapeHtml(m.name)}</td>
+        <td title="${escapeHtml(m.name)}">${escapeHtml(m.name)} <button class="btn-icon" data-action="rename" data-id="${m.id}" title="Rename">&#9998;</button></td>
         <td>${m.num_labels}</td>
         <td>${escapeHtml(m.media_type)}</td>
         <td title="${escapeHtml(m.text_examples)}">${escapeHtml(m.text_examples)}</td>
         <td title="${escapeHtml(m.media_examples)}">${escapeHtml(m.media_examples)}</td>
         <td title="${escapeHtml(m.origin)}">${escapeHtml(m.origin)}</td>
-        <td><div class="dashboard-row-actions">
-          <button class="btn-sm" data-action="rename" data-id="${m.id}">Rename</button>
-          <button class="btn-sm-danger" data-action="remove" data-id="${m.id}">Remove</button>
-        </div></td>
+        <td><button class="btn-icon btn-icon-danger" data-action="remove" data-id="${m.id}" title="Remove">&#128465;</button></td>
       </tr>`;
     }).join("");
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -640,7 +640,7 @@ video { max-width: 100%; }
 }
 .dashboard-table thead th:hover { color: var(--accent-light); }
 .dashboard-table thead th .sort-arrow { font-size: 0.6rem; display: inline-block; width: 1em; text-align: left; }
-.dashboard-table thead th.col-actions { cursor: default; width: 100px; }
+.dashboard-table thead th.col-actions { cursor: default; width: 40px; }
 .dashboard-table tbody td {
   padding: 6px 8px; border-bottom: 1px solid var(--border); color: var(--text-primary);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px;
@@ -649,6 +649,12 @@ video { max-width: 100%; }
 .dashboard-table tbody tr:hover { background: var(--bg-subtle); }
 .dashboard-table tbody tr.selected { background: var(--accent-highlight-bg); }
 .dashboard-row-actions { display: flex; gap: 4px; }
+.btn-icon {
+  background: none; border: none; cursor: pointer; color: var(--text-muted);
+  font-size: 0.85rem; padding: 0 3px; opacity: 0.5; transition: opacity 0.15s, color 0.15s;
+}
+.btn-icon:hover { opacity: 1; color: var(--text-primary); }
+.btn-icon-danger:hover { opacity: 1; color: var(--color-bad); }
 .dashboard-actions {
   display: flex; gap: 12px; justify-content: flex-end; padding-top: 8px;
 }


### PR DESCRIPTION
## Summary
Refactored the dashboard table action buttons to use compact icon-based buttons instead of text-based buttons, improving the UI density and visual consistency.

## Key Changes
- **Datasets and Models tables**: Moved "Rename" button from dedicated actions column to inline with the name cell, using a pencil icon (✎)
- **Remove button**: Converted to a trash can icon (🗑) in the actions column
- **Styling updates**:
  - Reduced actions column width from 100px to 40px to accommodate icon-only buttons
  - Added new `.btn-icon` class for icon button styling with hover effects
  - Added `.btn-icon-danger` variant for destructive actions (remove button)
  - Icon buttons use opacity transitions and color changes on hover for better UX
- **Removed**: `.dashboard-row-actions` flex container is now unused but kept for backward compatibility

## Implementation Details
- Icon buttons use Unicode characters (✎ for rename, 🗑 for remove) instead of text labels
- Buttons include `title` attributes for accessibility/tooltips
- Hover states provide visual feedback with opacity and color transitions
- Inline rename button placement reduces visual clutter while keeping actions discoverable

https://claude.ai/code/session_01Ld2QWTGQQKmsrygdVcPonj