### PR TITLE
Update documentation with corrected model names and dataset references

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -280,7 +280,7 @@ audio.load_models()
 To use an exporter standalone:
 
 ```python
-from vtsearch.exporters.file import EXPORTER
+from vtsearch.exporters.server_json_file import EXPORTER
 
 result = EXPORTER.export(
     results={"media_type": "audio", "results": {...}},

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -179,7 +179,7 @@ data/
 │   ├── models--laion--clap-htsat-unfused/
 │   ├── models--openai--clip-vit-base-patch32/
 │   ├── models--microsoft--xclip-base-patch32/
-│   └── models--sentence-transformers--e5-base-v2/
+│   └── models--intfloat--e5-base-v2/
 ├── embeddings/                       # Cached dataset embeddings (.pkl files)
 ├── trainable_models/                 # Persistent trainable model definitions (.json)
 ├── settings.json                     # User preferences, autorun config, thresholds

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -49,7 +49,7 @@ python -m vtsearch.eval [OPTIONS]
 
 ```bash
 # Text sort only, on image datasets, save JSON
-python -m vtsearch.eval --mode text --datasets animals_images vehicles_images --output results.json --plot-dir eval_output
+python -m vtsearch.eval --mode text --datasets caltech101_s caltech256_l --output results.json --plot-dir eval_output
 
 # Learned sort with a different train/test split
 python -m vtsearch.eval --mode learned --train-fraction 0.7 --seed 123 --plot-dir eval_output

--- a/docs/FEATURE_IDEAS.md
+++ b/docs/FEATURE_IDEAS.md
@@ -5,7 +5,7 @@ Brainstorm of potential features organized by category.
 **Note:** Some ideas below have been implemented since this list was written.
 Implemented features include: diversity-aware sampling (#8, via DiversityTree),
 document/PDF media type (#76, via the `document` media type and converters),
-high-contrast theme (#124, via "highviz" theme), and face detection (#87 partial,
+high-contrast theme (#126, via "highviz" theme), and face detection (partial,
 via FaceLocalizer).
 
 ---

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -24,6 +24,7 @@ When the app is running, click the hamburger menu in the top-left corner to open
 | **food101_a** | Crowd-sourced food photos across 101 Food-101 categories — a deliberately noisy benchmark |
 | **eurosat_a** | Sentinel-2 satellite imagery across 10 EuroSAT land use categories |
 | **stanford_dogs_a** | Fine-grained dog breed photos across 120 Stanford Dogs categories |
+| **ucsf_documents_a** | Scanned industry document pages from the UCSF Industry Documents Library — tobacco, food, drug, chemical, fossil fuel, and opioids |
 
 ## Text
 


### PR DESCRIPTION
## Summary
This PR updates documentation files to correct outdated or inaccurate references to model names, dataset identifiers, and issue numbers.

## Key Changes
- **ARCHITECTURE.md**: Updated exporter import path from `vtsearch.exporters.file` to `vtsearch.exporters.server_json_file` to reflect the correct module name
- **DEPLOYMENT.md**: Corrected the Hugging Face model identifier from `models--sentence-transformers--e5-base-v2` to `models--intfloat--e5-base-v2` to match the actual model source
- **EVAL.md**: Updated example command to use correct dataset identifiers (`caltech101_s` and `caltech256_l`) instead of the non-existent `animals_images` and `vehicles_images` datasets
- **FEATURE_IDEAS.md**: Fixed issue reference number for high-contrast theme feature from #124 to #126, and removed incorrect issue number from face detection feature reference
- **demos.md**: Added new demo dataset entry for `ucsf_documents_a` (UCSF Industry Documents Library) to the available datasets table

## Notable Details
These changes ensure that users following the documentation will reference the correct module paths, model identifiers, and dataset names when working with the vtsearch system.

https://claude.ai/code/session_01XNaTY95cjbfheFZWJQEhzS