### PR TITLE
Fix remaining PEP 604 union type errors in loader.py and detectors.py

### DIFF
--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -8,6 +8,8 @@ When omitted the functions fall back to the application-wide
 to use these functions outside the Flask app.
 """
 
+from __future__ import annotations
+
 import csv
 import gc
 import hashlib

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -1,5 +1,7 @@
 """Blueprint for detector, extractor, and localizer routes."""
 
+from __future__ import annotations
+
 import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path


### PR DESCRIPTION
Add `from __future__ import annotations` to the two remaining files that used `X | Y` type syntax without the future import:
- vtsearch/datasets/loader.py
- vtsearch/routes/detectors.py

https://claude.ai/code/session_01A4WDJHK23cMqB9BFAxEQei