### PR TITLE
Implement merge semantics for ProgressTracker.update()

### DIFF
--- a/tests/test_combine_datasets.py
+++ b/tests/test_combine_datasets.py
@@ -550,6 +550,6 @@ class TestProgressStagingResult:
         progress = get_progress()
         assert progress["staging_result"] == staging
 
-        # Clean up
-        update_progress("idle", "", 0, 0)
+        # Clean up — explicitly clear staging_result (update has merge semantics)
+        update_progress("idle", "", 0, 0, staging_result=None)
         assert get_progress()["staging_result"] is None

--- a/tests/test_tqdm_progress.py
+++ b/tests/test_tqdm_progress.py
@@ -142,3 +142,60 @@ class TestInterceptTqdmProgress:
             bar.close()
 
         assert all(s == "loading" for s in calls)
+
+
+class TestProgressTrackerUpdate:
+    """Tests for ProgressTracker.update() merge semantics."""
+
+    def test_update_preserves_unspecified_extra_fields(self):
+        """Calling update() without an extra field should not reset it."""
+        from vtsearch.utils.progress import ProgressTracker
+
+        tracker = ProgressTracker(extra_fields={"error": None, "staging_result": None})
+        tracker.update("loading", error="something broke")
+        # A subsequent update that doesn't mention 'error' should preserve it
+        tracker.update("loading", message="still going")
+        snap = tracker.get()
+        assert snap["error"] == "something broke"
+
+    def test_update_can_explicitly_overwrite_extra_field(self):
+        """Passing an extra field explicitly should overwrite the previous value."""
+        from vtsearch.utils.progress import ProgressTracker
+
+        tracker = ProgressTracker(extra_fields={"error": None})
+        tracker.update("loading", error="first error")
+        tracker.update("loading", error="second error")
+        assert tracker.get()["error"] == "second error"
+
+    def test_update_can_explicitly_clear_extra_field(self):
+        """Passing None for an extra field should clear it."""
+        from vtsearch.utils.progress import ProgressTracker
+
+        tracker = ProgressTracker(extra_fields={"error": None})
+        tracker.update("loading", error="oops")
+        tracker.update("idle", error=None)
+        assert tracker.get()["error"] is None
+
+    def test_update_preserves_multiple_extra_fields_independently(self):
+        """Each extra field is preserved independently when not specified."""
+        from vtsearch.utils.progress import ProgressTracker
+
+        tracker = ProgressTracker(extra_fields={"error": None, "staging_result": None})
+        tracker.update("idle", staging_result={"path": "/tmp/x"})
+        tracker.update("loading")
+        snap = tracker.get()
+        assert snap["staging_result"] == {"path": "/tmp/x"}
+        assert snap["error"] is None  # was never set, stays at default
+
+    def test_free_function_preserves_extra_fields(self):
+        """The update_progress() wrapper should also preserve unspecified extras."""
+        from vtsearch.utils.progress import dataset_progress, get_progress, update_progress
+
+        # Set error via the free function
+        update_progress("loading", error="whoops")
+        # Update without mentioning error
+        update_progress("loading", message="progress")
+        snap = get_progress()
+        assert snap["error"] == "whoops"
+        # Clean up for other tests
+        dataset_progress.update("idle", error=None, staging_result=None)

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -3,6 +3,8 @@
 import threading
 from typing import Any, Optional
 
+_UNSET = object()  # sentinel for "caller did not provide this argument"
+
 
 class ProgressTracker:
     """Thread-safe progress tracker for long-running operations.
@@ -51,8 +53,9 @@ class ProgressTracker:
             self._data["message"] = message
             self._data["current"] = current
             self._data["total"] = total
-            for key, default in self._extra_defaults.items():
-                self._data[key] = kwargs.get(key, default)
+            for key in self._extra_defaults:
+                if key in kwargs:
+                    self._data[key] = kwargs[key]
 
     def get(self) -> dict[str, Any]:
         """Return a snapshot of the current progress data.
@@ -85,16 +88,24 @@ def update_progress(
     message: str = "",
     current: int = 0,
     total: int = 0,
-    error: Optional[str] = None,
-    staging_result: Optional[dict] = None,
+    error: Any = _UNSET,
+    staging_result: Any = _UNSET,
 ) -> None:
     """Update the global dataset progress tracker.
 
     All write access is serialised internally so that background threads
     can safely report progress while the Flask request thread polls
     :func:`get_progress`.
+
+    Only extra fields explicitly supplied by the caller are forwarded;
+    omitted fields are left unchanged (true update/merge semantics).
     """
-    dataset_progress.update(status, message, current, total, error=error, staging_result=staging_result)
+    kwargs: dict[str, Any] = {}
+    if error is not _UNSET:
+        kwargs["error"] = error
+    if staging_result is not _UNSET:
+        kwargs["staging_result"] = staging_result
+    dataset_progress.update(status, message, current, total, **kwargs)
 
 
 def get_progress() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Changed `ProgressTracker.update()` to use true merge semantics for extra fields, where unspecified fields are preserved rather than reset to defaults. This allows multiple callers to independently update different fields without accidentally clearing each other's values.

## Key Changes
- **ProgressTracker.update()**: Modified to only update extra fields that are explicitly provided by the caller, preserving any previously-set values for omitted fields
- **update_progress() wrapper**: Updated to use a sentinel value (`_UNSET`) to distinguish between "caller didn't provide this argument" and "caller explicitly passed None", enabling proper merge semantics through the free function API
- **Test coverage**: Added comprehensive test suite (`TestProgressTrackerUpdate`) covering:
  - Preservation of unspecified extra fields across multiple updates
  - Explicit overwriting of extra fields when provided
  - Explicit clearing of extra fields by passing `None`
  - Independent preservation of multiple extra fields
  - Merge semantics working correctly through the free function wrapper
- **Existing test fix**: Updated `test_staging_result_in_progress` to explicitly pass `staging_result=None` when cleaning up, since the new merge semantics require explicit clearing

## Implementation Details
- Introduced `_UNSET` sentinel object to distinguish between "not provided" and "explicitly None" in function signatures
- Changed the extra fields update logic from `kwargs.get(key, default)` to only updating keys present in `kwargs`
- This ensures that if a caller doesn't mention an extra field, it retains its previous value rather than being reset to the default

https://claude.ai/code/session_01MKK46vCXNxnDGEW9YbyMzA