### PR TITLE
Fix exit code 134 (SIGABRT) after successful test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import vtsearch.config as config
@@ -13,7 +15,15 @@ from vtsearch.config import NUM_MEDIAS, SAMPLE_RATE
 from vtsearch.audio import generate_wav
 from vtsearch.models import initialize_models, train_and_score
 from vtsearch.models.progress import clear_progress_cache
-from vtsearch.utils import bad_votes, medias, good_votes, label_history, last_learned_scores, textsort_suggestions, vote_click_times
+from vtsearch.utils import (
+    bad_votes,
+    medias,
+    good_votes,
+    label_history,
+    last_learned_scores,
+    textsort_suggestions,
+    vote_click_times,
+)
 
 # Attach to app_module for backward compatibility with existing tests
 app_module.NUM_MEDIAS = NUM_MEDIAS
@@ -76,3 +86,17 @@ def client():
     app_module.app.config["TESTING"] = True
     with app_module.app.test_client() as c:
         yield c
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Force-exit to avoid SIGABRT (exit code 134) from native library cleanup.
+
+    PyTorch, OpenMP, numba (via librosa), and other native libraries spin up
+    C++ thread pools that sometimes call ``std::terminate()`` during Python
+    interpreter shutdown.  This produces "terminate called without an active
+    exception" and exit code 134, even though all tests passed.
+
+    ``os._exit()`` skips the normal interpreter teardown (atexit handlers,
+    C++ static destructors) so the problematic cleanup never runs.
+    """
+    os._exit(exitstatus)


### PR DESCRIPTION
Native libraries (PyTorch/OpenMP/numba) spin up C++ thread pools that sometimes call std::terminate() during interpreter shutdown, producing "terminate called without an active exception" and exit code 134 even when all tests pass.

Add pytest_sessionfinish hook that calls os._exit(exitstatus) to skip the problematic C++ destructor phase after pytest completes.

https://claude.ai/code/session_01XSZFvwbXTQbay6GLRPC6m2