### PR TITLE
Make dashboard dataset selection click handler async

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1338,7 +1338,7 @@
       });
 
       // Multi-select click (toggle)
-      tr.addEventListener("click", (e) => {
+      tr.addEventListener("click", async (e) => {
         if (e.ctrlKey || e.metaKey) {
           // Toggle individual selection
           if (dashSelectedDatasetIds.includes(ds.id)) {
@@ -1354,7 +1354,7 @@
             dashSelectedDatasetIds = [ds.id];
           }
         }
-        renderDashboardDatasets();
+        await renderDashboardDatasets();
         updateDashboardButtons();
       });
       tr.addEventListener("keydown", (e) => {


### PR DESCRIPTION
## Summary
Updated the dashboard dataset row click event handler to properly await the `renderDashboardDatasets()` function call, ensuring rendering completes before proceeding with subsequent operations.

## Key Changes
- Changed the click event listener callback from synchronous to `async` function
- Added `await` keyword when calling `renderDashboardDatasets()` to ensure the rendering operation completes before `updateDashboardButtons()` is called

## Implementation Details
This change ensures proper execution order when handling dataset selection. By awaiting the render operation, we guarantee that the dashboard UI is fully updated before updating button states, preventing potential race conditions or UI inconsistencies that could occur if `updateDashboardButtons()` executed before rendering was complete.

https://claude.ai/code/session_019YPB5rVeUMyV7cHFyE4za9