### PR TITLE
Fix documentation accuracy: exporter names, CLIP dim, method names, test listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
 - **Run all tests (CPU + GPU)**: `python -m pytest tests/ -v -m ''`
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
-- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter file --filepath results.json`
+- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter local_json_file --filepath results.json`
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings <settings.json>`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
@@ -21,14 +21,14 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
 - `vtsearch/config.py` — Constants (SAMPLE_RATE, NUM_MEDIAS, paths, model IDs)
 - `vtsearch/medias.py` — Test media generation and embedding cache management
 - `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detectors from settings, run inference, export results)
-- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails, favorite_media_types, favorite_processors); auto-saves to `data/settings.json`
+- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, favorite_media_types, favorite_processors); auto-saves to `data/settings.json`
 - `vtsearch/routes/` — Flask blueprints: `main.py`, `medias.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking, diversity tree
 - `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/rss_feed/youtube_playlist/combine_datasets); auto-discovered via `IMPORTER` sentinel
 - `vtsearch/eval/` — Evaluation framework: runner, metrics, visualisation, voting iterations
-- `vtsearch/exporters/` — Results exporters (file/gui/email_smtp/csv_file/webhook); auto-discovered via `EXPORTER` sentinel
-- `vtsearch/labels/importers/` — Label importers (json_file/csv_file); auto-discovered via `LABEL_IMPORTER` sentinel
-- `vtsearch/processors/importers/` — Processor importers (detector_file/label_file/csv_label_file); auto-discovered via `PROCESSOR_IMPORTER` sentinel
+- `vtsearch/exporters/` — Results exporters (local_json_file/server_json_file/local_csv_file/server_csv_file/email_smtp/webhook/gui); auto-discovered via `EXPORTER` sentinel
+- `vtsearch/labels/importers/` — Label importers (local_json_file/server_json_file/local_csv_file/server_csv_file); auto-discovered via `LABEL_IMPORTER` sentinel
+- `vtsearch/processors/importers/` — Processor importers (detector_file/server_detector_file/label_file/csv_label_file); auto-discovered via `PROCESSOR_IMPORTER` sentinel
 - `vtsearch/media/` — Media type plugins: audio, image, text, video
 - `vtsearch/utils/` — Global state (`medias` dict, votes), progress utilities
 - `static/` — Frontend (index.html, app.js, styles.css) and assets (favicons, logo.svg, logo.png)
@@ -40,9 +40,10 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_votes.py` — Voting and vote retrieval
   - `test_sorting.py` — Text sort, learned sort, example sort, train_and_score
   - `test_labels.py` — Label export/import (via /api/labels/export and /api/labels/import)
-  - `test_label_importers.py` — Label importer base class, registry, json_file/csv_file importers, API routes
+  - `test_label_importers.py` — Label importer base class, registry, local/server json_file/csv_file importers, API routes
   - `test_inclusion.py` — Inclusion GET/POST
   - `test_detectors.py` — Detector export, detector sort, favorites, auto-detect
+  - `test_clippers.py` — MediaClipper ABC tests and concrete clipper implementations
   - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag. Subprocess tests marked `slow` (~16s each, excluded from default run)
   - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
   - `test_dataset_split.py` — Train/test dataset splitting
@@ -56,12 +57,13 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_origin_labelset.py` — Origin class, LabeledElement, LabelSet, build_origin(), label export/import with origins, integration
   - `test_combine_datasets.py` — Combine-datasets importer: metadata, dedup, media type validation, CLI, API routes
   - `test_creation_info.py` — Legacy creation_info handling in pickle datasets
+  - `test_duplicates.py` — Duplicate-content collapsing: collapse_duplicates function, dupe counting, label export/import integration
   - `test_enrich_descriptions.py` — Enriched text-sort description embedding
   - `test_eval.py` — Evaluation framework runner and metrics
   - `test_eval_visualize.py` — Evaluation visualisation chart generation
   - `test_eval_voting_iterations.py` — Voting iterations evaluation
   - `test_safe_thresholds.py` — Safe threshold blending
