### PR TITLE
Refactor demo dataset loading to use shared background loader

### DIFF
--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -366,46 +366,12 @@ def load_demo_dataset_route():
     if not dataset_name or dataset_name not in DEMO_DATASETS:
         return jsonify({"error": "Invalid dataset name"}), 400
 
-    # Set progress to "loading" synchronously so the frontend never sees a
-    # stale "idle" status from a previous operation before the thread starts.
-    update_progress("loading", "Loading demo dataset...")
-
-    def load_task():
-        try:
-            clear_dataset()
-            gc.collect()
-            load_demo_dataset(dataset_name, medias)
-            demo_origin = {"importer": "demo", "params": {"name": dataset_name}}
-            _set_clip_origins(medias, demo_origin)
-            collapse_duplicates(medias)
-            build_diversity_tree()
-            # Auto-register in the dataset registry before signalling idle
-            # so the frontend sees the new entry when it refreshes the grid.
-            _auto_register_dataset(
-                name=dataset_name,
-                origin_str=f"demo:{dataset_name}",
-                source=demo_origin,
-            )
-            _load_embedder_for_clips()
-        except MemoryError:
-            medias.clear()
-            gc.collect()
-            update_progress(
-                "idle",
-                "",
-                0,
-                0,
-                "Out of memory — this dataset is too large. Try a smaller dataset or free up system RAM.",
-            )
-        except Exception as e:
-            update_progress("idle", "", 0, 0, str(e))
-
-    # Signal "loading" before the thread starts so frontend polling never
-    # sees a stale "idle" from a previous load and prematurely stops.
-    update_progress("loading", "Preparing to load dataset…", 0, 0)
-
-    thread = threading.Thread(target=load_task, daemon=True)
-    thread.start()
+    demo_origin = {"importer": "demo", "params": {"name": dataset_name}}
+    _run_origin_load_in_background(
+        lambda: load_demo_dataset(dataset_name, medias),
+        demo_origin,
+        name=dataset_name,
+    )
 
     return jsonify({"ok": True, "message": "Loading started"})
 

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -164,6 +164,12 @@ def _run_origin_load_in_background(load_fn, origin: dict, *, name: str = "") -> 
             clear_dataset()
             gc.collect()
             load_fn()
+            # Suppress any premature "idle" that load_fn may have emitted
+            # (e.g. load_demo_dataset signals idle before returning).
+            # The frontend must not see "idle" until registration and
+            # embedder warm-up are complete, otherwise the dashboard grid
+            # renders before the new entry exists in the registry.
+            update_progress("loading", "Finalizing…")
             _set_clip_origins(medias, origin)
             collapse_duplicates(medias)
             build_diversity_tree()


### PR DESCRIPTION
## Summary
Refactored the demo dataset loading route to use the shared `_run_origin_load_in_background` helper function, eliminating duplicate threading and progress management logic.

## Key Changes
- **Simplified `load_demo_dataset_route()`**: Removed inline threading, progress updates, and error handling code (~35 lines) and replaced it with a single call to `_run_origin_load_in_background()`
- **Enhanced `_run_origin_load_in_background()`**: Added logic to suppress premature "idle" status signals that may be emitted by load functions before they return, ensuring the frontend doesn't render the dashboard grid before the dataset is fully registered and embedders are warmed up

## Implementation Details
- The demo dataset loader now follows the same pattern as other origin-based loaders, reducing code duplication and maintenance burden
- Added a "Finalizing…" progress update after `load_fn()` completes to suppress any stale "idle" signals and keep the frontend in sync with the actual loading state
- This ensures the frontend's dataset registry grid only renders after the new dataset entry is registered and all post-load operations (embedder warm-up, duplicate collapsing, etc.) are complete

https://claude.ai/code/session_01RsXygknBCRDhGgnaYfsexw