### PR TITLE
Sort votes in API response instead of relying on insertion order

### DIFF
--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -80,16 +80,16 @@ class TestGetVotes:
         assert data["learned_scores"] == {}
 
     def test_returns_good_votes(self, client):
-        app_module.good_votes.update({k: None for k in [1, 3, 5]})
+        app_module.good_votes.update({k: None for k in [5, 1, 3]})
         resp = client.get("/api/votes")
         data = resp.get_json()
-        assert data["good"] == [1, 3, 5]  # sorted
+        assert data["good"] == [1, 3, 5]  # sorted regardless of insertion order
 
     def test_returns_bad_votes(self, client):
-        app_module.bad_votes.update({k: None for k in [2, 4]})
+        app_module.bad_votes.update({k: None for k in [4, 2]})
         resp = client.get("/api/votes")
         data = resp.get_json()
-        assert data["bad"] == [2, 4]  # sorted
+        assert data["bad"] == [2, 4]  # sorted regardless of insertion order
 
     def test_returns_both(self, client):
         app_module.good_votes[1] = None

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -166,8 +166,8 @@ def get_votes():
     learned_scores = get_learned_scores()
     return jsonify(
         {
-            "good": list(good_votes),  # Maintains insertion order (dict keys)
-            "bad": list(bad_votes),  # Maintains insertion order (dict keys)
+            "good": sorted(good_votes),
+            "bad": sorted(bad_votes),
             "click_times": {str(k): v for k, v in click_times.items()},
             "learned_scores": {str(k): round(v, 4) for k, v in learned_scores.items()},
         }


### PR DESCRIPTION
## Summary
Changed the `/api/votes` endpoint to return votes in sorted order rather than relying on dictionary insertion order, making the API response more predictable and consistent.

## Key Changes
- Modified `vtsearch/routes/sorting.py` to sort `good_votes` and `bad_votes` lists before returning them in the JSON response
- Updated test cases in `tests/test_votes.py` to verify sorting behavior by:
  - Inserting votes in non-sequential order (e.g., `[5, 1, 3]` instead of `[1, 3, 5]`)
  - Updating test comments to clarify that results are sorted regardless of insertion order

## Implementation Details
- The change replaces `list(good_votes)` and `list(bad_votes)` with `sorted(good_votes)` and `sorted(bad_votes)` respectively
- This ensures the API always returns votes in a consistent, sorted order independent of how they were added to the dictionaries
- Tests now explicitly verify this sorting behavior by inserting votes in random order and asserting they're returned sorted

https://claude.ai/code/session_017eMPidkr8hpUH3LYtsQ3gp