### PR TITLE
Refactor dataset loading UI with modal-based importer picker

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -340,15 +340,19 @@
 
   // Dashboard elements
   const dashboardView = document.getElementById("dashboard-view");
-  const dashDatasetTabs = document.getElementById("dash-dataset-tabs");
   const dashDatasetGrid = document.getElementById("dash-dataset-grid");
   const dashModelGrid = document.getElementById("dash-model-grid");
   const dashDatasetStatus = document.getElementById("dash-dataset-status");
   const dashLabelBtn = document.getElementById("dash-label-btn");
   const dashDetectBtn = document.getElementById("dash-detect-btn");
-  const dashLoadFileBtn = document.getElementById("dash-load-file-btn");
+  const dashAddDatasetBtn = document.getElementById("dash-add-dataset-btn");
   const dashChangeDatasetBtn = document.getElementById("dash-change-dataset-btn");
   const dashAddModelBtn = document.getElementById("dash-add-model-btn");
+  const datasetImporterModal = document.getElementById("dataset-importer-modal");
+  const datasetImporterModalClose = document.getElementById("dataset-importer-modal-close");
+  const datasetImporterList = document.getElementById("dataset-importer-list");
+  const datasetImporterFormDiv = document.getElementById("dataset-importer-form");
+  const datasetImporterBack = document.getElementById("dataset-importer-back");
   const dashFileInput = document.getElementById("dash-file-input");
   const dashProgress = document.getElementById("dash-progress");
   const dashProgressFill = document.getElementById("dash-progress-fill");
@@ -843,7 +847,7 @@
     }
 
     // Populate grids
-    await renderDashboardDatasets();
+    renderDashboardDatasets();
     await renderDashboardModels();
     updateDashboardButtons();
   }
@@ -854,173 +858,16 @@
     if (dashDetectBtn) dashDetectBtn.disabled = !(hasDataset && dashSelectedDetector);
   }
 
