### PR TITLE
Remove dataset change functionality from UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -288,7 +288,7 @@
   // Burger menu elements
   const burgerBtn = document.getElementById("burger-btn");
   const burgerDropdown = document.getElementById("burger-dropdown");
-  const menuDatasetChange = document.getElementById("menu-dataset-change");
+
   const menuLabelsExport = document.getElementById("menu-labels-export");
   const menuLabelsImport = document.getElementById("menu-labels-import");
   const menuLabelsStatus = document.getElementById("menu-labels-status");
@@ -367,7 +367,7 @@
   const dashLabelBtn = document.getElementById("dash-label-btn");
   const dashDetectBtn = document.getElementById("dash-detect-btn");
   const dashAddDatasetBtn = document.getElementById("dash-add-dataset-btn");
-  const dashChangeDatasetBtn = document.getElementById("dash-change-dataset-btn");
+
   const dashAddModelBtn = document.getElementById("dash-add-model-btn");
   const datasetImporterModal = document.getElementById("dataset-importer-modal");
   const datasetImporterModalClose = document.getElementById("dataset-importer-modal-close");
@@ -1156,10 +1156,8 @@
         ? `${mtInfo.icon} ${status.num_medias} ${mtInfo.name.toLowerCase()} loaded${dupeSuffix}`
         : `${status.num_medias} medias loaded${dupeSuffix}`;
       dashDatasetStatus.style.display = "";
-      dashChangeDatasetBtn.style.display = "";
     } else {
       dashDatasetStatus.style.display = "none";
-      dashChangeDatasetBtn.style.display = "none";
     }
 
     // Populate grids
@@ -1255,7 +1253,6 @@
             await fetch("/api/dataset/clear", { method: "POST" });
             datasetLoaded = false;
             dashDatasetStatus.style.display = "none";
-            dashChangeDatasetBtn.style.display = "none";
             await renderDashboardDatasets();
             updateDashboardButtons();
           } catch (_) {}
@@ -2500,27 +2497,6 @@
     });
   }
 
-  // Dataset change — clears current dataset and returns to dashboard
-  if (menuDatasetChange && burgerDropdown) {
-    menuDatasetChange.addEventListener("click", async () => {
-      if (await vtConfirm("Changing the dataset will erase your current dataset. Continue?")) {
-        fetch("/api/dataset/clear", { method: "POST" })
-          .then(() => {
-            medias = [];
-            votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
-            selected = null;
-            datasetLoaded = false;
-            dashSelectedDataset = null;
-            showDashboard();
-            renderVotes();
-            updateLabelCounts();
-            closeBurgerMenu();
-          });
-      } else {
-        closeBurgerMenu();
-      }
-    });
-  }
 
 
   // Labels export – open modal
@@ -6602,21 +6578,6 @@
       // Poll progress
       dashPendingAction = null;
       startDashProgressPolling();
-    });
-  }
-
-  // Dashboard: Change Dataset button
-  if (dashChangeDatasetBtn) {
-    dashChangeDatasetBtn.addEventListener("click", async () => {
-      if (await vtConfirm("Changing the dataset will erase your current dataset. Continue?")) {
-        await fetch("/api/dataset/clear", { method: "POST" });
-        medias = [];
-        votes = { good: [], bad: [], click_times: {}, learned_scores: {} };
-        selected = null;
-        datasetLoaded = false;
-        dashSelectedDataset = null;
-        showDashboard();
-      }
     });
   }
 

--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,6 @@
     <div class="burger-dropdown" id="burger-dropdown" role="menu" aria-label="Main menu">
       <div class="burger-section" role="group" aria-label="Dataset">
         <div class="burger-section-title" id="menu-section-dataset">Dataset</div>
-        <div class="burger-item" id="menu-dataset-change" role="menuitem" tabindex="-1">Change Dataset</div>
       </div>
       <div class="burger-section" role="group" aria-label="Labels">
         <div class="burger-section-title" id="menu-section-labels">Labels</div>
@@ -131,7 +130,6 @@
             <span class="dashboard-section-title">Datasets</span>
             <div class="dashboard-section-actions">
               <button class="btn-sm" id="dash-add-dataset-btn">+</button>
-              <button class="btn-sm" id="dash-change-dataset-btn" style="display:none">Change</button>
             </div>
           </div>
           <div id="dash-dataset-status" class="dashboard-status-bar" style="display:none"></div>


### PR DESCRIPTION
## Summary
This PR removes the "Change Dataset" feature from the application UI, including both the burger menu option and the dashboard button. The associated event listeners and state management logic have been removed.

## Key Changes
- Removed `menu-dataset-change` menu item from the burger dropdown in HTML
- Removed `dash-change-dataset-btn` button from the dashboard datasets section in HTML
- Removed DOM element references for both removed UI components in JavaScript
- Removed event listener for the burger menu "Change Dataset" option that cleared the dataset and returned to dashboard
- Removed event listener for the dashboard "Change Dataset" button with similar functionality
- Removed display/hide logic for the `dashChangeDatasetBtn` element that was triggered when dataset status changed

## Implementation Details
The removed functionality allowed users to clear their current dataset and return to the dashboard selection screen. This capability is now being removed entirely from the UI, though the underlying `/api/dataset/clear` endpoint remains available in the codebase for other potential uses.

https://claude.ai/code/session_01RRCogWburZqepyTqL6qCPe