### PR TITLE
Add persistent dataset/model registries and multi-select Find

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -31,6 +31,11 @@
   // Dashboard state
   let dashSelectedDataset = null;    // { name, label, ... } from demo list, or null
   let dashSelectedDetector = null;   // detector name string, or null
+  // Registry-based multi-select state
+  let dashSelectedDatasetIds = [];   // array of registry dataset IDs (for multi-select)
+  let dashSelectedModelIds = [];     // array of registry model IDs (for multi-select)
+  let dashRegisteredDatasets = [];   // cached from /api/datasets/registry
+  let dashRegisteredModels = [];     // cached from /api/models/registry
   let dashDemoDatasets = null;       // cached demo dataset list from API
   let dashPendingAction = null;      // "label" | "detect" — set before loading a dataset
   let currentView = "welcome";       // "welcome" | "dashboard" | "labeling"
@@ -1203,46 +1208,291 @@
   }
 
   function updateDashboardButtons() {
-    const hasDataset = datasetLoaded || dashSelectedDataset;
-    if (dashLabelBtn) dashLabelBtn.disabled = !hasDataset;
-    if (dashDetectBtn) dashDetectBtn.disabled = !(hasDataset && dashSelectedDetector);
+    // --- Label button validation ---
+    // Requires: exactly one dataset selected, exactly one model selected,
+    // MediaTypes match, model is trainable
+    if (dashLabelBtn) {
+      const selDs = dashRegisteredDatasets.filter(d => dashSelectedDatasetIds.includes(d.id));
+      const selMs = dashRegisteredModels.filter(m => dashSelectedModelIds.includes(m.id));
+      let labelDisabled = false;
+      let labelHint = "";
+
+      if (selDs.length === 0 && !dashSelectedDataset) {
+        labelDisabled = true;
+        labelHint = "No dataset selected";
+      } else if (selDs.length > 1) {
+        labelDisabled = true;
+        labelHint = "Select exactly one dataset";
+      } else if (selMs.length === 0) {
+        labelDisabled = true;
+        labelHint = "No model selected";
+      } else if (selMs.length > 1) {
+        labelDisabled = true;
+        labelHint = "Select exactly one model";
+      } else if (selDs.length === 1 && selMs.length === 1) {
+        const dsType = selDs[0].media_type;
+        const mType = selMs[0].media_type;
+        if (mType !== "any" && dsType !== mType) {
+          labelDisabled = true;
+          labelHint = "Dataset and Model types don't match";
+        } else if (!selMs[0].trainable) {
+          labelDisabled = true;
+          labelHint = "Model is not trainable";
+        }
+      }
+
+      dashLabelBtn.disabled = labelDisabled;
+      // Show/hide hint text
+      let hintEl = dashLabelBtn.parentElement.querySelector(".dash-btn-hint-label");
+      if (!hintEl) {
+        hintEl = document.createElement("span");
+        hintEl.className = "dash-btn-hint dash-btn-hint-label";
+        dashLabelBtn.parentElement.insertBefore(hintEl, dashLabelBtn.nextSibling);
+      }
+      hintEl.textContent = labelHint;
+    }
+
+    // --- Find button validation ---
+    // Requires: >= 1 dataset selected, >= 1 model selected, all same MediaType
+    if (dashDetectBtn) {
+      const selDs = dashRegisteredDatasets.filter(d => dashSelectedDatasetIds.includes(d.id));
+      const selMs = dashRegisteredModels.filter(m => dashSelectedModelIds.includes(m.id));
+      let findDisabled = false;
+      let findHint = "";
+
+      if (selDs.length === 0 && !dashSelectedDataset) {
+        findDisabled = true;
+        findHint = "Must select at least one dataset";
+      } else if (selMs.length === 0) {
+        findDisabled = true;
+        findHint = "Must select at least one model";
+      } else if (selDs.length >= 1 && selMs.length >= 1) {
+        const allTypes = new Set([
+          ...selDs.map(d => d.media_type),
+          ...selMs.filter(m => m.media_type !== "any").map(m => m.media_type),
+        ]);
+        if (allTypes.size > 1) {
+          findDisabled = true;
+          findHint = "All selections must have the same media type";
+        }
+      }
+
+      dashDetectBtn.disabled = findDisabled;
+      let hintEl = dashDetectBtn.parentElement.querySelector(".dash-btn-hint-find");
+      if (!hintEl) {
+        hintEl = document.createElement("span");
+        hintEl.className = "dash-btn-hint dash-btn-hint-find";
+        dashDetectBtn.parentElement.insertBefore(hintEl, dashDetectBtn.nextSibling);
+      }
+      hintEl.textContent = findHint;
+    }
   }
 
   async function renderDashboardDatasets() {
     if (!dashDatasetGrid) return;
 
-    if (datasetLoaded) {
-      // Fetch dataset info and display it in the grid
-      try {
-        const res = await fetch("/api/dashboard/dataset-info");
-        const info = await res.json();
-        const mtInfo = mediaTypesMap[info.media_type];
-        const icon = mtInfo ? mtInfo.icon : "";
-        const typeName = mtInfo ? mtInfo.name : info.media_type || "media";
-        const dupeSuffix = info.num_dupes ? ` (${info.num_dupes} dupes)` : "";
-        dashDatasetGrid.innerHTML = `<table class="dash-dataset-table">
-          <thead><tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Items</th>
-            <th>Origin</th>
-            <th class="col-actions-header"></th>
-          </tr></thead>
-          <tbody></tbody></table>`;
+    // Fetch the full dataset registry
+    try {
+      const res = await fetch("/api/datasets/registry");
+      const data = await res.json();
+      dashRegisteredDatasets = data.datasets || [];
+    } catch (_) {
+      dashRegisteredDatasets = [];
+    }
+
+    if (dashRegisteredDatasets.length === 0) {
+      dashDatasetGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No datasets yet. Use "+" to load one.</p>';
+      return;
+    }
+
+    const mediaIcons = Object.fromEntries(Object.entries(mediaTypesMap).map(([k, v]) => [k, v.icon]));
+
+    dashDatasetGrid.innerHTML = `<table class="dash-dataset-table">
+      <thead><tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Items</th>
+        <th>Loaded</th>
+        <th class="col-actions-header"></th>
+      </tr></thead>
+      <tbody></tbody></table>`;
+
+    const tbody = dashDatasetGrid.querySelector("tbody");
+
+    dashRegisteredDatasets.forEach(ds => {
+      const icon = mediaIcons[ds.media_type] || "";
+      const typeName = mediaTypesMap[ds.media_type] ? mediaTypesMap[ds.media_type].name : ds.media_type || "media";
+      const isSelected = dashSelectedDatasetIds.includes(ds.id);
+      const isLoaded = !!ds.loaded;
+      const tr = document.createElement("tr");
+      tr.className = "dash-dataset-row" + (isSelected ? " dash-selected" : "");
+      tr.setAttribute("role", "button");
+      tr.setAttribute("tabindex", "0");
+
+      const nameTd = document.createElement("td");
+      nameTd.className = "col-name";
+      nameTd.innerHTML = `<span class="dash-name-text">${escapeHtml(ds.name)}</span><button class="btn-icon dash-rename-btn" title="Rename" aria-label="Rename dataset">&#9998;</button>`;
+      tr.appendChild(nameTd);
+      tr.insertAdjacentHTML("beforeend", `
+        <td class="col-type">${escapeHtml(icon)} ${escapeHtml(typeName)}</td>
+        <td class="col-count">${ds.num_items || 0}</td>
+        <td class="col-loaded">${isLoaded ? '<span style="color:var(--good-color)">✓</span>' : ''}</td>
+        <td class="col-actions"><button class="btn-icon btn-icon-danger dash-delete-btn" title="Remove dataset" aria-label="Remove dataset">&#128465;</button></td>
+      `);
+
+      // Inline rename
+      const renameBtn = tr.querySelector(".dash-rename-btn");
+      renameBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const nameSpan = nameTd.querySelector(".dash-name-text");
+        const current = nameSpan.textContent;
+        nameSpan.style.display = "none";
+        renameBtn.style.display = "none";
+        const input = document.createElement("input");
+        input.type = "text";
+        input.className = "dash-rename-input";
+        input.value = current;
+        nameTd.insertBefore(input, nameSpan);
+        input.focus();
+        input.select();
+        const commit = async () => {
+          const newName = input.value.trim();
+          if (newName && newName !== current) {
+            try {
+              await fetch(`/api/datasets/registry/${encodeURIComponent(ds.id)}/rename`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name: newName }),
+              });
+              ds.name = newName;
+              nameSpan.textContent = newName;
+            } catch (_) {}
+          }
+          input.remove();
+          nameSpan.style.display = "";
+          renameBtn.style.display = "";
+        };
+        input.addEventListener("blur", commit);
+        input.addEventListener("keydown", (ev) => {
+          if (ev.key === "Enter") { ev.preventDefault(); input.blur(); }
+          if (ev.key === "Escape") { input.value = current; input.blur(); }
+        });
+      });
+
+      // Delete dataset
+      const deleteBtn = tr.querySelector(".dash-delete-btn");
+      deleteBtn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        if (!(await vtConfirm("Remove this dataset? Its saved file will be deleted."))) return;
+        try {
+          await fetch(`/api/datasets/registry/${encodeURIComponent(ds.id)}`, { method: "DELETE" });
+          dashSelectedDatasetIds = dashSelectedDatasetIds.filter(id => id !== ds.id);
+          if (ds.loaded) datasetLoaded = false;
+          await renderDashboardDatasets();
+          updateDashboardButtons();
+        } catch (_) {}
+      });
+
+      // Multi-select click (toggle)
+      tr.addEventListener("click", (e) => {
+        if (e.ctrlKey || e.metaKey) {
+          // Toggle individual selection
+          if (dashSelectedDatasetIds.includes(ds.id)) {
+            dashSelectedDatasetIds = dashSelectedDatasetIds.filter(id => id !== ds.id);
+          } else {
+            dashSelectedDatasetIds.push(ds.id);
+          }
+        } else {
+          // Single-click replaces selection
+          if (dashSelectedDatasetIds.length === 1 && dashSelectedDatasetIds[0] === ds.id) {
+            dashSelectedDatasetIds = [];
+          } else {
+            dashSelectedDatasetIds = [ds.id];
+          }
+        }
+        renderDashboardDatasets();
+        updateDashboardButtons();
+      });
+      tr.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); tr.click(); }
+      });
+
+      tbody.appendChild(tr);
+    });
+  }
+
+  async function renderDashboardModels() {
+    if (!dashModelGrid) return;
+
+    // Fetch the full model registry
+    try {
+      const res = await fetch("/api/models/registry");
+      const data = await res.json();
+      dashRegisteredModels = data.models || [];
+    } catch (_) {
+      dashRegisteredModels = [];
+    }
+
+    // Also fetch autorun detectors for backward compat
+    try {
+      const res = await fetch("/api/autorun-detectors");
+      const data = await res.json();
+      autorunDetectors = data.detectors || [];
+    } catch (_) {}
+
+    if (dashRegisteredModels.length === 0) {
+      dashModelGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No models yet. Use "+" to create one.</p>';
+      return;
+    }
+
+    const mediaIcons = Object.fromEntries(Object.entries(mediaTypesMap).map(([k, v]) => [k, v.icon]));
+
+    dashModelGrid.innerHTML = `<table class="dash-model-table">
+      <thead><tr>
+        <th data-sort="name">Name<span class="sort-arrow"></span></th>
+        <th data-sort="media_type">Type<span class="sort-arrow"></span></th>
+        <th data-sort="num_training" style="text-align:right"># Training<span class="sort-arrow"></span></th>
+        <th>Loaded</th>
+        <th class="col-actions-header"></th>
+      </tr></thead><tbody></tbody></table>`;
+
+    const table = dashModelGrid.querySelector(".dash-model-table");
+    let modelSort = { key: "name", asc: true };
+
+    function renderModelRows() {
+      const sorted = [...dashRegisteredModels].sort((a, b) => {
+        let va = a[modelSort.key], vb = b[modelSort.key];
+        if (modelSort.key === "num_training" || modelSort.key === "created_at") {
+          return modelSort.asc ? ((va || 0) - (vb || 0)) : ((vb || 0) - (va || 0));
+        }
+        va = String(va || "").toLowerCase(); vb = String(vb || "").toLowerCase();
+        return modelSort.asc ? va.localeCompare(vb) : vb.localeCompare(va);
+      });
+
+      const tbody = table.querySelector("tbody");
+      tbody.innerHTML = "";
+      sorted.forEach(m => {
+        const icon = mediaIcons[m.media_type] || "";
+        const isSelected = dashSelectedModelIds.includes(m.id);
+        const isLoaded = !!m.loaded;
+        const trainingText = m.trainable ? String(m.num_training || 0) : "-";
         const tr = document.createElement("tr");
-        tr.className = "dash-dataset-row dash-selected";
+        tr.className = "dash-model-row" + (isSelected ? " dash-selected" : "");
+        tr.setAttribute("role", "button");
+        tr.setAttribute("tabindex", "0");
+
         const nameTd = document.createElement("td");
         nameTd.className = "col-name";
-        nameTd.innerHTML = `<span class="dash-name-text">${escapeHtml(info.name)}</span><button class="btn-icon dash-rename-btn" title="Rename" aria-label="Rename dataset">&#9998;</button>`;
+        nameTd.innerHTML = `<span class="dash-name-text">${escapeHtml(m.name)}</span><button class="btn-icon dash-rename-btn" title="Rename" aria-label="Rename model">&#9998;</button>`;
         tr.appendChild(nameTd);
         tr.insertAdjacentHTML("beforeend", `
-          <td class="col-type">${escapeHtml(icon)} ${escapeHtml(typeName)}</td>
-          <td class="col-count">${info.num_medias}${escapeHtml(dupeSuffix)}</td>
-          <td class="col-origin">${escapeHtml(info.origin)}</td>
-          <td class="col-actions"><button class="btn-icon btn-icon-danger dash-delete-btn" title="Remove dataset" aria-label="Remove dataset">&#128465;</button></td>
+          <td class="col-type">${escapeHtml(icon)} ${escapeHtml(m.media_type)}</td>
+          <td class="col-num-training" style="text-align:right">${escapeHtml(trainingText)}</td>
+          <td class="col-loaded">${isLoaded ? '<span style="color:var(--good-color)">✓</span>' : ''}</td>
+          <td class="col-actions"><button class="btn-icon btn-icon-danger dash-delete-btn" title="Remove model" aria-label="Remove model">&#128465;</button></td>
         `);
 
-        // Inline rename for dataset
+        // Inline rename
         const renameBtn = tr.querySelector(".dash-rename-btn");
         renameBtn.addEventListener("click", (e) => {
           e.stopPropagation();
@@ -1261,11 +1511,12 @@
             const newName = input.value.trim();
             if (newName && newName !== current) {
               try {
-                await fetch("/api/dashboard/dataset-rename", {
+                await fetch(`/api/models/registry/${encodeURIComponent(m.id)}/rename`, {
                   method: "PUT",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({ name: newName }),
                 });
+                m.name = newName;
                 nameSpan.textContent = newName;
               } catch (_) {}
             }
@@ -1280,203 +1531,45 @@
           });
         });
 
-        // Delete dataset
-        const deleteBtn = tr.querySelector(".dash-delete-btn");
-        deleteBtn.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          if (!(await vtConfirm("Remove this dataset? All votes and labels will be cleared."))) return;
-          try {
-            await fetch("/api/dataset/clear", { method: "POST" });
-            datasetLoaded = false;
-            dashDatasetStatus.style.display = "none";
-            await renderDashboardDatasets();
-            updateDashboardButtons();
-          } catch (_) {}
-        });
-
-        dashDatasetGrid.querySelector("tbody").appendChild(tr);
-      } catch (_) {
-        dashDatasetGrid.innerHTML = "";
-      }
-      return;
-    }
-
-    dashDatasetGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No dataset loaded yet. Use "+" to load one.</p>';
-  }
-
-  async function renderDashboardModels() {
-    if (!dashModelGrid) return;
-
-    // Fetch fresh autorun detectors
-    try {
-      const res = await fetch("/api/autorun-detectors");
-      const data = await res.json();
-      autorunDetectors = data.detectors || [];
-    } catch (_) {}
-
-    if (autorunDetectors.length === 0) {
-      dashModelGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No detectors loaded yet. Use "+" to create one.</p>';
-      return;
-    }
-
-    const mediaIcons = Object.fromEntries(Object.entries(mediaTypesMap).map(([k, v]) => [k, v.icon]));
-
-    let html = `<table class="dash-model-table">
-      <thead><tr>
-        <th data-sort="name">Name<span class="sort-arrow"></span></th>
-        <th data-sort="media_type">Type<span class="sort-arrow"></span></th>
-        <th>Examples</th>
-        <th data-sort="num_labels" style="text-align:right">#TrainingLabels<span class="sort-arrow"></span></th>
-        <th data-sort="autodetect" style="text-align:center">Fav<span class="sort-arrow"></span></th>
-        <th data-sort="created_at">Created<span class="sort-arrow"></span></th>
-        <th class="col-actions-header"></th>
-      </tr></thead><tbody></tbody></table>`;
-    dashModelGrid.innerHTML = html;
-
-    const table = dashModelGrid.querySelector(".dash-model-table");
-    let modelSort = { key: "name", asc: true };
-
-    function renderModelRows() {
-      const sorted = [...autorunDetectors].sort((a, b) => {
-        let va = a[modelSort.key], vb = b[modelSort.key];
-        if (modelSort.key === "num_labels") return modelSort.asc ? (va || 0) - (vb || 0) : (vb || 0) - (va || 0);
-        if (modelSort.key === "created_at") return modelSort.asc ? (va || 0) - (vb || 0) : (vb || 0) - (va || 0);
-        if (modelSort.key === "autodetect") {
-          va = va ? 1 : 0; vb = vb ? 1 : 0;
-          return modelSort.asc ? va - vb : vb - va;
-        }
-        va = String(va || "").toLowerCase(); vb = String(vb || "").toLowerCase();
-        return modelSort.asc ? va.localeCompare(vb) : vb.localeCompare(va);
-      });
-
-      const tbody = table.querySelector("tbody");
-      tbody.innerHTML = "";
-      sorted.forEach(det => {
-        const icon = mediaIcons[det.media_type] || "\uD83D\uDD0D";
-        const created = det.created_at ? new Date(det.created_at * 1000).toLocaleDateString() : "";
-        const isSelected = dashSelectedDetector === det.name;
-        const isFav = det.autodetect;
-        const numLabels = det.num_labels || 0;
-        const tr = document.createElement("tr");
-        tr.className = "dash-model-row" + (isSelected ? " dash-selected" : "");
-        tr.setAttribute("role", "button");
-        tr.setAttribute("tabindex", "0");
-        const exArr = det.examples || [];
-        const exSummary = exArr.length === 0
-          ? '<span style="color:var(--text-muted)">none</span>'
-          : escapeHtml(exArr.map(e => e.value).join(", ")).substring(0, 40) + (exArr.map(e => e.value).join(", ").length > 40 ? "\u2026" : "");
-        tr.innerHTML = `
-          <td class="col-name"><span class="dash-name-text">${escapeHtml(det.name)}</span><button class="btn-icon dash-rename-btn" title="Rename" aria-label="Rename model">&#9998;</button></td>
-          <td class="col-type">${escapeHtml(icon)} ${escapeHtml(det.media_type)}</td>
-          <td class="col-examples"><span class="dash-examples-text">${exSummary}</span><button class="btn-icon dash-edit-examples-btn" title="Edit examples" aria-label="Edit examples">&#9998;</button></td>
-          <td class="col-num-labels" style="text-align:right">${numLabels > 0 ? numLabels : '<span style="color:var(--text-muted)">0</span>'}</td>
-          <td class="col-fav" style="text-align:center"><input type="checkbox" class="fav-checkbox" ${isFav ? "checked" : ""} aria-label="Favorite"></td>
-          <td class="col-date">${escapeHtml(created)}</td>
-          <td class="col-actions"><button class="btn-icon dash-export-btn" title="Export model" aria-label="Export model">&#128230;</button><button class="btn-icon btn-icon-danger dash-delete-btn" title="Remove model" aria-label="Remove model">&#128465;</button></td>
-        `;
-        // Inline rename for model
-        const renameBtn = tr.querySelector(".dash-rename-btn");
-        renameBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          const nameTd = tr.querySelector(".col-name");
-          const nameSpan = nameTd.querySelector(".dash-name-text");
-          const current = nameSpan.textContent;
-          nameSpan.style.display = "none";
-          renameBtn.style.display = "none";
-          const input = document.createElement("input");
-          input.type = "text";
-          input.className = "dash-rename-input";
-          input.value = current;
-          nameTd.insertBefore(input, nameSpan);
-          input.focus();
-          input.select();
-          const commit = async () => {
-            const newName = input.value.trim();
-            if (newName && newName !== current) {
-              try {
-                const res = await fetch(`/api/autorun-detectors/${encodeURIComponent(current)}/rename`, {
-                  method: "PUT",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ new_name: newName }),
-                });
-                if (res.ok) {
-                  det.name = newName;
-                  if (dashSelectedDetector === current) dashSelectedDetector = newName;
-                  nameSpan.textContent = newName;
-                }
-              } catch (_) {}
-            }
-            input.remove();
-            nameSpan.style.display = "";
-            renameBtn.style.display = "";
-          };
-          input.addEventListener("blur", commit);
-          input.addEventListener("keydown", (ev) => {
-            if (ev.key === "Enter") { ev.preventDefault(); input.blur(); }
-            if (ev.key === "Escape") { input.value = current; input.blur(); }
-          });
-        });
-        // Edit examples button
-        const editExBtn = tr.querySelector(".dash-edit-examples-btn");
-        editExBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          openExamplesEditorModal(det);
-        });
-        // Export model
-        const exportBtn = tr.querySelector(".dash-export-btn");
-        exportBtn.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          if (!det.weights) {
-            await vtAlert("This model has no trained weights to export. Label some data first.");
-            return;
-          }
-          await openDetectorExportModal(det.name);
-        });
         // Delete model
         const deleteBtn = tr.querySelector(".dash-delete-btn");
         deleteBtn.addEventListener("click", async (e) => {
           e.stopPropagation();
-          if (!(await vtConfirm(`Delete model "${det.name}"? This cannot be undone.`))) return;
+          if (!(await vtConfirm(`Delete model "${m.name}"? This cannot be undone.`))) return;
           try {
-            const res = await fetch(`/api/autorun-detectors/${encodeURIComponent(det.name)}`, { method: "DELETE" });
-            if (res.ok) {
-              autorunDetectors = autorunDetectors.filter(d => d.name !== det.name);
-              if (dashSelectedDetector === det.name) dashSelectedDetector = null;
-              renderModelRows();
-              updateDashboardButtons();
-              if (autorunDetectors.length === 0) {
-                dashModelGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No detectors loaded yet. Use "+" to create one.</p>';
-              }
-            }
+            await fetch(`/api/models/registry/${encodeURIComponent(m.id)}`, { method: "DELETE" });
+            dashSelectedModelIds = dashSelectedModelIds.filter(id => id !== m.id);
+            await renderDashboardModels();
+            updateDashboardButtons();
           } catch (_) {}
         });
