### PR TITLE
Sync model registry with detector lifecycle and fix load ordering

### DIFF
--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -371,14 +371,15 @@ def load_demo_dataset_route():
             demo_origin = {"importer": "demo", "params": {"name": dataset_name}}
             _set_clip_origins(medias, demo_origin)
             collapse_duplicates(medias)
-            _load_embedder_for_clips()
             build_diversity_tree()
-            # Auto-register in the dataset registry
+            # Auto-register in the dataset registry before signalling idle
+            # so the frontend sees the new entry when it refreshes the grid.
             _auto_register_dataset(
                 name=dataset_name,
                 origin_str=f"demo:{dataset_name}",
                 source=demo_origin,
             )
+            _load_embedder_for_clips()
         except MemoryError:
             medias.clear()
             gc.collect()
@@ -513,12 +514,12 @@ def load_registered_dataset(dataset_id: str):
             gc.collect()
             importer.run({"pkl_path": pkl_path}, medias)
             collapse_duplicates(medias)
-            _load_embedder_for_clips()
             build_diversity_tree()
             _reg_set_loaded(dataset_id)
             # Update item count in case it changed
             _reg_update(dataset_id, num_items=len(medias))
             set_dataset_display_name(entry.get("name", ""))
+            _load_embedder_for_clips()
         except MemoryError:
             medias.clear()
             gc.collect()
@@ -607,13 +608,13 @@ def _load_from_origin(source: dict):
                 demo_origin = {"importer": "demo", "params": {"name": demo_name}}
                 _set_clip_origins(medias, demo_origin)
                 collapse_duplicates(medias)
-                _load_embedder_for_clips()
                 build_diversity_tree()
                 _auto_register_dataset(
                     name=demo_name,
                     origin_str=f"demo:{demo_name}",
                     source=demo_origin,
                 )
+                _load_embedder_for_clips()
             except MemoryError:
                 medias.clear()
                 gc.collect()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -146,15 +146,16 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
             origin = importer.build_origin(field_values)
             _set_clip_origins(medias, origin)
             collapse_duplicates(medias)
-            _load_embedder_for_clips()
             build_diversity_tree()
-            # Auto-register in the dataset registry
+            # Auto-register in the dataset registry before signalling idle
+            # so the frontend sees the new entry when it refreshes the grid.
             origin_str = _origin_to_str(origin)
             _auto_register_dataset(
                 name=importer.display_name,
                 origin_str=origin_str,
                 source=origin,
             )
+            _load_embedder_for_clips()
         except MemoryError:
             medias.clear()
             gc.collect()

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -70,6 +70,20 @@ def add_autorun_detector_route():
     add_autorun_detector(
         name, media_type, weights, threshold, autodetect=autodetect, examples=examples, num_labels=num_labels
     )
+
+    # Also register in the persistent model registry so the dashboard grid
+    # picks up the new model immediately.
+    from vtsearch.models.registry import find_by_detector_name, register_model
+
+    if not find_by_detector_name(name):
+        register_model(
+            name=name,
+            media_type=media_type,
+            trainable=not weights,
+            num_training=num_labels,
+            detector_name=name,
+        )
+
     return jsonify({"success": True, "name": name})
 
 
@@ -77,6 +91,12 @@ def add_autorun_detector_route():
 def delete_autorun_detector_route(name):
     """Delete a autorun detector."""
     if remove_autorun_detector(name):
+        # Also remove from the persistent model registry.
+        from vtsearch.models.registry import find_by_detector_name, unregister_model
+
+        entry = find_by_detector_name(name)
+        if entry:
+            unregister_model(entry["id"])
         return jsonify({"success": True})
     return jsonify({"error": "Detector not found"}), 404
 
@@ -93,6 +113,12 @@ def rename_autorun_detector_route(name):
         return jsonify({"error": "new_name is required"}), 400
 
     if rename_autorun_detector(name, new_name):
+        # Keep the model registry in sync.
+        from vtsearch.models.registry import find_by_detector_name, update_model
+
+        entry = find_by_detector_name(name)
+        if entry:
+            update_model(entry["id"], name=new_name, detector_name=new_name)
         return jsonify({"success": True, "new_name": new_name})
     return jsonify({"error": "Detector not found or new name already exists"}), 400
 

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -458,6 +458,18 @@ def train_from_label_import(importer_name: str):
     media_type = next(iter(medias.values())).get("type", "audio")
     add_autorun_detector(name, media_type, weights, threshold)
 
+    # Register in the persistent model registry for the dashboard grid.
+    from vtsearch.models.registry import find_by_detector_name, register_model
+
+    if not find_by_detector_name(name):
+        register_model(
+            name=name,
+            media_type=media_type,
+            trainable=False,
+            num_training=loaded_count,
+            detector_name=name,
+        )
+
     return jsonify(
         {
             "success": True,

--- a/vtsearch/routes/processor_importers.py
+++ b/vtsearch/routes/processor_importers.py
@@ -120,6 +120,17 @@ def run_processor_import(importer_name: str):
     # (already checked above that name is non-empty, but importer may suggest)
     add_autorun_detector(name, media_type, weights, threshold)
 
+    # Register in the persistent model registry for the dashboard grid.
+    from vtsearch.models.registry import find_by_detector_name, register_model
+
+    if not find_by_detector_name(name):
+        register_model(
+            name=name,
+            media_type=media_type,
+            trainable=False,
+            detector_name=name,
+        )
+
     response: dict = {
         "success": True,
         "name": name,


### PR DESCRIPTION
## Summary
This PR ensures the persistent model registry stays synchronized with detector lifecycle operations and fixes the order of operations during dataset loading to prevent race conditions.

## Key Changes

**Model Registry Synchronization:**
- When adding autorun detectors (via CRUD, training, or import), automatically register them in the persistent model registry so the dashboard grid picks them up immediately
- When deleting autorun detectors, also remove the corresponding entry from the model registry
- When renaming autorun detectors, update the detector name in the model registry to keep it in sync

**Dataset Loading Order Fix:**
- Move `_load_embedder_for_clips()` to execute *after* dataset registration and tree building, rather than before
- This ensures the dataset is registered in the persistent registry before the embedder loads, preventing the frontend from missing newly loaded datasets when it refreshes the grid
- Applied consistently across three dataset loading paths: demo datasets, importer-based loads, and multi-dataset loads

## Implementation Details
- Registry synchronization uses existing `find_by_detector_name()`, `register_model()`, `unregister_model()`, and `update_model()` functions
- Checks are performed to avoid duplicate registrations (using `find_by_detector_name()` before registering)
- The reordering of `_load_embedder_for_clips()` ensures frontend synchronization happens before potentially long-running embedding operations

https://claude.ai/code/session_014Se1Wvz9NLhxkB28N35M16