### PR TITLE
Refactor autopilot examples UI to use modal editor

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -259,9 +259,8 @@
 
   // Autopilot examples elements
   const autopilotExamplesSection = document.getElementById("autopilot-examples-section");
-  const autopilotExamplesGrid = document.getElementById("autopilot-examples-grid");
-  const autopilotExampleType = document.getElementById("autopilot-example-type");
-  const autopilotExampleAdd = document.getElementById("autopilot-example-add");
+  const autopilotExamplesEdit = document.getElementById("autopilot-examples-edit");
+  const autopilotExamplesSummary = document.getElementById("autopilot-examples-summary");
   const autopilotStepsDiv = document.getElementById("autopilot-steps");
 
   // Settings modal elements
@@ -609,32 +608,15 @@
     }
     const model = _dashboardTrainMode.model;
     if (autopilotExamplesSection) autopilotExamplesSection.style.display = "";
-    if (autopilotExamplesGrid) {
-      renderExamplesGrid(autopilotExamplesGrid, model.examples || [], (updated) => {
-        model.examples = updated;
-        saveAutopilotExamples(model);
-      });
-    }
-    // Populate autopilot example type dropdown with importer options (once)
-    if (autopilotExampleType && !autopilotExampleType._importersLoaded) {
-      autopilotExampleType._importersLoaded = true;
-      Promise.all([
-        fetch("/api/processor-importers").then(r => r.ok ? r.json() : []).catch(() => []),
-        fetch("/api/label-importers").then(r => r.ok ? r.json() : []).catch(() => []),
-      ]).then(([procImps, lblImps]) => {
-        for (const imp of procImps) {
-          const opt = document.createElement("option");
-          opt.value = `proc_imp:${imp.name}`;
-          opt.textContent = `${imp.icon || '\u{1F9E9}'} ${imp.display_name}`;
-          autopilotExampleType.appendChild(opt);
-        }
-        for (const imp of lblImps) {
-          const opt = document.createElement("option");
-          opt.value = `label_imp:${imp.name}`;
-          opt.textContent = `${imp.icon || '\uD83C\uDFF7\uFE0F'} ${imp.display_name}`;
-          autopilotExampleType.appendChild(opt);
-        }
-      });
+    if (autopilotExamplesSummary) {
+      const examples = model.examples || [];
+      if (examples.length === 0) {
+        autopilotExamplesSummary.innerHTML = '<span class="ap-examples-empty">None yet</span>';
+      } else {
+        autopilotExamplesSummary.innerHTML = examples.map(ex =>
+          `<span class="ap-example-chip"><span class="ap-chip-label">${escapeHtml(ex.value || ex.type || "example")}</span></span>`
+        ).join("");
+      }
     }
   }
 
@@ -693,44 +675,10 @@
 
   function loadFavImporterButtons() { /* no-op until favorites modal HTML is added */ }
 
