### PR TITLE
Bind production mode to localhost only for security

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,4 +206,4 @@ if __name__ == "__main__":
         print("\u2705 VTSearch is ready!", flush=True)
         print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)
 
-        app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)
+        app.run(host="127.0.0.1", port=5000, debug=False, threaded=True)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -89,5 +89,5 @@ start, but the first dataset load is slower:
 python app.py --local
 ```
 
-Both modes bind to `0.0.0.0:5000` (accessible from other devices on the
-network).
+Production mode binds to `127.0.0.1:5000` (localhost only).  `--local` mode
+binds to `0.0.0.0:5000` (accessible from other devices on the network).


### PR DESCRIPTION
## Summary
Changed the default binding address for production mode from `0.0.0.0` (all interfaces) to `127.0.0.1` (localhost only) to improve security by restricting network access in production.

## Key Changes
- Modified `app.py` to bind production mode to `127.0.0.1:5000` instead of `0.0.0.0:5000`
- Updated `docs/CLI.md` to clarify the binding behavior:
  - Production mode now binds to localhost only
  - `--local` mode continues to bind to `0.0.0.0:5000` for network accessibility

## Implementation Details
This change prevents the application from being accidentally exposed to the network in production mode. Users who need network access can explicitly use the `--local` flag, which maintains the previous behavior of binding to all interfaces.

https://claude.ai/code/session_01S1gyeCdjeQNZCePmzVYn79