### PR TITLE
Add document media type and converters, remove local IO plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-Media explorer web app for browsing/voting on audio, images, text, or video. Semantic sorting (LAION-CLAP, CLIP, X-CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + vanilla JS + PyTorch.
+Media explorer web app for browsing/voting on audio, images, text, video, or documents. Semantic sorting (LAION-CLAP, CLIP, X-CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + vanilla JS + PyTorch.
 
 ## Commands
 - **Run tests (CPU, fast)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -v`
@@ -10,7 +10,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
 - **Run all tests (CPU + GPU)**: `python -m pytest tests/ -v -m ''`
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
-- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter local_json_file --filepath results.json`
+- **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter server_json_file --filepath results.json`
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings <settings.json>`
 - **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
 - **Lint**: `ruff check .`
@@ -21,18 +21,19 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
 - `vtsearch/config.py` — Constants (SAMPLE_RATE, NUM_MEDIAS, paths, model IDs)
 - `vtsearch/medias.py` — Test media generation and embedding cache management
 - `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detectors from settings, run inference, export results)
-- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors); auto-saves to `data/settings.json`
-- `vtsearch/routes/` — Flask blueprints: `main.py`, `medias.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`
+- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, autopilot_top_greens, autopilot_hard_reds); auto-saves to `data/settings.json`
+- `vtsearch/routes/` — Flask blueprints: `main.py`, `medias.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`, `trainable_models.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking, diversity tree
-- `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/rss_feed/youtube_playlist/combine_datasets); auto-discovered via `IMPORTER` sentinel
+- `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/combine_datasets); auto-discovered via `IMPORTER` sentinel
 - `vtsearch/eval/` — Evaluation framework: runner, metrics, visualisation, voting iterations
-- `vtsearch/exporters/` — Results exporters (local_json_file/server_json_file/local_csv_file/server_csv_file/email_smtp/webhook/gui); auto-discovered via `EXPORTER` sentinel
-- `vtsearch/labels/importers/` — Label importers (local_json_file/server_json_file/local_csv_file/server_csv_file); auto-discovered via `LABEL_IMPORTER` sentinel
-- `vtsearch/processors/importers/` — Processor importers (detector_file/server_detector_file/label_file/csv_label_file); auto-discovered via `PROCESSOR_IMPORTER` sentinel
-- `vtsearch/media/` — Media type plugins: audio, image, text, video
+- `vtsearch/exporters/` — Results exporters (server_json_file/server_csv_file/email_smtp/webhook/gui); auto-discovered via `EXPORTER` sentinel
+- `vtsearch/labels/importers/` — Label importers (server_json_file/server_csv_file); auto-discovered via `LABEL_IMPORTER` sentinel
+- `vtsearch/processors/importers/` — Processor importers (server_detector_file); auto-discovered via `PROCESSOR_IMPORTER` sentinel
+- `vtsearch/media/` — Media type plugins: audio, image, text, video, document
+- `vtsearch/converters/` — Media converters: document→image, document→text, video→audio, video→image
 - `vtsearch/utils/` — Global state (`medias` dict, votes), progress utilities
 - `static/` — Frontend (index.html, app.js, styles.css) and assets (favicons, logo.svg, logo.png)
-- `docs/` — Extended docs (ARCHITECTURE.md, CLI.md, DEPLOYMENT.md, EVAL.md, EXTENDING.md, FEATURE_IDEAS.md, HANDOFF.md, ML.md, SETUP.md, demos.md)
+- `docs/` — Extended docs (ARCHITECTURE.md, CLI.md, DEPLOYMENT.md, EVAL.md, EXTENDING.md, FEATURE_IDEAS.md, HANDOFF.md, ML.md, SETUP.md, demos.md, old_io.md)
 - `tests/` — Test suite split by module:
   - `conftest.py` — Shared fixtures: `reset_state` (autouse, clears all mutable global state), `isolated_settings` (autouse, redirects settings to tmp_path), `client` (Flask test client)
   - `test_audio.py` — WAV generation
@@ -40,7 +41,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_votes.py` — Voting and vote retrieval
   - `test_sorting.py` — Text sort, learned sort, example sort, train_and_score
   - `test_labels.py` — Label export/import (via /api/labels/export and /api/labels/import)
-  - `test_label_importers.py` — Label importer base class, registry, local/server json_file/csv_file importers, API routes
+  - `test_label_importers.py` — Label importer base class, registry, server json_file/csv_file importers, API routes
   - `test_inclusion.py` — Inclusion GET/POST
   - `test_detectors.py` — Detector export, detector sort, autorun detectors, auto-detect
   - `test_clippers.py` — MediaClipper ABC tests and concrete clipper implementations
@@ -48,11 +49,12 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
   - `test_dataset_split.py` — Train/test dataset splitting
   - `test_csv_webhook_exporters.py` — CSV and Webhook exporter metadata, CLI args, export logic
+  - `test_dashboard.py` — Dashboard API endpoint tests
   - `test_exporters.py` — Results exporter base classes, registry, built-in exporters, API routes
   - `test_importers.py` — Importer base class, HTTP archive/folder importer metadata, archive extraction
   - `test_extractors.py` — Image class extractor
   - `test_processors.py` — Media processor tests
-  - `test_processor_importers.py` — Processor importer base class, registry, detector_file/label_file importers, API routes
+  - `test_processor_importers.py` — Processor importer base class, registry, server_detector_file importer, API routes
   - `test_origin_labelset.py` — Origin class, LabeledElement, LabelSet, build_origin(), label export/import with origins, integration
   - `test_combine_datasets.py` — Combine-datasets importer: metadata, dedup, media type validation, CLI, API routes
   - `test_creation_info.py` — Legacy creation_info handling in pickle datasets
@@ -62,13 +64,14 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_eval_visualize.py` — Evaluation visualisation chart generation
   - `test_eval_voting_iterations.py` — Voting iterations evaluation
   - `test_safe_thresholds.py` — Safe threshold blending
-  - `test_settings.py` — Settings persistence (volume, inclusion, theme, swipe_animation, show_thumbnails_left, show_thumbnails_right, autorun processors)
+  - `test_settings.py` — Settings persistence (volume, inclusion, theme, swipe_animation, show_thumbnails_left, show_thumbnails_right, autopilot_top_greens, autopilot_hard_reds, autorun processors)
   - `test_thin_loading.py` — Thin (lazy) dataset loading mode for CLI
   - `test_chunked_loading.py` — Chunked (piecewise) dataset loading: folder/pickle chunked loaders, importer run_chunked interface, merge helper
   - `test_integration.py` — End-to-end user workflow simulations: chained API calls, state interactions, response format consistency
   - `test_label_sorting.py` — Label sorting features: click-time tracking, learned-sort score storage, enriched /api/votes response
   - `test_diversity_tree.py` — DiversityTree: hierarchical k-means clustering, seen tracking, diversity level, next sample
   - `test_diversity_tree_integration.py` — DiversityTree integration with Flask app: build, rebuild, voting, diversity-level endpoint
+  - `test_document_and_converters.py` — Document media type and media converters (document→image, document→text, video→audio, video→image)
   - `test_tqdm_progress.py` — tqdm-based progress bar tracking
   - `test_ag_news_download.py` — AG News dataset download and load_demo_source integration
   - `test_bbc_news_download.py` — BBC News dataset download and load_demo_source integration
@@ -82,6 +85,7 @@ Media explorer web app for browsing/voting on audio, images, text, or video. Sem
   - `test_preload_progress.py` — Console progress output during embedding model preloading
   - `test_slow_integration.py` — Slow integration tests: chunked loading, detector scoring, export, label round-trips, settings persistence (marked slow)
   - `test_thread_safety.py` — Thread-safe global state operations: _state_lock verification, concurrent vote/click-time/label history access
+  - `test_trainable_models.py` — Trainable models CRUD API: create, list, get, delete, rename, save labels, examples
   - `test_ucsf_documents_download.py` — UCSF Industry Documents demo dataset download and load_demo_source integration
   - `test_gpu.py` — GPU tests: training, cross-calibration, detectors, embedding models (CLAP/CLIP/X-CLIP/E5), CPU↔GPU equivalence, memory cleanup (skipped without CUDA)
 
@@ -129,9 +133,9 @@ All mutable global state is reset automatically before each test via two autouse
 - If a test needs to read the settings file path (e.g. to verify persistence), use `isolated_settings` as a parameter: `def test_foo(self, isolated_settings): ...`
 
 ## Key Details
-- Global state lives in `vtsearch/utils/state.py`: `medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `last_learned_scores`, `inclusion`, `textsort_suggestions`, `autorun_detectors`, `autorun_extractors`, `autorun_localizers` are module-level dicts/lists
+- Global state lives in `vtsearch/utils/state.py`: `medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `last_learned_scores`, `inclusion`, `textsort_suggestions`, `autorun_detectors`, `autorun_extractors`, `autorun_localizers`, `_dataset_display_name`, `_diversity_tree` are module-level dicts/lists; all protected by `_state_lock` (RLock)
 - Votes are `dict[int, None]` (not sets) — use `votes[id] = None` syntax
-- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors
+- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, autopilot_top_greens, autopilot_hard_reds
 - Each media item has `origin` (dict or None) and `origin_name` (str) for per-element provenance tracking
 - `Origin` class in `vtsearch/datasets/origin.py`; `LabelSet`/`LabeledElement` in `vtsearch/datasets/labelset.py`
 - Label export (`/api/labels/export`) returns a `LabelSet` with per-element origin info (superset of legacy format)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-A media explorer web app. Browse collections of audio clips, images, text paragraphs, or videos — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, CLIP, X-CLIP, or E5-base-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python) and vanilla JavaScript.
