### PR TITLE
Move _build_results_dict to test files as internal test utility

### DIFF
--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -12,7 +12,6 @@ import pytest
 import app as app_module
 from vtsearch.cli import (
     _build_multi_results_dict,
-    _build_results_dict,
     _detect_media_type,
     _run_exporter,
     _score_medias_with_detectors,
@@ -25,6 +24,25 @@ from vtsearch.datasets.loader import export_dataset_to_file
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _build_results_dict(hits, detector_path, media_type="unknown"):
+    """Build a single-detector results dict for testing (same shape as exporter input)."""
+    detector_data = json.loads(Path(detector_path).read_text())
+    detector_name = detector_data.get("name", Path(detector_path).stem)
+    threshold = detector_data.get("threshold", 0.5)
+    return {
+        "media_type": media_type,
+        "detectors_run": 1,
+        "results": {
+            detector_name: {
+                "detector_name": detector_name,
+                "threshold": threshold,
+                "total_hits": len(hits),
+                "hits": hits,
+            }
+        },
+    }
 
 
 def _make_dataset_file(tmp_path, clips_dict):

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -3,13 +3,13 @@
 import argparse
 import csv
 import json
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
 import app as app_module
 from vtsearch.cli import (
-    _build_results_dict,
     _run_exporter,
     run_autodetect,
 )
@@ -19,6 +19,25 @@ from vtsearch.datasets.loader import export_dataset_to_file
 # ---------------------------------------------------------------------------
 # Helpers (same pattern as test_cli_autodetect.py)
 # ---------------------------------------------------------------------------
+
+
+def _build_results_dict(hits, detector_path, media_type="unknown"):
+    """Build a single-detector results dict for testing (same shape as exporter input)."""
+    detector_data = json.loads(Path(detector_path).read_text())
+    detector_name = detector_data.get("name", Path(detector_path).stem)
+    threshold = detector_data.get("threshold", 0.5)
+    return {
+        "media_type": media_type,
+        "detectors_run": 1,
+        "results": {
+            detector_name: {
+                "detector_name": detector_name,
+                "threshold": threshold,
+                "total_hits": len(hits),
+                "hits": hits,
+            }
+        },
+    }
 
 
 def _make_dataset_file(tmp_path, clips_dict):

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -258,40 +258,6 @@ def _score_medias_with_detectors(
     return results
 
 
-def _build_results_dict(
-    hits: list[dict[str, Any]],
-    detector_path: str,
-    media_type: str = "unknown",
-) -> dict[str, Any]:
-    """Build the full results dict expected by exporters (single detector).
-
-    Args:
-        hits: List of hit dicts from :func:`_score_clips_with_detector`.
-        detector_path: Path to the detector JSON (re-read for metadata).
-        media_type: The media type string for the dataset.
-
-    Returns:
-        A dict matching the shape expected by
-        :meth:`~vtsearch.exporters.base.LabelsetExporter.export`.
-    """
-    detector_data = json.loads(Path(detector_path).read_text())
-    detector_name = detector_data.get("name", Path(detector_path).stem)
-    threshold = detector_data.get("threshold", 0.5)
-
-    return {
-        "media_type": media_type,
-        "detectors_run": 1,
-        "results": {
-            detector_name: {
-                "detector_name": detector_name,
-                "threshold": threshold,
-                "total_hits": len(hits),
-                "hits": hits,
-            }
-        },
-    }
-
-
 def _build_multi_results_dict(
     detector_results: dict[str, dict[str, Any]],
     media_type: str = "unknown",

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -142,7 +142,7 @@ class LabelSet:
 
         Args:
             results: A results dict as produced by ``/api/auto-detect`` or
-                :func:`~vtsearch.cli._build_results_dict`.
+                :func:`~vtsearch.cli._build_multi_results_dict`.
             medias: Optional medias dict for enriching hits with origin info.
                 When provided, origin data is looked up from the media; when
                 absent, origin data is taken from the hit dict itself (if


### PR DESCRIPTION
## Summary
Removed the `_build_results_dict` function from the public CLI module and moved it into the test files where it's used, since it's only needed for testing purposes.

## Key Changes
- Removed `_build_results_dict` from `vtsearch/cli.py` (was a private function only used in tests)
- Added local copies of `_build_results_dict` to both `tests/test_csv_webhook_exporters.py` and `tests/test_cli_autodetect.py` with appropriate docstrings
- Updated imports in test files to remove the import of `_build_results_dict` from `vtsearch.cli`
- Updated docstring reference in `vtsearch/datasets/labelset.py` to point to `_build_multi_results_dict` instead of the removed function

## Implementation Details
The function was duplicated in both test files rather than extracted to a shared test utility, keeping test dependencies localized and making each test file self-contained. This is a refactoring that improves code organization by removing an internal testing utility from the public CLI module.

https://claude.ai/code/session_015NWe4DD4t5iVB3NZTLW3gc