### PR TITLE
Add trainable models feature for iterative label collection

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from vtsearch.routes import (  # noqa: E402
     processor_importers_bp,
     settings_bp,
     sorting_bp,
+    trainable_models_bp,
 )
 from vtsearch.media import set_progress_callback  # noqa: E402
 from vtsearch.utils import update_progress  # noqa: E402
@@ -61,6 +62,7 @@ app.register_blueprint(exporters_bp)
 app.register_blueprint(label_importers_bp)
 app.register_blueprint(processor_importers_bp)
 app.register_blueprint(settings_bp)
+app.register_blueprint(trainable_models_bp)
 
 
 # ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -489,6 +489,7 @@
                 num_medias: info.num_medias,
                 media_type: info.media_type,
                 origin: info.origin,
+                source: info.source || null,
               });
             }
           } catch (_) { /* ignore */ }
@@ -499,6 +500,50 @@
           selected = null;
           datasetLoaded = false;
           showDashboard();
+          return;
+        }
+
+        // Dashboard train mode: dataset loaded, now apply labels and enter labeling UI
+        if (_dashboardTrainMode) {
+          const trainInfo = _dashboardTrainMode;
+          await fetchMedias();
+
+          // Import labels from the trainable model's labelset
+          try {
+            const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(trainInfo.model.name)}`);
+            if (modelRes.ok) {
+              const modelData = await modelRes.json();
+              const labels = modelData.labelset && modelData.labelset.labels;
+              if (labels && labels.length > 0) {
+                await fetch("/api/labels/import", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ labels }),
+                });
+              }
+            }
+          } catch (_) { /* ignore label import errors */ }
+
+          await fetchVotes();
+
+          // Set text sort mode and trigger sort with the model's text query
+          sortMode = "text";
+          textSortWrap.style.display = "";
+          learnedSortWrap.style.display = "none";
+          loadSortWrap.style.display = "none";
+          // Update radio buttons to reflect text sort mode
+          document.querySelectorAll('input[name="sort-mode"]').forEach(r => {
+            r.checked = r.value === "text";
+          });
+          textSortInput.value = trainInfo.model.text_query || "";
+          if (trainInfo.model.text_query) {
+            fetchTextSort(trainInfo.model.text_query);
+          }
+
+          // Select first media
+          if (medias.length > 0 && !selected) {
+            selectMedia(medias[0].id);
+          }
           return;
         }
 
@@ -1264,6 +1309,12 @@
     // If we came from the dashboard, go back to dashboard
     if (_dashboardAddDatasetMode) {
       _dashboardAddDatasetMode = false;
+      showDashboard();
+      return;
+    }
+    // If we were in a training session, save labels and return to dashboard
+    if (_dashboardTrainMode) {
+      saveTrainableModelLabels();
       showDashboard();
       return;
     }
@@ -5445,9 +5496,57 @@
   let dashboardSelectedDatasets = {};  // id -> true
   let dashboardSelectedModels = {};    // id -> true
   let _dashboardAddDatasetMode = false;
+  let _dashboardTrainMode = null;  // {model, dataset} when training a trainable model
   let _dashboardNextId = 1;
 
+  async function saveTrainableModelLabels() {
+    if (!_dashboardTrainMode) return;
+    const modelName = _dashboardTrainMode.model.name;
+    try {
+      const res = await fetch(`/api/trainable-models/${encodeURIComponent(modelName)}/labels`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        const result = await res.json();
+        // Update the dashboard model entry with new label count
+        const model = dashboardModels.find(m => m.name === modelName && m.trainable);
+        if (model) {
+          model.num_labels = result.num_labels || 0;
+        }
+      }
+    } catch (_) { /* ignore save errors */ }
+    _dashboardTrainMode = null;
+  }
+
+  async function loadTrainableModelsIntoDashboard() {
+    try {
+      const res = await fetch("/api/trainable-models");
+      if (!res.ok) return;
+      const data = await res.json();
+      const serverModels = data.models || [];
+      for (const sm of serverModels) {
+        // Skip if already present in dashboardModels (match by name + trainable flag)
+        if (dashboardModels.some(m => m.trainable && m.name === sm.name)) continue;
+        dashboardModels.push({
+          id: _dashboardNextId++,
+          name: sm.name,
+          num_labels: sm.num_labels || 0,
+          media_type: "any",
+          text_examples: sm.text_query || "-",
+          media_examples: "-",
+          origin: "Train New",
+          trainable: true,
+          text_query: sm.text_query || "",
+        });
+      }
+    } catch (_) { /* ignore */ }
+  }
+
   function showDashboard() {
+    // If leaving a training session, save labels first
+    if (_dashboardTrainMode) {
+      saveTrainableModelLabels();
+    }
     // Hide left/right panels and welcome screen
     leftPanel.style.display = "none";
     if (rightPanel) rightPanel.style.display = "none";
@@ -5458,9 +5557,12 @@
     center.innerHTML = "";
     center.appendChild(dashboardView);
     dashboardView.style.display = "flex";
-    renderDashboardDatasets();
-    renderDashboardModels();
-    updateDashboardButtons();
+    // Load trainable models from server, then render
+    loadTrainableModelsIntoDashboard().then(() => {
+      renderDashboardDatasets();
+      renderDashboardModels();
+      updateDashboardButtons();
+    });
   }
 
   function hideDashboard() {
@@ -5570,8 +5672,9 @@
     const sorted = dashboardSortRows(dashboardModels, dashboardModelSort);
     dashboardModelsTbody.innerHTML = sorted.map(m => {
       const sel = dashboardSelectedModels[m.id] ? " selected" : "";
+      const trainBadge = m.trainable ? ' <span class="trainable-badge">trainable</span>' : "";
       return `<tr data-id="${m.id}" class="${sel}">
-        <td title="${escapeHtml(m.name)}">${escapeHtml(m.name)}</td>
+        <td title="${escapeHtml(m.name)}">${escapeHtml(m.name)}${trainBadge}</td>
         <td>${m.num_labels}</td>
         <td>${escapeHtml(m.media_type)}</td>
         <td title="${escapeHtml(m.text_examples)}">${escapeHtml(m.text_examples)}</td>
@@ -5604,6 +5707,11 @@
       btn.addEventListener("click", async () => {
         const id = parseInt(btn.dataset.id);
         if (btn.dataset.action === "remove") {
+          const m = dashboardModels.find(m => m.id === id);
+          if (m && m.trainable) {
+            // Also delete from backend
+            fetch(`/api/trainable-models/${encodeURIComponent(m.name)}`, { method: "DELETE" }).catch(() => {});
+          }
           dashboardModels = dashboardModels.filter(m => m.id !== id);
           delete dashboardSelectedModels[id];
           renderDashboardModels();
@@ -5613,6 +5721,16 @@
           if (!m) return;
           const newName = await vtPrompt(`Rename model "${m.name}" to:`, m.name);
           if (newName && newName !== m.name) {
+            if (m.trainable) {
+              // Rename on backend too
+              try {
+                await fetch(`/api/trainable-models/${encodeURIComponent(m.name)}/rename`, {
+                  method: "PUT",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ new_name: newName }),
+                });
+              } catch (_) { /* ignore */ }
+            }
             m.name = newName;
             renderDashboardModels();
           }
@@ -5624,10 +5742,59 @@
   function updateDashboardButtons() {
     const numDS = Object.keys(dashboardSelectedDatasets).length;
     const numMD = Object.keys(dashboardSelectedModels).length;
-    // Train: exactly 1 dataset + exactly 1 model
-    dashboardTrainBtn.disabled = !(numDS === 1 && numMD === 1);
+    // Train: exactly 1 dataset + exactly 1 model (model must be trainable)
+    let trainEnabled = numDS === 1 && numMD === 1;
+    if (trainEnabled) {
+      const modelId = parseInt(Object.keys(dashboardSelectedModels)[0]);
+      const model = dashboardModels.find(m => m.id === modelId);
+      trainEnabled = model && model.trainable;
+    }
+    dashboardTrainBtn.disabled = !trainEnabled;
     // Run: at least 1 dataset + at least 1 model
     dashboardRunBtn.disabled = !(numDS >= 1 && numMD >= 1);
+  }
+
+  // -- Train button: load dataset + import labels + enter labeling UI --
+  if (dashboardTrainBtn) {
+    dashboardTrainBtn.addEventListener("click", async () => {
+      const dsId = parseInt(Object.keys(dashboardSelectedDatasets)[0]);
+      const mdId = parseInt(Object.keys(dashboardSelectedModels)[0]);
+      const dataset = dashboardDatasets.find(d => d.id === dsId);
+      const model = dashboardModels.find(m => m.id === mdId);
+      if (!dataset || !model || !model.trainable) return;
+
+      if (!dataset.source) {
+        await vtAlert("Cannot reload this dataset — no source info stored. Please re-add the dataset.", "warning");
+        return;
+      }
+
+      // Enter training mode
+      _dashboardTrainMode = { model, dataset };
+      hideDashboard();
+
+      // Kick off dataset reload from the stored source
+      try {
+        const res = await fetch("/api/dataset/load-source", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ source: dataset.source }),
+        });
+        if (!res.ok) {
+          const err = await res.json();
+          _dashboardTrainMode = null;
+          await vtAlert(err.error || "Failed to reload dataset", "warning");
+          showDashboard();
+          return;
+        }
+      } catch (err) {
+        _dashboardTrainMode = null;
+        await vtAlert(`Failed to reload dataset: ${err.message}`, "warning");
+        showDashboard();
+        return;
+      }
+
+      startProgressPolling();
+    });
   }
 
   // Wire sortable headers for datasets table
