### PR TITLE
Make media type registry dynamic for importers and settings

### DIFF
--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -103,7 +103,7 @@ class S3Importer(DatasetImporter):
             key="media_type",
             label="Media Type",
             field_type="select",
-            options=["sounds", "videos", "images", "paragraphs"],
+            options=all_folder_names(),  # from vtsearch.media
             default="sounds",
         ),
     ]

--- a/docs/old_io.md
+++ b/docs/old_io.md
@@ -621,7 +621,7 @@ class RSSDatasetImporter(DatasetImporter):
         ImporterField(key="url", label="Feed URL", field_type="url",
                       description="URL of an RSS or Atom feed with media enclosures."),
         ImporterField(key="media_type", label="Media Type", field_type="select",
-                      options=["sounds", "videos", "images", "paragraphs"], default="sounds",
+                      options=all_folder_names(), default="sounds",  # from vtsearch.media
                       description="Type of media to extract from the feed."),
         ImporterField(key="max_episodes", label="Max Episodes", field_type="text",
                       default="50", required=False,

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -18,6 +18,8 @@ Example – a minimal SFTP importer skeleton::
     # vtsearch/datasets/importers/sftp/__init__.py
     from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 
+    from vtsearch.media import all_folder_names
+
     class SftpImporter(DatasetImporter):
         name         = "sftp"
         display_name = "SFTP Server"
@@ -29,7 +31,7 @@ Example – a minimal SFTP importer skeleton::
             ImporterField("path",       "Remote Path", "text"),
             ImporterField(
                 "media_type", "Media Type", "select",
-                options=["sounds", "videos", "images", "paragraphs"],
+                options=all_folder_names(),
                 default="sounds",
             ),
         ]

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -148,7 +148,6 @@ class FolderDatasetImporter(DatasetImporter):
             label="Media Type",
             field_type="select",
             description="Type of media files to scan for in the folder.",
-            options=["sounds", "videos", "images", "paragraphs", "documents"],
             default="sounds",
         ),
         ImporterField(
@@ -158,6 +157,15 @@ class FolderDatasetImporter(DatasetImporter):
             description="Absolute path to the directory containing media files.",
         ),
     ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        from vtsearch.media import all_folder_names
+
+        for f in self.fields:
+            if f.key == "media_type":
+                f.options = all_folder_names()
+                break
 
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         folder = Path(field_values["path"])

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -170,10 +170,18 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             label="Media Type",
             field_type="select",
             description="Type of media files contained in the archive.",
-            options=["sounds", "videos", "images", "paragraphs"],
             default="sounds",
         ),
     ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        from vtsearch.media import all_folder_names
+
+        for f in self.fields:
+            if f.key == "media_type":
+                f.options = all_folder_names()
+                break
 
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         url = field_values["url"]

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -450,8 +450,7 @@ def load_dataset_from_folder(
     The ``medias`` dict is cleared before loading begins.
 
     ``media_type`` is looked up in the media type registry by
-    :attr:`~vtsearch.media.base.MediaType.folder_import_name` (e.g.
-    ``"sounds"``, ``"videos"``, ``"images"``, ``"paragraphs"``).  Adding a
+    :attr:`~vtsearch.media.base.MediaType.folder_import_name`.  Adding a
     new media type to the registry automatically makes it available here
     without any changes to this function.
 

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -77,6 +77,25 @@ def get_by_extension(ext: str) -> "MediaType | None":
     return None
 
 
+def all_folder_names() -> list[str]:
+    """Return the :attr:`~MediaType.folder_import_name` of every registered type.
+
+    Used by dataset importers to populate their media-type selection fields
+    dynamically, so adding a new media type to the registry is all that's
+    needed — no importer code changes required.
+    """
+    return [mt.folder_import_name for mt in _registry.values()]
+
+
+def all_type_ids() -> list[str]:
+    """Return the :attr:`~MediaType.type_id` of every registered type.
+
+    Used by settings validation so the set of valid media types stays in
+    sync with the registry automatically.
+    """
+    return list(_registry.keys())
+
+
 def all_types_dict() -> list[dict]:
     """Return a list of JSON-serialisable dicts describing all registered types.
 
@@ -160,6 +179,8 @@ __all__ = [
     "get_by_folder_name",
     "get_by_extension",
     "all_types",
+    "all_folder_names",
+    "all_type_ids",
     "all_types_dict",
     "all_demo_datasets",
     "set_progress_callback",

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -201,22 +201,28 @@ for _key, _cast, _coerce in _SETTING_SPECS:
 del _key, _cast, _coerce, _g, _s
 
 
-VALID_MEDIA_TYPES = ("audio", "document", "image", "paragraph", "video")
+def _valid_media_types() -> tuple[str, ...]:
+    """Return valid media type IDs from the media registry."""
+    from vtsearch.media import all_type_ids
+
+    return tuple(all_type_ids())
 
 
 def get_autoload_media_types() -> list[str]:
     """Return the list of autoload media type IDs (empty list if none set)."""
+    valid = _valid_media_types()
     with _settings_lock:
         raw = _ensure_loaded().get("autoload_media_types", _DEFAULTS["autoload_media_types"])
         if isinstance(raw, list):
-            return [v for v in raw if v in VALID_MEDIA_TYPES]
+            return [v for v in raw if v in valid]
         return []
 
 
 def set_autoload_media_types(value: list[str]) -> None:
     """Set and persist the full list of autoload media types."""
+    valid = _valid_media_types()
     for v in value:
-        if v not in VALID_MEDIA_TYPES:
+        if v not in valid:
             raise ValueError(f"Invalid media type: {v!r}")
     with _settings_lock:
         s = _ensure_loaded()
@@ -226,7 +232,7 @@ def set_autoload_media_types(value: list[str]) -> None:
 
 def toggle_autoload_media_type(type_id: str) -> list[str]:
     """Toggle a single media type's autoload status.  Returns the updated list."""
-    if type_id not in VALID_MEDIA_TYPES:
+    if type_id not in _valid_media_types():
         raise ValueError(f"Invalid media type: {type_id!r}")
     with _settings_lock:
         current = get_autoload_media_types()


### PR DESCRIPTION
## Summary
This PR makes the media type system more extensible by dynamically pulling valid media types from the registry instead of hardcoding them. This eliminates the need to update multiple files when adding a new media type.

## Key Changes

- **New registry functions** (`vtsearch/media/__init__.py`):
  - Added `all_folder_names()` to return folder import names for all registered media types
  - Added `all_type_ids()` to return type IDs for all registered media types
  - Both functions are exported in `__all__`

- **Settings validation** (`vtsearch/settings.py`):
  - Replaced hardcoded `VALID_MEDIA_TYPES` tuple with `_valid_media_types()` function that queries the registry
  - Updated `get_autoload_media_types()`, `set_autoload_media_types()`, and `toggle_autoload_media_type()` to use the dynamic validation

- **Dataset importers** (`vtsearch/datasets/importers/`):
  - `FolderDatasetImporter` and `HttpArchiveDatasetImporter` now populate media type options dynamically in `__init__()` instead of hardcoding them
  - Updated docstring example in `base.py` to show usage of `all_folder_names()`

- **Documentation** (`docs/`):
  - Updated examples to use `all_folder_names()` instead of hardcoded media type lists

## Implementation Details

- The dynamic options are set in importer `__init__()` methods by importing `all_folder_names()` and updating the appropriate field's options
- Settings validation now calls `_valid_media_types()` each time validation is needed, ensuring it stays in sync with the registry
- This approach maintains backward compatibility while making the system more maintainable

https://claude.ai/code/session_01Pk89iF5FdbgnqGmmsRmmKM