### PR TITLE
Fix test_clear_dataset to restore state after test execution

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -30,13 +30,14 @@ class TestDatasetEndpoints:
         assert "demos" in data or isinstance(data, dict)
 
     def test_clear_dataset(self, client):
-        resp = client.post("/api/dataset/clear")
-        assert resp.status_code == 200
-        # After clearing, medias should be empty
-        assert len(app_module.medias) == 0
-
-        # Re-initialize for other tests
-        app_module.init_medias()
+        saved = dict(app_module.medias)
+        try:
+            resp = client.post("/api/dataset/clear")
+            assert resp.status_code == 200
+            # After clearing, medias should be empty
+            assert len(app_module.medias) == 0
+        finally:
+            app_module.medias.update(saved)
 
 
 class TestStartupState:


### PR DESCRIPTION
## Summary
Modified the `test_clear_dataset` test to properly restore the application state after clearing the dataset, preventing test pollution and side effects on subsequent tests.

## Key Changes
- Replaced manual re-initialization with a try-finally block that saves and restores the `medias` state
- The test now preserves the original `medias` dictionary before clearing and restores it after assertions complete
- Removed the `app_module.init_medias()` call in favor of state restoration

## Implementation Details
The change improves test isolation by:
- Saving the current state of `app_module.medias` before the test runs
- Ensuring the state is restored in a `finally` block, guaranteeing cleanup even if assertions fail
- This approach is more robust than re-initialization as it preserves the exact pre-test state rather than relying on initialization logic

https://claude.ai/code/session_01EDsrXZexEr5z2JYgfaYPiY