### PR TITLE
Refactor dashboard progress bar to display inline within dataset grid

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1180,7 +1180,8 @@
     center.appendChild(dashboardView);
     center.className = "panel-center";
     dashboardView.style.display = "flex";
-    dashProgress.style.display = "none";
+    // Only hide the in-grid progress if no load is actively running
+    if (!dashProgressTimer) hideDashGridProgress();
 
     // Update dataset status bar
     if (datasetLoaded) {
@@ -1495,17 +1496,29 @@
     renderModelRows();
   }
 
-  // Dashboard: load a dataset from the selected demo, then run a callback
-  async function dashLoadSelectedDataset(callback) {
-    if (!dashSelectedDataset) return;
-
+  // Show the in-grid progress bar inside the dataset section, hiding the grid content
+  function showDashGridProgress(message) {
+    dashDatasetGrid.style.display = "none";
     dashProgress.style.display = "block";
     dashProgressFill.style.width = "0%";
     dashProgressFill.classList.add("indeterminate");
     dashProgressText.textContent = "";
-    dashProgressMessage.textContent = "Loading...";
+    dashProgressMessage.textContent = message || "Loading...";
     dashProgressMessage.style.color = "var(--text-secondary)";
     dashProgressEta.textContent = "";
+  }
+
+  // Hide the in-grid progress bar and restore the dataset grid
+  function hideDashGridProgress() {
+    dashProgress.style.display = "none";
+    dashDatasetGrid.style.display = "";
+  }
+
+  // Dashboard: load a dataset from the selected demo, then run a callback
+  async function dashLoadSelectedDataset(callback) {
+    if (!dashSelectedDataset) return;
+
+    showDashGridProgress("Loading...");
 
     try {
       const res = await fetch("/api/dataset/load-demo", {
@@ -1566,11 +1579,12 @@
 
       if (progress.status === "idle") {
         stopDashProgressPolling();
-        dashProgress.style.display = "none";
+        hideDashGridProgress();
 
         // Refresh dataset state
         await checkDatasetStatus();
         if (datasetLoaded) {
+          await renderDashboardDatasets();
           await fetchMedias();
           await fetchVotes();
 
@@ -6406,15 +6420,9 @@
       statusEl.textContent = "Importing\u2026";
       statusEl.style.color = "var(--text-secondary)";
 
-      // Close modal and show dashboard progress
+      // Close modal and show in-grid progress
       datasetImporterModal.classList.remove("show");
-      dashProgress.style.display = "block";
-      dashProgressFill.style.width = "0%";
-      dashProgressFill.classList.add("indeterminate");
-      dashProgressText.textContent = "";
-      dashProgressMessage.textContent = "Importing\u2026";
-      dashProgressMessage.style.color = "var(--text-secondary)";
-      dashProgressEta.textContent = "";
+      showDashGridProgress("Importing\u2026");
 
       try {
         const res = await fetch(`/api/dataset/import/${importer.name}`, { method: "POST", headers, body });
@@ -6619,13 +6627,7 @@
       const file = dashFileInput.files[0];
       if (!file) return;
 
-      dashProgress.style.display = "block";
-      dashProgressFill.style.width = "0%";
-      dashProgressFill.classList.add("indeterminate");
-      dashProgressText.textContent = "";
-      dashProgressMessage.textContent = "Uploading...";
-      dashProgressMessage.style.color = "var(--text-secondary)";
-      dashProgressEta.textContent = "";
+      showDashGridProgress("Uploading...");
 
       const formData = new FormData();
       formData.append("file", file);

--- a/static/index.html
+++ b/static/index.html
@@ -137,6 +137,15 @@
           <div id="dash-dataset-status" class="dashboard-status-bar" style="display:none"></div>
           <div class="dashboard-grid-wrap">
             <div id="dash-dataset-grid" class="dashboard-grid"></div>
+            <!-- In-grid progress bar for dataset loading -->
+            <div class="dataset-progress dash-grid-progress" id="dash-progress" style="display:none" role="status" aria-live="polite">
+              <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-fill indeterminate" id="dash-progress-fill" style="width:0%"></div>
+                <div class="progress-text" id="dash-progress-text" aria-hidden="true">0%</div>
+              </div>
+              <div class="progress-message" id="dash-progress-message">Loading...</div>
+              <div class="progress-eta" id="dash-progress-eta"></div>
+            </div>
           </div>
         </div>
         <!-- Model grid -->
@@ -155,15 +164,6 @@
       <div class="dashboard-actions">
         <button class="dashboard-action-btn" id="dash-label-btn" disabled>Label</button>
         <button class="dashboard-action-btn secondary" id="dash-detect-btn" disabled>Detect</button>
-      </div>
-      <!-- Reuse the progress bar for dataset loading within the dashboard -->
-      <div class="dataset-progress" id="dash-progress" style="display:none" role="status" aria-live="polite">
-        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-          <div class="progress-fill indeterminate" id="dash-progress-fill" style="width:0%"></div>
-          <div class="progress-text" id="dash-progress-text" aria-hidden="true">0%</div>
-        </div>
-        <div class="progress-message" id="dash-progress-message">Loading...</div>
-        <div class="progress-eta" id="dash-progress-eta"></div>
       </div>
       <input type="file" id="dash-file-input" accept=".pkl" style="display:none">
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -627,6 +627,11 @@ video { max-width: 100%; }
 .dashboard-grid-wrap { flex: 1; min-height: 0; overflow-y: auto; }
 .dashboard-grid { min-height: 0; }
 
+/* In-grid progress bar for dataset loading */
+.dash-grid-progress { max-width: none; padding: 16px 14px; }
+.dash-grid-progress .progress-message { max-width: none; text-align: left; }
+.dash-grid-progress .progress-eta { text-align: left; }
+
 /* Dashboard dataset table */
 .dashboard-grid .dash-dataset-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
 .dashboard-grid .dash-dataset-table thead th {


### PR DESCRIPTION
## Summary
This PR refactors the dashboard progress bar to display inline within the dataset grid section rather than as a separate overlay element. This improves the visual hierarchy and user experience by keeping the progress indicator contextually relevant to the dataset loading operations.

## Key Changes
- **Extracted progress bar display logic** into reusable `showDashGridProgress()` and `hideDashGridProgress()` functions to eliminate code duplication across dataset loading, importing, and file upload operations
- **Relocated progress bar HTML** from outside the dashboard grid to inside the `dashboard-grid-wrap` container, allowing it to replace the grid content during loading states
- **Added conditional progress bar hiding** in the dashboard view initialization to only hide the progress bar if no active load operation is running (checked via `dashProgressTimer`)
- **Added `renderDashboardDatasets()` call** after dataset status check to ensure the dataset grid is properly refreshed after loading completes
- **Updated styling** with new `.dash-grid-progress` class to adjust padding and text alignment for the inline context
- **Standardized progress bar initialization** across all three loading scenarios (demo dataset loading, dataset importing, and file uploading) using the new helper functions

## Implementation Details
- The progress bar now toggles visibility of `dashDatasetGrid` and `dashProgress` to create an inline replacement effect
- Custom messages are passed to `showDashGridProgress()` for different operations ("Loading...", "Importing...", "Uploading...")
- The refactoring maintains all existing functionality while reducing code duplication by ~30 lines

https://claude.ai/code/session_01Jd9byJTPe4g6GRkmsBsYLd