### PR TITLE
Fix race condition in progress status updates during dataset loading

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6484,6 +6484,10 @@
             _dashboardTrainMode = savedTrainMode;
 
             if (_dashboardTrainMode && _dashboardTrainMode.model) {
+              // Clear any votes from a previous session so they don't
+              // contaminate this model's labelset.
+              try { await fetch("/api/votes/clear", { method: "POST" }); } catch (_) {}
+
               // Import labels from the trainable model's labelset
               try {
                 const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(_dashboardTrainMode.model.name)}`);

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -366,6 +366,10 @@ def load_demo_dataset_route():
     if not dataset_name or dataset_name not in DEMO_DATASETS:
         return jsonify({"error": "Invalid dataset name"}), 400
 
+    # Set progress to "loading" synchronously so the frontend never sees a
+    # stale "idle" status from a previous operation before the thread starts.
+    update_progress("loading", "Loading demo dataset...")
+
     def load_task():
         try:
             clear_dataset()
@@ -506,12 +510,15 @@ def load_registered_dataset(dataset_id: str):
     if not pkl_path or not Path(pkl_path).is_file():
         return jsonify({"error": f"Saved dataset file not found: {pkl_path}"}), 404
 
+    # Set progress to "loading" synchronously so the frontend never sees a
+    # stale "idle" status from a previous operation before the thread starts.
+    update_progress("loading", "Loading dataset from file...")
+
     def load_task():
         try:
             clear_dataset()
             _reg_set_loaded(None)
             gc.collect()
-            update_progress("loading", "Loading dataset from file...", 0, 0)
             load_dataset_from_pickle(Path(pkl_path), medias)
             collapse_duplicates(medias)
             build_diversity_tree()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -153,6 +153,10 @@ def _run_origin_load_in_background(load_fn, origin: dict, *, name: str = "") -> 
         ``_origin_to_str(origin)`` when empty.
     """
 
+    # Set progress to "loading" synchronously so the frontend never sees a
+    # stale "idle" status from a previous operation before the thread starts.
+    update_progress("loading", "Preparing dataset...")
+
     def task():
         try:
             clear_dataset()


### PR DESCRIPTION
## Summary
This PR fixes a race condition where the frontend could briefly display a stale "idle" progress status from a previous operation before the background loading thread starts and updates the status to "loading". The fix ensures progress is set synchronously before spawning background threads.

## Key Changes
- **datasets.py**: Added synchronous `update_progress("loading", ...)` calls before spawning background threads in `load_demo_dataset_route()` and `load_registered_dataset()` to prevent stale status display
- **datasets_loading.py**: Added synchronous `update_progress("loading", ...)` call in `_run_origin_load_in_background()` before the background task starts
- **app.js**: Added vote clearing on dashboard initialization to prevent votes from previous sessions from contaminating the current model's labelset

## Implementation Details
The core issue was that progress status updates were happening inside background threads, creating a window where the frontend could see outdated "idle" status. By moving the initial progress update outside the thread (synchronously), we ensure the frontend always sees the correct "loading" status immediately when a load operation begins.

The vote clearing in app.js is a complementary fix that ensures clean state when switching between training sessions.

https://claude.ai/code/session_01GxtbTF9BsbmvQGc4tVWGjr