### PR TITLE
Add path traversal protection to file-based importers and exporters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ _TEST_GROUPS = {
         "test_api_contracts",
         "test_error_recovery",
         "test_dashboard",
+        "test_path_validation",
     ],
     "sorting": [
         "test_sorting",
@@ -105,6 +106,7 @@ def pytest_collection_modifyitems(items, config):
         group = _FILE_TO_GROUP.get(fname)
         if group:
             item.add_marker(getattr(pytest.mark, group))
+
 
 # Reduce training epochs for faster tests (default is 200; 30 is sufficient
 # for the tiny MLP to converge on the small test dataset).
@@ -195,6 +197,31 @@ _patch_embed_audio.stop()
 from vtsearch.media import get as _media_get
 
 _audio_mt = _media_get("audio")
+
+
+@pytest.fixture(autouse=True)
+def _allow_test_tmp_paths(monkeypatch):
+    """Allow tests to use system temp dirs with server file-path validation.
+
+    In production, ``validate_server_filepath`` restricts paths to
+    ``Path.cwd()``.  During tests, temp files live in the system temp
+    directory, so we widen the check to also accept that tree.
+    """
+    import tempfile
+    from pathlib import Path
+
+    import vtsearch.utils.paths as paths_mod
+
+    _original = paths_mod.validate_server_filepath
+
+    def _permissive(filepath_str, base_dir=None):
+        try:
+            return _original(filepath_str, base_dir)
+        except ValueError:
+            # Also allow the system temp directory (where pytest tmp_path lives).
+            return _original(filepath_str, Path(tempfile.gettempdir()))
+
+    monkeypatch.setattr(paths_mod, "validate_server_filepath", _permissive)
 
 
 @pytest.fixture(autouse=True)
@@ -320,8 +347,7 @@ def pytest_sessionfinish(session, exitstatus):
         print("=" * 60, flush=True)
         if failed or errors:
             print(
-                f"TESTS FAILED: {failed} failed, {errors} errors, "
-                f"{passed} passed, {skipped} skipped (total: {total})",
+                f"TESTS FAILED: {failed} failed, {errors} errors, {passed} passed, {skipped} skipped (total: {total})",
                 flush=True,
             )
         else:

--- a/tests/test_combine_datasets.py
+++ b/tests/test_combine_datasets.py
@@ -405,6 +405,14 @@ class TestCombineEndpoint:
         data = resp.get_json()
         assert data["ok"] is True
 
+    def test_path_traversal_rejected(self, client):
+        """Paths outside the allowed directory must be rejected."""
+        resp = client.post(
+            "/api/dataset/combine",
+            json={"datasets": ["/etc/passwd", "/etc/shadow"]},
+        )
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # Staging endpoints
@@ -424,8 +432,7 @@ class TestStageFileEndpoint:
         buf = BytesIO()
         data = {
             "medias": {
-                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in m.items()}
-                for cid, m in ds.items()
+                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in m.items()} for cid, m in ds.items()
             }
         }
         pickle.dump(data, buf)
@@ -483,8 +490,7 @@ class TestStageImportEndpoint:
         buf = BytesIO()
         data = {
             "medias": {
-                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in m.items()}
-                for cid, m in ds.items()
+                cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in m.items()} for cid, m in ds.items()
             }
         }
         pickle.dump(data, buf)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -634,3 +634,28 @@ class TestExportEndpoint:
         )
         # exporter_name will be empty → 400
         assert res.status_code == 400
+
+    def test_path_traversal_absolute_rejected(self, client):
+        """Absolute paths outside the allowed directory must be rejected."""
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "server_json_file",
+                "field_values": {"filepath": "/etc/passwd"},
+                "results": SAMPLE_RESULTS,
+            },
+        )
+        assert res.status_code == 400
+        assert "outside" in res.get_json()["error"].lower() or "must be within" in res.get_json()["error"].lower()
+
+    def test_path_traversal_relative_rejected(self, client):
+        """Relative paths that escape the base directory must be rejected."""
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "server_json_file",
+                "field_values": {"filepath": "../../../etc/shadow"},
+                "results": SAMPLE_RESULTS,
+            },
+        )
+        assert res.status_code == 400

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -449,6 +449,22 @@ class TestLabelImportEndpoint:
         assert set(app_module.good_votes) == {1, 2, 3}
         assert set(app_module.bad_votes) == {4, 5}
 
