### PR TITLE
Preserve relative paths for files in subdirectories during folder import

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -9,6 +9,7 @@ These tests verify:
 - Folder importer is not in _BUILTIN_IMPORTER_NAMES
 - load_dataset_from_folder content_vectors support
 - load_dataset_from_folder content_md5s support
+- load_dataset_from_folder preserves relative paths for files in subdirs
 """
 
 from __future__ import annotations
@@ -744,3 +745,128 @@ class TestLoadDatasetContentMD5s:
 
         assert len(medias) == 1
         assert medias[1]["md5"] == pre_md5
+
+
+# ---------------------------------------------------------------------------
+# load_dataset_from_folder – relative path preservation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDatasetRelativePaths:
+    """Verify that load_dataset_from_folder preserves relative paths."""
+
+    def _write_wav(self, path):
+        path.write_bytes(_make_wav_bytes())
+
+    def _make_fake_media_type(self, embed_return):
+        import unittest.mock as mock
+
+        mt = mock.MagicMock()
+        mt.type_id = "audio"
+        mt.file_extensions = ["*.wav"]
+        mt.embed_media.return_value = embed_return
+        mt.load_media_data.return_value = {"duration": 1.0}
+        return mt
+
+    def test_flat_files_use_basename(self, tmp_path):
+        """Files directly in the root folder should have basename-only filenames."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        self._write_wav(tmp_path / "a.wav")
+        mt = self._make_fake_media_type(embed_return=np.zeros(3))
+        medias: dict = {}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
+            load_dataset_from_folder(tmp_path, "sounds", medias, on_progress=lambda *a: None)
+
+        assert medias[1]["filename"] == "a.wav"
+        assert medias[1]["origin_name"] == "a.wav"
+
+    def test_subdir_files_use_relative_path(self, tmp_path):
+        """Files in subdirectories should keep the relative path."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        sub = tmp_path / "cat_a"
+        sub.mkdir()
+        self._write_wav(sub / "clip.wav")
+        mt = self._make_fake_media_type(embed_return=np.zeros(3))
+        medias: dict = {}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
+            load_dataset_from_folder(tmp_path, "sounds", medias, on_progress=lambda *a: None)
+
+        assert medias[1]["filename"] == "cat_a/clip.wav"
+        assert medias[1]["origin_name"] == "cat_a/clip.wav"
+
+    def test_same_name_different_dirs_are_distinct(self, tmp_path):
+        """Identically named files in different subdirs get distinct filenames."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        (tmp_path / "dir_a").mkdir()
+        (tmp_path / "dir_b").mkdir()
+        self._write_wav(tmp_path / "dir_a" / "clip.wav")
+        self._write_wav(tmp_path / "dir_b" / "clip.wav")
+        mt = self._make_fake_media_type(embed_return=np.zeros(3))
+        medias: dict = {}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
+            load_dataset_from_folder(tmp_path, "sounds", medias, on_progress=lambda *a: None)
+
+        filenames = {m["filename"] for m in medias.values()}
+        assert "dir_a/clip.wav" in filenames
+        assert "dir_b/clip.wav" in filenames
+        assert len(filenames) == 2
+
+    def test_content_vectors_fallback_to_basename(self, tmp_path):
+        """content_vectors keyed by basename should still work for flat files."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        self._write_wav(tmp_path / "x.wav")
+        pre = np.array([99.0, 99.0, 99.0])
+        mt = self._make_fake_media_type(embed_return=np.zeros(3))
+        medias: dict = {}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
+            load_dataset_from_folder(
+                tmp_path, "sounds", medias, content_vectors={"x.wav": pre}, on_progress=lambda *a: None
+            )
+
+        np.testing.assert_array_equal(medias[1]["embedding"], pre)
+
+    def test_chunked_preserves_relative_paths(self, tmp_path):
+        """Chunked loader should also preserve relative paths."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        self._write_wav(sub / "chunk.wav")
+        mt = self._make_fake_media_type(embed_return=np.zeros(3))
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
+            chunks = list(
+                load_dataset_from_folder_chunked(tmp_path, "sounds", 10, on_progress=lambda *a: None)
+            )
+
+        media = chunks[0][1]
+        assert media["filename"] == "sub/chunk.wav"
+        assert media["origin_name"] == "sub/chunk.wav"

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -29,7 +29,7 @@ def _load_pdf_images(
     ``origin`` is set to ``{"importer": "pdf", "params": {"path": ...}}``
     so the provenance points back to the source document.
     """
-    pdf_files = sorted(folder.glob("*.pdf"))
+    pdf_files = sorted(folder.rglob("*.pdf"))
     if not pdf_files:
         return
 
@@ -45,6 +45,9 @@ def _load_pdf_images(
     for pdf_path in pdf_files:
         origin = {"importer": "pdf", "params": {"path": str(pdf_path)}}
         pages = render_pdf_pages(pdf_path)
+        # Relative path prefix so that PDFs in different subdirectories
+        # produce distinct page names.
+        pdf_rel = pdf_path.relative_to(folder).as_posix()
 
         for page_name, pil_image in pages:
             embedding = mt.embed_pil_image(pil_image)
@@ -55,16 +58,25 @@ def _load_pdf_images(
             pil_image.save(buf, format="PNG")
             image_bytes = buf.getvalue()
 
+            # page_name is e.g. "doc.pdf-1"; prefix with relative dir
+            # so that identically-named PDFs in different folders stay
+            # distinct (e.g. "subdir/doc.pdf-1").
+            rel_dir = str(Path(pdf_rel).parent)
+            if rel_dir and rel_dir != ".":
+                full_page_name = f"{rel_dir}/{page_name}"
+            else:
+                full_page_name = page_name
+
             media_data: dict[str, Any] = {
                 "id": media_id,
                 "type": mt.type_id,
                 "file_size": len(image_bytes),
                 "md5": hashlib.md5(image_bytes).hexdigest(),
                 "embedding": embedding,
-                "filename": page_name,
+                "filename": full_page_name,
                 "category": "custom",
                 "origin": origin,
-                "origin_name": page_name,
+                "origin_name": full_page_name,
                 "media_bytes": None if thin else image_bytes,
                 "media_string": None,
                 "media_path": str(pdf_path.resolve()),

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -290,7 +290,7 @@ def load_image_metadata_from_folders(image_dir: Path, categories: list[str]) -> 
             not in this list are skipped.
 
     Returns:
-        A dict mapping image filename (basename only) to a dict with the keys:
+        A dict mapping ``category/filename`` to a dict with the keys:
 
         - ``"category"`` (``str``): Name of the category folder.
         - ``"path"`` (``Path``): Full path to the image file.
@@ -400,18 +400,19 @@ def load_dataset_from_folder(
     without any changes to this function.
 
     Args:
-        folder_path: Path to a flat directory containing media files.
+        folder_path: Path to the root directory containing media files.
+            Subdirectories are scanned recursively.
         media_type: Folder-import alias for the media type (e.g. ``"sounds"``).
         medias: Dict to populate in-place. Existing entries are removed before
             loading. Keys are sequential integer media IDs starting from 1.
-        content_vectors: Optional mapping of filename (basename) to a
-            pre-computed embedding ``numpy.ndarray``.  When a file's name is
-            found in this dict the supplied vector is used directly and the
-            embedding model is not invoked for that file.
-        content_md5s: Optional mapping of filename (basename) to a
-            pre-computed MD5 hex digest string.  When a file's name is found
-            in this dict the supplied hash is used directly and no MD5
-            calculation is performed for that file.
+        content_vectors: Optional mapping of filename to a pre-computed
+            embedding ``numpy.ndarray``.  Keys may be relative paths
+            (``"subdir/file.wav"``) or basenames (``"file.wav"``); relative
+            paths are checked first for an exact match, then basenames as a
+            fallback.
+        content_md5s: Optional mapping of filename to a pre-computed MD5 hex
+            digest string.  Keys follow the same lookup logic as
+            ``content_vectors`` (relative path first, then basename).
         origin: Optional serialised
             :class:`~vtsearch.datasets.origin.Origin` dict to attach to each
             media (as ``media["origin"]``).  When ``None`` no origin is set
@@ -442,10 +443,11 @@ def load_dataset_from_folder(
     if getattr(mt, "_model", None) is None:
         mt.load_models()
 
-    # Find all files of the specified media type
+    # Find all files of the specified media type (recursive so that
+    # subdirectory structures are preserved).
     media_files = []
     for ext in mt.file_extensions:
-        media_files.extend(folder_path.glob(ext))
+        media_files.extend(folder_path.rglob(ext))
 
     if not media_files:
         raise ValueError(f"No {media_type} files found in folder")
@@ -456,14 +458,22 @@ def load_dataset_from_folder(
 
     try:
         for i, file_path in enumerate(media_files):
+            # Preserve relative path from the import root so that files in
+            # different subdirectories with the same basename stay distinct.
+            rel_path = file_path.relative_to(folder_path).as_posix()
+
             on_progress(
                 "embedding",
-                f"Embedding {media_type} {file_path.name}...",
+                f"Embedding {media_type} {rel_path}...",
                 i + 1,
                 total_files,
             )
 
-            if content_vectors and file_path.name in content_vectors:
+            # Look up pre-computed vectors by relative path first, then
+            # fall back to basename for backward compatibility.
+            if content_vectors and rel_path in content_vectors:
+                embedding = content_vectors[rel_path]
+            elif content_vectors and file_path.name in content_vectors:
                 embedding = content_vectors[file_path.name]
             else:
                 embedding = mt.embed_media(file_path)
@@ -473,7 +483,9 @@ def load_dataset_from_folder(
             if thin:
                 # Thin mode: store file path reference, skip loading bytes.
                 # Use stat for file_size and streaming hash for MD5.
-                if content_md5s and file_path.name in content_md5s:
+                if content_md5s and rel_path in content_md5s:
+                    md5 = content_md5s[rel_path]
+                elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
                 else:
                     md5 = _streaming_md5(file_path)
@@ -483,10 +495,10 @@ def load_dataset_from_folder(
                     "file_size": file_path.stat().st_size,
                     "md5": md5,
                     "embedding": embedding,
-                    "filename": file_path.name,
+                    "filename": rel_path,
                     "category": "custom",
                     "origin": origin,
-                    "origin_name": file_path.name,
+                    "origin_name": rel_path,
                     "media_bytes": None,
                     "media_string": None,
                     "media_path": str(file_path.resolve()),
@@ -496,7 +508,9 @@ def load_dataset_from_folder(
                 with open(file_path, "rb") as f:
                     file_bytes = f.read()
 
-                if content_md5s and file_path.name in content_md5s:
+                if content_md5s and rel_path in content_md5s:
+                    md5 = content_md5s[rel_path]
+                elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
                 else:
                     md5 = hashlib.md5(file_bytes).hexdigest()
@@ -508,10 +522,10 @@ def load_dataset_from_folder(
                     "file_size": len(file_bytes),
                     "md5": md5,
                     "embedding": embedding,
-                    "filename": file_path.name,
+                    "filename": rel_path,
                     "category": "custom",
                     "origin": origin,
-                    "origin_name": file_path.name,
+                    "origin_name": rel_path,
                     # Null-out optional media fields so medias from different types
                     # stored in the same dict have consistent keys.
                     "media_bytes": None,
@@ -546,7 +560,7 @@ def load_dataset_from_folder_chunked(
     origin: dict[str, Any] | None = None,
     thin: bool = False,
 ) -> Iterator[dict[int, dict[str, Any]]]:
-    """Yield chunks of medias from a flat folder of media files.
+    """Yield chunks of medias from a folder of media files.
 
     Works identically to :func:`load_dataset_from_folder` but yields the
     medias in groups of at most *chunk_size*.  Each yielded dict is a
@@ -554,11 +568,14 @@ def load_dataset_from_folder_chunked(
     has processed a chunk, the dict can be discarded to free memory.
 
     Args:
-        folder_path: Path to a flat directory containing media files.
+        folder_path: Path to the root directory containing media files.
+            Subdirectories are scanned recursively.
         media_type: Folder-import alias (e.g. ``"sounds"``).
         chunk_size: Maximum number of medias per chunk.
-        content_vectors: Optional pre-computed embeddings keyed by filename.
-        content_md5s: Optional pre-computed MD5s keyed by filename.
+        content_vectors: Optional pre-computed embeddings keyed by filename
+            (relative path or basename; relative path is tried first).
+        content_md5s: Optional pre-computed MD5s keyed by filename (same
+            lookup logic as *content_vectors*).
         origin: Optional origin dict to attach to each media.
         thin: When ``True``, store ``media_path`` instead of ``media_bytes``.
 
@@ -587,10 +604,11 @@ def load_dataset_from_folder_chunked(
     if getattr(mt, "_model", None) is None:
         mt.load_models()
 
-    # Find all files of the specified media type
+    # Find all files of the specified media type (recursive so that
+    # subdirectory structures are preserved).
     media_files: list[Path] = []
     for ext in mt.file_extensions:
-        media_files.extend(folder_path.glob(ext))
+        media_files.extend(folder_path.rglob(ext))
 
     if not media_files:
         raise ValueError(f"No {media_type} files found in folder")
@@ -605,14 +623,18 @@ def load_dataset_from_folder_chunked(
 
         for i, file_path in enumerate(batch):
             global_idx = start + i
+            rel_path = file_path.relative_to(folder_path).as_posix()
+
             on_progress(
                 "embedding",
-                f"Embedding {media_type} {file_path.name} (chunk {start // chunk_size + 1})...",
+                f"Embedding {media_type} {rel_path} (chunk {start // chunk_size + 1})...",
                 global_idx + 1,
                 total_files,
             )
 
-            if content_vectors and file_path.name in content_vectors:
+            if content_vectors and rel_path in content_vectors:
+                embedding = content_vectors[rel_path]
+            elif content_vectors and file_path.name in content_vectors:
                 embedding = content_vectors[file_path.name]
             else:
                 embedding = mt.embed_media(file_path)
@@ -620,7 +642,9 @@ def load_dataset_from_folder_chunked(
                     continue
 
             if thin:
-                if content_md5s and file_path.name in content_md5s:
+                if content_md5s and rel_path in content_md5s:
+                    md5 = content_md5s[rel_path]
+                elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
                 else:
                     md5 = _streaming_md5(file_path)
@@ -630,10 +654,10 @@ def load_dataset_from_folder_chunked(
                     "file_size": file_path.stat().st_size,
                     "md5": md5,
                     "embedding": embedding,
-                    "filename": file_path.name,
+                    "filename": rel_path,
                     "category": "custom",
                     "origin": origin,
-                    "origin_name": file_path.name,
+                    "origin_name": rel_path,
                     "media_bytes": None,
                     "media_string": None,
                     "media_path": str(file_path.resolve()),
@@ -643,7 +667,9 @@ def load_dataset_from_folder_chunked(
                 with open(file_path, "rb") as f:
                     file_bytes = f.read()
 
-                if content_md5s and file_path.name in content_md5s:
+                if content_md5s and rel_path in content_md5s:
+                    md5 = content_md5s[rel_path]
+                elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
                 else:
                     md5 = hashlib.md5(file_bytes).hexdigest()
@@ -654,10 +680,10 @@ def load_dataset_from_folder_chunked(
                     "file_size": len(file_bytes),
                     "md5": md5,
                     "embedding": embedding,
-                    "filename": file_path.name,
+                    "filename": rel_path,
                     "category": "custom",
                     "origin": origin,
-                    "origin_name": file_path.name,
+                    "origin_name": rel_path,
                     "media_bytes": None,
                     "media_string": None,
                     "media_path": str(file_path.resolve()),

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -390,9 +390,12 @@ class AudioMediaType(MediaType):
         demo_origin: dict = {"importer": "demo", "params": {}}
 
         for i, (audio_path, meta) in enumerate(audio_files):
+            # Preserve category/filename so that identically-named files
+            # in different category folders remain distinguishable.
+            rel_name = f"{meta['category']}/{audio_path.name}"
             on_progress(
                 "embedding",
-                f"Embedding {meta['category']}: {audio_path.name} ({i + 1}/{total})",
+                f"Embedding {rel_name} ({i + 1}/{total})",
                 i + 1,
                 total,
             )
@@ -412,10 +415,10 @@ class AudioMediaType(MediaType):
                 "md5": hashlib.md5(wav_bytes).hexdigest(),
                 "embedding": embedding,
                 "media_bytes": wav_bytes,
-                "filename": audio_path.name,
+                "filename": rel_name,
                 "category": meta["category"],
                 "origin": demo_origin,
-                "origin_name": audio_path.name,
+                "origin_name": rel_name,
             }
             clip_id += 1
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -686,7 +686,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (img_path, category) in enumerate(selected):
-                on_progress("embedding", f"Embedding {category}: {img_path.name} ({i + 1}/{total})", i + 1, total)
+                on_progress("embedding", f"Embedding {category}/{img_path.name} ({i + 1}/{total})", i + 1, total)
                 embedding = self.embed_media(img_path)
                 if embedding is None:
                     continue
@@ -706,12 +706,12 @@ class ImageMediaType(MediaType):
                     "embedding": embedding,
                     "media_bytes": image_bytes,
                     "media_string": None,
-                    "filename": img_path.name,
+                    "filename": f"{category}/{img_path.name}",
                     "category": category,
                     "width": width,
                     "height": height,
                     "origin": demo_origin,
-                    "origin_name": img_path.name,
+                    "origin_name": f"{category}/{img_path.name}",
                 }
                 clip_id += 1
             return None  # bytes are inline
@@ -742,7 +742,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (img_path, category) in enumerate(selected):
-                on_progress("embedding", f"Embedding {category}: {img_path.name} ({i + 1}/{total})", i + 1, total)
+                on_progress("embedding", f"Embedding {category}/{img_path.name} ({i + 1}/{total})", i + 1, total)
                 embedding = self.embed_media(img_path)
                 if embedding is None:
                     continue
@@ -762,12 +762,12 @@ class ImageMediaType(MediaType):
                     "embedding": embedding,
                     "media_bytes": image_bytes,
                     "media_string": None,
-                    "filename": img_path.name,
+                    "filename": f"{category}/{img_path.name}",
                     "category": category,
                     "width": width,
                     "height": height,
                     "origin": demo_origin,
-                    "origin_name": img_path.name,
+                    "origin_name": f"{category}/{img_path.name}",
                 }
                 clip_id += 1
             return None  # bytes are inline
@@ -801,7 +801,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (img_path, category) in enumerate(selected):
-                on_progress("embedding", f"Embedding {category}: {img_path.name} ({i + 1}/{total})", i + 1, total)
+                on_progress("embedding", f"Embedding {category}/{img_path.name} ({i + 1}/{total})", i + 1, total)
                 embedding = self.embed_media(img_path)
                 if embedding is None:
                     continue
@@ -821,12 +821,12 @@ class ImageMediaType(MediaType):
                     "embedding": embedding,
                     "media_bytes": image_bytes,
                     "media_string": None,
-                    "filename": img_path.name,
+                    "filename": f"{category}/{img_path.name}",
                     "category": category,
                     "width": width,
                     "height": height,
                     "origin": demo_origin,
-                    "origin_name": img_path.name,
+                    "origin_name": f"{category}/{img_path.name}",
                 }
                 clip_id += 1
             return None  # bytes are inline
@@ -867,7 +867,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (img_path, category) in enumerate(selected):
-                on_progress("embedding", f"Embedding {category}: {img_path.name} ({i + 1}/{total})", i + 1, total)
+                on_progress("embedding", f"Embedding {category}/{img_path.name} ({i + 1}/{total})", i + 1, total)
                 embedding = self.embed_media(img_path)
                 if embedding is None:
                     continue
@@ -887,12 +887,12 @@ class ImageMediaType(MediaType):
                     "embedding": embedding,
                     "media_bytes": image_bytes,
                     "media_string": None,
-                    "filename": img_path.name,
+                    "filename": f"{category}/{img_path.name}",
                     "category": category,
                     "width": width,
                     "height": height,
                     "origin": demo_origin,
-                    "origin_name": img_path.name,
+                    "origin_name": f"{category}/{img_path.name}",
                 }
                 clip_id += 1
             return None  # bytes are inline
@@ -938,6 +938,7 @@ class ImageMediaType(MediaType):
                 img_buffer = _io.BytesIO()
                 pil_image.save(img_buffer, format="PNG")
                 image_bytes = img_buffer.getvalue()
+                rel_name = f"{category}/{page_name}"
                 clips[clip_id] = {
                     "id": clip_id,
                     "type": self.type_id,
@@ -947,12 +948,12 @@ class ImageMediaType(MediaType):
                     "embedding": embedding,
                     "media_bytes": image_bytes,
                     "media_string": None,
-                    "filename": f"{page_name}.png",
+                    "filename": f"{rel_name}.png",
                     "category": category,
                     "width": pil_image.width,
                     "height": pil_image.height,
                     "origin": demo_origin,
-                    "origin_name": page_name,
+                    "origin_name": rel_name,
                 }
                 clip_id += 1
             return None  # bytes are inline
@@ -995,7 +996,7 @@ class ImageMediaType(MediaType):
                 embedding = embed_image_file_from_pil(img)
                 if embedding is None:
                     continue
-                fname = f"{category}_{clip_id}.png"
+                fname = f"{category}/{category}_{clip_id}.png"
                 clips[clip_id] = {
                     "id": clip_id,
                     "type": self.type_id,

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -290,7 +290,7 @@ class TextMediaType(MediaType):
             word_count = len(text_content.split())
             character_count = len(text_content)
             text_bytes = text_content.encode("utf-8")
-            fname = f"{category}_{clip_id}.txt"
+            fname = f"{category}/{category}_{clip_id}.txt"
             clips[clip_id] = {
                 "id": clip_id,
                 "type": self.type_id,

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -211,9 +211,10 @@ class VideoMediaType(MediaType):
         demo_origin: dict = {"importer": "demo", "params": {}}
 
         for i, (video_path, meta) in enumerate(video_files):
+            rel_name = f"{meta['category']}/{video_path.name}"
             on_progress(
                 "embedding",
-                f"Embedding {meta['category']}: {video_path.name} ({i + 1}/{total})",
+                f"Embedding {rel_name} ({i + 1}/{total})",
                 i + 1,
                 total,
             )
@@ -223,7 +224,6 @@ class VideoMediaType(MediaType):
             with open(video_path, "rb") as f:
                 video_bytes = f.read()
             media_fields = self.load_media_data(video_path)
-            rel_filename = str(video_path.relative_to(video_dir))
             clips[clip_id] = {
                 "id": clip_id,
                 "type": self.type_id,
@@ -232,10 +232,10 @@ class VideoMediaType(MediaType):
                 "md5": hashlib.md5(video_bytes).hexdigest(),
                 "embedding": embedding,
                 "media_bytes": video_bytes,
-                "filename": rel_filename,
+                "filename": rel_name,
                 "category": meta["category"],
                 "origin": demo_origin,
-                "origin_name": video_path.name,
+                "origin_name": rel_name,
             }
             clip_id += 1
 


### PR DESCRIPTION
## Summary
This change updates the folder import functionality to preserve relative paths for media files located in subdirectories, ensuring that identically-named files in different folders remain distinct and organized.

## Key Changes

- **Recursive file discovery**: Changed `glob()` to `rglob()` in `load_dataset_from_folder()` and `load_dataset_from_folder_chunked()` to recursively scan subdirectories
- **Relative path preservation**: Files now use relative paths (e.g., `"subdir/file.wav"`) instead of just basenames (e.g., `"file.wav"`) in `filename` and `origin_name` fields
- **Backward-compatible lookup**: Pre-computed embeddings and MD5 hashes can be keyed by either relative path or basename, with relative path checked first for exact matches
- **Consistent naming across media types**: Updated image, audio, and video demo loaders to use relative paths (e.g., `"category/filename"`) for consistency
- **PDF subdirectory support**: PDF importer now uses `rglob()` and preserves relative paths for extracted pages (e.g., `"subdir/doc.pdf-1"`)
- **Documentation updates**: Clarified that folder paths can contain subdirectories and updated parameter descriptions for `content_vectors` and `content_md5s`

## Implementation Details

- Relative paths are computed using `file_path.relative_to(folder_path).as_posix()` to ensure cross-platform compatibility
- Progress messages now display relative paths for better user feedback
- Flat files (directly in root) use basename-only filenames for simplicity
- Comprehensive test coverage added for flat files, subdirectory files, duplicate names in different directories, and chunked loading

https://claude.ai/code/session_016aDx6ReZtAcvn2F866fpTA