### PR TITLE
Add favorite detector management with untrained model support

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -921,7 +921,7 @@
         tr.innerHTML = `
           <td class="col-name">${escapeHtml(det.name)}</td>
           <td class="col-type">${escapeHtml(icon)} ${escapeHtml(det.media_type)}</td>
-          <td class="col-threshold">${det.threshold.toFixed(2)}</td>
+          <td class="col-threshold">${det.weights ? det.threshold.toFixed(2) : '<span style="color:var(--text-muted)">Untrained</span>'}</td>
           <td class="col-date">${escapeHtml(created)}</td>
         `;
         tr.addEventListener("click", () => {
@@ -4855,6 +4855,8 @@
     processorImporterFormDiv.innerHTML = "";
     processorImporterBack.style.display = "none";
     processorImporterList.style.display = "";
+    const modalTitle = document.getElementById("processor-importer-modal-title");
+    if (modalTitle) modalTitle.textContent = "Import Detector";
 
     if (importers.length === 0) {
       processorImporterList.innerHTML = '<p style="color:var(--text-muted);">No processor importers available.</p>';
@@ -4958,6 +4960,7 @@
           statusEl.style.color = "var(--color-good)";
           setTimeout(() => {
             processorImporterModal.classList.remove("show");
+            if (currentView === "dashboard") renderDashboardModels();
           }, 1500);
         } else {
           statusEl.textContent = result.error || "Import failed";
@@ -4973,6 +4976,7 @@
   if (processorImporterModalClose) {
     processorImporterModalClose.addEventListener("click", () => {
       processorImporterModal.classList.remove("show");
+      if (currentView === "dashboard") renderDashboardModels();
     });
   }
 
@@ -6040,29 +6044,139 @@
     });
   }
 
-  // Dashboard: Add Model button — opens the existing Manage Favorites modal
+  // Dashboard: Add Model button — opens a picker with New Model + processor importers
   if (dashAddModelBtn) {
-    dashAddModelBtn.addEventListener("click", async () => {
-      await loadFavoriteDetectors();
-      loadFavImporterButtons();
-      if (favAddName && !favAddName.value.trim()) {
-        try {
-          const sugRes = await fetch("/api/textsort-suggestions");
-          const sugData = await sugRes.json();
-          if (sugData.suggestions && sugData.suggestions.length > 0) {
-            favAddName.value = sugData.suggestions[sugData.suggestions.length - 1];
-          }
-        } catch (_) {}
-      }
-      favoritesModal.classList.add("show");
-    });
+    dashAddModelBtn.addEventListener("click", () => openAddModelPicker());
   }
 
