### PR TITLE
Add guidance for interpreting test results with "error" in names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,21 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - **`gpu`**: CUDA-only tests. Run with `-m gpu`.
 - **All tests**: Use `-m ''` to run everything.
 
+## Reading Test Results (IMPORTANT)
+
+Many test names contain the word "error" (e.g., `test_memory_errors.py`, `TestErrorResponseFormat`, `test_http_error_propagates`, `test_errors_dont_corrupt_state`). These are tests that **verify error-handling behavior** — they are not failures.
+
+**To determine whether tests passed or failed, ONLY look at the pytest summary line at the bottom of the output.** Examples:
+- `== 250 passed in 34.12s ==` → all tests passed (green)
+- `== 3 failed, 247 passed in 35.00s ==` → 3 actual failures
+- `FAILED tests/test_foo.py::TestBar::test_baz` → this specific test failed
+
+**Do NOT scan test names or output for the word "error" to detect failures.** A line like:
+```
+tests/test_memory_errors.py::TestPickleMemoryError::test_importer_background_oom_reports_error PASSED
+```
+means the test **passed** — the word "error" is part of the test name, not an indication of failure.
+
 ## Test Workflow (IMPORTANT)
 
 Testing can crash the session. To avoid losing work, follow this workflow:


### PR DESCRIPTION
## Summary
Added documentation to clarify how to correctly interpret pytest test results, particularly when test names contain the word "error".

## Changes
- Added new "Reading Test Results (IMPORTANT)" section to CLAUDE.md
- Explains that test names containing "error" (e.g., `test_memory_errors.py`, `test_http_error_propagates`) are verification tests, not failures
- Provides clear guidance to only check the pytest summary line at the bottom of output to determine pass/fail status
- Includes concrete examples of passing vs. failing test output
- Warns against scanning test names for the word "error" as a failure indicator

## Details
This documentation addresses a common source of confusion when reviewing test output. Many tests are specifically designed to verify that error-handling behavior works correctly, so their names naturally contain "error". This can lead to misinterpretation of test results when scanning output manually. The new section provides clear, actionable guidance with examples to prevent this confusion.

https://claude.ai/code/session_01KMFLpbYqoG9Lse3RZdLHWv