### PR TITLE
Fix race condition in dataset loading progress state

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6484,6 +6484,10 @@
             _dashboardTrainMode = savedTrainMode;
 
             if (_dashboardTrainMode && _dashboardTrainMode.model) {
+              // Clear any votes from a previous session so they don't
+              // contaminate this model's labelset.
+              try { await fetch("/api/votes/clear", { method: "POST" }); } catch (_) {}
+
               // Import labels from the trainable model's labelset
               try {
                 const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(_dashboardTrainMode.model.name)}`);

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -588,3 +588,72 @@ class TestUCF101SubsetDownload:
                         f"Video demo '{name}' uses category '{cat}' "
                         f"not in UCF-101 subset"
                     )
+
+
+class TestLoadProgressRaceCondition:
+    """Dataset load endpoints must set progress to 'loading' before the thread starts.
+
+    Without this, the frontend's progress poll can see a stale 'idle' from
+    a previous load and prematurely stop polling, causing it to proceed
+    with the old dataset's data and votes (the label-leak bug).
+    """
+
+    def test_load_registered_dataset_sets_progress_before_thread(self, client):
+        """After POST to load a registered dataset, progress must not be 'idle'."""
+        import time
+
+        from vtsearch.utils.progress import get_progress
+
+        # Register the current medias as a dataset entry so we can load it
+        saved = dict(app_module.medias)
+        try:
+            # First, export current medias to a pkl for registration
+            from vtsearch.datasets.loader import export_dataset_to_file
+            from vtsearch.datasets.registry import SAVED_DATASETS_DIR
+
+            SAVED_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
+            pkl_path = str(SAVED_DATASETS_DIR / "test_race.pkl")
+            from pathlib import Path
+
+            Path(pkl_path).write_bytes(export_dataset_to_file(app_module.medias))
+
+            # Register in the dataset registry
+            from vtsearch.datasets.registry import register_dataset
+
+            entry = register_dataset(
+                name="test_race",
+                media_type="audio",
+                num_items=len(app_module.medias),
+                pkl_path=pkl_path,
+            )
+            dataset_id = entry["id"]
+
+            # Set progress to idle (simulating a previous completed load)
+            from vtsearch.utils.progress import update_progress
+
+            update_progress("idle", "Ready")
+
+            # POST to load the dataset
+            resp = client.post(f"/api/datasets/registry/{dataset_id}/load")
+            assert resp.status_code == 200
+
+            # Immediately check progress — it must NOT be 'idle'
+            progress = get_progress()
+            assert progress["status"] != "idle", (
+                "Progress must be set to 'loading' before the thread starts "
+                "to prevent the frontend from seeing a stale 'idle' state"
+            )
+
+            # Wait for the background thread to finish
+            for _ in range(60):
+                time.sleep(0.1)
+                if get_progress()["status"] == "idle":
+                    break
+        finally:
+            app_module.medias.clear()
+            app_module.medias.update(saved)
+            # Clean up
+            Path(pkl_path).unlink(missing_ok=True)
+            from vtsearch.datasets.registry import unregister_dataset
+
+            unregister_dataset(dataset_id)

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -394,6 +394,10 @@ def load_demo_dataset_route():
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
 
+    # Signal "loading" before the thread starts so frontend polling never
+    # sees a stale "idle" from a previous load and prematurely stops.
+    update_progress("loading", "Preparing to load dataset…", 0, 0)
+
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
 
@@ -525,6 +529,10 @@ def load_registered_dataset(dataset_id: str):
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
 
+    # Signal "loading" before the thread starts so frontend polling never
+    # sees a stale "idle" from a previous load and prematurely stops.
+    update_progress("loading", "Preparing to load dataset…", 0, 0)
+
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
     return jsonify({"ok": True, "message": "Loading started"})
@@ -620,6 +628,7 @@ def _load_from_origin(source: dict):
             except Exception as e:
                 update_progress("idle", "", 0, 0, str(e))
 
+        update_progress("loading", "Preparing to load dataset…", 0, 0)
         threading.Thread(target=load_task, daemon=True).start()
         return jsonify({"ok": True, "message": "Loading started"})
 
@@ -651,6 +660,7 @@ def _load_from_origin(source: dict):
             except Exception as e:
                 update_progress("idle", "", 0, 0, str(e))
 
+        update_progress("loading", "Preparing to load dataset…", 0, 0)
         threading.Thread(target=load_pkl_task, daemon=True).start()
         return jsonify({"ok": True, "message": "Loading started"})
 

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -169,6 +169,10 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
 
+    # Signal "loading" before the thread starts so frontend polling never
+    # sees a stale "idle" from a previous load and prematurely stops.
+    update_progress("loading", "Preparing to load dataset…", 0, 0)
+
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
 


### PR DESCRIPTION
## Summary
This PR fixes a race condition in dataset loading endpoints where the frontend could see a stale "idle" progress state from a previous load and prematurely stop polling, causing it to proceed with outdated dataset data and votes (the "label-leak" bug).

## Key Changes
- **Backend progress state fix**: Updated all dataset loading endpoints to set progress to "loading" *before* spawning the background thread, ensuring the frontend never observes a stale "idle" state during the critical polling window
  - Modified 4 dataset loading routes in `vtsearch/routes/datasets.py` and `vtsearch/routes/datasets_loading.py`
  - Each endpoint now calls `update_progress("loading", "Preparing to load dataset…", 0, 0)` before `thread.start()`

- **Frontend vote clearing**: Added explicit vote clearing when switching to a trainable model in dashboard mode to prevent votes from a previous session from contaminating the new model's labelset

- **Test coverage**: Added comprehensive test `TestLoadProgressRaceCondition` that verifies progress is never "idle" immediately after a dataset load request is posted

## Implementation Details
The fix ensures proper synchronization between frontend polling and backend state changes:
1. Frontend POSTs to load a dataset
2. Backend immediately sets progress to "loading" (before thread starts)
3. Frontend's polling loop sees "loading" and continues polling
4. Background thread performs the actual load and updates progress
5. Frontend sees final "idle" state only when load is complete

This prevents the race condition where the frontend could see a stale "idle" from a previous load and stop polling prematurely.

https://claude.ai/code/session_014WsWjP5hNnLEfSNEYuSLoQ