### PR TITLE
Defer torch configuration and stub embeddings in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,19 @@ _EMBEDDING_DIM = 512
 
 
 def _fake_embed_audio(path):
-    """Deterministic fake audio embedding derived from the file path."""
-    rng = np.random.RandomState(hash(str(path)) % 2**31)
+    """Deterministic fake audio embedding derived from the file contents.
+
+    Uses the first 1000 bytes of the file as a seed so that different audio
+    files (even when written to the same temp path) produce distinct vectors.
+    """
+    import hashlib
+
+    try:
+        data = open(path, "rb").read(1000)
+        seed = int(hashlib.md5(data).hexdigest(), 16) % 2**31
+    except Exception:
+        seed = hash(str(path)) % 2**31
+    rng = np.random.RandomState(seed)
     return rng.randn(_EMBEDDING_DIM).astype(np.float32)
 
 
@@ -78,13 +89,14 @@ def _stub_embedding_models():
     """Prevent CLAP (and librosa) from loading during individual tests.
 
     Patches ``embed_audio_file``, the audio media-type's ``embed_text``,
-    and ``load_models`` so that any test-time calls (e.g. via ``/api/sort``)
-    return cheap deterministic fake vectors instead of loading a ~600 MB
-    model.
+    ``embed_media``, and ``load_models`` so that any test-time calls
+    (e.g. via ``/api/sort``) return cheap deterministic fake vectors
+    instead of loading a ~600 MB model.
     """
     with (
         patch("vtsearch.medias.embed_audio_file", side_effect=_fake_embed_audio),
         patch.object(_audio_mt, "embed_text", side_effect=_fake_embed_text),
+        patch.object(_audio_mt, "embed_media", side_effect=_fake_embed_audio),
         patch.object(_audio_mt, "load_models"),
     ):
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import numpy as np
 import pytest
 
 import vtsearch.config as config
@@ -5,6 +8,35 @@ import vtsearch.config as config
 # Reduce training epochs for faster tests (default is 200; 30 is sufficient
 # for the tiny MLP to converge on the small test dataset).
 config.TRAIN_EPOCHS = 30
+
+# ---------------------------------------------------------------------------
+# Stub out heavy embedding models BEFORE importing the app.
+#
+# Tests don't need semantically meaningful embeddings — they just need
+# deterministic vectors of the correct dimension (512 for CLAP audio).
+# By patching embed_audio_file and the AudioMediaType's embed_text, we
+# avoid loading the ~600 MB CLAP model, the ~100-200 MB librosa/numba
+# stack, and the CLAP processor.  This cuts ~700-800 MB of RSS.
+# ---------------------------------------------------------------------------
+
+_EMBEDDING_DIM = 512
+
+
+def _fake_embed_audio(path):
+    """Deterministic fake audio embedding derived from the file path."""
+    rng = np.random.RandomState(hash(str(path)) % 2**31)
+    return rng.randn(_EMBEDDING_DIM).astype(np.float32)
+
+
+def _fake_embed_text(text):
+    """Deterministic fake text embedding derived from the query string."""
+    rng = np.random.RandomState(hash(text) % 2**31)
+    return rng.randn(_EMBEDDING_DIM).astype(np.float32)
+
+
+# Patch embed_audio_file so init_medias() never triggers CLAP model loading.
+_patch_embed_audio = patch("vtsearch.medias.embed_audio_file", side_effect=_fake_embed_audio)
+_patch_embed_audio.start()
 
 import app as app_module
 
@@ -27,6 +59,35 @@ app_module.bad_votes = bad_votes
 # Initialize models and medias
 initialize_models()
 app_module.init_medias()