-  // Re-render dashboard model grid when favorites modal closes (detectors may have changed)
-  if (favoritesModalClose) {
-    const origClose = favoritesModalClose.onclick;
-    favoritesModalClose.addEventListener("click", () => {
-      if (currentView === "dashboard") renderDashboardModels();
+  async function openAddModelPicker() {
+    // Fetch processor importers for the importer options
+    let importers = [];
+    try {
+      const res = await fetch("/api/processor-importers");
+      if (res.ok) importers = await res.json();
+    } catch (_) { /* ignore */ }
+
+    // Reset modal to list view
+    processorImporterFormDiv.style.display = "none";
+    processorImporterFormDiv.innerHTML = "";
+    processorImporterBack.style.display = "none";
+    processorImporterList.style.display = "";
+
+    // Update modal title
+    const modalTitle = document.getElementById("processor-importer-modal-title");
+    if (modalTitle) modalTitle.textContent = "Add Model";
+
+    // Build options: New Model first, then processor importers
+    let html = `
+      <div class="processor-importer-option option-card" data-name="__new_model__" role="button" tabindex="0">
+        <span class="option-card-icon">\u2795</span>
+        <div>
+          <div class="option-card-title">New Model</div>
+          <div class="option-card-desc">Create a new model with a name and media type.</div>
+        </div>
+      </div>`;
+
+    html += importers.map(imp => `
+      <div class="processor-importer-option option-card" data-name="${escapeHtml(imp.name)}" role="button" tabindex="0">
+        <span class="option-card-icon">${escapeHtml(imp.icon || '\u{1F9E9}')}</span>
+        <div>
+          <div class="option-card-title">${escapeHtml(imp.display_name)}</div>
+          <div class="option-card-desc">${escapeHtml(imp.description)}</div>
+        </div>
+      </div>
+    `).join("");
+
+    processorImporterList.innerHTML = html;
+
+    // Wire up click handlers
+    processorImporterList.querySelectorAll(".processor-importer-option").forEach(el => {
+      const name = el.dataset.name;
+      el.addEventListener("click", () => {
+        if (name === "__new_model__") {
+          showNewModelForm();
+        } else {
+          const imp = importers.find(i => i.name === name);
+          if (imp) showProcessorImporterForm(imp);
+        }
+      });
+      el.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); el.click(); }
+      });
+    });
+
+    processorImporterModal.classList.add("show");
+  }
+
+  function showNewModelForm() {
+    processorImporterList.style.display = "none";
+    processorImporterBack.style.display = "inline-block";
+
+    // Build media type options from the registry
+    const mtOptions = Object.entries(mediaTypesMap).map(([id, mt]) =>
+      `<option value="${escapeHtml(id)}">${escapeHtml(mt.icon || "")} ${escapeHtml(mt.name || id)}</option>`
+    ).join("");
+
+    let html = `<h3 class="form-heading">New Model</h3>`;
+    html += `<form id="new-model-form">`;
+    html += `<div class="form-group">`;
+    html += `<label class="form-label">Model Name *</label>`;
+    html += `<input type="text" name="name" placeholder="e.g. Dog Barks" class="form-input" required>`;
+    html += `<div class="form-hint">A short name for this model.</div>`;
+    html += `</div>`;
+    html += `<div class="form-group">`;
+    html += `<label class="form-label">Media Type *</label>`;
+    html += `<select name="media_type" class="form-input" required>`;
+    html += mtOptions || `<option value="audio">Audio</option><option value="image">Image</option><option value="paragraph">Text</option><option value="video">Video</option>`;
+    html += `</select>`;
+    html += `<div class="form-hint">The type of media this model will be trained on.</div>`;
+    html += `</div>`;
+    html += `<div id="new-model-status" class="status-text compact"></div>`;
+    html += `<button type="submit" class="btn-block-primary">Create</button>`;
+    html += `</form>`;
+
+    processorImporterFormDiv.innerHTML = html;
+    processorImporterFormDiv.style.display = "block";
+
+    const statusEl = processorImporterFormDiv.querySelector("#new-model-status");
+
+    processorImporterFormDiv.querySelector("#new-model-form").addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const formEl = e.target;
+      const name = formEl.elements["name"].value.trim();
+      const media_type = formEl.elements["media_type"].value;
+
+      if (!name) {
+        statusEl.textContent = "Name is required";
+        statusEl.style.color = "var(--color-bad)";
+        return;
+      }
+
+      statusEl.textContent = "Creating\u2026";
+      statusEl.style.color = "var(--text-muted)";
+
+      try {
+        const res = await fetch("/api/favorite-detectors", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, media_type }),
+        });
+        const result = await res.json();
+        if (res.ok) {
+          statusEl.textContent = `Created "${name}"`;
+          statusEl.style.color = "var(--color-good)";
+          setTimeout(() => {
+            processorImporterModal.classList.remove("show");
+            if (currentView === "dashboard") renderDashboardModels();
+          }, 800);
+        } else {
+          statusEl.textContent = result.error || "Failed to create model";
+          statusEl.style.color = "var(--color-bad)";
+        }
+      } catch (err) {
+        statusEl.textContent = `Error: ${err.message}`;
+        statusEl.style.color = "var(--color-bad)";
+      }
     });
   }
 

--- a/static/app.js
+++ b/static/app.js
@@ -892,6 +892,7 @@
         <th data-sort="name">Name<span class="sort-arrow"></span></th>
         <th data-sort="media_type">Type<span class="sort-arrow"></span></th>
         <th data-sort="threshold">Threshold<span class="sort-arrow"></span></th>
