### PR TITLE
Add keyboard shortcuts to dialog modals

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -99,18 +99,38 @@
         vtDialogInput.style.display = "none";
       }
 
+      function closeWith(value) {
+        document.removeEventListener("keydown", keyHandler);
+        vtDialogModal.classList.remove("show");
+        resolve(value);
+      }
+
+      function keyHandler(e) {
+        if (!vtDialogModal.classList.contains("show")) return;
+        if (e.key === "Enter") {
+          e.preventDefault();
+          const primaryBtn = buttons.find((b) => b.primary);
+          if (primaryBtn) closeWith(primaryBtn.value === "input" ? vtDialogInput.value : primaryBtn.value);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          const cancelBtn = buttons.find((b) => !b.primary);
+          if (cancelBtn) closeWith(cancelBtn.value === "input" ? vtDialogInput.value : cancelBtn.value);
+          else closeWith(buttons[0].value === "input" ? vtDialogInput.value : buttons[0].value);
+        }
+      }
+
       vtDialogActions.innerHTML = "";
       buttons.forEach((btn) => {
         const el = document.createElement("button");
         el.className = "vt-dialog-btn " + (btn.primary ? "primary" : "secondary");
         el.textContent = btn.label;
         el.addEventListener("click", () => {
-          vtDialogModal.classList.remove("show");
-          resolve(btn.value === "input" ? vtDialogInput.value : btn.value);
+          closeWith(btn.value === "input" ? vtDialogInput.value : btn.value);
         });
         vtDialogActions.appendChild(el);
       });
 
+      document.addEventListener("keydown", keyHandler);
       vtDialogModal.classList.add("show");
       if (showInput) {
         setTimeout(() => vtDialogInput.focus(), 50);
@@ -6596,6 +6616,9 @@
       [detectorExportModal, detectorExportModalClose],
       [processorImporterModal, processorImporterModalClose],
       [autodetectModal, autodetectModalClose],
+      [datasetImporterModal, datasetImporterModalClose],
+      [loadSortModal, loadSortModalClose],
+      [settingsModal, settingsModalClose],
       [progressModal, modalClose],
     ];
     for (const [modal, closeBtn] of modalClosePairs) {


### PR DESCRIPTION
## Summary
Enhanced dialog modals with keyboard navigation support, allowing users to confirm dialogs with Enter and cancel with Escape keys.

## Key Changes
- **Keyboard event handling**: Added `keyHandler` function to listen for Enter and Escape key presses
  - Enter key triggers the primary button action
  - Escape key triggers the cancel button (or first button if no cancel button exists)
  - Properly prevents default browser behavior for these keys
- **Refactored dialog closing logic**: Extracted `closeWith()` helper function to centralize modal cleanup and event listener removal
- **Extended modal coverage**: Added keyboard support to three additional modals:
  - Dataset importer modal
  - Load sort modal
  - Settings modal

## Implementation Details
- Keyboard event listener is attached when the dialog opens and removed when it closes
- The handler checks if the modal is visible before processing key events to avoid interference with other UI elements
- Input field values are properly captured when the dialog uses input mode
- Button click handlers now use the shared `closeWith()` function for consistent behavior

https://claude.ai/code/session_01ThrcJ534xafkCYRdhhvbE1