### PR TITLE
Move dashboard progress bar from table row to section header

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -298,11 +298,11 @@
   const datasetImporterFormDiv = document.getElementById("dataset-importer-form");
   const datasetImporterBack = document.getElementById("dataset-importer-back");
   const dashFileInput = document.getElementById("dash-file-input");
-  // Dashboard progress elements — created dynamically as a table row
-  let dashProgressFill = null;
-  let dashProgressText = null;
-  let dashProgressMessage = null;
-  let dashProgressEta = null;
+  // Dashboard progress elements — in the section header
+  const dashHeaderProgress = document.getElementById("dash-header-progress");
+  const dashProgressFill = document.getElementById("dash-progress-fill");
+  const dashProgressText = document.getElementById("dash-progress-text");
+  const dashProgressMessage = document.getElementById("dash-progress-message");
   const headerDashboardBtn = document.getElementById("header-dashboard-btn");
   const menuDashboard = document.getElementById("menu-dashboard");
   let showThumbnailsRight = true;
@@ -1146,7 +1146,7 @@
     center.appendChild(dashboardView);
     center.className = "panel-center";
     dashboardView.style.display = "flex";
-    // Only hide the in-grid progress if no load is actively running
+    // Only hide the header progress if no load is actively running
     if (!dashProgressTimer) hideDashGridProgress();
 
     // Populate grids
@@ -1547,45 +1547,22 @@
 
   // Show a progress row inside the dataset table (keeps existing rows visible)
   function showDashGridProgress(message) {
-    // Remove any existing progress row first
-    hideDashGridProgress();
-    // Ensure the table exists; if the grid is empty, create a minimal table
-    let tbody = dashDatasetGrid.querySelector("tbody");
-    if (!tbody) {
-      dashDatasetGrid.innerHTML = `<table class="dash-dataset-table">
-        <thead><tr>
-          <th>Name</th><th>Type</th><th>Items</th><th>Loaded</th><th class="col-actions-header"></th>
-        </tr></thead><tbody></tbody></table>`;
-      tbody = dashDatasetGrid.querySelector("tbody");
+    if (!dashHeaderProgress) return;
+    // Reset bar to indeterminate
+    if (dashProgressFill) {
+      dashProgressFill.style.width = "0%";
+      dashProgressFill.classList.add("indeterminate");
     }
-    const tr = document.createElement("tr");
-    tr.id = "dash-progress-row";
-    tr.className = "dash-progress-row";
-    tr.innerHTML = `<td colspan="5" class="dash-progress-cell" role="status" aria-live="polite">
-      <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-        <div class="progress-fill indeterminate" id="dash-progress-fill" style="width:0%"></div>
-        <div class="progress-text" id="dash-progress-text" aria-hidden="true"></div>
-      </div>
-      <div class="progress-message" id="dash-progress-message">${escapeHtml(message || "Loading...")}</div>
-      <div class="progress-eta" id="dash-progress-eta"></div>
-    </td>`;
-    tbody.appendChild(tr);
-    // Update element references
-    dashProgressFill = tr.querySelector("#dash-progress-fill");
-    dashProgressText = tr.querySelector("#dash-progress-text");
-    dashProgressMessage = tr.querySelector("#dash-progress-message");
-    dashProgressEta = tr.querySelector("#dash-progress-eta");
-    dashProgressMessage.style.color = "var(--text-secondary)";
+    if (dashProgressText) dashProgressText.textContent = "";
+    if (dashProgressMessage) {
+      dashProgressMessage.textContent = message || "Loading...";
+      dashProgressMessage.style.color = "var(--text-secondary)";
+    }
+    dashHeaderProgress.style.display = "flex";
   }
 
-  // Remove the progress row from the dataset table
   function hideDashGridProgress() {
-    const row = document.getElementById("dash-progress-row");
-    if (row) row.remove();
-    dashProgressFill = null;
-    dashProgressText = null;
-    dashProgressMessage = null;
-    dashProgressEta = null;
+    if (dashHeaderProgress) dashHeaderProgress.style.display = "none";
   }
 
   // Dashboard: load a dataset from the selected demo, then run a callback
@@ -1626,6 +1603,8 @@
     if (dashProgressTimer) { clearInterval(dashProgressTimer); dashProgressTimer = null; }
   }
 
