### PR TITLE
Add restricted pickle unpickler to prevent RCE from untrusted .pkl files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ _TEST_GROUPS = {
         "test_thin_loading",
         "test_chunked_loading",
         "test_memory_errors",
+        "test_pickle_safety",
     ],
     "io": [
         "test_exporters",

--- a/tests/test_memory_errors.py
+++ b/tests/test_memory_errors.py
@@ -39,7 +39,7 @@ class TestPickleMemoryError:
         pkl.write_bytes(pickle.dumps({"medias": {}}))
 
         target: dict = {}
-        with mock.patch("vtsearch.datasets.loader.pickle.load", side_effect=MemoryError):
+        with mock.patch("vtsearch.datasets.loader.safe_pickle_load", side_effect=MemoryError):
             with pytest.raises(MemoryError, match="too large for available RAM"):
                 load_dataset_from_pickle(pkl, target)
 

--- a/tests/test_pickle_safety.py
+++ b/tests/test_pickle_safety.py
@@ -1,0 +1,280 @@
+"""Tests for the restricted pickle unpickler (RCE prevention).
+
+Verifies that ``RestrictedUnpickler`` and ``safe_pickle_load`` block
+arbitrary code execution while still allowing legitimate VTSearch
+dataset pickles (plain Python types + numpy arrays).
+"""
+
+import io
+import pickle
+
+import numpy as np
+import pytest
+
+from vtsearch.datasets.loader import (
+    RestrictedUnpickler,
+    export_dataset_to_file,
+    load_dataset_from_pickle,
+    load_dataset_from_pickle_chunked,
+    safe_pickle_load,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dumps(obj):
+    """Pickle an object to bytes."""
+    buf = io.BytesIO()
+    pickle.dump(obj, buf)
+    return buf.getvalue()
+
+
+def _safe_loads(data: bytes, **kwargs):
+    """Deserialise bytes via safe_pickle_load."""
+    return safe_pickle_load(io.BytesIO(data), **kwargs)
+
+
+def _make_malicious_pickle() -> bytes:
+    """Build a pickle payload that would execute ``os.system('echo pwned')``
+    if loaded with the standard ``pickle.load``.
+    """
+    # Uses the classic __reduce__ exploit: the unpickler calls
+    # os.system("echo pwned") and returns the result.
+    import os
+
+    class Exploit:
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    return _dumps(Exploit())
+
+
+# ---------------------------------------------------------------------------
+# RestrictedUnpickler — blocks malicious payloads
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictedUnpicklerBlocks:
+    """Verify that dangerous pickle payloads are rejected."""
+
+    def test_blocks_os_system(self):
+        """os.system() call via __reduce__ must be rejected."""
+        payload = _make_malicious_pickle()
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            _safe_loads(payload)
+
+    def test_blocks_subprocess(self):
+        """subprocess.Popen via __reduce__ must be rejected."""
+        import subprocess
+
+        class Exploit:
+            def __reduce__(self):
+                return (subprocess.Popen, (["echo", "pwned"],))
+
+        payload = _dumps(Exploit())
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            _safe_loads(payload)
+
+    def test_blocks_eval(self):
+        """builtins.eval via __reduce__ must be rejected."""
+
+        class Exploit:
+            def __reduce__(self):
+                return (eval, ("1+1",))
+
+        payload = _dumps(Exploit())
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            _safe_loads(payload)
+
+    def test_blocks_exec(self):
+        """builtins.exec via __reduce__ must be rejected."""
+
+        class Exploit:
+            def __reduce__(self):
+                return (exec, ("import os",))
+
+        payload = _dumps(Exploit())
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            _safe_loads(payload)
+
+    def test_blocks_arbitrary_class(self):
+        """An arbitrary user-defined class must be rejected."""
+
+        class MyObj:
+            pass
+
+        payload = _dumps(MyObj())
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            _safe_loads(payload)
+
+    def test_error_message_contains_module_and_name(self):
+        """The error message should identify which class was blocked."""
+        payload = _make_malicious_pickle()
+        with pytest.raises(pickle.UnpicklingError, match=r"os\.system"):
+            _safe_loads(payload)
+
+
+# ---------------------------------------------------------------------------
+# RestrictedUnpickler — allows safe types
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictedUnpicklerAllows:
+    """Verify that legitimate data types load correctly."""
+
+    def test_plain_dict(self):
+        data = {"key": "value", "num": 42, "nested": {"a": [1, 2, 3]}}
+        assert _safe_loads(_dumps(data)) == data
+
+    def test_list_and_tuple(self):
+        data = [1, "two", (3.0, None, True, False)]
+        assert _safe_loads(_dumps(data)) == data
+
+    def test_bytes_and_bytearray(self):
+        data = {"raw": b"\x00\x01\x02", "ba": bytearray(b"\x03\x04")}
+        result = _safe_loads(_dumps(data))
+        assert result["raw"] == b"\x00\x01\x02"
+        assert result["ba"] == bytearray(b"\x03\x04")
+
+    def test_numpy_array(self):
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = _safe_loads(_dumps(arr))
+        np.testing.assert_array_equal(result, arr)
+
+    def test_numpy_in_dict(self):
+        data = {"embedding": np.zeros(10, dtype=np.float32), "id": 1}
+        result = _safe_loads(_dumps(data))
+        np.testing.assert_array_equal(result["embedding"], data["embedding"])
+        assert result["id"] == 1
+
+    def test_ordered_dict(self):
+        from collections import OrderedDict
+
+        data = OrderedDict([("a", 1), ("b", 2)])
+        result = _safe_loads(_dumps(data))
+        assert list(result.keys()) == ["a", "b"]
+
+    def test_set_and_frozenset(self):
+        data = {"s": {1, 2, 3}, "fs": frozenset([4, 5])}
+        result = _safe_loads(_dumps(data))
+        assert result["s"] == {1, 2, 3}
+        assert result["fs"] == frozenset([4, 5])
+
+    def test_none_and_booleans(self):
+        data = {"none": None, "true": True, "false": False}
+        assert _safe_loads(_dumps(data)) == data
+
+
+# ---------------------------------------------------------------------------
+# Integration: export_dataset_to_file → load_dataset_from_pickle round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSafePickleRoundTrip:
+    """Exported datasets must load successfully through the restricted unpickler."""
+
+    def test_export_import_round_trip(self, tmp_path):
+        """A dataset exported by VTSearch should load cleanly via safe_pickle_load."""
+        medias = {
+            1: {
+                "id": 1,
+                "type": "audio",
+                "duration": 1.0,
+                "file_size": 1024,
+                "md5": "abc123",
+                "embedding": np.random.randn(512).astype(np.float32),
+                "filename": "test.wav",
+                "category": "test",
+                "origin": {"importer": "test", "params": {}},
+                "origin_name": "test.wav",
+                "media_bytes": b"\x00" * 100,
+                "media_string": None,
+                "media_path": None,
+                "word_count": None,
+                "character_count": None,
+                "width": None,
+                "height": None,
+            },
+        }
+        data_bytes = export_dataset_to_file(medias)
+        pkl_path = tmp_path / "test.pkl"
+        pkl_path.write_bytes(data_bytes)
+
+        loaded = {}
+        load_dataset_from_pickle(pkl_path, loaded)
+        assert len(loaded) == 1
+        assert loaded[1]["md5"] == "abc123"
+
+    def test_chunked_round_trip(self, tmp_path):
+        """Chunked loading should also work through the restricted unpickler."""
+        medias = {}
+        for i in range(5):
+            medias[i + 1] = {
+                "id": i + 1,
+                "type": "audio",
+                "duration": 1.0,
+                "file_size": 1024,
+                "md5": f"md5_{i}",
+                "embedding": np.random.randn(512).astype(np.float32),
+                "filename": f"test_{i}.wav",
+                "category": "test",
+                "origin": None,
+                "origin_name": f"test_{i}.wav",
+                "media_bytes": b"\x00" * 100,
+                "media_string": None,
+                "media_path": None,
+                "word_count": None,
+                "character_count": None,
+                "width": None,
+                "height": None,
+            }
+        data_bytes = export_dataset_to_file(medias)
+        pkl_path = tmp_path / "test.pkl"
+        pkl_path.write_bytes(data_bytes)
+
+        chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=2, thin=True))
+        total = sum(len(c) for c in chunks)
+        assert total == 5
+
+
+# ---------------------------------------------------------------------------
+# Integration: malicious pickle rejected by load_dataset_from_pickle
+# ---------------------------------------------------------------------------
+
+
+class TestMaliciousPickleInLoader:
+    """Verify that malicious pickles are rejected when loaded through the
+    main dataset loading functions."""
+
+    def test_load_dataset_from_pickle_rejects_rce(self, tmp_path):
+        """load_dataset_from_pickle must reject an RCE payload."""
+        pkl_path = tmp_path / "evil.pkl"
+        pkl_path.write_bytes(_make_malicious_pickle())
+        target = {}
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            load_dataset_from_pickle(pkl_path, target)
+
+    def test_load_dataset_from_pickle_chunked_rejects_rce(self, tmp_path):
+        """load_dataset_from_pickle_chunked must reject an RCE payload."""
+        pkl_path = tmp_path / "evil.pkl"
+        pkl_path.write_bytes(_make_malicious_pickle())
+        with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
+            list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10))
+
+    def test_stage_file_rejects_rce(self, client, tmp_path):
+        """The /api/dataset/stage-file endpoint must not execute RCE payloads."""
+        payload = _make_malicious_pickle()
+        data = {"file": (io.BytesIO(payload), "evil.pkl")}
+        resp = client.post(
+            "/api/dataset/stage-file",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        # The endpoint catches exceptions and returns count=0 for unparseable files
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["count"] == 0
+        assert body["media_type"] == "unknown"

--- a/tests/test_pickle_safety.py
+++ b/tests/test_pickle_safety.py
@@ -25,6 +25,12 @@ from vtsearch.datasets.loader import (
 # ---------------------------------------------------------------------------
 
 
+class _ArbitraryObj:
+    """A plain class with no __reduce__; used to test that arbitrary classes
+    are rejected by the restricted unpickler."""
+    pass
+
+
 def _dumps(obj):
     """Pickle an object to bytes."""
     buf = io.BytesIO()
@@ -102,18 +108,17 @@ class TestRestrictedUnpicklerBlocks:
 
     def test_blocks_arbitrary_class(self):
         """An arbitrary user-defined class must be rejected."""
-
-        class MyObj:
-            pass
-
-        payload = _dumps(MyObj())
+        # Build a pickle stream that references a module-level class by
+        # manually constructing the payload (local classes can't be pickled).
+        payload = _dumps(_ArbitraryObj())
         with pytest.raises(pickle.UnpicklingError, match="Forbidden pickle class"):
             _safe_loads(payload)
 
     def test_error_message_contains_module_and_name(self):
         """The error message should identify which class was blocked."""
         payload = _make_malicious_pickle()
-        with pytest.raises(pickle.UnpicklingError, match=r"os\.system"):
+        # On Linux, os.system is stored as posix.system in the pickle stream
+        with pytest.raises(pickle.UnpicklingError, match=r"system"):
             _safe_loads(payload)
 
 

--- a/tests/test_pickle_safety.py
+++ b/tests/test_pickle_safety.py
@@ -12,7 +12,6 @@ import numpy as np
 import pytest
 
 from vtsearch.datasets.loader import (
-    RestrictedUnpickler,
     export_dataset_to_file,
     load_dataset_from_pickle,
     load_dataset_from_pickle_chunked,

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -10,7 +10,6 @@ to use these functions outside the Flask app.
 
 from __future__ import annotations
 
-import collections
 import csv
 import gc
 import hashlib

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -10,6 +10,7 @@ to use these functions outside the Flask app.
 
 from __future__ import annotations
 
+import collections
 import csv
 import gc
 import hashlib
@@ -25,6 +26,62 @@ from vtsearch.config import EMBEDDINGS_DIR
 from vtsearch.datasets.config import DEMO_DATASETS
 
 ProgressCallback = Callable[[str, str, int, int], None]
+
+
+# ---------------------------------------------------------------------------
+# Restricted unpickler – prevents arbitrary code execution from .pkl files
+# ---------------------------------------------------------------------------
+
+# Allowlist of (module, name) pairs that may be instantiated during unpickling.
+# VTSearch pickles only contain plain Python containers and numpy arrays.
+_PICKLE_SAFE_CLASSES: set[tuple[str, str]] = {
+    # builtins (needed for dict/list/set/bytes subclasses & booleans)
+    ("builtins", "set"),
+    ("builtins", "frozenset"),
+    ("builtins", "bytes"),
+    ("builtins", "bytearray"),
+    ("builtins", "complex"),
+    # collections
+    ("collections", "OrderedDict"),
+    # numpy – reconstruction helpers used by numpy's __reduce__
+    ("numpy", "ndarray"),
+    ("numpy", "dtype"),
+    ("numpy.core.multiarray", "_reconstruct"),
+    ("numpy.core.multiarray", "scalar"),
+    ("numpy", "_core.multiarray._reconstruct"),
+    ("numpy._core.multiarray", "_reconstruct"),
+    ("numpy._core.multiarray", "scalar"),
+    ("numpy.core.numeric", "_frombuffer"),
+    ("numpy._core.numeric", "_frombuffer"),
+}
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """An ``Unpickler`` that refuses to instantiate classes outside an allowlist.
+
+    Plain Python primitives (int, float, str, None, bool, dict, list, tuple)
+    are handled by the pickle protocol directly and never trigger
+    ``find_class``.  This restricts only explicit class/callable references
+    in the pickle stream.
+    """
+
+    def find_class(self, module: str, name: str) -> Any:
+        if (module, name) in _PICKLE_SAFE_CLASSES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Forbidden pickle class: {module}.{name}. "
+            "Only plain Python types and numpy arrays are allowed."
+        )
+
+
+def safe_pickle_load(f: io.BufferedIOBase, **kwargs: Any) -> Any:
+    """Deserialise a pickle stream using the restricted unpickler.
+
+    Drop-in replacement for ``pickle.load(f)`` that blocks arbitrary code
+    execution.  Any extra keyword arguments (e.g. ``encoding``) are
+    forwarded to the underlying ``Unpickler``.
+    """
+    return RestrictedUnpickler(f, **kwargs).load()
 
 
 def _default_progress() -> ProgressCallback:
@@ -210,7 +267,7 @@ def load_cifar10_batch(file_path: Path) -> tuple[np.ndarray, list[int], list[str
           ``label_names[i]`` corresponds to label value ``i``.
     """
     with open(file_path, "rb") as f:
-        batch = pickle.load(f, encoding="bytes")
+        batch = safe_pickle_load(f, encoding="bytes")
 
     # CIFAR-10 label names
     label_names = [
@@ -739,7 +796,7 @@ def load_dataset_from_pickle(
     """
     try:
         with open(file_path, "rb") as f:
-            data = pickle.load(f)
+            data = safe_pickle_load(f)
     except MemoryError:
         gc.collect()
         raise MemoryError(
@@ -940,7 +997,7 @@ def load_dataset_from_pickle_chunked(
         A dict mapping int media IDs (starting at 1) to media data dicts.
     """
     with open(file_path, "rb") as f:
-        data = pickle.load(f)
+        data = safe_pickle_load(f)
 
     if isinstance(data, dict) and ("medias" in data or "clips" in data):
         medias_data = data["medias"] if "medias" in data else data["clips"]

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -21,7 +21,7 @@ from flask import Blueprint, jsonify, request, send_file
 from vtsearch.config import EMBEDDINGS_DIR
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers, load_demo_dataset
-from vtsearch.datasets.loader import load_dataset_from_pickle
+from vtsearch.datasets.loader import load_dataset_from_pickle, safe_pickle_load
 from vtsearch.datasets.registry import (
     get_loaded_id as _reg_loaded_id,
     list_datasets as _reg_list_datasets,
@@ -192,7 +192,7 @@ def stage_file():
     # Peek inside the pkl to get count and media type.
     try:
         with open(staging_path, "rb") as f:
-            data = pickle.load(f)  # noqa: S301
+            data = safe_pickle_load(f)
         if isinstance(data, dict) and "medias" in data:
             media_dict = data["medias"]
         elif isinstance(data, dict):

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -11,7 +11,6 @@ remain here.
 
 import gc
 import io
-import pickle
 import threading
 from pathlib import Path
 from uuid import uuid4

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -526,10 +526,10 @@ def multi_find():
     detection.  Returns a merged results table.
     """
     import gc
-    import pickle
 
     import torch
 
+    from vtsearch.datasets.loader import safe_pickle_load
     from vtsearch.datasets.registry import get_dataset as reg_get_ds
     from vtsearch.models.registry import get_model as reg_get_model
     from vtsearch.routes.trainable_models import _model_path, _read_model
@@ -609,7 +609,7 @@ def multi_find():
         try:
             pkl_path = ds["pkl_path"]
             with open(pkl_path, "rb") as f:
-                pkl_data = pickle.load(f)
+                pkl_data = safe_pickle_load(f)
             if isinstance(pkl_data, dict) and "medias" in pkl_data:
                 raw_medias = pkl_data["medias"]
             else:


### PR DESCRIPTION
## Summary
Adds a `RestrictedUnpickler` class and `safe_pickle_load()` function to prevent arbitrary code execution when loading pickle files. This is a critical security fix for handling untrusted or user-uploaded `.pkl` dataset files.

## Key Changes

- **New `RestrictedUnpickler` class** in `vtsearch/datasets/loader.py`:
  - Extends `pickle.Unpickler` with a custom `find_class()` method
  - Maintains an allowlist (`_PICKLE_SAFE_CLASSES`) of permitted classes: plain Python types (dict, list, set, bytes, etc.), collections.OrderedDict, and numpy array reconstruction helpers
  - Raises `pickle.UnpicklingError` for any attempt to instantiate classes outside the allowlist
  - Blocks dangerous callables like `os.system`, `subprocess.Popen`, `eval`, `exec`, and arbitrary user-defined classes

- **New `safe_pickle_load()` function**:
  - Drop-in replacement for `pickle.load()` that uses `RestrictedUnpickler`
  - Forwards keyword arguments (e.g., `encoding`) to the underlying unpickler

- **Updated all pickle loading calls** to use `safe_pickle_load()`:
  - `load_dataset_from_pickle()` in loader.py
  - `load_dataset_from_pickle_chunked()` in loader.py
  - `load_cifar10_batch()` in loader.py
  - Dataset staging endpoint in `vtsearch/routes/datasets.py`
  - Model detection endpoint in `vtsearch/routes/detectors_training.py`

- **Comprehensive test suite** (`tests/test_pickle_safety.py`):
  - Tests that malicious payloads (os.system, subprocess.Popen, eval, exec, arbitrary classes) are rejected
  - Tests that legitimate data types (dicts, lists, numpy arrays, OrderedDict, sets, bytes) load correctly
  - Integration tests verifying round-trip export/import of real datasets
  - Tests confirming malicious pickles are rejected by the main loader functions and API endpoints

## Implementation Details

- The allowlist approach is safe because pickle's protocol handles primitive types (int, float, str, None, bool, dict, list, tuple) directly without calling `find_class()`
- Supports both legacy and modern numpy module paths (`numpy.core.multiarray` and `numpy._core.multiarray`)
- Error messages identify the blocked class module and name for debugging
- All existing legitimate dataset loading workflows continue to work unchanged

https://claude.ai/code/session_01JcTTuS92WmYzuBNDaGr1Si