### PR TITLE
Fix 15 bugs found in comprehensive codebase review

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6800,7 +6800,8 @@
     if (e.key !== "Escape") return;
 
     // VT dialog gets priority (it's an alertdialog)
-    if (vtDialogModal.classList.contains("show")) return;
+    const vtDlg = document.getElementById("vt-dialog-modal");
+    if (vtDlg && vtDlg.classList.contains("show")) return;
 
     // Close any open modal on Escape, from most specific to least
     const modalClosePairs = [

--- a/static/charts.js
+++ b/static/charts.js
@@ -131,12 +131,6 @@
     }
 
     const dataToPlot = stabilityData;
-    if (dataToPlot.length === 0) {
-      ctx.fillStyle = themeColor("--text-muted");
-      ctx.font = "14px sans-serif";
-      ctx.fillText("Need more labels for stability analysis", 20, canvas.height / 2);
-      return;
-    }
 
     const numLabels = dataToPlot.map(d => d.num_labels);
     const numFlips = dataToPlot.map(d => d.num_flips);

--- a/static/results.js
+++ b/static/results.js
@@ -196,7 +196,7 @@
     autodetectSummary.innerHTML = `
       <p style="color: var(--text-primary);">
         <strong>Media Type:</strong> ${escapeHtml(data.media_type)} &nbsp;|&nbsp;
-        <strong>Detectors Run:</strong> ${data.detectors_run} &nbsp;|&nbsp;
+        <strong>Detectors Run:</strong> ${escapeHtml(data.detectors_run)} &nbsp;|&nbsp;
         ${countText}
       </p>
     `;
@@ -256,7 +256,7 @@
     autodetectSummary.innerHTML = `
       <p style="color: var(--text-primary);">
         <strong>Media Type:</strong> ${escapeHtml(data.media_type)} &nbsp;|&nbsp;
-        <strong>Detectors Run:</strong> ${data.detectors_run} &nbsp;|&nbsp;
+        <strong>Detectors Run:</strong> ${escapeHtml(data.detectors_run)} &nbsp;|&nbsp;
         <strong>Good Results:</strong> ${allHits.length}
       </p>
     `;