+
+# Stop the module-level patch (init_medias is done); the per-test autouse
+# fixture below re-applies the patches for every test so that /api/sort and
+# other routes that call embed_text don't trigger CLAP loading either.
+_patch_embed_audio.stop()
+
+# Grab the audio media-type singleton so the per-test fixture can patch
+# embed_text and load_models on it, preventing CLAP from loading during
+# /api/sort and similar calls.
+from vtsearch.media import get as _media_get
+
+_audio_mt = _media_get("audio")
+
+
+@pytest.fixture(autouse=True)
+def _stub_embedding_models():
+    """Prevent CLAP (and librosa) from loading during individual tests.
+
+    Patches ``embed_audio_file``, the audio media-type's ``embed_text``,
+    and ``load_models`` so that any test-time calls (e.g. via ``/api/sort``)
+    return cheap deterministic fake vectors instead of loading a ~600 MB
+    model.
+    """
+    with (
+        patch("vtsearch.medias.embed_audio_file", side_effect=_fake_embed_audio),
+        patch.object(_audio_mt, "embed_text", side_effect=_fake_embed_text),
+        patch.object(_audio_mt, "load_models"),
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -433,6 +433,9 @@ class AudioMediaType(MediaType):
 
         from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
 
+        from vtsearch.models.loader import ensure_torch_configured
+
+        ensure_torch_configured()
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading CLAP model weights…", 0, 0)

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -1032,6 +1032,9 @@ class ImageMediaType(MediaType):
 
         from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
 
+        from vtsearch.models.loader import ensure_torch_configured
+
+        ensure_torch_configured()
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         # Use total=0 so the frontend shows an indeterminate progress bar.

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -328,6 +328,9 @@ class TextMediaType(MediaType):
 
         from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
+        from vtsearch.models.loader import ensure_torch_configured
+
+        ensure_torch_configured()
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading E5 model…", 0, 0)

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -261,6 +261,9 @@ class VideoMediaType(MediaType):
 
         from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
 
+        from vtsearch.models.loader import ensure_torch_configured
+
+        ensure_torch_configured()
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading X-CLIP model weights…", 0, 0)

--- a/vtsearch/models/loader.py
+++ b/vtsearch/models/loader.py
@@ -16,20 +16,40 @@ import sys
 from vtsearch.config import MODELS_CACHE_DIR
 
 
+_torch_configured = False
+
+
+def ensure_torch_configured() -> None:
+    """Set ``torch.set_num_threads(1)`` once, the first time torch is used.
+
+    Safe to call multiple times — the configuration is applied only once.
+    Call this from any code path that imports torch before doing work
+    (e.g. ``load_models``, ``train_model``).
+    """
+    global _torch_configured
+    if _torch_configured:
+        return
+    if "torch" not in sys.modules:
+        return
+    import torch  # noqa: PLC0415
+
+    torch.set_num_threads(1)
+    _torch_configured = True
+
+
 def initialize_models() -> None:
     """Prepare the runtime environment for embedding models.
 
-    Creates the model cache directory and configures PyTorch thread count.
-    Models themselves are **not** loaded here — each
-    :class:`~vtsearch.media.base.MediaType` loads its model lazily the
-    first time it is needed (e.g. when ``embed_media`` or ``embed_text``
-    is called).
+    Creates the model cache directory and configures PyTorch thread count
+    **if torch is already imported**.  When torch has not been imported yet
+    (e.g. during fast test startup) the thread-count configuration is
+    deferred until ``ensure_torch_configured`` is called by the first code
+    path that actually imports torch.
+
+    Models themselves are **not** loaded here.
     """
     MODELS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-
-    import torch
-
-    torch.set_num_threads(1)
+    ensure_torch_configured()
     gc.collect()
 
 

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -191,6 +191,10 @@ def train_model(
     import torch  # noqa: PLC0415
     import torch.nn as nn  # noqa: PLC0415
 
+    from vtsearch.models.loader import ensure_torch_configured
+
+    ensure_torch_configured()
+
     n_train = len(X_train)
     if hidden_dim is None:
         hidden_dim = _auto_hidden_dim(n_train)


### PR DESCRIPTION
## Summary
This PR optimizes test startup time by deferring PyTorch configuration until it's actually needed and by stubbing out heavy embedding models during testing. These changes reduce test memory footprint by ~700-800 MB by avoiding loading the CLAP model (~600 MB), librosa/numba stack (~100-200 MB), and related dependencies.

## Key Changes

- **Deferred torch configuration**: Introduced `ensure_torch_configured()` in `vtsearch/models/loader.py` that configures PyTorch thread count only when torch is first imported, rather than eagerly during `initialize_models()`. This allows tests to skip torch initialization entirely if they don't need it.

- **Test embedding stubs**: Added deterministic fake embedding functions (`_fake_embed_audio` and `_fake_embed_text`) in `tests/conftest.py` that generate consistent vectors based on input content without loading actual models.

- **Module-level and per-test patching**: Implemented a two-stage patching strategy:
  - Module-level patch of `embed_audio_file` before app initialization to prevent CLAP loading during `init_medias()`
  - Per-test autouse fixture that patches `embed_audio_file`, audio media-type's `embed_text`/`embed_media`/`load_models` to prevent model loading during test execution (e.g., in `/api/sort` calls)

- **Torch configuration in load paths**: Added `ensure_torch_configured()` calls in all model loading code paths (`train_model`, and `load_models` methods in audio/image/text/video media types) to ensure torch is properly configured when these paths are actually executed.

## Implementation Details

- Fake embeddings use deterministic seeding (MD5 hash of file contents for audio, hash of text for queries) to ensure reproducibility while avoiding actual model computation
- The patching strategy allows the app to initialize normally while preventing expensive model loads during tests
- All changes are backward compatible and don't affect production behavior

https://claude.ai/code/session_01YF5PHqvUF8v7Ltk7UhcJPQ