### PR TITLE
Add thread-safety locks to settings and progress caches

### DIFF
--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -2,7 +2,9 @@
 
 Validates that the ``_state_lock`` in ``vtsearch.utils.state`` correctly
 serialises concurrent access to votes, click-times, label history, and
-autorun detectors.
+autorun detectors.  Also validates the ``_settings_lock`` in
+``vtsearch.settings`` and the ``_progress_lock`` in
+``vtsearch.models.progress``.
 """
 
 import threading
@@ -19,6 +21,8 @@ from vtsearch.utils import (
 )
 import vtsearch.utils.state as _state
 import vtsearch.utils.state_core as _core
+import vtsearch.settings as _settings_mod
+import vtsearch.models.progress as _progress_mod
 
 
 class TestStateLock:
@@ -248,3 +252,114 @@ class TestConcurrentApplyLabel:
                 assert i in good_votes
             else:
                 assert i in bad_votes
+
+
+class TestSettingsLock:
+    """Verify that _settings_lock exists and is an RLock."""
+
+    def test_lock_is_rlock(self):
+        assert isinstance(_settings_mod._settings_lock, type(threading.RLock()))
+
+    def test_lock_is_reentrant(self):
+        """RLock should allow the same thread to acquire it multiple times."""
+        with _settings_mod._settings_lock:
+            with _settings_mod._settings_lock:
+                pass  # should not deadlock
+
+
+class TestConcurrentSettingsAccess:
+    """Verify that concurrent settings reads and writes don't corrupt state."""
+
+    def test_concurrent_get_set_volume(self):
+        """Concurrent get/set on the same setting should not raise."""
+        num_threads = 20
+        errors = []
+
+        def reader():
+            try:
+                for _ in range(50):
+                    _settings_mod.get_volume()
+            except Exception as e:
+                errors.append(e)
+
+        def writer(val):
+            try:
+                for _ in range(50):
+                    _settings_mod.set_volume(val)
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for i in range(num_threads):
+            if i % 2 == 0:
+                threads.append(threading.Thread(target=reader))
+            else:
+                threads.append(threading.Thread(target=writer, args=(i / num_threads,)))
+
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert not errors
+        # Volume should be a valid float in [0, 1]
+        vol = _settings_mod.get_volume()
+        assert 0.0 <= vol <= 1.0
+
+    def test_concurrent_get_all(self):
+        """Concurrent get_all calls should not raise."""
+        num_threads = 20
+        errors = []
+
+        def worker():
+            try:
+                for _ in range(50):
+                    result = _settings_mod.get_all()
+                    assert isinstance(result, dict)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert not errors
+
+
+class TestProgressLock:
+    """Verify that _progress_lock exists and is an RLock."""
+
+    def test_lock_is_rlock(self):
+        assert isinstance(_progress_mod._progress_lock, type(threading.RLock()))
+
+    def test_lock_is_reentrant(self):
+        """RLock should allow the same thread to acquire it multiple times."""
+        with _progress_mod._progress_lock:
+            with _progress_mod._progress_lock:
+                pass  # should not deadlock
+
+
+class TestConcurrentProgressCache:
+    """Verify that concurrent progress cache operations don't corrupt state."""
+
+    def test_concurrent_clear_progress_cache(self):
+        """Concurrent clears should not raise."""
+        num_threads = 20
+        errors = []
+
+        def worker():
+            try:
+                for _ in range(50):
+                    _progress_mod.clear_progress_cache()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert not errors

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -7,6 +7,7 @@ models that have already been computed.
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -31,6 +32,11 @@ _cache_bad_ids: set[int] = set()
 _cache_prev_predictions: Optional[dict[int, int]] = None
 _cache_diversity_tree: Any = None  # DiversityTree | None
 