@@ -435,6 +435,11 @@
         const text = values.join(sep);
         navigator.clipboard.writeText(text).then(() => {
           copyResultsBtn.textContent = "Copied!";
+          setTimeout(() => {
+            copyResultsBtn.textContent = "Copy To Clipboard";
+          }, 2000);
+        }).catch(() => {
+          copyResultsBtn.textContent = "Copy failed";
           setTimeout(() => {
             copyResultsBtn.textContent = "Copy To Clipboard";
           }, 2000);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,10 @@ def _fake_embed_audio(path):
 
 def _fake_embed_text(text):
     """Deterministic fake text embedding derived from the query string."""
-    rng = np.random.RandomState(hash(text) % 2**31)
+    import hashlib as _hl
+
+    seed = int(_hl.md5(text.encode()).hexdigest(), 16) % 2**31
+    rng = np.random.RandomState(seed)
     return rng.randn(_EMBEDDING_DIM).astype(np.float32)
 
 

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -49,6 +49,9 @@ def _extract_archive(
                     i,
                     total,
                 )
+                target = (extract_dir / member).resolve()
+                if not str(target).startswith(str(extract_dir.resolve())):
+                    raise ValueError(f"Path traversal detected in archive: {member}")
                 zf.extract(member, extract_dir)
 
     elif tarfile.is_tarfile(archive_path):
@@ -81,6 +84,9 @@ def _extract_archive(
                     i,
                     total,
                 )
+                target = (extract_dir / member).resolve()
+                if not str(target).startswith(str(extract_dir.resolve())):
+                    raise ValueError(f"Path traversal detected in archive: {member}")
                 rf.extract(member, extract_dir)
 
     else:

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -6,6 +6,7 @@ the core requirements.
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -45,10 +46,14 @@ class PickleDatasetImporter(DatasetImporter):
         file_obj = field_values["file"]  # werkzeug FileStorage
         progress = _get_progress()
         progress("loading", "Loading dataset from file...", 0, 0)
-        temp_path = DATA_DIR / "temp_upload.pkl"
         DATA_DIR.mkdir(exist_ok=True)
-        file_obj.save(temp_path)
+        fd, tmp_name = tempfile.mkstemp(suffix=".pkl", dir=DATA_DIR)
+        temp_path = Path(tmp_name)
         try:
+            import os
+
+            os.close(fd)
+            file_obj.save(temp_path)
             load_dataset_from_pickle(temp_path, medias, thin=thin)
         finally:
             temp_path.unlink(missing_ok=True)

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -1180,10 +1180,9 @@ def load_demo_dataset(
         on_progress=on_progress,
     )
 
-    # Stamp the demo origin on all medias
-    demo_origin: dict[str, Any] = {"importer": "demo", "params": {"name": dataset_name}}
+    # Stamp the demo origin on all medias (fresh dict per media to avoid shared-reference mutation bugs)
     for media in medias.values():
-        media["origin"] = demo_origin
+        media["origin"] = {"importer": "demo", "params": {"name": dataset_name}}
 
     # Build the pickle cache payload
     # For types with external media dirs (audio, video), exclude media_bytes

--- a/vtsearch/eval/visualize.py
+++ b/vtsearch/eval/visualize.py
@@ -368,8 +368,8 @@ def _plot_iterations_metric(
     fig, ax = plt.subplots(figsize=(9, 5))
     palette = plt.cm.tab10.colors  # type: ignore[attr-defined]
 
-    groups = df.groupby(["dataset", "category"])
-    for idx, ((ds, cat), group) in enumerate(groups):
+    grouped = list(df.groupby(["dataset", "category"]))
+    for idx, ((ds, cat), group) in enumerate(grouped):
         colour = palette[idx % len(palette)]
         agg = group.groupby("t")[metric].agg(["mean", "std"]).reset_index()
         t = agg["t"].values
@@ -383,8 +383,7 @@ def _plot_iterations_metric(
     ax.set_xlabel("Voting Iteration (t)")
     ax.set_ylabel(ylabel)
     ax.set_title(f"Voting Iterations: {ylabel}")
-    n_groups = len(list(groups))
-    if n_groups <= 15:
+    if len(grouped) <= 15:
         ax.legend(fontsize=7, loc="best")
 
     fig.tight_layout()

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -273,7 +273,7 @@ class TextMediaType(MediaType):
         clip_id = 1
         total = len(selected_texts)
         on_progress("embedding", f"Starting embedding for {total} paragraphs...", 0, total)
-        demo_origin: dict = {"importer": "demo", "params": {}}
+        demo_origin_template: dict = {"importer": "demo", "params": {}}
 
         for i, (text_content, category) in enumerate(zip(selected_texts, selected_categories)):
             on_progress("embedding", f"Embedding {category}: paragraph {i + 1}/{total}", i + 1, total)
@@ -304,7 +304,7 @@ class TextMediaType(MediaType):
                 "category": category,
                 "word_count": word_count,
                 "character_count": character_count,
-                "origin": demo_origin,
+                "origin": {**demo_origin_template},
                 "origin_name": fname,
             }
             clip_id += 1

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -208,7 +208,7 @@ class VideoMediaType(MediaType):
         clip_id = 1
         total = len(video_files)
         on_progress("embedding", f"Starting embedding for {total} video files...", 0, total)
-        demo_origin: dict = {"importer": "demo", "params": {}}
+        demo_origin_template: dict = {"importer": "demo", "params": {}}
 
         for i, (video_path, meta) in enumerate(video_files):
             rel_name = f"{meta['category']}/{video_path.name}"
@@ -234,7 +234,7 @@ class VideoMediaType(MediaType):
                 "media_bytes": video_bytes,
                 "filename": rel_name,
                 "category": meta["category"],
-                "origin": demo_origin,
+                "origin": {**demo_origin_template},
                 "origin_name": rel_name,
             }
             clip_id += 1

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -303,7 +303,7 @@ def _eval_cached_models(
     eval_embs: list[np.ndarray] = []
     eval_labels: list[float] = []
     for cid, lbl in current_labels.items():
-        if cid in clips_dict:
+        if cid in clips_dict and clips_dict[cid].get("embedding") is not None:
             eval_embs.append(clips_dict[cid]["embedding"])
             eval_labels.append(lbl)
 

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -539,7 +539,7 @@ def train_and_score(
         scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 
     if safe_thresholds:
-        n_labels = len(good_votes) + len(bad_votes)
+        n_labels = len(X_list)
         threshold = calculate_safe_threshold(threshold, scores, n_labels)
 
     # Sort by raw scores (full precision) so that tiny differences still

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -305,7 +305,8 @@ def clear_staging():
     """Remove all files from the staging directory."""
     if STAGING_DIR.exists():
         for f in STAGING_DIR.iterdir():
-            f.unlink(missing_ok=True)
+            if f.is_file():
+                f.unlink(missing_ok=True)
     return jsonify({"ok": True})
 
 

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -47,6 +47,9 @@ def detector_sort():
     # Reconstruct the model from weights
     model = build_model_from_weights(weights)
 
+    if not medias:
+        return jsonify({"error": "no medias loaded"}), 400
+
     # Score every media
     all_ids = sorted(medias.keys())
     all_embs = np.array([medias[cid]["embedding"] for cid in all_ids])


### PR DESCRIPTION
Bugs fixed (by severity):

Security:
- Zip slip vulnerability in http_zip importer: zip and rar extraction now validates paths stay within extract_dir (CVE-class)
- Missing escapeHtml on data.detectors_run in results.js innerHTML
- Pickle importer used hardcoded temp filename causing race condition; now uses tempfile.mkstemp for unique names per upload

Correctness:
- eval/visualize.py: exhausted GroupBy iterator caused n_groups to always be 0, so chart legend was always shown regardless of count
- models/progress.py: _eval_cached_models missing None-embedding guard (other code paths had it; this one was missed)
- models/training.py: safe_thresholds n_labels counted all votes instead of only those with embeddings in the training set
- routes/detectors_scoring.py: detector_sort missing empty medias guard (auto_detect had it; detector_sort did not)

Frontend:
- app.js: vtDialogModal ReferenceError — variable scoped in dialogs.js IIFE but referenced from app.js; now uses getElementById
- results.js: missing .catch() on navigator.clipboard.writeText
- charts.js: dead code branch in renderStabilityChart that could never execute (guarded by identical earlier check)

Robustness:
- routes/datasets.py: clear_staging crashed with IsADirectoryError if subdirectories existed; now skips non-files
- Shared mutable origin dict in demo loaders (text, video, loader.py) could cause silent cross-media data corruption if any code path mutated an origin in place; now creates fresh dict per media

Tests:
- conftest.py: _fake_embed_text used Python hash() which is non-deterministic across processes (PYTHONHASHSEED); now uses hashlib.md5 like _fake_embed_audio

All 1673 tests pass.

https://claude.ai/code/session_01TUWLUfQvq3rQd7PmbjT9XY