### PR TITLE
Fix duplicate expansion in trainable model label persistence

### DIFF
--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -317,3 +317,25 @@ class TestCollapseDuplicatesIntegration:
         assert len(good_labels) == 2
         assert len(bad_labels) == 1
         assert {el["filename"] for el in good_labels} == {"x.wav", "y.wav"}
+
+    def test_collapse_then_vote_no_expand(self):
+        """With expand_dupes=False, dupe-set reps emit a single label entry."""
+        media_dict = {
+            1: _make_media(1, md5="same", filename="x.wav"),
+            2: _make_media(2, md5="same", filename="y.wav"),
+            3: _make_media(3, md5="other", filename="z.wav"),
+        }
+        collapse_duplicates(media_dict)
+
+        good = {1: None}
+        bad = {3: None}
+        ls = LabelSet.from_clips_and_votes(media_dict, good, bad, expand_dupes=False)
+        exported = ls.to_dict()
+
+        # Without expansion the dupe-set representative produces 1 label, not 2
+        good_labels = [e for e in exported["labels"] if e["label"] == "good"]
+        bad_labels = [e for e in exported["labels"] if e["label"] == "bad"]
+        assert len(good_labels) == 1
+        assert len(bad_labels) == 1
+        # The single good label uses the representative's MD5
+        assert good_labels[0]["md5"] == "same"

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -276,3 +276,46 @@ class TestSaveLabels:
     def test_save_labels_nonexistent_model(self, client):
         res = client.post("/api/trainable-models/nonexistent/labels")
         assert res.status_code == 404
+
+    def test_save_labels_does_not_expand_dupes(self, client):
+        """Saving labels for a dupe-set representative should NOT expand members.
+
+        Regression test: previously, a vote on a dupe-set representative
+        with N members produced N label entries, inflating the stored
+        label count.  Trainable model persistence should store one entry
+        per vote, not one per duplicate.
+        """
+        import copy
+
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded for this test")
+
+        first_id = next(iter(medias))
+        original = copy.deepcopy(medias[first_id])
+
+        # Turn the first media into a dupe-set representative with 5 members
+        medias[first_id]["origin"] = {
+            "importer": "dupe_set",
+            "params": {"name": original.get("filename", "a.wav")},
+            "members": [
+                {"origin": {"importer": "test", "params": {}}, "origin_name": f"dup_{i}.wav", "filename": f"dup_{i}.wav", "category": "c"}
+                for i in range(5)
+            ],
+        }
+        try:
+            client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+            client.post("/api/trainable-models", json={"name": "DupeTest", "text_query": "test"})
+
+            res = client.post("/api/trainable-models/DupeTest/labels")
+            assert res.status_code == 200
+            data = res.get_json()
+            # Should be 1 label (the vote), NOT 5 (the dupe members)
+            assert data["num_labels"] == 1
+
+            model_res = client.get("/api/trainable-models/DupeTest")
+            labels = model_res.get_json()["labelset"]["labels"]
+            assert len(labels) == 1
+        finally:
+            medias[first_id] = original

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -106,6 +106,8 @@ class LabelSet:
         medias: dict[int, dict[str, Any]],
         good_votes: dict[int, None],
         bad_votes: dict[int, None],