@@ -5695,10 +5862,19 @@
     processorImporterBack.style.display = "none";
     processorImporterList.style.display = "";
 
-    if (importers.length === 0) {
-      processorImporterList.innerHTML = '<p style="color:var(--text-muted);">No processor importers available.</p>';
-    } else {
-      processorImporterList.innerHTML = importers.map(imp => `
+    // Build option cards: "Train New" first, then processor importers
+    let html = `
+      <div class="processor-importer-option option-card" data-name="__train_new__">
+        <span class="option-card-icon">\u{1F9E0}</span>
+        <div>
+          <div class="option-card-title">Train New</div>
+          <div class="option-card-desc">Create a trainable model with a text description. Add labels over time.</div>
+        </div>
+      </div>
+    `;
+
+    if (importers.length > 0) {
+      html += importers.map(imp => `
         <div class="processor-importer-option option-card" data-name="${escapeHtml(imp.name)}">
           <span class="option-card-icon">${escapeHtml(imp.icon || '\u{1F9E9}')}</span>
           <div>
@@ -5707,20 +5883,100 @@
           </div>
         </div>
       `).join("");
+    }
 
-      processorImporterList.querySelectorAll(".processor-importer-option").forEach(el => {
-        el.setAttribute("role", "button");
-        el.setAttribute("tabindex", "0");
-        const name = el.dataset.name;
+    processorImporterList.innerHTML = html;
+
+    processorImporterList.querySelectorAll(".processor-importer-option").forEach(el => {
+      el.setAttribute("role", "button");
+      el.setAttribute("tabindex", "0");
+      const name = el.dataset.name;
+      if (name === "__train_new__") {
+        el.addEventListener("click", () => showTrainNewFormForDashboard());
+        el.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); showTrainNewFormForDashboard(); }
+        });
+      } else {
         const imp = importers.find(i => i.name === name);
         el.addEventListener("click", () => showProcessorImporterFormForDashboard(imp));
         el.addEventListener("keydown", (e) => {
           if (e.key === "Enter" || e.key === " ") { e.preventDefault(); showProcessorImporterFormForDashboard(imp); }
         });
-      });
-    }
+      }
+    });
 
     processorImporterModal.classList.add("show");
+  }
+
+  function showTrainNewFormForDashboard() {
+    processorImporterList.style.display = "none";
+    processorImporterBack.style.display = "inline-block";
+
+    let html = `<h3 class="form-heading">Train New Model</h3>`;
+    html += `<form id="train-new-form">`;
+    html += `<div class="form-group">`;
+    html += `<label class="form-label">Model Name *</label>`;
+    html += `<input type="text" name="name" placeholder="e.g. Dog Barks" class="form-input" required>`;
+    html += `<div class="form-hint">A name for this trainable model.</div>`;
+    html += `</div>`;
+    html += `<div class="form-group">`;
+    html += `<label class="form-label">Text Sort Query *</label>`;
+    html += `<input type="text" name="text_query" placeholder="e.g. sounds of dogs barking" class="form-input" required>`;
+    html += `<div class="form-hint">Describes what to look for. Used for initial text-based sorting.</div>`;
+    html += `</div>`;
+    html += `<div id="train-new-status" class="status-text compact"></div>`;
+    html += `<button type="submit" class="btn-block-primary">Create Model</button>`;
+    html += `</form>`;
+
+    processorImporterFormDiv.innerHTML = html;
+    processorImporterFormDiv.style.display = "block";
+
+    const statusEl = processorImporterFormDiv.querySelector("#train-new-status");
+
+    processorImporterFormDiv.querySelector("#train-new-form").addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const formEl = e.target;
+      const name = formEl.elements["name"].value.trim();
+      const textQuery = formEl.elements["text_query"].value.trim();
+      if (!name || !textQuery) return;
+
+      statusEl.textContent = "Creating\u2026";
+      statusEl.style.color = "var(--text-muted)";
+
+      try {
+        const res = await fetch("/api/trainable-models", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, text_query: textQuery }),
+        });
+        const result = await res.json();
+        if (res.ok) {
+          dashboardModels.push({
+            id: _dashboardNextId++,
+            name: result.name,
+            num_labels: 0,
+            media_type: "any",
+            text_examples: result.text_query,
+            media_examples: "-",
+            origin: "Train New",
+            trainable: true,
+            text_query: result.text_query,
+          });
+          statusEl.textContent = `Created "${result.name}"`;
+          statusEl.style.color = "var(--color-good)";
+          setTimeout(() => {
+            processorImporterModal.classList.remove("show");
+            showDashboard();
+          }, 800);
+        } else {
+          statusEl.textContent = result.error || "Creation failed";
+          statusEl.style.color = "var(--color-bad)";
+        }
+      } catch (err) {
+        statusEl.textContent = `Error: ${err.message}`;
+        statusEl.style.color = "var(--color-bad)";
+      }
+    });
   }
 
   function showProcessorImporterFormForDashboard(importer) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -653,3 +653,9 @@ video { max-width: 100%; }
   display: flex; gap: 12px; justify-content: flex-end; padding-top: 8px;
 }
 .dashboard-actions .btn-block-primary { width: auto; padding: 10px 32px; }
+.trainable-badge {
+  display: inline-block; font-size: 0.65rem; padding: 1px 5px;
+  background: var(--accent); color: #fff; border-radius: 3px;
+  vertical-align: middle; margin-left: 4px; font-weight: 600;
+  letter-spacing: 0.03em;
+}

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -1,0 +1,244 @@
+"""Tests for trainable model CRUD and label persistence."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from vtsearch.routes.trainable_models import TRAINABLE_MODELS_DIR
+
+
+@pytest.fixture(autouse=True)
+def clean_trainable_models_dir():
+    """Remove the trainable models directory before and after each test."""
+    if TRAINABLE_MODELS_DIR.is_dir():
+        shutil.rmtree(TRAINABLE_MODELS_DIR)
+    yield
+    if TRAINABLE_MODELS_DIR.is_dir():
+        shutil.rmtree(TRAINABLE_MODELS_DIR)
+
+
+class TestCreateTrainableModel:
+    def test_create_success(self, client):
+        res = client.post(
+            "/api/trainable-models",
+            json={"name": "Dog Barks", "text_query": "sounds of dogs barking"},
+        )
+        assert res.status_code == 201
+        data = res.get_json()
+        assert data["success"] is True
+        assert data["name"] == "Dog Barks"
+        assert data["text_query"] == "sounds of dogs barking"
+        assert data["num_labels"] == 0
+
+    def test_create_missing_name(self, client):
+        res = client.post(
+            "/api/trainable-models",
+            json={"text_query": "sounds"},
+        )
+        assert res.status_code == 400
+        assert "name" in res.get_json()["error"]
+
+    def test_create_missing_text_query(self, client):
+        res = client.post(
+            "/api/trainable-models",
+            json={"name": "Test"},
+        )
+        assert res.status_code == 400
+        assert "text_query" in res.get_json()["error"]
+
+    def test_create_duplicate(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Dog Barks", "text_query": "dogs"},
+        )
+        res = client.post(
+            "/api/trainable-models",
+            json={"name": "Dog Barks", "text_query": "dogs again"},
+        )
+        assert res.status_code == 409
+
+    def test_file_created_on_disk(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Test Model", "text_query": "test"},
+        )
+        files = list(TRAINABLE_MODELS_DIR.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["name"] == "Test Model"
+        assert data["text_query"] == "test"
+        assert data["labelset"] == {"labels": []}
+
+
+class TestListTrainableModels:
+    def test_empty_list(self, client):
+        res = client.get("/api/trainable-models")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["models"] == []
+
+    def test_list_after_create(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Model A", "text_query": "a"},
+        )
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Model B", "text_query": "b"},
+        )
+        res = client.get("/api/trainable-models")
+        data = res.get_json()
+        names = [m["name"] for m in data["models"]]
+        assert "Model A" in names
+        assert "Model B" in names
+
+
+class TestGetTrainableModel:
+    def test_get_existing(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "My Model", "text_query": "test query"},
+        )
+        res = client.get("/api/trainable-models/My%20Model")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["name"] == "My Model"
+        assert data["text_query"] == "test query"
+        assert "labelset" in data
+
+    def test_get_nonexistent(self, client):
+        res = client.get("/api/trainable-models/nonexistent")
+        assert res.status_code == 404
+
+
+class TestDeleteTrainableModel:
+    def test_delete_existing(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "To Delete", "text_query": "test"},
+        )
+        res = client.delete("/api/trainable-models/To%20Delete")
+        assert res.status_code == 200
+        assert res.get_json()["success"] is True
+
+        # Verify it's gone
+        res = client.get("/api/trainable-models/To%20Delete")
+        assert res.status_code == 404
+
+    def test_delete_nonexistent(self, client):
+        res = client.delete("/api/trainable-models/nonexistent")
+        assert res.status_code == 404
+
+
+class TestRenameTrainableModel:
+    def test_rename_success(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Old Name", "text_query": "test"},
+        )
+        res = client.put(
+            "/api/trainable-models/Old%20Name/rename",
+            json={"new_name": "New Name"},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert data["new_name"] == "New Name"
+
+        # Old name should be gone
+        res = client.get("/api/trainable-models/Old%20Name")
+        assert res.status_code == 404
+
+        # New name should exist
+        res = client.get("/api/trainable-models/New%20Name")
+        assert res.status_code == 200
+        assert res.get_json()["name"] == "New Name"
+
+    def test_rename_nonexistent(self, client):
+        res = client.put(
+            "/api/trainable-models/nonexistent/rename",
+            json={"new_name": "Foo"},
+        )
+        assert res.status_code == 404
+
+    def test_rename_missing_new_name(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Test", "text_query": "test"},
+        )
+        res = client.put(
+            "/api/trainable-models/Test/rename",
+            json={},
+        )
+        assert res.status_code == 400
+
+    def test_rename_conflict(self, client):
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Model A", "text_query": "a"},
+        )
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Model B", "text_query": "b"},
+        )
+        res = client.put(
+            "/api/trainable-models/Model%20A/rename",
+            json={"new_name": "Model B"},
+        )
+        assert res.status_code == 409
+
+
+class TestSaveLabels:
+    def test_save_labels_empty(self, client):
+        """Save labels when there are no votes — should produce empty labelset."""
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Labeler", "text_query": "test"},
+        )
+        res = client.post("/api/trainable-models/Labeler/labels")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert data["num_labels"] == 0
+
+    def test_save_labels_with_votes(self, client):
+        """Save labels after casting votes — labelset should contain the voted medias."""
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded for this test")
+
+        # Cast a good vote on the first media
+        first_id = next(iter(medias))
+        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+
+        # Cast a bad vote on the second media
+        media_ids = list(medias.keys())
+        if len(media_ids) < 2:
+            pytest.skip("Need at least 2 medias")
+        second_id = media_ids[1]
+        client.post(f"/api/medias/{second_id}/vote", json={"vote": "bad"})
+
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Voted Model", "text_query": "test"},
+        )
+        res = client.post("/api/trainable-models/Voted%20Model/labels")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["num_labels"] == 2
+
+        # Verify the labels are persisted on disk
+        model_res = client.get("/api/trainable-models/Voted%20Model")
+        model_data = model_res.get_json()
+        labels = model_data["labelset"]["labels"]
+        assert len(labels) == 2
+        label_values = {l["label"] for l in labels}
+        assert "good" in label_values
+        assert "bad" in label_values
+
+    def test_save_labels_nonexistent_model(self, client):
+        res = client.post("/api/trainable-models/nonexistent/labels")
+        assert res.status_code == 404

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -9,6 +9,7 @@ from vtsearch.routes.main import main_bp
 from vtsearch.routes.processor_importers import processor_importers_bp
 from vtsearch.routes.settings import settings_bp
 from vtsearch.routes.sorting import sorting_bp
+from vtsearch.routes.trainable_models import trainable_models_bp
 
 __all__ = [
     "main_bp",
@@ -20,4 +21,5 @@ __all__ = [
     "label_importers_bp",
     "processor_importers_bp",
     "settings_bp",
+    "trainable_models_bp",
 ]

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -764,9 +764,105 @@ def dashboard_dataset_info():
     if origin and ":" in origin:
         name = origin.split(":", 1)[1] or origin
 
+    # Build a source dict that can be used to reload the dataset later
+    source = None
+    for m in medias.values():
+        o = m.get("origin")
+        if isinstance(o, dict):
+            source = o
+            break
+
     return jsonify({
         "name": name,
         "num_medias": num_medias,
         "media_type": media_type,
         "origin": origin or "unknown",
+        "source": source,
     })
+
+
+@datasets_bp.route("/api/dataset/load-source", methods=["POST"])
+def load_dataset_from_source():
+    """Reload a dataset from a stored source origin dict.
+
+    Accepts JSON with a ``source`` key containing the raw origin dict
+    (as returned by ``/api/dashboard/dataset-info``).  Supports demo,
+    pickle, folder, and other importer origins.
+
+    Returns ``{"ok": true}`` and begins loading in a background thread.
+    Poll ``/api/progress`` for status.
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    source = data.get("source")
+    if not isinstance(source, dict):
+        return jsonify({"error": "source must be an origin dict"}), 400
+    return _load_from_origin(source)
+
+
+def _load_from_origin(source: dict):
+    """Start loading a dataset from a raw origin dict (internal helper)."""
+    importer_name = source.get("importer", "")
+    params = source.get("params", {})
+
+    if importer_name == "dupe_set":
+        members = source.get("members", [])
+        if members:
+            member_origin = members[0].get("origin")
+            if isinstance(member_origin, dict):
+                return _load_from_origin(member_origin)
+        return jsonify({"error": "Cannot reload from dupe_set origin"}), 400
+
+    if importer_name == "demo":
+        demo_name = params.get("name", "")
+        if demo_name not in DEMO_DATASETS:
+            return jsonify({"error": f"Unknown demo dataset: {demo_name}"}), 400
+
+        def load_task():
+            try:
+                clear_dataset()
+                gc.collect()
+                load_demo_dataset(demo_name, medias)
+                _set_clip_origins(medias, {"importer": "demo", "params": {"name": demo_name}})
+                collapse_duplicates(medias)
+                _load_embedder_for_clips()
+                build_diversity_tree()
+            except MemoryError:
+                medias.clear()
+                gc.collect()
+                update_progress("idle", "", 0, 0, "Out of memory — dataset too large.")
+            except Exception as e:
+                update_progress("idle", "", 0, 0, str(e))
+
+        threading.Thread(target=load_task, daemon=True).start()
+        return jsonify({"ok": True, "message": "Loading started"})
+
+    if importer_name == "pickle":
+        pkl_path = params.get("path", "")
+        if not pkl_path or not Path(pkl_path).is_file():
+            return jsonify({"error": f"Pickle file not found: {pkl_path}"}), 400
+        importer = get_importer("pickle")
+        if importer is None:
+            return jsonify({"error": "pickle importer not available"}), 500
+        _run_importer_in_background(importer, {"pkl_path": pkl_path})
+        return jsonify({"ok": True, "message": "Loading started"})
+
+    if importer_name == "folder":
+        folder_path = params.get("path", "")
+        if not folder_path or not Path(folder_path).is_dir():
+            return jsonify({"error": f"Folder not found: {folder_path}"}), 400
+        importer = get_importer("folder")
+        if importer is None:
+            return jsonify({"error": "folder importer not available"}), 500
+        field_values = {"path": folder_path}
+        media_type = params.get("media_type", "")
+        if media_type:
+            field_values["media_type"] = media_type
+        _run_importer_in_background(importer, field_values)
+        return jsonify({"ok": True, "message": "Loading started"})
+
+    # Generic fallback: try the named importer with the stored params
+    importer = get_importer(importer_name)
+    if importer is None:
+        return jsonify({"error": f"Unknown importer: {importer_name}"}), 400
+    _run_importer_in_background(importer, params)
+    return jsonify({"ok": True, "message": "Loading started"})

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -1,0 +1,232 @@
+"""Blueprint for trainable model routes.
+
+Trainable models are a persistent reference to a labelset file plus a text-sort
+query.  They live on disk in ``data/trainable_models/<slug>.json`` and can
+accumulate labels over repeated training sessions.
+
+Endpoints
+---------
+GET  /api/trainable-models
+    List all trainable models.
+
+POST /api/trainable-models
+    Create a new trainable model (requires ``name`` and ``text_query``).
+
+GET  /api/trainable-models/<name>
+    Retrieve a single trainable model with its labelset.
+
+DELETE /api/trainable-models/<name>
+    Delete a trainable model.
+
+PUT  /api/trainable-models/<name>/rename
+    Rename a trainable model.
+
+POST /api/trainable-models/<name>/labels
+    Save the current votes as the model's labelset.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+from vtsearch.config import DATA_DIR
+
+trainable_models_bp = Blueprint("trainable_models", __name__)
+
+TRAINABLE_MODELS_DIR = DATA_DIR / "trainable_models"
+
+
+def _slug(name: str) -> str:
+    """Turn a human-readable name into a filesystem-safe slug."""
+    return re.sub(r"[^a-z0-9_-]+", "_", name.lower()).strip("_") or "model"
+
+
+def _model_path(name: str) -> Path:
+    return TRAINABLE_MODELS_DIR / f"{_slug(name)}.json"
+
+
+def _read_model(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_model(path: Path, data: dict) -> None:
+    TRAINABLE_MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _list_all() -> list[dict]:
+    """Return summary info for every trainable model on disk."""
+    if not TRAINABLE_MODELS_DIR.is_dir():
+        return []
+    models = []
+    for p in sorted(TRAINABLE_MODELS_DIR.iterdir()):
+        if p.suffix != ".json":
+            continue
+        data = _read_model(p)
+        if data is None:
+            continue
+        labels = data.get("labelset", {}).get("labels", [])
+        models.append({
+            "name": data["name"],
+            "text_query": data.get("text_query", ""),
+            "num_labels": len(labels),
+            "created_at": data.get("created_at", 0),
+        })
+    return models
+
+
+# ---------------------------------------------------------------------------
+# GET /api/trainable-models
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models", methods=["GET"])
+def list_trainable_models():
+    """Return all trainable models (summary only, no full labelset)."""
+    return jsonify({"models": _list_all()})
+
+
+# ---------------------------------------------------------------------------
+# POST /api/trainable-models
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models", methods=["POST"])
+def create_trainable_model():
+    """Create a new trainable model.
+
+    Expects JSON::
+
+        {"name": "Dog Barks", "text_query": "dog barking sounds"}
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    name = data.get("name", "").strip()
+    text_query = data.get("text_query", "").strip()
+
+    if not name:
+        return jsonify({"error": "name is required"}), 400
+    if not text_query:
+        return jsonify({"error": "text_query is required"}), 400
+
+    path = _model_path(name)
+    if path.exists():
+        return jsonify({"error": f"A trainable model named '{name}' already exists"}), 409
+
+    model_data = {
+        "name": name,
+        "text_query": text_query,
+        "created_at": time.time(),
+        "labelset": {"labels": []},
+    }
+    _write_model(path, model_data)
+
+    return jsonify({
+        "success": True,
+        "name": name,
+        "text_query": text_query,
+        "num_labels": 0,
+    }), 201
+
+
+# ---------------------------------------------------------------------------
+# GET /api/trainable-models/<name>
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models/<name>", methods=["GET"])
+def get_trainable_model(name: str):
+    """Retrieve a single trainable model with its full labelset."""
+    path = _model_path(name)
+    data = _read_model(path)
+    if data is None:
+        return jsonify({"error": f"Trainable model '{name}' not found"}), 404
+    return jsonify(data)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/trainable-models/<name>
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models/<name>", methods=["DELETE"])
+def delete_trainable_model(name: str):
+    """Delete a trainable model."""
+    path = _model_path(name)
+    if not path.exists():
+        return jsonify({"error": f"Trainable model '{name}' not found"}), 404
+    path.unlink()
+    return jsonify({"success": True, "name": name})
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/trainable-models/<name>/rename
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models/<name>/rename", methods=["PUT"])
+def rename_trainable_model(name: str):
+    """Rename a trainable model.
+
+    Expects JSON::
+
+        {"new_name": "Cat Meows"}
+    """
+    old_path = _model_path(name)
+    data = _read_model(old_path)
+    if data is None:
+        return jsonify({"error": f"Trainable model '{name}' not found"}), 404
+
+    body = request.get_json(force=True, silent=True) or {}
+    new_name = body.get("new_name", "").strip()
+    if not new_name:
+        return jsonify({"error": "new_name is required"}), 400
+
+    new_path = _model_path(new_name)
+    if new_path.exists() and new_path != old_path:
+        return jsonify({"error": f"A model named '{new_name}' already exists"}), 409
+
+    data["name"] = new_name
+    _write_model(new_path, data)
+    if new_path != old_path:
+        old_path.unlink(missing_ok=True)
+
+    return jsonify({"success": True, "old_name": name, "new_name": new_name})
+
+
+# ---------------------------------------------------------------------------
+# POST /api/trainable-models/<name>/labels
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models/<name>/labels", methods=["POST"])
+def save_trainable_model_labels(name: str):
+    """Save the current votes as the model's labelset.
+
+    Reads good_votes/bad_votes from global state and the current medias
+    to build a fresh LabelSet, then persists it into the model's JSON file.
+    """
+    path = _model_path(name)
+    data = _read_model(path)
+    if data is None:
+        return jsonify({"error": f"Trainable model '{name}' not found"}), 404
+
+    from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.utils import bad_votes, good_votes, medias
+
+    labelset = LabelSet.from_clips_and_votes(medias, good_votes, bad_votes)
+    data["labelset"] = labelset.to_dict()
+    _write_model(path, data)
+
+    return jsonify({
+        "success": True,
+        "name": name,
+        "num_labels": len(labelset),
+    })


### PR DESCRIPTION
## Summary
This PR introduces a new "trainable models" feature that allows users to create persistent, reusable models for iterative label collection. Users can now create a trainable model with a text description, load datasets, label media samples, and save those labels back to the model for future training sessions.

## Key Changes

### Backend (Python/Flask)
- **New trainable models blueprint** (`vtsearch/routes/trainable_models.py`):
  - CRUD endpoints for trainable models (create, list, get, delete, rename)
  - Models stored as JSON files in `data/trainable_models/` with persistent labelsets
  - `POST /api/trainable-models/<name>/labels` endpoint to save current votes as the model's labelset
  - Slug-based filesystem naming for safe storage

- **Dataset loading enhancement** (`vtsearch/routes/datasets.py`):
  - Store `source` metadata when loading datasets so they can be reloaded later
  - New `POST /api/dataset/load-source` endpoint to reload datasets from stored source origins
  - Supports demo, pickle, folder, and other importer sources

- **Test coverage** (`tests/test_trainable_models.py`):
  - Comprehensive tests for model CRUD operations
  - Tests for label persistence and vote-to-labelset conversion
  - 244 lines of test cases covering success and error paths

### Frontend (JavaScript/UI)
- **Dashboard integration**:
  - Display trainable models in the dashboard with a "trainable" badge
  - Load trainable models from server on dashboard view
  - Enable train button only when a trainable model is selected

- **Training workflow**:
  - New "Train New" option in the importer modal to create trainable models
  - Form to create model with name and text query
  - Training mode (`_dashboardTrainMode`) that:
    - Reloads the selected dataset from stored source
    - Imports the model's labelset as initial labels
    - Sets up text-based sorting with the model's query
    - Allows users to vote on media samples
    - Saves votes back to the model on exit

- **Model management**:
  - Rename trainable models (synced to backend)
  - Delete trainable models (synced to backend)
  - Display label count for each model

### Styling
- Added `.trainable-badge` CSS class for visual distinction of trainable models

## Notable Implementation Details

- **Persistent labelsets**: Models accumulate labels across multiple training sessions via the `/labels` endpoint
- **Source tracking**: Dataset origins are captured and stored to enable reliable reloading
- **Graceful fallback**: Training mode handles missing source info with user-friendly error messages
- **Background loading**: Dataset reloading happens in background threads with progress polling
- **Label import**: When entering training mode, the model's existing labelset is imported as initial labels for the session

https://claude.ai/code/session_01LCAtp5zyVxNNNiPqqnKEw9