-        // Favorite checkbox toggle
-        const checkbox = tr.querySelector(".fav-checkbox");
-        checkbox.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          const newVal = checkbox.checked;
-          try {
-            await fetch(`/api/autorun-detectors/${encodeURIComponent(det.name)}/autodetect`, {
-              method: "PUT",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ autodetect: newVal }),
-            });
-            det.autodetect = newVal;
-          } catch (_) {
-            checkbox.checked = !newVal; // revert on failure
+
+        // Multi-select click (toggle)
+        tr.addEventListener("click", (e) => {
+          if (e.ctrlKey || e.metaKey) {
+            if (dashSelectedModelIds.includes(m.id)) {
+              dashSelectedModelIds = dashSelectedModelIds.filter(id => id !== m.id);
+            } else {
+              dashSelectedModelIds.push(m.id);
+            }
+          } else {
+            if (dashSelectedModelIds.length === 1 && dashSelectedModelIds[0] === m.id) {
+              dashSelectedModelIds = [];
+            } else {
+              dashSelectedModelIds = [m.id];
+            }
           }
-        });
-        tr.addEventListener("click", () => {
-          dashSelectedDetector = det.name;
           renderModelRows();
           updateDashboardButtons();
         });
         tr.addEventListener("keydown", (e) => {
           if (e.key === "Enter" || e.key === " ") { e.preventDefault(); tr.click(); }
         });
+
         tbody.appendChild(tr);
       });
 
