### PR TITLE
Fix dashboard actions container width layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -692,7 +692,7 @@ video { max-width: 100%; }
 .demo-row.dash-selected .col-name, .dash-dataset-row.dash-selected .col-name, .dash-model-row.dash-selected .col-name { color: var(--accent); }
 
 /* Dashboard action buttons */
-.dashboard-actions { display: flex; gap: 12px; flex-shrink: 0; padding-top: 4px; }
+.dashboard-actions { display: flex; gap: 12px; flex-shrink: 0; padding-top: 4px; width: 100%; }
 .dashboard-action-btn {
   flex: 1; padding: 12px 24px; font-size: 1rem; font-weight: 600;
   border: 2px solid var(--accent); border-radius: 8px;


### PR DESCRIPTION
## Summary
Fixed the dashboard actions container to properly utilize full available width by adding `width: 100%` to the `.dashboard-actions` CSS class.

## Changes
- Added `width: 100%` to `.dashboard-actions` flexbox container to ensure it spans the full width of its parent element

## Details
The dashboard action buttons container was not expanding to fill the available horizontal space. By adding the `width: 100%` property, the flexbox container now properly stretches to match its parent's width, allowing the child buttons (which use `flex: 1`) to distribute space correctly and maintain consistent sizing across different viewport widths.

https://claude.ai/code/session_01AVjh7FDjFd5hxXataXj7Ey