### PR TITLE
Replace early return with pytest.skip in diversity tree test

### DIFF
--- a/tests/test_diversity_tree_integration.py
+++ b/tests/test_diversity_tree_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for diversity tree wiring: build, label, unlabel, API."""
 
+import pytest
+
 from vtsearch.utils import (
     add_label_to_history,
     bad_votes,
@@ -308,8 +310,7 @@ class TestSpanLevelProgression:
         tree = _build_tree()
         depth = tree.depth()
         if depth < 1:
-            # Tree too shallow to test progression beyond 0
-            return
+            pytest.skip("Tree too shallow to test progression beyond 0")
 
         # Use next_sample to find medias from each depth-1 subtree and vote on them
         for _ in range(len(medias)):


### PR DESCRIPTION
## Summary
Updated test skip logic to use pytest's built-in `pytest.skip()` function instead of an early return statement, improving test reporting and consistency with pytest conventions.

## Key Changes
- Added `pytest` import to the test module
- Replaced conditional early `return` with `pytest.skip()` in `test_span_advances_beyond_zero_via_votes()` when tree depth is insufficient
- Updated skip message to match the original return condition comment

## Implementation Details
This change improves test visibility by properly marking skipped tests in pytest's output rather than silently returning early. When a test is skipped using `pytest.skip()`, it's clearly reported in test results as a skip rather than a pass, making it easier to identify tests that couldn't run due to preconditions not being met.

https://claude.ai/code/session_01Stgk6YauSwvmKJ3jti56yu