### PR TITLE
Display loaded dataset info in dashboard grid

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -847,7 +847,7 @@
     }
 
     // Populate grids
-    renderDashboardDatasets();
+    await renderDashboardDatasets();
     await renderDashboardModels();
     updateDashboardButtons();
   }
@@ -858,12 +858,36 @@
     if (dashDetectBtn) dashDetectBtn.disabled = !(hasDataset && dashSelectedDetector);
   }
 
-  function renderDashboardDatasets() {
+  async function renderDashboardDatasets() {
     if (!dashDatasetGrid) return;
 
     if (datasetLoaded) {
-      // Dataset is already loaded — status bar shows the info; grid can be minimal
-      dashDatasetGrid.innerHTML = "";
+      // Fetch dataset info and display it in the grid
+      try {
+        const res = await fetch("/api/dashboard/dataset-info");
+        const info = await res.json();
+        const mtInfo = mediaTypesMap[info.media_type];
+        const icon = mtInfo ? mtInfo.icon : "";
+        const typeName = mtInfo ? mtInfo.name : info.media_type || "media";
+        const dupeSuffix = info.num_dupes ? ` (${info.num_dupes} dupes)` : "";
+        dashDatasetGrid.innerHTML = `<table class="dash-dataset-table">
+          <thead><tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Items</th>
+            <th>Origin</th>
+          </tr></thead>
+          <tbody>
+            <tr class="dash-dataset-row dash-selected">
+              <td class="col-name">${escapeHtml(info.name)}</td>
+              <td class="col-type">${escapeHtml(icon)} ${escapeHtml(typeName)}</td>
+              <td class="col-count">${info.num_medias}${escapeHtml(dupeSuffix)}</td>
+              <td class="col-origin">${escapeHtml(info.origin)}</td>
+            </tr>
+          </tbody></table>`;
+      } catch (_) {
+        dashDatasetGrid.innerHTML = "";
+      }
       return;
     }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -627,7 +627,24 @@ video { max-width: 100%; }
 .dashboard-grid-wrap { flex: 1; min-height: 0; overflow-y: auto; }
 .dashboard-grid { min-height: 0; }
 
-/* Dashboard uses demo-table styles for dataset grid; model grid uses its own table */
+/* Dashboard dataset table */
+.dashboard-grid .dash-dataset-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
+.dashboard-grid .dash-dataset-table thead th {
+  text-align: left; padding: 5px 8px; color: var(--text-secondary);
+  font-size: 0.7rem; font-weight: 600; border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.dashboard-grid .dash-dataset-table thead th:nth-child(1) { width: 35%; }
+.dashboard-grid .dash-dataset-table thead th:nth-child(2) { width: 20%; }
+.dashboard-grid .dash-dataset-table thead th:nth-child(3) { width: 15%; }
+.dashboard-grid .dash-dataset-table thead th:nth-child(4) { width: 30%; }
+.dash-dataset-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
+.dash-dataset-row .col-name { font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dash-dataset-row .col-type { white-space: nowrap; }
+.dash-dataset-row .col-count { font-family: monospace; font-size: 0.72rem; color: var(--text-muted); }
+.dash-dataset-row .col-origin { font-size: 0.72rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Dashboard model table */
 .dashboard-grid .dash-model-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
 .dashboard-grid .dash-model-table thead th {
   text-align: left; padding: 5px 8px; color: var(--text-secondary);

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -800,6 +800,7 @@ def dashboard_dataset_info():
     return jsonify({
         "name": name,
         "num_medias": num_medias,
+        "num_dupes": get_dupe_count(),
         "media_type": media_type,
         "origin": origin or "unknown",
         "source": source,


### PR DESCRIPTION
## Summary
Enhanced the dashboard to display detailed information about the currently loaded dataset in a formatted table grid, rather than leaving it empty.

## Key Changes
- Made `renderDashboardDatasets()` async and added a fetch call to `/api/dashboard/dataset-info` endpoint when a dataset is loaded
- Display dataset metadata in a table with columns: Name, Type, Items, and Origin
- Added duplicate count to the dataset info display (e.g., "100 items (5 dupes)")
- Implemented comprehensive styling for the dataset table with proper column widths, typography, and responsive text truncation
- Updated the backend `/api/dashboard/dataset-info` endpoint to include `num_dupes` in the response
- Added proper error handling with fallback to empty grid if the API call fails

## Implementation Details
- The dataset table uses `table-layout: fixed` for predictable column sizing (35%, 20%, 15%, 30%)
- Dataset name and origin columns use text truncation with ellipsis for long values
- Item count is displayed in monospace font for better readability
- All user-provided content is properly escaped using `escapeHtml()` to prevent XSS
- The change maintains backward compatibility by gracefully handling API failures

https://claude.ai/code/session_01A9ePKDZ5kPwTqhw3TVHZxC