### PR TITLE
Reorganize settings modal to 3-column layout with actions in sidebar

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -538,9 +538,8 @@
     </div>
     <div class="modal-body">
       <div class="settings-columns">
-        <!-- Left column: Appearance + Sorting -->
+        <!-- Column 1: Appearance -->
         <div>
-          <!-- Appearance -->
           <div class="settings-section">
             <div class="settings-section-title">Appearance</div>
             <div class="settings-row">
@@ -564,7 +563,9 @@
               <input type="checkbox" id="show-thumbnails-right-checkbox" checked style="accent-color:var(--accent)">
             </div>
           </div>
-          <!-- Sorting -->
+        </div>
+        <!-- Column 2: Sorting + Calibration -->
+        <div>
           <div class="settings-section">
             <div class="settings-section-title">Sorting</div>
             <div class="settings-row">
@@ -572,10 +573,6 @@
               <input type="checkbox" id="enrich-descriptions-checkbox" style="accent-color:var(--accent)">
             </div>
           </div>
-        </div>
-        <!-- Right column: Calibration + Autoload Media Types -->
-        <div>
-          <!-- Calibration -->
           <div class="settings-section">
             <div class="settings-section-title">Calibration</div>
             <div class="settings-row">
@@ -591,7 +588,9 @@
               <input type="checkbox" id="safe-thresholds-checkbox" style="accent-color:var(--accent)">
             </div>
           </div>
-          <!-- Autopilot -->
+        </div>
+        <!-- Column 3: Autopilot + Autoload Media Types + Actions -->
+        <div>
           <div class="settings-section">
             <div class="settings-section-title">Autopilot</div>
             <div class="settings-row">
@@ -603,7 +602,6 @@
               <input type="number" id="autopilot-hard-reds-input" min="1" value="4" step="1" class="settings-number-input">
             </div>
           </div>
-          <!-- Autoload Media Types -->
           <div class="settings-section">
             <div class="settings-section-title">Autoload Media Types</div>
             <div class="settings-row">
@@ -623,14 +621,13 @@
               <input type="checkbox" id="fav-mt-video" data-media-type="video" style="accent-color:var(--accent)">
             </div>
           </div>
+          <div class="settings-actions">
+            <button id="settings-default-btn" class="settings-btn secondary">Default</button>
+            <input type="file" id="settings-import-file" accept=".json" style="display:none">
+            <button id="settings-import-btn" class="settings-btn secondary">Import</button>
+            <button id="settings-export-btn" class="settings-btn secondary">Export</button>
+          </div>
         </div>
-      </div>
-      <!-- Actions -->
-      <div class="settings-actions">
-        <button id="settings-default-btn" class="settings-btn secondary">Default</button>
-        <input type="file" id="settings-import-file" accept=".json" style="display:none">
-        <button id="settings-import-btn" class="settings-btn secondary">Import</button>
-        <button id="settings-export-btn" class="settings-btn secondary">Export</button>
       </div>
     </div>
   </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -460,16 +460,17 @@ video { max-width: 100%; }
 .vt-dialog-btn.secondary:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* Settings modal */
-.settings-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 0 32px; }
-.settings-section { margin-bottom: 20px; }
+.settings-columns { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0 24px; }
+.settings-columns > div { display: flex; flex-direction: column; }
+.settings-section { margin-bottom: 16px; }
 .settings-section-title { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 10px; }
 .settings-row { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; }
 .settings-row + .settings-row { border-top: 1px solid var(--border-subtle); }
 .settings-label { font-size: 0.85rem; color: var(--text-secondary); cursor: pointer; }
 .settings-number-input { width: 72px; padding: 5px 8px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg-panel); color: var(--text-primary); font-size: 0.85rem; text-align: center; outline: none; }
 .settings-number-input:focus { border-color: var(--accent); }
-.settings-actions { display: flex; gap: 8px; padding-top: 16px; border-top: 1px solid var(--border); }
-.settings-btn { flex: 1; padding: 8px 12px; border-radius: 4px; font-size: 0.8rem; cursor: pointer; transition: all 0.15s; border: 1px solid var(--border); }
+.settings-actions { display: flex; flex-direction: column; gap: 6px; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--border); }
+.settings-btn { padding: 7px 12px; border-radius: 4px; font-size: 0.8rem; cursor: pointer; transition: all 0.15s; border: 1px solid var(--border); }
 .settings-btn.secondary { background: var(--bg-surface); color: var(--text-secondary); }
 .settings-btn.secondary:hover { background: var(--bg-hover); color: var(--text-primary); }
 


### PR DESCRIPTION
## Summary
Restructured the settings modal from a 2-column layout to a 3-column layout, moving the action buttons (Default, Import, Export) into the third column instead of displaying them below all settings.

## Key Changes
- **Layout restructuring**: Changed `.settings-columns` grid from 2 columns (`1fr 1fr`) to 3 columns (`1fr 1fr 1fr`)
- **Column reorganization**:
  - Column 1: Appearance settings only
  - Column 2: Sorting and Calibration settings
  - Column 3: Autopilot, Autoload Media Types, and action buttons
- **Action buttons repositioning**: Moved `.settings-actions` from a separate section below the grid into the third column, using `margin-top: auto` to align them to the bottom
- **Styling adjustments**:
  - Reduced gap between columns from 32px to 24px
  - Changed `.settings-actions` to `flex-direction: column` with reduced gap (6px)
  - Removed `flex: 1` from `.settings-btn` to allow natural sizing
  - Added `display: flex; flex-direction: column` to column containers for proper vertical alignment
  - Adjusted margins and padding for better spacing consistency

## Implementation Details
- The action buttons now use `margin-top: auto` on their container to stick to the bottom of the third column, creating a more compact and organized layout
- Column containers use flexbox with column direction to enable the auto-margin behavior
- HTML structure was updated to nest the actions div inside the third column div rather than as a sibling to the columns container

https://claude.ai/code/session_01G2sCvsVFWEux9T57zwmaxt