### PR TITLE
Add pencil rename button for detector name in Labeling interface

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -213,6 +213,7 @@
   const trainDatasetName = document.getElementById("train-dataset-name");
   const trainDetectorBar = document.getElementById("train-detector-bar");
   const trainDetectorName = document.getElementById("train-detector-name");
+  const trainRenameBtn = document.getElementById("train-rename-btn");
   // Export Detector / Export Labels buttons removed from right panel;
   // now accessible via burger menu items (menu-detector-export, menu-labels-export)
 
@@ -1127,6 +1128,74 @@
       refreshAutopilotExamples();
       startAutopilot();
     }
+  }
+
+  // ---- Inline rename for detector in labeling bar ----
+  if (trainRenameBtn) {
+    trainRenameBtn.addEventListener("click", () => {
+      if (!trainDetectorName || !_dashboardTrainMode || !_dashboardTrainMode.model) return;
+      const current = trainDetectorName.textContent;
+      trainDetectorName.style.display = "none";
+      trainRenameBtn.style.display = "none";
+      const input = document.createElement("input");
+      input.type = "text";
+      input.className = "train-rename-input";
+      input.value = current;
+      trainDetectorName.parentNode.insertBefore(input, trainDetectorName);
+      input.focus();
+      input.select();
+      const commit = async () => {
+        const newName = input.value.trim();
+        if (newName && newName !== current) {
+          const model = _dashboardTrainMode.model;
+          const registryId = model.registry_id;
+          if (registryId) {
+            try {
+              const res = await fetch(`/api/models/registry/${encodeURIComponent(registryId)}/rename`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name: newName }),
+              });
+              if (res.ok) {
+                model.name = newName;
+                model.detector_name = newName;
+                trainDetectorName.textContent = newName;
+                // Sync dashboard grid if cached
+                const regEntry = dashRegisteredModels.find(m => m.id === registryId);
+                if (regEntry) {
+                  regEntry.name = newName;
+                  regEntry.detector_name = newName;
+                  regEntry.trainable_model_name = newName;
+                }
+              }
+            } catch (_) { /* ignore */ }
+          } else {
+            // Fallback: rename via autorun-detectors API
+            try {
+              const detName = model.detector_name || current;
+              const res = await fetch(`/api/autorun-detectors/${encodeURIComponent(detName)}/rename`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ new_name: newName }),
+              });
+              if (res.ok) {
+                model.name = newName;
+                model.detector_name = newName;
+                trainDetectorName.textContent = newName;
+              }
+            } catch (_) { /* ignore */ }
+          }
+        }
+        input.remove();
+        trainDetectorName.style.display = "";
+        trainRenameBtn.style.display = "";
+      };
+      input.addEventListener("blur", commit);
+      input.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter") { ev.preventDefault(); input.blur(); }
+        if (ev.key === "Escape") { input.value = current; input.blur(); }
+      });
+    });
   }
 
   // ---- Dashboard view ----
@@ -6450,6 +6519,8 @@
             name: regModel.trainable_model_name || regModel.name,
             text_query: regModel.text_query || "",
             trainable: true,
+            registry_id: regModel.id,
+            detector_name: regModel.detector_name || regModel.name,
           },
         };
 

--- a/static/index.html
+++ b/static/index.html
@@ -209,7 +209,7 @@
       <div class="train-context-header">
         <div>
           <span class="train-context-label">Detector</span>
-          <span class="train-context-name" id="train-detector-name"></span>
+          <span class="train-context-name" id="train-detector-name"></span><button class="btn-icon train-rename-btn" id="train-rename-btn" title="Rename detector" aria-label="Rename detector">&#9998;</button>
         </div>
       </div>
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -323,7 +323,9 @@ video { max-width: 100%; }
 /* Training context bar – dataset / detector name shown during training */
 .train-context-bar { padding: 6px 10px; border-bottom: 1px solid var(--border); background: var(--accent-highlight-bg); flex-shrink: 0; overflow: hidden; }
 .train-context-label { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); display: block; line-height: 1; margin-bottom: 2px; }
-.train-context-name { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.train-context-name { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); display: inline; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.train-rename-btn { vertical-align: middle; margin-left: 4px; font-size: 0.68rem; }
+.train-rename-input { width: 140px; padding: 1px 4px; font-size: 0.8rem; font-weight: 600; border: 1px solid var(--accent); border-radius: 3px; outline: none; background: var(--bg-panel); color: var(--text-primary); }
 .train-context-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; }
 .train-context-actions { display: flex; gap: 4px; flex-shrink: 0; }
 .train-context-btn { font-size: 0.6rem; padding: 2px 6px; border: 1px solid var(--border); border-radius: 3px; background: var(--bg-panel); color: var(--text-muted); cursor: pointer; white-space: nowrap; }


### PR DESCRIPTION
Adds an inline rename flow for the current detector in the Labeling context bar, matching the pattern used in the Dashboard model grid. Clicking the pencil icon replaces the name with an editable input; on Enter/blur the rename is persisted via the model registry API (or autorun-detectors API as fallback) so the Dashboard stays in sync.

https://claude.ai/code/session_01QcAU4NQWxdb6U65gH1aDgF