### PR TITLE
Refactor dashboard button hints to be inline elements

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1173,14 +1173,9 @@
       }
 
       dashLabelBtn.disabled = labelDisabled;
-      // Show/hide hint text
-      let hintEl = dashLabelBtn.parentElement.querySelector(".dash-btn-hint-label");
-      if (!hintEl) {
-        hintEl = document.createElement("span");
-        hintEl.className = "dash-btn-hint dash-btn-hint-label";
-        dashLabelBtn.parentElement.insertBefore(hintEl, dashLabelBtn.nextSibling);
-      }
-      hintEl.textContent = labelHint;
+      // Show hint inside button
+      const labelHintEl = dashLabelBtn.querySelector(".dash-btn-hint");
+      if (labelHintEl) labelHintEl.textContent = labelHint;
     }
 
     // --- Find button validation ---
@@ -1209,13 +1204,9 @@
       }
 
       dashDetectBtn.disabled = findDisabled;
-      let hintEl = dashDetectBtn.parentElement.querySelector(".dash-btn-hint-find");
-      if (!hintEl) {
-        hintEl = document.createElement("span");
-        hintEl.className = "dash-btn-hint dash-btn-hint-find";
-        dashDetectBtn.parentElement.insertBefore(hintEl, dashDetectBtn.nextSibling);
-      }
-      hintEl.textContent = findHint;
+      // Show hint inside button
+      const findHintEl = dashDetectBtn.querySelector(".dash-btn-hint");
+      if (findHintEl) findHintEl.textContent = findHint;
     }
   }
 

--- a/static/index.html
+++ b/static/index.html
@@ -151,8 +151,14 @@
         </div>
       </div>
       <div class="dashboard-actions">
-        <button class="dashboard-action-btn" id="dash-label-btn" disabled>Label</button>
-        <button class="dashboard-action-btn secondary" id="dash-detect-btn" disabled>Find</button>
+        <button class="dashboard-action-btn" id="dash-label-btn" disabled>
+          <span class="dash-btn-title">Label</span>
+          <span class="dash-btn-hint" id="dash-label-hint"></span>
+        </button>
+        <button class="dashboard-action-btn secondary" id="dash-detect-btn" disabled>
+          <span class="dash-btn-title">Find</span>
+          <span class="dash-btn-hint" id="dash-detect-hint"></span>
+        </button>
       </div>
       <input type="file" id="dash-file-input" accept=".pkl" style="display:none">
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -617,7 +617,7 @@ video { max-width: 100%; }
 /* ---- Dashboard view ---- */
 .dashboard-view {
   display: flex; flex-direction: column; width: 100%;
-  padding: 24px 32px; gap: 16px; flex: 1; min-height: 0;
+  padding: 8px 32px 24px; gap: 12px; flex: 1; min-height: 0;
 }
 .dashboard-header h2 { font-size: 1.4rem; color: var(--accent); margin: 0; }
 .dashboard-grids { display: grid; grid-template-columns: 1fr; gap: 20px; flex: 1; min-height: 0; }
@@ -696,25 +696,30 @@ video { max-width: 100%; }
 .demo-row.dash-selected .col-name, .dash-dataset-row.dash-selected .col-name, .dash-model-row.dash-selected .col-name { color: var(--accent); }
 
 /* Dashboard action buttons */
-.dashboard-actions { display: flex; gap: 12px; flex-shrink: 0; padding-top: 4px; width: 100%; }
+.dashboard-actions { display: flex; gap: 12px; flex-shrink: 0; padding-top: 4px; width: 100%; flex-wrap: nowrap; align-items: stretch; }
 .dashboard-action-btn {
-  flex: 1; padding: 12px 24px; font-size: 1rem; font-weight: 600;
+  flex: 1; padding: 10px 24px; font-size: 1rem; font-weight: 600;
   border: 2px solid var(--accent); border-radius: 8px;
   background: var(--accent); color: #fff; cursor: pointer;
   transition: all 0.15s;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
 }
+.dashboard-action-btn .dash-btn-title { line-height: 1.3; }
+.dashboard-action-btn .dash-btn-hint {
+  display: block; font-size: 0.68rem; font-weight: 400; opacity: 0.85;
+  line-height: 1.2; min-height: 0;
+}
+.dashboard-action-btn .dash-btn-hint:empty { display: none; }
 .dashboard-action-btn:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
 .dashboard-action-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+/* Label button is always the dominant button */
+.dashboard-action-btn:first-child { flex: 2; font-size: 1.1rem; padding: 12px 24px; }
 .dashboard-action-btn.secondary {
   background: transparent; color: var(--accent);
 }
+.dashboard-action-btn.secondary .dash-btn-hint { opacity: 0.7; color: var(--text-muted); }
 .dashboard-action-btn.secondary:hover { background: var(--accent-highlight-bg); }
 .dashboard-action-btn.secondary:disabled { background: transparent; }
-.dashboard-actions { flex-wrap: nowrap; }
-.dash-btn-hint {
-  display: block; width: 100%; font-size: 0.72rem; color: var(--text-muted);
-  text-align: center; margin-top: 2px; min-height: 1em;
-}
 
 /* Header nav button (Dashboard link visible during labeling) */
 .header-nav-btn {


### PR DESCRIPTION
## Summary
Refactored the dashboard action buttons (Label and Find) to display hint text as inline elements within the buttons rather than as separate sibling elements. This improves layout consistency and simplifies the DOM structure.

## Key Changes
- **HTML Structure**: Modified button markup to include hint text as child `<span>` elements with dedicated classes (`dash-btn-title` and `dash-btn-hint`)
- **JavaScript Logic**: Simplified hint text management by querying for hints inside buttons instead of creating/managing sibling elements in the parent container
- **CSS Styling**: 
  - Updated `.dashboard-action-btn` to use flexbox layout for vertical stacking of title and hint
  - Added dedicated styles for `.dash-btn-title` and `.dash-btn-hint` with appropriate sizing and opacity
  - Removed old `.dash-btn-hint` styles that positioned hints as separate block elements
  - Enhanced button layout with `flex-direction: column` and proper alignment
  - Made the Label button (first child) more prominent with increased flex ratio and font size
  - Adjusted dashboard view padding and gaps for better spacing

## Implementation Details
- Hint elements are now queried with `.querySelector(".dash-btn-hint")` instead of being dynamically created as siblings
- Hint text only displays when non-empty via CSS rule `.dash-btn-hint:empty { display: none; }`
- Secondary buttons (Find) have slightly reduced hint opacity for visual hierarchy
- Button padding and sizing adjusted to accommodate the new inline hint layout

https://claude.ai/code/session_01E2C6dPzMaRVtDgDkJe1jtK