+        *,
+        expand_dupes: bool = True,
     ) -> LabelSet:
         """Build a ``LabelSet`` from the current media and vote state.
 
@@ -113,6 +115,12 @@ class LabelSet:
             medias: The global medias dict.
             good_votes: Dict of media IDs voted "good".
             bad_votes: Dict of media IDs voted "bad".
+            expand_dupes: When ``True`` (default), dupe-set representatives
+                are expanded into one element per member so that an exported
+                labelset records full provenance.  Set to ``False`` when the
+                labelset will be re-imported into the same system (e.g.
+                trainable-model persistence) to avoid inflating the label
+                count.
 
         Returns:
             A new ``LabelSet`` containing one :class:`LabeledElement` per
@@ -122,11 +130,11 @@ class LabelSet:
         for cid in good_votes:
             media = medias.get(cid)
             if media:
-                elements.extend(_clip_to_elements(media, "good"))
+                elements.extend(_clip_to_elements(media, "good", expand_dupes=expand_dupes))
         for cid in bad_votes:
             media = medias.get(cid)
             if media:
-                elements.extend(_clip_to_elements(media, "bad"))
+                elements.extend(_clip_to_elements(media, "bad", expand_dupes=expand_dupes))
         return cls(elements)
 
     @classmethod
@@ -205,15 +213,21 @@ class LabelSet:
         return cls(elements)
 
 
-def _clip_to_elements(media: dict[str, Any], label: str) -> list[LabeledElement]:
+def _clip_to_elements(
+    media: dict[str, Any], label: str, *, expand_dupes: bool = True
+) -> list[LabeledElement]:
     """Convert a media dict into one or more :class:`LabeledElement` instances.
 
-    When the media is a dupe-set representative (origin importer is
-    ``"dupe_set"``), one element is produced for each original member so
-    that an exported labelset reflects the full duplicate set.
+    When *expand_dupes* is ``True`` and the media is a dupe-set
+    representative (origin importer is ``"dupe_set"``), one element is
+    produced for each original member so that an exported labelset reflects
+    the full duplicate set.  When ``False``, a single element is emitted
+    using the representative's own MD5 and origin, which avoids inflating
+    the label count for internal round-trip use cases (e.g. trainable-model
+    persistence).
     """
     origin = media.get("origin")
-    if isinstance(origin, dict) and origin.get("importer") == "dupe_set":
+    if expand_dupes and isinstance(origin, dict) and origin.get("importer") == "dupe_set":
         members = origin.get("members", [])
         if members:
             md5 = media["md5"]

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -275,7 +275,7 @@ def save_trainable_model_labels(name: str):
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.utils import bad_votes, good_votes, medias
 
-    labelset = LabelSet.from_clips_and_votes(medias, good_votes, bad_votes)
+    labelset = LabelSet.from_clips_and_votes(medias, good_votes, bad_votes, expand_dupes=False)
     data["labelset"] = labelset.to_dict()
     _write_model(path, data)
 


### PR DESCRIPTION
## Summary
Fix a regression where saving labels for trainable models would incorrectly expand dupe-set representatives into multiple label entries, inflating the stored label count. Trainable model persistence should store one entry per vote, not one per duplicate member.

## Changes
- **vtsearch/datasets/labelset.py**: Added `expand_dupes` parameter (default `True`) to `from_clips_and_votes()` and `_clip_to_elements()` functions to control whether dupe-set representatives are expanded into individual member entries
  - When `expand_dupes=True` (default): maintains existing behavior for exports, expanding representatives into one element per member for full provenance
  - When `expand_dupes=False`: emits a single element using the representative's own MD5 and origin, avoiding label count inflation for internal round-trip use cases

- **vtsearch/routes/trainable_models.py**: Updated `save_trainable_model_labels()` to call `LabelSet.from_clips_and_votes()` with `expand_dupes=False` to prevent duplicate expansion during model persistence

- **tests/test_trainable_models.py**: Added regression test `test_save_labels_does_not_expand_dupes()` verifying that voting on a dupe-set representative with 5 members produces exactly 1 label entry, not 5

- **tests/test_duplicates.py**: Added test `test_collapse_then_vote_no_expand()` verifying the new `expand_dupes=False` behavior produces single label entries for dupe-set representatives

## Implementation Details
The fix introduces a keyword-only parameter to control dupe-set expansion behavior at the point where labelsets are created. This allows external exports to maintain full provenance information while internal persistence operations avoid inflating counts. The default behavior remains unchanged for backward compatibility.

https://claude.ai/code/session_014Ao88aj8umLQZnqtapNt8S