### PR TITLE
Add thread-safe locking to PluginRegistry discovery

### DIFF
--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -363,3 +363,47 @@ class TestConcurrentProgressCache:
             th.join()
 
         assert not errors
+
+
+class TestPluginRegistryLock:
+    """Verify that PluginRegistry._ensure_discovered is thread-safe."""
+
+    def test_registry_has_lock(self):
+        from vtsearch.utils.registry import PluginRegistry
+
+        reg = PluginRegistry(package="vtsearch.exporters", sentinel="EXPORTER", label="exporter")
+        assert isinstance(reg._lock, type(threading.Lock()))
+
+    def test_concurrent_first_access_discovers_once(self):
+        """Concurrent .list() calls should trigger _discover exactly once."""
+        from unittest.mock import patch
+        from vtsearch.utils.registry import PluginRegistry
+
+        reg = PluginRegistry(package="vtsearch.exporters", sentinel="EXPORTER", label="exporter")
+        call_count = 0
+        original_discover = reg._discover
+
+        def counting_discover():
+            nonlocal call_count
+            call_count += 1
+            original_discover()
+
+        barrier = threading.Barrier(10)
+        errors = []
+
+        def worker():
+            try:
+                barrier.wait()
+                reg.list()
+            except Exception as e:
+                errors.append(e)
+
+        with patch.object(reg, "_discover", side_effect=counting_discover):
+            threads = [threading.Thread(target=worker) for _ in range(10)]
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join()
+
+        assert not errors
+        assert call_count == 1, f"_discover called {call_count} times, expected 1"

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import pkgutil
+import threading
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -184,6 +185,7 @@ class PluginRegistry(Generic[T]):
         self._label = label
         self._items: dict[str, T] = {}
         self._discovered = False
+        self._lock = threading.Lock()
 
     # -- Discovery ----------------------------------------------------------
 
@@ -206,9 +208,12 @@ class PluginRegistry(Generic[T]):
                 )
 
     def _ensure_discovered(self) -> None:
-        if not self._discovered:
-            self._discover()
-            self._discovered = True
+        if self._discovered:
+            return
+        with self._lock:
+            if not self._discovered:
+                self._discover()
+                self._discovered = True
 
     # -- Public API ---------------------------------------------------------
 


### PR DESCRIPTION
## Summary
This PR adds thread-safety to the `PluginRegistry._ensure_discovered()` method to prevent race conditions when multiple threads access the registry concurrently for the first time.

## Key Changes
- Added `threading.Lock` import to `vtsearch/utils/registry.py`
- Introduced `_lock` attribute to `PluginRegistry.__init__()` to synchronize access to the discovery mechanism
- Refactored `_ensure_discovered()` to use double-checked locking pattern:
  - Fast path: early return if already discovered (without lock)
  - Slow path: acquire lock and check again before calling `_discover()` to prevent multiple concurrent discoveries
- Added comprehensive test coverage in `tests/test_thread_safety.py`:
  - `test_registry_has_lock()`: verifies the lock is properly initialized
  - `test_concurrent_first_access_discovers_once()`: confirms that 10 concurrent threads trigger `_discover()` exactly once

## Implementation Details
The double-checked locking pattern ensures minimal performance impact for the common case (already discovered) while guaranteeing thread-safety during initial discovery. The lock is only held during the actual discovery process, not during subsequent list operations.

https://claude.ai/code/session_01LXDdZVVCPdHDaiigBDSEYT