### PR TITLE
Improve autopilot examples edit button styling and UX

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -107,7 +107,7 @@
         <div id="autopilot-examples-section" style="display:none">
           <div class="ap-examples-header">
             <span class="sort-label">Examples</span>
-            <button id="autopilot-examples-edit" class="btn-sm ap-examples-edit-btn">Edit</button>
+            <button id="autopilot-examples-edit" class="ap-examples-edit-btn" title="Edit examples">&#9998;</button>
           </div>
           <div id="autopilot-examples-summary" class="ap-examples-summary"></div>
         </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -206,7 +206,9 @@ header h1 { margin-left: 0; }
 /* Autopilot panel */
 .autopilot-panel { padding: 8px 10px; }
 .ap-examples-header { display: flex; align-items: center; justify-content: space-between; }
-.ap-examples-edit-btn { font-size: 0.65rem; padding: 2px 8px; }
+.ap-examples-header .sort-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); display: block; margin-bottom: 0; }
+.ap-examples-edit-btn { font-size: 0.7rem; padding: 2px 4px; background: none; border: none; color: var(--text-muted); cursor: pointer; line-height: 1; }
+.ap-examples-edit-btn:hover { color: var(--text-secondary); }
 .ap-examples-summary { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px; }
 .ap-example-chip {
   display: inline-flex; align-items: center; gap: 2px;


### PR DESCRIPTION
## Summary
Enhanced the styling and user experience of the autopilot examples edit button by replacing text-based button with an icon button and improving visual hierarchy with better styling for the section header.

## Key Changes
- **Edit button redesign**: Changed from text "Edit" button to a pencil icon (✎) with improved styling
  - Removed `btn-sm` class dependency
  - Added custom styling with transparent background and muted color
  - Implemented hover state for better interactivity
  - Adjusted padding and font size for better icon presentation
  - Added `title` attribute for accessibility

- **Sort label styling**: Added dedicated styles for the "Examples" header label
  - Applied uppercase text transformation
  - Added letter spacing for improved readability
  - Set muted color to establish visual hierarchy
  - Ensured consistent spacing with `margin-bottom: 0`

## Implementation Details
- The edit button now uses a Unicode pencil character (&#9998;) instead of text, providing a more intuitive visual indicator
- Hover state changes text color to secondary color for clear interactive feedback
- All styling is self-contained in the `.ap-examples-edit-btn` class, removing reliance on generic button classes
- The sort label styling improves visual distinction between the section header and interactive elements

https://claude.ai/code/session_015tBYRfG17UjXPsESJXW2iC