### PR TITLE
Convert dashboard progress bar to dynamic table row

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -295,11 +295,11 @@
   const datasetImporterFormDiv = document.getElementById("dataset-importer-form");
   const datasetImporterBack = document.getElementById("dataset-importer-back");
   const dashFileInput = document.getElementById("dash-file-input");
-  const dashProgress = document.getElementById("dash-progress");
-  const dashProgressFill = document.getElementById("dash-progress-fill");
-  const dashProgressText = document.getElementById("dash-progress-text");
-  const dashProgressMessage = document.getElementById("dash-progress-message");
-  const dashProgressEta = document.getElementById("dash-progress-eta");
+  // Dashboard progress elements — created dynamically as a table row
+  let dashProgressFill = null;
+  let dashProgressText = null;
+  let dashProgressMessage = null;
+  let dashProgressEta = null;
   const headerDashboardBtn = document.getElementById("header-dashboard-btn");
   const menuDashboard = document.getElementById("menu-dashboard");
   let showThumbnailsRight = true;
@@ -1576,22 +1576,47 @@
     renderModelRows();
   }
 
-  // Show the in-grid progress bar inside the dataset section, hiding the grid content
+  // Show a progress row inside the dataset table (keeps existing rows visible)
   function showDashGridProgress(message) {
-    dashDatasetGrid.style.display = "none";
-    dashProgress.style.display = "block";
-    dashProgressFill.style.width = "0%";
-    dashProgressFill.classList.add("indeterminate");
-    dashProgressText.textContent = "";
-    dashProgressMessage.textContent = message || "Loading...";
+    // Remove any existing progress row first
+    hideDashGridProgress();
+    // Ensure the table exists; if the grid is empty, create a minimal table
+    let tbody = dashDatasetGrid.querySelector("tbody");
+    if (!tbody) {
+      dashDatasetGrid.innerHTML = `<table class="dash-dataset-table">
+        <thead><tr>
+          <th>Name</th><th>Type</th><th>Items</th><th>Loaded</th><th class="col-actions-header"></th>
+        </tr></thead><tbody></tbody></table>`;
+      tbody = dashDatasetGrid.querySelector("tbody");
+    }
+    const tr = document.createElement("tr");
+    tr.id = "dash-progress-row";
+    tr.className = "dash-progress-row";
+    tr.innerHTML = `<td colspan="5" class="dash-progress-cell" role="status" aria-live="polite">
+      <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-fill indeterminate" id="dash-progress-fill" style="width:0%"></div>
+        <div class="progress-text" id="dash-progress-text" aria-hidden="true"></div>
+      </div>
+      <div class="progress-message" id="dash-progress-message">${escapeHtml(message || "Loading...")}</div>
+      <div class="progress-eta" id="dash-progress-eta"></div>
+    </td>`;
+    tbody.appendChild(tr);
+    // Update element references
+    dashProgressFill = tr.querySelector("#dash-progress-fill");
+    dashProgressText = tr.querySelector("#dash-progress-text");
+    dashProgressMessage = tr.querySelector("#dash-progress-message");
+    dashProgressEta = tr.querySelector("#dash-progress-eta");
     dashProgressMessage.style.color = "var(--text-secondary)";
-    dashProgressEta.textContent = "";
   }
 
-  // Hide the in-grid progress bar and restore the dataset grid
+  // Remove the progress row from the dataset table
   function hideDashGridProgress() {
-    dashProgress.style.display = "none";
-    dashDatasetGrid.style.display = "";
+    const row = document.getElementById("dash-progress-row");
+    if (row) row.remove();
+    dashProgressFill = null;
+    dashProgressText = null;
+    dashProgressMessage = null;
+    dashProgressEta = null;
   }
 
   // Dashboard: load a dataset from the selected demo, then run a callback
@@ -1608,13 +1633,11 @@
       });
       if (!res.ok) {
         const error = await res.json();
-        dashProgressMessage.textContent = `Error: ${error.error}`;
-        dashProgressMessage.style.color = "var(--color-bad)";
+        if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${error.error}`; dashProgressMessage.style.color = "var(--color-bad)"; }
         return;
       }
     } catch (e) {
-      dashProgressMessage.textContent = `Error: ${e.message}`;
-      dashProgressMessage.style.color = "var(--color-bad)";
+      if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${e.message}`; dashProgressMessage.style.color = "var(--color-bad)"; }
       return;
     }
 
