### PR TITLE
Fix concurrent embedder loading callback trampling with lock

### DIFF
--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,4 +1,5 @@
 import io
+import unittest.mock
 
 import numpy as np
 import torch
@@ -374,3 +375,67 @@ class TestTextsortSuggestions:
 
         resp = client.get("/api/textsort-suggestions")
         assert resp.get_json()["suggestions"] == []
+
+
+class TestLoadEmbedderConcurrentCallback:
+    """Verify _load_embedder_with_progress does not trample _on_progress."""
+
+    def test_lock_exists(self):
+        """The module-level lock must exist to serialise concurrent callers."""
+        import threading
+
+        from vtsearch.routes.sorting import _embedder_load_lock
+
+        assert isinstance(_embedder_load_lock, type(threading.Lock()))
+
+    def test_concurrent_calls_restore_original_callback(self):
+        """Two threads calling _load_embedder_with_progress must leave
+        _on_progress set to the *original* callback, not a stale lambda."""
+        import threading
+        import time
+        from unittest.mock import MagicMock
+
+        from vtsearch.routes.sorting import _load_embedder_with_progress
+
+        original_cb = MagicMock(name="original_cb")
+        mock_mt = MagicMock()
+        mock_mt._model = None  # force "needs loading"
+        mock_mt._on_progress = original_cb
+
+        def slow_load_models():
+            """Simulate a slow load; first call loads, second sees it loaded."""
+            time.sleep(0.05)
+            mock_mt._model = True  # mark as loaded
+
+        mock_mt.load_models = slow_load_models
+
+        with unittest.mock.patch("vtsearch.media.get", return_value=mock_mt):
+            t1 = threading.Thread(target=_load_embedder_with_progress, args=("audio", 5))
+            t2 = threading.Thread(target=_load_embedder_with_progress, args=("audio", 5))
+            t1.start()
+            t2.start()
+            t1.join(timeout=10)
+            t2.join(timeout=10)
+
+        # The lock ensures thread 1 finishes (restores original_cb) before
+        # thread 2 enters; thread 2 sees _model is loaded and returns early.
+        assert mock_mt._on_progress is original_cb, (
+            "_on_progress was not restored to the original callback after concurrent calls"
+        )
+
+    def test_callback_restored_after_load_error(self):
+        """_on_progress must be restored even when load_models raises."""
+        from unittest.mock import MagicMock
+
+        from vtsearch.routes.sorting import _load_embedder_with_progress
+
+        original_cb = MagicMock(name="original_cb")
+        mock_mt = MagicMock()
+        mock_mt._model = None
+        mock_mt._on_progress = original_cb
+        mock_mt.load_models.side_effect = RuntimeError("boom")
+
+        with unittest.mock.patch("vtsearch.media.get", return_value=mock_mt):
+            _load_embedder_with_progress("audio", 5)
+
+        assert mock_mt._on_progress is original_cb

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -425,6 +425,7 @@ class TestLoadEmbedderConcurrentCallback:
 
     def test_callback_restored_after_load_error(self):
         """_on_progress must be restored even when load_models raises."""
+        import pytest
         from unittest.mock import MagicMock
 
         from vtsearch.routes.sorting import _load_embedder_with_progress
@@ -436,6 +437,7 @@ class TestLoadEmbedderConcurrentCallback:
         mock_mt.load_models.side_effect = RuntimeError("boom")
 
         with unittest.mock.patch("vtsearch.media.get", return_value=mock_mt):
-            _load_embedder_with_progress("audio", 5)
+            with pytest.raises(RuntimeError):
+                _load_embedder_with_progress("audio", 5)
 
         assert mock_mt._on_progress is original_cb

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -1,6 +1,7 @@
 """Blueprint for sorting and voting routes."""
 
 import json
+import threading
 from pathlib import Path
 
 import numpy as np
@@ -79,29 +80,35 @@ def _cosine_sort(query_vec):
     return results, round(threshold, 4)
 
 
+_embedder_load_lock = threading.Lock()
+
+
 def _load_embedder_with_progress(media_type, total_steps):
     """Load the embedding model for *media_type*, forwarding progress to the sort progress bar.
 
-    If the model is already loaded this is a no-op.
+    If the model is already loaded this is a no-op.  A lock serialises
+    concurrent callers so that only one request touches ``_on_progress``
+    at a time, preventing the save/restore from trampling another
+    request's callback.
     """
     from vtsearch.media import get as media_get
 
     try:
         mt = media_get(media_type)
-        needs_loading = getattr(mt, "_model", None) is None
     except KeyError:
         return
 
-    if not needs_loading:
-        return
+    with _embedder_load_lock:
+        if getattr(mt, "_model", None) is not None:
+            return
 
-    update_sort_progress("sorting", "Loading embedder…", 0, total_steps)
-    original_cb = mt._on_progress
-    mt._on_progress = lambda status, msg, cur, tot: update_sort_progress("sorting", msg, cur, tot)
-    try:
-        mt.load_models()
-    finally:
-        mt._on_progress = original_cb
+        update_sort_progress("sorting", "Loading embedder…", 0, total_steps)
+        original_cb = mt._on_progress
+        mt._on_progress = lambda status, msg, cur, tot: update_sort_progress("sorting", msg, cur, tot)
+        try:
+            mt.load_models()
+        finally:
+            mt._on_progress = original_cb
 
 
 @sorting_bp.route("/api/sort", methods=["POST"])


### PR DESCRIPTION
## Summary
Fix a race condition in `_load_embedder_with_progress` where concurrent requests could trample each other's progress callbacks. The function now uses a module-level lock to serialize access to the media type's `_on_progress` callback during model loading.

## Changes
- Add `_embedder_load_lock` (threading.Lock) to serialize concurrent embedder loading operations
- Wrap the model loading logic with the lock to ensure only one thread modifies `_on_progress` at a time
- Move the "already loaded" check inside the lock to prevent race conditions between the check and load
- Add comprehensive test coverage for concurrent callback handling and error cases

## Implementation Details
- The lock ensures that when multiple threads call `_load_embedder_with_progress` concurrently, only one thread enters the critical section where `_on_progress` is temporarily replaced
- The "already loaded" check is now performed inside the lock, preventing a thread from checking the model state, then having another thread load it before the first thread proceeds
- The callback restoration is guaranteed to happen even if `load_models()` raises an exception, thanks to the try/finally block
- Tests verify: lock existence, concurrent calls restore the original callback, and callbacks are restored after load errors

https://claude.ai/code/session_01YDh8nZqUctFeubFmFcejr9