### PR TITLE
Remove dataset management UI and auto-persist labels in train mode

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -255,8 +255,6 @@
   // Burger menu elements
   const burgerBtn = document.getElementById("burger-btn");
   const burgerDropdown = document.getElementById("burger-dropdown");
-  const menuDatasetExport = document.getElementById("menu-dataset-export");
-  const menuDatasetChange = document.getElementById("menu-dataset-change");
   const menuLabelsExport = document.getElementById("menu-labels-export");
   const menuLabelsImport = document.getElementById("menu-labels-import");
   const menuLabelsStatus = document.getElementById("menu-labels-status");
@@ -356,10 +354,6 @@
     const res = await fetch("/api/dataset/status");
     const status = await res.json();
     datasetLoaded = status.loaded;
-
-    if (menuDatasetExport) {
-      menuDatasetExport.classList.toggle("disabled", !datasetLoaded);
-    }
 
     if (datasetLoaded) {
       showMainUI();
@@ -1418,37 +1412,6 @@
         if (burgerDropdown.classList.contains("show")) {
           closeBurgerMenu();
         }
-      }
-    });
-  }
-
-  // Dataset export
-  if (menuDatasetExport && burgerDropdown) {
-    menuDatasetExport.addEventListener("click", () => {
-      if (menuDatasetExport.classList.contains("disabled")) return;
-      window.location.href = "/api/dataset/export";
-      closeBurgerMenu();
-    });
-  }
-
-  // Dataset change
-  if (menuDatasetChange && burgerDropdown) {
-    menuDatasetChange.addEventListener("click", async () => {
-      if (await vtConfirm("Changing the dataset will erase your current dataset. Continue?")) {
-        fetch("/api/dataset/clear", { method: "POST" })
-          .then(() => {
-            medias = [];
-            votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
-            selected = null;
-            datasetLoaded = false;
-            if (menuDatasetExport) menuDatasetExport.classList.add("disabled");
-            showWelcomeScreen();
-            renderVotes();
-            updateLabelCounts();
-            closeBurgerMenu();
-          });
-      } else {
-        closeBurgerMenu();
       }
     });
   }
@@ -3708,6 +3671,12 @@
       announce(`Voted ${vote} on ${mediaName}`);
       await fetchVotes();
 
+      // In dashboard train mode, persist labels to the trainable model's
+      // labelset after every vote so work is never lost.
+      if (_dashboardTrainMode) {
+        _persistTrainableModelLabels(); // fire-and-forget
+      }
+
       // When voting Good while a text-sort query is active, store the query
       // as a suggested name for saving detectors / labelsets later.
       if (vote === "good" && sortMode === "text") {
@@ -5499,7 +5468,7 @@
   let _dashboardTrainMode = null;  // {model, dataset} when training a trainable model
   let _dashboardNextId = 1;
 
-  async function saveTrainableModelLabels() {
+  async function _persistTrainableModelLabels() {
     if (!_dashboardTrainMode) return;
     const modelName = _dashboardTrainMode.model.name;
     try {
@@ -5515,6 +5484,10 @@
         }
       }
     } catch (_) { /* ignore save errors */ }
+  }
+
+  async function saveTrainableModelLabels() {
+    await _persistTrainableModelLabels();
     _dashboardTrainMode = null;
   }
 

--- a/static/index.html
+++ b/static/index.html
@@ -16,10 +16,8 @@
       <span aria-hidden="true"></span>
     </button>
     <div class="burger-dropdown" id="burger-dropdown" role="menu" aria-label="Main menu">
-      <div class="burger-section" role="group" aria-label="Dataset">
-        <div class="burger-section-title" id="menu-section-dataset">Dataset</div>
-        <div class="burger-item" id="menu-dataset-change" role="menuitem" tabindex="-1">Change Dataset</div>
-        <div class="burger-item disabled" id="menu-dataset-export" role="menuitem" tabindex="-1">Export Dataset</div>
+      <div class="burger-section">
+        <div class="burger-item" id="menu-dashboard" role="menuitem" tabindex="-1">Return to Dashboard</div>
       </div>
       <div class="burger-section" role="group" aria-label="Labels">
         <div class="burger-section-title" id="menu-section-labels">Labels</div>
@@ -40,10 +38,7 @@
         <div class="burger-status" id="menu-favorites-status" aria-live="polite"></div>
       </div>
       <div class="burger-section">
-        <div class="burger-item" id="menu-dashboard">Dashboard</div>
-      </div>
-      <div class="burger-section">
-        <div class="burger-item" id="menu-settings">Settings</div>
+        <div class="burger-item" id="menu-settings" role="menuitem" tabindex="-1">Settings</div>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
This PR removes the dataset export and change functionality from the UI and improves label persistence in dashboard training mode by automatically saving labels after each vote.

## Key Changes

- **Removed dataset management menu items** from the burger menu:
  - Deleted "Change Dataset" and "Export Dataset" menu items from HTML
  - Removed associated JavaScript event listeners and DOM element references
  - Removed the "Dataset" section header from the menu

- **Refactored label persistence logic**:
  - Extracted the core label-saving logic into a new `_persistTrainableModelLabels()` function
  - Modified `saveTrainableModelLabels()` to call the extracted function and handle cleanup
  - Added automatic label persistence after every vote when in dashboard training mode, ensuring work is never lost

- **Updated menu structure**:
  - Changed "Dashboard" menu item text to "Return to Dashboard" for clarity
  - Added proper ARIA attributes (`role="menuitem"`, `tabindex="-1"`) to menu items
  - Consolidated menu sections

## Implementation Details

The auto-persistence feature fires after each vote in training mode without blocking the UI (fire-and-forget pattern). This prevents data loss while maintaining a responsive user experience. The refactored `_persistTrainableModelLabels()` function handles all error cases gracefully by silently ignoring save failures.

https://claude.ai/code/session_01AQ4prECu1eJWNa3fSKimAP