### PR TITLE
Add SSRF protection to URL validation

### DIFF
--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -421,6 +421,8 @@ class TestWebhookExporterCLI:
 class TestWebhookExporterExport:
     """Tests for the Webhook export() method using mocked HTTP."""
 
+    _PATCH_VALIDATE = mock.patch("vtsearch.exporters.webhook.validate_url")
+
     def test_posts_json_to_url(self):
         from vtsearch.exporters.webhook import WebhookLabelsetExporter
 
@@ -431,7 +433,9 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp) as mock_post:
+        with self._PATCH_VALIDATE, mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ) as mock_post:
             result = exp.export(results, {"url": "https://example.com/hook"})
 
         mock_post.assert_called_once()
@@ -450,7 +454,9 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp) as mock_post:
+        with self._PATCH_VALIDATE, mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ) as mock_post:
             exp.export(results, {"url": "https://example.com/hook", "auth_header": "Bearer my-token"})
 
         call_kwargs = mock_post.call_args
@@ -466,7 +472,9 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp) as mock_post:
+        with self._PATCH_VALIDATE, mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ) as mock_post:
             exp.export(results, {"url": "https://example.com/hook", "auth_header": ""})
 
         call_kwargs = mock_post.call_args
@@ -488,7 +496,9 @@ class TestWebhookExporterExport:
         mock_resp = mock.MagicMock()
         mock_resp.raise_for_status.side_effect = Exception("500 Server Error")
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp):
+        with self._PATCH_VALIDATE, mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ):
             with pytest.raises(Exception, match="500 Server Error"):
                 exp.export(results, {"url": "https://example.com/hook"})
 
@@ -502,7 +512,9 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp):
+        with self._PATCH_VALIDATE, mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ):
             result = exp.export(results, {"url": "https://example.com/hook"})
 
         assert "3 hit(s)" in result["message"]
@@ -518,7 +530,9 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 201
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp):
+        with self._PATCH_VALIDATE, mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ):
             result = exp.export(results, {"url": "https://example.com/hook"})
 
         assert result["status_code"] == 201
@@ -539,7 +553,9 @@ class TestWebhookExporterIntegration:
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp):
+        with mock.patch("vtsearch.exporters.webhook.validate_url"), mock.patch(
+            "vtsearch.exporters.webhook.requests.post", return_value=mock_resp
+        ):
             _run_exporter("webhook", {"url": "https://example.com/hook"}, results)
 
     def test_unknown_exporter_still_raises(self):

