### PR TITLE
Improve documentation accuracy, completeness, and cross-references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, autopilot_top_greens, autopilot_hard_reds); auto-saves to `data/settings.json`
 - `vtsearch/routes/` — Flask blueprints: `main.py`, `medias.py`, `sorting.py`, `detectors.py`, `datasets.py`, `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`, `trainable_models.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking, diversity tree
-- `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/combine_datasets); auto-discovered via `IMPORTER` sentinel
+- `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/combine_datasets); auto-discovered via `IMPORTER` sentinel. Note: the `http_zip` directory registers as `http_archive` (its API/CLI name)
 - `vtsearch/eval/` — Evaluation framework: runner, metrics, visualisation, voting iterations
 - `vtsearch/exporters/` — Results exporters (server_json_file/server_csv_file/email_smtp/webhook/gui); auto-discovered via `EXPORTER` sentinel
 - `vtsearch/labels/importers/` — Label importers (server_json_file/server_csv_file); auto-discovered via `LABEL_IMPORTER` sentinel

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ See [docs/SETUP.md](docs/SETUP.md) for instructions on running tests, including 
 │   ├── HANDOFF.md                  # Project handoff & orientation guide
 │   ├── DEPLOYMENT.md               # Deployment, offline mode, operations
 │   ├── ARCHITECTURE.md             # Architecture deep-dive
+│   ├── API.md                      # HTTP API reference (all REST endpoints)
 │   ├── EXTENDING.md                # Plugin authoring guide
 │   ├── EVAL.md                     # Evaluation framework guide
 │   ├── CLI.md                      # CLI reference
@@ -74,6 +75,10 @@ See [docs/SETUP.md](docs/SETUP.md) for instructions on running tests, including 
 │   └── old_io.md                   # Retired IO module reference implementations
 └── requirements*.txt               # Dependency files (cpu, gpu, dev, importers, exporters)
 ```
+
+## HTTP API
+
+VTSearch exposes a REST-style JSON API. See [docs/API.md](docs/API.md) for the full endpoint reference, including media listing, sorting, voting, dataset management, detector/exporter/importer operations, settings, and trainable models.
 
 ## Deployment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ VTSearch/
 │   │       ├── base.py             DatasetImporter ABC + ImporterField
 │   │       ├── folder/             Local directory importer
 │   │       ├── pickle/             .pkl file importer
-│   │       ├── http_zip/           HTTP archive importer
+│   │       ├── http_zip/           HTTP archive importer (API name: http_archive)
 │   │       └── combine_datasets/   Merge multiple pickle datasets
 │   │
 │   ├── exporters/                  Plugin system for output destinations

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,10 +18,10 @@ python app.py --autodetect --dataset path/to/dataset.pkl --settings settings.jso
 
 ```bash
 python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings settings.json
-python app.py --autodetect --importer http_zip --url https://example.com/data.zip --settings settings.json
+python app.py --autodetect --importer http_archive --url https://example.com/data.zip --settings settings.json
 ```
 
-Available importers: `folder`, `pickle`, `http_zip`, `combine_datasets`. Each importer adds its own flags — run `python app.py --autodetect --importer <name> --help` to see them.
+Available importers: `folder`, `pickle`, `http_archive`, `combine_datasets`. Each importer adds its own flags — run `python app.py --autodetect --importer <name> --help` to see them.
 
 **Chunked loading** — for large datasets, use `--chunk-size N` to process in batches to limit memory:
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1,14 +1,15 @@
 # Extending VTSearch
 
 This guide explains how to add a new **Data Importer**, **Results Exporter**,
-**Label Importer**, **Processor Importer**, or **Media Type** to VTSearch.
-Each section describes the interface contract, where files go, and how to wire
-up dependencies.
+**Label Importer**, **Processor Importer**, **Media Type**, or **Media
+Converter** to VTSearch. Each section describes the interface contract, where
+files go, and how to wire up dependencies.
 
 All four plugin systems (data importers, results exporters, label importers,
 processor importers) share the same architecture: an abstract base class, a
 field dataclass for UI forms, auto-discovery via `pkgutil`, and CLI support
-auto-derived from field definitions.
+auto-derived from field definitions. Media types and converters use explicit
+registration instead.
 
 ---
 
