### PR TITLE
Restore dashboard train mode and import labels after dataset load

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1653,7 +1653,7 @@
 
           const cb = dashPendingAction;
           dashPendingAction = null;
-          if (typeof cb === "function") cb();
+          if (typeof cb === "function") await cb();
         }
       }
     } catch (_) {}
@@ -6437,7 +6437,51 @@
           try {
             await fetch(`/api/datasets/registry/${encodeURIComponent(selDs[0].id)}/load`, { method: "POST" });
           } catch (_) {}
-          startProgressPolling();
+          const savedTrainMode = _dashboardTrainMode;
+          dashPendingAction = async () => {
+            _dashboardTrainMode = savedTrainMode;
+
+            if (_dashboardTrainMode && _dashboardTrainMode.model) {
+              // Import labels from the trainable model's labelset
+              try {
+                const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(_dashboardTrainMode.model.name)}`);
+                if (modelRes.ok) {
+                  const modelData = await modelRes.json();
+                  const labels = modelData.labelset && modelData.labelset.labels;
+                  if (labels && labels.length > 0) {
+                    await fetch("/api/labels/import", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ labels }),
+                    });
+                  }
+                }
+              } catch (_) { /* ignore label import errors */ }
+
+              await fetchVotes();
+
+              // Set text sort mode and trigger sort with the model's first example or text_query
+              const exQuery = _dashboardTrainMode.model.text_query
+                || (_dashboardTrainMode.model.examples && _dashboardTrainMode.model.examples.length > 0 && _dashboardTrainMode.model.examples[0].type === "text" ? _dashboardTrainMode.model.examples[0].value : "");
+              sortMode = "text";
+              textSortWrap.style.display = "";
+              learnedSortWrap.style.display = "none";
+              loadSortWrap.style.display = "none";
+              document.querySelectorAll('input[name="sort-mode"]').forEach(r => {
+                r.checked = r.value === "text";
+              });
+              textSortInput.value = exQuery;
+              if (exQuery) {
+                fetchTextSort(exQuery);
+              }
+            }
+
+            showMainUI();
+            if (medias.length > 0 && !selected) {
+              selectMedia(medias[0].id);
+            }
+          };
+          startDashProgressPolling();
         }
         return;
       }


### PR DESCRIPTION
## Summary
This PR improves the dataset loading workflow by restoring the dashboard's train mode state and automatically importing labels from the associated trainable model after a dataset is loaded.

## Key Changes
- Modified the `dashPendingAction` callback invocation to properly await async operations
- Replaced direct `startProgressPolling()` call with a comprehensive async `dashPendingAction` that:
  - Restores the previously saved train mode state
  - Fetches and imports labels from the trainable model's labelset
  - Refreshes votes data
  - Automatically configures text-based sorting using the model's text query or first example
  - Restores the main UI and selects the first media item if available
- Renamed the progress polling function call to `startDashProgressPolling()` for clarity

## Implementation Details
- The train mode state is captured before the dataset load operation and restored afterward, ensuring the user's model context is preserved
- Label import errors are silently ignored to prevent blocking the workflow
- Text sort mode is automatically activated with the model's query/example, providing a seamless transition to the sorted view
- The async pending action pattern allows the progress polling to complete before executing the restoration logic

https://claude.ai/code/session_01Kn54FpTGHa3R7CAGhoWMHn