### PR TITLE
Rename showMainUI to showTrainingUI for clarity

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -359,7 +359,7 @@
     datasetLoaded = status.loaded;
 
     if (datasetLoaded) {
-      showMainUI();
+      showTrainingUI();
       const mtInfo = mediaTypesMap[status.media_type];
       const dupeSuffix = status.num_dupes ? ` (${status.num_dupes} dupes)` : "";
       datasetInfo.textContent = mtInfo
@@ -403,7 +403,7 @@
     if (menuDetectorExport) menuDetectorExport.classList.add("disabled");
   }
 
-  function showMainUI() {
+  function showTrainingUI() {
     datasetWelcome.style.display = "none";
     leftPanel.style.display = "";
     if (rightPanel) rightPanel.style.display = "";
@@ -455,7 +455,7 @@
       stopProgressPolling();
 
       // If we are in combine-datasets staging mode, handle the staging result
-      // instead of loading the dataset into the main UI.
+      // instead of loading the dataset into the training UI.
       if (_combineState && progress.staging_result) {
         _combineState.push(progress.staging_result);
         showCombineDatasetsForm();
@@ -2654,7 +2654,7 @@
         populateSettingsModal(defaults);
         // Apply theme immediately
         applyTheme(defaults.theme || "dark");
-        // Update main UI controls that live outside the modal
+        // Update training UI controls that live outside the modal
         if (inclusionSlider) { inclusionSlider.value = defaults.inclusion || 0; inclusionValue.textContent = defaults.inclusion || 0; inclusion = defaults.inclusion || 0; }
         audioVolume = defaults.volume != null ? defaults.volume : 1.0;
         const audioEl = document.getElementById("media-audio");


### PR DESCRIPTION
## Summary
Renamed the `showMainUI()` function to `showTrainingUI()` throughout the codebase to better reflect its purpose and improve code clarity.

## Key Changes
- Renamed function `showMainUI()` to `showTrainingUI()` in the function definition
- Updated all function calls from `showMainUI()` to `showTrainingUI()`
- Updated related comments to reference "training UI" instead of "main UI" for consistency

## Details
This refactoring improves code readability by using more descriptive naming that accurately represents the UI state being displayed. The function is responsible for showing the training interface when a dataset is loaded, so the new name better communicates its purpose. Comments were also updated to maintain consistency with the new terminology throughout the codebase.

https://claude.ai/code/session_01EFwTDvYMRbNiRjaG1bvef8