+        <th data-sort="autodetect" style="text-align:center">Fav<span class="sort-arrow"></span></th>
         <th data-sort="created_at">Created<span class="sort-arrow"></span></th>
       </tr></thead><tbody></tbody></table>`;
     dashModelGrid.innerHTML = html;
@@ -904,6 +905,10 @@
         let va = a[modelSort.key], vb = b[modelSort.key];
         if (modelSort.key === "threshold") return modelSort.asc ? va - vb : vb - va;
         if (modelSort.key === "created_at") return modelSort.asc ? (va || 0) - (vb || 0) : (vb || 0) - (va || 0);
+        if (modelSort.key === "autodetect") {
+          va = va ? 1 : 0; vb = vb ? 1 : 0;
+          return modelSort.asc ? va - vb : vb - va;
+        }
         va = String(va || "").toLowerCase(); vb = String(vb || "").toLowerCase();
         return modelSort.asc ? va.localeCompare(vb) : vb.localeCompare(va);
       });
@@ -914,6 +919,7 @@
         const icon = mediaIcons[det.media_type] || "\uD83D\uDD0D";
         const created = det.created_at ? new Date(det.created_at * 1000).toLocaleDateString() : "";
         const isSelected = dashSelectedDetector === det.name;
+        const isFav = det.autodetect;
         const tr = document.createElement("tr");
         tr.className = "dash-model-row" + (isSelected ? " dash-selected" : "");
         tr.setAttribute("role", "button");
@@ -922,8 +928,25 @@
           <td class="col-name">${escapeHtml(det.name)}</td>
           <td class="col-type">${escapeHtml(icon)} ${escapeHtml(det.media_type)}</td>
           <td class="col-threshold">${det.weights ? det.threshold.toFixed(2) : '<span style="color:var(--text-muted)">Untrained</span>'}</td>
+          <td class="col-fav" style="text-align:center"><input type="checkbox" class="fav-checkbox" ${isFav ? "checked" : ""} aria-label="Favorite"></td>
           <td class="col-date">${escapeHtml(created)}</td>
         `;
+        // Favorite checkbox toggle
+        const checkbox = tr.querySelector(".fav-checkbox");
+        checkbox.addEventListener("click", async (e) => {
+          e.stopPropagation();
+          const newVal = checkbox.checked;
+          try {
+            await fetch(`/api/favorite-detectors/${encodeURIComponent(det.name)}/autodetect`, {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ autodetect: newVal }),
+            });
+            det.autodetect = newVal;
+          } catch (_) {
+            checkbox.checked = !newVal; // revert on failure
+          }
+        });
         tr.addEventListener("click", () => {
           dashSelectedDetector = det.name;
           renderModelRows();

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -109,16 +109,16 @@ class TestDashboardHtmlPresent:
         resp = client.get("/")
         assert resp.status_code == 200
         assert b"dashboard-view" in resp.data
-        assert b"My Datasets" in resp.data
-        assert b"My Models" in resp.data
+        assert b"Datasets" in resp.data
+        assert b"Models" in resp.data
 
     def test_dashboard_menu_item(self, client):
         """The burger menu should have a Dashboard entry."""
         resp = client.get("/")
         assert b"menu-dashboard" in resp.data
 
-    def test_train_and_run_buttons(self, client):
-        """Train and Run buttons should be present and disabled by default."""
+    def test_label_and_detect_buttons(self, client):
+        """Label and Detect buttons should be present and disabled by default."""
         resp = client.get("/")
-        assert b"dashboard-train-btn" in resp.data
-        assert b"dashboard-run-btn" in resp.data
+        assert b"dash-label-btn" in resp.data
+        assert b"dash-detect-btn" in resp.data

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -176,12 +176,17 @@ class TestFavoriteDetectors:
         )
         assert resp.status_code == 400
 
-    def test_add_missing_weights_returns_400(self, client):
+    def test_add_without_weights_creates_untrained(self, client):
         resp = client.post(
             "/api/favorite-detectors",
             json={"name": "test", "media_type": "audio"},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+
+        detectors = client.get("/api/favorite-detectors").get_json()["detectors"]
+        det = [d for d in detectors if d["name"] == "test"][0]
+        assert det["weights"] is None
+        assert det["autodetect"] is False
 
     def test_add_multiple_detectors(self, client):
         det = self._export_detector(client)
@@ -348,7 +353,7 @@ class TestAutoDetect:
     """Tests for POST /api/auto-detect."""
 
     def _add_audio_detector(self, client, name="test-detector"):
-        """Helper: create and save an audio detector."""
+        """Helper: create and save an audio detector with autodetect enabled."""
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
         export_resp = client.post("/api/detector/export")
@@ -362,6 +367,7 @@ class TestAutoDetect:
                 "media_type": "audio",
                 "weights": detector["weights"],
                 "threshold": detector["threshold"],
+                "autodetect": True,
             },
         )
         assert save_resp.status_code == 200
@@ -384,7 +390,7 @@ class TestAutoDetect:
         app_module.good_votes.clear()
         app_module.bad_votes.clear()
 
