### PR TITLE
Remove dataset status bar from dashboard

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -284,7 +284,6 @@
   const dashboardView = document.getElementById("dashboard-view");
   const dashDatasetGrid = document.getElementById("dash-dataset-grid");
   const dashModelGrid = document.getElementById("dash-model-grid");
-  const dashDatasetStatus = document.getElementById("dash-dataset-status");
   const dashLabelBtn = document.getElementById("dash-label-btn");
   const dashDetectBtn = document.getElementById("dash-detect-btn");
   const dashAddDatasetBtn = document.getElementById("dash-add-dataset-btn");
@@ -1117,20 +1116,6 @@
     dashboardView.style.display = "flex";
     // Only hide the in-grid progress if no load is actively running
     if (!dashProgressTimer) hideDashGridProgress();
-
-    // Update dataset status bar
-    if (datasetLoaded) {
-      const res = await fetch("/api/dataset/status");
-      const status = await res.json();
-      const mtInfo = mediaTypesMap[status.media_type];
-      const dupeSuffix = status.num_dupes ? ` (${status.num_dupes} dupes)` : "";
-      dashDatasetStatus.textContent = mtInfo
-        ? `${mtInfo.icon} ${status.num_medias} ${mtInfo.name.toLowerCase()} loaded${dupeSuffix}`
-        : `${status.num_medias} medias loaded${dupeSuffix}`;
-      dashDatasetStatus.style.display = "";
-    } else {
-      dashDatasetStatus.style.display = "none";
-    }
 
     // Populate grids
     await renderDashboardDatasets();

--- a/static/index.html
+++ b/static/index.html
@@ -132,7 +132,6 @@
               <button class="btn-sm" id="dash-add-dataset-btn">+</button>
             </div>
           </div>
-          <div id="dash-dataset-status" class="dashboard-status-bar" style="display:none"></div>
           <div class="dashboard-grid-wrap">
             <div id="dash-dataset-grid" class="dashboard-grid"></div>
           </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -633,10 +633,6 @@ video { max-width: 100%; }
 }
 .dashboard-section-title { font-size: 0.8rem; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.06em; }
 .dashboard-section-actions { display: flex; gap: 6px; }
-.dashboard-status-bar {
-  padding: 8px 14px; font-size: 0.82rem; color: var(--text-primary);
-  border-bottom: 1px solid var(--border); background: var(--bg-subtle); flex-shrink: 0;
-}
 .dashboard-grid-wrap { flex: 1; min-height: 0; overflow-y: auto; }
 .dashboard-grid { min-height: 0; }
 


### PR DESCRIPTION
## Summary
This PR removes the dataset status bar UI component from the dashboard view, including its HTML markup, CSS styling, and the JavaScript logic that populated it with dataset information.

## Key Changes
- **HTML**: Removed the `dash-dataset-status` div element that displayed dataset status information
- **CSS**: Removed the `.dashboard-status-bar` styling rules
- **JavaScript**: 
  - Removed the `dashDatasetStatus` DOM element reference
  - Removed the status bar update logic that fetched `/api/dataset/status` and displayed media count, type, and duplicate information

## Details
The status bar was previously displayed below the dashboard section header when a dataset was loaded, showing information like the number of media files, media type icon, and duplicate count. This functionality has been completely removed from the UI layer, though the backend API endpoint remains unchanged.

https://claude.ai/code/session_011qKVA9X4JjBzqUABnYo8rL