+A media explorer web app. Browse collections of audio clips, images, text paragraphs, videos, or documents — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, CLIP, X-CLIP, or E5-base-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python) and vanilla JavaScript.
 
 ## Setup
 
@@ -65,7 +65,8 @@ This runs fast CPU tests only. Additional test modes:
 │   ├── settings.py                 # Persistent settings & autorun processors
 │   ├── routes/                     # Flask blueprints
 │   ├── models/                     # ML models (embeddings, training, progress)
-│   ├── media/                      # Media type plugins (audio, image, text, video)
+│   ├── media/                      # Media type plugins (audio, image, text, video, document)
+│   ├── converters/                 # Media converters (document→image, video→audio, etc.)
 │   ├── datasets/                   # Dataset loading, downloading, importers
 │   ├── eval/                       # Evaluation framework (metrics, runner, visualisation)
 │   ├── exporters/                  # Results exporter plugins
@@ -85,7 +86,8 @@ This runs fast CPU tests only. Additional test modes:
 │   ├── ML.md                       # ML model details
 │   ├── SETUP.md                    # Setup instructions
 │   ├── FEATURE_IDEAS.md            # Brainstorm of potential features
-│   └── demos.md                    # Demo dataset listing
+│   ├── demos.md                    # Demo dataset listing
+│   └── old_io.md                   # Retired IO module reference implementations
 └── requirements*.txt               # Dependency files (cpu, gpu, dev, importers, exporters)
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,8 +21,8 @@ which pieces you need and how to pull them out.
 ## What VTSearch does
 
 VTSearch is a media-explorer web app for browsing, voting on, and
