### PR TITLE
Fix race condition in set_inclusion by holding lock during disk write

### DIFF
--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -254,6 +254,35 @@ class TestConcurrentApplyLabel:
                 assert i in bad_votes
 
 
+class TestConcurrentSetInclusion:
+    """Verify that concurrent set_inclusion keeps in-memory and on-disk state in sync."""
+
+    def test_concurrent_set_inclusion_memory_disk_sync(self, isolated_settings):
+        """After concurrent writes, in-memory inclusion must equal the persisted value."""
+        num_threads = 20
+        iterations = 30
+        errors = []
+
+        def worker(value):
+            try:
+                for _ in range(iterations):
+                    _state.set_inclusion(value)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i % 5,)) for i in range(num_threads)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert not errors
+        # The critical invariant: in-memory value must match the on-disk value.
+        in_memory = _state.get_inclusion()
+        on_disk = _settings_mod.get_inclusion()
+        assert in_memory == on_disk
+
+
 class TestSettingsLock:
     """Verify that _settings_lock exists and is an RLock."""
 

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -152,16 +152,15 @@ def set_inclusion(value: int) -> None:
     Also clears the progress model cache since cached models were trained
     with the old inclusion value.
     """
+    from vtsearch import settings
+
     with _state_lock:
         if value != _core.inclusion:
             from vtsearch.models.progress import clear_progress_cache
 
             clear_progress_cache()
         _core.inclusion = value
-
-    from vtsearch import settings
-
-    settings.set_inclusion(value)
+        settings.set_inclusion(value)
 
 
 def get_dataset_display_name() -> str | None:


### PR DESCRIPTION
## Summary
Fixed a critical race condition in `set_inclusion()` where the in-memory state and on-disk persisted state could become out of sync during concurrent writes. The issue occurred because the lock was released before writing to disk, allowing other threads to modify the state in between.

## Key Changes
- **Moved `settings.set_inclusion(value)` call inside the `_state_lock` critical section** in `vtsearch/utils/state.py`. This ensures that both the in-memory state update and the disk persistence happen atomically without allowing other threads to interleave.
- **Added comprehensive test coverage** in `tests/test_thread_safety.py` with `TestConcurrentSetInclusion` class that verifies the invariant: after concurrent writes, the in-memory inclusion value must exactly match the persisted on-disk value.

## Implementation Details
The fix ensures that the entire operation (clearing cache, updating `_core.inclusion`, and persisting to disk via `settings.set_inclusion()`) is protected by a single lock acquisition, preventing any window where concurrent threads could observe or cause inconsistency between the two state representations.

https://claude.ai/code/session_01MfgKfKSSqun4VQrbVaPWoL