### PR TITLE
Consolidate test documentation into SETUP.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,7 @@ You can also load your own data from pickle files or folders via the same menu.
 
 ## Running the tests
 
-Install dev dependencies (includes pytest):
-
-```bash
-pip install -r requirements-dev.txt
-```
-
-Then run:
-
-```bash
-python -m pytest tests/ -v
-```
-
-This runs fast CPU tests only. Additional test modes:
-
-- **Full CPU tests** (includes slow CLI subprocess tests): `python -m pytest tests/ -v -m 'not gpu'`
-- **GPU tests** (requires CUDA): `python -m pytest tests/test_gpu.py -v -m gpu`
-- **All tests**: `python -m pytest tests/ -v -m ''`
+See [docs/SETUP.md](docs/SETUP.md) for instructions on running tests, including the default fast CPU mode and additional modes for full CPU, GPU, and all tests.
 
 ## Project structure
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -182,9 +182,43 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml build  # GPU
 
 Add `--no-cache` to force a full rebuild (e.g. after dependency changes).
 
+## Running the tests
+
+Install dev dependencies (includes pytest):
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Then run:
+
+```bash
+python -m pytest tests/ -v
+```
+
+This runs fast CPU tests only. Additional test modes:
+
+**Full CPU tests** (includes slow CLI subprocess tests):
+
+```bash
+python -m pytest tests/ -v -m 'not gpu'
+```
+
+**GPU tests** (requires CUDA):
+
+```bash
+python -m pytest tests/test_gpu.py -v -m gpu
+```
+
+**All tests**:
+
+```bash
+python -m pytest tests/ -v -m ''
+```
+
 ## Next steps
 
 - **Load a dataset**: Click the hamburger menu in the top-left corner to browse demo datasets or import your own data.
-- **Run tests**: `python -m pytest tests/ -v`
+- **Run tests**: See [Running the tests](#running-the-tests) above.
 - **CLI workflows**: See [CLI.md](CLI.md) for running detectors and exporters from the command line.
 - **Extend**: See [EXTENDING.md](EXTENDING.md) for adding new media types, importers, or exporters.


### PR DESCRIPTION
## Summary
Moved detailed test running instructions from README.md to docs/SETUP.md to reduce duplication and improve documentation organization. The README now references the SETUP.md guide instead of duplicating the content.

## Key Changes
- Moved comprehensive test running instructions (including installation, fast CPU tests, full CPU tests, GPU tests, and all tests modes) from README.md to docs/SETUP.md under a new "Running the tests" section
- Updated the "Next steps" section in SETUP.md to reference the new test documentation section via anchor link
- Simplified README.md's "Running the tests" section to a single line with a reference to docs/SETUP.md for full instructions

## Benefits
- Single source of truth for test documentation
- Reduces maintenance burden by eliminating duplicate content
- Keeps README.md concise while preserving access to detailed instructions
- Better organization with setup-related documentation in SETUP.md

https://claude.ai/code/session_015zWJfpzw7AMEUGgL2mTRaX