### PR TITLE
Auto-select single dataset and model when only one exists

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1281,6 +1281,11 @@
       dashRegisteredDatasets = [];
     }
 
+    // Auto-select when exactly one dataset exists
+    if (dashRegisteredDatasets.length === 1 && dashSelectedDatasetIds.length === 0) {
+      dashSelectedDatasetIds = [dashRegisteredDatasets[0].id];
+    }
+
     if (dashRegisteredDatasets.length === 0) {
       dashDatasetGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No datasets yet. Use "+" to load one.</p>';
       return;
@@ -1420,6 +1425,11 @@
       const data = await res.json();
       autorunDetectors = data.detectors || [];
     } catch (_) {}
+
+    // Auto-select when exactly one model exists
+    if (dashRegisteredModels.length === 1 && dashSelectedModelIds.length === 0) {
+      dashSelectedModelIds = [dashRegisteredModels[0].id];
+    }
 
     if (dashRegisteredModels.length === 0) {
       dashModelGrid.innerHTML = '<p style="color:var(--text-muted); padding:16px;">No models yet. Use "+" to create one.</p>';


### PR DESCRIPTION
## Summary
This change improves the user experience by automatically selecting the only available dataset or model when exactly one exists and nothing is currently selected.

## Key Changes
- **Dataset auto-selection**: When exactly one dataset is registered and no datasets are currently selected, it is automatically selected
- **Model auto-selection**: When exactly one model is registered and no models are currently selected, it is automatically selected

## Implementation Details
- Both auto-selection checks are performed after loading the respective items but before rendering the UI
- The checks only trigger when the collection has exactly one item (`length === 1`) and the selection is empty (`length === 0`)
- This prevents unnecessary user interaction when there's only one option available, streamlining the workflow for single-item scenarios

https://claude.ai/code/session_01HsNe7Nvvh4No1YJmXpYR43