### PR TITLE
Use unique extract directories for HTTP archive imports

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -887,14 +887,12 @@ class TestHttpArchiveExtractDirIsolation:
         from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
 
         imp = HttpArchiveDatasetImporter()
-        dirs_created = []
+        dirs_used = []
 
-        original_mkdir = Path.mkdir
+        real_load = None
 
-        def spy_mkdir(self_path, *args, **kwargs):
-            if "http_archive_extract_" in str(self_path):
-                dirs_created.append(str(self_path))
-            return original_mkdir(self_path, *args, **kwargs)
+        def capture_load(extract_dir, *args, **kwargs):
+            dirs_used.append(str(extract_dir))
 
         with (
             mock.patch(
@@ -903,18 +901,18 @@ class TestHttpArchiveExtractDirIsolation:
             ),
             mock.patch(
                 "vtsearch.datasets.importers.http_zip.load_dataset_from_folder",
+                side_effect=capture_load,
             ),
             mock.patch(
                 "vtsearch.datasets.importers.http_zip.DATA_DIR", tmp_path,
             ),
-            mock.patch.object(Path, "mkdir", spy_mkdir),
         ):
             imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
             imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
 
-        assert len(dirs_created) >= 2
+        assert len(dirs_used) == 2
         # The two extract dirs must be different
-        assert dirs_created[-1] != dirs_created[-2]
+        assert dirs_used[0] != dirs_used[1]
 
     def test_old_shared_dir_name_not_used(self, tmp_path):
         """The old fixed name 'http_archive_extract' must no longer appear."""

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -870,3 +870,162 @@ class TestLoadDatasetRelativePaths:
         media = chunks[0][1]
         assert media["filename"] == "sub/chunk.wav"
         assert media["origin_name"] == "sub/chunk.wav"