-semantically sorting collections of audio, images, text, or video.  It
-combines:
+semantically sorting collections of audio, images, text, video, or
+documents.  It combines:
 
 - **Semantic sorting** — LAION-CLAP (audio), CLIP (images), X-CLIP
   (video), E5-base-v2 (text) for embedding-based similarity search.
@@ -52,7 +52,15 @@ VTSearch/
 │   │   ├── audio/media_type.py     CLAP embeddings
 │   │   ├── image/media_type.py     CLIP embeddings
 │   │   ├── text/media_type.py      E5 embeddings
-│   │   └── video/media_type.py     X-CLIP embeddings
+│   │   ├── video/media_type.py     X-CLIP embeddings
+│   │   └── document/media_type.py  Document handling (no embedder; convert first)
+│   │
+│   ├── converters/                 Media type converters
+│   │   ├── base.py                 MediaConverter ABC
+│   │   ├── document2image.py       Render document pages as images
+│   │   ├── document2text.py        Extract text from documents
+│   │   ├── video2audio.py          Extract audio track from video
+│   │   └── video2image.py          Sample frames from video as images
 │   │
 │   ├── models/                     ML model wrappers
 │   │   ├── training.py             MLP training, GMM thresholds (pure PyTorch)
@@ -74,15 +82,11 @@ VTSearch/
 │   │       ├── folder/             Local directory importer
 │   │       ├── pickle/             .pkl file importer
 │   │       ├── http_zip/           HTTP archive importer
-│   │       ├── rss_feed/           RSS/Podcast feed importer
-│   │       ├── youtube_playlist/   YouTube yt-dlp importer
 │   │       └── combine_datasets/   Merge multiple pickle datasets
 │   │
 │   ├── exporters/                  Plugin system for output destinations
 │   │   ├── base.py                 LabelsetExporter ABC + ExporterField
-│   │   ├── local_json_file/        JSON file download (local)
 │   │   ├── server_json_file/       JSON file on server
-│   │   ├── local_csv_file/         CSV file download (local)
 │   │   ├── server_csv_file/        CSV file on server
 │   │   ├── email_smtp/             SMTP email sender
 │   │   ├── webhook/                HTTP POST webhook
@@ -90,17 +94,12 @@ VTSearch/
 │   │
 │   ├── labels/importers/           Plugin system for label sources
 │   │   ├── base.py                 LabelImporter ABC + LabelImporterField
-│   │   ├── local_json_file/        Upload JSON label file (local)
 │   │   ├── server_json_file/       JSON label file on server
-│   │   ├── local_csv_file/         Upload CSV label file (local)
 │   │   └── server_csv_file/        CSV label file on server
 │   │
 │   ├── processors/importers/       Plugin system for processor sources
 │   │   ├── base.py                 ProcessorImporter ABC + ProcessorImporterField
-│   │   ├── detector_file/          Import detector from uploaded JSON file
-│   │   ├── server_detector_file/   Import detector from server JSON file
-│   │   ├── label_file/             Train detector from a labeled media file
-│   │   └── csv_label_file/         Train detector from a CSV label file
+│   │   └── server_detector_file/   Import detector from server JSON file
 │   │
 │   ├── eval/                       Evaluation framework
 │   │   ├── __main__.py             CLI entry point (python -m vtsearch.eval)
@@ -111,15 +110,16 @@ VTSearch/
 │   │   └── voting_iterations.py    Voting-iteration simulation
 │   │
 │   ├── routes/                     Flask blueprints (HTTP layer)
