### PR TITLE
Fix diversity value rounding to use floor instead of round

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -768,8 +768,9 @@
     }
     if (st.phase === "new") {
       const frac = st.fracDiversity ?? 0;
+      const fracFloored = Math.floor(frac * 10) / 10;
       const pct = Math.min(100, Math.max(0, Math.round((frac / 4) * 100)));
-      return `Diversity ${frac.toFixed(1)} / 4 `
+      return `Diversity ${fracFloored.toFixed(1)} / 4 `
         + `<span class="ap-progress-bar"><span class="ap-progress-fill" style="width:${pct}%"></span></span>`;
     }
     return "";
@@ -5812,9 +5813,10 @@
       const dvChart = document.getElementById("diversity-chart");
       if (dvChart) {
         dvChart.setAttribute("role", "img");
-        const lastLevel = data.diversity_level_over_time && data.diversity_level_over_time.length > 0
-          ? data.diversity_level_over_time[data.diversity_level_over_time.length - 1].diversity_level.toFixed(2)
-          : "N/A";
+        const lastLevelRaw = data.diversity_level_over_time && data.diversity_level_over_time.length > 0
+          ? data.diversity_level_over_time[data.diversity_level_over_time.length - 1].diversity_level
+          : null;
+        const lastLevel = lastLevelRaw !== null ? (Math.floor(lastLevelRaw * 100) / 100).toFixed(2) : "N/A";
         dvChart.setAttribute("aria-label", `Diversity level chart with ${(data.diversity_level_over_time || []).length} data points. Latest level: ${lastLevel}`);
       }
       // Update span info text from cached status


### PR DESCRIPTION
## Summary
This PR fixes the diversity value display to use floor-based rounding instead of standard rounding, ensuring more conservative and consistent representation of diversity metrics.

## Key Changes
- **Diversity display in phase "new"**: Changed from direct `frac` value to `fracFloored` which uses `Math.floor(frac * 10) / 10` to round down to one decimal place
- **Diversity chart aria-label**: Updated the calculation of `lastLevel` to use floor-based rounding (`Math.floor(lastLevelRaw * 100) / 100`) instead of standard rounding, with refactored logic to separate raw value extraction from formatting

## Implementation Details
- Both changes apply the same floor-based rounding strategy: multiply by a power of 10, apply `Math.floor()`, then divide back
- The diversity chart update also improves code clarity by separating the raw value retrieval (`lastLevelRaw`) from the formatted display value (`lastLevel`)
- The rounding behavior now consistently floors values to the nearest 0.01 (for chart) and 0.1 (for phase display) rather than using standard rounding

https://claude.ai/code/session_01LUW3tZtrpqHLoC3sLmdkSL