### PR TITLE
Display autodetect results after label export

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2794,6 +2794,10 @@
         a.click();
         URL.revokeObjectURL(url);
       }
+      // Handle GUI display if the exporter returns display_results
+      if (result.display_results) {
+        displayAutodetectResults(result.display_results);
+      }
       menuLabelsStatus.textContent = result.message || "Labels exported";
       setTimeout(() => { menuLabelsStatus.textContent = ""; }, 4000);
     } catch (e) {


### PR DESCRIPTION
## Summary
Added support for displaying autodetect results in the GUI after a label export operation completes, if the exporter returns display results.

## Key Changes
- Added conditional check for `result.display_results` after label export
- Calls `displayAutodetectResults()` with the returned display results to render them in the UI
- Maintains existing export message and status timeout behavior

## Implementation Details
The change allows exporters to optionally return display results that will be automatically rendered in the GUI. This enables a better user experience by showing relevant information or results immediately after an export operation without requiring additional user actions.

https://claude.ai/code/session_01KsfomZTvkoP77F4iidj4aE