-  async function renderDashboardDatasets() {
+  function renderDashboardDatasets() {
     if (!dashDatasetGrid) return;
 
-    // Fetch demo datasets if not cached
-    if (!dashDemoDatasets) {
-      try {
-        const res = await fetch("/api/dataset/demo-list");
-        if (res.ok) {
-          const data = await res.json();
-          dashDemoDatasets = data.datasets || [];
-        } else {
-          dashDemoDatasets = [];
-        }
-      } catch (_) {
-        dashDemoDatasets = [];
-      }
-    }
-
-    if (dashDemoDatasets.length === 0) {
-      dashDatasetTabs.innerHTML = "";
-      dashDatasetGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No demo datasets available. Use "Load File" to load a .pkl dataset.</p>';
+    if (datasetLoaded) {
+      // Dataset is already loaded — status bar shows the info; grid can be minimal
+      dashDatasetGrid.innerHTML = "";
       return;
     }
 
-    const grouped = {};
-    dashDemoDatasets.forEach(ds => {
-      const mt = ds.media_type || "audio";
-      if (!grouped[mt]) grouped[mt] = [];
-      grouped[mt].push(ds);
-    });
-    const mediaOrder = Object.keys(mediaTypesMap).filter(mt => (grouped[mt] || []).length > 0);
-
-    const statusOrder = { ready: 0, needs_embedding: 1, needs_download: 2 };
-    const sortColumns = [
-      { key: "label",          label: "Name" },
-      { key: "num_files",      label: "# Media" },
-      { key: "num_categories", label: "# Cat." },
-      { key: "description",    label: "Description" },
-      { key: "status",         label: "Readiness" },
-    ];
-
-    function buildStatusBadge(st) {
-      if (st === "ready") return '<span class="ready-badge">Ready</span>';
-      if (st === "needs_embedding") return '<span class="embedding-badge">Needs Embed</span>';
-      return '<span class="download-badge">Needs Download</span>';
-    }
-
-    function renderTable(items, section) {
-      const sortState = section._demoSort || { key: "label", asc: true };
-      const sorted = [...items].sort((a, b) => {
-        let va = a[sortState.key], vb = b[sortState.key];
-        if (sortState.key === "status") { va = statusOrder[va] ?? 3; vb = statusOrder[vb] ?? 3; }
-        if (typeof va === "number" && typeof vb === "number") return sortState.asc ? va - vb : vb - va;
-        va = String(va || "").toLowerCase(); vb = String(vb || "").toLowerCase();
-        return sortState.asc ? va.localeCompare(vb) : vb.localeCompare(va);
-      });
-
-      const tbody = section.querySelector("tbody");
-      tbody.innerHTML = "";
-      sorted.forEach(ds => {
-        const st = ds.status || (ds.ready ? "ready" : "needs_download");
-        const tr = document.createElement("tr");
-        const isSelected = dashSelectedDataset && dashSelectedDataset.name === ds.name;
-        tr.className = "demo-row" + (st === "ready" ? " ready" : st === "needs_embedding" ? " needs-embedding" : "") + (isSelected ? " dash-selected" : "");
-        tr.setAttribute("role", "button");
-        tr.setAttribute("tabindex", "0");
-        tr.setAttribute("aria-label", `${ds.label}: ${ds.description}`);
-        tr.addEventListener("click", () => {
-          dashSelectedDataset = ds;
-          // Re-render all tables to update selection highlight
-          Object.values(dashSections).forEach(sec => renderTable(grouped[sec._mt], sec));
-          updateDashboardButtons();
-        });
-        tr.addEventListener("keydown", (e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            tr.click();
-          }
-        });
-        const descShort = ds.description.length > 60 ? ds.description.slice(0, 57) + "\u2026" : ds.description;
-        tr.innerHTML = `
-          <td class="col-name">${escapeHtml(ds.label)}</td>
-          <td class="col-num">${ds.num_files}</td>
-          <td class="col-num">${ds.num_categories}</td>
-          <td class="col-desc" title="${escapeHtml(ds.description)}">${escapeHtml(descShort)}</td>
-          <td class="col-status">${buildStatusBadge(st)}</td>
-        `;
-        tbody.appendChild(tr);
-      });
-
-      section.querySelectorAll("th[data-sort]").forEach(th => {
-        const arrow = th.querySelector(".sort-arrow");
-        if (th.dataset.sort === sortState.key) {
-          arrow.textContent = sortState.asc ? " \u25B2" : " \u25BC";
-        } else {
-          arrow.textContent = "";
-        }
-      });
-    }
-
-    // Pick initial tab
-    let initialTab = mediaOrder[0] || Object.keys(mediaTypesMap)[0] || "audio";
-    try {
-      const settingsRes = await fetch("/api/settings");
-      if (settingsRes.ok) {
-        const settingsData = await settingsRes.json();
-        const favs = settingsData.favorite_media_types || [];
-        const firstFav = favs.find(f => mediaOrder.includes(f));
-        if (firstFav) initialTab = firstFav;
-      }
-    } catch (_) {}
-
-    dashDatasetTabs.innerHTML = "";
-    dashDatasetGrid.innerHTML = "";
-
-    const dashSections = {};
-
-    mediaOrder.forEach(mt => {
-      const items = grouped[mt];
-      const mtInfo = mediaTypesMap[mt] || { icon: "\uD83D\uDCC1", tab_title: mt };
-
-      const tab = document.createElement("button");
-      tab.className = "demo-tab";
-      tab.dataset.mediaType = mt;
-      tab.textContent = `${mtInfo.icon} ${mtInfo.tab_title}`;
-      tab.addEventListener("click", () => {
-        dashDatasetTabs.querySelectorAll(".demo-tab").forEach(t => t.classList.remove("active"));
-        tab.classList.add("active");
-        Object.keys(dashSections).forEach(k => {
-          dashSections[k].style.display = k === mt ? "" : "none";
-        });
-      });
-      dashDatasetTabs.appendChild(tab);
-
-      const section = document.createElement("div");
-      section.className = "demo-section";
-      section._demoSort = { key: "num_files", asc: true };
-      section._mt = mt;
-      section.style.display = "none";
-
-      const headerRow = sortColumns.map(col =>
-        `<th data-sort="${col.key}">${col.label}<span class="sort-arrow"></span></th>`
-      ).join("");
-      section.innerHTML = `<table class="demo-table"><thead><tr>${headerRow}</tr></thead><tbody></tbody></table>`;
-
-      section.querySelectorAll("th[data-sort]").forEach(th => {
-        th.addEventListener("click", () => {
-          const key = th.dataset.sort;
-          if (section._demoSort.key === key) {
-            section._demoSort.asc = !section._demoSort.asc;
-          } else {
-            section._demoSort = { key, asc: true };
-          }
-          renderTable(items, section);
-        });
-      });
-
-      renderTable(items, section);
-      dashSections[mt] = section;
-      dashDatasetGrid.appendChild(section);
-    });
-
-    const initialTabBtn = dashDatasetTabs.querySelector(`.demo-tab[data-media-type="${initialTab}"]`);
-    if (initialTabBtn) {
-      initialTabBtn.classList.add("active");
-      if (dashSections[initialTab]) dashSections[initialTab].style.display = "";
-    }
+    dashDatasetGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No dataset loaded yet. Use "Add" to load one.</p>';
   }
 
   async function renderDashboardModels() {
@@ -1034,7 +881,7 @@
     } catch (_) {}
 
     if (favoriteDetectors.length === 0) {
-      dashModelGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No detectors saved yet. Use "Add" to create one.</p>';
+      dashModelGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No detectors loaded yet. Use "Add" to create one.</p>';
       return;
     }
 
@@ -5764,9 +5611,382 @@
     });
   }
 
