### PR TITLE
Add dashboard workflow for creating trainable models with autopilot

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1768,7 +1768,9 @@
 
           await fetchVotes();
 
-          // Set text sort mode and trigger sort with the model's text query
+          // Set text sort mode and trigger sort with the model's text query or first text example
+          const exQuery = trainInfo.model.text_query
+            || (trainInfo.model.examples && trainInfo.model.examples.length > 0 && trainInfo.model.examples[0].type === "text" ? trainInfo.model.examples[0].value : "");
           sortMode = "text";
           textSortWrap.style.display = "";
           learnedSortWrap.style.display = "none";
@@ -1777,9 +1779,9 @@
           document.querySelectorAll('input[name="sort-mode"]').forEach(r => {
             r.checked = r.value === "text";
           });
-          textSortInput.value = trainInfo.model.text_query || "";
-          if (trainInfo.model.text_query) {
-            fetchTextSort(trainInfo.model.text_query);
+          textSortInput.value = exQuery;
+          if (exQuery) {
+            fetchTextSort(exQuery);
           }
 
           // Select first media
@@ -6328,6 +6330,31 @@
             trainable: true,
           },
         };
+
+        // Fetch examples from the trainable model or autorun detector so
+        // that Autopilot mode has the data it needs to start.
+        const modelName = _dashboardTrainMode.model.name;
+        try {
+          const tmRes = await fetch(`/api/trainable-models/${encodeURIComponent(modelName)}`);
+          if (tmRes.ok) {
+            const tmData = await tmRes.json();
+            _dashboardTrainMode.model.examples = tmData.examples || [];
+            if (!_dashboardTrainMode.model.text_query && tmData.text_query) {
+              _dashboardTrainMode.model.text_query = tmData.text_query;
+            }
+          }
+        } catch (_) { /* ignore */ }
+        // Fallback: try the autorun detector if no examples yet
+        if (!_dashboardTrainMode.model.examples || _dashboardTrainMode.model.examples.length === 0) {
+          const detName = regModel.detector_name || regModel.name;
+          try {
+            const detRes = await fetch(`/api/autorun-detectors/${encodeURIComponent(detName)}/examples`);
+            if (detRes.ok) {
+              const detData = await detRes.json();
+              _dashboardTrainMode.model.examples = detData.examples || [];
+            }
+          } catch (_) { /* ignore */ }
+        }
       } else {
         _dashboardTrainMode = null;
       }