-  - `test_settings.py` — Settings persistence (volume, inclusion, theme, swipe_animation, show_thumbnails, favorites)
+  - `test_settings.py` — Settings persistence (volume, inclusion, theme, swipe_animation, show_thumbnails_left, show_thumbnails_right, favorites)
   - `test_thin_loading.py` — Thin (lazy) dataset loading mode for CLI
   - `test_chunked_loading.py` — Chunked (piecewise) dataset loading: folder/pickle chunked loaders, importer run_chunked interface, merge helper
   - `test_integration.py` — End-to-end user workflow simulations: chained API calls, state interactions, response format consistency
@@ -72,8 +74,16 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_ag_news_download.py` — AG News dataset download and load_demo_source integration
   - `test_bbc_news_download.py` — BBC News dataset download and load_demo_source integration
   - `test_export_options.py` — Export boolean options, negative_hits in CLI scoring, fill-from-sort
+  - `test_gtzan_download.py` — GTZAN dataset download and load_demo_source integration
+  - `test_image_sources_download.py` — Image dataset downloads: Oxford Flowers 102, Food-101, EuroSAT, Stanford Dogs, and load_demo_source integration
+  - `test_imdb_download.py` — IMDB dataset download and load_demo_source integration
+  - `test_load_sort_window.py` — Load Sort window endpoints: example-sort, server-media-files, detector server-files
   - `test_memory_errors.py` — Graceful MemoryError handling during dataset loading
+  - `test_pdf_import.py` — PDF-to-image import: render_pdf_pages conversion, folder importer PDF handling, origin tracking
   - `test_preload_progress.py` — Console progress output during embedding model preloading
+  - `test_slow_integration.py` — Slow integration tests: chunked loading, detector scoring, export, label round-trips, settings persistence (marked slow)
+  - `test_thread_safety.py` — Thread-safe global state operations: _state_lock verification, concurrent vote/click-time/label history access
+  - `test_ucsf_documents_download.py` — UCSF Industry Documents demo dataset download and load_demo_source integration
   - `test_gpu.py` — GPU tests: training, cross-calibration, detectors, embedding models (CLAP/CLIP/X-CLIP/E5), CPU↔GPU equivalence, memory cleanup (skipped without CUDA)
 
 ## Test Markers
@@ -122,7 +132,7 @@ All mutable global state is reset automatically before each test via two autouse
 ## Key Details
 - Global state lives in `vtsearch/utils/state.py`: `medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `last_learned_scores`, `inclusion`, `textsort_suggestions`, `favorite_detectors`, `favorite_extractors`, `favorite_localizers` are module-level dicts/lists
 - Votes are `dict[int, None]` (not sets) — use `votes[id] = None` syntax
-- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails, favorite_media_types, favorite_processors
+- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, favorite_media_types, favorite_processors
 - Each media item has `origin` (dict or None) and `origin_name` (str) for per-element provenance tracking
 - `Origin` class in `vtsearch/datasets/origin.py`; `LabelSet`/`LabeledElement` in `vtsearch/datasets/labelset.py`
 - Label export (`/api/labels/export`) returns a `LabelSet` with per-element origin info (superset of legacy format)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,7 @@ VTSearch/
 │   ├── settings.py                 Persistent settings & favorite processors
 │   │
 │   ├── media/                      Media type registry + plugins
-│   │   ├── base.py                 MediaType ABC, MediaResponse, Processor, Detector, Extractor
+│   │   ├── base.py                 MediaType ABC, MediaResponse, Processor, Detector, Localizer, Extractor, MediaClipper
 │   │   ├── __init__.py             Registry (register/get/all_types)
 │   │   ├── audio/media_type.py     CLAP embeddings
 │   │   ├── image/media_type.py     CLIP embeddings
