### PR TITLE
Make model training thread-safe with isolated RNG state

### DIFF
--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -146,7 +146,8 @@ def simulate_voting_iterations(
         ``seed, dataset, category, t, cost, fpr, fnr, elapsed_seconds``.
     """
     rng = np.random.RandomState(seed)
-    torch.manual_seed(seed)
+    # Note: no torch.manual_seed() here — train_model handles its own
+    # RNG seeding via fork_rng, keeping it thread-safe.
     start_time = time.monotonic()
 
     sim_ids, test_ids = _split_media_ids(clips_dict, sim_fraction, rng)

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -165,8 +165,9 @@ def train_model(
     (positive) or fewer (positive) items.
 
     A local ``torch.Generator`` seeded with *seed* is used for model-weight
-    initialisation, so the same inputs always produce the same trained model
-    without mutating PyTorch's global RNG (thread-safe).
+    initialisation, and ``torch.random.fork_rng`` isolates the global RNG
+    (used by ``nn.Dropout``) so concurrent calls don't overwrite each
+    other's seed (thread-safe and deterministic).
 
     Args:
         X_train: Float tensor of shape ``(N, input_dim)`` containing training embeddings.
@@ -199,9 +200,9 @@ def train_model(
     if hidden_dim is None:
         hidden_dim = _auto_hidden_dim(n_train)
 
-    # Seed both a local Generator (for weight init) and the global RNG
-    # (for nn.Dropout during training) so results are reproducible.
-    torch.manual_seed(seed)
+    # Use a local Generator for weight init and fork_rng for nn.Dropout
+    # so that concurrent training calls don't overwrite each other's
+    # global seed (thread-safe and deterministic).
     g = torch.Generator()
     g.manual_seed(seed)
 
@@ -233,8 +234,11 @@ def train_model(
     weights = torch.where(y_train == 1, weight_true, weight_false).squeeze()
     loss_fn = nn.BCEWithLogitsLoss(reduction="none")
 
+    # Fork the global RNG so the Dropout seed is isolated per call —
+    # concurrent training invocations each get their own RNG state.
     model.train()
-    with torch.enable_grad():
+    with torch.random.fork_rng(), torch.enable_grad():
+        torch.manual_seed(seed)
         for _ in range(TRAIN_EPOCHS):
             optimizer.zero_grad()
             logits = model(X_train)


### PR DESCRIPTION
## Summary
Refactored RNG seeding in model training to use `torch.random.fork_rng()` for isolating the global RNG state, ensuring concurrent training calls don't interfere with each other while maintaining deterministic results.

## Key Changes
- **training.py**: 
  - Replaced global `torch.manual_seed(seed)` call with `torch.random.fork_rng()` context manager to isolate the global RNG used by `nn.Dropout`
  - Moved `torch.manual_seed(seed)` inside the `fork_rng()` context so each training call has its own isolated RNG state
  - Updated docstring to clarify that `fork_rng` isolates the global RNG for thread-safety and determinism
  - Updated inline comments to explain the thread-safe RNG handling strategy

- **voting_iterations.py**:
  - Removed `torch.manual_seed(seed)` call since `train_model()` now handles its own RNG seeding
  - Added clarifying comment explaining that RNG seeding is delegated to `train_model()`

## Implementation Details
The key improvement is using `torch.random.fork_rng()` as a context manager around the training loop. This creates an isolated copy of the global RNG state for that scope, preventing concurrent calls to `train_model()` from overwriting each other's seeds. The local `torch.Generator` continues to handle weight initialization deterministically, while `nn.Dropout` now uses the isolated global RNG state.

https://claude.ai/code/session_01FHesBvCzkoGqnm6JSyvhs3