+      // Sort arrows
       table.querySelectorAll("th[data-sort]").forEach(th => {
         const arrow = th.querySelector(".sort-arrow");
         if (th.dataset.sort === modelSort.key) {
@@ -2974,6 +3067,74 @@
     if (exportersList.length === 0) loadExportersList();
 
     // Show modal
+    autodetectModal.classList.add("show");
+  }
+
+  function displayFindResults(data) {
+    // Display multi-dataset, multi-model Find results
+    const results = data.results || [];
+    const modelNames = data.models || [];
+    const datasetNames = data.datasets || [];
+    const multiDs = data.multiple_datasets;
+    const multiMs = data.multiple_models;
+
+    // Summary
+    autodetectSummary.innerHTML = `
+      <p style="color: var(--text-primary);">
+        <strong>Datasets:</strong> ${datasetNames.join(", ")} &nbsp;|&nbsp;
+        <strong>Models:</strong> ${modelNames.join(", ")} &nbsp;|&nbsp;
+        <strong>Good Results:</strong> ${results.length}
+      </p>
+    `;
+
+    if (results.length === 0) {
+      autodetectResults.innerHTML = '<p style="color: var(--text-muted);">No positive hits found.</p>';
+    } else {
+      let tableHtml = `<table class="results-table"><thead><tr>`;
+      if (multiDs) tableHtml += `<th>Dataset</th>`;
+      tableHtml += `<th>Name</th>`;
+      tableHtml += `<th>MD5</th>`;
+      if (multiMs) {
+        for (const mn of modelNames) {
+          tableHtml += `<th>${escapeHtml(mn)}</th>`;
+        }
+      }
+      tableHtml += `</tr></thead><tbody>`;
+      for (const hit of results) {
+        const name = escapeHtml(hit.origin_name || hit.filename || "");
+        const md5 = escapeHtml(hit.md5 || "");
+        tableHtml += `<tr>`;
+        if (multiDs) tableHtml += `<td class="col-secondary">${escapeHtml(hit.dataset_name || "")}</td>`;
+        tableHtml += `<td>${name}</td>`;
+        tableHtml += `<td class="col-muted">${md5}</td>`;
+        if (multiMs) {
+          for (const mn of modelNames) {
+            const v = (hit.model_verdicts || {})[mn];
+            if (v) {
+              const cls = v.verdict === "Good" ? "style=\"color:var(--good-color)\"" : "";
+              tableHtml += `<td ${cls}>${escapeHtml(v.verdict)}</td>`;
+            } else {
+              tableHtml += `<td>-</td>`;
+            }
+          }
+        }
+        tableHtml += `</tr>`;
+      }
+      tableHtml += `</tbody></table>`;
+      autodetectResults.innerHTML = tableHtml;
+    }
+
+    // Store for copying
+    window.autodetectResultsData = data;
+    window.autodetectAllHits = results;
+
+    // Reset export controls
+    const goodRadio = document.querySelector('input[name="export-sides"][value="good"]');
+    if (goodRadio) goodRadio.checked = true;
+    if (fillFromSortCheckbox) fillFromSortCheckbox.checked = false;
+    if (fillFromSortInfo) fillFromSortInfo.textContent = "";
+    setExportStatus("", "var(--text-muted)");
+    if (exportersList.length === 0) loadExportersList();
     autodetectModal.classList.add("show");
   }
 
@@ -6916,26 +7077,45 @@
   // Dashboard: Label button
   if (dashLabelBtn) {
     dashLabelBtn.addEventListener("click", async () => {
-      // Activate train mode when a model is selected
-      if (dashSelectedDetector) {
-        const det = (favoriteDetectors || []).find(d => d.name === dashSelectedDetector);
-        if (det) {
-          _dashboardTrainMode = { model: det };
-        }
+      // Get the selected model from registry
+      const selMs = dashRegisteredModels.filter(m => dashSelectedModelIds.includes(m.id));
+      if (selMs.length === 1 && selMs[0].trainable) {
+        // Build a model object compatible with _dashboardTrainMode
+        const regModel = selMs[0];
+        _dashboardTrainMode = {
+          model: {
+            name: regModel.trainable_model_name || regModel.name,
+            text_query: regModel.text_query || "",
+            trainable: true,
+          },
+        };
       } else {
         _dashboardTrainMode = null;
       }
 
-      if (datasetLoaded) {
-        // Dataset already loaded — go straight to labeling
-        showMainUI();
-        if (medias.length > 0 && !selected) {
-          selectMedia(medias[0].id);
+      // Get the selected dataset from registry
+      const selDs = dashRegisteredDatasets.filter(d => dashSelectedDatasetIds.includes(d.id));
+
+      if (selDs.length === 1) {
+        if (selDs[0].loaded) {
+          // Already loaded — go straight to labeling
+          showMainUI();
+          if (medias.length > 0 && !selected) {
+            selectMedia(medias[0].id);
+          }
+        } else {
+          // Load from registry, then go to labeling
+          showDashGridProgress("Loading dataset...");
+          try {
+            await fetch(`/api/datasets/registry/${encodeURIComponent(selDs[0].id)}/load`, { method: "POST" });
+          } catch (_) {}
+          pollProgress();
         }
         return;
       }
+
+      // Fallback to old behavior for demo dataset selection
       if (dashSelectedDataset) {
-        // Need to load the selected demo dataset first, then go to labeling
         dashLoadSelectedDataset(() => {
           showMainUI();
           if (medias.length > 0 && !selected) {
@@ -6946,30 +7126,71 @@
     });
   }
 
-  // Dashboard: Detect button
+  // Dashboard: Find button
   if (dashDetectBtn) {
     dashDetectBtn.addEventListener("click", async () => {
-      async function runDetect() {
+      const selDs = dashRegisteredDatasets.filter(d => dashSelectedDatasetIds.includes(d.id));
+      const selMs = dashRegisteredModels.filter(m => dashSelectedModelIds.includes(m.id));
+
+      if (selDs.length === 0 && selMs.length === 0) {
+        // Fallback to old single-detector behavior
         if (!dashSelectedDetector) {
-          await vtAlert("Select a detector from the Model grid first.", "warning");
+          await vtAlert("Select a model from the Model grid first.", "warning");
           return;
         }
-        // Run auto-detect
-        autodetectProgressModal.classList.add("show");
-        autodetectProgressText.textContent = "Running auto-detect...";
-        autodetectProgressBar.style.width = "0%";
+        async function runDetectLegacy() {
+          autodetectProgressModal.classList.add("show");
+          autodetectProgressText.textContent = "Running Find...";
+          autodetectProgressBar.style.width = "0%";
+          let progress = 0;
+          const progressInterval = setInterval(() => {
+            progress += 5;
+            if (progress > 90) progress = 90;
+            autodetectProgressBar.style.width = `${progress}%`;
+          }, 200);
+          const res = await fetch("/api/auto-detect", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ detector_name: dashSelectedDetector }),
+          });
+          clearInterval(progressInterval);
+          autodetectProgressBar.style.width = "100%";
+          setTimeout(async () => {
+            autodetectProgressModal.classList.remove("show");
+            if (!res.ok) {
+              await vtAlert("Find failed.", "error");
+              return;
+            }
+            res.json().then(data => displayAutodetectResults(data));
+          }, 500);
+        }
+        if (datasetLoaded) {
+          await runDetectLegacy();
+        } else if (dashSelectedDataset) {
+          dashLoadSelectedDataset(() => runDetectLegacy());
+        }
+        return;
+      }
 
-        let progress = 0;
-        const progressInterval = setInterval(() => {
-          progress += 5;
-          if (progress > 90) progress = 90;
-          autodetectProgressBar.style.width = `${progress}%`;
-        }, 200);
+      // Multi-dataset, multi-model Find via /api/find
+      autodetectProgressModal.classList.add("show");
+      autodetectProgressText.textContent = "Running Find across datasets and models...";
+      autodetectProgressBar.style.width = "0%";
+      let progress = 0;
+      const progressInterval = setInterval(() => {
+        progress += 3;
+        if (progress > 90) progress = 90;
+        autodetectProgressBar.style.width = `${progress}%`;
+      }, 300);
 
-        const res = await fetch("/api/auto-detect", {
+      try {
+        const res = await fetch("/api/find", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ detector_name: dashSelectedDetector }),
+          body: JSON.stringify({
+            dataset_ids: selDs.map(d => d.id),
+            model_ids: selMs.map(m => m.id),
+          }),
         });
 
         clearInterval(progressInterval);
@@ -6978,17 +7199,17 @@
         setTimeout(async () => {
           autodetectProgressModal.classList.remove("show");
           if (!res.ok) {
-            await vtAlert("Auto-detect failed. Make sure you have saved a detector for this media type.", "error");
+            const err = await res.json().catch(() => ({}));
+            await vtAlert(err.error || "Find failed.", "error");
             return;
           }
-          res.json().then(data => displayAutodetectResults(data));
+          const data = await res.json();
+          displayFindResults(data);
         }, 500);
-      }
-
-      if (datasetLoaded) {
-        await runDetect();
-      } else if (dashSelectedDataset) {
-        dashLoadSelectedDataset(() => runDetect());
+      } catch (e) {
+        clearInterval(progressInterval);
+        autodetectProgressModal.classList.remove("show");
+        await vtAlert("Find failed: " + e.message, "error");
       }
     });
   }

--- a/static/app.js
+++ b/static/app.js
@@ -660,7 +660,7 @@
         }
 
         const url = kind === "label"
-          ? `/api/favorite-detectors/from-label-import/${encodeURIComponent(importer.name)}`
+          ? `/api/autorun-detectors/from-label-import/${encodeURIComponent(importer.name)}`
           : `/api/processor-importers/import/${encodeURIComponent(importer.name)}`;
 
         try {
@@ -671,7 +671,7 @@
             statusEl.style.color = "var(--color-good)";
             // Refresh detectors list so the new one is available
             try {
-              const dRes = await fetch("/api/favorite-detectors");
+              const dRes = await fetch("/api/autorun-detectors");
               if (dRes.ok) { const d = await dRes.json(); favoriteDetectors = d.detectors || []; }
             } catch (_) { /* ignore */ }
             setTimeout(() => {
@@ -5687,7 +5687,7 @@
       }
 
       try {
-        const res = await fetch(`/api/favorite-detectors/from-label-import/${encodeURIComponent(importer.name)}`, {
+        const res = await fetch(`/api/autorun-detectors/from-label-import/${encodeURIComponent(importer.name)}`, {
           method: "POST", headers, body,
         });
         const result = await res.json();
@@ -7028,7 +7028,7 @@
         examplesEditorStatus.style.color = "var(--text-muted)";
       }
       try {
-        const url = `/api/favorite-detectors/${encodeURIComponent(det.name)}/examples`;
+        const url = `/api/autorun-detectors/${encodeURIComponent(det.name)}/examples`;
         const res = await fetch(url, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },

--- a/static/index.html
+++ b/static/index.html
@@ -156,7 +156,7 @@
       </div>
       <div class="dashboard-actions">
         <button class="dashboard-action-btn" id="dash-label-btn" disabled>Label</button>
-        <button class="dashboard-action-btn secondary" id="dash-detect-btn" disabled>Detect</button>
+        <button class="dashboard-action-btn secondary" id="dash-detect-btn" disabled>Find</button>
       </div>
       <input type="file" id="dash-file-input" accept=".pkl" style="display:none">
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -696,6 +696,11 @@ video { max-width: 100%; }
 }
 .dashboard-action-btn.secondary:hover { background: var(--accent-highlight-bg); }
 .dashboard-action-btn.secondary:disabled { background: transparent; }
+.dashboard-actions { flex-wrap: wrap; }
+.dash-btn-hint {
+  display: block; width: 100%; font-size: 0.72rem; color: var(--text-muted);
+  text-align: center; margin-top: 2px; min-height: 1em;
+}
 
 /* Header nav button (Dashboard link visible during labeling) */
 .header-nav-btn {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,13 @@ def reset_state():
     _state.autorun_localizers.clear()
     clear_progress_cache()
 
+    # Reset the dataset and model registries
+    from vtsearch.datasets.registry import reset_for_tests as _reset_ds_reg
+    from vtsearch.models.registry import reset_for_tests as _reset_model_reg
+
+    _reset_ds_reg()
+    _reset_model_reg()
+
 
 @pytest.fixture(autouse=True)
 def isolated_settings(tmp_path, monkeypatch):
@@ -151,8 +158,21 @@ def isolated_settings(tmp_path, monkeypatch):
     test_settings_path = tmp_path / "settings.json"
     monkeypatch.setattr(settings_mod, "SETTINGS_PATH", test_settings_path)
     settings_mod.reset()
+
+    # Also redirect dataset and model registries to temp paths
+    from vtsearch.datasets import registry as ds_reg_mod
+    from vtsearch.models import registry as model_reg_mod
+
+    monkeypatch.setattr(ds_reg_mod, "REGISTRY_PATH", tmp_path / "dataset_registry.json")
+    monkeypatch.setattr(ds_reg_mod, "SAVED_DATASETS_DIR", tmp_path / "saved_datasets")
+    monkeypatch.setattr(model_reg_mod, "REGISTRY_PATH", tmp_path / "model_registry.json")
+    ds_reg_mod.reset_for_tests()
+    model_reg_mod.reset_for_tests()
+
     yield test_settings_path
     settings_mod.reset()
+    ds_reg_mod.reset_for_tests()
+    model_reg_mod.reset_for_tests()
 
 
 @pytest.fixture

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -555,7 +555,7 @@ class TestFromLabelImportEndpoint:
 
     def test_trains_from_csv_label_import(self, client, tmp_path):
         """Verify from-label-import works with the server_csv_file label importer."""
-        from vtsearch.utils import favorite_detectors, medias
+        from vtsearch.utils import autorun_detectors, medias
 
         md5s = []
         for cid in sorted(medias.keys()):
@@ -577,7 +577,7 @@ class TestFromLabelImportEndpoint:
         p = tmp_path / "labels.csv"
         p.write_text("\n".join(lines))
         res = client.post(
-            "/api/favorite-detectors/from-label-import/server_csv_file",
+            "/api/autorun-detectors/from-label-import/server_csv_file",
             json={"filepath": str(p), "name": "csv_label_import_test"},
         )
         assert res.status_code == 200
@@ -585,7 +585,7 @@ class TestFromLabelImportEndpoint:
         assert result["success"] is True
         assert result["name"] == "csv_label_import_test"
         assert result["loaded"] >= 2
-        assert "csv_label_import_test" in favorite_detectors
+        assert "csv_label_import_test" in autorun_detectors
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/datasets/registry.py
+++ b/vtsearch/datasets/registry.py
@@ -1,0 +1,196 @@
+"""Persistent dataset registry.
+
+Maintains a JSON manifest at ``data/dataset_registry.json`` that tracks every
+dataset the user has loaded.  Each entry stores enough metadata to display the
+dataset in the dashboard grid and to re-load it from its saved ``.pkl`` file.
+
+At most one dataset is *loaded* into memory at a time, but the registry
+remembers all datasets across app restarts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from vtsearch.config import DATA_DIR
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_PATH = DATA_DIR / "dataset_registry.json"
+SAVED_DATASETS_DIR = DATA_DIR / "saved_datasets"
+
+_lock = threading.RLock()
+
+# In-memory cache — loaded once from disk, written back on every mutation.
+_entries: list[dict[str, Any]] | None = None
+
+# The ``id`` of the currently loaded dataset entry, or ``None``.
+_loaded_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _load() -> list[dict[str, Any]]:
+    """Read the registry from disk, returning an empty list on failure."""
+    if REGISTRY_PATH.exists():
+        try:
+            text = REGISTRY_PATH.read_text(encoding="utf-8")
+            data = json.loads(text)
+            if isinstance(data, list):
+                return data
+        except Exception as exc:
+            logger.warning("Failed to read dataset registry: %s", exc)
+    return []
+
+
+def _save(entries: list[dict[str, Any]]) -> None:
+    """Write *entries* to disk atomically."""
+    import os
+
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = REGISTRY_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    os.replace(str(tmp), str(REGISTRY_PATH))
+
+
+def _ensure_loaded() -> list[dict[str, Any]]:
+    """Return the in-memory cache, loading from disk on first call."""
+    global _entries
+    if _entries is None:
+        _entries = _load()
+    return _entries
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_datasets() -> list[dict[str, Any]]:
+    """Return summary info for all registered datasets."""
+    with _lock:
+        return list(_ensure_loaded())
+
+
+def get_dataset(dataset_id: str) -> dict[str, Any] | None:
+    """Return a single registry entry by *dataset_id*, or ``None``."""
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry["id"] == dataset_id:
+                return dict(entry)
+    return None
+
+
+def register_dataset(
+    *,
+    name: str,
+    media_type: str,
+    num_items: int,
+    pkl_path: str,
+    origin: str = "unknown",
+    source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Add a new dataset to the registry and persist.
+
+    Returns the newly created entry (with a generated ``id``).
+    """
+    import uuid
+
+    entry: dict[str, Any] = {
+        "id": uuid.uuid4().hex,
+        "name": name,
+        "media_type": media_type,
+        "num_items": num_items,
+        "pkl_path": pkl_path,
+        "origin": origin,
+        "source": source,
+        "created_at": time.time(),
+    }
+    with _lock:
+        entries = _ensure_loaded()
+        entries.append(entry)
+        _save(entries)
+    return entry
+
+
+def unregister_dataset(dataset_id: str) -> bool:
+    """Remove a dataset from the registry and delete its pkl file.
+
+    Returns ``True`` if the dataset was found and removed.
+    """
+    global _loaded_id
+    with _lock:
+        entries = _ensure_loaded()
+        for i, entry in enumerate(entries):
+            if entry["id"] == dataset_id:
+                pkl = Path(entry.get("pkl_path", ""))
+                if pkl.is_file():
+                    pkl.unlink(missing_ok=True)
+                entries.pop(i)
+                if _loaded_id == dataset_id:
+                    _loaded_id = None
+                _save(entries)
+                return True
+    return False
+
+
+def rename_dataset(dataset_id: str, new_name: str) -> bool:
+    """Rename a registered dataset. Returns ``True`` on success."""
+    with _lock:
+        entries = _ensure_loaded()
+        for entry in entries:
+            if entry["id"] == dataset_id:
+                entry["name"] = new_name
+                _save(entries)
+                return True
+    return False
+
+
+def update_dataset(dataset_id: str, **fields: Any) -> bool:
+    """Update arbitrary fields on a registered dataset."""
+    with _lock:
+        entries = _ensure_loaded()
+        for entry in entries:
+            if entry["id"] == dataset_id:
+                entry.update(fields)
+                _save(entries)
+                return True
+    return False
+
+
+def get_loaded_id() -> str | None:
+    """Return the ID of the currently loaded dataset, or ``None``."""
+    with _lock:
+        return _loaded_id
+
+
+def set_loaded_id(dataset_id: str | None) -> None:
+    """Mark *dataset_id* as the currently loaded dataset (or ``None``)."""
+    global _loaded_id
+    with _lock:
+        _loaded_id = dataset_id
+
+
+def find_by_pkl_path(pkl_path: str) -> dict[str, Any] | None:
+    """Return the entry whose ``pkl_path`` matches, or ``None``."""
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry.get("pkl_path") == pkl_path:
+                return dict(entry)
+    return None
+
+
+def reset_for_tests() -> None:
+    """Reset the in-memory cache (for test isolation)."""
+    global _entries, _loaded_id
+    with _lock:
+        _entries = None
+        _loaded_id = None

--- a/vtsearch/models/registry.py
+++ b/vtsearch/models/registry.py
@@ -21,7 +21,6 @@ import json
 import logging
 import threading
 import time
-from pathlib import Path
 from typing import Any
 
 from vtsearch.config import DATA_DIR

--- a/vtsearch/models/registry.py
+++ b/vtsearch/models/registry.py
@@ -1,0 +1,213 @@
+"""Persistent model registry.
+
+Maintains a JSON manifest at ``data/model_registry.json`` that tracks every
+model (detector / processor) the user has created.  Each entry stores enough
+metadata to display the model in the dashboard grid.
+
+Models come in two flavours:
+
+* **Trainable** — backed by a labelset (``data/trainable_models/<slug>.json``).
+  Shows a training-count in the "# Training" column.  Can be loaded for
+  labeling and then used for Find.
+* **Non-trainable** (pregen) — backed by weights (in-memory autorun detector
+  or a detector JSON file on disk).  Shows "-" in the "# Training" column.
+
+At most one model is *loaded* into memory at a time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from vtsearch.config import DATA_DIR
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_PATH = DATA_DIR / "model_registry.json"
+
+_lock = threading.RLock()
+
+_entries: list[dict[str, Any]] | None = None
+
+# The ``id`` of the currently loaded model, or ``None``.
+_loaded_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _load() -> list[dict[str, Any]]:
+    if REGISTRY_PATH.exists():
+        try:
+            text = REGISTRY_PATH.read_text(encoding="utf-8")
+            data = json.loads(text)
+            if isinstance(data, list):
+                return data
+        except Exception as exc:
+            logger.warning("Failed to read model registry: %s", exc)
+    return []
+
+
+def _save(entries: list[dict[str, Any]]) -> None:
+    import os
+
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = REGISTRY_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    os.replace(str(tmp), str(REGISTRY_PATH))
+
+
+def _ensure_loaded() -> list[dict[str, Any]]:
+    global _entries
+    if _entries is None:
+        _entries = _load()
+    return _entries
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_models() -> list[dict[str, Any]]:
+    """Return summary info for all registered models."""
+    with _lock:
+        return list(_ensure_loaded())
+
+
+def get_model(model_id: str) -> dict[str, Any] | None:
+    """Return a single registry entry by *model_id*, or ``None``."""
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry["id"] == model_id:
+                return dict(entry)
+    return None
+
+
+def register_model(
+    *,
+    name: str,
+    media_type: str,
+    trainable: bool,
+    num_training: int = 0,
+    detector_name: str = "",
+    trainable_model_name: str = "",
+    text_query: str = "",
+) -> dict[str, Any]:
+    """Add a new model to the registry and persist.
+
+    Args:
+        name: Display name for the dashboard.
+        media_type: ``"audio"``, ``"image"``, ``"video"``, ``"paragraph"``, etc.
+        trainable: Whether the model has a labelset that can be extended.
+        num_training: Number of training examples (label count or "-" marker).
+        detector_name: The key used in ``autorun_detectors`` (for non-trainable).
+        trainable_model_name: The key used in ``data/trainable_models/`` (for trainable).
+        text_query: Text-sort query associated with the model.
+
+    Returns:
+        The newly created entry dict.
+    """
+    import uuid
+
+    entry: dict[str, Any] = {
+        "id": uuid.uuid4().hex,
+        "name": name,
+        "media_type": media_type,
+        "trainable": trainable,
+        "num_training": num_training,
+        "detector_name": detector_name,
+        "trainable_model_name": trainable_model_name,
+        "text_query": text_query,
+        "created_at": time.time(),
+    }
+    with _lock:
+        entries = _ensure_loaded()
+        entries.append(entry)
+        _save(entries)
+    return entry
+
+
+def unregister_model(model_id: str) -> bool:
+    """Remove a model from the registry. Returns ``True`` if found."""
+    global _loaded_id
+    with _lock:
+        entries = _ensure_loaded()
+        for i, entry in enumerate(entries):
+            if entry["id"] == model_id:
+                entries.pop(i)
+                if _loaded_id == model_id:
+                    _loaded_id = None
+                _save(entries)
+                return True
+    return False
+
+
+def rename_model(model_id: str, new_name: str) -> bool:
+    """Rename a registered model. Returns ``True`` on success."""
+    with _lock:
+        entries = _ensure_loaded()
+        for entry in entries:
+            if entry["id"] == model_id:
+                entry["name"] = new_name
+                _save(entries)
+                return True
+    return False
+
+
+def update_model(model_id: str, **fields: Any) -> bool:
+    """Update arbitrary fields on a registered model."""
+    with _lock:
+        entries = _ensure_loaded()
+        for entry in entries:
+            if entry["id"] == model_id:
+                entry.update(fields)
+                _save(entries)
+                return True
+    return False
+
+
+def find_by_detector_name(det_name: str) -> dict[str, Any] | None:
+    """Return the entry whose ``detector_name`` matches, or ``None``."""
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry.get("detector_name") == det_name:
+                return dict(entry)
+    return None
+
+
+def find_by_trainable_model_name(tm_name: str) -> dict[str, Any] | None:
+    """Return the entry whose ``trainable_model_name`` matches, or ``None``."""
+    with _lock:
+        for entry in _ensure_loaded():
+            if entry.get("trainable_model_name") == tm_name:
+                return dict(entry)
+    return None
+
+
+def get_loaded_id() -> str | None:
+    """Return the ID of the currently loaded model, or ``None``."""
+    with _lock:
+        return _loaded_id
+
+
+def set_loaded_id(model_id: str | None) -> None:
+    """Mark *model_id* as the currently loaded model (or ``None``)."""
+    global _loaded_id
+    with _lock:
+        _loaded_id = model_id
+
+
+def reset_for_tests() -> None:
+    """Reset the in-memory cache (for test isolation)."""
+    global _entries, _loaded_id
+    with _lock:
+        _entries = None
+        _loaded_id = None

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -13,7 +13,6 @@ from vtsearch.config import DATA_DIR, EMBEDDINGS_DIR
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers, load_demo_dataset
 from vtsearch.datasets.registry import (
     SAVED_DATASETS_DIR,
-    find_by_pkl_path as _reg_find_by_pkl,
     get_loaded_id as _reg_loaded_id,
     list_datasets as _reg_list_datasets,
     register_dataset as _reg_register,

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -11,6 +11,18 @@ from flask import Blueprint, jsonify, request, send_file
 
 from vtsearch.config import DATA_DIR, EMBEDDINGS_DIR
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers, load_demo_dataset
+from vtsearch.datasets.registry import (
+    SAVED_DATASETS_DIR,
+    find_by_pkl_path as _reg_find_by_pkl,
+    get_loaded_id as _reg_loaded_id,
+    list_datasets as _reg_list_datasets,
+    register_dataset as _reg_register,
+    rename_dataset as _reg_rename,
+    set_loaded_id as _reg_set_loaded,
+    unregister_dataset as _reg_unregister,
+    update_dataset as _reg_update,
+    get_dataset as _reg_get,
+)
 from vtsearch.utils import (
     bad_votes,
     build_diversity_tree,
@@ -116,6 +128,48 @@ def _set_clip_origins(clips_dict: dict, origin: dict) -> None:
             media["origin_name"] = media.get("filename", "")
 
 
+def _auto_register_dataset(name: str = "", origin_str: str = "unknown", source: dict | None = None) -> None:
+    """Save the current medias as a pkl and register in the dataset registry.
+
+    Called at the end of every successful dataset load.  Skips if medias is
+    empty or if a registry entry with the same pkl path already exists (to
+    avoid duplicating on reload).
+    """
+    if not medias:
+        return
+    from uuid import uuid4
+
+    first = next(iter(medias.values()))
+    media_type = first.get("type", "audio")
+    num_items = len(medias)
+
+    # Derive name from display-name override, origin, or fallback
+    if not name:
+        name = get_dataset_display_name() or origin_str or "Untitled"
+        if ":" in name:
+            name = name.split(":", 1)[1] or name
+
+    # Save to a pkl file in saved_datasets/
+    SAVED_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
+    pkl_path = str(SAVED_DATASETS_DIR / f"ds_{uuid4().hex}.pkl")
+    try:
+        data_bytes = export_dataset_to_file(medias)
+        Path(pkl_path).write_bytes(data_bytes)
+        del data_bytes
+    except Exception:
+        return
+
+    entry = _reg_register(
+        name=name,
+        media_type=media_type,
+        num_items=num_items,
+        pkl_path=pkl_path,
+        origin=origin_str,
+        source=source,
+    )
+    _reg_set_loaded(entry["id"])
+
+
 def _run_importer_in_background(importer, field_values: dict) -> None:
     """Start *importer*.run() in a daemon thread after clearing the dataset."""
 
@@ -124,10 +178,18 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
             clear_dataset()
             gc.collect()
             importer.run(field_values, medias)
-            _set_clip_origins(medias, importer.build_origin(field_values))
+            origin = importer.build_origin(field_values)
+            _set_clip_origins(medias, origin)
             collapse_duplicates(medias)
             _load_embedder_for_clips()
             build_diversity_tree()
+            # Auto-register in the dataset registry
+            origin_str = _origin_to_str(origin)
+            _auto_register_dataset(
+                name=importer.display_name,
+                origin_str=origin_str,
+                source=origin,
+            )
         except MemoryError:
             medias.clear()
             gc.collect()
@@ -141,6 +203,23 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
 
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
+
+
+def _origin_to_str(origin: dict | None) -> str:
+    """Convert an origin dict to a human-readable string."""
+    if not origin:
+        return "unknown"
+    importer = origin.get("importer", "")
+    params = origin.get("params", {})
+    if importer == "demo":
+        return f"demo:{params.get('name', '')}"
+    elif importer == "pickle":
+        return f"file:{params.get('filename', '')}"
+    elif importer == "folder":
+        return f"folder:{params.get('path', '')}"
+    elif importer:
+        return importer
+    return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -652,6 +731,12 @@ def load_demo_dataset_route():
             collapse_duplicates(medias)
             _load_embedder_for_clips()
             build_diversity_tree()
+            # Auto-register in the dataset registry
+            _auto_register_dataset(
+                name=dataset_name,
+                origin_str=f"demo:{dataset_name}",
+                source=demo_origin,
+            )
         except MemoryError:
             medias.clear()
             gc.collect()
@@ -751,6 +836,7 @@ def export_dataset():
 def clear_dataset_route():
     """Clear the current dataset."""
     clear_dataset()
+    _reg_set_loaded(None)
     return jsonify({"ok": True})
 
 
@@ -828,6 +914,101 @@ def dashboard_dataset_rename():
     return jsonify({"success": True, "name": new_name})
 
 
+# ---------------------------------------------------------------------------
+# Dataset registry endpoints
+# ---------------------------------------------------------------------------
+
+
+@datasets_bp.route("/api/datasets/registry")
+def list_registered_datasets():
+    """Return all registered datasets with their loaded state."""
+    entries = _reg_list_datasets()
+    loaded_id = _reg_loaded_id()
+    for entry in entries:
+        entry["loaded"] = entry["id"] == loaded_id
+    return jsonify({"datasets": entries})
+
+
+@datasets_bp.route("/api/datasets/registry/<dataset_id>/load", methods=["POST"])
+def load_registered_dataset(dataset_id: str):
+    """Load a registered dataset from its saved pkl file."""
+    entry = _reg_get(dataset_id)
+    if entry is None:
+        return jsonify({"error": "Dataset not found in registry"}), 404
+
+    pkl_path = entry.get("pkl_path", "")
+    if not pkl_path or not Path(pkl_path).is_file():
+        return jsonify({"error": f"Saved dataset file not found: {pkl_path}"}), 404
+
+    importer = get_importer("pickle")
+    if importer is None:
+        return jsonify({"error": "pickle importer not available"}), 500
+
+    def load_task():
+        try:
+            clear_dataset()
+            _reg_set_loaded(None)
+            gc.collect()
+            importer.run({"pkl_path": pkl_path}, medias)
+            collapse_duplicates(medias)
+            _load_embedder_for_clips()
+            build_diversity_tree()
+            _reg_set_loaded(dataset_id)
+            # Update item count in case it changed
+            _reg_update(dataset_id, num_items=len(medias))
+            set_dataset_display_name(entry.get("name", ""))
+        except MemoryError:
+            medias.clear()
+            gc.collect()
+            update_progress("idle", "", 0, 0, "Out of memory — dataset too large.")
+        except Exception as e:
+            update_progress("idle", "", 0, 0, str(e))
+
+    thread = threading.Thread(target=load_task, daemon=True)
+    thread.start()
+    return jsonify({"ok": True, "message": "Loading started"})
+
+
+@datasets_bp.route("/api/datasets/registry/<dataset_id>/unload", methods=["POST"])
+def unload_registered_dataset(dataset_id: str):
+    """Unload the currently loaded dataset (clear from memory)."""
+    loaded = _reg_loaded_id()
+    if loaded != dataset_id:
+        return jsonify({"error": "This dataset is not currently loaded"}), 400
+    clear_dataset()
+    _reg_set_loaded(None)
+    return jsonify({"ok": True})
+
+
+@datasets_bp.route("/api/datasets/registry/<dataset_id>", methods=["DELETE"])
+def delete_registered_dataset(dataset_id: str):
+    """Remove a dataset from the registry and delete its pkl file."""
+    loaded = _reg_loaded_id()
+    if loaded == dataset_id:
+        clear_dataset()
+        _reg_set_loaded(None)
+    ok = _reg_unregister(dataset_id)
+    if not ok:
+        return jsonify({"error": "Dataset not found"}), 404
+    return jsonify({"ok": True})
+
+
+@datasets_bp.route("/api/datasets/registry/<dataset_id>/rename", methods=["PUT"])
+def rename_registered_dataset(dataset_id: str):
+    """Rename a registered dataset."""
+    data = request.get_json(force=True, silent=True) or {}
+    new_name = data.get("name", "").strip()
+    if not new_name:
+        return jsonify({"error": "name is required"}), 400
+    ok = _reg_rename(dataset_id, new_name)
+    if not ok:
+        return jsonify({"error": "Dataset not found"}), 404
+    # Also update display name if this is the loaded dataset
+    if _reg_loaded_id() == dataset_id:
+        set_dataset_display_name(new_name)
+    return jsonify({"ok": True, "name": new_name})
+
+
 @datasets_bp.route("/api/dataset/load-source", methods=["POST"])
 def load_dataset_from_source():
     """Reload a dataset from a stored source origin dict.
@@ -869,10 +1050,16 @@ def _load_from_origin(source: dict):
                 clear_dataset()
                 gc.collect()
                 load_demo_dataset(demo_name, medias)
-                _set_clip_origins(medias, {"importer": "demo", "params": {"name": demo_name}})
+                demo_origin = {"importer": "demo", "params": {"name": demo_name}}
+                _set_clip_origins(medias, demo_origin)
                 collapse_duplicates(medias)
                 _load_embedder_for_clips()
                 build_diversity_tree()
+                _auto_register_dataset(
+                    name=demo_name,
+                    origin_str=f"demo:{demo_name}",
+                    source=demo_origin,
+                )
             except MemoryError:
                 medias.clear()
                 gc.collect()

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -887,12 +887,9 @@ def multi_find():
     """
     import gc
     import pickle
-    import threading
 
     import torch
 
-    from vtsearch.datasets import export_dataset_to_file
-    from vtsearch.datasets.loader import load_dataset_from_pickle
     from vtsearch.datasets.registry import get_dataset as reg_get_ds
     from vtsearch.models.registry import get_model as reg_get_model
     from vtsearch.routes.trainable_models import _model_path, _read_model
@@ -1030,7 +1027,6 @@ def multi_find():
                 # Trainable model — train from labelset, then score
                 tm_data = mc["trainable_model_data"]
                 labels = tm_data.get("labelset", {}).get("labels", [])
-                text_query = tm_data.get("text_query", "")
 
                 # Try to match labels to this dataset's medias and train
                 try:

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -867,6 +867,247 @@ def auto_detect():
 
 
 # ---------------------------------------------------------------------------
+# Multi-dataset, multi-model Find
+# ---------------------------------------------------------------------------
+
+
+@detectors_bp.route("/api/find", methods=["POST"])
+def multi_find():
+    """Run selected models on selected datasets and return merged results.
+
+    Expects JSON::
+
+        {
+            "dataset_ids": ["abc123", "def456"],
+            "model_ids": ["ghi789", "jkl012"]
+        }
+
+    For each dataset: loads it from its saved pkl, then for each model runs
+    detection.  Returns a merged results table.
+    """
+    import gc
+    import pickle
+    import threading
+
+    import torch
+
+    from vtsearch.datasets import export_dataset_to_file
+    from vtsearch.datasets.loader import load_dataset_from_pickle
+    from vtsearch.datasets.registry import get_dataset as reg_get_ds
+    from vtsearch.models.registry import get_model as reg_get_model
+    from vtsearch.routes.trainable_models import _model_path, _read_model
+
+    body = request.get_json(force=True, silent=True) or {}
+    dataset_ids = body.get("dataset_ids", [])
+    model_ids = body.get("model_ids", [])
+
+    if not dataset_ids:
+        return jsonify({"error": "No datasets selected"}), 400
+    if not model_ids:
+        return jsonify({"error": "No models selected"}), 400
+
+    # Resolve datasets and models from registries
+    datasets = []
+    for ds_id in dataset_ids:
+        ds = reg_get_ds(ds_id)
+        if ds is None:
+            return jsonify({"error": f"Dataset '{ds_id}' not found"}), 404
+        pkl_path = ds.get("pkl_path", "")
+        if not pkl_path or not Path(pkl_path).is_file():
+            return jsonify({"error": f"Dataset file missing for '{ds.get('name', ds_id)}'"}), 404
+        datasets.append(ds)
+
+    models = []
+    for m_id in model_ids:
+        m = reg_get_model(m_id)
+        if m is None:
+            return jsonify({"error": f"Model '{m_id}' not found"}), 404
+        models.append(m)
+
+    # Build the list of detector configs (weights+threshold) for each model
+    model_configs = []
+    for m in models:
+        det_name = m.get("detector_name", "")
+        tm_name = m.get("trainable_model_name", "")
+
+        # Try autorun detector first (has weights)
+        if det_name:
+            det = get_autorun_detectors().get(det_name)
+            if det and det.get("weights"):
+                model_configs.append({
+                    "name": m["name"],
+                    "model_id": m["id"],
+                    "weights": det["weights"],
+                    "threshold": det.get("threshold", 0.5),
+                })
+                continue
+
+        # For trainable models, we need to train on-the-fly from their labelset
+        if tm_name:
+            tm_path = _model_path(tm_name)
+            tm_data = _read_model(tm_path)
+            if tm_data and tm_data.get("labelset", {}).get("labels"):
+                model_configs.append({
+                    "name": m["name"],
+                    "model_id": m["id"],
+                    "trainable_model_data": tm_data,
+                })
+                continue
+
+        return jsonify({"error": f"Model '{m['name']}' has no weights or labels for detection"}), 400
+
+    # Run Find across all datasets × models
+    all_results = []
+    multiple_datasets = len(datasets) > 1
+    multiple_models = len(model_configs) > 1
+    model_names = [mc["name"] for mc in model_configs]
+
+    for ds in datasets:
+        # Load dataset from pkl
+        temp_medias: dict = {}
+        try:
+            pkl_path = ds["pkl_path"]
+            with open(pkl_path, "rb") as f:
+                pkl_data = pickle.load(f)
+            if isinstance(pkl_data, dict) and "medias" in pkl_data:
+                raw_medias = pkl_data["medias"]
+            else:
+                raw_medias = pkl_data
+
+            for cid, mdata in raw_medias.items():
+                mid = int(cid) if not isinstance(cid, int) else cid
+                emb = mdata.get("embedding")
+                if emb is not None:
+                    emb = np.array(emb, dtype=np.float32)
+                temp_medias[mid] = {**mdata, "id": mid, "embedding": emb}
+        except Exception as e:
+            return jsonify({"error": f"Failed to load dataset '{ds['name']}': {e}"}), 500
+
+        if not temp_medias:
+            continue
+
+        # Build embeddings tensor
+        all_ids = sorted(temp_medias.keys())
+        all_embs = np.array([temp_medias[cid]["embedding"] for cid in all_ids])
+        X_all = torch.tensor(all_embs, dtype=torch.float32)
+
+        # Per-media result: {media_id -> {info, per_model_scores}}
+        media_results: dict[int, dict] = {}
+        for cid in all_ids:
+            clip = temp_medias[cid]
+            media_results[cid] = {
+                "id": cid,
+                "filename": clip.get("filename", ""),
+                "md5": clip.get("md5", ""),
+                "origin_name": clip.get("origin_name", clip.get("filename", "")),
+                "origin": clip.get("origin"),
+                "dataset_name": ds["name"],
+                "model_verdicts": {},
+            }
+
+        # Run each model on this dataset
+        for mc in model_configs:
+            if "weights" in mc:
+                # Pre-trained detector with weights
+                try:
+                    model = build_model_from_weights(mc["weights"])
+                    with torch.no_grad():
+                        scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
+                    threshold = mc.get("threshold", 0.5)
+                    for cid, score in zip(all_ids, scores):
+                        verdict = "Good" if score >= threshold else "Bad"
+                        media_results[cid]["model_verdicts"][mc["name"]] = {
+                            "verdict": verdict,
+                            "score": round(score, 4),
+                        }
+                except Exception:
+                    for cid in all_ids:
+                        media_results[cid]["model_verdicts"][mc["name"]] = {
+                            "verdict": "Error",
+                            "score": 0,
+                        }
+            elif "trainable_model_data" in mc:
+                # Trainable model — train from labelset, then score
+                tm_data = mc["trainable_model_data"]
+                labels = tm_data.get("labelset", {}).get("labels", [])
+                text_query = tm_data.get("text_query", "")
+
+                # Try to match labels to this dataset's medias and train
+                try:
+                    from vtsearch.utils import build_media_lookup, resolve_media_ids
+
+                    origin_lookup, md5_lookup = build_media_lookup(temp_medias)
+                    good_ids, bad_ids = [], []
+                    for lbl in labels:
+                        matched = resolve_media_ids(lbl, origin_lookup, md5_lookup)
+                        label_val = lbl.get("label", "")
+                        for mid in matched:
+                            if label_val == "good":
+                                good_ids.append(mid)
+                            elif label_val == "bad":
+                                bad_ids.append(mid)
+
+                    if good_ids and bad_ids:
+                        good_embs = [temp_medias[i]["embedding"] for i in good_ids if i in temp_medias]
+                        bad_embs = [temp_medias[i]["embedding"] for i in bad_ids if i in temp_medias]
+                        X_list = good_embs + bad_embs
+                        y_list = [1.0] * len(good_embs) + [0.0] * len(bad_embs)
+
+                        from vtsearch.models import calculate_cross_calibration_threshold, train_model
+
+                        input_dim = X_list[0].shape[0]
+                        threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim)
+
+                        import torch
+
+                        X_train = torch.tensor(np.array(X_list), dtype=torch.float32)
+                        y_train = torch.tensor([[v] for v in y_list], dtype=torch.float32)
+                        model = train_model(X_train, y_train, input_dim)
+
+                        with torch.no_grad():
+                            scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
+
+                        for cid, score in zip(all_ids, scores):
+                            verdict = "Good" if score >= threshold else "Bad"
+                            media_results[cid]["model_verdicts"][mc["name"]] = {
+                                "verdict": verdict,
+                                "score": round(score, 4),
+                            }
+                    else:
+                        # Not enough labels matched this dataset
+                        for cid in all_ids:
+                            media_results[cid]["model_verdicts"][mc["name"]] = {
+                                "verdict": "N/A",
+                                "score": 0,
+                            }
+                except Exception:
+                    for cid in all_ids:
+                        media_results[cid]["model_verdicts"][mc["name"]] = {
+                            "verdict": "Error",
+                            "score": 0,
+                        }
+
+        # Collect positive hits (Good for at least one model)
+        for cid, mr in media_results.items():
+            verdicts = mr["model_verdicts"]
+            if any(v["verdict"] == "Good" for v in verdicts.values()):
+                all_results.append(mr)
+
+        # Free memory
+        del temp_medias, X_all
+        gc.collect()
+
+    return jsonify({
+        "results": all_results,
+        "datasets": [ds["name"] for ds in datasets],
+        "models": model_names,
+        "multiple_datasets": multiple_datasets,
+        "multiple_models": multiple_models,
+        "total_hits": len(all_results),
+    })
+
+
+# ---------------------------------------------------------------------------
 # Extractor routes
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -271,8 +271,147 @@ def save_trainable_model_labels(name: str):
     data["labelset"] = labelset.to_dict()
     _write_model(path, data)
 
+    # Also update the model registry entry if one exists
+    from vtsearch.models.registry import find_by_trainable_model_name, update_model
+
+    reg_entry = find_by_trainable_model_name(name)
+    if reg_entry:
+        update_model(reg_entry["id"], num_training=len(labelset))
+
     return jsonify({
         "success": True,
         "name": name,
         "num_labels": len(labelset),
     })
+
+
+# ---------------------------------------------------------------------------
+# Model registry endpoints
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/models/registry")
+def list_registered_models():
+    """Return all registered models with their loaded state."""
+    from vtsearch.models.registry import get_loaded_id, list_models
+
+    entries = list_models()
+    loaded_id = get_loaded_id()
+    for entry in entries:
+        entry["loaded"] = entry["id"] == loaded_id
+    return jsonify({"models": entries})
+
+
+@trainable_models_bp.route("/api/models/registry", methods=["POST"])
+def register_model_route():
+    """Register a new model in the model registry.
+
+    Expects JSON::
+
+        {
+            "name": "Dog Barks",
+            "media_type": "audio",
+            "trainable": true,
+            "text_query": "dog barking sounds"
+        }
+    """
+    from vtsearch.models.registry import register_model
+
+    data = request.get_json(force=True, silent=True) or {}
+    name = data.get("name", "").strip()
+    media_type = data.get("media_type", "").strip()
+    trainable = data.get("trainable", True)
+    text_query = data.get("text_query", "")
+    detector_name = data.get("detector_name", "")
+    trainable_model_name = data.get("trainable_model_name", "")
+
+    if not name:
+        return jsonify({"error": "name is required"}), 400
+
+    # If trainable, also create the trainable model file if needed
+    if trainable and not trainable_model_name:
+        trainable_model_name = name
+        tm_path = _model_path(name)
+        if not tm_path.exists():
+            examples = []
+            if text_query:
+                examples = [{"type": "text", "value": text_query}]
+            model_data = {
+                "name": name,
+                "text_query": text_query,
+                "media_type": media_type or "any",
+                "examples": examples,
+                "created_at": time.time(),
+                "labelset": {"labels": []},
+            }
+            _write_model(tm_path, model_data)
+
+    entry = register_model(
+        name=name,
+        media_type=media_type or "any",
+        trainable=trainable,
+        text_query=text_query,
+        detector_name=detector_name,
+        trainable_model_name=trainable_model_name,
+    )
+    return jsonify({"ok": True, "model": entry}), 201
+
+
+@trainable_models_bp.route("/api/models/registry/<model_id>", methods=["DELETE"])
+def delete_registered_model(model_id: str):
+    """Remove a model from the registry."""
+    from vtsearch.models.registry import get_model, unregister_model
+
+    entry = get_model(model_id)
+    if entry is None:
+        return jsonify({"error": "Model not found"}), 404
+
+    # Also clean up the underlying trainable model file
+    tm_name = entry.get("trainable_model_name", "")
+    if tm_name:
+        tm_path = _model_path(tm_name)
+        if tm_path.exists():
+            tm_path.unlink(missing_ok=True)
+
+    # Clean up the autorun detector if any
+    det_name = entry.get("detector_name", "")
+    if det_name:
+        from vtsearch.utils import remove_autorun_detector
+
+        remove_autorun_detector(det_name)
+
+    unregister_model(model_id)
+    return jsonify({"ok": True})
+
+
+@trainable_models_bp.route("/api/models/registry/<model_id>/rename", methods=["PUT"])
+def rename_registered_model(model_id: str):
+    """Rename a registered model."""
+    from vtsearch.models.registry import get_model, rename_model
+
+    data = request.get_json(force=True, silent=True) or {}
+    new_name = data.get("name", "").strip()
+    if not new_name:
+        return jsonify({"error": "name is required"}), 400
+
+    entry = get_model(model_id)
+    if entry is None:
+        return jsonify({"error": "Model not found"}), 404
+
+    # Rename the underlying trainable model file if applicable
+    tm_name = entry.get("trainable_model_name", "")
+    if tm_name:
+        old_path = _model_path(tm_name)
+        tm_data = _read_model(old_path)
+        if tm_data:
+            new_path = _model_path(new_name)
+            tm_data["name"] = new_name
+            _write_model(new_path, tm_data)
+            if new_path != old_path:
+                old_path.unlink(missing_ok=True)
+        from vtsearch.models.registry import update_model
+
+        update_model(model_id, trainable_model_name=new_name)
+
+    rename_model(model_id, new_name)
+    return jsonify({"ok": True, "name": new_name})


### PR DESCRIPTION
## Summary

This PR introduces persistent registries for datasets and models, enabling users to manage multiple datasets and models across app restarts. It also adds a new multi-dataset, multi-model "Find" operation that runs detection across selected combinations.

## Key Changes

- **Dataset Registry** (`vtsearch/datasets/registry.py`): New persistent JSON manifest tracking all loaded datasets with metadata (name, media type, item count, pkl path). Datasets are auto-registered when loaded and can be renamed/deleted via the dashboard.

- **Model Registry** (`vtsearch/models/registry.py`): New persistent JSON manifest tracking all created models (both trainable and non-trainable) with metadata (name, media type, training count, backing detector/trainable model). Models are registered when created and can be managed via the dashboard.

- **Multi-select Dashboard UI**: Refactored dashboard dataset and model grids to support multi-select (Ctrl/Cmd+click for toggle, single-click for replace). Each item shows a "loaded" indicator. Selection state drives button validation.

- **Button Validation Logic**: 
  - Label button: requires exactly 1 dataset + 1 trainable model with matching media types
  - Find button: requires ≥1 dataset + ≥1 model, all with compatible media types
  - Both buttons now display contextual hint text explaining why they're disabled

- **Multi-dataset Find** (`/api/find` endpoint): New POST endpoint that accepts multiple dataset IDs and model IDs, loads each dataset from its saved pkl, runs all selected models on all datasets, and returns merged results with per-model verdicts.

- **API Endpoints**: Added registry endpoints for listing, registering, deleting, and renaming datasets and models:
  - `GET /api/datasets/registry` — list all datasets with loaded state
  - `POST /api/datasets/registry/<id>/load` — load a dataset from pkl
  - `DELETE /api/datasets/registry/<id>` — remove a dataset
  - `PUT /api/datasets/registry/<id>/rename` — rename a dataset
  - `GET /api/models/registry` — list all models with loaded state
  - `POST /api/models/registry` — register a new model
  - `DELETE /api/models/registry/<id>` — remove a model
  - `PUT /api/models/registry/<id>/rename` — rename a model

- **Auto-registration**: Datasets are automatically registered in the registry when loaded via importers or demo datasets. Trainable models update their training count in the registry when labels are saved.

- **Backward Compatibility**: Renamed `/api/favorite-detectors` to `/api/autorun-detectors` throughout for consistency.

## Notable Implementation Details

- Registries use thread-safe in-memory caching with atomic file writes to avoid corruption
- Dataset pkl files are stored in `data/saved_datasets/` with UUID-based filenames
- Model registry entries track both `detector_name` (for pre-trained models) and `trainable_model_name` (for trainable models)
- Multi-find operation handles both pre-trained detectors (with weights) and trainable models (trained on-the-fly from labelsets)
- Dashboard button hints are dynamically created/updated to provide user feedback on validation failures

https://claude.ai/code/session_0168xR2Uo3jUapc2EdVMWxqt