### PR TITLE
Replace diversity tree representative with score-based selection

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3876,7 +3876,21 @@
 
   async function fetchDiversityTreeNext() {
     try {
-      const res = await fetch("/api/diversity-tree/next");
+      // Send current sort scores so the diversity tree picks the
+      // highest-ranked element within the next unseen node.
+      const body = {};
+      if (sortOrder && sortOrder.length > 0) {
+        const scores = {};
+        for (const entry of sortOrder) {
+          scores[entry.id] = entry.score ?? entry.similarity ?? 0;
+        }
+        body.scores = scores;
+      }
+      const res = await fetch("/api/diversity-tree/next", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
       const data = await res.json();
       return data;  // { id: int|null, diversity_level: int, exhausted: bool }
     } catch {

--- a/tests/test_diversity_tree.py
+++ b/tests/test_diversity_tree.py
@@ -52,7 +52,7 @@ class TestConstruction:
         tree = DiversityTree(vecs, k=2, min_node_size=20)
         assert len(tree.nodes) == 1
         assert tree.vector_to_leaf[1] == "0"
-        assert tree.nodes["0"]["representative"] == 1
+        assert 1 in tree.nodes["0"]["ids"]
 
     def test_small_set_stays_single_node(self):
         vecs = _make_vectors(10)
@@ -97,21 +97,11 @@ class TestConstruction:
         for node in tree.nodes.values():
             assert node["depth"] <= 3
 
-    def test_representative_is_in_node(self):
+    def test_node_has_ids(self):
         vecs = _make_vectors(100)
         tree = DiversityTree(vecs, k=3, min_node_size=10)
         for name, node in tree.nodes.items():
-            assert node["representative"] in node["ids"]
-
-    def test_representative_closest_to_centroid(self):
-        vecs = _make_vectors(100)
-        tree = DiversityTree(vecs, k=2, min_node_size=10)
-        for name, node in tree.nodes.items():
-            node_vecs = np.array([vecs[vid] for vid in node["ids"]])
-            centroid = node_vecs.mean(axis=0)
-            dists = np.linalg.norm(node_vecs - centroid, axis=1)
-            closest_idx = int(np.argmin(dists))
-            assert node["representative"] == node["ids"][closest_idx]
+            assert len(node["ids"]) > 0
 
     def test_invalid_k_raises(self):
         with pytest.raises(ValueError, match="k must be between 2 and 9"):
@@ -410,24 +400,23 @@ class TestNextSample:
         tree = DiversityTree({})
         assert tree.next_sample() is None
 
-    def test_first_sample_is_root_representative(self):
+    def test_first_sample_is_from_root(self):
         vecs = _make_vectors(100)
         tree = DiversityTree(vecs, k=2, min_node_size=10)
         sample = tree.next_sample()
-        assert sample == tree.nodes["0"]["representative"]
+        assert sample in tree.nodes["0"]["ids"]
 
-    def test_after_labeling_root_rep_returns_child(self):
+    def test_after_labeling_first_returns_child(self):
         vecs = _make_vectors(100)
         tree = DiversityTree(vecs, k=2, min_node_size=10)
-        root_rep = tree.nodes["0"]["representative"]
-        tree.label(root_rep)
+        first = tree.next_sample()
+        tree.label(first)
 
-        # Next sample should not be the root representative anymore
+        # Next sample should not be the same element anymore
         # (root is seen now, so we descend to first unseen child)
         sample = tree.next_sample()
         if sample is not None:
-            # It should be the representative of some unseen child
-            assert sample != root_rep or len(tree.nodes) == 1
+            assert sample != first or len(tree.nodes) == 1
 
     def test_all_seen_returns_none(self):
         vecs = _make_vectors(10)
@@ -447,19 +436,46 @@ class TestNextSample:
         vecs = _make_clustered_vectors([30, 30], dim=32)
         tree = DiversityTree(vecs, k=2, min_node_size=10)
 
-        # First sample is root rep
+        # First sample is from root
         s1 = tree.next_sample()
-        assert s1 == tree.nodes["0"]["representative"]
+        assert s1 in tree.nodes["0"]["ids"]
 
-        # After labeling root rep, next should be first unseen child
+        # After labeling, next should be from first unseen child
         tree.label(s1)
         s2 = tree.next_sample()
 
         children = tree.nodes["0"]["children"]
-        # s2 should be the representative of one of the unseen children
         unseen_children = [c for c in children if c not in tree.seen]
         if unseen_children:
-            assert s2 == tree.nodes[unseen_children[0]]["representative"]
+            assert s2 in tree.nodes[unseen_children[0]]["ids"]
+
+    def test_next_sample_with_scores(self):
+        """When scores are provided, return the highest-scored element from the node."""
+        vecs = _make_vectors(50)
+        tree = DiversityTree(vecs, k=2, min_node_size=20)
+        # Single node tree; assign highest score to vector 5
+        scores = {i: float(i) for i in range(1, 51)}
+        sample = tree.next_sample(scores=scores)
+        # Vector 50 has the highest score
+        assert sample == 50
+
+    def test_next_sample_with_scores_picks_from_unseen_node(self):
+        """Scores should influence selection within the correct unseen node."""
+        vecs = _make_clustered_vectors([30, 30], dim=32)
+        tree = DiversityTree(vecs, k=2, min_node_size=10)
+
+        # Give high scores to cluster-1 vectors, low to cluster-0
+        scores = {}
+        for vid in range(1, 31):
+            scores[vid] = 0.1
+        for vid in range(31, 61):
+            scores[vid] = 0.9
+
+        # First sample (from root) should be the highest-scored element overall
+        s1 = tree.next_sample(scores=scores)
+        assert s1 in tree.nodes["0"]["ids"]
+        # Should pick a high-scoring element
+        assert scores[s1] == 0.9
 
 
 # ---------------------------------------------------------------------------
@@ -476,7 +492,7 @@ class TestWorkflow:
         assert tree.diversity_level() >= 0
         tree.unlabel(1)
         assert tree.diversity_level() == -1
-        assert tree.next_sample() == tree.nodes["0"]["representative"]
+        assert tree.next_sample() in tree.nodes["0"]["ids"]
 
     def test_progressive_labeling(self):
         """Label vectors progressively and verify diversity level grows."""

--- a/tests/test_diversity_tree_integration.py
+++ b/tests/test_diversity_tree_integration.py
@@ -108,7 +108,7 @@ class TestDiversityTreeNextSample:
         first = diversity_tree_next_sample()
         diversity_tree_label(first)
         second = diversity_tree_next_sample()
-        # After labeling the root representative, the tree should suggest
+        # After labeling the first sample, the tree should suggest
         # a different media (or None if fully seen).
         if second is not None:
             assert second != first or len(medias) == 1
@@ -122,7 +122,7 @@ class TestDiversityTreeNextSample:
 class TestDiversityTreeNextEndpoint:
     def test_returns_id_when_tree_exists(self, client):
         _build_tree()
-        resp = client.get("/api/diversity-tree/next")
+        resp = client.post("/api/diversity-tree/next", json={})
         assert resp.status_code == 200
         data = resp.get_json()
         assert "id" in data
@@ -134,18 +134,27 @@ class TestDiversityTreeNextEndpoint:
         assert data["exhausted"] is False
 
     def test_returns_null_when_no_tree(self, client):
-        resp = client.get("/api/diversity-tree/next")
+        resp = client.post("/api/diversity-tree/next", json={})
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["id"] is None
         assert data["diversity_level"] == -1
         assert data["exhausted"] is False  # no tree != exhausted
 
+    def test_get_still_works(self, client):
+        """GET without scores still returns a valid result."""
+        _build_tree()
+        resp = client.get("/api/diversity-tree/next")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["id"] is not None
+        assert data["id"] in medias
+
     def test_diversity_level_after_labeling(self, client):
         tree = _build_tree()
-        root_rep = tree.nodes["0"]["representative"]
-        diversity_tree_label(root_rep)
-        resp = client.get("/api/diversity-tree/next")
+        first_id = tree.nodes["0"]["ids"][0]
+        diversity_tree_label(first_id)
+        resp = client.post("/api/diversity-tree/next", json={})
         data = resp.get_json()
         assert data["diversity_level"] >= 0
 
@@ -155,10 +164,23 @@ class TestDiversityTreeNextEndpoint:
         # Label every vector so all leaves (and ancestors) become seen
         for vid in tree.vector_to_leaf:
             diversity_tree_label(vid)
-        resp = client.get("/api/diversity-tree/next")
+        resp = client.post("/api/diversity-tree/next", json={})
         data = resp.get_json()
         assert data["id"] is None
         assert data["exhausted"] is True
+
+    def test_scores_influence_selection(self, client):
+        """When scores are posted, the highest-scored element in the node is returned."""
+        tree = _build_tree()
+        # Build scores: give the highest score to a specific media
+        all_ids = list(tree.vector_to_leaf.keys())
+        target_id = all_ids[-1]  # pick the last one
+        scores = {str(vid): 0.1 for vid in all_ids}
+        scores[str(target_id)] = 1.0
+
+        resp = client.post("/api/diversity-tree/next", json={"scores": scores})
+        data = resp.get_json()
+        assert data["id"] == target_id
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -1,15 +1,14 @@
 """Diversity Tree: hierarchical k-means clustering for diverse sampling.
 
 A k-Diversity Tree recursively partitions a set of vectors using k-means
-clustering. Each node tracks a "representative" (the vector closest to the
-node's centroid) and a "seen" flag driven by label activity.
+clustering. Each node tracks a "seen" flag driven by label activity.
 
 The tree supports:
 - Lookup: given a vector ID, return the name of its deepest (leaf) node.
 - Labeling: when a vector is labeled, mark its leaf and all ancestors as seen.
 - Unlabeling: when a label is removed, propagate unseen status upward.
 - Diversity level: the deepest tree level at which every node is seen.
-- Next sample: the representative of the first unseen node in BFS order.
+- Next sample: the highest-scored element of the first unseen node in BFS order.
 """
 
 from __future__ import annotations
@@ -56,7 +55,7 @@ class DiversityTree:
         self.max_depth = max_depth
         self.min_node_size = min_node_size
 
-        # Node storage: name -> {ids, representative, children, depth, parent}
+        # Node storage: name -> {ids, children, depth, parent}
         self.nodes: dict[str, dict] = {}
         # Vector ID -> leaf node name
         self.vector_to_leaf: dict[int, str] = {}
@@ -80,14 +79,8 @@ class DiversityTree:
         parent: str | None,
     ) -> None:
         """Recursively build a tree node and its children."""
-        # Compute representative: vector closest to centroid
-        centroid = vecs.mean(axis=0)
-        dists = np.linalg.norm(vecs - centroid, axis=1)
-        rep_idx = int(np.argmin(dists))
-
         self.nodes[name] = {
             "ids": ids,
-            "representative": ids[rep_idx],
             "children": [],
             "depth": depth,
             "parent": parent,
@@ -218,10 +211,15 @@ class DiversityTree:
         seen_count = sum(1 for name in nodes_at_next if name in self.seen)
         return level + seen_count / len(nodes_at_next)
 
-    def next_sample(self) -> int | None:
-        """Return the representative of the first unseen node in BFS order.
+    def next_sample(self, scores: dict[int, float] | None = None) -> int | None:
+        """Return an element from the first unseen node in BFS order.
 
-        Returns None if all nodes have been seen.
+        When *scores* is provided, returns the highest-scored element in the
+        node (so the sort mode influences which element is picked from the
+        diverse region).  When *scores* is ``None``, returns the first element
+        in the node's ID list.
+
+        Returns ``None`` if all nodes have been seen.
         """
         if not self.nodes:
             return None
@@ -230,7 +228,10 @@ class DiversityTree:
         while queue:
             name = queue.popleft()
             if name not in self.seen:
-                return self.nodes[name]["representative"]
+                ids = self.nodes[name]["ids"]
+                if scores:
+                    return max(ids, key=lambda i: scores.get(i, 0.0))
+                return ids[0]
             children = self.nodes[name]["children"]
             queue.extend(children)
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -716,9 +716,13 @@ def labeling_status_indicator():
         return jsonify({"error": str(e)}), 500
 
 
-@sorting_bp.route("/api/diversity-tree/next")
+@sorting_bp.route("/api/diversity-tree/next", methods=["GET", "POST"])
 def diversity_tree_next():
     """Return the next diverse sample from the Diversity Tree.
+
+    Accepts an optional POST body with ``{"scores": {id: score, ...}}``
+    so the sort mode influences which element is picked from the next
+    unseen node.  Without scores the first element in the node is returned.
 
     Returns ``{"id": <media_id>}`` or ``{"id": null}`` when the tree is
     exhausted or not yet built.  Also includes ``diversity_level`` so the
@@ -726,8 +730,15 @@ def diversity_tree_next():
     and ``exhausted`` (bool) which is true when the tree exists but every
     node has already been seen.
     """
+    scores = None
+    if request.method == "POST":
+        data = request.get_json(force=True, silent=True) or {}
+        raw_scores = data.get("scores")
+        if isinstance(raw_scores, dict):
+            scores = {int(k): float(v) for k, v in raw_scores.items()}
+
     tree = get_diversity_tree()
-    next_id = diversity_tree_next_sample()
+    next_id = diversity_tree_next_sample(scores=scores)
     level = tree.diversity_level() if tree is not None else -1
     exhausted = tree is not None and next_id is None
     return jsonify({"id": next_id, "diversity_level": level, "exhausted": exhausted})

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -636,12 +636,16 @@ def get_diversity_tree():
         return _diversity_tree
 
 
-def diversity_tree_next_sample() -> int | None:
-    """Return the next diverse sample ID, or ``None`` if unavailable."""
+def diversity_tree_next_sample(scores: dict[int, float] | None = None) -> int | None:
+    """Return the next diverse sample ID, or ``None`` if unavailable.
+
+    When *scores* is provided, the highest-scored element in the next
+    unseen node is returned (so the sort mode influences selection).
+    """
     with _state_lock:
         if _diversity_tree is None:
             return None
-        return _diversity_tree.next_sample()
+        return _diversity_tree.next_sample(scores=scores)
 
 
 def diversity_tree_label(media_id: int) -> None:


### PR DESCRIPTION
## Summary
This PR removes the "representative" concept from the Diversity Tree and replaces it with score-based element selection. Instead of always returning the vector closest to a node's centroid, the tree now returns the highest-scored element from the next unseen node, allowing the sort mode to influence which element is picked from diverse regions.

## Key Changes

- **Removed representative tracking**: Eliminated the `representative` field from node storage and the logic that computed it (finding the vector closest to the centroid).

- **Added score-based selection**: The `next_sample()` method now accepts an optional `scores` dictionary. When provided, it returns the highest-scored element from the next unseen node; otherwise, it returns the first element in the node's ID list.

- **Updated API endpoint**: Changed `/api/diversity-tree/next` to accept POST requests with an optional `{"scores": {...}}` body, while maintaining backward compatibility with GET requests.

- **Frontend integration**: Modified `fetchDiversityTreeNext()` to send current sort scores to the API, enabling the diversity tree to respect the user's sort preferences when selecting samples.

- **Updated tests**: Replaced tests that verified representative selection with tests that verify score-based selection and node ID presence. Added new tests for score-influenced sampling behavior.

## Implementation Details

- The `next_sample()` method uses `max(ids, key=lambda i: scores.get(i, 0.0))` to select the highest-scored element, with a default score of 0.0 for elements without scores.
- The API endpoint parses scores from the POST body and converts string keys to integers before passing to the tree.
- The frontend builds scores from the current `sortOrder` array, using the score/similarity field as the value.
- All node structure changes are backward compatible with existing tree operations (labeling, unlabeling, diversity level calculation).

https://claude.ai/code/session_01XmEc6xgvEfx1T1PPD7uUCZ