-        # Save as "image" type — medias are audio, so it won't match
+        # Save as "image" type with autodetect — medias are audio, so it won't match
         client.post(
             "/api/favorite-detectors",
             json={
@@ -392,6 +398,7 @@ class TestAutoDetect:
                 "media_type": "image",
                 "weights": detector["weights"],
                 "threshold": detector["threshold"],
+                "autodetect": True,
             },
         )
         resp = client.post("/api/auto-detect")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,8 +44,8 @@ def _export_detector(client):
     return data
 
 
-def _save_favorite_detector(client, name, detector):
-    """Save a detector as a favorite."""
+def _save_favorite_detector(client, name, detector, *, autodetect=True):
+    """Save a detector as a favorite with autodetect enabled by default."""
     resp = client.post(
         "/api/favorite-detectors",
         json={
@@ -53,6 +53,7 @@ def _save_favorite_detector(client, name, detector):
             "media_type": "audio",
             "weights": detector["weights"],
             "threshold": detector["threshold"],
+            "autodetect": autodetect,
         },
     )
     assert resp.status_code == 200, f"Save favorite failed: {resp.get_json()}"

--- a/tests/test_slow_integration.py
+++ b/tests/test_slow_integration.py
@@ -775,7 +775,7 @@ class TestDetectorFavoriteRoundTrip:
         assert resp.status_code == 200
         detector = resp.get_json()
 
-        # Step 2: Save as favorite
+        # Step 2: Save as favorite with autodetect
         resp = client.post(
             "/api/favorite-detectors",
             json={
@@ -783,6 +783,7 @@ class TestDetectorFavoriteRoundTrip:
                 "media_type": "audio",
                 "weights": detector["weights"],
                 "threshold": detector["threshold"],
+                "autodetect": True,
             },
         )
         assert resp.status_code == 200
@@ -1068,6 +1069,7 @@ class TestAutoDetectExporterLabelRoundTrip:
                 "media_type": "audio",
                 "weights": detector["weights"],
                 "threshold": detector["threshold"],
+                "autodetect": True,
             },
         )
         assert resp.status_code == 200
@@ -1306,7 +1308,7 @@ class TestLabelImporterDetectorChain:
         assert resp.status_code == 200
         detector = resp.get_json()
 
-        # Step 5: Save as favorite
+        # Step 5: Save as favorite with autodetect
         resp = client.post(
             "/api/favorite-detectors",
             json={
@@ -1314,6 +1316,7 @@ class TestLabelImporterDetectorChain:
                 "media_type": "audio",
                 "weights": detector["weights"],
                 "threshold": detector["threshold"],
+                "autodetect": True,
             },
         )
         assert resp.status_code == 200

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -314,6 +314,7 @@ def add_favorite_detector_route():
     media_type = data.get("media_type", "").strip()
     weights = data.get("weights")
     threshold = data.get("threshold", 0.5)
+    autodetect = data.get("autodetect", False)
 
     examples = data.get("examples")
 
@@ -322,7 +323,7 @@ def add_favorite_detector_route():
     if not media_type:
         return jsonify({"error": "media_type is required"}), 400
 
-    add_favorite_detector(name, media_type, weights, threshold, examples=examples)
+    add_favorite_detector(name, media_type, weights, threshold, autodetect=autodetect, examples=examples)
     return jsonify({"success": True, "name": name})
 
 

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -301,7 +301,11 @@ def get_favorite_detectors_route():
 
 @detectors_bp.route("/api/favorite-detectors", methods=["POST"])
 def add_favorite_detector_route():
-    """Add a new favorite detector."""
+    """Add a new favorite detector.
+
+    Weights are optional: when omitted the detector is created as an untrained
+    stub that can be trained later through labeling.
+    """
     data = request.get_json(force=True)
     if data is None:
         return jsonify({"error": "Invalid request body"}), 400
@@ -317,8 +321,6 @@ def add_favorite_detector_route():
         return jsonify({"error": "name is required"}), 400
     if not media_type:
         return jsonify({"error": "media_type is required"}), 400
-    if not weights:
-        return jsonify({"error": "weights are required"}), 400
 
     add_favorite_detector(name, media_type, weights, threshold, examples=examples)
     return jsonify({"success": True, "name": name})

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -401,6 +401,7 @@ def ensure_favorite_processors_imported() -> list[str]:
                 result.get("media_type", "audio"),
                 result["weights"],
                 result.get("threshold", 0.5),
