### PR TITLE
Fix device placement for model inputs in embedding pipelines

### DIFF
--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -443,6 +443,8 @@ class AudioMediaType(MediaType):
             self._model = ClapModel.from_pretrained(
                 CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
+        # Materialize any tensors left on the ``meta`` device.
+        self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLAP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
@@ -472,6 +474,8 @@ class AudioMediaType(MediaType):
             truncation=True,
         )
         self._on_progress("loading", "Warming up audio pipeline: running model…", 3, 3)
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():
             outputs = self._model.audio_model(**inputs)
             self._model.audio_projection(outputs.pooler_output)
@@ -494,6 +498,8 @@ class AudioMediaType(MediaType):
                 max_length=480000,
                 truncation=True,
             )
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 outputs = self._model.audio_model(**inputs)
                 embedding = self._model.audio_projection(outputs.pooler_output).detach().cpu().numpy()
@@ -511,6 +517,8 @@ class AudioMediaType(MediaType):
             import torch  # noqa: PLC0415
 
             inputs = self._processor(text=[text], return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 outputs = self._model.text_model(**inputs)
                 text_vec = self._model.text_projection(outputs.pooler_output).detach().cpu().numpy()[0]

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -1048,6 +1048,10 @@ class ImageMediaType(MediaType):
             self._model = CLIPModel.from_pretrained(
                 CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
+        # Materialize any tensors left on the ``meta`` device.
+        # ``low_cpu_mem_usage=True`` creates params on ``meta`` first; ignored
+        # checkpoint keys (e.g. position_ids) stay there, causing runtime errors.
+        self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = CLIPProcessor.from_pretrained(
@@ -1079,6 +1083,8 @@ class ImageMediaType(MediaType):
 
             image = image.convert("RGB")
             inputs = self._processor(images=image, return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 outputs = self._model.get_image_features(**inputs)
                 embedding = _extract_tensor(outputs).detach().cpu().numpy()
@@ -1096,6 +1102,8 @@ class ImageMediaType(MediaType):
             import torch  # noqa: PLC0415
 
             inputs = self._processor(text=[text], return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
             return text_vec

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -271,6 +271,8 @@ class VideoMediaType(MediaType):
             self._model = XCLIPModel.from_pretrained(
                 XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
+        # Materialize any tensors left on the ``meta`` device.
+        self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading X-CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
             self._processor = XCLIPProcessor.from_pretrained(
@@ -316,6 +318,8 @@ class VideoMediaType(MediaType):
                 return None
 
             inputs = self._processor(videos=list(frames), return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 outputs = self._model.get_video_features(**inputs)
                 embedding = _extract_tensor(outputs).detach().cpu().numpy()
@@ -333,6 +337,8 @@ class VideoMediaType(MediaType):
             import torch  # noqa: PLC0415
 
             inputs = self._processor(text=[text], return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
             return text_vec


### PR DESCRIPTION
## Summary
This PR fixes device placement issues in the audio, image, and video embedding pipelines by ensuring model inputs are moved to the correct device before inference, and materializing tensors that may be left on the `meta` device after model loading.

## Key Changes
- **Model Loading**: Added `.to("cpu")` calls after loading CLAP, CLIP, and X-CLIP models to materialize any tensors left on the `meta` device when using `low_cpu_mem_usage=True`. This prevents runtime errors from ignored checkpoint keys (e.g., position_ids) that remain on the meta device.

- **Input Device Placement**: Added device detection and input tensor movement in all embedding methods:
  - Audio: `load_models()`, `embed_media()`, and `embed_text()`
  - Image: `embed_pil_image()` and `embed_text()`
  - Video: `embed_media()` and `embed_text()`
  
  Each method now detects the model's device via `next(self._model.parameters()).device` and moves all input tensors to that device before inference.

## Implementation Details
- The device detection pattern `next(self._model.parameters()).device` is used consistently across all three media types to dynamically determine where the model parameters reside.
- Input tensors are moved using a dictionary comprehension: `{k: v.to(device) for k, v in inputs.items()}` to handle all input keys uniformly.
- These changes ensure the code works correctly regardless of whether the model is on CPU, GPU, or other devices, improving robustness and flexibility.

https://claude.ai/code/session_013GD3wC6rWeCBQ4m7rNZ8Tc