### PR TITLE
Select Autopilot tab by default when entering labeling from dashboard

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1768,6 +1768,9 @@
           }
 
           showMainUI();
+          if (tabAutopilot) {
+            tabAutopilot.click();
+          }
           // Select first media
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);
@@ -6428,6 +6431,9 @@
           }
 
           showMainUI();
+          if (_dashboardTrainMode && tabAutopilot) {
+            tabAutopilot.click();
+          }
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);
           }
@@ -6446,6 +6452,9 @@
       if (dashSelectedDataset) {
         dashLoadSelectedDataset(() => {
           showMainUI();
+          if (_dashboardTrainMode && tabAutopilot) {
+            tabAutopilot.click();
+          }
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);
           }


### PR DESCRIPTION
When the user clicks the Label button on the dashboard, the labeling interface now automatically activates the Autopilot tab instead of starting on the Manual tab. This applies to all three code paths: direct entry (dataset already loaded), deferred entry (after progress polling completes), and the legacy demo-dataset fallback.

https://claude.ai/code/session_019xmHhx2VsLwQp6NQLbZFQM