### PR TITLE
Fix race condition in dataset loading progress state

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6484,6 +6484,10 @@
             _dashboardTrainMode = savedTrainMode;
 
             if (_dashboardTrainMode && _dashboardTrainMode.model) {
+              // Clear any votes from a previous session so they don't
+              // contaminate this model's labelset.
+              try { await fetch("/api/votes/clear", { method: "POST" }); } catch (_) {}
+
               // Import labels from the trainable model's labelset
               try {
                 const modelRes = await fetch(`/api/trainable-models/${encodeURIComponent(_dashboardTrainMode.model.name)}`);

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -588,3 +588,72 @@ class TestUCF101SubsetDownload:
                         f"Video demo '{name}' uses category '{cat}' "
                         f"not in UCF-101 subset"
                     )
+
+
+class TestLoadProgressRaceCondition:
+    """Dataset load endpoints must set progress to 'loading' before the thread starts.
+
+    Without this, the frontend's progress poll can see a stale 'idle' from
+    a previous load and prematurely stop polling, causing it to proceed
+    with the old dataset's data and votes (the label-leak bug).
+    """
+
+    def test_load_registered_dataset_sets_progress_before_thread(self, client):
+        """After POST to load a registered dataset, progress must not be 'idle'."""
+        import time
+
+        from vtsearch.utils.progress import get_progress
+
+        # Register the current medias as a dataset entry so we can load it
+        saved = dict(app_module.medias)
+        try:
+            # First, export current medias to a pkl for registration
+            from vtsearch.datasets.loader import export_dataset_to_file
+            from vtsearch.datasets.registry import SAVED_DATASETS_DIR
+
+            SAVED_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
+            pkl_path = str(SAVED_DATASETS_DIR / "test_race.pkl")
+            from pathlib import Path
+
+            Path(pkl_path).write_bytes(export_dataset_to_file(app_module.medias))
+
+            # Register in the dataset registry
+            from vtsearch.datasets.registry import register_dataset
+
+            entry = register_dataset(
+                name="test_race",
+                media_type="audio",
+                num_items=len(app_module.medias),
+                pkl_path=pkl_path,
+            )
+            dataset_id = entry["id"]
+
+            # Set progress to idle (simulating a previous completed load)
+            from vtsearch.utils.progress import update_progress
+
+            update_progress("idle", "Ready")
+
+            # POST to load the dataset
+            resp = client.post(f"/api/datasets/registry/{dataset_id}/load")
+            assert resp.status_code == 200
+
+            # Immediately check progress — it must NOT be 'idle'
+            progress = get_progress()
+            assert progress["status"] != "idle", (
+                "Progress must be set to 'loading' before the thread starts "
+                "to prevent the frontend from seeing a stale 'idle' state"
+            )
+
+            # Wait for the background thread to finish
+            for _ in range(60):
+                time.sleep(0.1)
+                if get_progress()["status"] == "idle":
+                    break
+        finally:
+            app_module.medias.clear()
+            app_module.medias.update(saved)
+            # Clean up
+            Path(pkl_path).unlink(missing_ok=True)
+            from vtsearch.datasets.registry import unregister_dataset
+
+            unregister_dataset(dataset_id)

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -396,6 +396,10 @@ def load_demo_dataset_route():
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
 
+    # Signal "loading" before the thread starts so frontend polling never
+    # sees a stale "idle" from a previous load and prematurely stops.
+    update_progress("loading", "Preparing to load dataset…", 0, 0)
+
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
 
@@ -526,6 +530,10 @@ def load_registered_dataset(dataset_id: str):
             update_progress("idle", "", 0, 0, "Out of memory — dataset too large.")
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
+
+    # Signal "loading" before the thread starts so frontend polling never
+    # sees a stale "idle" from a previous load and prematurely stops.
+    update_progress("loading", "Preparing to load dataset…", 0, 0)
 
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -181,6 +181,10 @@ def _run_origin_load_in_background(load_fn, origin: dict, *, name: str = "") -> 
         except Exception as e:
             update_progress("idle", "", 0, 0, str(e))
 
+    # Signal "loading" before the thread starts so frontend polling never
+    # sees a stale "idle" from a previous load and prematurely stops.
+    update_progress("loading", "Preparing to load dataset…", 0, 0)
+
     threading.Thread(target=task, daemon=True).start()
 
 


### PR DESCRIPTION
## Summary
Fixes a race condition where the frontend could see a stale "idle" progress state from a previous dataset load, causing it to prematurely stop polling and proceed with outdated dataset data and votes (the "label-leak bug").

## Key Changes
- **Dataset loading endpoints** (`/api/datasets/registry/{id}/load`, `/api/datasets/upload`, and related endpoints): Set progress to "loading" state *before* spawning the background thread, ensuring the frontend never observes a stale "idle" state during the critical polling window.
- **Frontend vote clearing**: Added automatic clearing of votes when loading a trainable model to prevent votes from a previous session from contaminating the new model's labelset.
- **Test coverage**: Added `TestLoadProgressRaceCondition` test class that verifies progress is set to a non-idle state immediately after a dataset load request, before the background thread completes.

## Implementation Details
The fix applies the same pattern across three dataset loading code paths:
1. `vtsearch/routes/datasets.py` - registered dataset loading
2. `vtsearch/routes/datasets.py` - custom dataset loading  
3. `vtsearch/routes/datasets_loading.py` - upload endpoint

Each now calls `update_progress("loading", "Preparing to load dataset…", 0, 0)` synchronously before `threading.Thread(...).start()`, guaranteeing the frontend's progress polling will see the updated state rather than a stale "idle" from a previous operation.

https://claude.ai/code/session_01AkhrdGP881aShAnreUAdvL