### PR TITLE
Use media type registry for pickle loading instead of hardcoded keys

### DIFF
--- a/tests/test_chunked_loading.py
+++ b/tests/test_chunked_loading.py
@@ -243,6 +243,176 @@ class TestPickleChunked:
         assert media["filename"] == "clip_1.wav"
         assert media["category"] == "cat_1"
 
+    def test_image_extra_fields_preserved(self, tmp_path):
+        """Image-specific fields (width, height) are preserved via the registry."""
+        medias_data = {
+            1: {
+                "type": "image",
+                "embedding": np.random.randn(512).tolist(),
+                "media_bytes": b"\x89PNG fake",
+                "filename": "photo.png",
+                "width": 640,
+                "height": 480,
+                "category": "test",
+            }
+        }
+        pkl_path = tmp_path / "img.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": medias_data}, f)
+
+        # Full mode
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        media = chunks[0][1]
+        assert media["type"] == "image"
+        assert media["width"] == 640
+        assert media["height"] == 480
+
+        # Thin mode
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        media = chunks[0][1]
+        assert media["width"] == 640
+        assert media["height"] == 480
+
+    def test_text_extra_fields_preserved(self, tmp_path):
+        """Text-specific fields (word_count, character_count) are preserved via the registry."""
+        medias_data = {
+            1: {
+                "type": "paragraph",
+                "embedding": np.random.randn(512).tolist(),
+                "media_string": "Hello world",
+                "media_bytes": b"Hello world",
+                "filename": "doc.txt",
+                "word_count": 2,
+                "character_count": 11,
+                "category": "test",
+            }
+        }
+        pkl_path = tmp_path / "txt.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": medias_data}, f)
+
+        # Full mode
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        media = chunks[0][1]
+        assert media["type"] == "paragraph"
+        assert media["word_count"] == 2
+        assert media["character_count"] == 11
+
+        # Thin mode
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        media = chunks[0][1]
+        assert media["word_count"] == 2
+        assert media["character_count"] == 11
+
+    def test_document_type_loaded_via_registry(self, tmp_path):
+        """Document media type loads correctly in chunked mode (previously silently failed)."""
+        medias_data = {
+            1: {
+                "type": "document",
+                "embedding": np.random.randn(512).tolist(),
+                "media_bytes": b"%PDF-1.4 fake",
+                "filename": "report.pdf",
+                "category": "test",
+            }
+        }
+        pkl_path = tmp_path / "doc.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": medias_data}, f)
+
+        # Full mode — was silently skipped before registry fix
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        assert len(chunks) == 1
+        media = chunks[0][1]
+        assert media["type"] == "document"
+        assert media["media_bytes"] == b"%PDF-1.4 fake"
+
+        # Thin mode
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        assert len(chunks) == 1
+        assert chunks[0][1]["type"] == "document"
+
+    def test_legacy_bytes_keys_via_registry(self, tmp_path):
+        """Legacy pickle keys (e.g. wav_bytes, image_bytes) are resolved via the registry."""
+        medias_data = {
+            1: {
+                "type": "audio",
+                "embedding": np.random.randn(512).tolist(),
+                "wav_bytes": _make_wav_bytes(),
+                "filename": "clip.wav",
+                "category": "test",
+            },
+            2: {
+                "type": "image",
+                "embedding": np.random.randn(512).tolist(),
+                "image_bytes": b"\x89PNG fake",
+                "filename": "pic.png",
+                "category": "test",
+            },
+        }
+        pkl_path = tmp_path / "legacy.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": medias_data}, f)
+
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        loaded = chunks[0]
+        assert len(loaded) == 2
+        types = {m["type"] for m in loaded.values()}
+        assert types == {"audio", "image"}
+
+    def test_external_dir_via_registry(self, tmp_path):
+        """External directory loading uses registry dir_key instead of hardcoded keys."""
+        doc_dir = tmp_path / "docs"
+        doc_dir.mkdir()
+        (doc_dir / "report.pdf").write_bytes(b"%PDF fake content")
+
+        medias_data = {
+            1: {
+                "type": "document",
+                "embedding": np.random.randn(512).tolist(),
+                "filename": "report.pdf",
+                "category": "test",
+            }
+        }
+        pkl_path = tmp_path / "ext_doc.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": medias_data, "document_dir": str(doc_dir)}, f)
+
+        # Full mode — loads bytes from the external document_dir
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        assert len(chunks) == 1
+        media = chunks[0][1]
+        assert media["type"] == "document"
+        assert media["media_bytes"] == b"%PDF fake content"
+
+        # Thin mode — resolves media_path from document_dir
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=True))
+        assert len(chunks) == 1
+        media = chunks[0][1]
+        assert media["media_path"] is not None
+        assert "report.pdf" in media["media_path"]
+
+    def test_text_legacy_key_via_registry(self, tmp_path):
+        """Legacy text_content key is resolved via the registry for paragraph type."""
+        medias_data = {
+            1: {
+                "type": "paragraph",
+                "embedding": np.random.randn(512).tolist(),
+                "text_content": "Some text paragraph",
+                "filename": "para.txt",
+                "category": "test",
+            }
+        }
+        pkl_path = tmp_path / "txt_legacy.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": medias_data}, f)
+
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
+        assert len(chunks) == 1
+        media = chunks[0][1]
+        assert media["type"] == "paragraph"
+        assert media["media_string"] == "Some text paragraph"
+        assert media["media_bytes"] == b"Some text paragraph"
+
 
 # ======================================================================
 # DatasetImporter.run_chunked / run_chunked_cli (base class default)

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -813,8 +813,9 @@ def load_dataset_from_pickle(
             bytes_val = media_info.get("media_bytes") or media_info.get("clip_bytes")
             if bytes_val is None:
                 for legacy_key in _legacy_bytes.get(media_type, []):
-                    bytes_val = media_info.get(legacy_key)
-                    if bytes_val is not None:
+                    val = media_info.get(legacy_key)
+                    if isinstance(val, bytes):
+                        bytes_val = val
                         break
 
             # Try media_string (text media), then legacy keys
@@ -996,8 +997,9 @@ def load_dataset_from_pickle_chunked(
             bytes_val = media_info.get("media_bytes") or media_info.get("clip_bytes")
             if bytes_val is None:
                 for legacy_key in _legacy_bytes.get(media_type, []):
-                    bytes_val = media_info.get(legacy_key)
-                    if bytes_val is not None:
+                    val = media_info.get(legacy_key)
+                    if isinstance(val, bytes):
+                        bytes_val = val
                         break
 
             # Try media_string (text media), then legacy keys

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -717,8 +717,7 @@ def load_dataset_from_pickle(
     except MemoryError:
         gc.collect()
         raise MemoryError(
-            f"Out of memory while reading {file_path.name}. "
-            "The pickle file is too large for available RAM."
+            f"Out of memory while reading {file_path.name}. The pickle file is too large for available RAM."
         )
 
     medias.clear()
@@ -741,15 +740,16 @@ def load_dataset_from_pickle(
             "params": creation_info.get("field_values", {}),
         }
 
-    # Build the dir_key mapping dynamically from the media type registry.
-    # Also build the legacy-bytes-key mapping for backward compat with old pickles.
+    # Build lookup tables dynamically from the media type registry.
     from vtsearch.media import all_types
 
     _dir_keys: dict[str, str] = {}
     _legacy_bytes: dict[str, list[str]] = {}
+    _extra_fields: dict[str, list[str]] = {}
     for mt in all_types():
         _dir_keys[mt.type_id] = mt.dir_key
         _legacy_bytes[mt.type_id] = mt.legacy_bytes_keys
+        _extra_fields[mt.type_id] = mt.pickle_extra_fields
 
     # Convert to the app's media format
     missing_media = 0
@@ -793,12 +793,8 @@ def load_dataset_from_pickle(
                     "origin": media_info.get("origin", fallback_origin),
                     "origin_name": media_info.get("origin_name", fname),
                 }
-                if media_type == "image":
-                    media_data["width"] = media_info.get("width")
-                    media_data["height"] = media_info.get("height")
-                elif media_type == "paragraph":
-                    media_data["word_count"] = media_info.get("word_count")
-                    media_data["character_count"] = media_info.get("character_count")
+                for field in _extra_fields.get(media_type, []):
+                    media_data[field] = media_info.get(field)
 
                 medias[media_id] = media_data
                 loaded_count += 1
@@ -869,13 +865,8 @@ def load_dataset_from_pickle(
                     "origin": media_info.get("origin", fallback_origin),
                     "origin_name": media_info.get("origin_name", fname),
                 }
-                # Add media-specific metadata
-                if media_type == "image":
-                    media_data["width"] = media_info.get("width")
-                    media_data["height"] = media_info.get("height")
-                elif media_type == "paragraph":
-                    media_data["word_count"] = media_info.get("word_count")
-                    media_data["character_count"] = media_info.get("character_count")
+                for field in _extra_fields.get(media_type, []):
+                    media_data[field] = media_info.get(field)
 
                 medias[media_id] = media_data
                 loaded_count += 1
@@ -938,12 +929,17 @@ def load_dataset_from_pickle_chunked(
             "params": creation_info.get("field_values", {}),
         }
 
-    _dir_keys = {
-        "audio": "audio_dir",
-        "video": "video_dir",
-        "image": "image_dir",
-        "paragraph": "text_dir",
-    }
+    # Build lookup tables dynamically from the media type registry,
+    # matching the approach used by load_dataset_from_pickle.
+    from vtsearch.media import all_types
+
+    _dir_keys: dict[str, str] = {}
+    _legacy_bytes: dict[str, list[str]] = {}
+    _extra_fields: dict[str, list[str]] = {}
+    for mt in all_types():
+        _dir_keys[mt.type_id] = mt.dir_key
+        _legacy_bytes[mt.type_id] = mt.legacy_bytes_keys
+        _extra_fields[mt.type_id] = mt.pickle_extra_fields
 
     all_media_ids = sorted(medias_data.keys())
 
@@ -984,12 +980,8 @@ def load_dataset_from_pickle_chunked(
                     "origin": media_info.get("origin", fallback_origin),
                     "origin_name": media_info.get("origin_name", fname),
                 }
-                if media_type == "image":
-                    media_data["width"] = media_info.get("width")
-                    media_data["height"] = media_info.get("height")
-                elif media_type == "paragraph":
-                    media_data["word_count"] = media_info.get("word_count")
-                    media_data["character_count"] = media_info.get("character_count")
+                for field in _extra_fields.get(media_type, []):
+                    media_data[field] = media_info.get(field)
 
                 chunk_medias[new_id] = media_data
                 new_id += 1
@@ -1000,60 +992,42 @@ def load_dataset_from_pickle_chunked(
             media_string = None
             media_path = None
 
-            if media_type == "audio":
-                media_bytes = (
-                    media_info.get("media_bytes")
-                    or media_info.get("clip_bytes")
-                    or media_info.get("wav_bytes")
-                )
-                if not media_bytes and "filename" in media_info and "audio_dir" in data:
-                    audio_path = Path(data["audio_dir"]) / media_info["filename"]
-                    if audio_path.exists():
-                        with open(audio_path, "rb") as f:
-                            media_bytes = f.read()
-                        media_path = str(audio_path.resolve())
+            # Try media_bytes first (binary media), then legacy keys via registry
+            bytes_val = media_info.get("media_bytes") or media_info.get("clip_bytes")
+            if bytes_val is None:
+                for legacy_key in _legacy_bytes.get(media_type, []):
+                    bytes_val = media_info.get(legacy_key)
+                    if bytes_val is not None:
+                        break
 
-            elif media_type == "video":
-                media_bytes = (
-                    media_info.get("media_bytes")
-                    or media_info.get("clip_bytes")
-                    or media_info.get("video_bytes")
-                )
-                if not media_bytes and "filename" in media_info and "video_dir" in data:
-                    video_path = Path(data["video_dir"]) / media_info["filename"]
-                    if video_path.exists():
-                        with open(video_path, "rb") as f:
-                            media_bytes = f.read()
-                        media_path = str(video_path.resolve())
+            # Try media_string (text media), then legacy keys
+            string_val = media_info.get("media_string") or media_info.get("clip_string")
+            if string_val is None:
+                for legacy_key in _legacy_bytes.get(media_type, []):
+                    val = media_info.get(legacy_key)
+                    if isinstance(val, str):
+                        string_val = val
+                        break
 
-            elif media_type == "image":
-                media_bytes = (
-                    media_info.get("media_bytes")
-                    or media_info.get("clip_bytes")
-                    or media_info.get("image_bytes")
-                )
-                if not media_bytes and "filename" in media_info and "image_dir" in data:
-                    image_path = Path(data["image_dir"]) / media_info["filename"]
-                    if image_path.exists():
-                        with open(image_path, "rb") as f:
-                            media_bytes = f.read()
-                        media_path = str(image_path.resolve())
-
-            elif media_type == "paragraph":
-                media_string = (
-                    media_info.get("media_string")
-                    or media_info.get("clip_string")
-                    or media_info.get("text_content")
-                )
-                if media_string is not None:
-                    media_bytes = media_string.encode("utf-8")
-                elif "filename" in media_info and "text_dir" in data:
-                    text_path = Path(data["text_dir"]) / media_info["filename"]
-                    if text_path.exists():
-                        with open(text_path, "r", encoding="utf-8") as f:
-                            media_string = f.read()
-                            media_bytes = media_string.encode("utf-8")
-                        media_path = str(text_path.resolve())
+            if bytes_val is not None:
+                media_bytes = bytes_val
+            elif string_val is not None:
+                media_string = string_val
+                media_bytes = string_val.encode("utf-8")
+            else:
+                # Try loading from the external directory via registry dir_key
+                dir_key = _dir_keys.get(media_type)
+                if dir_key and dir_key in data and "filename" in media_info:
+                    ext_path = Path(data[dir_key]) / media_info["filename"]
+                    if ext_path.exists():
+                        if media_string is None and ext_path.suffix in (".txt", ".md"):
+                            with open(ext_path, "r", encoding="utf-8") as f:
+                                media_string = f.read()
+                                media_bytes = media_string.encode("utf-8")
+                        else:
+                            with open(ext_path, "rb") as f:
+                                media_bytes = f.read()
+                        media_path = str(ext_path.resolve())
 
             if media_bytes is not None:
                 fname = media_info.get("filename", f"media_{media_id}.{media_type}")
@@ -1072,12 +1046,8 @@ def load_dataset_from_pickle_chunked(
                     "origin": media_info.get("origin", fallback_origin),
                     "origin_name": media_info.get("origin_name", fname),
                 }
-                if media_type == "image":
-                    media_data["width"] = media_info.get("width")
-                    media_data["height"] = media_info.get("height")
-                elif media_type == "paragraph":
-                    media_data["word_count"] = media_info.get("word_count")
-                    media_data["character_count"] = media_info.get("character_count")
+                for field in _extra_fields.get(media_type, []):
+                    media_data[field] = media_info.get(field)
 
                 chunk_medias[new_id] = media_data
                 new_id += 1

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -278,6 +278,21 @@ class MediaType(ABC):
         """
         return []
 
+    @property
+    def pickle_extra_fields(self) -> list[str]:
+        """Extra field names to preserve when loading media from pickle files.
+
+        When a pickle stores type-specific metadata beyond the standard
+        fields (id, type, duration, file_size, md5, embedding, etc.),
+        list the field names here so the loader copies them automatically.
+
+        For example, the image type returns ``["width", "height"]`` and
+        the text type returns ``["word_count", "character_count"]``.
+
+        Defaults to an empty list (no extra fields).
+        """
+        return []
+
     # ------------------------------------------------------------------
     # Viewer behaviour
     # ------------------------------------------------------------------

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -112,6 +112,10 @@ class ImageMediaType(MediaType):
     def legacy_bytes_keys(self) -> list[str]:
         return ["image_bytes"]
 
+    @property
+    def pickle_extra_fields(self) -> list[str]:
+        return ["width", "height"]
+
     # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -76,6 +76,10 @@ class TextMediaType(MediaType):
     def legacy_bytes_keys(self) -> list[str]:
         return ["text_content"]
 
+    @property
+    def pickle_extra_fields(self) -> list[str]:
+        return ["word_count", "character_count"]
+
     # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Refactored pickle loading functions to dynamically build lookup tables from the media type registry instead of using hardcoded type-specific keys. This makes the loader extensible for custom media types and fixes issues with document type loading and legacy field handling.

## Key Changes

- **Registry-driven lookup tables**: Both `load_dataset_from_pickle()` and `load_dataset_from_pickle_chunked()` now build `_dir_keys`, `_legacy_bytes`, and `_extra_fields` mappings dynamically from `all_types()` instead of hardcoding them.

- **New `pickle_extra_fields` property**: Added to `MediaType` base class to declare type-specific metadata fields (e.g., `width`/`height` for images, `word_count`/`character_count` for text) that should be preserved during pickle loading.

- **Unified extra field handling**: Replaced multiple conditional blocks checking for specific media types with a single loop that applies all registered extra fields for each type.

- **Improved legacy bytes key resolution**: Enhanced the legacy key lookup to explicitly check `isinstance(val, bytes)` before accepting a value, preventing accidental type mismatches.

- **Generalized external directory loading**: Refactored the chunked loader's media bytes resolution to use the registry's `dir_key` instead of hardcoded directory names (`audio_dir`, `image_dir`, etc.), enabling support for custom media types with external storage.

- **Consistent implementation**: Both full and chunked loaders now use identical logic for building lookup tables and resolving media content.

## Implementation Details

- The `MediaType` subclasses (`ImageMediaType`, `TextMediaType`) now implement `pickle_extra_fields` to declare their type-specific metadata.
- Legacy key resolution now validates that retrieved values match the expected type (bytes vs. string) before using them.
- External directory loading gracefully falls back to checking if a file exists at the expected path, supporting both inline bytes and external file references.
- All changes maintain backward compatibility with existing pickle files while enabling support for new media types without code modifications.

https://claude.ai/code/session_01EPjcN6jUs8432UqTzfendN