### PR TITLE
Fix arrow key hotkeys blocked when autodetect modal is open

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6695,8 +6695,9 @@
   }
 
   document.addEventListener("keydown", (e) => {
-    // Never intercept keys when a dialog is open
-    if (vtDialogModal.classList.contains("show")) return;
+    // Never intercept keys when any modal is open (dialogs, autodetect
+    // results, settings, load-sort, etc.).  All modals use .modal.show.
+    if (document.querySelector(".modal.show")) return;
 
     // Never intercept keys when typing in text fields
     if (isTyping()) return;


### PR DESCRIPTION
The keyboard shortcut handler only checked vtDialogModal, so arrow keys (vote, volume, spacebar) were silently swallowed whenever a SELECT element inside another modal had focus (isTyping() returned true). Replace the single-modal check with a generic .modal.show query so shortcuts are properly disabled while *any* modal is visible and re-enabled as soon as it closes.

https://claude.ai/code/session_01PVTQC4qCp3r66ecDitHYG5