### PR TITLE
Move progress indicators above dataset bar in UI layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -76,6 +76,24 @@
           </div>
         </div>
       </div>
+      <div class="progress-check-bar">
+        <span class="progress-check-label">Progress</span>
+        <button id="smart-indicator" class="labeling-indicator" data-status="" aria-label="Smart level: error cost flatness" title="Has the model stopped learning over time?">
+          <span class="indicator-dot" aria-hidden="true"></span>
+          <span class="indicator-label">Smart</span>
+          <span class="indicator-subtext" id="smart-subtext"></span>
+        </button>
+        <button id="stable-indicator" class="labeling-indicator" data-status="" aria-label="Stable level: prediction flip stability" title="Has the model stopped changing predicted labels?">
+          <span class="indicator-dot" aria-hidden="true"></span>
+          <span class="indicator-label">Stable</span>
+          <span class="indicator-subtext" id="stable-subtext"></span>
+        </button>
+        <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Diverse level: diversity tree coverage" title="Do we have good label coverage over the dataset?">
+          <span class="indicator-dot" aria-hidden="true"></span>
+          <span class="indicator-label">Diverse</span>
+          <span class="indicator-subtext" id="span-subtext"></span>
+        </button>
+      </div>
       <div class="dataset-bar" id="dataset-bar" style="display:none">
         <span class="dataset-info" id="dataset-info">No dataset loaded</span>
       </div>
@@ -188,24 +206,6 @@
       </div>
     </div>
     <!-- import-file removed: label import now uses the label importer modal -->
-    <div class="progress-check-bar">
-      <span class="progress-check-label">Progress</span>
-      <button id="smart-indicator" class="labeling-indicator" data-status="" aria-label="Smart level: error cost flatness" title="Has the model stopped learning over time?">
-        <span class="indicator-dot" aria-hidden="true"></span>
-        <span class="indicator-label">Smart</span>
-        <span class="indicator-subtext" id="smart-subtext"></span>
-      </button>
-      <button id="stable-indicator" class="labeling-indicator" data-status="" aria-label="Stable level: prediction flip stability" title="Has the model stopped changing predicted labels?">
-        <span class="indicator-dot" aria-hidden="true"></span>
-        <span class="indicator-label">Stable</span>
-        <span class="indicator-subtext" id="stable-subtext"></span>
-      </button>
-      <button id="span-indicator" class="labeling-indicator" data-status="" aria-label="Diverse level: diversity tree coverage" title="Do we have good label coverage over the dataset?">
-        <span class="indicator-dot" aria-hidden="true"></span>
-        <span class="indicator-label">Diverse</span>
-        <span class="indicator-subtext" id="span-subtext"></span>
-      </button>
-    </div>
     <div class="label-sort-bar">
       <span class="sort-label" style="font-size:0.7rem; color:var(--text-dim);">Sort labels</span>
       <label for="label-sort-select" class="sr-only">Sort labels</label>


### PR DESCRIPTION
## Summary
Reorganized the HTML layout to move the progress check bar (containing Smart, Stable, and Diverse indicators) to appear earlier in the DOM, positioning it above the dataset bar instead of below the file import section.

## Changes
- Relocated the `progress-check-bar` div from its original position (after the file import section) to an earlier position in the layout (after the search/filter controls and before the dataset bar)
- The progress indicators now appear higher in the visual hierarchy, making them more prominent and accessible to users earlier in the interface
- No functional changes to the indicators themselves—only DOM reordering

## Implementation Details
- The progress check bar maintains all its original HTML structure and attributes (button IDs, ARIA labels, data attributes, etc.)
- This is a pure layout/positioning change with no modifications to styling or JavaScript functionality
- The indicators will now be visible/accessible sooner when users interact with the interface

https://claude.ai/code/session_01DTeHaP4M8bRDJjZUGdEdD4