### PR TITLE
Remove max-width constraint from dashboard view layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -603,8 +603,8 @@ video { max-width: 100%; }
 
 /* ---- Dashboard view ---- */
 .dashboard-view {
-  display: flex; flex-direction: column; width: 100%; max-width: 1100px;
-  margin: 0 auto; padding: 24px 32px; gap: 16px; flex: 1; min-height: 0;
+  display: flex; flex-direction: column; width: 100%;
+  padding: 24px 32px; gap: 16px; flex: 1; min-height: 0;
 }
 .dashboard-header h2 { font-size: 1.4rem; color: var(--accent); margin: 0; }
 .dashboard-grids { display: grid; grid-template-columns: 1fr; gap: 20px; flex: 1; min-height: 0; }


### PR DESCRIPTION
## Summary
Removed the `max-width: 1100px` constraint and `margin: 0 auto` centering from the `.dashboard-view` CSS class to allow the dashboard to utilize the full available width.

## Changes
- Removed `max-width: 1100px` property that was limiting dashboard width
- Removed `margin: 0 auto` property that was centering the dashboard container
- Kept all other layout properties intact (flexbox, padding, gap, flex: 1, min-height: 0)

## Details
This change allows the dashboard view to expand to fill the full width of its container rather than being constrained to a maximum width of 1100px. The dashboard will now be more responsive to larger screen sizes while maintaining its existing flex layout behavior and spacing.

https://claude.ai/code/session_013JM9K3XqYRoeMy9Jm6xwvo