+                autodetect=True,
             )
             imported.append(name)
         except Exception as exc:

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -280,7 +280,7 @@ def add_favorite_detector(
     weights: dict[str, Any] | None = None,
     threshold: float = 0.5,
     *,
-    autodetect: bool = True,
+    autodetect: bool = False,
     examples: list[dict[str, str]] | None = None,
 ) -> None:
     """Add or overwrite a named favorite detector in the global store.
@@ -296,8 +296,8 @@ def add_favorite_detector(
             May be ``None`` for an untrained detector stub.
         threshold: Decision boundary score in ``[0, 1]``. Clips scoring at or
             above this value are classified as positive.  Defaults to ``0.5``.
-        autodetect: Whether this detector should be included when running
-            autodetect.  Defaults to ``True``.
+        autodetect: Whether this detector is a "favorite" included when
+            running autodetect.  Defaults to ``False``.
         examples: Optional list of example dicts, each with ``"type"``
             (``"text"``, ``"media"``, or ``"detector"``) and ``"value"`` (str).
     """

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -277,8 +277,8 @@ def get_textsort_suggestions() -> list[str]:
 def add_favorite_detector(
     name: str,
     media_type: str,
-    weights: dict[str, Any],
-    threshold: float,
+    weights: dict[str, Any] | None = None,
+    threshold: float = 0.5,
     *,
     autodetect: bool = True,
     examples: list[dict[str, str]] | None = None,
@@ -293,8 +293,9 @@ def add_favorite_detector(
             ``"video"``, ``"image"``, or ``"paragraph"``).
         weights: Dict mapping layer-parameter names (e.g. ``"0.weight"``) to
             lists of float values, representing the serialised MLP state dict.
+            May be ``None`` for an untrained detector stub.
         threshold: Decision boundary score in ``[0, 1]``. Clips scoring at or
-            above this value are classified as positive.
+            above this value are classified as positive.  Defaults to ``0.5``.
         autodetect: Whether this detector should be included when running
             autodetect.  Defaults to ``True``.
         examples: Optional list of example dicts, each with ``"type"``
@@ -445,7 +446,7 @@ def get_autodetect_detectors_by_media(media_type: str) -> dict[str, dict[str, An
         return {
             name: det
             for name, det in favorite_detectors.items()
-            if det["media_type"] == media_type and det.get("autodetect", True)
+            if det["media_type"] == media_type and det.get("autodetect", True) and det.get("weights")
         }
 
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive favorite detector management to the dashboard, including support for creating untrained model stubs, toggling favorite status, and an improved "Add Model" workflow that combines new model creation with processor importer options.

## Key Changes

### Favorite Detector Management
- **Favorite checkbox column**: Added a "Fav" column to the dashboard model grid that allows users to toggle the `autodetect` flag for each detector via checkbox
- **Favorite API endpoint**: Added `PUT /api/favorite-detectors/{name}/autodetect` to update the favorite status of a detector
- **Sorting support**: Implemented sorting by the `autodetect` field in the model grid

### Untrained Model Support
- **Optional weights**: Modified `add_favorite_detector()` to accept `None` for weights, allowing creation of untrained detector stubs
- **Threshold display**: Updated the threshold column to show "Untrained" for detectors without weights
- **Autodetect filtering**: Updated `get_autodetect_detectors_by_media()` to exclude detectors without weights from autodetect runs
- **Default autodetect**: Changed the default value of `autodetect` parameter from `True` to `False` for new detectors

### Improved Add Model Workflow
- **Unified picker**: Replaced the direct "Manage Favorites" modal with a new "Add Model" picker that presents two options:
  - "New Model": Creates an untrained detector stub with name and media type
  - Processor importers: Lists available processor importers for importing pre-trained models
- **New model form**: Added a form to create untrained models with name and media type selection
- **Modal state management**: Ensured the dashboard re-renders after model creation or import completion

### API Changes
- `POST /api/favorite-detectors` now accepts optional `weights` and `threshold` parameters
- Added `autodetect` parameter to control favorite status at creation time
- Updated route documentation to clarify untrained detector support

### Test Updates
- Updated test expectations to reflect new untrained model behavior
- Modified helper functions to explicitly set `autodetect=True` where needed
- Changed test assertions for button IDs and dashboard labels to match updated UI

## Implementation Details
- Favorite checkbox state is persisted via API calls with optimistic UI updates and rollback on failure
- The modal title dynamically updates based on context ("Add Model" vs "Import Detector")
- Media type options are populated from the `mediaTypesMap` registry for consistency
- Keyboard accessibility maintained for the new model picker with Enter/Space key support

https://claude.ai/code/session_01HJjE99WSVoJMLb9iwu87Aw