+  let dashEtaState = null;
+
   async function pollDashProgress() {
     try {
       const res = await fetch("/api/dataset/progress");
@@ -1633,24 +1612,47 @@
 
       if (progress.error) {
         stopDashProgressPolling();
+        dashEtaState = null;
         if (dashProgressMessage) { dashProgressMessage.textContent = `Error: ${progress.error}`; dashProgressMessage.style.color = "var(--color-bad)"; }
         if (dashProgressFill) dashProgressFill.classList.remove("indeterminate");
         return;
       }
 
+      // Build the status text: message + optional ETA
+      let statusText = progress.message || "Loading...";
+
       if (progress.pct != null && dashProgressFill) {
         dashProgressFill.classList.remove("indeterminate");
         dashProgressFill.style.width = `${progress.pct}%`;
         if (dashProgressText) dashProgressText.textContent = `${progress.pct}%`;
+
+        // ETA calculation during embedding phase
+        const now = Date.now();
+        if (progress.status === "embedding" && progress.total > 0) {
+          if (!dashEtaState || dashEtaState.total !== progress.total) {
+            dashEtaState = { startTime: now, startCurrent: progress.current, total: progress.total };
+          }
+          const elapsed = (now - dashEtaState.startTime) / 1000;
+          const done = progress.current - dashEtaState.startCurrent;
+          if (done > 0 && elapsed > 1 && progress.current < progress.total) {
+            const rate = done / elapsed;
+            const remaining = (progress.total - progress.current) / rate;
+            statusText += ` — ${formatETA(remaining)}`;
+          }
+        } else {
+          dashEtaState = null;
+        }
       }
-      if (progress.message && dashProgressMessage) {
-        dashProgressMessage.textContent = progress.message;
+
+      if (dashProgressMessage) {
+        dashProgressMessage.textContent = statusText;
         dashProgressMessage.style.color = "var(--text-secondary)";
       }
 
       if (progress.status === "idle") {
         stopDashProgressPolling();
         hideDashGridProgress();
+        dashEtaState = null;
 
         // Refresh dataset state
         await checkDatasetStatus();

--- a/static/index.html
+++ b/static/index.html
@@ -128,6 +128,13 @@
         <div class="dashboard-section">
           <div class="dashboard-section-header">
             <span class="dashboard-section-title">Datasets</span>
+            <div class="dash-header-progress" id="dash-header-progress" style="display:none" role="status" aria-live="polite">
+              <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-fill indeterminate" id="dash-progress-fill" style="width:0%"></div>
+                <div class="progress-text" id="dash-progress-text" aria-hidden="true"></div>
+              </div>
+              <span class="progress-message" id="dash-progress-message">Loading...</span>
+            </div>
             <div class="dashboard-section-actions">
               <button class="btn-sm" id="dash-add-dataset-btn">+</button>
             </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -636,13 +636,11 @@ video { max-width: 100%; }
 .dashboard-grid-wrap { flex: 1; min-height: 0; overflow-y: auto; }
 .dashboard-grid { min-height: 0; }
 
-/* In-table progress row for dataset loading */
-.dash-progress-row td { padding: 0 !important; border-bottom: 1px solid var(--border); }
-.dash-progress-cell { padding: 8px 8px 6px !important; }
-.dash-progress-cell .progress-bar { height: 18px; }
-.dash-progress-cell .progress-message { max-width: none; text-align: left; font-size: 0.75rem; margin-top: 4px; }
-.dash-progress-cell .progress-eta { text-align: left; font-size: 0.7rem; margin-top: 2px; }
-.dash-progress-cell .progress-text { font-size: 0.65rem; }
+/* Header progress bar for dataset loading */
+.dash-header-progress { flex: 1; display: flex; align-items: center; gap: 8px; margin: 0 12px; min-width: 0; }
+.dash-header-progress .progress-bar { flex: 1; height: 14px; min-width: 60px; }
+.dash-header-progress .progress-text { font-size: 0.6rem; }
+.dash-header-progress .progress-message { font-size: 0.7rem; color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin: 0; max-width: none; }
 
 /* Dashboard dataset table */
 .dashboard-grid .dash-dataset-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }


### PR DESCRIPTION
## Summary
Refactored the dashboard dataset loading progress indicator to display in the section header instead of as a row within the dataset table. This improves the UI by keeping the progress visible while maintaining a cleaner table layout.

## Key Changes
- **HTML Structure**: Added a new progress bar container (`dash-header-progress`) in the dashboard section header with progress fill, text, and message elements
- **JavaScript Logic**: 
  - Changed progress element references from dynamically created table row elements to static DOM elements queried by ID
  - Simplified `showDashGridProgress()` to reset and show the header progress bar instead of creating a table row
  - Simplified `hideDashGridProgress()` to hide the header element instead of removing a DOM node
  - Refactored `pollDashProgress()` to build a combined status text that includes both the message and ETA calculation
  - Added `dashEtaState` object to track embedding phase progress for accurate ETA calculations
- **Styling**: 
  - Removed styles for in-table progress row (`.dash-progress-row`, `.dash-progress-cell`)
  - Added new styles for header progress bar with flexbox layout, proper spacing, and text truncation
  - Adjusted progress bar height and font sizes for the header context

## Implementation Details
- Progress elements are now queried once at initialization rather than created/destroyed on each load
- ETA calculation is only performed during the "embedding" status phase and requires at least 1 second of elapsed time
- The header progress bar uses flexbox to align with other header elements and includes proper accessibility attributes (`role="status"`, `aria-live="polite"`)
- Status text combines the progress message with formatted ETA when available (e.g., "Loading... — 2m 30s remaining")

https://claude.ai/code/session_01WfUPExSLGDmpCgv11Y3uZh