### PR TITLE
Add PEP 563 future annotations import to route modules

### DIFF
--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -1,5 +1,7 @@
 """Blueprint for main application routes."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from flask import Blueprint, Response, current_app, send_from_directory

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -1,5 +1,7 @@
 """Blueprint for media-related routes."""
 
+from __future__ import annotations
+
 import io
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
## Summary
Added `from __future__ import annotations` to the route modules to enable PEP 563 postponed evaluation of annotations.

## Changes
- Added `from __future__ import annotations` to `vtsearch/routes/main.py`
- Added `from __future__ import annotations` to `vtsearch/routes/medias.py`

## Details
This change enables postponed evaluation of type annotations as strings, which allows for:
- Using type hints that reference classes not yet defined
- Reducing import overhead at module load time
- Better forward compatibility with future Python versions

The import is placed at the top of each module (after the docstring) as per PEP 563 requirements.

https://claude.ai/code/session_01A4WDJHK23cMqB9BFAxEQei