### PR TITLE
Change dashboard actions layout from wrap to nowrap

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -696,7 +696,7 @@ video { max-width: 100%; }
 }
 .dashboard-action-btn.secondary:hover { background: var(--accent-highlight-bg); }
 .dashboard-action-btn.secondary:disabled { background: transparent; }
-.dashboard-actions { flex-wrap: wrap; }
+.dashboard-actions { flex-wrap: nowrap; }
 .dash-btn-hint {
   display: block; width: 100%; font-size: 0.72rem; color: var(--text-muted);
   text-align: center; margin-top: 2px; min-height: 1em;


### PR DESCRIPTION
## Summary
Modified the dashboard actions container to prevent flex items from wrapping to multiple lines.

## Changes
- Updated `.dashboard-actions` flex-wrap property from `wrap` to `nowrap`
  - This prevents dashboard action buttons from breaking into multiple rows
  - Buttons will now stay on a single line, with overflow handled by the flex container's default behavior

## Implementation Details
This is a CSS-only change that affects the layout behavior of the dashboard action buttons. The `nowrap` value ensures that all action buttons remain horizontally aligned on a single line rather than reflowing to subsequent lines when space is constrained.

https://claude.ai/code/session_01DZmTAdkkkNZVCZygskH1ig