### PR TITLE
Fix autopilot hard-phase progress to use total LabelSet clicks

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -28,7 +28,7 @@
   let swipeAnimation = true;         // Swipe animation on vote (persisted setting)
   let isVoting = false;              // Re-entrance guard for castVote
   let _combineState = null;          // When non-null, we are in combine-datasets staging mode
-  // Autopilot state machine: null when inactive, or {phase, goodToStart, badToStart, hardLabels, ...}
+  // Autopilot state machine: null when inactive, or {phase, goodToStart, badToStart, ...}
   // phase: "good" | "bad" | "hard" | "new" | "done"
   let _autopilotState = null;
   // Pending autopilot transition: deferred until the current vote finishes so
@@ -754,10 +754,10 @@
         + `<span class="ap-progress-bar"><span class="ap-progress-fill" style="width:${pct}%"></span></span>`;
     }
     if (st.phase === "hard") {
-      const n = st.hardLabels || 0;
+      const n = votes.good.length + votes.bad.length;
       const smartSt = st.smartStatus || "";
       const stableSt = st.stableStatus || "";
-      return `${n} hard labels applied `
+      return `${n} labels applied `
         + `<span class="ap-indicator-dot" data-status="${smartSt}" title="Smart"></span>`
         + `<span class="ap-indicator-dot" data-status="${stableSt}" title="Stable"></span>`
         + ` Smart + Stable`;
@@ -824,7 +824,7 @@
 
     _autopilotState = {
       phase: "good", goodToStart, badToStart,
-      hardLabels: 0, smartStatus: "", stableStatus: "", spanStatus: "",
+      smartStatus: "", stableStatus: "", spanStatus: "",
       fracDiversity: 0,
     };
 
@@ -917,7 +917,6 @@
         if (isVoting) {
           _pendingAutopilotTransition = () => {
             st.phase = "hard";
-            st.hardLabels = 0;
             _apActivateLearnedSort();
             _apSetSelectMode("hard");
             fetchLearnedSort(true);
@@ -927,7 +926,6 @@
           return;
         }
         st.phase = "hard";
-        st.hardLabels = 0;
         _apActivateLearnedSort();
         _apSetSelectMode("hard");
         fetchLearnedSort(true);
@@ -983,16 +981,6 @@
       }
     }
     checkAutopilotPhase();
-  }
-
-  /**
-   * Increment the hard-labels counter.  Called from castVote when
-   * autopilot is in the "hard" phase.
-   */
-  function _autopilotCountHardLabel() {
-    if (_autopilotState && _autopilotState.phase === "hard") {
-      _autopilotState.hardLabels = (_autopilotState.hardLabels || 0) + 1;
-    }
   }
 
   /** Fetch a diversity-tree sample and navigate to it. */
@@ -4153,8 +4141,7 @@
         }
       }
 
-      // Autopilot: count hard labels and check if the phase should advance.
-      _autopilotCountHardLabel();
+      // Autopilot: check if the phase should advance.
       checkAutopilotPhase();
 
       // Auto-advance to next media.  When swipe animation is enabled, play a


### PR DESCRIPTION
Switch the progress indicator on the Autopilot "hard" step from tracking only clicks made in Learn Hard mode (hardLabels counter) to using total votes (good + bad). This way, leaving Autopilot and returning no longer resets the count to 0 — the progress reflects all labeling work done.

https://claude.ai/code/session_01GvPThX2fMWGsFF28VHEYnf