### PR TITLE
Add duplicate count and model training metadata to registries

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1262,6 +1262,7 @@
         <th>Name</th>
         <th>Type</th>
         <th>Items</th>
+        <th>#Dupes</th>
         <th>Created</th>
         <th>Origin</th>
         <th>Details</th>
@@ -1295,9 +1296,11 @@
         const parts = Object.values(params).filter(Boolean);
         dsDetails = parts.length ? parts.join(", ") : dsSource.importer || "-";
       }
+      const dsDupes = ds.num_dupes || 0;
       tr.insertAdjacentHTML("beforeend", `
         <td class="col-type">${escapeHtml(icon)} ${escapeHtml(typeName)}</td>
         <td class="col-count">${ds.num_items || 0}</td>
+        <td class="col-dupes" style="text-align:right">${dsDupes}</td>
         <td class="col-date">${escapeHtml(dsCreated)}</td>
         <td class="col-origin" title="${escapeHtml(dsOrigin)}">${escapeHtml(dsOrigin)}</td>
         <td class="col-details" title="${escapeHtml(dsDetails)}">${escapeHtml(dsDetails)}</td>
@@ -1422,6 +1425,8 @@
         <th data-sort="name">Name<span class="sort-arrow"></span></th>
         <th data-sort="media_type">Type<span class="sort-arrow"></span></th>
         <th data-sort="num_training" style="text-align:right"># Training<span class="sort-arrow"></span></th>
+        <th>Trainable?</th>
+        <th data-sort="last_trained_at">Last Trained<span class="sort-arrow"></span></th>
         <th data-sort="created_at">Created<span class="sort-arrow"></span></th>
         <th>Autorun?</th>
         <th>Loaded?</th>
@@ -1434,7 +1439,7 @@
     function renderModelRows() {
       const sorted = [...dashRegisteredModels].sort((a, b) => {
         let va = a[modelSort.key], vb = b[modelSort.key];
-        if (modelSort.key === "num_training" || modelSort.key === "created_at") {
+        if (modelSort.key === "num_training" || modelSort.key === "created_at" || modelSort.key === "last_trained_at") {
           return modelSort.asc ? ((va || 0) - (vb || 0)) : ((vb || 0) - (va || 0));
         }
         va = String(va || "").toLowerCase(); vb = String(vb || "").toLowerCase();
@@ -1458,10 +1463,13 @@
         nameTd.innerHTML = `<span class="dash-name-text">${escapeHtml(m.name)}</span><button class="btn-icon dash-rename-btn" title="Rename" aria-label="Rename model">&#9998;</button>`;
         tr.appendChild(nameTd);
         const mCreated = m.created_at ? new Date(m.created_at * 1000).toLocaleDateString() : "-";
+        const mLastTrained = m.last_trained_at ? new Date(m.last_trained_at * 1000).toLocaleDateString() : "-";
         const isAutorun = !!m.autodetect;
         tr.insertAdjacentHTML("beforeend", `
           <td class="col-type">${escapeHtml(icon)} ${escapeHtml(m.media_type)}</td>
           <td class="col-num-training" style="text-align:right">${escapeHtml(trainingText)}</td>
+          <td class="col-trainable">${m.trainable ? '<span style="color:var(--color-good)">✓</span>' : ''}</td>
+          <td class="col-last-trained">${escapeHtml(mLastTrained)}</td>
           <td class="col-date">${escapeHtml(mCreated)}</td>
           <td class="col-autorun"><input type="checkbox" class="dash-autorun-cb" ${isAutorun ? "checked" : ""} title="Include in CLI autorun" aria-label="Autorun"></td>
           <td class="col-loaded">${isLoaded ? '<span style="color:var(--color-good)">✓</span>' : ''}</td>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -261,6 +261,37 @@ class TestDashboardDatasetRegistryColumns:
         assert isinstance(ds["loaded"], bool)
 
 
+class TestDashboardDatasetDupesColumn:
+    """Tests that the dataset registry API returns the num_dupes field."""
+
+    def test_dataset_registry_includes_num_dupes(self, client):
+        """Registered datasets include a num_dupes integer."""
+        register_dataset(name="dupes-ds", media_type="audio", num_items=10, pkl_path="/tmp/dupes.pkl")
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert "num_dupes" in ds
+        assert isinstance(ds["num_dupes"], int)
+
+    def test_dataset_registry_num_dupes_defaults_to_zero(self, client):
+        """Datasets registered without num_dupes default to 0."""
+        register_dataset(name="no-dupes", media_type="audio", num_items=5, pkl_path="/tmp/nodupes.pkl")
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert ds["num_dupes"] == 0
+
+    def test_dataset_registry_stores_explicit_num_dupes(self, client):
+        """Datasets registered with explicit num_dupes retain the value."""
+        register_dataset(
+            name="with-dupes", media_type="audio", num_items=20, pkl_path="/tmp/wdupes.pkl", num_dupes=3
+        )
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert ds["num_dupes"] == 3
+
+
 class TestDashboardModelRegistryColumns:
     """Tests that the model registry API returns fields needed for new columns."""
 
@@ -333,6 +364,40 @@ class TestDashboardModelRegistryColumns:
         assert "loaded" in m
         assert isinstance(m["loaded"], bool)
 
+    def test_model_registry_includes_trainable_field(self, client):
+        """Registered models include the trainable boolean."""
+        register_model(name="trainable-m", media_type="audio", trainable=True)
+        register_model(name="pregen-m", media_type="audio", trainable=False)
+        resp = client.get("/api/models/registry")
+        data = resp.get_json()
+        by_name = {m["name"]: m for m in data["models"]}
+        assert by_name["trainable-m"]["trainable"] is True
+        assert by_name["pregen-m"]["trainable"] is False
+
+    def test_model_registry_includes_last_trained_at(self, client):
+        """Registered models include the last_trained_at field (None by default)."""
+        register_model(name="lt-model", media_type="audio", trainable=True)
+        resp = client.get("/api/models/registry")
+        data = resp.get_json()
+        m = data["models"][0]
+        assert "last_trained_at" in m
+        assert m["last_trained_at"] is None
+
+    def test_model_registry_last_trained_at_set_on_label_save(self, client):
+        """Saving labels updates last_trained_at to a timestamp."""
+        from vtsearch.models.registry import register_model as reg_model, update_model
+
+        entry = reg_model(name="lt-save", media_type="audio", trainable=True, trainable_model_name="lt_save")
+        import time
+
+        now = time.time()
+        update_model(entry["id"], last_trained_at=now)
+        resp = client.get("/api/models/registry")
+        data = resp.get_json()
+        m = data["models"][0]
+        assert isinstance(m["last_trained_at"], (int, float))
+        assert m["last_trained_at"] >= now
+
 
 class TestDashboardColumnHeaders:
     """Verify the frontend JS contains the updated column headers."""
@@ -345,6 +410,7 @@ class TestDashboardColumnHeaders:
         assert ">Origin<" in text
         assert ">Details<" in text
         assert ">Loaded?<" in text
+        assert ">#Dupes<" in text
 
     def test_model_grid_has_new_column_headers(self, client):
         """app.js should include the new model column headers."""
@@ -352,3 +418,5 @@ class TestDashboardColumnHeaders:
         text = resp.data.decode("utf-8")
         assert ">Autorun?<" in text
         assert "dash-autorun-cb" in text
+        assert ">Trainable?<" in text
+        assert ">Last Trained<" in text

--- a/vtsearch/datasets/registry.py
+++ b/vtsearch/datasets/registry.py
@@ -97,6 +97,7 @@ def register_dataset(
     pkl_path: str,
     origin: str = "unknown",
     source: dict[str, Any] | None = None,
+    num_dupes: int = 0,
 ) -> dict[str, Any]:
     """Add a new dataset to the registry and persist.
 
@@ -109,6 +110,7 @@ def register_dataset(
         "name": name,
         "media_type": media_type,
         "num_items": num_items,
+        "num_dupes": num_dupes,
         "pkl_path": pkl_path,
         "origin": origin,
         "source": source,

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -500,6 +500,10 @@ def list_registered_datasets():
     loaded_id = _reg_loaded_id()
     for entry in entries:
         entry["loaded"] = entry["id"] == loaded_id
+        if entry["loaded"]:
+            entry["num_dupes"] = get_dupe_count()
+        else:
+            entry.setdefault("num_dupes", 0)
     return jsonify({"datasets": entries})
 
 
@@ -527,8 +531,8 @@ def load_registered_dataset(dataset_id: str):
             collapse_duplicates(medias)
             build_diversity_tree()
             _reg_set_loaded(dataset_id)
-            # Update item count in case it changed
-            _reg_update(dataset_id, num_items=len(medias))
+            # Update item count and dupe count in case they changed
+            _reg_update(dataset_id, num_items=len(medias), num_dupes=get_dupe_count())
             set_dataset_display_name(entry.get("name", ""))
             _load_embedder_for_clips()
         except MemoryError:

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -19,6 +19,7 @@ from vtsearch.utils import (
     clear_all,
     collapse_duplicates,
     get_dataset_display_name,
+    get_dupe_count,
     medias,
     update_progress,
 )
@@ -128,6 +129,7 @@ def _auto_register_dataset(name: str = "", origin_str: str = "unknown", source: 
         name=name,
         media_type=media_type,
         num_items=num_items,
+        num_dupes=get_dupe_count(),
         pkl_path=pkl_path,
         origin=origin_str,
         source=source,

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -282,9 +282,11 @@ def save_trainable_model_labels(name: str):
     # Also update the model registry entry if one exists
     from vtsearch.models.registry import find_by_trainable_model_name, update_model
 
+    import time as _time
+
     reg_entry = find_by_trainable_model_name(name)
     if reg_entry:
-        update_model(reg_entry["id"], num_training=len(labelset))
+        update_model(reg_entry["id"], num_training=len(labelset), last_trained_at=_time.time())
 
     return jsonify({
         "success": True,
@@ -312,6 +314,7 @@ def list_registered_models():
         det_name = entry.get("detector_name", "")
         det = detectors.get(det_name) if det_name else None
         entry["autodetect"] = bool(det.get("autodetect")) if det else False
+        entry.setdefault("last_trained_at", None)
     return jsonify({"models": entries})
 
 


### PR DESCRIPTION
## Summary
This PR extends the dataset and model registries to track additional metadata: duplicate counts for datasets and training status/timestamps for models. These fields are now persisted in the registry, displayed in the dashboard UI, and updated when datasets are loaded or models are trained.

## Key Changes

**Dataset Registry (`num_dupes` field):**
- Added `num_dupes` parameter to `register_dataset()` with a default value of 0
- When a dataset is loaded, `num_dupes` is populated from `get_dupe_count()` and persisted
- The dataset registry API endpoint now includes `num_dupes` for all datasets
- Dashboard displays the duplicate count in a new "#Dupes" column

**Model Registry (`trainable` and `last_trained_at` fields):**
- Added `trainable` boolean field to model registry (already supported, now exposed in API)
- Added `last_trained_at` timestamp field to track when a model was last trained
- When labels are saved for a trainable model, `last_trained_at` is updated to the current timestamp
- The model registry API endpoint now includes both fields for all models
- Dashboard displays trainable status with a checkmark and last trained date in new columns
- Sorting by `last_trained_at` is supported in the model grid

**Frontend Updates:**
- Added "#Dupes" column header and cell rendering for datasets
- Added "Trainable?" and "Last Trained" column headers and cell rendering for models
- Updated sorting logic to handle numeric `last_trained_at` field
- Proper date formatting for `last_trained_at` display (shows "-" if null)

## Implementation Details
- Duplicate count is only fetched from the loaded dataset; unloaded datasets default to 0
- `last_trained_at` defaults to `None` for models that haven't been trained yet
- The timestamp is captured at the moment labels are saved, providing an accurate training record
- All new fields are backward compatible with existing registry entries via `setdefault()`

https://claude.ai/code/session_01CCygzJkMuFVofYstk6USKH