### PR TITLE
Add vote clearing to prevent label session cross-contamination

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1733,6 +1733,9 @@
           const trainInfo = _dashboardTrainMode;
           await fetchMedias();
 
+          // Clear any leftover votes so only this model's labels are active
+          try { await fetch("/api/votes/clear", { method: "POST" }); } catch (_) {}
+
           // Import labels from the trainable model's labelset
           try {
             const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(trainInfo.model.name)}`);
@@ -6393,6 +6396,10 @@
           await fetchMedias();
 
           if (_dashboardTrainMode && _dashboardTrainMode.model) {
+            // Clear any votes from a previous session so they don't
+            // contaminate this model's labelset.
+            try { await fetch("/api/votes/clear", { method: "POST" }); } catch (_) {}
+
             // Import labels from the trainable model's labelset
             try {
               const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(_dashboardTrainMode.model.name)}`);

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -319,3 +319,71 @@ class TestSaveLabels:
             assert len(labels) == 1
         finally:
             medias[first_id] = original
+
+
+class TestLabelVoteIsolation:
+    """Clearing votes before importing a model's labels prevents cross-contamination."""
+
+    def test_clear_votes_before_import_prevents_leakage(self, client):
+        """Votes from Model A must not persist into a Model B label session.
+
+        Simulates the Label-button flow: clear votes, then import a model's
+        labels.  Without the clear, votes from a prior session leak in.
+        """
+        from vtsearch.utils import good_votes, bad_votes, medias
+
+        ids = list(medias.keys())
+        if len(ids) < 4:
+            pytest.skip("Need at least 4 medias")
+
+        # Create two trainable models
+        client.post("/api/trainable-models", json={"name": "Model A", "text_query": "a"})
+        client.post("/api/trainable-models", json={"name": "Model B", "text_query": "b"})
+
+        # Simulate labeling with Model A: vote on ids[0] and ids[1]
+        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
+        client.post("/api/trainable-models/Model%20A/labels")  # save 2 labels
+
+        # Now clear votes (as the Label button should do) and import Model B's labels
+        client.post("/api/votes/clear")
+        assert len(good_votes) == 0
+        assert len(bad_votes) == 0
+
+        # Model B has no labels, so import is a no-op — votes should remain empty
+        model_b = client.get("/api/trainable-models/Model%20B").get_json()
+        assert len(model_b["labelset"]["labels"]) == 0
+
+        client.post("/api/labels/import", json={"labels": model_b["labelset"]["labels"]})
+        assert len(good_votes) == 0, "Model A's votes should not leak into Model B's session"
+        assert len(bad_votes) == 0
+
+    def test_import_after_clear_only_has_model_labels(self, client):
+        """After clearing + importing, only the target model's labels are active."""
+        from vtsearch.utils import good_votes, bad_votes, medias
+
+        ids = list(medias.keys())
+        if len(ids) < 4:
+            pytest.skip("Need at least 4 medias")
+
+        # Create model and label 2 items
+        client.post("/api/trainable-models", json={"name": "Target", "text_query": "t"})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
+        client.post("/api/trainable-models/Target/labels")
+
+        # Add extra votes that DON'T belong to the model (simulating stale state)
+        client.post(f"/api/medias/{ids[2]}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{ids[3]}/vote", json={"vote": "bad"})
+        assert len(good_votes) == 2  # ids[0] + ids[2]
+        assert len(bad_votes) == 2  # ids[1] + ids[3]
+
+        # Clear votes, then import only Target's labels
+        client.post("/api/votes/clear")
+        target_data = client.get("/api/trainable-models/Target").get_json()
+        client.post("/api/labels/import", json={"labels": target_data["labelset"]["labels"]})
+
+        # Should only have the 2 labels from Target, not the 4 from before
+        assert len(good_votes) + len(bad_votes) == 2
+        assert ids[2] not in good_votes, "Stale vote should be gone after clear+import"
+        assert ids[3] not in bad_votes, "Stale vote should be gone after clear+import"

--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -108,6 +108,39 @@ class TestGetVotes:
         assert 5 in data["bad"]
 
 
+class TestClearVotes:
+    def test_clear_votes_empties_good_and_bad(self, client):
+        """POST /api/votes/clear should remove all votes."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        assert 1 in app_module.good_votes
+        assert 2 in app_module.bad_votes
+
+        resp = client.post("/api/votes/clear")
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+        assert len(app_module.good_votes) == 0
+        assert len(app_module.bad_votes) == 0
+
+    def test_clear_votes_preserves_medias(self, client):
+        """Clearing votes should not affect loaded medias."""
+        num_before = len(medias)
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        resp = client.post("/api/votes/clear")
+        assert resp.status_code == 200
+        assert len(medias) == num_before
+
+    def test_get_votes_empty_after_clear(self, client):
+        """GET /api/votes should return empty lists after clear."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        client.post("/api/votes/clear")
+        resp = client.get("/api/votes")
+        data = resp.get_json()
+        assert data["good"] == []
+        assert data["bad"] == []
+
+
 class TestLabelHistory:
     def test_vote_adds_history_entry(self, client):
         client.post("/api/medias/1/vote", json={"vote": "good"})

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -179,6 +179,19 @@ def get_votes():
     )
 
 
+@sorting_bp.route("/api/votes/clear", methods=["POST"])
+def clear_votes_route():
+    """Clear all votes without clearing medias.
+
+    Used by the Label flow to reset votes before importing a model's labelset
+    so that labels from a previous session don't contaminate the new model.
+    """
+    from vtsearch.utils import clear_votes
+
+    clear_votes()
+    return jsonify({"ok": True})
+
+
 @sorting_bp.route("/api/textsort-suggestions")
 def get_textsort_suggestions_route():
     """Return stored text-sort suggestions (most recent last)."""


### PR DESCRIPTION
## Summary
This PR adds functionality to clear votes before importing a trainable model's labels, preventing votes from a previous labeling session from contaminating the current model's labelset.

## Key Changes
- **New API endpoint** (`POST /api/votes/clear`): Clears all votes without affecting loaded medias, allowing clean state transitions between model labeling sessions
- **New utility function** (`clear_votes()`): Empties both `good_votes` and `bad_votes` collections
- **Frontend integration**: Updated the Label button flow to call `/api/votes/clear` before importing a model's labels in two locations:
  - When entering label mode for a trainable model
  - When switching between different trainable models
- **Comprehensive test coverage**: Added tests to verify:
  - Vote clearing works correctly and preserves medias
  - Votes from Model A don't leak into Model B's labeling session
  - After clear + import, only the target model's labels are active

## Implementation Details
The fix addresses a cross-contamination issue where votes from a previous labeling session would persist when switching to a new model. By clearing votes before importing a model's labelset, the UI ensures a clean state where only the current model's labels are active. The implementation is defensive with try-catch blocks in the frontend to gracefully handle any failures in the clear operation.

https://claude.ai/code/session_01LLeA7UPkR14MQSoDQvMUwu