@@ -1641,18 +1664,17 @@
 
       if (progress.error) {
         stopDashProgressPolling();
-        dashProgressMessage.textContent = `Error: ${progress.error}`;
-        dashProgressMessage.style.color = "var(--color-bad)";
-        dashProgressFill.classList.remove("indeterminate");
+        if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${progress.error}`; dashProgressMessage.style.color = "var(--color-bad)"; }
+        if (dashProgressFill) dashProgressFill.classList.remove("indeterminate");
         return;
       }
 
-      if (progress.pct != null) {
+      if (progress.pct != null && dashProgressFill) {
         dashProgressFill.classList.remove("indeterminate");
         dashProgressFill.style.width = `${progress.pct}%`;
-        dashProgressText.textContent = `${progress.pct}%`;
+        if (dashProgressText) dashProgressText.textContent = `${progress.pct}%`;
       }
-      if (progress.message) {
+      if (progress.message && dashProgressMessage) {
         dashProgressMessage.textContent = progress.message;
         dashProgressMessage.style.color = "var(--text-secondary)";
       }
@@ -5771,13 +5793,11 @@
         const res = await fetch(`/api/dataset/import/${importer.name}`, { method: "POST", headers, body });
         if (!res.ok) {
           const err = await res.json();
-          dashProgressMessage.textContent = `Error: ${err.error}`;
-          dashProgressMessage.style.color = "var(--color-bad)";
+          if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${err.error}`; dashProgressMessage.style.color = "var(--color-bad)"; }
           return;
         }
       } catch (err) {
-        dashProgressMessage.textContent = `Error: ${err.message}`;
-        dashProgressMessage.style.color = "var(--color-bad)";
+        if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${err.message}`; dashProgressMessage.style.color = "var(--color-bad)"; }
         return;
       }
 
@@ -5978,14 +5998,12 @@
         const res = await fetch("/api/dataset/load-file", { method: "POST", body: formData });
         if (!res.ok) {
           const data = await res.json();
-          dashProgressMessage.textContent = `Error: ${data.error || "Upload failed"}`;
-          dashProgressMessage.style.color = "var(--color-bad)";
+          if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${data.error || "Upload failed"}`; dashProgressMessage.style.color = "var(--color-bad)"; }
           dashFileInput.value = "";
           return;
         }
       } catch (e) {
-        dashProgressMessage.textContent = `Error: ${e.message}`;
-        dashProgressMessage.style.color = "var(--color-bad)";
+        if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${e.message}`; dashProgressMessage.style.color = "var(--color-bad)"; }
         dashFileInput.value = "";
         return;
       }

--- a/static/index.html
+++ b/static/index.html
@@ -130,15 +130,6 @@
           <div id="dash-dataset-status" class="dashboard-status-bar" style="display:none"></div>
           <div class="dashboard-grid-wrap">
             <div id="dash-dataset-grid" class="dashboard-grid"></div>
-            <!-- In-grid progress bar for dataset loading -->
-            <div class="dataset-progress dash-grid-progress" id="dash-progress" style="display:none" role="status" aria-live="polite">
-              <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                <div class="progress-fill indeterminate" id="dash-progress-fill" style="width:0%"></div>
-                <div class="progress-text" id="dash-progress-text" aria-hidden="true">0%</div>
-              </div>
-              <div class="progress-message" id="dash-progress-message">Loading...</div>
-              <div class="progress-eta" id="dash-progress-eta"></div>
-            </div>
           </div>
         </div>
         <!-- Model grid -->

--- a/static/styles.css
+++ b/static/styles.css
@@ -627,10 +627,13 @@ video { max-width: 100%; }
 .dashboard-grid-wrap { flex: 1; min-height: 0; overflow-y: auto; }
 .dashboard-grid { min-height: 0; }
 
-/* In-grid progress bar for dataset loading */
-.dash-grid-progress { max-width: none; padding: 16px 14px; }
-.dash-grid-progress .progress-message { max-width: none; text-align: left; }
-.dash-grid-progress .progress-eta { text-align: left; }
+/* In-table progress row for dataset loading */
+.dash-progress-row td { padding: 0 !important; border-bottom: 1px solid var(--border); }
+.dash-progress-cell { padding: 8px 8px 6px !important; }
+.dash-progress-cell .progress-bar { height: 18px; }
+.dash-progress-cell .progress-message { max-width: none; text-align: left; font-size: 0.75rem; margin-top: 4px; }
+.dash-progress-cell .progress-eta { text-align: left; font-size: 0.7rem; margin-top: 2px; }
+.dash-progress-cell .progress-text { font-size: 0.65rem; }
 
 /* Dashboard dataset table */
 .dashboard-grid .dash-dataset-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }


### PR DESCRIPTION
## Summary
Refactored the dashboard dataset loading progress indicator from a static hidden element to a dynamically created table row that integrates seamlessly with the dataset grid. This allows the progress bar to display inline with existing dataset rows rather than replacing the entire grid view.

## Key Changes
- **Removed static HTML progress element** from `index.html` and replaced with dynamic creation in JavaScript
- **Changed progress element references** from static DOM queries to dynamically assigned variables that are populated when the progress row is created
- **Updated `showDashGridProgress()`** to:
  - Create a table row with proper accessibility attributes (`role="status"`, `aria-live="polite"`)
  - Ensure the dataset grid has a table structure before inserting the progress row
  - Dynamically assign element references for progress fill, text, message, and ETA
  - Keep existing dataset rows visible during loading
- **Updated `hideDashGridProgress()`** to remove the progress row and reset element references to null
- **Added null checks** throughout progress update code to safely handle cases where progress elements may not exist
- **Updated CSS** to style the progress row as a table cell with appropriate padding and font sizing for the compact table layout

## Implementation Details
- Progress elements are now created as a `<tr>` with `id="dash-progress-row"` containing a single `<td colspan="5">` that spans all table columns
- The progress row includes proper ARIA attributes for accessibility (status role, live region, progressbar role)
- All progress update operations check if elements exist before manipulating them, preventing errors if progress is hidden
- The `escapeHtml()` function is used when setting the initial progress message to prevent XSS vulnerabilities
- CSS styling adjusted to work within table cell constraints with smaller font sizes and appropriate spacing

https://claude.ai/code/session_01YUD4jGQoFrdRNjHfVLukwY