### PR TITLE
Show main UI after fetching text sort results

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1816,6 +1816,7 @@
             fetchTextSort(exQuery);
           }
 
+          showMainUI();
           // Select first media
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);


### PR DESCRIPTION
## Summary
Added a call to `showMainUI()` after text sort query results are fetched to ensure the main UI is displayed to the user.

## Key Changes
- Added `showMainUI()` call in the media fetching logic after `fetchTextSort()` completes
- This ensures the UI is visible before attempting to select the first media item

## Implementation Details
The `showMainUI()` call is placed strategically after the text sort fetch operation and before the automatic selection of the first media item. This timing ensures that the interface is rendered and ready for user interaction once the data has been retrieved.

https://claude.ai/code/session_019jGQkakQUmLxUF6Sf7iXi4