### PR TITLE
Add training context bars to display dataset and detector names

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -251,6 +251,10 @@
   const leftPanel = document.getElementById("left-panel");
   const rightPanel = document.querySelector(".panel-right");
   const sortBar = document.getElementById("sort-bar");
+  const trainDatasetBar = document.getElementById("train-dataset-bar");
+  const trainDatasetName = document.getElementById("train-dataset-name");
+  const trainDetectorBar = document.getElementById("train-detector-bar");
+  const trainDetectorName = document.getElementById("train-detector-name");
 
   // Burger menu elements
   const burgerBtn = document.getElementById("burger-btn");
@@ -390,6 +394,8 @@
     if (autodetectToggle) autodetectToggle.style.display = "";
     sortBar.style.display = "none";
     datasetBar.style.display = "none";
+    trainDatasetBar.style.display = "none";
+    trainDetectorBar.style.display = "none";
     mediaList.innerHTML = "";
     leftPanel.style.display = "none";
     if (rightPanel) rightPanel.style.display = "none";
@@ -5526,6 +5532,8 @@
     sortBar.style.display = "none";
     datasetBar.style.display = "none";
     datasetWelcome.style.display = "none";
+    trainDatasetBar.style.display = "none";
+    trainDetectorBar.style.display = "none";
     center.className = "panel-center";
     center.innerHTML = "";
     center.appendChild(dashboardView);
@@ -5738,6 +5746,11 @@
       // Enter training mode
       _dashboardTrainMode = { model, dataset };
       hideDashboard();
+      // Show dataset/detector context bars
+      trainDatasetName.textContent = dataset.name;
+      trainDatasetBar.style.display = "";
+      trainDetectorName.textContent = model.name;
+      trainDetectorBar.style.display = "";
 
       // Kick off dataset reload from the stored source
       try {

--- a/static/index.html
+++ b/static/index.html
@@ -48,6 +48,10 @@
 <div class="layout" role="presentation">
   <!-- Left panel -->
   <div class="panel-left" id="left-panel" role="region" aria-label="Media list">
+    <div class="train-context-bar" id="train-dataset-bar" style="display:none">
+      <span class="train-context-label">Dataset</span>
+      <span class="train-context-name" id="train-dataset-name"></span>
+    </div>
     <div class="left-tabs" role="tablist" aria-label="Panel mode">
       <button class="left-tab active" id="tab-manual" role="tab" aria-selected="true" aria-controls="tab-panel-manual">Manual</button>
       <button class="left-tab" id="tab-autopilot" role="tab" aria-selected="false" aria-controls="tab-panel-autopilot">Autopilot</button>
@@ -202,6 +206,10 @@
 
   <!-- Right panel -->
   <aside class="panel-right" aria-label="Labels">
+    <div class="train-context-bar" id="train-detector-bar" style="display:none">
+      <span class="train-context-label">Detector</span>
+      <span class="train-context-name" id="train-detector-name"></span>
+    </div>
     <!-- import-file removed: label import now uses the label importer modal -->
     <div class="progress-check-bar">
       <span class="progress-check-label">Progress</span>

--- a/static/styles.css
+++ b/static/styles.css
@@ -303,6 +303,11 @@ video { max-width: 100%; }
 .btn-bad::after { content: "Bad"; font-weight: 700; display: block; height: 0; overflow: hidden; visibility: hidden; pointer-events: none; }
 .btn-bad.voted, .btn-bad.vote-flash { background: var(--color-bad); color: #fff; }
 
+/* Training context bar – dataset / detector name shown during training */
+.train-context-bar { padding: 6px 10px; border-bottom: 1px solid var(--border); background: var(--accent-highlight-bg); flex-shrink: 0; overflow: hidden; }
+.train-context-label { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); display: block; line-height: 1; margin-bottom: 2px; }
+.train-context-name { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
 /* Right panel – votes */
 .panel-right { width: 220px; border-left: 1px solid var(--border); overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
 .label-sort-bar { padding: 8px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 6px; flex-shrink: 0; }


### PR DESCRIPTION
## Summary
This PR adds visual context bars to the left and right panels that display the currently selected dataset and detector model names during training mode. This provides users with clear visibility into which dataset and model they are actively training.

## Key Changes
- **HTML Structure**: Added two new context bar elements:
  - `train-dataset-bar` in the left panel to show the active dataset name
  - `train-detector-bar` in the right panel to show the active detector/model name
  
- **JavaScript Logic**: 
  - Added element references for the new context bars and their name spans
  - Hide context bars when clearing the dashboard or switching views
  - Populate and display context bars when entering training mode with dataset and model information
  
- **Styling**: 
  - Created `.train-context-bar` class with padding, border, and accent background
  - Styled `.train-context-label` for uppercase, muted labels
  - Styled `.train-context-name` for bold, truncated model/dataset names with ellipsis overflow handling

## Implementation Details
- Context bars are hidden by default (`display: none`) and only shown when training mode is active
- The bars are positioned at the top of their respective panels using flexbox with `flex-shrink: 0` to prevent collapse
- Text overflow is handled with `text-overflow: ellipsis` for long dataset/model names
- Context bars are properly hidden when exiting training mode or switching dashboard views

https://claude.ai/code/session_016FpGTTMeCbzLRdtr5JxW1D