### PR TITLE
Center-align dashboard table cells for consistent layout

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1300,7 +1300,7 @@
       tr.insertAdjacentHTML("beforeend", `
         <td class="col-type">${escapeHtml(icon)} ${escapeHtml(typeName)}</td>
         <td class="col-count">${ds.num_items || 0}</td>
-        <td class="col-dupes" style="text-align:right">${dsDupes}</td>
+        <td class="col-dupes">${dsDupes}</td>
         <td class="col-date">${escapeHtml(dsCreated)}</td>
         <td class="col-origin" title="${escapeHtml(dsOrigin)}">${escapeHtml(dsOrigin)}</td>
         <td class="col-details" title="${escapeHtml(dsDetails)}">${escapeHtml(dsDetails)}</td>
@@ -1424,7 +1424,7 @@
       <thead><tr>
         <th data-sort="name">Name<span class="sort-arrow"></span></th>
         <th data-sort="media_type">Type<span class="sort-arrow"></span></th>
-        <th data-sort="num_training" style="text-align:right"># Training<span class="sort-arrow"></span></th>
+        <th data-sort="num_training"># Training<span class="sort-arrow"></span></th>
         <th>Trainable?</th>
         <th data-sort="last_trained_at">Last Trained<span class="sort-arrow"></span></th>
         <th data-sort="created_at">Created<span class="sort-arrow"></span></th>
@@ -1467,7 +1467,7 @@
         const isAutorun = !!m.autodetect;
         tr.insertAdjacentHTML("beforeend", `
           <td class="col-type">${escapeHtml(icon)} ${escapeHtml(m.media_type)}</td>
-          <td class="col-num-training" style="text-align:right">${escapeHtml(trainingText)}</td>
+          <td class="col-num-training">${escapeHtml(trainingText)}</td>
           <td class="col-trainable">${m.trainable ? '<span style="color:var(--color-good)">✓</span>' : ''}</td>
           <td class="col-last-trained">${escapeHtml(mLastTrained)}</td>
           <td class="col-date">${escapeHtml(mCreated)}</td>

--- a/static/styles.css
+++ b/static/styles.css
@@ -647,7 +647,7 @@ video { max-width: 100%; }
 /* Dashboard dataset table */
 .dashboard-grid .dash-dataset-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
 .dashboard-grid .dash-dataset-table thead th {
-  text-align: left; padding: 5px 8px; color: var(--text-secondary);
+  text-align: center; padding: 5px 8px; color: var(--text-secondary);
   font-size: 0.7rem; font-weight: 600; border-bottom: 1px solid var(--border);
   white-space: nowrap;
 }
@@ -659,7 +659,7 @@ video { max-width: 100%; }
 .dashboard-grid .dash-dataset-table thead th:nth-child(6) { width: 16%; }
 .dashboard-grid .dash-dataset-table thead th:nth-child(7) { width: 10%; }
 .dashboard-grid .dash-dataset-table thead th:nth-child(8) { width: 32px; }
-.dash-dataset-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
+.dash-dataset-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); text-align: center; }
 .dash-dataset-row .col-name { font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dash-dataset-row .col-type { white-space: nowrap; }
 .dash-dataset-row .col-count { font-family: monospace; font-size: 0.72rem; color: var(--text-muted); }
@@ -670,7 +670,7 @@ video { max-width: 100%; }
 /* Dashboard model table */
 .dashboard-grid .dash-model-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
 .dashboard-grid .dash-model-table thead th {
-  text-align: left; padding: 5px 8px; color: var(--text-secondary);
+  text-align: center; padding: 5px 8px; color: var(--text-secondary);
   font-size: 0.7rem; font-weight: 600; border-bottom: 1px solid var(--border);
   cursor: pointer; user-select: none; white-space: nowrap;
 }
@@ -685,13 +685,12 @@ video { max-width: 100%; }
 .dashboard-grid .dash-model-table thead th:nth-child(7) { width: 8%; }
 
 .dash-model-row { cursor: pointer; transition: background 0.15s; }
-.dash-model-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
+.dash-model-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); text-align: center; }
 .dash-model-row:hover { background: var(--bg-subtle); }
 .dash-model-row .col-name { font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dash-model-row .col-type { white-space: nowrap; }
 .dash-model-row .col-threshold { font-family: monospace; font-size: 0.72rem; color: var(--text-muted); }
 .dash-model-row .col-date { font-size: 0.72rem; color: var(--text-muted); }
-.dash-model-row .col-autorun { text-align: center; }
 .dash-autorun-cb { cursor: pointer; }
 
 /* Single-select highlight for both grids */


### PR DESCRIPTION
## Summary
Standardized text alignment across dashboard dataset and model tables by applying center alignment to all table cells through CSS, removing redundant inline styles from HTML.

## Key Changes
- Updated `.dash-dataset-table thead th` to use `text-align: center` instead of `left`
- Updated `.dash-model-table thead th` to use `text-align: center` instead of `left`
- Added `text-align: center` to `.dash-dataset-row td` and `.dash-model-row td` CSS rules to apply center alignment to all data cells
- Removed inline `style="text-align:right"` attributes from individual table cells in app.js (col-dupes, col-num-training)
- Removed redundant `.dash-model-row .col-autorun { text-align: center; }` CSS rule (now covered by general td alignment)

## Implementation Details
This change consolidates alignment rules from inline styles into the stylesheet, improving maintainability and ensuring consistent center alignment across all dashboard table content. The removal of inline styles reduces HTML bloat and makes future alignment changes easier to manage from a single CSS location.

https://claude.ai/code/session_01Wsiqmmk3Wqy3nbTVQRtGcT