### PR TITLE
Optimize media list selection and vote class updates

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3865,8 +3865,22 @@
     _rebuildVoteSets();
     renderVotes();
     renderStripe();
+    _syncMediaListVoteClasses();
     updateSortModeAvailability();
     if (selected) renderCenter();
+  }
+
+  /**
+   * Sync vote label classes (labeled-good / labeled-bad) on existing
+   * media-list items without rebuilding the DOM.
+   */
+  function _syncMediaListVoteClasses() {
+    const items = mediaList.querySelectorAll("[data-media-id]");
+    items.forEach(el => {
+      const id = parseInt(el.getAttribute("data-media-id"), 10);
+      el.classList.toggle("labeled-good", goodVoteSet.has(id));
+      el.classList.toggle("labeled-bad", badVoteSet.has(id));
+    });
   }
 
   async function fetchInclusion() {
@@ -3920,6 +3934,7 @@
       if (isGood) className += " labeled-good";
       if (isBad) className += " labeled-bad";
       div.className = className;
+      div.setAttribute("data-media-id", c.id);
       div.setAttribute("role", "option");
       div.setAttribute("tabindex", "0");
       div.setAttribute("aria-selected", selected === c.id ? "true" : "false");
@@ -3954,8 +3969,16 @@
   }
 
   function selectMedia(id) {
+    const prev = selected;
     selected = id;
-    renderMediaList();
+
+    // Try lightweight in-place selection update instead of full DOM rebuild.
+    // This avoids destroying and re-creating all thumbnail <img>/<video>
+    // elements, which would cause the browser to re-fetch visible media.
+    const didLightweight = _updateSelectionInPlace(prev, id);
+    if (!didLightweight) {
+      renderMediaList();
+    }
     renderCenter();
 
     const activeItem = mediaList.querySelector(".media-item.active");
@@ -3967,6 +3990,58 @@
     if (c) {
       announce(`Selected ${c.filename || 'Media #' + c.id}`);
     }
+  }
+
+  /**
+   * Update the active selection highlight in the media list and stripe
+   * without rebuilding the DOM.  Returns true if it succeeded, false if
+   * a full rebuild is needed (e.g. the list hasn't been rendered yet).
+   */
+  function _updateSelectionInPlace(prevId, newId) {
+    // If the media list has no items with data-media-id, fall back to full rebuild.
+    if (!mediaList.querySelector("[data-media-id]")) return false;
+
+    // Deactivate previously selected item
+    if (prevId != null) {
+      const prevEl = mediaList.querySelector(`[data-media-id="${prevId}"]`);
+      if (prevEl) {
+        prevEl.classList.remove("active");
+        prevEl.setAttribute("aria-selected", "false");
+      }
+    }
+
+    // Activate newly selected item
+    const newEl = mediaList.querySelector(`[data-media-id="${newId}"]`);
+    if (newEl) {
+      newEl.classList.add("active");
+      newEl.setAttribute("aria-selected", "true");
+    }
+
+    // Update stripe selected dot in-place
+    _updateStripeSelectedDot(newId);
+
+    return true;
+  }
+
+  /**
+   * Move the "selected" dot on the stripe to reflect the new selection
+   * without rebuilding the entire stripe.
+   */
+  function _updateStripeSelectedDot(newId) {
+    // Remove old selected dot
+    const oldDot = stripeContainer.querySelector(".stripe-dot.selected");
+    if (oldDot) oldDot.remove();
+
+    if (!sortOrder || sortOrder.length === 0) return;
+
+    const totalClips = sortOrder.length;
+    const idx = sortOrder.findIndex(item => item.id === newId);
+    if (idx < 0) return;
+
+    const dot = document.createElement("div");
+    dot.className = "stripe-dot selected";
+    dot.style.top = `${(idx / totalClips) * 100}%`;
+    stripeContainer.appendChild(dot);
   }
 
   // Stored references for window-level mouse handlers used by image pan,


### PR DESCRIPTION
## Summary
This PR optimizes the media list UI updates by avoiding unnecessary full DOM rebuilds when selecting items or updating vote classes. Instead of re-rendering the entire list, the code now performs lightweight in-place updates to selection state and vote labels.

## Key Changes
- **Added `_syncMediaListVoteClasses()` function**: Efficiently updates vote label classes (`labeled-good`/`labeled-bad`) on existing media list items without DOM reconstruction
- **Added `_updateSelectionInPlace()` function**: Performs lightweight selection updates by toggling the `active` class and `aria-selected` attribute instead of rebuilding the entire media list
- **Added `_updateStripeSelectedDot()` function**: Updates the stripe indicator dot position without rebuilding the entire stripe
- **Added `data-media-id` attribute**: Media list items now store their ID as a data attribute to enable efficient DOM queries for in-place updates
- **Modified `selectMedia()` function**: Now attempts lightweight in-place selection updates first, falling back to full `renderMediaList()` only when necessary
- **Modified `renderMediaList()` function**: Now sets the `data-media-id` attribute when creating media items

## Implementation Details
- The in-place selection update checks if the media list has been rendered (by looking for elements with `data-media-id`) and falls back to a full rebuild if not
- Vote class syncing is called after vote set rebuilds to keep the DOM in sync without full re-renders
- The stripe selected dot is recreated in-place rather than rebuilding the entire stripe, preserving media element state and preventing unnecessary re-fetches

https://claude.ai/code/session_01VDZj5mVzzCZufQoDr4HqiX