### PR TITLE
Clarify API validation behavior for empty bodies and boolean inputs

### DIFF
--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -63,9 +63,8 @@ class TestInvalidRequestBodies:
 
     def test_settings_put_with_empty_body(self):
         resp = self.client.put("/api/settings", json={})
-        # Empty but valid dict — should succeed (no fields to update)
-        # OR may return 400 for empty body depending on impl
-        assert resp.status_code in (200, 400)
+        # Empty dict is falsy → route rejects with 400
+        assert resp.status_code == 400
 
     def test_settings_put_with_null_body(self):
         resp = self.client.put(
@@ -187,9 +186,10 @@ class TestTypeMismatches:
 
     def test_inclusion_boolean_value(self):
         resp = self.client.post("/api/inclusion", json={"inclusion": True})
-        # True is not a number in the strict check (isinstance True of int is True in Python,
-        # but the route may or may not accept it). Let's check it doesn't crash.
-        assert resp.status_code in (200, 400)
+        # bool is a subclass of int in Python, so isinstance(True, (int, float))
+        # passes validation.  True → int(1) → clamped to 1.
+        assert resp.status_code == 200
+        assert resp.get_json()["inclusion"] == 1
 
     def test_safe_thresholds_string_value(self):
         resp = self.client.post("/api/safe-thresholds", json={"safe_thresholds": "yes"})


### PR DESCRIPTION
## Summary
Updated test expectations to reflect the actual API validation behavior for edge cases involving empty request bodies and boolean type inputs.

## Key Changes
- **Empty body handling**: Changed `test_settings_put_with_empty_body` to expect a definitive 400 status code instead of accepting both 200 and 400. Empty dicts are now treated as falsy values that the route rejects.
- **Boolean input validation**: Updated `test_inclusion_boolean_value` to expect successful validation (200) instead of accepting both 200 and 400. Since `bool` is a subclass of `int` in Python, `isinstance(True, (int, float))` passes validation, and `True` is correctly coerced to integer value `1` and clamped appropriately.
- **Added assertion**: Included a response body assertion in `test_inclusion_boolean_value` to verify the boolean is correctly converted to its integer equivalent (1).

## Implementation Details
These changes remove ambiguity from the test suite by replacing permissive status code checks with specific expected values, making the API's validation behavior explicit and testable.

https://claude.ai/code/session_01Dmq2oL91DffseahR6N3LTV