+    def test_path_traversal_absolute_rejected(self, client):
+        """Absolute paths outside the allowed directory must be rejected."""
+        res = client.post(
+            "/api/label-importers/import/server_json_file",
+            json={"filepath": "/etc/passwd"},
+        )
+        assert res.status_code == 400
+
+    def test_path_traversal_relative_rejected(self, client):
+        """Relative paths that escape the base directory must be rejected."""
+        res = client.post(
+            "/api/label-importers/import/server_csv_file",
+            json={"filepath": "../../../etc/shadow"},
+        )
+        assert res.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # resolve_media_ids: union matching (origin+name AND md5)

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -1,0 +1,65 @@
+"""Tests for the server file-path validation utility.
+
+Covers:
+- validate_server_filepath: rejects path traversal, accepts safe paths
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vtsearch.utils.paths import validate_server_filepath
+
+
+class TestValidateServerFilepath:
+    """Direct unit tests for validate_server_filepath (no Flask client)."""
+
+    def test_relative_path_within_base(self, tmp_path):
+        result = validate_server_filepath("sub/file.json", base_dir=tmp_path)
+        assert result == (tmp_path / "sub" / "file.json").resolve()
+
+    def test_absolute_path_within_base(self, tmp_path):
+        target = tmp_path / "file.json"
+        result = validate_server_filepath(str(target), base_dir=tmp_path)
+        assert result == target.resolve()
+
+    def test_rejects_absolute_path_outside_base(self, tmp_path):
+        with pytest.raises(ValueError, match="must be within"):
+            validate_server_filepath("/etc/passwd", base_dir=tmp_path)
+
+    def test_rejects_relative_path_traversal(self, tmp_path):
+        with pytest.raises(ValueError, match="must be within"):
+            validate_server_filepath("../../etc/passwd", base_dir=tmp_path)
+
+    def test_rejects_dotdot_in_middle(self, tmp_path):
+        with pytest.raises(ValueError, match="must be within"):
+            validate_server_filepath("sub/../../etc/shadow", base_dir=tmp_path)
+
+    def test_accepts_simple_filename(self, tmp_path):
+        result = validate_server_filepath("results.json", base_dir=tmp_path)
+        assert result == (tmp_path / "results.json").resolve()
+
+    def test_accepts_nested_relative(self, tmp_path):
+        result = validate_server_filepath("data/output/file.csv", base_dir=tmp_path)
+        assert result == (tmp_path / "data" / "output" / "file.csv").resolve()
+
+    def test_defaults_to_cwd(self):
+        cwd = Path.cwd()
+        result = validate_server_filepath("some_file.json")
+        assert result == (cwd / "some_file.json").resolve()
+
+    def test_rejects_absolute_outside_cwd(self):
+        with pytest.raises(ValueError, match="must be within"):
+            validate_server_filepath("/etc/passwd")
+
+    def test_rejects_symlink_escape(self, tmp_path):
+        """A symlink that points outside base_dir should be rejected."""
+        link = tmp_path / "escape_link"
+        try:
+            link.symlink_to("/etc")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+        with pytest.raises(ValueError, match="must be within"):
+            validate_server_filepath("escape_link/passwd", base_dir=tmp_path)

--- a/tests/test_processor_importers.py
+++ b/tests/test_processor_importers.py
@@ -471,6 +471,30 @@ class TestProcessorImportEndpoint:
         )
         assert res.status_code == 400
 
+    def test_path_traversal_absolute_rejected(self, client):
+        """Absolute paths outside the allowed directory must be rejected."""
+        res = client.post(
+            "/api/processor-importers/import/server_detector_file",
+            json={"filepath": "/etc/passwd", "name": "evil_det"},
+        )
+        assert res.status_code == 400
+
+    def test_path_traversal_relative_rejected(self, client):
+        """Relative paths that escape the base directory must be rejected."""
+        res = client.post(
+            "/api/processor-importers/import/server_detector_file",
+            json={"filepath": "../../../etc/shadow", "name": "evil_det"},
+        )
+        assert res.status_code == 400
+
+    def test_path_traversal_from_label_import_rejected(self, client):
+        """Path traversal via the from-label-import endpoint must be rejected."""
+        res = client.post(
+            "/api/autorun-detectors/from-label-import/server_json_file",
+            json={"filepath": "/etc/passwd", "name": "evil"},
+        )
+        assert res.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # API – POST /api/autorun-detectors/from-label-import/<name>

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -42,7 +42,7 @@ from vtsearch.utils import (
     set_dataset_display_name,
     update_progress,
 )
-from vtsearch.utils.paths import validate_server_filepath
+import vtsearch.utils.paths as _paths
 
 # Re-export loading helpers so existing importers keep working.
 from vtsearch.routes.datasets_loading import (  # noqa: F401
@@ -161,7 +161,7 @@ def combine_datasets_route():
 
     for p in dataset_paths:
         try:
-            validate_server_filepath(str(p))
+            _paths.validate_server_filepath(str(p))
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
         if not Path(p).exists():
@@ -421,7 +421,7 @@ def load_dataset_folder():
         return jsonify({"error": "No folder path provided"}), 400
 
     try:
-        validate_server_filepath(str(folder_path))
+        _paths.validate_server_filepath(str(folder_path))
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -606,7 +606,7 @@ def _load_from_origin(source: dict):
     if importer_name == "pickle":
         pkl_path = params.get("path", "")
         try:
-            validate_server_filepath(str(pkl_path)) if pkl_path else None
+            _paths.validate_server_filepath(str(pkl_path)) if pkl_path else None
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
         if not pkl_path or not Path(pkl_path).is_file():
@@ -623,7 +623,7 @@ def _load_from_origin(source: dict):
     if importer_name == "folder":
         folder_path = params.get("path", "")
         try:
-            validate_server_filepath(str(folder_path)) if folder_path else None
+            _paths.validate_server_filepath(str(folder_path)) if folder_path else None
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
         if not folder_path or not Path(folder_path).is_dir():

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -42,6 +42,7 @@ from vtsearch.utils import (
     set_dataset_display_name,
     update_progress,
 )
+from vtsearch.utils.paths import validate_server_filepath
 
 # Re-export loading helpers so existing importers keep working.
 from vtsearch.routes.datasets_loading import (  # noqa: F401
@@ -159,6 +160,10 @@ def combine_datasets_route():
         return jsonify({"error": "Provide at least two dataset file paths."}), 400
 
     for p in dataset_paths:
+        try:
+            validate_server_filepath(str(p))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         if not Path(p).exists():
             return jsonify({"error": f"File not found: {p}"}), 400
 
@@ -415,6 +420,11 @@ def load_dataset_folder():
     if not folder_path:
         return jsonify({"error": "No folder path provided"}), 400
 
+    try:
+        validate_server_filepath(str(folder_path))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
     folder = Path(folder_path)
     if not folder.exists() or not folder.is_dir():
         return jsonify({"error": "Invalid folder path"}), 400
@@ -595,6 +605,10 @@ def _load_from_origin(source: dict):
 
     if importer_name == "pickle":
         pkl_path = params.get("path", "")
+        try:
+            validate_server_filepath(str(pkl_path)) if pkl_path else None
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         if not pkl_path or not Path(pkl_path).is_file():
             return jsonify({"error": f"Pickle file not found: {pkl_path}"}), 400
         origin = {"importer": "pickle", "params": params}
@@ -608,6 +622,10 @@ def _load_from_origin(source: dict):
 
     if importer_name == "folder":
         folder_path = params.get("path", "")
+        try:
+            validate_server_filepath(str(folder_path)) if folder_path else None
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         if not folder_path or not Path(folder_path).is_dir():
             return jsonify({"error": f"Folder not found: {folder_path}"}), 400
         importer = get_importer("folder")

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -24,6 +24,7 @@ from vtsearch.utils import (
     get_safe_thresholds,
     medias,
 )
+from vtsearch.utils.paths import validate_server_filepath
 
 from vtsearch.routes.detectors_crud import get_detectors_dir
 
@@ -412,6 +413,13 @@ def train_from_label_import(importer_name: str):
 
     if not name:
         return jsonify({"error": "name is required"}), 400
+
+    # Validate server file paths to prevent path traversal
+    if "filepath" in field_values and str(field_values["filepath"]).strip():
+        try:
+            validate_server_filepath(str(field_values["filepath"]))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     try:
         label_entries = importer.run(field_values)

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -24,7 +24,7 @@ from vtsearch.utils import (
     get_safe_thresholds,
     medias,
 )
-from vtsearch.utils.paths import validate_server_filepath
+import vtsearch.utils.paths as _paths
 
 from vtsearch.routes.detectors_crud import get_detectors_dir
 
@@ -417,7 +417,7 @@ def train_from_label_import(importer_name: str):
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]))
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/exporters.py
+++ b/vtsearch/routes/exporters.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.exporters import get_exporter, list_exporters
+from vtsearch.utils.paths import validate_server_filepath
 
 exporters_bp = Blueprint("exporters", __name__)
 
@@ -95,6 +96,13 @@ def run_export():
             ),
             400,
         )
+
+    # Validate server file paths to prevent path traversal
+    if "filepath" in field_values and str(field_values["filepath"]).strip():
+        try:
+            validate_server_filepath(str(field_values["filepath"]))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     try:
         outcome = exporter.export(results, field_values)

--- a/vtsearch/routes/exporters.py
+++ b/vtsearch/routes/exporters.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.exporters import get_exporter, list_exporters
-from vtsearch.utils.paths import validate_server_filepath
+import vtsearch.utils.paths as _paths
 
 exporters_bp = Blueprint("exporters", __name__)
 
@@ -100,7 +100,7 @@ def run_export():
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]))
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.labels.importers import get_label_importer, list_label_importers
-from vtsearch.utils.paths import validate_server_filepath
+import vtsearch.utils.paths as _paths
 from vtsearch.utils import (
     apply_label,
     build_media_lookup,
@@ -144,7 +144,7 @@ def run_label_import(importer_name: str):
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]))
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.labels.importers import get_label_importer, list_label_importers
+from vtsearch.utils.paths import validate_server_filepath
 from vtsearch.utils import (
     apply_label,
     build_media_lookup,
@@ -139,6 +140,13 @@ def run_label_import(importer_name: str):
             jsonify({"error": f"Missing required field(s): {missing_fields}", "missing_fields": missing_fields}),
             400,
         )
+
+    # Validate server file paths to prevent path traversal
+    if "filepath" in field_values and str(field_values["filepath"]).strip():
+        try:
+            validate_server_filepath(str(field_values["filepath"]))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     try:
         label_entries = importer.run(field_values)

--- a/vtsearch/routes/processor_importers.py
+++ b/vtsearch/routes/processor_importers.py
@@ -24,6 +24,7 @@ from flask import Blueprint, jsonify, request
 
 from vtsearch.processors.importers import get_processor_importer, list_processor_importers
 from vtsearch.utils import add_autorun_detector
+from vtsearch.utils.paths import validate_server_filepath
 
 processor_importers_bp = Blueprint("processor_importers", __name__)
 
@@ -98,6 +99,13 @@ def run_processor_import(importer_name: str):
             jsonify({"error": f"Missing required field(s): {missing}", "missing_fields": missing}),
             400,
         )
+
+    # Validate server file paths to prevent path traversal
+    if "filepath" in field_values and str(field_values["filepath"]).strip():
+        try:
+            validate_server_filepath(str(field_values["filepath"]))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     try:
         result = importer.run(field_values)

--- a/vtsearch/routes/processor_importers.py
+++ b/vtsearch/routes/processor_importers.py
@@ -24,7 +24,7 @@ from flask import Blueprint, jsonify, request
 
 from vtsearch.processors.importers import get_processor_importer, list_processor_importers
 from vtsearch.utils import add_autorun_detector
-from vtsearch.utils.paths import validate_server_filepath
+import vtsearch.utils.paths as _paths
 
 processor_importers_bp = Blueprint("processor_importers", __name__)
 
@@ -103,7 +103,7 @@ def run_processor_import(importer_name: str):
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]))
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/utils/paths.py
+++ b/vtsearch/utils/paths.py
@@ -1,0 +1,53 @@
+"""Server file-path validation utilities.
+
+Prevents path-traversal attacks by ensuring user-supplied file paths
+resolve within an allowed base directory.  Used by the web API routes
+for server-file importers and exporters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) -> Path:
+    """Validate that *filepath_str* resolves within *base_dir*.
+
+    Parameters
+    ----------
+    filepath_str:
+        User-supplied file path (absolute or relative).
+    base_dir:
+        The directory the resolved path must reside in.
+        Defaults to ``Path.cwd()``.
+
+    Returns
+    -------
+    Path
+        The resolved, canonicalised path.
+
+    Raises
+    ------
+    ValueError
+        If the resolved path is outside *base_dir*.
+    """
+    if base_dir is None:
+        base_dir = Path.cwd()
+
+    path = Path(filepath_str)
+
+    # Resolve relative paths against base_dir, absolute paths as-is
+    if not path.is_absolute():
+        path = base_dir / path
+
+    resolved = path.resolve()
+    base_resolved = base_dir.resolve()
+
+    try:
+        resolved.relative_to(base_resolved)
+    except ValueError:
+        raise ValueError(
+            f"Path must be within '{base_resolved}'. The given path resolves outside the allowed directory."
+        )
+
+    return resolved