-  // Dashboard: Load File button
-  if (dashLoadFileBtn && dashFileInput) {
-    dashLoadFileBtn.addEventListener("click", () => dashFileInput.click());
+  // Dashboard: Add Dataset button — opens the dataset importer picker modal
+  if (dashAddDatasetBtn) {
+    dashAddDatasetBtn.addEventListener("click", () => openDatasetImporterPicker());
+  }
+
+  // Dataset importer picker modal — close / back buttons
+  if (datasetImporterModalClose) {
+    datasetImporterModalClose.addEventListener("click", () => {
+      datasetImporterModal.classList.remove("show");
+    });
+  }
+  if (datasetImporterBack) {
+    datasetImporterBack.addEventListener("click", () => {
+      datasetImporterFormDiv.style.display = "none";
+      datasetImporterFormDiv.innerHTML = "";
+      datasetImporterBack.style.display = "none";
+      datasetImporterList.style.display = "";
+    });
+  }
+
+  async function openDatasetImporterPicker() {
+    // Reset to list view
+    datasetImporterFormDiv.style.display = "none";
+    datasetImporterFormDiv.innerHTML = "";
+    datasetImporterBack.style.display = "none";
+    datasetImporterList.style.display = "";
+
+    // Fetch all importers
+    let importers = [];
+    try {
+      const res = await fetch("/api/dataset/all-importers");
+      if (res.ok) {
+        const data = await res.json();
+        importers = data.importers || [];
+      }
+    } catch (_) {}
+
+    // Also add demo datasets as an option
+    const options = importers.map(imp => `
+      <div class="dataset-importer-option option-card" data-name="${escapeHtml(imp.name)}" data-type="importer">
+        <span class="option-card-icon">${escapeHtml(imp.icon || '\uD83D\uDD0C')}</span>
+        <div>
+          <div class="option-card-title">${escapeHtml(imp.display_name)}</div>
+          <div class="option-card-desc">${escapeHtml(imp.description)}</div>
+        </div>
+      </div>
+    `).join("");
+
+    // Add demo dataset option
+    const demoOption = `
+      <div class="dataset-importer-option option-card" data-name="demo" data-type="demo">
+        <span class="option-card-icon">\uD83C\uDFC6</span>
+        <div>
+          <div class="option-card-title">Load Demo Dataset</div>
+          <div class="option-card-desc">Choose from a selection of pre-configured demo datasets</div>
+        </div>
+      </div>
+    `;
+
+    datasetImporterList.innerHTML = options + demoOption;
+
+    // Wire up click handlers
+    datasetImporterList.querySelectorAll(".dataset-importer-option").forEach(el => {
+      el.setAttribute("role", "button");
+      el.setAttribute("tabindex", "0");
+      const name = el.dataset.name;
+      const type = el.dataset.type;
+      el.addEventListener("click", () => {
+        if (type === "demo") {
+          showDashDemoDatasetPicker();
+        } else if (name === "pickle") {
+          // Pickle = file upload — close modal and trigger file input
+          datasetImporterModal.classList.remove("show");
+          dashFileInput.click();
+        } else if (name === "combine_datasets") {
+          // Combine = close modal and go to welcome screen combine flow
+          datasetImporterModal.classList.remove("show");
+          showCombineDatasetsForm();
+          datasetWelcome.style.display = "flex";
+          dashboardView.style.display = "none";
+        } else {
+          const imp = importers.find(i => i.name === name);
+          if (imp) showDashImporterForm(imp);
+        }
+      });
+      el.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); el.click(); }
+      });
+    });
+
+    datasetImporterModal.classList.add("show");
+  }
+
+  // Show an importer's form inline within the dataset importer picker modal
+  function showDashImporterForm(importer) {
+    datasetImporterList.style.display = "none";
+    datasetImporterBack.style.display = "";
+
+    let html = `<h3 style="margin-bottom:12px;">${escapeHtml(importer.icon || '\uD83D\uDD0C')} ${escapeHtml(importer.display_name)}</h3>`;
+    html += `<form id="dash-imp-form">`;
+    for (const field of importer.fields) {
+      html += `<div class="form-group">`;
+      html += `<label class="form-label">${escapeHtml(field.label)}${field.required ? " *" : ""}</label>`;
+      if (field.field_type === "file") {
+        html += `<input type="file" name="${escapeHtml(field.key)}" accept="${escapeHtml(field.accept || "")}" class="form-input" ${field.required ? "required" : ""}>`;
+      } else if (field.field_type === "select") {
+        html += `<select name="${escapeHtml(field.key)}" class="form-input">`;
+        for (const opt of field.options) {
+          html += `<option value="${escapeHtml(opt)}"${opt === field.default ? " selected" : ""}>${escapeHtml(opt)}</option>`;
+        }
+        html += `</select>`;
+      } else if (field.field_type === "folder") {
+        html += `<div class="form-row"><input type="text" name="${escapeHtml(field.key)}" placeholder="${escapeHtml(field.description)}" class="form-input" style="flex:1;" data-folder-input="true" ${field.required ? "required" : ""}>`;
+        html += `<button type="button" data-browse-btn="true" class="btn-browse">Browse\u2026</button></div>`;
+        html += `<input type="file" data-folder-picker="true" webkitdirectory style="display:none;">`;
+      } else {
+        const itype = field.field_type === "url" ? "url" : "text";
+        html += `<input type="${itype}" name="${escapeHtml(field.key)}" value="${escapeHtml(field.default || "")}" placeholder="${escapeHtml(field.description)}" class="form-input" ${field.required ? "required" : ""}>`;
+      }
+      if (field.description) {
+        html += `<div class="form-hint">${escapeHtml(field.description)}</div>`;
+      }
+      html += `</div>`;
+    }
+    html += `<div id="dash-imp-status" class="status-text" style="min-height:1.2em; margin:8px 0;"></div>`;
+    html += `<button type="submit" class="btn-block-primary">Import</button>`;
+    html += `</form>`;
+
+    datasetImporterFormDiv.innerHTML = html;
+    datasetImporterFormDiv.style.display = "block";
+
+    // Wire up folder browse buttons
+    const browseBtn = datasetImporterFormDiv.querySelector("[data-browse-btn]");
+    const folderPicker = datasetImporterFormDiv.querySelector("[data-folder-picker]");
+    const folderTextInput = datasetImporterFormDiv.querySelector("[data-folder-input]");
+    if (browseBtn && folderPicker && folderTextInput) {
+      browseBtn.addEventListener("click", () => folderPicker.click());
+      folderPicker.addEventListener("change", () => {
+        if (folderPicker.files.length > 0) {
+          const topFolder = folderPicker.files[0].webkitRelativePath.split("/")[0];
+          if (!folderTextInput.value) {
+            folderTextInput.placeholder = `Selected: ${topFolder} \u2014 enter full path below`;
+          }
+        }
+      });
+    }
+
+    document.getElementById("dash-imp-form").addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const formEl = e.target;
+      const statusEl = document.getElementById("dash-imp-status");
+      const hasFiles = importer.fields.some(f => f.field_type === "file");
+      let body, headers = {};
+      if (hasFiles) {
+        body = new FormData(formEl);
+      } else {
+        const obj = {};
+        for (const field of importer.fields) {
+          obj[field.key] = formEl.elements[field.key].value;
+        }
+        body = JSON.stringify(obj);
+        headers["Content-Type"] = "application/json";
+      }
+
+      statusEl.textContent = "Importing\u2026";
+      statusEl.style.color = "var(--text-secondary)";
+
+      // Close modal and show dashboard progress
+      datasetImporterModal.classList.remove("show");
+      dashProgress.style.display = "block";
+      dashProgressFill.style.width = "0%";
+      dashProgressFill.classList.add("indeterminate");
+      dashProgressText.textContent = "";
+      dashProgressMessage.textContent = "Importing\u2026";
+      dashProgressMessage.style.color = "var(--text-secondary)";
+      dashProgressEta.textContent = "";
+
+      try {
+        const res = await fetch(`/api/dataset/import/${importer.name}`, { method: "POST", headers, body });
+        if (!res.ok) {
+          const err = await res.json();
+          dashProgressMessage.textContent = `Error: ${err.error}`;
+          dashProgressMessage.style.color = "var(--color-bad)";
+          return;
+        }
+      } catch (err) {
+        dashProgressMessage.textContent = `Error: ${err.message}`;
+        dashProgressMessage.style.color = "var(--color-bad)";
+        return;
+      }
+
+      dashSelectedDataset = null;
+      dashPendingAction = null;
+      startDashProgressPolling();
+    });
+  }
+
+  // Show demo dataset picker within the dataset importer modal
+  async function showDashDemoDatasetPicker() {
+    datasetImporterList.style.display = "none";
+    datasetImporterBack.style.display = "";
+
+    datasetImporterFormDiv.innerHTML = '<p style="color:var(--text-muted); padding:8px;">Loading demo datasets\u2026</p>';
+    datasetImporterFormDiv.style.display = "block";
+
+    let demos = [];
+    try {
+      const res = await fetch("/api/dataset/demo-list");
+      if (res.ok) {
+        const data = await res.json();
+        demos = data.datasets || [];
+      }
+    } catch (_) {}
+
+    if (demos.length === 0) {
+      datasetImporterFormDiv.innerHTML = '<p style="color:var(--text-muted); padding:8px;">No demo datasets available.</p>';
+      return;
+    }
+
+    // Group by media type
+    const grouped = {};
+    demos.forEach(ds => {
+      const mt = ds.media_type || "audio";
+      if (!grouped[mt]) grouped[mt] = [];
+      grouped[mt].push(ds);
+    });
+    const mediaOrder = Object.keys(mediaTypesMap).filter(mt => (grouped[mt] || []).length > 0);
+
+    const statusOrder = { ready: 0, needs_embedding: 1, needs_download: 2 };
+
+    function buildStatusBadge(st) {
+      if (st === "ready") return '<span class="ready-badge">Ready</span>';
+      if (st === "needs_embedding") return '<span class="embedding-badge">Needs Embed</span>';
+      return '<span class="download-badge">Needs Download</span>';
+    }
+
+    // Build tabs + table content
+    const wrapper = document.createElement("div");
+
+    const tabBar = document.createElement("div");
+    tabBar.className = "demo-tab-bar";
+    wrapper.appendChild(tabBar);
+
+    const contentArea = document.createElement("div");
+    contentArea.className = "demo-content-area";
+    wrapper.appendChild(contentArea);
+
+    const sections = {};
+
+    const sortColumns = [
+      { key: "label", label: "Name" },
+      { key: "num_files", label: "# Media" },
+      { key: "num_categories", label: "# Cat." },
+      { key: "description", label: "Description" },
+      { key: "status", label: "Readiness" },
+    ];
+
+    function renderTable(items, section) {
+      const sortState = section._demoSort || { key: "label", asc: true };
+      const sorted = [...items].sort((a, b) => {
+        let va = a[sortState.key], vb = b[sortState.key];
+        if (sortState.key === "status") { va = statusOrder[va] ?? 3; vb = statusOrder[vb] ?? 3; }
+        if (typeof va === "number" && typeof vb === "number") return sortState.asc ? va - vb : vb - va;
+        va = String(va || "").toLowerCase(); vb = String(vb || "").toLowerCase();
+        return sortState.asc ? va.localeCompare(vb) : vb.localeCompare(va);
+      });
+
+      const tbody = section.querySelector("tbody");
+      tbody.innerHTML = "";
+      sorted.forEach(ds => {
+        const st = ds.status || (ds.ready ? "ready" : "needs_download");
+        const tr = document.createElement("tr");
+        tr.className = "demo-row" + (st === "ready" ? " ready" : st === "needs_embedding" ? " needs-embedding" : "");
+        tr.setAttribute("role", "button");
+        tr.setAttribute("tabindex", "0");
+        tr.setAttribute("aria-label", `${ds.label}: ${ds.description}`);
+        tr.addEventListener("click", () => {
+          datasetImporterModal.classList.remove("show");
+          dashSelectedDataset = ds;
+          // Load the selected demo dataset immediately from dashboard
+          dashPendingAction = null;
+          dashLoadSelectedDataset();
+        });
+        tr.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); tr.click(); }
+        });
+        const descShort = ds.description.length > 60 ? ds.description.slice(0, 57) + "\u2026" : ds.description;
+        tr.innerHTML = `
+          <td class="col-name">${escapeHtml(ds.label)}</td>
+          <td class="col-num">${ds.num_files}</td>
+          <td class="col-num">${ds.num_categories}</td>
+          <td class="col-desc" title="${escapeHtml(ds.description)}">${escapeHtml(descShort)}</td>
+          <td class="col-status">${buildStatusBadge(st)}</td>
+        `;
+        tbody.appendChild(tr);
+      });
+
+      section.querySelectorAll("th[data-sort]").forEach(th => {
+        const arrow = th.querySelector(".sort-arrow");
+        if (th.dataset.sort === sortState.key) {
+          arrow.textContent = sortState.asc ? " \u25B2" : " \u25BC";
+        } else {
+          arrow.textContent = "";
+        }
+      });
+    }
+
+    // Pick initial tab
+    let initialTab = mediaOrder[0] || Object.keys(mediaTypesMap)[0] || "audio";
+    try {
+      const settingsRes = await fetch("/api/settings");
+      if (settingsRes.ok) {
+        const settingsData = await settingsRes.json();
+        const favs = settingsData.favorite_media_types || [];
+        const firstFav = favs.find(f => mediaOrder.includes(f));
+        if (firstFav) initialTab = firstFav;
+      }
+    } catch (_) {}
+
+    mediaOrder.forEach(mt => {
+      const items = grouped[mt];
+      const mtInfo = mediaTypesMap[mt] || { icon: "\uD83D\uDCC1", tab_title: mt };
+
+      const tab = document.createElement("button");
+      tab.className = "demo-tab";
+      tab.dataset.mediaType = mt;
+      tab.textContent = `${mtInfo.icon} ${mtInfo.tab_title}`;
+      tab.addEventListener("click", () => {
+        tabBar.querySelectorAll(".demo-tab").forEach(t => t.classList.remove("active"));
+        tab.classList.add("active");
+        Object.keys(sections).forEach(k => {
+          sections[k].style.display = k === mt ? "" : "none";
+        });
+      });
+      tabBar.appendChild(tab);
+
+      const section = document.createElement("div");
+      section.className = "demo-section";
+      section._demoSort = { key: "num_files", asc: true };
+      section._mt = mt;
+      section.style.display = "none";
+
+      const headerRow = sortColumns.map(col =>
+        `<th data-sort="${col.key}">${col.label}<span class="sort-arrow"></span></th>`
+      ).join("");
+      section.innerHTML = `<table class="demo-table"><thead><tr>${headerRow}</tr></thead><tbody></tbody></table>`;
+
+      section.querySelectorAll("th[data-sort]").forEach(th => {
+        th.addEventListener("click", () => {
+          const key = th.dataset.sort;
+          if (section._demoSort.key === key) {
+            section._demoSort.asc = !section._demoSort.asc;
+          } else {
+            section._demoSort = { key, asc: true };
+          }
+          renderTable(items, section);
+        });
+      });
+
+      renderTable(items, section);
+      sections[mt] = section;
+      contentArea.appendChild(section);
+    });
+
+    const initialTabBtn = tabBar.querySelector(`.demo-tab[data-media-type="${initialTab}"]`);
+    if (initialTabBtn) {
+      initialTabBtn.classList.add("active");
+      if (sections[initialTab]) sections[initialTab].style.display = "";
+    }
+
+    datasetImporterFormDiv.innerHTML = "";
+    datasetImporterFormDiv.appendChild(wrapper);
+  }
+
+  // Dashboard: File input for pickle upload (used by pickle importer option)
+  if (dashFileInput) {
     dashFileInput.addEventListener("change", async () => {
       const file = dashFileInput.files[0];
       if (!file) return;

--- a/static/index.html
+++ b/static/index.html
@@ -128,22 +128,21 @@
         <!-- Dataset grid -->
         <div class="dashboard-section">
           <div class="dashboard-section-header">
-            <span class="dashboard-section-title">Dataset</span>
+            <span class="dashboard-section-title">Datasets</span>
             <div class="dashboard-section-actions">
-              <button class="btn-sm" id="dash-load-file-btn">Load File</button>
+              <button class="btn-sm" id="dash-add-dataset-btn">Add</button>
               <button class="btn-sm" id="dash-change-dataset-btn" style="display:none">Change</button>
             </div>
           </div>
           <div id="dash-dataset-status" class="dashboard-status-bar" style="display:none"></div>
           <div class="dashboard-grid-wrap">
-            <div id="dash-dataset-tabs" class="demo-tab-bar"></div>
-            <div id="dash-dataset-grid" class="dashboard-grid demo-content-area"></div>
+            <div id="dash-dataset-grid" class="dashboard-grid"></div>
           </div>
         </div>
         <!-- Model grid -->
         <div class="dashboard-section">
           <div class="dashboard-section-header">
-            <span class="dashboard-section-title">Model</span>
+            <span class="dashboard-section-title">Models</span>
             <div class="dashboard-section-actions">
               <button class="btn-sm" id="dash-add-model-btn">Add</button>
             </div>
@@ -381,6 +380,21 @@
       <div style="background: var(--border); border-radius: 8px; overflow: hidden; height: 24px;" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Auto-detect progress">
         <div id="autodetect-progress-bar" style="background: var(--accent); height: 100%; width: 0%; transition: width 0.3s;"></div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Dataset Importer Picker Modal -->
+<div id="dataset-importer-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="dataset-importer-modal-title">
+  <div class="modal-content" style="max-width: 600px;">
+    <div class="modal-header">
+      <h2 id="dataset-importer-modal-title">Add Dataset</h2>
+      <button class="modal-close" id="dataset-importer-modal-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div id="dataset-importer-list"></div>
+      <div id="dataset-importer-form" style="display:none"></div>
+      <button id="dataset-importer-back" aria-label="Back to importer list" class="btn-sm" style="display:none; margin-top:12px; padding:6px 14px;">&#8592; Back</button>
     </div>
   </div>
 </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -162,7 +162,7 @@
   outline-offset: 2px;
 }
 .media-item:focus-visible, .vote-entry:focus-visible, .burger-item:focus-visible,
-.label-importer-option:focus-visible, .processor-importer-option:focus-visible,
+.label-importer-option:focus-visible, .processor-importer-option:focus-visible, .dataset-importer-option:focus-visible,
 .demo-dataset:focus-visible, .dataset-option:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
@@ -607,7 +607,7 @@ video { max-width: 100%; }
   margin: 0 auto; padding: 24px 32px; gap: 16px; flex: 1; min-height: 0;
 }
 .dashboard-header h2 { font-size: 1.4rem; color: var(--accent); margin: 0; }
-.dashboard-grids { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; flex: 1; min-height: 0; }
+.dashboard-grids { display: grid; grid-template-columns: 1fr; gap: 20px; flex: 1; min-height: 0; }
 .dashboard-section {
   display: flex; flex-direction: column; min-height: 0;
   border: 1px solid var(--border); border-radius: 8px;

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -258,6 +258,31 @@ def dataset_importers():
     return jsonify({"importers": extended})
 
 
+@datasets_bp.route("/api/dataset/all-importers")
+def dataset_all_importers():
+    """List all registered importers (including built-in ones).
+
+    Used by the dashboard's dataset importer picker modal, which needs
+    to show every available way to add a dataset.
+
+    Returns a JSON object::
+
+        {
+          "importers": [
+            {
+              "name": "pickle",
+              "display_name": "Pickle File",
+              "description": "...",
+              "fields": [ ... ]
+            },
+            ...
+          ]
+        }
+    """
+    all_importers = [imp.to_dict() for imp in list_importers()]
+    return jsonify({"importers": all_importers})
+
+
 # ---------------------------------------------------------------------------
 # Available dataset files (for the Combine Existing Datasets UI)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Replaced the inline demo dataset browser in the dashboard with a modal-based dataset importer picker. This provides a unified interface for users to choose between different dataset import methods (demo datasets, pickle files, custom importers, etc.) before loading.

## Key Changes

- **Removed inline demo dataset UI**: Eliminated the tabbed demo dataset browser that was displayed directly in the dashboard grid (`dashDatasetTabs`, `renderDashboardDatasets` async logic)

- **Added dataset importer modal**: New modal dialog (`dataset-importer-modal`) that presents users with a list of available import options:
  - Demo datasets (with their own tabbed browser inside the modal)
  - Pickle file upload
  - Combine datasets workflow
  - Custom importers (via `/api/dataset/all-importers` endpoint)

- **New backend endpoint**: Added `/api/dataset/all-importers` route to list all registered importers including built-in ones, used by the dashboard's importer picker

- **Refactored dataset loading flow**:
  - "Load File" button renamed to "Add" and now opens the importer picker modal
  - Demo dataset picker moved inside the modal with preserved tabbed interface and sorting
  - File input handling moved to direct pickle upload path
  - Simplified `renderDashboardDatasets()` to show minimal UI when dataset is loaded

- **UI/UX improvements**:
  - Dashboard section titles pluralized ("Dataset" → "Datasets", "Model" → "Models")
  - Cleaner dashboard grid when dataset is already loaded
  - Modal-based workflow reduces clutter in main dashboard view
  - Back button in modal allows navigation between importer options and forms

- **Preserved functionality**: Demo dataset selection, sorting, status badges, and all importer form handling remain intact, just reorganized into the modal context

https://claude.ai/code/session_0161AMa7Pam7sZEFS9B2yhZZ