--- a/tests/test_ssrf_validation.py
+++ b/tests/test_ssrf_validation.py
@@ -1,0 +1,230 @@
+"""Tests for SSRF URL validation.
+
+Verifies that :func:`vtsearch.utils.url_validation.validate_url` blocks
+requests to private/internal network addresses while allowing public URLs.
+Also verifies that the HTTP archive importer and webhook exporter both
+call the validator.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from vtsearch.utils.url_validation import validate_url
+
+
+# ---------------------------------------------------------------------------
+# validate_url – scheme enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlScheme:
+    def test_rejects_ftp_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            validate_url("ftp://example.com/file.zip")
+
+    def test_rejects_file_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            validate_url("file:///etc/passwd")
+
+    def test_rejects_no_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            validate_url("example.com/file.zip")
+
+    def test_rejects_javascript_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            validate_url("javascript:alert(1)")
+
+    def test_accepts_http(self):
+        with mock.patch("vtsearch.utils.url_validation.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+            assert validate_url("http://example.com") == "http://example.com"
+
+    def test_accepts_https(self):
+        with mock.patch("vtsearch.utils.url_validation.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+            assert validate_url("https://example.com") == "https://example.com"
+
+
+# ---------------------------------------------------------------------------
+# validate_url – hostname enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlHostname:
+    def test_rejects_empty_hostname(self):
+        with pytest.raises(ValueError, match="hostname"):
+            validate_url("http://")
+
+    def test_rejects_missing_hostname(self):
+        with pytest.raises(ValueError, match="hostname"):
+            validate_url("http:///path")
+
+
+# ---------------------------------------------------------------------------
+# validate_url – private IP blocking
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlPrivateIPs:
+    def _mock_resolve(self, ip):
+        return mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", (ip, 0))],
+        )
+
+    def test_blocks_localhost_127_0_0_1(self):
+        with self._mock_resolve("127.0.0.1"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://localhost/admin")
+
+    def test_blocks_127_x(self):
+        with self._mock_resolve("127.0.0.2"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://some-host.example/")
+
+    def test_blocks_10_x(self):
+        with self._mock_resolve("10.0.0.1"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://internal.corp/")
+
+    def test_blocks_172_16_x(self):
+        with self._mock_resolve("172.16.0.1"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://internal.corp/")
+
+    def test_blocks_192_168_x(self):
+        with self._mock_resolve("192.168.1.1"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://router.local/")
+
+    def test_blocks_link_local(self):
+        with self._mock_resolve("169.254.169.254"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://metadata.internal/")
+
+    def test_blocks_ipv6_loopback(self):
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[(10, 1, 0, "", ("::1", 0, 0, 0))],
+        ):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://ip6-localhost/")
+
+    def test_allows_public_ip(self):
+        with self._mock_resolve("93.184.216.34"):
+            result = validate_url("https://example.com/archive.zip")
+            assert result == "https://example.com/archive.zip"
+
+    def test_blocks_unresolvable_hostname(self):
+        import socket
+
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            with pytest.raises(ValueError, match="Could not resolve"):
+                validate_url("http://this-does-not-exist.invalid/")
+
+    def test_blocks_zero_address(self):
+        with self._mock_resolve("0.0.0.0"):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://zero.example/")
+
+    def test_checks_all_resolved_addresses(self):
+        """If a hostname has multiple A records, block if ANY is private."""
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 0, "", ("93.184.216.34", 0)),
+                (2, 1, 0, "", ("127.0.0.1", 0)),
+            ],
+        ):
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://dual-homed.example/")
+
+
+# ---------------------------------------------------------------------------
+# HTTP archive importer – SSRF protection integration
+# ---------------------------------------------------------------------------
+
+
+class TestHttpArchiveImporterSSRF:
+    """Verify that the HTTP archive importer validates URLs before downloading."""
+
+    def test_run_rejects_private_url(self):
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("127.0.0.1", 0))],
+        ):
+            with pytest.raises(ValueError, match="private/internal"):
+                imp.run({"url": "http://localhost:8080/secret.zip", "media_type": "sounds"}, {})
+
+    def test_run_rejects_non_http_scheme(self):
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+        with pytest.raises(ValueError, match="http or https"):
+            imp.run({"url": "file:///etc/passwd", "media_type": "sounds"}, {})
+
+    def test_download_and_extract_rejects_private_url(self):
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        imp = HttpArchiveDatasetImporter()
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("10.0.0.5", 0))],
+        ):
+            with pytest.raises(ValueError, match="private/internal"):
+                imp._download_and_extract({"url": "http://internal-server/data.tar.gz"})
+
+
+# ---------------------------------------------------------------------------
+# Webhook exporter – SSRF protection integration
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookExporterSSRF:
+    """Verify that the webhook exporter validates URLs before POSTing."""
+
+    def test_export_rejects_private_url(self):
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
+
+        exp = WebhookLabelsetExporter()
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("192.168.1.1", 0))],
+        ):
+            with pytest.raises(ValueError, match="private/internal"):
+                exp.export({}, {"url": "http://192.168.1.1:9090/hook"})
+
+    def test_export_rejects_non_http_scheme(self):
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
+
+        exp = WebhookLabelsetExporter()
+        with pytest.raises(ValueError, match="http or https"):
+            exp.export({}, {"url": "ftp://evil.example/hook"})
+
+    def test_export_allows_public_url(self):
+        from vtsearch.exporters.webhook import WebhookLabelsetExporter
+
+        exp = WebhookLabelsetExporter()
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        with mock.patch(
+            "vtsearch.utils.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
+        ):
+            with mock.patch("vtsearch.exporters.webhook.requests.post", return_value=mock_resp):
+                result = exp.export(
+                    {"detectors_run": 0, "results": {}},
+                    {"url": "https://example.com/hook"},
+                )
+        assert result["status_code"] == 200

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -17,6 +17,7 @@ from vtsearch.config import DATA_DIR
 from vtsearch.datasets.downloader import download_file_with_progress
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 from vtsearch.datasets.loader import load_dataset_from_folder
+from vtsearch.utils.url_validation import validate_url
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -131,6 +132,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         url = field_values["url"]
+        validate_url(url)
         media_type = field_values.get("media_type", "sounds")
 
         DATA_DIR.mkdir(exist_ok=True)
@@ -166,6 +168,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
     def _download_and_extract(self, field_values: dict[str, Any]) -> Path:
         """Download and extract the archive, returning the extraction dir."""
         url = field_values["url"]
+        validate_url(url)
 
         DATA_DIR.mkdir(exist_ok=True)
         progress = _default_progress()

--- a/vtsearch/exporters/webhook/__init__.py
+++ b/vtsearch/exporters/webhook/__init__.py
@@ -10,6 +10,7 @@ from typing import Any
 import requests
 
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
+from vtsearch.utils.url_validation import validate_url
 
 
 class WebhookLabelsetExporter(LabelsetExporter):
@@ -45,6 +46,7 @@ class WebhookLabelsetExporter(LabelsetExporter):
         url = field_values.get("url", "").strip()
         if not url:
             raise ValueError("A webhook URL is required.")
+        validate_url(url)
 
         headers: dict[str, str] = {"Content-Type": "application/json"}
         auth_header = field_values.get("auth_header", "").strip()

--- a/vtsearch/utils/url_validation.py
+++ b/vtsearch/utils/url_validation.py
@@ -1,0 +1,57 @@
+"""URL validation utilities to prevent SSRF (Server-Side Request Forgery).
+
+Provides :func:`validate_url` which resolves the hostname and rejects URLs
+that point to private/internal network addresses.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Return True if *ip_str* belongs to a private, loopback, or reserved range."""
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # unparseable → treat as unsafe
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_reserved
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def validate_url(url: str) -> str:
+    """Validate *url* for safe external use and return the cleaned URL.
+
+    Raises :class:`ValueError` if the URL uses a non-HTTP(S) scheme, has no
+    hostname, or resolves to a private/internal IP address.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL must use http or https scheme, got: {parsed.scheme!r}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL must contain a hostname.")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        raise ValueError(f"Could not resolve hostname: {hostname}")
+
+    for family, _, _, _, sockaddr in infos:
+        ip_str = sockaddr[0]
+        if _is_private_ip(ip_str):
+            raise ValueError(
+                f"URL points to a private/internal network address ({ip_str}). "
+                "Only publicly routable URLs are allowed."
+            )
+
+    return url


