### PR TITLE
Add export buttons to training detector context bar

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -210,6 +210,8 @@
   const trainDatasetName = document.getElementById("train-dataset-name");
   const trainDetectorBar = document.getElementById("train-detector-bar");
   const trainDetectorName = document.getElementById("train-detector-name");
+  const trainExportDetectorBtn = document.getElementById("train-export-detector");
+  const trainExportLabelsBtn = document.getElementById("train-export-labels");
 
   // Burger menu elements
   const burgerBtn = document.getElementById("burger-btn");
@@ -2672,7 +2674,9 @@
   }
 
   // Labels export – open modal (used by detector export modal)
-  async function openLabelExporterModal() {
+  // Options: { goodsOnly: bool } — when true, only export "good" labels
+  async function openLabelExporterModal(options) {
+    const goodsOnly = options && options.goodsOnly;
     let exporters = [];
     try {
       const res = await fetch("/api/exporters");
@@ -2699,23 +2703,28 @@
         const exp = exporters.find(e => e.name === name);
         el.addEventListener("click", () => {
           labelExporterModal.classList.remove("show");
-          runLabelExport(exp);
+          runLabelExport(exp, { goodsOnly });
         });
         el.addEventListener("keydown", (e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             labelExporterModal.classList.remove("show");
-            runLabelExport(exp);
+            runLabelExport(exp, { goodsOnly });
           }
         });
       });
     }
 
+    // Update modal title to reflect what's being exported
+    const titleEl = document.getElementById("label-exporter-modal-title");
+    if (titleEl) titleEl.textContent = goodsOnly ? "Export Labels (Goods)" : "Export Labels";
+
     labelExporterModal.classList.add("show");
   }
 
-  async function runLabelExport(exp) {
+  async function runLabelExport(exp, options) {
     menuLabelsStatus.textContent = "";
+    const goodsOnly = options && options.goodsOnly;
     // Collect required field values via prompts
     const fieldValues = {};
     for (const field of exp.fields) {
@@ -2734,7 +2743,8 @@
 
     menuLabelsStatus.textContent = "Exporting labels\u2026";
     try {
-      const labelsRes = await fetch("/api/labels/export");
+      const labelsUrl = goodsOnly ? "/api/labels/export?goods_only=1" : "/api/labels/export";
+      const labelsRes = await fetch(labelsUrl);
       const labelsData = await labelsRes.json();
 
       const exportRes = await fetch("/api/exporters/export", {
@@ -2999,6 +3009,19 @@
       const err = await res.json().catch(() => ({}));
       if (menuDetectorStatus) { menuDetectorStatus.textContent = err.error || "Server export failed"; setTimeout(() => { menuDetectorStatus.textContent = ""; }, 3000); }
     }
+  }
+
+  // Train-context-bar export buttons
+  if (trainExportDetectorBtn) {
+    trainExportDetectorBtn.addEventListener("click", () => {
+      const name = trainDetectorName ? trainDetectorName.textContent : "";
+      if (name) openDetectorExportModal(name);
+    });
+  }
+  if (trainExportLabelsBtn) {
+    trainExportLabelsBtn.addEventListener("click", () => {
+      openLabelExporterModal({ goodsOnly: true });
+    });
   }
 
   // Results display, export controls, escapeHtml, formatOrigin

--- a/static/index.html
+++ b/static/index.html
@@ -181,8 +181,16 @@
   <!-- Right panel -->
   <aside class="panel-right" aria-label="Labels">
     <div class="train-context-bar" id="train-detector-bar" style="display:none">
-      <span class="train-context-label">Detector</span>
-      <span class="train-context-name" id="train-detector-name"></span>
+      <div class="train-context-header">
+        <div>
+          <span class="train-context-label">Detector</span>
+          <span class="train-context-name" id="train-detector-name"></span>
+        </div>
+        <div class="train-context-actions">
+          <button class="train-context-btn" id="train-export-detector" title="Export detector weights and labels">Export Detector</button>
+          <button class="train-context-btn" id="train-export-labels" title="Export labels (goods)">Export Labels</button>
+        </div>
+      </div>
     </div>
     <!-- import-file removed: label import now uses the label importer modal -->
     <div class="progress-check-bar">

--- a/static/styles.css
+++ b/static/styles.css
@@ -311,6 +311,10 @@ video { max-width: 100%; }
 .train-context-bar { padding: 6px 10px; border-bottom: 1px solid var(--border); background: var(--accent-highlight-bg); flex-shrink: 0; overflow: hidden; }
 .train-context-label { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); display: block; line-height: 1; margin-bottom: 2px; }
 .train-context-name { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.train-context-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; }
+.train-context-actions { display: flex; gap: 4px; flex-shrink: 0; }
+.train-context-btn { font-size: 0.6rem; padding: 2px 6px; border: 1px solid var(--border); border-radius: 3px; background: var(--bg-panel); color: var(--text-muted); cursor: pointer; white-space: nowrap; }
+.train-context-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* Right panel – votes */
 .panel-right { width: 220px; border-left: 1px solid var(--border); overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -209,10 +209,15 @@ def export_labels():
     so that consumers know exactly where each labeled element came from.
     The format is a superset of the legacy export format — old consumers
     that only read ``md5`` and ``label`` keys continue to work unchanged.
+
+    Query params:
+        goods_only: If ``"1"`` or ``"true"``, only export good labels.
     """
     from vtsearch.datasets.labelset import LabelSet
 
-    labelset = LabelSet.from_clips_and_votes(medias, good_votes, bad_votes)
+    goods_only = request.args.get("goods_only", "").lower() in ("1", "true")
+    bads = {} if goods_only else bad_votes
+    labelset = LabelSet.from_clips_and_votes(medias, good_votes, bads)
     result: dict = labelset.to_dict()
     return jsonify(result)
 


### PR DESCRIPTION
## Summary
This PR adds export functionality to the training detector context bar, allowing users to quickly export detector weights/labels and training labels directly from the detector panel.

## Key Changes

- **UI Updates**: Added "Export Detector" and "Export Labels" buttons to the train-context-bar in the right panel, with improved layout using flexbox
- **Export Labels Enhancement**: Modified `openLabelExporterModal()` and `runLabelExport()` to support a `goodsOnly` option that filters out bad labels when exporting
- **Backend Support**: Updated `/api/labels/export` endpoint to accept a `goods_only` query parameter that excludes bad votes from the export
- **Event Handlers**: Added click handlers for the new export buttons that trigger detector and label export modals with appropriate options
- **Styling**: Added CSS classes for the new button layout and hover states

## Implementation Details

- The "Export Labels" button in the context bar uses `goodsOnly: true` to export only good labels, while the standard labels export remains unchanged
- The label exporter modal title dynamically updates to reflect whether "goods only" labels are being exported
- The backend change is backward compatible—the `goods_only` parameter is optional and defaults to false
- Button styling matches the existing design system with proper hover states and responsive sizing

https://claude.ai/code/session_01BCtv1KeieWPG1UUwPybin6