+
+
+# ---------------------------------------------------------------------------
+# HTTP Archive importer – unique extract directories
+# ---------------------------------------------------------------------------
+
+
+class TestHttpArchiveExtractDirIsolation:
+    """Concurrent HTTP archive imports must use separate extract directories."""
+
+    def test_run_uses_unique_extract_dir(self, tmp_path):
+        """Each run() call should create a uniquely-named extract directory."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+        dirs_created = []
+
+        original_mkdir = Path.mkdir
+
+        def spy_mkdir(self_path, *args, **kwargs):
+            if "http_archive_extract_" in str(self_path):
+                dirs_created.append(str(self_path))
+            return original_mkdir(self_path, *args, **kwargs)
+
+        with (
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.download_file_with_progress",
+                side_effect=lambda url, path, **kw: _write_zip_to(path, tmp_path),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.load_dataset_from_folder",
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.DATA_DIR", tmp_path,
+            ),
+            mock.patch.object(Path, "mkdir", spy_mkdir),
+        ):
+            imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
+            imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
+
+        assert len(dirs_created) >= 2
+        # The two extract dirs must be different
+        assert dirs_created[-1] != dirs_created[-2]
+
+    def test_old_shared_dir_name_not_used(self, tmp_path):
+        """The old fixed name 'http_archive_extract' must no longer appear."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+
+        with (
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.download_file_with_progress",
+                side_effect=lambda url, path, **kw: _write_zip_to(path, tmp_path),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.load_dataset_from_folder",
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.DATA_DIR", tmp_path,
+            ),
+        ):
+            imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
+
+        # The old shared directory should not exist
+        assert not (tmp_path / "http_archive_extract").exists()
+
+    def test_extract_dir_cleaned_up_after_run(self, tmp_path):
+        """The unique extract directory should be removed after run() completes."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+
+        with (
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.download_file_with_progress",
+                side_effect=lambda url, path, **kw: _write_zip_to(path, tmp_path),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.load_dataset_from_folder",
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.DATA_DIR", tmp_path,
+            ),
+        ):
+            imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
+
+        # No http_archive_extract_* dirs should remain
+        remaining = list(tmp_path.glob("http_archive_extract_*"))
+        assert remaining == []
+
+    def test_extract_dir_cleaned_up_on_error(self, tmp_path):
+        """The extract directory should still be cleaned up if loading fails."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+
+        with (
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.download_file_with_progress",
+                side_effect=lambda url, path, **kw: _write_zip_to(path, tmp_path),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.load_dataset_from_folder",
+                side_effect=RuntimeError("boom"),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.DATA_DIR", tmp_path,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                imp.run({"url": "http://example.com/a.zip", "media_type": "sounds"}, {})
+
+        remaining = list(tmp_path.glob("http_archive_extract_*"))
+        assert remaining == []
+
+    def test_chunked_extract_dir_cleaned_up(self, tmp_path):
+        """run_chunked() should clean up its extract directory after iteration."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+
+        with (
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.download_file_with_progress",
+                side_effect=lambda url, path, **kw: _write_zip_to(path, tmp_path),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip._extract_archive",
+            ),
+            mock.patch(
+                "vtsearch.datasets.loader.load_dataset_from_folder_chunked",
+                return_value=iter([{1: {"test": True}}]),
+            ),
+            mock.patch(
+                "vtsearch.datasets.importers.http_zip.DATA_DIR", tmp_path,
+            ),
+        ):
+            chunks = list(imp.run_chunked({"url": "http://example.com/a.zip", "media_type": "sounds"}, 10))
+
+        assert len(chunks) == 1
+        remaining = list(tmp_path.glob("http_archive_extract_*"))
+        assert remaining == []
+
+
+def _write_zip_to(archive_path, tmp_path):
+    """Helper: write a minimal .zip so _extract_archive succeeds."""
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("dummy.wav", _make_wav_bytes())

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -8,10 +8,12 @@ Requires only ``requests``, which is already a core dependency.
 
 from __future__ import annotations
 
+import shutil
 import tarfile
 import zipfile
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
+from uuid import uuid4
 
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets.downloader import download_file_with_progress
@@ -100,9 +102,10 @@ class HttpArchiveDatasetImporter(DatasetImporter):
     """Download a publicly-accessible archive and load its media files.
 
     The archive is streamed to a temporary file in ``DATA_DIR``, extracted
-    to ``DATA_DIR/http_archive_extract/``, then scanned with the standard
+    to a unique ``DATA_DIR/http_archive_extract_<id>/`` directory, then
+    scanned with the standard
     :func:`~vtsearch.datasets.loader.load_dataset_from_folder` pipeline.
-    Both temporary paths are cleaned up after a successful run.
+    Both temporary paths are cleaned up after the run completes.
 
     Supported archive formats: ``.zip``, ``.tar``, ``.tar.gz``,
     ``.tar.bz2``, ``.tar.xz``, ``.rar`` (requires ``rarfile`` package).
@@ -140,8 +143,9 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         # Derive a local filename from the URL so we preserve the extension
         url_path = url.split("?")[0].rstrip("/")
         url_filename = url_path.split("/")[-1] or "archive"
+        run_id = uuid4().hex[:12]
         archive_path = DATA_DIR / f"http_archive_download_{url_filename}"
-        extract_dir = DATA_DIR / "http_archive_extract"
+        extract_dir = DATA_DIR / f"http_archive_extract_{run_id}"
 
         progress("downloading", "Downloading archive...", 0, 0)
         download_file_with_progress(url, archive_path, on_progress=progress)
@@ -151,7 +155,10 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         _extract_archive(archive_path, extract_dir, on_progress=progress)
         archive_path.unlink(missing_ok=True)
 
-        load_dataset_from_folder(extract_dir, media_type, medias, on_progress=progress, thin=thin)
+        try:
+            load_dataset_from_folder(extract_dir, media_type, medias, on_progress=progress, thin=thin)
+        finally:
+            shutil.rmtree(extract_dir, ignore_errors=True)
 
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         url = field_values.get("url", "")
@@ -164,7 +171,12 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         return True
 
     def _download_and_extract(self, field_values: dict[str, Any]) -> Path:
-        """Download and extract the archive, returning the extraction dir."""
+        """Download and extract the archive, returning the extraction dir.
+
+        Each call creates a unique extraction directory so concurrent imports
+        do not interfere with each other.  Callers are responsible for cleaning
+        up the returned directory when they are done with it.
+        """
         url = field_values["url"]
 
         DATA_DIR.mkdir(exist_ok=True)
@@ -172,8 +184,9 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
         url_path = url.split("?")[0].rstrip("/")
         url_filename = url_path.split("/")[-1] or "archive"
+        run_id = uuid4().hex[:12]
         archive_path = DATA_DIR / f"http_archive_download_{url_filename}"
-        extract_dir = DATA_DIR / "http_archive_extract"
+        extract_dir = DATA_DIR / f"http_archive_extract_{run_id}"
 
         progress("downloading", "Downloading archive...", 0, 0)
         download_file_with_progress(url, archive_path, on_progress=progress)
@@ -192,7 +205,10 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
         extract_dir = self._download_and_extract(field_values)
         media_type = field_values.get("media_type", "sounds")
-        yield from load_dataset_from_folder_chunked(extract_dir, media_type, chunk_size, thin=thin)
+        try:
+            yield from load_dataset_from_folder_chunked(extract_dir, media_type, chunk_size, thin=thin)
+        finally:
+            shutil.rmtree(extract_dir, ignore_errors=True)
 
     def run_chunked_cli(
         self, field_values: dict[str, Any], chunk_size: int, thin: bool = False,


### PR DESCRIPTION
## Summary
This change fixes a concurrency issue in the HTTP archive importer by using unique, isolated extract directories for each import operation instead of a shared fixed directory name.

## Key Changes
- **Unique extract directories**: Each `run()` and `run_chunked()` call now creates a uniquely-named extract directory using `http_archive_extract_<uuid>` instead of the fixed `http_archive_extract` directory
- **Automatic cleanup**: Extract directories are now cleaned up in a `try/finally` block, ensuring they are removed even if the import fails
- **Concurrent safety**: Multiple simultaneous imports no longer interfere with each other by overwriting the same extraction directory

## Implementation Details
- Added `uuid4().hex[:12]` to generate unique 12-character identifiers for each extraction directory
- Imported `shutil` module for directory cleanup via `shutil.rmtree()`
- Both `run()` and `_download_and_extract()` methods now generate unique directory names
- Extract directory cleanup is guaranteed via `try/finally` blocks in both `run()` and `run_chunked()` methods
- Updated docstring to reflect that the extraction directory is now unique and caller-managed in `_download_and_extract()`

## Tests Added
Comprehensive test coverage for the new behavior:
- Verification that each `run()` call uses a different extract directory
- Confirmation that the old fixed directory name is no longer used
- Validation that extract directories are cleaned up after successful runs
- Validation that extract directories are cleaned up even when errors occur
- Validation that `run_chunked()` also properly cleans up its extract directory

https://claude.ai/code/session_01Ru2xp4ve9KXchTwdQ5U9DL