### PR TITLE
Strengthen logit unboundedness assertion in model output test

### DIFF
--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -126,8 +126,11 @@ class TestBuildModel:
         X = torch.ones(1, 32) * 100.0
         with torch.no_grad():
             logit = model(X).item()
-        # Raw logit can be any real number (not clamped to [0, 1])
+        # Raw logit is unbounded — with extreme input it should land outside [0, 1]
         assert isinstance(logit, float)
+        assert logit < 0.0 or logit > 1.0, (
+            f"Expected unbounded logit outside [0,1] with extreme input, got {logit}"
+        )
 
     def test_build_model_has_no_sigmoid_layer(self):
         from vtsearch.models.training import build_model


### PR DESCRIPTION
## Summary
Enhanced the test assertion for model logit output to explicitly verify that raw logits are unbounded and can fall outside the [0, 1] range when given extreme inputs.

## Changes
- Updated the comment to clarify that logits are unbounded rather than just "not clamped"
- Added an explicit assertion that validates the logit value falls outside [0, 1] when the model receives extreme input (all 100.0 values)
- Included a descriptive error message to aid debugging if the assertion fails

## Details
This change strengthens the test's validation that the model's output layer produces raw logits without any sigmoid activation or clamping. By asserting that extreme inputs produce logits outside [0, 1], the test now actively verifies the absence of a sigmoid layer rather than just checking the type.

https://claude.ai/code/session_01R4DgPF7ijK7ckdAg8eK3Rb