### PR DESCRIPTION
## Summary
Implements Server-Side Request Forgery (SSRF) protection by adding URL validation that blocks requests to private/internal network addresses while allowing public URLs. This validation is integrated into the HTTP archive importer and webhook exporter.

## Key Changes
- **New module**: `vtsearch/utils/url_validation.py`
  - `validate_url()` function that enforces HTTP(S) schemes, validates hostnames, and resolves them to check for private/internal IP addresses
  - `_is_private_ip()` helper that uses Python's `ipaddress` module to detect private, loopback, reserved, link-local, multicast, and unspecified addresses
  - Blocks access to: 127.x.x.x, 10.x.x.x, 172.16-31.x.x, 192.168.x.x, 169.254.x.x, ::1 (IPv6 loopback), 0.0.0.0, and other reserved ranges

- **Integration points**:
  - `vtsearch/datasets/importers/http_zip/__init__.py`: Calls `validate_url()` in `run()` and `_download_and_extract()` methods
  - `vtsearch/exporters/webhook/__init__.py`: Calls `validate_url()` in `export()` method

- **Comprehensive test coverage**: `tests/test_ssrf_validation.py`
  - Tests for scheme enforcement (rejects ftp, file, javascript, etc.)
  - Tests for hostname validation (rejects empty/missing hostnames)
  - Tests for private IP blocking (127.x, 10.x, 172.16.x, 192.168.x, link-local, IPv6 loopback, 0.0.0.0)
  - Tests for multi-address resolution (blocks if ANY resolved address is private)
  - Integration tests verifying both importers and exporters properly validate URLs

- **Existing test updates**: `tests/test_csv_webhook_exporters.py`
  - Updated webhook exporter tests to mock `validate_url()` to avoid DNS resolution during testing

## Implementation Details
- Uses `socket.getaddrinfo()` to resolve hostnames and check all returned addresses
- Rejects URLs if any resolved address is in a private/internal range
- Provides clear error messages distinguishing between scheme errors, hostname errors, resolution failures, and private IP detection
- Returns the original URL string on successful validation for use in downstream code

https://claude.ai/code/session_01XkXP4s4YGSKaypMRkYvU8L