### PR TITLE
Fix dashboard menu state management and prevent disabled clicks

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1129,6 +1129,7 @@
     if (rightPanel) rightPanel.style.display = "none";
     if (headerDashboardBtn) headerDashboardBtn.style.display = "none";
     stripeContainer.innerHTML = "";
+    if (menuDashboard) menuDashboard.classList.remove("disabled");
     if (menuLabelsImport) menuLabelsImport.classList.add("disabled");
     if (menuLabelsExport) menuLabelsExport.classList.add("disabled");
     if (menuDetectorImport) menuDetectorImport.classList.add("disabled");
@@ -1156,6 +1157,7 @@
       center.innerHTML = '<p>Select a media from the left panel</p>';
       announce("Dataset loaded. Select a media from the left panel to begin.");
     }
+    if (menuDashboard) menuDashboard.classList.remove("disabled");
     if (menuLabelsImport) menuLabelsImport.classList.remove("disabled");
     if (menuDetectorImport) menuDetectorImport.classList.remove("disabled");
     // menuLabelsExport and menuDetectorExport stay disabled until votes are loaded (updateSortModeAvailability)
@@ -1174,6 +1176,7 @@
     sortBar.style.display = "none";
     datasetBar.style.display = "none";
     if (headerDashboardBtn) headerDashboardBtn.style.display = "none";
+    if (menuDashboard) menuDashboard.classList.add("disabled");
 
     // Show dashboard
     center.innerHTML = "";
@@ -6234,6 +6237,7 @@
   // Burger menu "Dashboard" item
   if (menuDashboard) {
     menuDashboard.addEventListener("click", () => {
+      if (menuDashboard.classList.contains("disabled")) return;
       closeBurgerMenu();
       showDashboard();
     });


### PR DESCRIPTION
## Summary
This PR improves the dashboard menu item state management by ensuring the menu is properly enabled/disabled based on the application state, and prevents users from clicking the dashboard menu when it's disabled.

## Key Changes
- **Enable dashboard menu on initialization**: Added `menuDashboard.classList.remove("disabled")` when the app initializes and when a dataset is loaded, ensuring the dashboard is accessible when appropriate
- **Disable dashboard menu when showing dashboard**: Added `menuDashboard.classList.add("disabled")` when the dashboard view is displayed, preventing redundant navigation
- **Prevent disabled menu clicks**: Added a guard clause in the dashboard menu click handler to return early if the menu item has the "disabled" class, preventing unintended behavior when the menu is disabled

## Implementation Details
The changes follow the existing pattern used for other menu items (labels import/export, detector import) where disabled state is managed via CSS classes. The click handler guard ensures that even if a disabled menu item is somehow clicked, it won't trigger the dashboard display logic.

https://claude.ai/code/session_01YEXDck9xJvWNxFAy8vM5Mc