### PR TITLE
Sync trainable model renames to model registry

### DIFF
--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -173,6 +173,41 @@ class TestRenameTrainableModel:
         )
         assert res.status_code == 400
 
+    def test_rename_updates_model_registry(self, client):
+        """Renaming a trainable model should update registry references."""
+        from vtsearch.models.registry import find_by_trainable_model_name, get_model
+
+        # Create a trainable model and register it in the model registry
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Original", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={"name": "Original", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        assert res.status_code == 201
+        model_id = res.get_json()["model"]["id"]
+
+        # Rename the trainable model directly (not through the registry endpoint)
+        res = client.put(
+            "/api/trainable-models/Original/rename",
+            json={"new_name": "Renamed"},
+        )
+        assert res.status_code == 200
+
+        # Registry entry should now reference the new name
+        entry = get_model(model_id)
+        assert entry is not None
+        assert entry["name"] == "Renamed"
+        assert entry["trainable_model_name"] == "Renamed"
+
+        # Look up by old name should fail
+        assert find_by_trainable_model_name("Original") is None
+
+        # Look up by new name should succeed
+        assert find_by_trainable_model_name("Renamed") is not None
+
     def test_rename_conflict(self, client):
         client.post(
             "/api/trainable-models",

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -211,6 +211,14 @@ def rename_trainable_model(name: str):
     if new_path != old_path:
         old_path.unlink(missing_ok=True)
 
+    # Update the model registry entry that references this trainable model
+    from vtsearch.models.registry import find_by_trainable_model_name, rename_model, update_model
+
+    reg_entry = find_by_trainable_model_name(name)
+    if reg_entry:
+        update_model(reg_entry["id"], trainable_model_name=new_name)
+        rename_model(reg_entry["id"], new_name)
+
     return jsonify({"success": True, "old_name": name, "new_name": new_name})
 
 


### PR DESCRIPTION
## Summary
When a trainable model is renamed via the API, the corresponding entry in the model registry is now automatically updated to maintain consistency between the two systems.

## Changes
- **vtsearch/routes/trainable_models.py**: Updated the `rename_trainable_model` endpoint to sync renames to the model registry by:
  - Looking up the registry entry by the old trainable model name
  - Updating both the `trainable_model_name` and `name` fields in the registry entry
  
- **tests/test_trainable_models.py**: Added comprehensive test `test_rename_updates_model_registry` that verifies:
  - Registry entries are updated when a trainable model is renamed
  - The old name can no longer be found in the registry
  - The new name can be found in the registry
  - Both `name` and `trainable_model_name` fields are correctly updated

## Implementation Details
The rename operation now performs a two-step update on the registry entry:
1. Updates the `trainable_model_name` field to the new name
2. Renames the model entry itself (updates the `name` field)

This ensures that lookups by trainable model name will correctly resolve to the renamed model.

https://claude.ai/code/session_01YGNaX9n8Fn6Pz5zJhjeYR7