+# Reentrant lock protecting all module-level cache variables.
+# RLock is used because public functions call _ensure_cache which may
+# call clear_progress_cache internally when the inclusion value changes.
+_progress_lock = threading.RLock()
+
 
 def clear_progress_cache() -> None:
     """Clear all cached progress data.
@@ -39,12 +45,13 @@ def clear_progress_cache() -> None:
     is altered so that stale models are not reused.
     """
     global _cache_inclusion, _cache_prev_predictions, _cache_diversity_tree
-    _cached_steps.clear()
-    _cache_good_ids.clear()
-    _cache_bad_ids.clear()
-    _cache_prev_predictions = None
-    _cache_inclusion = None
-    _cache_diversity_tree = None
+    with _progress_lock:
+        _cached_steps.clear()
+        _cache_good_ids.clear()
+        _cache_bad_ids.clear()
+        _cache_prev_predictions = None
+        _cache_inclusion = None
+        _cache_diversity_tree = None
 
 
 def _ensure_cache(
@@ -329,10 +336,11 @@ def recreate_model_at_time(
     if time_index < 0 or time_index >= len(label_history):
         return None, None, [], []
 
-    _ensure_cache(clips_dict, label_history, inclusion_value)
+    with _progress_lock:
+        _ensure_cache(clips_dict, label_history, inclusion_value)
 
-    step = _cached_steps[time_index]
-    return step["model"], step["threshold"], step["good_ids"], step["bad_ids"]
+        step = _cached_steps[time_index]
+        return step["model"], step["threshold"], step["good_ids"], step["bad_ids"]
 
 
 def calculate_error_cost_over_time(
@@ -346,8 +354,9 @@ def calculate_error_cost_over_time(
 
     Uses cached models — no retraining.
     """
-    _ensure_cache(clips_dict, label_history, inclusion_value)
-    return _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
+    with _progress_lock:
+        _ensure_cache(clips_dict, label_history, inclusion_value)
+        return _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
 
 
 def calculate_prediction_stability_over_time(
@@ -356,8 +365,9 @@ def calculate_prediction_stability_over_time(
     inclusion_value: int = 0,
 ) -> list[dict[str, Any]]:
     """Return cached prediction-stability metrics for every step."""
-    _ensure_cache(clips_dict, label_history, inclusion_value)
-    return [step["stability"] for step in _cached_steps if step["stability"] is not None]
+    with _progress_lock:
+        _ensure_cache(clips_dict, label_history, inclusion_value)
+        return [step["stability"] for step in _cached_steps if step["stability"] is not None]
 
 
 def _compute_smart_status(
@@ -478,12 +488,13 @@ def compute_labeling_status(
     bad = len(current_bad_votes)
     total = good + bad
 
-    _ensure_cache(clips_dict, label_history, inclusion_value)
+    with _progress_lock:
+        _ensure_cache(clips_dict, label_history, inclusion_value)
 
-    smart = _compute_smart_status(
-        clips_dict, label_history, current_good_votes, current_bad_votes, inclusion_value, good, bad, total
-    )
-    stable = _compute_stable_status(good, bad, total)
+        smart = _compute_smart_status(
+            clips_dict, label_history, current_good_votes, current_bad_votes, inclusion_value, good, bad, total
+        )
+        stable = _compute_stable_status(good, bad, total)
 
     # Span status from diversity tree info (passed in from the route)
     if span_info is None:
@@ -545,7 +556,8 @@ def calculate_diversity_level_over_time(
     ``_ensure_cache`` before calling this function, so the cache is always
     current by the time we arrive here.
     """
-    return [step["diversity"] for step in _cached_steps if step.get("diversity") is not None]
+    with _progress_lock:
+        return [step["diversity"] for step in _cached_steps if step.get("diversity") is not None]
 
 
 def analyze_labeling_progress(
@@ -560,13 +572,14 @@ def analyze_labeling_progress(
     Models and stability metrics are read from the per-step cache.  Error
     cost is recomputed cheaply using cached models (forward passes only).
     """
-    _ensure_cache(clips_dict, label_history, inclusion_value)
+    with _progress_lock:
+        _ensure_cache(clips_dict, label_history, inclusion_value)
 
-    error_cost = _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
+        error_cost = _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
 
-    stability = [step["stability"] for step in _cached_steps if step["stability"] is not None]
+        stability = [step["stability"] for step in _cached_steps if step["stability"] is not None]
 
-    diversity = calculate_diversity_level_over_time(clips_dict, label_history)
+        diversity = calculate_diversity_level_over_time(clips_dict, label_history)
 
     return {
         "error_cost_over_time": error_cost,

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +55,11 @@ _DEFAULTS: dict[str, Any] = {
 
 # In-memory cache — loaded once, written on every mutation.
 _settings: dict[str, Any] | None = None
+
+# Reentrant lock protecting the in-memory cache.  RLock is used because
+# some public functions (e.g. toggle_autoload_media_type) call other public
+# functions that also acquire the lock.
+_settings_lock = threading.RLock()
 
 
 def _load() -> dict[str, Any]:
@@ -85,9 +91,10 @@ def _save(data: dict[str, Any]) -> None:
 
 def _ensure_loaded() -> dict[str, Any]:
     global _settings
-    if _settings is None:
-        _settings = _load()
-    return _settings
+    with _settings_lock:
+        if _settings is None:
+            _settings = _load()
+        return _settings
 
 
 # -------------------------------------------------------------------
@@ -102,10 +109,11 @@ def get_defaults() -> dict[str, Any]:
 
 def get_all() -> dict[str, Any]:
     """Return the full settings dict (with defaults filled in)."""
-    s = _ensure_loaded()
-    result = dict(_DEFAULTS)
-    result.update(s)
-    return result
+    with _settings_lock:
+        s = _ensure_loaded()
+        result = dict(_DEFAULTS)
+        result.update(s)
+        return result
 
 
 VALID_THEMES = ("dark", "light", "highviz")
@@ -126,12 +134,14 @@ def _make_accessors(key: str, cast: type, coerce=None):
         coerce = cast
 
     def getter():
-        return cast(_ensure_loaded().get(key, _DEFAULTS[key]))
+        with _settings_lock:
+            return cast(_ensure_loaded().get(key, _DEFAULTS[key]))
 
     def setter(value):
-        s = _ensure_loaded()
-        s[key] = coerce(value)
-        _save(s)
+        with _settings_lock:
+            s = _ensure_loaded()
+            s[key] = coerce(value)
+            _save(s)
 
     getter.__name__ = f"get_{key}"
     setter.__name__ = f"set_{key}"
@@ -189,10 +199,11 @@ VALID_MEDIA_TYPES = ("audio", "document", "image", "paragraph", "video")
 
 def get_autoload_media_types() -> list[str]:
     """Return the list of autoload media type IDs (empty list if none set)."""
-    raw = _ensure_loaded().get("autoload_media_types", _DEFAULTS["autoload_media_types"])
-    if isinstance(raw, list):
-        return [v for v in raw if v in VALID_MEDIA_TYPES]
-    return []
+    with _settings_lock:
+        raw = _ensure_loaded().get("autoload_media_types", _DEFAULTS["autoload_media_types"])
+        if isinstance(raw, list):
+            return [v for v in raw if v in VALID_MEDIA_TYPES]
+        return []
 
 
 def set_autoload_media_types(value: list[str]) -> None:
@@ -200,27 +211,30 @@ def set_autoload_media_types(value: list[str]) -> None:
     for v in value:
         if v not in VALID_MEDIA_TYPES:
             raise ValueError(f"Invalid media type: {v!r}")
-    s = _ensure_loaded()
-    s["autoload_media_types"] = list(dict.fromkeys(value))  # deduplicate, preserve order
-    _save(s)
+    with _settings_lock:
+        s = _ensure_loaded()
+        s["autoload_media_types"] = list(dict.fromkeys(value))  # deduplicate, preserve order
+        _save(s)
 
 
 def toggle_autoload_media_type(type_id: str) -> list[str]:
     """Toggle a single media type's autoload status.  Returns the updated list."""
     if type_id not in VALID_MEDIA_TYPES:
         raise ValueError(f"Invalid media type: {type_id!r}")
-    current = get_autoload_media_types()
-    if type_id in current:
-        current.remove(type_id)
-    else:
-        current.append(type_id)
-    set_autoload_media_types(current)
-    return current
+    with _settings_lock:
+        current = get_autoload_media_types()
+        if type_id in current:
+            current.remove(type_id)
+        else:
+            current.append(type_id)
+        set_autoload_media_types(current)
+        return current
 
 
 def get_autorun_processors() -> list[dict[str, Any]]:
     """Return the list of autorun processor recipes."""
-    return list(_ensure_loaded().get("autorun_processors", []))
+    with _settings_lock:
+        return list(_ensure_loaded().get("autorun_processors", []))
 
 
 def add_autorun_processor(
@@ -229,31 +243,33 @@ def add_autorun_processor(
     field_values: dict[str, Any],
 ) -> None:
     """Add a autorun processor recipe (or overwrite one with the same name)."""
-    s = _ensure_loaded()
-    procs: list[dict[str, Any]] = s.setdefault("autorun_processors", [])
-    # Remove existing entry with same name
-    procs[:] = [p for p in procs if p.get("processor_name") != processor_name]
-    procs.append(
-        {
-            "processor_name": processor_name,
-            "processor_importer": processor_importer,
-            "field_values": field_values,
-        }
-    )
-    _save(s)
+    with _settings_lock:
+        s = _ensure_loaded()
+        procs: list[dict[str, Any]] = s.setdefault("autorun_processors", [])
+        # Remove existing entry with same name
+        procs[:] = [p for p in procs if p.get("processor_name") != processor_name]
+        procs.append(
+            {
+                "processor_name": processor_name,
+                "processor_importer": processor_importer,
+                "field_values": field_values,
+            }
+        )
+        _save(s)
 
 
 def remove_autorun_processor(processor_name: str) -> bool:
     """Remove a autorun processor by name.  Returns True if found."""
-    s = _ensure_loaded()
-    procs: list[dict[str, Any]] = s.get("autorun_processors", [])
-    before = len(procs)
-    procs[:] = [p for p in procs if p.get("processor_name") != processor_name]
-    if len(procs) < before:
-        s["autorun_processors"] = procs
-        _save(s)
-        return True
-    return False
+    with _settings_lock:
+        s = _ensure_loaded()
+        procs: list[dict[str, Any]] = s.get("autorun_processors", [])
+        before = len(procs)
+        procs[:] = [p for p in procs if p.get("processor_name") != processor_name]
+        if len(procs) < before:
+            s["autorun_processors"] = procs
+            _save(s)
+            return True
+        return False
 
 
 def to_settings_json(entry: dict[str, Any]) -> str:
@@ -337,11 +353,13 @@ def set_settings_path(path: str | Path) -> None:
     CLI flag).
     """
     global SETTINGS_PATH, _settings
-    SETTINGS_PATH = Path(path)
-    _settings = None  # force reload on next access
+    with _settings_lock:
+        SETTINGS_PATH = Path(path)
+        _settings = None  # force reload on next access
 
 
 def reset() -> None:
     """Reset the in-memory cache (for testing)."""
     global _settings
-    _settings = None
+    with _settings_lock:
+        _settings = None


### PR DESCRIPTION
settings.py had no synchronization on the in-memory _settings cache, allowing concurrent Flask request threads to race on lazy initialization and read-modify-write sequences. Added _settings_lock (RLock) protecting all cache access.

progress.py module-level caches (_cached_steps, _cache_good_ids, etc.) had no synchronization, allowing concurrent progress queries to corrupt cache state. Added _progress_lock (RLock) protecting all cache reads, writes, and clears.

Both use RLock because some public functions call other public functions that also acquire the lock (e.g. toggle_autoload_media_type calls get/set_autoload_media_types; _ensure_cache calls clear_progress_cache).

https://claude.ai/code/session_01U5Lm8AVqUYmhzgkzPL7Rp4