@@ -6337,7 +6364,44 @@
 
       if (selDs.length === 1) {
         if (selDs[0].loaded) {
-          // Already loaded — go straight to labeling
+          // Already loaded — set up labeling (import labels, text sort, etc.)
+          await fetchMedias();
+
+          if (_dashboardTrainMode && _dashboardTrainMode.model) {
+            // Import labels from the trainable model's labelset
+            try {
+              const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(_dashboardTrainMode.model.name)}`);
+              if (modelRes.ok) {
+                const modelData = await modelRes.json();
+                const labels = modelData.labelset && modelData.labelset.labels;
+                if (labels && labels.length > 0) {
+                  await fetch("/api/labels/import", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ labels }),
+                  });
+                }
+              }
+            } catch (_) { /* ignore label import errors */ }
+
+            await fetchVotes();
+
+            // Set text sort mode and trigger sort with the model's first example or text_query
+            const exQuery = _dashboardTrainMode.model.text_query
+              || (_dashboardTrainMode.model.examples && _dashboardTrainMode.model.examples.length > 0 && _dashboardTrainMode.model.examples[0].type === "text" ? _dashboardTrainMode.model.examples[0].value : "");
+            sortMode = "text";
+            textSortWrap.style.display = "";
+            learnedSortWrap.style.display = "none";
+            loadSortWrap.style.display = "none";
+            document.querySelectorAll('input[name="sort-mode"]').forEach(r => {
+              r.checked = r.value === "text";
+            });
+            textSortInput.value = exQuery;
+            if (exQuery) {
+              fetchTextSort(exQuery);
+            }
+          }
+
           showMainUI();
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -882,3 +883,178 @@ class TestSafeThresholdsWorkflow:
         # Both should be valid floats
         assert isinstance(threshold_off, (int, float))
         assert isinstance(threshold_on, (int, float))
+
+
+# ---------------------------------------------------------------------------
+# 18. Dashboard → Create Model → Label → Autopilot Workflow
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardToAutopilotWorkflow:
+    """Simulates the full dashboard workflow: create a trainable model via
+    the autorun-detectors endpoint (as the "New Model" form does), verify it
+    appears in the model registry with examples and text_query, then enter
+    labeling with the model, vote, and verify autopilot-related state."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_trainable_models(self):
+        """Remove trainable model files created during tests."""
+        from vtsearch.routes.trainable_models import TRAINABLE_MODELS_DIR
+
+        if TRAINABLE_MODELS_DIR.is_dir():
+            shutil.rmtree(TRAINABLE_MODELS_DIR)
+        yield
+        if TRAINABLE_MODELS_DIR.is_dir():
+            shutil.rmtree(TRAINABLE_MODELS_DIR)
+
+    def test_create_model_registers_with_examples_and_text_query(self, client):
+        """Creating a model via POST /api/autorun-detectors should register
+        the model in the model registry with text_query and create a
+        trainable model file with examples."""
+        # Step 1: Create a model via the same endpoint the GUI "New Model" form uses
+        resp = client.post(
+            "/api/autorun-detectors",
+            json={
+                "name": "Bird Songs",
+                "media_type": "audio",
+                "examples": [
+                    {"type": "text", "value": "bird singing in the morning"},
+                    {"type": "text", "value": "chirping sounds"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+
+        # Step 2: Verify model appears in the model registry
+        resp = client.get("/api/models/registry")
+        assert resp.status_code == 200
+        models = resp.get_json()["models"]
+        bird_model = [m for m in models if m["name"] == "Bird Songs"]
+        assert len(bird_model) == 1
+        entry = bird_model[0]
+        assert entry["trainable"] is True
+        assert entry["media_type"] == "audio"
+        # text_query should be populated from the first text example
+        assert entry.get("text_query") == "bird singing in the morning"
+        # trainable_model_name should be set so the Label button can find it
+        assert entry.get("trainable_model_name") == "Bird Songs"
+
+        # Step 3: Verify trainable model file was created with examples
+        resp = client.get("/api/trainable-models/Bird Songs")
+        assert resp.status_code == 200
+        tm_data = resp.get_json()
+        assert tm_data["name"] == "Bird Songs"
+        assert tm_data["text_query"] == "bird singing in the morning"
+        assert len(tm_data["examples"]) == 2
+        assert tm_data["examples"][0]["type"] == "text"
+        assert tm_data["examples"][0]["value"] == "bird singing in the morning"
+        assert tm_data["examples"][1]["value"] == "chirping sounds"
+
+    def test_create_model_then_fetch_examples_for_autopilot(self, client):
+        """After creating a model, the examples should be fetchable from both
+        the autorun detector and the trainable model endpoints — this is the
+        path the Label button + Autopilot tab use."""
+        # Create model
+        client.post(
+            "/api/autorun-detectors",
+            json={
+                "name": "Ocean Waves",
+                "media_type": "audio",
+                "examples": [{"type": "text", "value": "ocean waves crashing"}],
+            },
+        )
+
+        # Fetch examples from the autorun detector
+        resp = client.get("/api/autorun-detectors/Ocean Waves/examples")
+        assert resp.status_code == 200
+        det_examples = resp.get_json()["examples"]
+        assert len(det_examples) == 1
+        assert det_examples[0]["value"] == "ocean waves crashing"
+
+        # Fetch examples from the trainable model
+        resp = client.get("/api/trainable-models/Ocean Waves")
+        assert resp.status_code == 200
+        tm_data = resp.get_json()
+        assert len(tm_data["examples"]) == 1
+        assert tm_data["examples"][0]["value"] == "ocean waves crashing"
+
+    def test_label_workflow_with_trainable_model(self, client):
+        """Simulates: create model → enter labeling → vote → save labels →
+        verify labels persist on the trainable model."""
+        # Step 1: Create model
+        resp = client.post(
+            "/api/autorun-detectors",
+            json={
+                "name": "Thunder",
+                "media_type": "audio",
+                "examples": [{"type": "text", "value": "thunder rumbling"}],
+            },
+        )
+        assert resp.status_code == 200
+
+        # Step 2: List medias (as the GUI does when entering labeling)
+        resp = client.get("/api/medias")
+        assert resp.status_code == 200
+        all_medias = resp.get_json()
+        assert len(all_medias) >= 4
+
+        # Step 3: Text sort with model's text query
+        resp = client.post("/api/sort", json={"text": "thunder rumbling"})
+        assert resp.status_code == 200
+        sort_data = resp.get_json()
+        assert "results" in sort_data
+        assert len(sort_data["results"]) > 0
+
+        # Step 4: Vote on some medias
+        top_ids = [r["id"] for r in sort_data["results"][:3]]
+        bottom_ids = [r["id"] for r in sort_data["results"][-4:]]
+        _vote_clips(client, top_ids, bottom_ids)
+
+        # Step 5: Save labels to the trainable model
+        resp = client.post("/api/trainable-models/Thunder/labels")
+        assert resp.status_code == 200
+        label_data = resp.get_json()
+        assert label_data["success"] is True
+        assert label_data["num_labels"] == 7  # 3 good + 4 bad
+
+        # Step 6: Verify model registry shows updated training count
+        resp = client.get("/api/models/registry")
+        models = resp.get_json()["models"]
+        thunder = [m for m in models if m["name"] == "Thunder"]
+        assert len(thunder) == 1
+        assert thunder[0]["num_training"] == 7
+
+        # Step 7: Verify trainable model has the labels persisted
+        resp = client.get("/api/trainable-models/Thunder")
+        assert resp.status_code == 200
+        tm_data = resp.get_json()
+        labels = tm_data["labelset"]["labels"]
+        assert len(labels) == 7
+        good_labels = [l for l in labels if l["label"] == "good"]
+        bad_labels = [l for l in labels if l["label"] == "bad"]
+        assert len(good_labels) == 3
+        assert len(bad_labels) == 4
+
+    def test_autopilot_indicators_after_voting(self, client):
+        """After enough votes, the labeling-status endpoint should return
+        indicator statuses that autopilot uses for phase transitions."""
+        # Get medias
+        resp = client.get("/api/medias")
+        all_medias = resp.get_json()
+        ids = [m["id"] for m in all_medias]
+
+        # Vote: 5 good, 5 bad
+        _vote_clips(client, ids[:5], ids[5:10])
+
+        # Check labeling status — should now return indicator data
+        resp = client.get("/api/labeling-status")
+        assert resp.status_code == 200
+        status = resp.get_json()
+        assert "smart" in status
+        assert "stable" in status
+        assert "span" in status
+        assert status["smart"]["status"] in ("red", "yellow", "green")
+        assert status["stable"]["status"] in ("red", "yellow", "green")
+        assert status["span"]["status"] in ("red", "yellow", "green")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1032,8 +1032,8 @@ class TestDashboardToAutopilotWorkflow:
         tm_data = resp.get_json()
         labels = tm_data["labelset"]["labels"]
         assert len(labels) == 7
-        good_labels = [l for l in labels if l["label"] == "good"]
-        bad_labels = [l for l in labels if l["label"] == "bad"]
+        good_labels = [lb for lb in labels if lb["label"] == "good"]
+        bad_labels = [lb for lb in labels if lb["label"] == "bad"]
         assert len(good_labels) == 3
         assert len(bad_labels) == 4
 

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -72,17 +72,47 @@ def add_autorun_detector_route():
         name, media_type, weights, threshold, autodetect=autodetect, examples=examples, num_labels=num_labels
     )
 
+    # Extract text_query from examples (first text example) for the registry
+    text_query = ""
+    if examples:
+        for ex in examples:
+            if isinstance(ex, dict) and ex.get("type") == "text" and ex.get("value"):
+                text_query = ex["value"]
+                break
+
     # Also register in the persistent model registry so the dashboard grid
     # picks up the new model immediately.
     from vtsearch.models.registry import find_by_detector_name, register_model
 
     if not find_by_detector_name(name):
+        # When trainable (no pre-existing weights), also create a trainable
+        # model file so that labels and examples persist across restarts.
+        trainable_model_name = ""
+        if not weights:
+            from vtsearch.routes.trainable_models import _model_path, _write_model
+            import time as _time
+
+            trainable_model_name = name
+            tm_path = _model_path(name)
+            if not tm_path.exists():
+                model_data = {
+                    "name": name,
+                    "text_query": text_query,
+                    "media_type": media_type or "any",
+                    "examples": examples or [],
+                    "created_at": _time.time(),
+                    "labelset": {"labels": []},
+                }
+                _write_model(tm_path, model_data)
+
         register_model(
             name=name,
             media_type=media_type,
             trainable=not weights,
             num_training=num_labels,
             detector_name=name,
+            text_query=text_query,
+            trainable_model_name=trainable_model_name,
         )
 
     return jsonify({"success": True, "name": name})


### PR DESCRIPTION
## Summary
This PR implements the complete dashboard workflow for creating trainable models, labeling them, and integrating with the autopilot system. It enables users to create models via the "New Model" form, have them automatically registered with examples and text queries, and then seamlessly enter the labeling interface with pre-populated sort queries and imported labels.

## Key Changes

- **Model Creation & Registration**: When a model is created via `/api/autorun-detectors` without pre-existing weights, it now:
  - Extracts the first text example as `text_query` for the model registry
  - Creates a persistent trainable model file with examples, text_query, and an empty labelset
  - Registers the model in the dashboard grid with `trainable=true` and `trainable_model_name` set

- **Label Persistence**: Added support for saving and loading labels from trainable model files:
  - Labels voted on during labeling can be saved to the trainable model via `/api/trainable-models/{name}/labels`
  - Labels are automatically imported when re-entering labeling for an already-loaded dataset
  - Model registry displays `num_training` count reflecting persisted labels

- **Autopilot Integration**: Enhanced the labeling UI to support autopilot workflows:
  - Fetches examples from trainable models or autorun detectors when entering labeling
  - Falls back to first text example if `text_query` is not available
  - Automatically sets text sort mode and triggers sort with the model's query
  - Imports previously saved labels when re-entering labeling

- **Frontend Updates**: Modified `app.js` to:
  - Fetch trainable model data (examples, text_query) when entering labeling
  - Use examples as fallback for text sort if text_query is unavailable
  - Import labels from trainable model's labelset when dataset is already loaded
  - Support both new model creation and re-entry into existing labeling workflows

- **Test Coverage**: Added comprehensive integration tests (`TestDashboardToAutopilotWorkflow`) covering:
  - Model creation and registry registration with examples and text_query
  - Example fetching from both autorun detectors and trainable models
  - Full label workflow: create → label → vote → save → verify persistence
  - Autopilot indicator status after voting

## Implementation Details

- Trainable model files are stored as JSON with structure: `{name, text_query, media_type, examples, created_at, labelset}`
- Text query extraction prioritizes the first text-type example from the creation request
- Label import/export uses the existing `/api/labels/import` endpoint
- Cleanup fixture ensures trainable model files are removed between tests
- Fallback logic ensures UI works whether text_query or examples are available

https://claude.ai/code/session_013jUDYhTz5kj8kpm9E5S2M9