### PR TITLE
Use median-based surprise selection in diversity tree New mode

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4032,8 +4032,9 @@
 
   async function fetchDiversityTreeNext() {
     try {
-      // Send current sort scores so the diversity tree picks the
-      // highest-ranked element within the next unseen node.
+      // Send current sort scores and threshold so the diversity tree picks
+      // the most surprising element within the next unseen node: the lowest-
+      // scored element in above-threshold nodes, the highest in below.
       const body = {};
       if (sortOrder && sortOrder.length > 0) {
         const scores = {};
@@ -4041,6 +4042,9 @@
           scores[entry.id] = entry.score ?? entry.similarity ?? 0;
         }
         body.scores = scores;
+      }
+      if (threshold !== null) {
+        body.threshold = threshold;
       }
       const res = await fetch("/api/diversity-tree/next", {
         method: "POST",

--- a/tests/test_diversity_tree.py
+++ b/tests/test_diversity_tree.py
@@ -477,6 +477,44 @@ class TestNextSample:
         # Should pick a high-scoring element
         assert scores[s1] == 0.9
 
+    def test_threshold_above_median_picks_lowest(self):
+        """When the node's median score is >= threshold, return the lowest-scored element."""
+        vecs = _make_vectors(50)
+        tree = DiversityTree(vecs, k=2, min_node_size=20)
+        # Single node tree; scores 1..50
+        scores = {i: float(i) for i in range(1, 51)}
+        # Median of 1..50 is 25.5 — set threshold below that
+        sample = tree.next_sample(scores=scores, threshold=20.0)
+        # Median (25.5) >= 20.0, so we pick the lowest-scored element
+        assert sample == 1
+
+    def test_threshold_below_median_picks_highest(self):
+        """When the node's median score is below threshold, return the highest-scored element."""
+        vecs = _make_vectors(50)
+        tree = DiversityTree(vecs, k=2, min_node_size=20)
+        scores = {i: float(i) for i in range(1, 51)}
+        # Median of 1..50 is 25.5 — set threshold above that
+        sample = tree.next_sample(scores=scores, threshold=30.0)
+        # Median (25.5) < 30.0, so we pick the highest-scored element
+        assert sample == 50
+
+    def test_threshold_none_always_picks_highest(self):
+        """When threshold is None, always return the highest-scored element (original behavior)."""
+        vecs = _make_vectors(50)
+        tree = DiversityTree(vecs, k=2, min_node_size=20)
+        scores = {i: float(i) for i in range(1, 51)}
+        sample = tree.next_sample(scores=scores, threshold=None)
+        assert sample == 50
+
+    def test_threshold_at_median_picks_lowest(self):
+        """When threshold equals the median exactly, treat as above — pick lowest."""
+        vecs = _make_vectors(50)
+        tree = DiversityTree(vecs, k=2, min_node_size=20)
+        scores = {i: float(i) for i in range(1, 51)}
+        # Median of 1..50 is 25.5
+        sample = tree.next_sample(scores=scores, threshold=25.5)
+        assert sample == 1
+
 
 # ---------------------------------------------------------------------------
 # Integration / workflow

--- a/tests/test_diversity_tree_integration.py
+++ b/tests/test_diversity_tree_integration.py
@@ -182,6 +182,41 @@ class TestDiversityTreeNextEndpoint:
         data = resp.get_json()
         assert data["id"] == target_id
 
+    def test_threshold_flips_to_lowest(self, client):
+        """When threshold is below the node median, the lowest-scored element is returned."""
+        tree = _build_tree()
+        all_ids = list(tree.vector_to_leaf.keys())
+        # Give all media high scores (above threshold) so median > threshold
+        scores = {str(vid): 0.9 for vid in all_ids}
+        lowest_id = all_ids[0]
+        scores[str(lowest_id)] = 0.1  # one outlier low score
+
+        resp = client.post(
+            "/api/diversity-tree/next",
+            json={"scores": scores, "threshold": 0.5},
+        )
+        data = resp.get_json()
+        # Median of the node is 0.9 (most elements) which is >= 0.5,
+        # so the lowest-scored element should be returned
+        assert data["id"] == lowest_id
+
+    def test_threshold_keeps_highest_when_below(self, client):
+        """When threshold is above the node median, the highest-scored element is returned."""
+        tree = _build_tree()
+        all_ids = list(tree.vector_to_leaf.keys())
+        # Give all media low scores (below threshold)
+        scores = {str(vid): 0.1 for vid in all_ids}
+        highest_id = all_ids[-1]
+        scores[str(highest_id)] = 0.3  # still below threshold
+
+        resp = client.post(
+            "/api/diversity-tree/next",
+            json={"scores": scores, "threshold": 0.5},
+        )
+        data = resp.get_json()
+        # Median is ~0.1 which is < 0.5, so highest-scored element returned
+        assert data["id"] == highest_id
+
 
 # ---------------------------------------------------------------------------
 # Vote integration: voting via the API should update the tree

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -8,7 +8,7 @@ The tree supports:
 - Labeling: when a vector is labeled, mark its leaf and all ancestors as seen.
 - Unlabeling: when a label is removed, propagate unseen status upward.
 - Diversity level: the deepest tree level at which every node is seen.
-- Next sample: the highest-scored element of the first unseen node in BFS order.
+- Next sample: a surprise-maximising element of the first unseen node in BFS order.
 """
 
 from __future__ import annotations
@@ -211,13 +211,24 @@ class DiversityTree:
         seen_count = sum(1 for name in nodes_at_next if name in self.seen)
         return level + seen_count / len(nodes_at_next)
 
-    def next_sample(self, scores: dict[int, float] | None = None) -> int | None:
+    def next_sample(
+        self,
+        scores: dict[int, float] | None = None,
+        threshold: float | None = None,
+    ) -> int | None:
         """Return an element from the first unseen node in BFS order.
 
-        When *scores* is provided, returns the highest-scored element in the
-        node (so the sort mode influences which element is picked from the
-        diverse region).  When *scores* is ``None``, returns the first element
-        in the node's ID list.
+        When *scores* is provided, the selection depends on the node's median
+        score relative to *threshold*:
+
+        - If *threshold* is given and the median score in the node is **at or
+          above** it, the **lowest**-scored element is returned (the one most
+          likely to surprise the user in a predominantly-good region).
+        - Otherwise the **highest**-scored element is returned (the one most
+          likely to surprise the user in a predominantly-bad region).
+
+        When *scores* is ``None``, returns the first element in the node's ID
+        list.
 
         Returns ``None`` if all nodes have been seen.
         """
@@ -230,6 +241,11 @@ class DiversityTree:
             if name not in self.seen:
                 ids = self.nodes[name]["ids"]
                 if scores is not None:
+                    node_scores = [scores.get(i, 0.0) for i in ids]
+                    if threshold is not None:
+                        median = float(np.median(node_scores))
+                        if median >= threshold:
+                            return min(ids, key=lambda i: scores.get(i, 0.0))
                     return max(ids, key=lambda i: scores.get(i, 0.0))
                 return ids[0]
             children = self.nodes[name]["children"]

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -721,9 +721,13 @@ def labeling_status_indicator():
 def diversity_tree_next():
     """Return the next diverse sample from the Diversity Tree.
 
-    Accepts an optional POST body with ``{"scores": {id: score, ...}}``
-    so the sort mode influences which element is picked from the next
-    unseen node.  Without scores the first element in the node is returned.
+    Accepts an optional POST body with ``{"scores": {id: score, ...},
+    "threshold": <float>}`` so the sort mode influences which element is
+    picked from the next unseen node.  When a threshold is provided, the
+    node's median score determines direction: above-threshold nodes yield
+    the lowest-scored element (surprise in a "good" region), while
+    below-threshold nodes yield the highest-scored element (surprise in a
+    "bad" region).  Without scores the first element in the node is returned.
 
     Returns ``{"id": <media_id>}`` or ``{"id": null}`` when the tree is
     exhausted or not yet built.  Also includes ``diversity_level`` so the
@@ -732,6 +736,7 @@ def diversity_tree_next():
     node has already been seen.
     """
     scores = None
+    threshold = None
     if request.method == "POST":
         data = request.get_json(force=True, silent=True) or {}
         raw_scores = data.get("scores")
@@ -740,9 +745,15 @@ def diversity_tree_next():
                 scores = {int(k): float(v) for k, v in raw_scores.items()}
             except (ValueError, TypeError):
                 return jsonify({"error": "Invalid score keys or values"}), 400
+        raw_threshold = data.get("threshold")
+        if raw_threshold is not None:
+            try:
+                threshold = float(raw_threshold)
+            except (ValueError, TypeError):
+                return jsonify({"error": "Invalid threshold value"}), 400
 
     tree = get_diversity_tree()
-    next_id = diversity_tree_next_sample(scores=scores)
+    next_id = diversity_tree_next_sample(scores=scores, threshold=threshold)
     level = tree.diversity_level() if tree is not None else -1
     exhausted = tree is not None and next_id is None
     return jsonify({"id": next_id, "diversity_level": level, "exhausted": exhausted})

--- a/vtsearch/utils/state_diversity.py
+++ b/vtsearch/utils/state_diversity.py
@@ -48,16 +48,21 @@ def get_diversity_tree():
         return _core._diversity_tree
 
 
-def diversity_tree_next_sample(scores: dict[int, float] | None = None) -> int | None:
+def diversity_tree_next_sample(
+    scores: dict[int, float] | None = None,
+    threshold: float | None = None,
+) -> int | None:
     """Return the next diverse sample ID, or ``None`` if unavailable.
 
-    When *scores* is provided, the highest-scored element in the next
-    unseen node is returned (so the sort mode influences selection).
+    When *scores* and *threshold* are provided, the selection picks the
+    element most likely to surprise the user: the lowest-scored element
+    if the node's median score is above the threshold, or the highest-
+    scored element otherwise.
     """
     with _state_lock:
         if _core._diversity_tree is None:
             return None
-        return _core._diversity_tree.next_sample(scores=scores)
+        return _core._diversity_tree.next_sample(scores=scores, threshold=threshold)
 
 
 def diversity_tree_label(media_id: int) -> None:


### PR DESCRIPTION
When selecting the next media from an unseen diversity tree node, compute the median sort score in that node. If the median is at or above the sort's threshold, pick the LOWEST-scored element (surprising in a "good" region). If below threshold, pick the HIGHEST-scored element (surprising in a "bad" region, the previous behavior). Without a threshold the original max-score behavior is preserved.

The threshold is passed from the frontend through the API endpoint to DiversityTree.next_sample().

https://claude.ai/code/session_01GrLypPS9EJFon5RGgfPSy2