### PR TITLE
Strengthen labeling status API response validation

### DIFF
--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -558,8 +558,13 @@ class TestLabelingStatusContract:
         resp = self.client.get("/api/labeling-status")
         assert resp.status_code == 200
         data = resp.get_json()
-        # Should have status indicators or at minimum no error
-        assert "error" not in data or "good_count" in data
+        assert "error" not in data
+        assert "good_count" in data
+        assert "bad_count" in data
+        assert "total_count" in data
+        for key in ("smart", "stable", "span"):
+            assert key in data
+            assert "status" in data[key]
 
 
 class TestFillFromSortContract:


### PR DESCRIPTION
## Summary
Enhanced the test assertions for the labeling status API endpoint to enforce stricter validation of the response structure and required fields.

## Key Changes
- Replaced loose conditional assertion with explicit validation that `error` field must not be present
- Added explicit assertions for required count fields: `good_count`, `bad_count`, and `total_count`
- Added validation that status indicator objects (`smart`, `stable`, `span`) are present in the response
- Added assertion that each status indicator object contains a `status` field

## Details
The original test used a permissive assertion (`assert "error" not in data or "good_count" in data`) that would pass if either no error was present OR if good_count existed. The updated test now enforces that:
1. The response must never contain an error field
2. All count metrics must be present in the response
3. All three status indicators must be present with their required `status` field

This change ensures the API contract is properly validated and prevents regressions in the response structure.

https://claude.ai/code/session_01EbNJmTRwu3SFL8mr2fdyeN