+│   │   ├── main.py                 Root route, favicon, logo
 │   │   ├── medias.py               Media listing, serving, voting
-│   │   ├── sorting.py              Text/learned/example sort
-│   │   ├── detectors.py            Detector export/import/run
-│   │   ├── datasets.py             Dataset loading & management
+│   │   ├── sorting.py              Text/learned/example sort, labels, diversity
+│   │   ├── detectors.py            Detector/extractor/localizer management, autodetect
+│   │   ├── datasets.py             Dataset loading, demos, dashboard
 │   │   ├── exporters.py            Exporter registry & execution
 │   │   ├── label_importers.py      Label importer registry & execution
 │   │   ├── processor_importers.py  Processor importer registry & execution
 │   │   ├── settings.py             Settings persistence (volume, theme, etc.)
-│   │   └── main.py                 Root route
+│   │   └── trainable_models.py     Persistent trainable model definitions (CRUD)
 │   │
 │   ├── utils/
 │   │   ├── state.py                Global state (medias, votes, autorun config, history)
@@ -156,10 +156,11 @@ modules on the right.
 ┌──────────────┐ ┌────────────┐ ┌───────────────────┐
 │ media/*      │ │ models/    │ │ datasets/          │
 │              │ │            │ │                     │
-│ audio  ─┐   │ │ training   │ │ loader ──► media/*  │
-│ image  ─┤   │ │ progress   │ │ downloader          │
-│ text   ─┤   │ │ embeddings │ │ importers/*         │
-│ video  ─┘   │ │ loader     │ │                     │
+│ audio    ─┐ │ │ training   │ │ loader ──► media/*  │
+│ image    ─┤ │ │ progress   │ │ downloader          │
+│ text     ─┤ │ │ embeddings │ │ importers/*         │
+│ video    ─┤ │ │ loader     │ │                     │
+│ document ─┘ │ │            │ │                     │
 │   │         │ │   │        │ │                     │
 │   ▼         │ │   ▼        │ └───────────────────┘
 │ config.py   │ │ media/*    │
@@ -171,12 +172,11 @@ modules on the right.
 │ exporters/*              │  │ labels/importers/*      │  │ processors/importers/*   │
 │                          │  │                          │  │                          │
 │ base.py (ABC)            │  │ base.py (ABC)           │  │ base.py (ABC)            │
-│ local_json, server_json  │  │ local_json, server_json │  │ detector_file, label_file│
-│ local_csv, server_csv    │  │ local_csv, server_csv   │  │ server_detector_file     │
-│ email_smtp, webhook, gui │  │                          │  │ csv_label_file           │
-│                          │  │ (NO Flask, NO state,     │  │                          │
-│ (NO Flask, NO state,     │  │  pure data processing)   │  │ (NO Flask, NO state,     │
-│  pure data in/out)       │  │                          │  │  pure data processing)   │
+│ server_json, server_csv  │  │ server_json, server_csv │  │ server_detector_file     │
+│ email_smtp, webhook, gui │  │                          │  │                          │
+│                          │  │ (NO Flask, NO state,     │  │ (NO Flask, NO state,     │
+│ (NO Flask, NO state,     │  │  pure data processing)   │  │  pure data processing)   │
+│  pure data in/out)       │  │                          │  │                          │
 └──────────────────────────┘  └────────────────────────┘  └──────────────────────────┘
 ```
 
@@ -211,7 +211,8 @@ modules on the right.
 | `eval/*` | No | No | **Yes** — needs media + datasets |
 | `settings.py` | No | No | **Yes** — JSON file I/O |
 | `media/base.py` | No | No | **Yes** — abstract only |
-| `media/audio,image,text,video` | No | No | **Yes** — torch + HF models |
+| `media/audio,image,text,video,document` | No | No | **Yes** — torch + HF models |
+| `converters/*` | No | No | **Yes** — pure media conversion |
 | `utils/progress.py` | No | No | **Yes** — threading only |
 | `utils/state.py` | No | N/A (IS the state) | **Yes** — plain Python dicts |
 | `config.py` | No | No | **Yes** — just constants |
@@ -338,7 +339,7 @@ class, and expose the sentinel.  See `EXTENDING.md` (in this directory) for full
 ## State management
 
 Application state lives in `vtsearch/utils/state.py` as module-level
-dicts:
+dicts, all protected by `_state_lock` (a `threading.RLock`):
 
 | Variable | Type | Purpose |
 |----------|------|---------|
@@ -350,17 +351,24 @@ dicts:
 | `last_learned_scores` | `dict[int, float]` | Media ID → score from the most recent learned sort |
 | `inclusion` | `int \| None` | FPR/FNR trade-off parameter; lazy-loaded from settings |
 | `textsort_suggestions` | `list[str]` | Text queries that received a Good vote (MRU order) |
-| `autorun_detectors` | `dict` | Saved detector configurations |
+| `autorun_detectors` | `dict` | Saved detector configurations (with `autodetect` flag, `examples`, `num_labels`) |
 | `autorun_extractors` | `dict` | Saved extractor configurations |
 | `autorun_localizers` | `dict` | Saved localizer configurations |
+| `_diversity_tree` | `DiversityTree \| None` | Hierarchical k-means tree for diverse sampling |
+| `_dataset_display_name` | `str \| None` | Custom display name for the loaded dataset |
 
 Persistent settings (volume, theme, inclusion, `enrich_descriptions`,
 `safe_thresholds`, `calibrate_count`, `calibration_fraction`,
 `swipe_animation`, `show_thumbnails_left`, `show_thumbnails_right`,
+`autopilot_top_greens`, `autopilot_hard_reds`,
 autorun processor recipes) live
 separately in `vtsearch/settings.py` and are auto-saved to
 `data/settings.json`.
 Theme supports three modes: `dark`, `light`, and `highviz` (high-contrast).
+
+Trainable models are persisted as JSON files in `data/trainable_models/`
+via the `trainable_models_bp` route blueprint.  Each stores a name,
+text query, media type, examples list, and labelset.
 
 **Only Flask routes mutate this state.**  All ML and dataset functions
 accept state as parameters — they never import it directly.  This means

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -6,7 +6,7 @@ VTSearch provides a CLI workflow for running detectors on datasets and exporting
 
 Score every item in a dataset with your autorun processors (detectors) and output the items predicted as "Good."
 
-Detectors are specified via a **settings file** (`--settings`) that lists autorun processors. Each processor is a recipe referencing a processor importer (e.g. `detector_file` for a pre-trained detector JSON, or `label_file` to train a detector from labeled media). See below for how to create one.
+Detectors are specified via a **settings file** (`--settings`) that lists autorun processors. Each processor is a recipe referencing a processor importer (e.g. `server_detector_file` for a pre-trained detector JSON on disk). See below for how to create one.
 
 **From a pickle file:**
 
@@ -14,26 +14,31 @@ Detectors are specified via a **settings file** (`--settings`) that lists autoru
 python app.py --autodetect --dataset path/to/dataset.pkl --settings settings.json
 ```
 
-**From any supported data source** (folder, HTTP archive, RSS feed, YouTube playlist):
+**From any supported data source** (folder, HTTP archive):
 
 ```bash
 python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings settings.json
 python app.py --autodetect --importer http_zip --url https://example.com/data.zip --settings settings.json
-python app.py --autodetect --importer rss_feed --url https://example.com/feed.xml --settings settings.json
-python app.py --autodetect --importer youtube_playlist --url https://youtube.com/playlist?list=... --settings settings.json
 ```
 
-Available importers: `folder`, `pickle`, `http_zip`, `rss_feed`, `youtube_playlist`, `combine_datasets`. Each importer adds its own flags — run `python app.py --autodetect --importer <name> --help` to see them (e.g. `--max-episodes` for RSS, `--max-videos` for YouTube).
+Available importers: `folder`, `pickle`, `http_zip`, `combine_datasets`. Each importer adds its own flags — run `python app.py --autodetect --importer <name> --help` to see them.
+
+**Chunked loading** — for large datasets, use `--chunk-size N` to process in batches to limit memory:
+
+```bash
+python app.py --autodetect --dataset data.pkl --settings settings.json --chunk-size 1000
+python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings settings.json --chunk-size 500
+```
 
 **Exporting results** — by default results are printed to the console. Add `--exporter <name>` to send them elsewhere:
 
 ```bash
-python app.py --autodetect --dataset data.pkl --settings settings.json --exporter local_json_file --filepath results.json
-python app.py --autodetect --dataset data.pkl --settings settings.json --exporter local_csv_file --filepath results.csv
+python app.py --autodetect --dataset data.pkl --settings settings.json --exporter server_json_file --filepath results.json
+python app.py --autodetect --dataset data.pkl --settings settings.json --exporter server_csv_file --filepath results.csv
 python app.py --autodetect --dataset data.pkl --settings settings.json --exporter webhook --url https://example.com/hook
 ```
 
-Available exporters: `local_json_file` (JSON to local file), `server_json_file` (JSON to server), `local_csv_file` (CSV to local file), `server_csv_file` (CSV to server), `webhook` (HTTP POST), `email_smtp`, `gui` (default — print to console).
+Available exporters: `server_json_file` (JSON to server path), `server_csv_file` (CSV to server path), `webhook` (HTTP POST), `email_smtp`, `gui` (default — print to console).
 
 **How to get the files:**
 
@@ -45,22 +50,8 @@ Available exporters: `local_json_file` (JSON to local file), `server_json_file` 
   "autorun_processors": [
     {
       "processor_name": "my detector",
-      "processor_importer": "detector_file",
-      "field_values": { "file": "path/to/detector.json" }
-    }
-  ]
-}
-```
-
-To use a labelset (labeled media) as a detector, use the `label_file` processor importer — VTSearch will load the referenced media clips, compute their embeddings, train a model, and use that as a detector:
-
-```json
-{
-  "autorun_processors": [
-    {
-      "processor_name": "trained from labels",
-      "processor_importer": "label_file",
-      "field_values": { "file": "path/to/labels.json" }
+      "processor_importer": "server_detector_file",
+      "field_values": { "filepath": "/path/to/detector.json" }
     }
   ]
 }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -81,10 +81,8 @@ These features require network access only when explicitly used:
 
 | Feature | Network target | Fallback |
 |---------|---------------|----------|
-| YouTube playlist importer | YouTube (via yt-dlp) | Use folder/pickle importer |
-| RSS feed importer | RSS/Atom feed server | Use folder/pickle importer |
 | HTTP archive importer | User-provided URL | Use folder/pickle importer |
-| Webhook exporter | User-provided endpoint | Use file/CSV exporter |
+| Webhook exporter | User-provided endpoint | Use server file exporter |
 
 ### pip install during build
 
@@ -162,10 +160,10 @@ docker run -p 5000:5000 \
 |-----------|--------|---------|
 | Models not cached | **Cannot load any dataset** | Error during model initialization |
 | Demo datasets | Cannot use demo datasets | Download error in web UI |
-| YouTube/RSS/HTTP importers | Those importers fail | Network error in importer |
+| HTTP archive importer | That importer fails | Network error in importer |
 | Webhook exporter | That exporter fails | Connection error on export |
 
-Everything else (folder/pickle import, file/CSV export, ML training,
+Everything else (folder/pickle import, server file export, ML training,
 evaluation, sorting, voting) works fully offline.
 
 ---
@@ -183,11 +181,13 @@ data/
 │   ├── models--microsoft--xclip-base-patch32/
 │   └── models--sentence-transformers--e5-base-v2/
 ├── embeddings/                       # Cached dataset embeddings (.pkl files)
+├── trainable_models/                 # Persistent trainable model definitions (.json)
 ├── settings.json                     # User preferences, autorun config, thresholds
 ├── audio/                            # Audio media files
 ├── video/                            # Video media files
 ├── images/                           # Image media files
-└── paragraphs/                       # Text media files
+├── paragraphs/                       # Text media files
+└── documents/                        # Document media files (PDF, DOC, PPT)
 ```
 
 ### What to preserve vs. what's safe to delete
@@ -197,7 +197,8 @@ data/
 | `data/models/` | **Yes** | Re-downloading is slow (~3.1 GB) |
 | `data/embeddings/` | **Yes** | Contains cached embeddings; losing them means recomputing |
 | `data/settings.json` | **Yes** | User preferences, trained detectors, autorun processors |
-| `data/audio/`, `video/`, `images/`, `paragraphs/` | Depends | Media files from imported datasets; re-import if lost |
+| `data/trainable_models/` | **Yes** | Persistent trainable model definitions with labelsets |
+| `data/audio/`, `video/`, `images/`, `paragraphs/`, `documents/` | Depends | Media files from imported datasets; re-import if lost |
 | Demo dataset archives (`.zip`, `.tar.gz`) | Safe to delete | Can be re-downloaded |
 | Extracted demo folders (`ESC-50-master/`, etc.) | Safe to delete | Can be re-extracted from archives |
 
@@ -218,6 +219,8 @@ and auto-saved on every change. Schema:
   "swipe_animation": true,
   "show_thumbnails_left": false,
   "show_thumbnails_right": true,
+  "autopilot_top_greens": 3,
+  "autopilot_hard_reds": 4,
   "autoload_media_types": [],
   "autorun_processors": []
 }
@@ -320,9 +323,9 @@ requirements.txt              ← Generic (includes all)
 Each plugin has its own `requirements.txt` in its subdirectory:
 
 ```
-vtsearch/media/{audio,image,text,video}/requirements.txt
-vtsearch/datasets/importers/{folder,pickle,http_zip,rss_feed,youtube_playlist,combine_datasets}/requirements.txt
-vtsearch/exporters/{file,csv_file,gui,email_smtp,webhook}/requirements.txt
+vtsearch/media/{audio,image,text,video,document}/requirements.txt
+vtsearch/datasets/importers/{folder,pickle,http_zip,combine_datasets}/requirements.txt
+vtsearch/exporters/{server_json_file,server_csv_file,gui,email_smtp,webhook}/requirements.txt
 ```
 
 ### Key dependencies
@@ -338,8 +341,7 @@ vtsearch/exporters/{file,csv_file,gui,email_smtp,webhook}/requirements.txt
 | `ultralytics` | latest | YOLO-based image processing |
 | `laion_clap` | latest | Audio embedding preprocessing |
 | `librosa` | latest | Audio file loading and processing |
-| `feedparser` | latest | RSS feed importer |
-| `yt-dlp` | latest | YouTube playlist importer |
+| `PyMuPDF` | latest | Document (PDF/DOC/PPT) rendering and text extraction |
 
 ---
 
@@ -395,5 +397,5 @@ pip install -r requirements-cpu.txt    # or requirements-gpu.txt
 pip install -r requirements-exporters.txt
 ```
 
-For specific importers (RSS, YouTube), install their individual
+For specific importers or media types, install their individual
 `requirements.txt` as well.

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -835,12 +835,11 @@ requirements.txt              # Core deps + includes per-media + per-importer + 
 ├── vtsearch/media/video/requirements.txt
 ├── vtsearch/media/image/requirements.txt
 ├── vtsearch/media/text/requirements.txt
+├── vtsearch/media/document/requirements.txt
 ├── requirements-importers.txt          # Aggregates all data importer deps
 │   ├── vtsearch/datasets/importers/pickle/requirements.txt
 │   ├── vtsearch/datasets/importers/folder/requirements.txt
 │   ├── vtsearch/datasets/importers/http_zip/requirements.txt
-│   ├── vtsearch/datasets/importers/rss_feed/requirements.txt
-│   ├── vtsearch/datasets/importers/youtube_playlist/requirements.txt
 │   └── vtsearch/datasets/importers/combine_datasets/requirements.txt
 ├── requirements-exporters.txt          # Aggregates all exporter deps
 │   ├── vtsearch/exporters/gui/requirements.txt

--- a/docs/FEATURE_IDEAS.md
+++ b/docs/FEATURE_IDEAS.md
@@ -2,6 +2,12 @@
 
 Brainstorm of potential features organized by category.
 
+**Note:** Some ideas below have been implemented since this list was written.
+Implemented features include: diversity-aware sampling (#8, via DiversityTree),
+document/PDF media type (#76, via the `document` media type and converters),
+high-contrast theme (#124, via "highviz" theme), and face detection (#87 partial,
+via FaceLocalizer).
+
 ---
 
 ## Sorting & Ranking

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -23,7 +23,8 @@ to know first.
 ## What is VTSearch?
 
 VTSearch is a media explorer web app for browsing and voting on collections
-of audio, images, text, or video. It supports two sorting strategies:
+of audio, images, text, video, or documents. It supports two sorting
+strategies:
 
 - **Semantic sorting** — uses pretrained embedding models (CLAP, CLIP,
   X-CLIP, E5) to rank items by similarity to a text query.
@@ -48,6 +49,7 @@ runs locally or in Docker.
 | [EXTENDING.md](EXTENDING.md) | Plugin authoring guide (importers, exporters, media types) |
 | [FEATURE_IDEAS.md](FEATURE_IDEAS.md) | 132 brainstormed feature ideas |
 | [demos.md](demos.md) | Available demo datasets |
+| [old_io.md](old_io.md) | Retired IO module reference implementations |
 
 ---
 
@@ -90,7 +92,7 @@ both the learned-sort training and the label export.
 
 ### Media types
 
-Four media types are supported, each with its own embedding model:
+Five media types are supported:
 
 | Media type | Embedding model | Model ID |
 |-----------|----------------|----------|
@@ -98,26 +100,34 @@ Four media types are supported, each with its own embedding model:
 | Image | CLIP | `openai/clip-vit-base-patch32` |
 | Video | X-CLIP | `microsoft/xclip-base-patch32` |
 | Text | E5 | `intfloat/e5-base-v2` |
+| Document | None (convert first) | N/A — use converters to transform to image/text |
 
 Models are loaded lazily on first use. Total download size: ~3.1 GB.
+
+### Converters
+
+Media converters transform content between types (e.g. document pages to
+images, video to audio). Available converters: `Document2ImageConverter`,
+`Document2TextConverter`, `Video2AudioConverter`, `Video2ImageConverter`.
+See `vtsearch/converters/`.
 
 ### Detectors and processors
 
 A **detector** is a trained MLP that classifies clips as positive/negative.
-An **extractor** groups clips into categories. Both are types of
-**processors** and can be exported/imported as JSON files.
+An **extractor** groups clips into categories. A **localizer** identifies
+regions of interest within clips (e.g. face detection). All three are types
+of **processors** and can be exported/imported as JSON files.
 
 ### Plugin systems
 
 Four auto-discovered plugin systems share the same architecture:
 
-- **Dataset importers** — load data from folders, pickles, URLs, RSS feeds,
-  YouTube playlists, or combined datasets.
-- **Results exporters** — write autodetect results to files, CSV, email,
-  webhooks, or the GUI.
-- **Label importers** — import labels from JSON or CSV files.
-- **Processor importers** — import detectors/extractors from JSON files or
-  train them from labeled data.
+- **Dataset importers** — load data from folders, pickles, HTTP archives,
+  or combined datasets.
+- **Results exporters** — write autodetect results to server files (JSON/CSV),
+  email, webhooks, or the GUI.
+- **Label importers** — import labels from server-side JSON or CSV files.
+- **Processor importers** — import detectors from server-side JSON files.
 
 See [EXTENDING.md](EXTENDING.md) for how to add new plugins.
 
@@ -150,7 +160,9 @@ argument parsing. Key startup sequence:
 | Global state (medias, votes) | `vtsearch/utils/state.py` |
 | Persistent settings | `vtsearch/settings.py` → `data/settings.json` |
 | ML training and inference | `vtsearch/models/training.py` |
-| Embedding models | `vtsearch/media/{audio,image,text,video}/media_type.py` |
+| Embedding models | `vtsearch/media/{audio,image,text,video,document}/media_type.py` |
+| Media converters | `vtsearch/converters/` |
+| Trainable model definitions | `vtsearch/routes/trainable_models.py` → `data/trainable_models/` |
 | Dataset loading and downloading | `vtsearch/datasets/` |
 | Plugin registries | `vtsearch/datasets/importers/`, `vtsearch/exporters/`, `vtsearch/labels/importers/`, `vtsearch/processors/importers/` |
 | Constants and model IDs | `vtsearch/config.py` |
@@ -250,7 +262,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for full details.
 python app.py --autodetect \
   --dataset data.pkl \
   --settings settings.json \
-  --exporter local_json_file --filepath results.json
+  --exporter server_json_file --filepath results.json
 ```
 
 This loads the dataset, runs all detectors from the settings file, and
@@ -265,8 +277,8 @@ exports results without starting the web server.
 
 ### Import pre-trained processors
 
-Use the processor importers panel or CLI to load detectors/extractors
-from JSON files, labeled media files, or CSV label files.
+Use the processor importers panel or CLI to load detectors from
+server-side JSON files.
 
 ### Evaluate sorting quality
 

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -77,6 +77,9 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Image | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 768 |
 | Video | Microsoft X-CLIP (`microsoft/xclip-base-patch32`) | 768 |
 | Text | E5 (`intfloat/e5-base-v2`) | 768 |
+| Document | None (no embedder) | N/A |
+
+The **document** media type has no embedding model of its own. Documents (PDF, DOC, PPT) are intended to be converted to other media types (images or text) via media converters in `vtsearch/converters/` before embedding.
 
 Embeddings are computed once when a dataset is loaded and stored as `numpy.ndarray` in each clip's `"embedding"` field. The MLP trains on these pre-computed vectors, so training is fast (typically < 1 second for 200 epochs on a few hundred labeled examples).
 


### PR DESCRIPTION
## Summary

This PR adds support for document media types (PDF, DOC, PPT) and introduces a media converter system to transform content between types. It also removes deprecated local file IO plugins in favor of server-side file handling.

## Key Changes

### New Features
- **Document media type** (`vtsearch/media/document/`) — Added as a fifth media type alongside audio, image, text, and video. Documents have no embedding model; they must be converted to other types first.
- **Media converters** (`vtsearch/converters/`) — New plugin system for transforming media between types:
  - `Document2ImageConverter` — Render document pages as images
  - `Document2TextConverter` — Extract text from documents
  - `Video2AudioConverter` — Extract audio track from video
  - `Video2ImageConverter` — Sample frames from video as images
- **Trainable models persistence** (`vtsearch/routes/trainable_models.py`) — New route blueprint for CRUD operations on trainable model definitions stored in `data/trainable_models/`
- **Diversity tree state** — Added `_diversity_tree` to global state for hierarchical k-means sampling
- **Dataset display name** — Added `_dataset_display_name` to global state for custom dataset naming
- **Autopilot settings** — Added `autopilot_top_greens` and `autopilot_hard_reds` to persistent settings

### Removed Features
- **Local file IO plugins** — Removed `local_json_file`, `local_csv_file` exporters and label importers (users now upload files to server instead)
- **Dataset importers** — Removed `rss_feed` and `youtube_playlist` importers; retained `folder`, `pickle`, `http_zip`, and `combine_datasets`
- **Processor importers** — Removed `detector_file`, `label_file`, and `csv_label_file` importers; retained `server_detector_file` only
- **CLI support** — Removed CLI flags for RSS feeds and YouTube playlists

### Documentation Updates
- Updated ARCHITECTURE.md with new media type, converters, and route blueprints
- Updated HANDOFF.md to reflect document media type and converter system
- Updated CLI.md to remove RSS/YouTube examples and add chunked loading support
- Updated DEPLOYMENT.md with document storage directory and removed network dependencies
- Updated EXTENDING.md to reflect removed plugins
- Updated ML.md to document document media type (no embedder)
- Added reference to new `old_io.md` for retired IO module implementations
- Updated FEATURE_IDEAS.md with note on implemented features

### State Management
- Protected all state mutations with `_state_lock` (threading.RLock)
- Updated state variable documentation to reflect new fields and their purposes

## Implementation Details

- Document conversion uses PyMuPDF for rendering and text extraction
- Converters follow the same plugin architecture as importers/exporters (auto-discovered via sentinel)
- Trainable models stored as JSON in `data/trainable_models/` with name, text query, media type, examples, and labelset
- All local file operations now require server-side file paths instead of client uploads
- Chunk-size support added to CLI for memory-efficient batch processing of large datasets

https://claude.ai/code/session_017iX4cMeadGGdt7jnYaDqXK