### PR TITLE
Improve progress bar calculation and indeterminate state handling

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1676,14 +1676,15 @@
       // Build the status text: message + optional ETA
       let statusText = progress.message || "Loading...";
 
-      if (progress.pct != null && dashProgressFill) {
+      if (progress.total > 0 && dashProgressFill) {
+        const pct = Math.round((progress.current / progress.total) * 100);
         dashProgressFill.classList.remove("indeterminate");
-        dashProgressFill.style.width = `${progress.pct}%`;
-        if (dashProgressText) dashProgressText.textContent = `${progress.pct}%`;
+        dashProgressFill.style.width = `${pct}%`;
+        if (dashProgressText) dashProgressText.textContent = `${pct}%`;
 
         // ETA calculation during embedding phase
         const now = Date.now();
-        if (progress.status === "embedding" && progress.total > 0) {
+        if (progress.status === "embedding") {
           if (!dashEtaState || dashEtaState.total !== progress.total) {
             dashEtaState = { startTime: now, startCurrent: progress.current, total: progress.total };
           }
@@ -1697,6 +1698,11 @@
         } else {
           dashEtaState = null;
         }
+      } else if (dashProgressFill) {
+        dashProgressFill.classList.add("indeterminate");
+        dashProgressFill.style.width = "0%";
+        if (dashProgressText) dashProgressText.textContent = "";
+        dashEtaState = null;
       }
 
       if (dashProgressMessage) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -359,8 +359,8 @@ video { max-width: 100%; }
 .progress-fill.indeterminate { width: 30% !important; animation: indeterminate 1.5s ease-in-out infinite; }
 @keyframes indeterminate { 0% { margin-left: 0%; } 50% { margin-left: 70%; } 100% { margin-left: 0%; } }
 .progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 0.75rem; color: #fff; font-weight: bold; }
-.progress-message { font-size: 0.85rem; color: var(--text-secondary); margin-top: 8px; text-align: center; width: 100%; max-width: 500px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.progress-eta { font-size: 0.75rem; color: var(--text-muted); margin-top: 4px; text-align: center; min-height: 1.1em; }
+.progress-message { font-size: 0.85rem; color: var(--text-secondary); margin-top: 2px; text-align: center; width: 100%; max-width: 500px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.progress-eta { font-size: 0.75rem; color: var(--text-muted); margin-top: 1px; text-align: center; min-height: 1.1em; }
 .demo-datasets { display: flex; flex-direction: column; width: 100%; margin-top: 16px; overflow: hidden; }
 .dataset-welcome.demo-mode { flex: 1; min-height: 0; justify-content: flex-start; }
 .dataset-welcome.demo-mode .demo-datasets { flex: 1; min-height: 0; }


### PR DESCRIPTION
## Summary
This PR refactors the progress bar logic to calculate percentage directly from current/total values instead of relying on pre-calculated percentages, and improves handling of indeterminate states when progress data is unavailable.

## Key Changes
- **Progress calculation**: Changed from checking `progress.pct != null` to calculating percentage as `Math.round((progress.current / progress.total) * 100)` when `progress.total > 0`
- **Indeterminate state handling**: Added explicit handling for when progress data is unavailable (total ≤ 0), setting the progress bar to indeterminate mode with cleared text
- **ETA calculation simplification**: Removed redundant `progress.total > 0` check in the embedding phase condition since it's already validated in the parent condition
- **Styling refinements**: Reduced margins on progress message (8px → 2px) and ETA text (4px → 1px) for tighter spacing

## Implementation Details
- The progress percentage is now calculated client-side from `current` and `total` values, making the UI more responsive to actual progress data
- When `progress.total` is 0 or negative, the progress bar gracefully falls back to indeterminate animation mode
- The ETA state is properly reset when entering the indeterminate state to prevent stale calculations

https://claude.ai/code/session_015oGRfWiuFboUqHfG2xYhQg