@@ -19,7 +20,8 @@ auto-derived from field definitions.
 3. [Adding a Label Importer](#adding-a-label-importer)
 4. [Adding a Processor Importer](#adding-a-processor-importer)
 5. [Adding a Media Type](#adding-a-media-type)
-6. [Dependency Management (requirements.txt)](#dependency-management)
+6. [Adding a Media Converter](#adding-a-media-converter)
+7. [Dependency Management (requirements.txt)](#dependency-management)
 
 ---
 
@@ -824,6 +826,88 @@ and render accordingly.
 
 ---
 
+## Adding a Media Converter
+
+Media converters transform content from one media type to another (e.g.
+document pages to images, video to audio). Unlike the four plugin systems
+above, converters use **explicit registration** in
+`vtsearch/converters/__init__.py` — they are not auto-discovered.
+
+### Built-in converters
+
+| Converter | Source → Target | Description |
+|-----------|----------------|-------------|
+| `Document2ImageMediaConverter` | document → image | Render document pages as images |
+| `Document2TextMediaConverter` | document → text | Extract embedded text from documents |
+| `Video2AudioMediaConverter` | video → audio | Extract the audio track from a video |
+| `Video2ImageMediaConverter` | video → image | Sample frames from a video as images |
+
+### File structure
+
+Create a new module in `vtsearch/converters/`:
+
+```
+vtsearch/converters/<source>2<target>.py   # Your converter class
+```
+
+### What to implement
+
+Subclass `MediaConverter` from `vtsearch.converters.base`:
+
+```python
+# vtsearch/converters/audio2text.py
+
+from vtsearch.converters.base import MediaConverter
+
+
+class Audio2TextMediaConverter(MediaConverter):
+    @property
+    def source_type(self) -> str:
+        return "audio"
+
+    @property
+    def target_type(self) -> str:
+        return "text"
+
+    def convert(self, media: dict) -> list[dict]:
+        """Transcribe audio to text.
+
+        Args:
+            media: A media dict with at least "media_bytes" or "media_path".
+
+        Returns:
+            A list of media dicts, each with "filename" and "media_string"
+            keys. Returns an empty list if conversion fails.
+        """
+        # ... transcription logic ...
+        return [{"filename": "transcript.txt", "media_string": transcript}]
+```
+
+### Register the converter
+
+Add an import and export in `vtsearch/converters/__init__.py`:
+
+```python
+from vtsearch.converters.audio2text import Audio2TextMediaConverter
+```
+
+And add it to `__all__`.
+
+### Abstract interface reference
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `source_type` | `str` (property) | The `type_id` of the input media type |
+| `target_type` | `str` (property) | The `type_id` of the output media type |
+| `convert(media)` | `(dict) -> list[dict]` | Convert one media dict into one or more target-type media dicts |
+
+Each returned dict must include a `"filename"` key and the data fields expected
+by the target media type (e.g. `"media_bytes"` for images, `"media_string"` for
+text). The returned dicts do **not** include `"id"`, `"embedding"`, or `"md5"`
+— the caller handles those.
+
+---
+
 ## Dependency Management
 
 VTSearch uses a layered requirements file structure to keep dependencies
@@ -962,3 +1046,10 @@ requirements-dev.txt          # Dev tools (pytest)
 - [ ] Update `export_dataset_to_file()` in `vtsearch/datasets/loader.py` if you use custom clip keys
 - [ ] Add rendering logic in `static/index.html` if the generic viewer isn't sufficient
 - [ ] Test: start the app, import a folder of your media type, verify clips appear and are sortable
+
+### New Media Converter Checklist
+
+- [ ] Create `vtsearch/converters/<source>2<target>.py`
+- [ ] Subclass `MediaConverter`, implement `source_type`, `target_type`, and `convert()`
+- [ ] Add import and `__all__` entry in `vtsearch/converters/__init__.py`
+- [ ] Test: import a dataset of the source type, convert it, verify the output media dicts are valid

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -43,6 +43,7 @@ runs locally or in Docker.
 | [SETUP.md](SETUP.md) | Installation, prerequisites, getting started, basic Docker usage |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Production deployment, offline mode, network deps, env vars, data directory, troubleshooting |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Module structure, dependency graph, extractability matrix, state management |
+| [API.md](API.md) | HTTP API reference (all REST endpoints, request/response formats) |
 | [CLI.md](CLI.md) | Command-line interface reference (autodetect, importers, exporters) |
 | [ML.md](ML.md) | MLP architecture, training config, embedding models, threshold calibration |
 | [EVAL.md](EVAL.md) | Evaluation framework (metrics, runner, visualisation) |

--- a/vtsearch/exporters/server_csv_file/requirements.txt
+++ b/vtsearch/exporters/server_csv_file/requirements.txt
@@ -1,0 +1,1 @@
+# Server CSV file exporter — no additional dependencies beyond core.

--- a/vtsearch/exporters/server_json_file/requirements.txt
+++ b/vtsearch/exporters/server_json_file/requirements.txt
@@ -1,0 +1,1 @@
+# Server JSON file exporter — no additional dependencies beyond core.

--- a/vtsearch/labels/importers/server_csv_file/requirements.txt
+++ b/vtsearch/labels/importers/server_csv_file/requirements.txt
@@ -1,0 +1,1 @@
+# Server CSV label importer — no additional dependencies beyond core.

--- a/vtsearch/labels/importers/server_json_file/requirements.txt
+++ b/vtsearch/labels/importers/server_json_file/requirements.txt
@@ -1,0 +1,1 @@
+# Server JSON label importer — no additional dependencies beyond core.

--- a/vtsearch/processors/importers/server_detector_file/requirements.txt
+++ b/vtsearch/processors/importers/server_detector_file/requirements.txt
@@ -1,0 +1,1 @@
+# Server detector file importer — no additional dependencies beyond core.


### PR DESCRIPTION
- Fix CLI.md: correct importer name from http_zip to http_archive (the directory is http_zip/ but the API/CLI name is http_archive)
- Add API.md to HANDOFF.md documentation map table
- Add API.md to README.md project structure tree and new HTTP API section
- Add CLAUDE.md clarification about http_zip vs http_archive naming
- Add ARCHITECTURE.md annotation about http_zip's API name
- Add media converter section to EXTENDING.md (interface, example, checklist)
- Add missing requirements.txt files for 5 plugin directories: server_json_file and server_csv_file exporters, server_json_file and server_csv_file label importers, server_detector_file processor importer

https://claude.ai/code/session_01HzRnWweqBtakzoYMG33wAB