### PR TITLE
Add dashboard train mode stub functions

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -34,6 +34,7 @@
   let dashDemoDatasets = null;       // cached demo dataset list from API
   let dashPendingAction = null;      // "label" | "detect" — set before loading a dataset
   let currentView = "welcome";       // "welcome" | "dashboard" | "labeling"
+  let _dashboardTrainMode = null;    // {model, dataset} when training via dashboard
   const mediaList = document.getElementById("media-list");
   const center = document.getElementById("center");
   const goodList = document.getElementById("good-list");
@@ -933,6 +934,13 @@
     if (menuDetectorImport) menuDetectorImport.classList.remove("disabled");
     // menuLabelsExport and menuDetectorExport stay disabled until votes are loaded (updateSortModeAvailability)
   }
+
+  // ---- Dashboard train mode stubs ----
+  // The full dashboard-train-mode implementation was removed during the
+  // dashboard rework.  These stubs keep references in castVote and the
+  // back-button handler from throwing ReferenceError.
+  async function _persistTrainableModelLabels() {}
+  async function saveTrainableModelLabels() { _dashboardTrainMode = null; }
 
   // ---- Dashboard view ----
 


### PR DESCRIPTION
## Summary
Added stub implementations for dashboard training mode functions that were removed during a dashboard rework. These stubs prevent ReferenceErrors when the functions are referenced in other parts of the codebase.

## Changes
- Added `_dashboardTrainMode` state variable to track training context (`{model, dataset}`)
- Implemented `_persistTrainableModelLabels()` as an empty async stub
- Implemented `saveTrainableModelLabels()` as an async stub that clears the training mode state
- Added explanatory comment documenting that full dashboard-train-mode implementation was removed

## Details
These stub functions maintain backward compatibility with existing code that references them (specifically in `castVote` and the back-button handler) while the full dashboard training mode implementation is being reworked. The stubs allow the application to continue functioning without throwing ReferenceErrors.

https://claude.ai/code/session_01DWbyZvHsWsP5TDc8pyVmiz