### PR TITLE
Make Autopilot the default tab in the Labeling interface

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1122,6 +1122,11 @@
     if (menuDashboard) menuDashboard.classList.remove("disabled");
     if (menuLabelsImport) menuLabelsImport.classList.remove("disabled");
     if (menuDetectorImport) menuDetectorImport.classList.remove("disabled");
+    // Start autopilot if the autopilot tab is the active one
+    if (tabAutopilot && tabAutopilot.classList.contains("active")) {
+      refreshAutopilotExamples();
+      startAutopilot();
+    }
   }
 
   // ---- Dashboard view ----
@@ -1779,9 +1784,6 @@
           }
 
           showMainUI();
-          if (tabAutopilot) {
-            tabAutopilot.click();
-          }
           // Select first media
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);
@@ -6471,9 +6473,6 @@
           }
 
           showMainUI();
-          if (_dashboardTrainMode && tabAutopilot) {
-            tabAutopilot.click();
-          }
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);
           }
@@ -6536,9 +6535,6 @@
       if (dashSelectedDataset) {
         dashLoadSelectedDataset(() => {
           showMainUI();
-          if (_dashboardTrainMode && tabAutopilot) {
-            tabAutopilot.click();
-          }
           if (medias.length > 0 && !selected) {
             selectMedia(medias[0].id);
           }

--- a/static/index.html
+++ b/static/index.html
@@ -36,10 +36,10 @@
       <span class="train-context-name" id="train-dataset-name"></span>
     </div>
     <div class="left-tabs" role="tablist" aria-label="Panel mode">
-      <button class="left-tab active" id="tab-manual" role="tab" aria-selected="true" aria-controls="tab-panel-manual">Manual</button>
-      <button class="left-tab" id="tab-autopilot" role="tab" aria-selected="false" aria-controls="tab-panel-autopilot">Autopilot</button>
+      <button class="left-tab" id="tab-manual" role="tab" aria-selected="false" aria-controls="tab-panel-manual">Manual</button>
+      <button class="left-tab active" id="tab-autopilot" role="tab" aria-selected="true" aria-controls="tab-panel-autopilot">Autopilot</button>
     </div>
-    <div id="tab-panel-manual" class="left-tab-panel" role="tabpanel" aria-labelledby="tab-manual">
+    <div id="tab-panel-manual" class="left-tab-panel" role="tabpanel" aria-labelledby="tab-manual" style="display:none">
       <div class="sort-bar" id="sort-bar">
         <span class="sort-label">Sort</span>
         <div class="sort-mode">
@@ -102,7 +102,7 @@
         <div class="stripe-container" id="stripe-container" aria-hidden="true"></div>
       </div>
     </div>
-    <div id="tab-panel-autopilot" class="left-tab-panel" role="tabpanel" aria-labelledby="tab-autopilot" style="display:none">
+    <div id="tab-panel-autopilot" class="left-tab-panel" role="tabpanel" aria-labelledby="tab-autopilot">
       <div class="autopilot-panel">
         <div id="autopilot-examples-section" style="display:none">
           <div class="ap-examples-header">


### PR DESCRIPTION
The Manual tab was always selected by default when opening the Labeling view. Now Autopilot is selected instead: the HTML defaults are swapped (active class, aria-selected, panel display) and showMainUI() starts the autopilot state machine whenever the Autopilot tab is active. Redundant tabAutopilot.click() calls in dashboard flows are removed since showMainUI() now handles this.

https://claude.ai/code/session_01HbsWhnGn2FMnLbU1N9Lncu