@@ -80,20 +80,25 @@ VTSearch/
 │   │
 │   ├── exporters/                  Plugin system for output destinations
 │   │   ├── base.py                 LabelsetExporter ABC + ExporterField
-│   │   ├── file/                   JSON file writer
-│   │   ├── csv_file/               CSV file writer
+│   │   ├── local_json_file/        JSON file download (local)
+│   │   ├── server_json_file/       JSON file on server
+│   │   ├── local_csv_file/         CSV file download (local)
+│   │   ├── server_csv_file/        CSV file on server
 │   │   ├── email_smtp/             SMTP email sender
 │   │   ├── webhook/                HTTP POST webhook
 │   │   └── gui/                    In-browser / console display
 │   │
 │   ├── labels/importers/           Plugin system for label sources
 │   │   ├── base.py                 LabelImporter ABC + LabelImporterField
-│   │   ├── json_file/              JSON label file reader
-│   │   └── csv_file/               CSV label file reader
+│   │   ├── local_json_file/        Upload JSON label file (local)
+│   │   ├── server_json_file/       JSON label file on server
+│   │   ├── local_csv_file/         Upload CSV label file (local)
+│   │   └── server_csv_file/        CSV label file on server
 │   │
 │   ├── processors/importers/       Plugin system for processor sources
 │   │   ├── base.py                 ProcessorImporter ABC + ProcessorImporterField
-│   │   ├── detector_file/          Import detector from JSON file
+│   │   ├── detector_file/          Import detector from uploaded JSON file
+│   │   ├── server_detector_file/   Import detector from server JSON file
 │   │   ├── label_file/             Train detector from a labeled media file
 │   │   └── csv_label_file/         Train detector from a CSV label file
 │   │
@@ -162,17 +167,17 @@ modules on the right.
 │ (NO Flask)  │ │ (NO Flask) │
 └──────────────┘ └────────────┘
 
