### PR TITLE
Extract dialog system from app.js into static/dialogs.js

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -85,108 +85,11 @@
     return getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
   }
 
-  // --- Custom VTSearch dialog system (replaces native alert/confirm/prompt) ---
-  const vtDialogModal = document.getElementById("vt-dialog-modal");
-  const vtDialogIcon = document.getElementById("vt-dialog-icon");
-  const vtDialogMessage = document.getElementById("vt-dialog-message");
-  const vtDialogInput = document.getElementById("vt-dialog-input");
-  const vtDialogActions = document.getElementById("vt-dialog-actions");
-
-  const VT_ICONS = {
-    warning: "\u26A0\uFE0F",
-    error: "\u274C",
-    success: "\u2705",
-    info: "\u2139\uFE0F",
-  };
-
-  function vtShowDialog({ message, type, showInput, inputDefault, buttons }) {
-    return new Promise((resolve) => {
-      vtDialogIcon.textContent = VT_ICONS[type] || VT_ICONS.info;
-      vtDialogIcon.className = "vt-dialog-icon " + (type || "info");
-      vtDialogMessage.textContent = message;
-
-      if (showInput) {
-        vtDialogInput.style.display = "";
-        vtDialogInput.value = inputDefault || "";
-      } else {
-        vtDialogInput.style.display = "none";
-      }
-
-      function closeWith(value) {
-        document.removeEventListener("keydown", keyHandler);
-        vtDialogModal.classList.remove("show");
-        resolve(value);
-      }
-
-      function keyHandler(e) {
-        if (!vtDialogModal.classList.contains("show")) return;
-        if (e.key === "Enter") {
-          e.preventDefault();
-          const primaryBtn = buttons.find((b) => b.primary);
-          if (primaryBtn) closeWith(primaryBtn.value === "input" ? vtDialogInput.value : primaryBtn.value);
-        } else if (e.key === "Escape") {
-          e.preventDefault();
-          const cancelBtn = buttons.find((b) => !b.primary);
-          if (cancelBtn) closeWith(cancelBtn.value === "input" ? vtDialogInput.value : cancelBtn.value);
-          else closeWith(buttons[0].value === "input" ? vtDialogInput.value : buttons[0].value);
-        }
-      }
-
-      vtDialogActions.innerHTML = "";
-      buttons.forEach((btn) => {
-        const el = document.createElement("button");
-        el.className = "vt-dialog-btn " + (btn.primary ? "primary" : "secondary");
-        el.textContent = btn.label;
-        el.addEventListener("click", () => {
-          closeWith(btn.value === "input" ? vtDialogInput.value : btn.value);
-        });
-        vtDialogActions.appendChild(el);
-      });
-
-      document.addEventListener("keydown", keyHandler);
-      vtDialogModal.classList.add("show");
-      if (showInput) {
-        setTimeout(() => vtDialogInput.focus(), 50);
-      }
-    });
-  }
-
-  function vtAlert(message, type) {
-    type = type || "info";
-    return vtShowDialog({
-      message,
-      type,
-      showInput: false,
-      buttons: [{ label: "OK", primary: true, value: true }],
-    });
-  }
-
-  function vtConfirm(message, type) {
-    type = type || "warning";
-    return vtShowDialog({
-      message,
-      type,
-      showInput: false,
-      buttons: [
-        { label: "Cancel", primary: false, value: false },
-        { label: "OK", primary: true, value: true },
-      ],
-    });
-  }
-
-  function vtPrompt(message, defaultValue, type) {
-    type = type || "info";
-    return vtShowDialog({
-      message,
-      type,
-      showInput: true,
-      inputDefault: defaultValue || "",
-      buttons: [
-        { label: "Cancel", primary: false, value: null },
-        { label: "OK", primary: true, value: "input" },
-      ],
-    });
-  }
+  // Dialog system delegated to static/dialogs.js (window.VTDialogs)
+  const vtShowDialog = window.VTDialogs.vtShowDialog;
+  const vtAlert = window.VTDialogs.vtAlert;
+  const vtConfirm = window.VTDialogs.vtConfirm;
+  const vtPrompt = window.VTDialogs.vtPrompt;
 
   function showSortProgress(label) {
     sortStatus.textContent = label;
@@ -2989,8 +2892,6 @@
   const displayAutodetectResults = window.VTResults.displayAutodetectResults;
   const displayFindResults = window.VTResults.displayFindResults;
   window.VTResults.init({
-    vtAlert,
-    vtConfirm,
     getSortOrder: () => sortOrder,
     getThreshold: () => threshold,
     getVotes: () => votes,

--- a/static/dialogs.js
+++ b/static/dialogs.js
@@ -1,0 +1,118 @@
+/**
+ * VTSearch dialog system — custom modal dialogs replacing native
+ * alert/confirm/prompt with themed, accessible alternatives.
+ *
+ * Exposed on window.VTDialogs so other modules can call them.
+ */
+(function () {
+  "use strict";
+
+  const vtDialogModal = document.getElementById("vt-dialog-modal");
+  const vtDialogIcon = document.getElementById("vt-dialog-icon");
+  const vtDialogMessage = document.getElementById("vt-dialog-message");
+  const vtDialogInput = document.getElementById("vt-dialog-input");
+  const vtDialogActions = document.getElementById("vt-dialog-actions");
+
+  const VT_ICONS = {
+    warning: "\u26A0\uFE0F",
+    error: "\u274C",
+    success: "\u2705",
+    info: "\u2139\uFE0F",
+  };
+
+  function vtShowDialog({ message, type, showInput, inputDefault, buttons }) {
+    return new Promise((resolve) => {
+      vtDialogIcon.textContent = VT_ICONS[type] || VT_ICONS.info;
+      vtDialogIcon.className = "vt-dialog-icon " + (type || "info");
+      vtDialogMessage.textContent = message;
+
+      if (showInput) {
+        vtDialogInput.style.display = "";
+        vtDialogInput.value = inputDefault || "";
+      } else {
+        vtDialogInput.style.display = "none";
+      }
+
+      function closeWith(value) {
+        document.removeEventListener("keydown", keyHandler);
+        vtDialogModal.classList.remove("show");
+        resolve(value);
+      }
+
+      function keyHandler(e) {
+        if (!vtDialogModal.classList.contains("show")) return;
+        if (e.key === "Enter") {
+          e.preventDefault();
+          const primaryBtn = buttons.find((b) => b.primary);
+          if (primaryBtn) closeWith(primaryBtn.value === "input" ? vtDialogInput.value : primaryBtn.value);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          const cancelBtn = buttons.find((b) => !b.primary);
+          if (cancelBtn) closeWith(cancelBtn.value === "input" ? vtDialogInput.value : cancelBtn.value);
+          else closeWith(buttons[0].value === "input" ? vtDialogInput.value : buttons[0].value);
+        }
+      }
+
+      vtDialogActions.innerHTML = "";
+      buttons.forEach((btn) => {
+        const el = document.createElement("button");
+        el.className = "vt-dialog-btn " + (btn.primary ? "primary" : "secondary");
+        el.textContent = btn.label;
+        el.addEventListener("click", () => {
+          closeWith(btn.value === "input" ? vtDialogInput.value : btn.value);
+        });
+        vtDialogActions.appendChild(el);
+      });
+
+      document.addEventListener("keydown", keyHandler);
+      vtDialogModal.classList.add("show");
+      if (showInput) {
+        setTimeout(() => vtDialogInput.focus(), 50);
+      }
+    });
+  }
+
+  function vtAlert(message, type) {
+    type = type || "info";
+    return vtShowDialog({
+      message,
+      type,
+      showInput: false,
+      buttons: [{ label: "OK", primary: true, value: true }],
+    });
+  }
+
+  function vtConfirm(message, type) {
+    type = type || "warning";
+    return vtShowDialog({
+      message,
+      type,
+      showInput: false,
+      buttons: [
+        { label: "Cancel", primary: false, value: false },
+        { label: "OK", primary: true, value: true },
+      ],
+    });
+  }
+
+  function vtPrompt(message, defaultValue, type) {
+    type = type || "info";
+    return vtShowDialog({
+      message,
+      type,
+      showInput: true,
+      inputDefault: defaultValue || "",
+      buttons: [
+        { label: "Cancel", primary: false, value: null },
+        { label: "OK", primary: true, value: "input" },
+      ],
+    });
+  }
+
+  window.VTDialogs = {
+    vtShowDialog,
+    vtAlert,
+    vtConfirm,
+    vtPrompt,
+  };
+})();

--- a/static/index.html
+++ b/static/index.html
@@ -636,6 +636,7 @@
   </div>
 </div>
 
+<script src="/static/dialogs.js"></script>
 <script src="/static/charts.js"></script>
 <script src="/static/results.js"></script>
 <script src="/static/app.js"></script>

--- a/static/results.js
+++ b/static/results.js
@@ -471,7 +471,7 @@
           const sortOrder = _deps.getSortOrder();
           const threshold = _deps.getThreshold();
           if (!sortOrder || threshold === null) {
-            await _deps.vtAlert("No sort results available. Run a sort first.", "warning");
+            await window.VTDialogs.vtAlert("No sort results available. Run a sort first.", "warning");
             return;
           }
 
@@ -493,7 +493,7 @@
           const counts = await dryRes.json();
           const total = (counts.good_count || 0) + (counts.bad_count || 0);
           if (total === 0) {
-            await _deps.vtAlert("No unlabeled elements to fill. All elements in the sort results are already labeled.", "info");
+            await window.VTDialogs.vtAlert("No unlabeled elements to fill. All elements in the sort results are already labeled.", "info");
             return;
           }
 
@@ -502,7 +502,7 @@
           else if (sides === "bad") desc = `${counts.bad_count} Bad label${counts.bad_count !== 1 ? "s" : ""}`;
           else desc = `${counts.good_count} Good + ${counts.bad_count} Bad label${total !== 1 ? "s" : ""}`;
 
-          const confirmed = await _deps.vtConfirm(`This will add ${desc} to the LabelSet and export. Continue?`);
+          const confirmed = await window.VTDialogs.vtConfirm(`This will add ${desc} to the LabelSet and export. Continue?`);
           if (!confirmed) return;
 
           setExportStatus("Filling labels\u2026", "var(--text-muted)");


### PR DESCRIPTION
Move vtShowDialog/vtAlert/vtConfirm/vtPrompt (~100 lines) to a standalone module exposed as window.VTDialogs. This is the cleanest extraction target in app.js: zero coupling to app state, used by 34 call sites across app.js and results.js.

Also simplifies results.js by removing the vtAlert/vtConfirm dependency injection — it now reads from window.VTDialogs directly.

https://claude.ai/code/session_019RR8sbVLtj9TaDwuug8261