### PR TITLE
Rename pollProgress to startProgressPolling for clarity

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6412,7 +6412,7 @@
           try {
             await fetch(`/api/datasets/registry/${encodeURIComponent(selDs[0].id)}/load`, { method: "POST" });
           } catch (_) {}
-          pollProgress();
+          startProgressPolling();
         }
         return;
       }


### PR DESCRIPTION
## Summary
Renamed the `pollProgress()` function call to `startProgressPolling()` to better reflect the function's purpose and improve code readability.

## Key Changes
- Renamed function call from `pollProgress()` to `startProgressPolling()` in the dataset registry load handler

## Implementation Details
This change improves code clarity by using a more descriptive function name that explicitly indicates the function initiates a polling mechanism for progress tracking, rather than the more ambiguous `pollProgress` name.

https://claude.ai/code/session_014GqY43CqnXrnH5Csmjnwqd