-┌─────────────────────┐  ┌────────────────────────┐  ┌──────────────────────────┐
-│ exporters/*         │  │ labels/importers/*      │  │ processors/importers/*   │
-│                     │  │                          │  │                          │
-│ base.py (ABC)       │  │ base.py (ABC)           │  │ base.py (ABC)            │
-│ file, csv, webhook  │  │ json_file, csv_file     │  │ detector_file, label_file│
-│ email_smtp, gui     │  │                          │  │ csv_label_file           │
-│                     │  │ (NO Flask, NO state,     │  │                          │
-│ (NO Flask,          │  │  pure data processing)   │  │ (NO Flask, NO state,     │
-│  NO state,          │  │                          │  │  pure data processing)   │
-│  pure data in/out)  │  └────────────────────────┘  └──────────────────────────┘
-└─────────────────────┘
+┌──────────────────────────┐  ┌────────────────────────┐  ┌──────────────────────────┐
+│ exporters/*              │  │ labels/importers/*      │  │ processors/importers/*   │
+│                          │  │                          │  │                          │
+│ base.py (ABC)            │  │ base.py (ABC)           │  │ base.py (ABC)            │
+│ local_json, server_json  │  │ local_json, server_json │  │ detector_file, label_file│
+│ local_csv, server_csv    │  │ local_csv, server_csv   │  │ server_detector_file     │
+│ email_smtp, webhook, gui │  │                          │  │ csv_label_file           │
+│                          │  │ (NO Flask, NO state,     │  │                          │
+│ (NO Flask, NO state,     │  │  pure data processing)   │  │ (NO Flask, NO state,     │
+│  pure data in/out)       │  │                          │  │  pure data processing)   │
+└──────────────────────────┘  └────────────────────────┘  └──────────────────────────┘
 ```
 
 ### Key observations
@@ -294,7 +299,7 @@ load_dataset_from_folder(
     medias=medias,
     on_progress=lambda s, m, c, t: print(f"{m} {c}/{t}"),
 )
-# medias is now {1: {"id": 1, "embedding": ..., "clip_bytes": ..., ...}, ...}
+# medias is now {1: {"id": 1, "embedding": ..., "media_bytes": ..., ...}, ...}
 ```
 
 ### Progress tracking
@@ -351,7 +356,8 @@ dicts:
 
 Persistent settings (volume, theme, inclusion, `enrich_descriptions`,
 `safe_thresholds`, `calibrate_count`, `calibration_fraction`,
-`swipe_animation`, `show_thumbnails`, favorite processor recipes) live
+`swipe_animation`, `show_thumbnails_left`, `show_thumbnails_right`,
+favorite processor recipes) live
 separately in `vtsearch/settings.py` and are auto-saved to
 `data/settings.json`.
 Theme supports three modes: `dark`, `light`, and `highviz` (high-contrast).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,12 +28,12 @@ Available importers: `folder`, `pickle`, `http_zip`, `rss_feed`, `youtube_playli
 **Exporting results** — by default results are printed to the console. Add `--exporter <name>` to send them elsewhere:
 
 ```bash
-python app.py --autodetect --dataset data.pkl --settings settings.json --exporter file --filepath results.json
-python app.py --autodetect --dataset data.pkl --settings settings.json --exporter csv_file --filepath results.csv
+python app.py --autodetect --dataset data.pkl --settings settings.json --exporter local_json_file --filepath results.json
+python app.py --autodetect --dataset data.pkl --settings settings.json --exporter local_csv_file --filepath results.csv
 python app.py --autodetect --dataset data.pkl --settings settings.json --exporter webhook --url https://example.com/hook
 ```
 
-Available exporters: `file` (JSON), `csv_file` (CSV), `webhook` (HTTP POST), `email_smtp`, `gui` (default — print to console).
+Available exporters: `local_json_file` (JSON to local file), `server_json_file` (JSON to server), `local_csv_file` (CSV to local file), `server_csv_file` (CSV to server), `webhook` (HTTP POST), `email_smtp`, `gui` (default — print to console).
 
 **How to get the files:**
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -729,7 +729,7 @@ class CodeMediaType(MediaType):
         """
         content = file_path.read_text(errors="replace")
         return {
-            "clip_string": content,
+            "media_string": content,
             "duration": 0,
             "line_count": content.count("\n") + 1,
         }
@@ -738,16 +738,16 @@ class CodeMediaType(MediaType):
     # HTTP serving (required method)
     # ------------------------------------------------------------------
 
-    def clip_response(self, clip: dict) -> MediaResponse:
-        """Return a MediaResponse serving this clip's content.
+    def media_response(self, media: dict) -> MediaResponse:
+        """Return a MediaResponse serving this media's content.
 
         Set data to bytes for binary media (with an appropriate mimetype)
         or to a dict for JSON responses.
         """
         return MediaResponse(
             data={
-                "content": clip.get("clip_string", ""),
-                "line_count": clip.get("line_count", 0),
+                "content": media.get("media_string", ""),
+                "line_count": media.get("line_count", 0),
             },
             mimetype="application/json",
         )
@@ -772,7 +772,7 @@ additional changes:
 |------------------------|---------------------------------------------------------------|
 | **Model init**         | `load_models()` is called at startup for your type            |
 | **Folder import**      | Files matching your `file_extensions` are found and embedded  |
-| **Generic media route**| `GET /api/medias/<id>/media` delegates to your `clip_response()`|
+| **Generic media route**| `GET /api/medias/<id>/media` delegates to your `media_response()`|
 | **Text sorting**       | `embed_text()` is called for text-query cosine similarity     |
 | **Demo listing**       | Your `demo_datasets` appear in `GET /api/dataset/demo-list`   |
 | **Dataset export**     | Clip data is serialized to pickle (including your custom fields)|
@@ -804,13 +804,13 @@ additional changes:
 | `embed_media(file_path)`            | `(Path) -> Optional[np.ndarray]`                   |
 | `embed_text(text)`                  | `(str) -> Optional[np.ndarray]`                    |
 | `load_media_data(file_path)`        | `(Path) -> dict` (must include `"duration"` key)   |
-| `clip_response(clip)`               | `(dict) -> MediaResponse`                           |
+| `media_response(media)`             | `(dict) -> MediaResponse`                           |
 
 ### Making dataset export aware of custom clip fields
 
 The existing `export_dataset_to_file()` in `vtsearch/datasets/loader.py`
-serializes a fixed set of keys (`clip_bytes`, `clip_string`, `word_count`,
-`character_count`, `width`, `height`).  If your
+serializes a fixed set of keys (`media_bytes`, `media_string`, `media_path`,
+`word_count`, `character_count`, `width`, `height`).  If your
 media type stores clip data under different keys, add those keys to the export
 function so they survive a round-trip through pickle export/import.
 
@@ -844,9 +844,7 @@ requirements.txt              # Core deps + includes per-media + per-importer + 
 │   └── vtsearch/datasets/importers/combine_datasets/requirements.txt
 ├── requirements-exporters.txt          # Aggregates all exporter deps
 │   ├── vtsearch/exporters/gui/requirements.txt
-│   ├── vtsearch/exporters/file/requirements.txt
 │   ├── vtsearch/exporters/email_smtp/requirements.txt
-│   ├── vtsearch/exporters/csv_file/requirements.txt
 │   └── vtsearch/exporters/webhook/requirements.txt
 requirements-cpu.txt          # CPU-specific pins (lists packages INLINE)
 requirements-gpu.txt          # GPU-specific (minimal, includes importers)

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -250,7 +250,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for full details.
 python app.py --autodetect \
   --dataset data.pkl \
   --settings settings.json \
-  --exporter file --filepath results.json
+  --exporter local_json_file --filepath results.json
 ```
 
 This loads the dataset, runs all detectors from the settings file, and

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -74,7 +74,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Media type | Model | Embedding dim |
 |------------|-------|--------------|
 | Audio | LAION CLAP (`laion/clap-htsat-unfused`) | 512 |
-| Image | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 512 |
+| Image | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 768 |
 | Video | Microsoft X-CLIP (`microsoft/xclip-base-patch32`) | 768 |
 | Text | E5 (`intfloat/e5-base-v2`) | 768 |
 

--- a/requirements-exporters.txt
+++ b/requirements-exporters.txt
@@ -8,7 +8,5 @@
 #
 # ── Built-in exporters ──────────────────────────────────────────────────────
 -r vtsearch/exporters/gui/requirements.txt
--r vtsearch/exporters/file/requirements.txt
 -r vtsearch/exporters/email_smtp/requirements.txt
--r vtsearch/exporters/csv_file/requirements.txt
 -r vtsearch/exporters/webhook/requirements.txt


### PR DESCRIPTION
- Fix CLIP embedding dimension: 512 → 768 in ML.md (matches actual code)
- Update exporter names: file/csv_file → local_json_file/local_csv_file etc. across
  CLI.md, CLAUDE.md, HANDOFF.md, ARCHITECTURE.md
- Fix method name: clip_response(clip) → media_response(media) in EXTENDING.md
- Fix key names: clip_bytes/clip_string → media_bytes/media_string in EXTENDING.md
  and ARCHITECTURE.md
- Fix show_thumbnails → show_thumbnails_left/show_thumbnails_right across all docs
- Add Localizer and MediaClipper to ARCHITECTURE.md base.py listing
- Add 10 missing test files to CLAUDE.md (clippers, duplicates, gtzan_download,
  image_sources_download, imdb_download, load_sort_window, pdf_import,
  slow_integration, thread_safety, ucsf_documents_download)
- Add server_detector_file to processor importer listings
- Update label importer names to local/server variants across all docs
- Fix requirements-exporters.txt: remove references to nonexistent
  exporters/file/ and exporters/csv_file/ directories
- Fix stray closing bracket in ARCHITECTURE.md dependency diagram

https://claude.ai/code/session_01UFSYAGNRnvZURPCBEm5WEb