### PR TITLE
Replace native confirm() with custom vtConfirm() dialog

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1250,7 +1250,7 @@
         const deleteBtn = tr.querySelector(".dash-delete-btn");
         deleteBtn.addEventListener("click", async (e) => {
           e.stopPropagation();
-          if (!confirm("Remove this dataset? All votes and labels will be cleared.")) return;
+          if (!(await vtConfirm("Remove this dataset? All votes and labels will be cleared."))) return;
           try {
             await fetch("/api/dataset/clear", { method: "POST" });
             datasetLoaded = false;
@@ -1381,7 +1381,7 @@
         const deleteBtn = tr.querySelector(".dash-delete-btn");
         deleteBtn.addEventListener("click", async (e) => {
           e.stopPropagation();
-          if (!confirm(`Delete model "${det.name}"? This cannot be undone.`)) return;
+          if (!(await vtConfirm(`Delete model "${det.name}"? This cannot be undone.`))) return;
           try {
             const res = await fetch(`/api/favorite-detectors/${encodeURIComponent(det.name)}`, { method: "DELETE" });
             if (res.ok) {


### PR DESCRIPTION
## Summary
Replaced all instances of the native browser `confirm()` dialog with a custom `vtConfirm()` function to provide a more consistent and customizable user experience for confirmation prompts.

## Key Changes
- Updated dataset deletion confirmation to use `await vtConfirm()` instead of `confirm()`
- Updated model deletion confirmation to use `await vtConfirm()` instead of `confirm()`
- Both changes maintain the same confirmation messages and logic flow

## Implementation Details
- The `vtConfirm()` function is awaited, indicating it returns a Promise
- The conditional logic remains unchanged - operations are cancelled if the user does not confirm
- This change allows for custom styling and behavior of confirmation dialogs throughout the application

https://claude.ai/code/session_01Xkxua2xsDspLDvrzPaJ8i5