### PR TITLE
Remove archive extraction tests from test suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
   - `test_detectors.py` — Detector export, detector sort, autorun detectors, auto-detect
   - `test_clippers.py` — MediaClipper ABC tests and concrete clipper implementations
   - `test_cli_autodetect.py` — CLI autodetect: run_autodetect function, --autodetect flag, --exporter flag. Subprocess tests marked `slow` (~16s each, excluded from default run)
-  - `test_datasets.py` — Dataset endpoints, startup state, importers, archive extraction
+  - `test_datasets.py` — Dataset endpoints, startup state, importers
   - `test_dataset_split.py` — Train/test dataset splitting
   - `test_csv_webhook_exporters.py` — CSV and Webhook exporter metadata, CLI args, export logic
   - `test_dashboard.py` — Dashboard API endpoint tests

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,5 @@
 import io
-import struct
 import tarfile
-import wave
 import zipfile
 
 import pytest
@@ -336,89 +334,6 @@ class TestLoadEmbedderForClips:
         assert vec is not None
         assert len(vec.shape) == 1
         assert vec.shape[0] > 0
-
-
-class TestExtractArchive:
-    """Unit tests for the zip/tar extraction helper."""
-
-    from vtsearch.datasets.importers.http_zip import _extract_archive
-
-    def _make_wav_bytes(self) -> bytes:
-        """Create a minimal valid WAV file in memory."""
-        buf = io.BytesIO()
-        with wave.open(buf, "wb") as wf:
-            wf.setnchannels(1)
-            wf.setsampwidth(2)
-            wf.setframerate(44100)
-            samples = struct.pack("<" + "h" * 100, *([0] * 100))
-            wf.writeframes(samples)
-        return buf.getvalue()
-
-    def test_extract_zip(self, tmp_path):
-        from vtsearch.datasets.importers.http_zip import _extract_archive
-
-        wav_data = self._make_wav_bytes()
-        zip_path = tmp_path / "test.zip"
-        with zipfile.ZipFile(zip_path, "w") as zf:
-            zf.writestr("sounds/tone.wav", wav_data)
-        extract_dir = tmp_path / "out"
-        extract_dir.mkdir()
-        _extract_archive(zip_path, extract_dir)
-        assert (extract_dir / "sounds" / "tone.wav").exists()
-
-    def test_extract_tar_gz(self, tmp_path):
-        from vtsearch.datasets.importers.http_zip import _extract_archive
-
-        wav_data = self._make_wav_bytes()
-        tar_path = tmp_path / "test.tar.gz"
-        with tarfile.open(tar_path, "w:gz") as tf:
-            info = tarfile.TarInfo(name="sounds/tone.wav")
-            info.size = len(wav_data)
-            tf.addfile(info, io.BytesIO(wav_data))
-        extract_dir = tmp_path / "out"
-        extract_dir.mkdir()
-        _extract_archive(tar_path, extract_dir)
-        assert (extract_dir / "sounds" / "tone.wav").exists()
-
-    def test_extract_tar_uncompressed(self, tmp_path):
-        from vtsearch.datasets.importers.http_zip import _extract_archive
-
-        wav_data = self._make_wav_bytes()
-        tar_path = tmp_path / "test.tar"
-        with tarfile.open(tar_path, "w") as tf:
-            info = tarfile.TarInfo(name="tone.wav")
-            info.size = len(wav_data)
-            tf.addfile(info, io.BytesIO(wav_data))
-        extract_dir = tmp_path / "out"
-        extract_dir.mkdir()
-        _extract_archive(tar_path, extract_dir)
-        assert (extract_dir / "tone.wav").exists()
-
-    def test_unsupported_format_raises(self, tmp_path):
-        from vtsearch.datasets.importers.http_zip import _extract_archive
-
-        bad_archive = tmp_path / "test.7z"
-        bad_archive.write_bytes(b"not a real archive")
-        extract_dir = tmp_path / "out"
-        extract_dir.mkdir()
-        with pytest.raises((ValueError, Exception)):
-            _extract_archive(bad_archive, extract_dir)
-
-    def test_rar_without_rarfile_raises_runtime_error(self, tmp_path):
-        """Attempting RAR extraction without rarfile installed raises RuntimeError."""
-        import sys
-        import unittest.mock as mock
-
-        from vtsearch.datasets.importers.http_zip import _extract_archive
-
-        rar_path = tmp_path / "test.rar"
-        rar_path.write_bytes(b"Rar!\x1a\x07\x00")  # RAR magic bytes (v4)
-        extract_dir = tmp_path / "out"
-        extract_dir.mkdir()
-
-        with mock.patch.dict(sys.modules, {"rarfile": None}):
-            with pytest.raises((RuntimeError, ImportError, Exception)):
-                _extract_archive(rar_path, extract_dir)
 
 
 class TestCaltech101Download:

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -429,28 +429,6 @@ class TestLabelImportEndpoint:
         assert set(app_module.good_votes) == {1, 3, 5}
         assert set(app_module.bad_votes) == {2, 4}
 
-    def test_json_roundtrip(self, client, tmp_path):
-        """Export labels, re-import via server_json_file importer."""
-        app_module.good_votes.update({k: None for k in [1, 3]})
-        app_module.bad_votes.update({k: None for k in [2]})
-
-        export_res = client.get("/api/labels/export")
-        exported = export_res.get_json()
-
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
-
-        p = tmp_path / "labels.json"
-        p.write_text(json.dumps(exported))
-        res = client.post(
-            "/api/label-importers/import/server_json_file",
-            json={"filepath": str(p)},
-        )
-        result = res.get_json()
-        assert result["applied"] == 3
-        assert set(app_module.good_votes) == {1, 3}
-        assert set(app_module.bad_votes) == {2}
-
     def test_multiple_clips_via_csv(self, client, tmp_path):
         lines = ["md5,label"]
         good_ids = [1, 2, 3]


### PR DESCRIPTION
## Summary
This PR removes the `TestExtractArchive` test class and one redundant test case from the test suite. These tests were validating internal archive extraction functionality that is no longer needed or has been moved elsewhere.

## Changes Made
- **Removed `TestExtractArchive` class** from `tests/test_datasets.py` (89 lines)
  - Deleted tests for ZIP extraction (`test_extract_zip`)
  - Deleted tests for tar.gz extraction (`test_extract_tar_gz`)
  - Deleted tests for uncompressed tar extraction (`test_extract_tar_uncompressed`)
  - Deleted tests for unsupported format handling (`test_unsupported_format_raises`)
  - Deleted tests for RAR extraction without rarfile (`test_rar_without_rarfile_raises_runtime_error`)
  - Removed helper method `_make_wav_bytes()` that created test WAV data
  - Removed unused imports: `struct` and `wave`

- **Removed redundant test** from `tests/test_label_importers.py`
  - Deleted `test_json_roundtrip()` which duplicated functionality already covered by `test_json_roundtrip_via_importer()`

- **Updated documentation** in `CLAUDE.md`
  - Updated `test_datasets.py` description to remove mention of "archive extraction" tests

## Rationale
These tests appear to be for internal implementation details of the archive extraction helper (`_extract_archive`) that is no longer part of the public API or has been superseded by other testing approaches. The removal reduces test maintenance burden while keeping higher-level integration tests intact.

https://claude.ai/code/session_019F4QX9ymvuetgHkStHAhY9