### PR DESCRIPTION
## Summary
This PR adds comprehensive path traversal attack protection across all file-based import/export routes by introducing a new `validate_server_filepath()` utility function that ensures user-supplied file paths resolve within an allowed base directory.

## Key Changes

- **New utility module** (`vtsearch/utils/paths.py`):
  - Implements `validate_server_filepath()` function that validates file paths against path traversal attacks
  - Resolves both absolute and relative paths, then verifies they stay within the base directory
  - Handles symlink escapes by using `Path.resolve()` before validation
  - Defaults to current working directory if no base directory specified

- **Route protection** - Added path validation to all file-based endpoints:
  - `vtsearch/routes/exporters.py`: Export routes with `filepath` parameter
  - `vtsearch/routes/label_importers.py`: Label import routes with `filepath` parameter
  - `vtsearch/routes/processor_importers.py`: Processor/detector import routes with `filepath` parameter
  - `vtsearch/routes/detectors_training.py`: Training from label import routes with `filepath` parameter
  - `vtsearch/routes/datasets.py`: Dataset loading routes (combine, folder load, pickle load)

- **Comprehensive test coverage** (`tests/test_path_validation.py`):
  - Unit tests for the validation function covering:
    - Safe relative and absolute paths within base directory
    - Rejection of absolute paths outside base directory
    - Rejection of relative path traversal attempts (`../..`)
    - Rejection of symlink-based escapes
    - Default behavior using current working directory

- **Integration tests** - Added path traversal rejection tests to existing test suites:
  - `tests/test_exporters.py`: Tests for absolute and relative path traversal rejection
  - `tests/test_processor_importers.py`: Tests for multiple import endpoints
  - `tests/test_label_importers.py`: Tests for label import endpoints
  - `tests/test_combine_datasets.py`: Tests for dataset combination endpoint

- **Test infrastructure** (`tests/conftest.py`):
  - Added `_allow_test_tmp_paths` fixture to permit pytest's temporary directories during testing while maintaining production security

## Implementation Details

- Validation occurs before file existence checks, providing early rejection of malicious paths
- All validation errors return HTTP 400 with descriptive error messages
- The validation function uses `Path.resolve()` to canonicalize paths and detect symlink escapes
- Uses `Path.relative_to()` to verify the resolved path is within the allowed base directory

https://claude.ai/code/session_01T48Q6XYaHTWftz2J4D2yxT