### PR TITLE
Remove heading from new model form

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6114,7 +6114,7 @@
       exTypeOptions += `<option value="label_imp:${escapeHtml(imp.name)}">${escapeHtml(imp.icon || '\uD83C\uDFF7\uFE0F')} ${escapeHtml(imp.display_name)}</option>`;
     }
 
-    let html = `<h3 class="form-heading">New Model</h3>`;
+    let html = ``;
     html += `<form id="new-model-form">`;
     html += `<div class="form-group">`;
     html += `<label class="form-label">Model Name *</label>`;


### PR DESCRIPTION
## Summary
Removed the "New Model" heading that was displayed above the new model form.

## Changes
- Removed the `<h3 class="form-heading">New Model</h3>` heading element from the form initialization
- The form now starts directly without a preceding heading element

## Details
This change simplifies the form markup by eliminating the redundant heading. The form heading may now be handled elsewhere in the UI or the heading was determined to be unnecessary for the user interface.

https://claude.ai/code/session_01PebhK8DpCZh1LiirFaWWNQ