### PR TITLE
Make label-file-sort use current media type embedder

### DIFF
--- a/tests/test_label_sorting.py
+++ b/tests/test_label_sorting.py
@@ -1,10 +1,16 @@
 """Tests for label sorting features: click-time tracking, learned-sort scores,
-and the enriched /api/votes response."""
+the enriched /api/votes response, and label-file-sort model selection."""
+
+import io
+import json
+from unittest.mock import patch
+
+import numpy as np
 
 import app as app_module
 import vtsearch.utils.state as _state
 import vtsearch.utils.state_core as _core
-from vtsearch.utils import vote_click_times, last_learned_scores
+from vtsearch.utils import medias, vote_click_times, last_learned_scores
 
 
 class TestClickTimeTracking:
@@ -119,3 +125,85 @@ class TestClearVotesResetsState:
         _state.last_learned_scores[1] = 0.9
         _state.clear_votes()
         assert len(last_learned_scores) == 0
+
+
+class TestLabelFileSortModelSelection:
+    """Verify that /api/label-file-sort uses the correct model for the current media type."""
+
+    def _make_label_file(self, paths_and_labels):
+        """Create a JSON label file in memory."""
+        labels = [{"path": str(p), "label": lbl} for p, lbl in paths_and_labels]
+        content = json.dumps({"labels": labels})
+        buf = io.BytesIO(content.encode("utf-8"))
+        buf.name = "labels.json"
+        return buf
+
+    def test_no_file_returns_400(self, client):
+        resp = client.post("/api/label-file-sort")
+        assert resp.status_code == 400
+
+    def test_no_medias_returns_400(self, client):
+        saved = dict(medias)
+        medias.clear()
+        try:
+            buf = self._make_label_file([])
+            resp = client.post(
+                "/api/label-file-sort",
+                data={"file": (buf, "labels.json")},
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 400
+        finally:
+            medias.update(saved)
+
+    def test_uses_current_media_type_embedder(self, client, tmp_path):
+        """The endpoint should call embed_media on the media type matching the loaded dataset,
+        not hardcode embed_audio_file / CLAP."""
+        # Determine the current media type from loaded test medias
+        media_type = next(iter(medias.values())).get("type", "audio")
+        embedding_dim = next(iter(medias.values()))["embedding"].shape[0]
+
+        # Create fake media files on disk
+        good_file = tmp_path / "good.bin"
+        bad_file = tmp_path / "bad.bin"
+        good_file.write_bytes(b"\x00" * 100)
+        bad_file.write_bytes(b"\x00" * 100)
+
+        fake_emb = np.random.default_rng(42).standard_normal(embedding_dim).astype(np.float32)
+
+        from vtsearch.media import get as media_get
+
+        mt = media_get(media_type)
+
+        with patch.object(mt, "embed_media", return_value=fake_emb) as mock_embed:
+            buf = self._make_label_file([(good_file, "good"), (bad_file, "bad")])
+            resp = client.post(
+                "/api/label-file-sort",
+                data={"file": (buf, "labels.json")},
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert "results" in data
+            assert data["loaded"] == 2
+            # Verify embed_media was called (not embed_audio_file)
+            assert mock_embed.call_count == 2
+
+    def test_invalid_label_file_returns_400(self, client):
+        buf = io.BytesIO(b"not json")
+        resp = client.post(
+            "/api/label-file-sort",
+            data={"file": (buf, "labels.json")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "invalid" in resp.get_json()["error"].lower()
+
+    def test_empty_labels_returns_400(self, client):
+        buf = io.BytesIO(json.dumps({"labels": []}).encode())
+        resp = client.post(
+            "/api/label-file-sort",
+            data={"file": (buf, "labels.json")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -15,9 +15,7 @@ from vtsearch.models import (
     calculate_gmm_threshold,
     calculate_safe_threshold,
     compute_labeling_status,
-    embed_audio_file,
     embed_text_query,
-    get_clap_model,
     train_and_score,
     train_model,
 )
@@ -527,7 +525,7 @@ def example_sort_server():
 
 @sorting_bp.route("/api/label-file-sort", methods=["POST"])
 def label_file_sort():
-    """Train MLP on external audio files from a label file, then sort all medias."""
+    """Train MLP on external media files from a label file, then sort all medias."""
     if "file" not in request.files:
         return jsonify({"error": "No file provided"}), 400
 
@@ -535,9 +533,14 @@ def label_file_sort():
     if not file.filename:
         return jsonify({"error": "No file selected"}), 400
 
-    clap_model, clap_processor = get_clap_model()
-    if clap_model is None or clap_processor is None:
-        return jsonify({"error": "CLAP model not loaded"}), 500
+    if not medias:
+        return jsonify({"error": "No medias loaded"}), 400
+
+    # Determine media type from loaded dataset and get the appropriate embedder
+    media_type = next(iter(medias.values())).get("type", "audio")
+    from vtsearch.media import get as media_get
+
+    mt = media_get(media_type)
 
     try:
         # Parse the label file
@@ -552,7 +555,7 @@ def label_file_sort():
         if not labels:
             return jsonify({"error": "No labels found in file"}), 400
 
-        # Load and embed each labeled audio file
+        # Load and embed each labeled media file
         X_list = []
         y_list = []
         loaded_count = 0
@@ -564,19 +567,19 @@ def label_file_sort():
                 skipped_count += 1
                 continue
 
-            # Try to get audio file path
-            audio_path = entry.get("path") or entry.get("file") or entry.get("filename")
-            if not audio_path:
+            # Try to get media file path
+            media_path = entry.get("path") or entry.get("file") or entry.get("filename")
+            if not media_path:
                 skipped_count += 1
                 continue
 
-            audio_path = Path(audio_path)
-            if not audio_path.exists():
+            media_path = Path(media_path)
+            if not media_path.exists():
                 skipped_count += 1
                 continue
 
-            # Embed the audio file
-            embedding = embed_audio_file(audio_path)
+            # Embed the media file using the appropriate model for the current media type
+            embedding = mt.embed_media(media_path)
             if embedding is None:
                 skipped_count += 1
                 continue


### PR DESCRIPTION
## Summary
Refactored the `/api/label-file-sort` endpoint to dynamically select the appropriate media embedder based on the currently loaded dataset's media type, rather than hardcoding CLAP audio embeddings.

## Key Changes
- **Dynamic media type detection**: The endpoint now determines the media type from the first loaded media in the dataset and uses the corresponding embedder
- **Removed hardcoded CLAP dependency**: Replaced `embed_audio_file()` and `get_clap_model()` calls with a generic `mt.embed_media()` call that works with any media type
- **Improved error handling**: Added validation to ensure medias are loaded before processing
- **Updated variable naming**: Changed `audio_path`/`audio_file` references to `media_path`/`media_file` for clarity and accuracy
- **Enhanced test coverage**: Added comprehensive test suite (`TestLabelFileSortModelSelection`) with 5 test cases covering:
  - Missing file validation
  - Missing medias validation
  - Correct embedder selection for current media type
  - Invalid label file handling
  - Empty labels validation

## Implementation Details
- Uses `vtsearch.media.get()` to retrieve the media type handler at runtime
- Maintains backward compatibility with existing label file format (supports "path", "file", or "filename" keys)
- The endpoint now works with any media type supported by the media module, not just audio

https://claude.ai/code/session_01CUSXfok3jyuwL9JJwQSdjV