-  function renderExamplesGrid(container, examples, onUpdate) {
-    if (!container) return;
-    container.innerHTML = "";
-    examples.forEach((ex, i) => {
-      const div = document.createElement("div");
-      div.className = "example-chip";
-      div.textContent = ex.value || ex.type || "example";
-      const removeBtn = document.createElement("button");
-      removeBtn.textContent = "\u00d7";
-      removeBtn.className = "example-remove";
-      removeBtn.onclick = () => {
-        const updated = examples.filter((_, j) => j !== i);
-        if (onUpdate) onUpdate(updated);
-      };
-      div.appendChild(removeBtn);
-      container.appendChild(div);
-    });
-  }
-
-  async function promptForExample(type) {
-    if (type === "text") {
-      const value = prompt("Enter a text example:");
-      return value ? { type: "text", value } : null;
-    }
-    return null;
-  }
-
-  if (autopilotExampleAdd) {
-    autopilotExampleAdd.addEventListener("click", async () => {
+  if (autopilotExamplesEdit) {
+    autopilotExamplesEdit.addEventListener("click", () => {
       if (!_dashboardTrainMode || !_dashboardTrainMode.model) return;
-      const model = _dashboardTrainMode.model;
-      if (!model.examples) model.examples = [];
-      const ex = await promptForExample(autopilotExampleType.value);
-      if (ex) {
-        model.examples.push(ex);
-        refreshAutopilotExamples();
-        saveAutopilotExamples(model);
-      }
+      openExamplesEditorModal(_dashboardTrainMode.model);
     });
   }
 
@@ -6277,6 +6225,28 @@
     refresh();
     examplesEditorModal.classList.add("show");
 
+    // Populate editor type dropdown with importer options (once)
+    if (examplesEditorType && !examplesEditorType._importersLoaded) {
+      examplesEditorType._importersLoaded = true;
+      Promise.all([
+        fetch("/api/processor-importers").then(r => r.ok ? r.json() : []).catch(() => []),
+        fetch("/api/label-importers").then(r => r.ok ? r.json() : []).catch(() => []),
+      ]).then(([procImps, lblImps]) => {
+        for (const imp of procImps) {
+          const opt = document.createElement("option");
+          opt.value = `proc_imp:${imp.name}`;
+          opt.textContent = `${imp.icon || '\u{1F9E9}'} ${imp.display_name}`;
+          examplesEditorType.appendChild(opt);
+        }
+        for (const imp of lblImps) {
+          const opt = document.createElement("option");
+          opt.value = `label_imp:${imp.name}`;
+          opt.textContent = `${imp.icon || '\uD83C\uDFF7\uFE0F'} ${imp.display_name}`;
+          examplesEditorType.appendChild(opt);
+        }
+      });
+    }
+
     // Wire Add button (replace handler to avoid stacking)
     const addHandler = async () => {
       const type = examplesEditorType.value;
@@ -6297,7 +6267,9 @@
         examplesEditorStatus.style.color = "var(--text-muted)";
       }
       try {
-        const url = `/api/autorun-detectors/${encodeURIComponent(det.name)}/examples`;
+        const url = det.trainable
+          ? `/api/trainable-models/${encodeURIComponent(det.name)}/examples`
+          : `/api/autorun-detectors/${encodeURIComponent(det.name)}/examples`;
         const res = await fetch(url, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },

--- a/static/index.html
+++ b/static/index.html
@@ -87,16 +87,11 @@
     <div id="tab-panel-autopilot" class="left-tab-panel" role="tabpanel" aria-labelledby="tab-autopilot" style="display:none">
       <div class="autopilot-panel">
         <div id="autopilot-examples-section" style="display:none">
-          <span class="sort-label">Examples</span>
-          <div id="autopilot-examples-grid" class="examples-grid"></div>
-          <div class="examples-add-bar">
-            <select id="autopilot-example-type" class="form-select-inline" style="font-size:0.75rem">
-              <option value="text">Text</option>
-              <option value="media">Media</option>
-              <option value="detector">Detector</option>
-            </select>
-            <button id="autopilot-example-add" class="btn-sm" style="font-size:0.7rem">+ Add</button>
+          <div class="ap-examples-header">
+            <span class="sort-label">Examples</span>
+            <button id="autopilot-examples-edit" class="btn-sm ap-examples-edit-btn">Edit</button>
           </div>
+          <div id="autopilot-examples-summary" class="ap-examples-summary"></div>
         </div>
         <div id="autopilot-steps" class="autopilot-steps"></div>
       </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -205,6 +205,17 @@ header h1 { margin-left: 48px; }
 .left-tab-panel { display: flex; flex-direction: column; flex: 1; min-height: 0; position: relative; }
 /* Autopilot panel */
 .autopilot-panel { padding: 8px 10px; }
+.ap-examples-header { display: flex; align-items: center; justify-content: space-between; }
+.ap-examples-edit-btn { font-size: 0.65rem; padding: 2px 8px; }
+.ap-examples-summary { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px; }
+.ap-example-chip {
+  display: inline-flex; align-items: center; gap: 2px;
+  font-size: 0.65rem; padding: 1px 6px; border-radius: 3px;
+  background: var(--bg-hover); color: var(--text-secondary);
+  max-width: 100%; overflow: hidden;
+}
+.ap-example-chip .ap-chip-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ap-examples-empty { font-size: 0.72rem; color: var(--text-muted); padding: 4px 0; }
 .autopilot-status-input { width: 100%; padding: 6px 8px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg-surface); color: var(--text-primary); font-size: 0.85rem; outline: none; margin-top: 4px; }
 .autopilot-status-input:focus { border-color: var(--accent); }
 /* Autopilot checklist */
@@ -665,8 +676,6 @@ video { max-width: 100%; }
 .dashboard-grid .dash-model-table thead th:nth-child(3) { width: 20%; }
 .dashboard-grid .dash-model-table thead th:nth-child(4) { width: 12%; }
 .dashboard-grid .dash-model-table thead th:nth-child(5) { width: 8%; }
-.dashboard-grid .dash-model-table thead th:nth-child(6) { width: 14%; }
-.dashboard-grid .dash-model-table thead th:nth-child(7) { width: 32px; }
 
 .dash-model-row { cursor: pointer; transition: background 0.15s; }
 .dash-model-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
@@ -725,9 +734,6 @@ video { max-width: 100%; }
 .col-actions { width: 56px; text-align: center; white-space: nowrap; }
 .dash-name-text { vertical-align: middle; }
 .dash-rename-btn { vertical-align: middle; margin-left: 4px; font-size: 0.72rem; }
-.col-examples { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.dash-examples-text { vertical-align: middle; font-size: 0.72rem; color: var(--text-muted); }
-.dash-edit-examples-btn { vertical-align: middle; margin-left: 4px; font-size: 0.72rem; }
 .dash-rename-input {
   width: calc(100% - 4px); padding: 2px 4px; font-size: 0.75rem; font-weight: 600;
   border: 1px solid var(--accent); border-radius: 3px; outline: none;


### PR DESCRIPTION
## Summary
Refactored the autopilot examples interface to use a dedicated modal editor instead of inline grid controls. The examples section now displays a read-only summary of examples with an "Edit" button that opens a modal for managing them.

## Key Changes
- **UI Restructuring**: Replaced inline examples grid and add controls with a compact summary display showing example chips
- **Modal Integration**: Moved example management logic to `openExamplesEditorModal()` function, consolidating editor functionality
- **Element Updates**: 
  - Removed `autopilot-examples-grid`, `autopilot-example-type`, and `autopilot-example-add` elements
  - Added `autopilot-examples-edit` button and `autopilot-examples-summary` display area
- **Styling**: Added new CSS classes for the summary display (`.ap-examples-header`, `.ap-example-chip`, `.ap-examples-empty`, etc.)
- **Importer Loading**: Moved importer dropdown population from autopilot initialization to the modal editor's `openExamplesEditorModal()` function
- **API Endpoint**: Updated examples save endpoint to support both trainable models and autorun detectors

## Implementation Details
- Examples are now displayed as read-only chips in the autopilot panel, showing the example value or type
- Empty state displays "None yet" message
- Clicking "Edit" opens the modal editor for full example management
- Importer options are loaded once when the modal is first opened, improving initial load performance
- The modal editor now handles both `/api/trainable-models/` and `/api/autorun-detectors/` endpoints based on detector type

https://claude.ai/code/session_01Pw89jjagzKWTGL83bBPN4R