### PR TITLE
Refactor metadata display to use type-specific display_metadata()

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4032,43 +4032,26 @@
           <span class="metadata-label">Name</span>
           <span class="metadata-value">${escapeHtml(c.filename || 'Media #' + c.id)}</span>
         </div>
-        ${c.frequency ? `
-        <div class="metadata-item">
-          <span class="metadata-label">Frequency</span>
-          <span class="metadata-value">${escapeHtml(String(c.frequency))} Hz</span>
-        </div>` : ''}
-        ${c.category && c.category !== 'unknown' ? `
-        <div class="metadata-item">
-          <span class="metadata-label">Category</span>
-          <span class="metadata-value">${escapeHtml(c.category)}</span>
-        </div>` : ''}
         <div class="metadata-item">
           <span class="metadata-label">Media Type</span>
           <span class="metadata-value">${escapeHtml(mtInfo ? mtInfo.name : mediaType)}</span>
         </div>
-        ${(c.duration && c.duration > 0) ? `
-        <div class="metadata-item">
-          <span class="metadata-label">Duration</span>
-          <span class="metadata-value">${c.duration.toFixed(1)}s</span>
-        </div>` : ''}
-        ${(c.width && c.height) ? `
-        <div class="metadata-item">
-          <span class="metadata-label">Dimensions</span>
-          <span class="metadata-value">${c.width}×${c.height}</span>
-        </div>` : ''}
-        ${(c.word_count) ? `
-        <div class="metadata-item">
-          <span class="metadata-label">Word Count</span>
-          <span class="metadata-value">${c.word_count}</span>
-        </div>
-        <div class="metadata-item">
-          <span class="metadata-label">Characters</span>
-          <span class="metadata-value">${c.character_count}</span>
-        </div>` : ''}
-        ${c.file_size ? `<div class="metadata-item">
-          <span class="metadata-label">File Size</span>
-          <span class="metadata-value">${(c.file_size / 1024).toFixed(1)} KB</span>
-        </div>` : ''}
+        ${Object.entries(c.custom_metadata || {}).map(([label, value]) => {
+          let displayValue;
+          if (label === 'File Size' && typeof value === 'number') {
+            displayValue = (value / 1024).toFixed(1) + ' KB';
+          } else if (label === 'Duration' && typeof value === 'number') {
+            displayValue = value.toFixed(1) + 's';
+          } else if (label === 'Frequency' && typeof value === 'number') {
+            displayValue = value + ' Hz';
+          } else {
+            displayValue = escapeHtml(String(value));
+          }
+          return `<div class="metadata-item">
+          <span class="metadata-label">${escapeHtml(label)}</span>
+          <span class="metadata-value">${displayValue}</span>
+        </div>`;
+        }).join('')}
         <div class="metadata-item">
           <span class="metadata-label">MD5</span>
           <span class="metadata-value metadata-md5">${escapeHtml(c.md5)}</span>

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -33,9 +33,15 @@ class TestMediasContract:
     def test_each_media_has_required_fields(self):
         resp = self.client.get("/api/medias")
         data = resp.get_json()
-        required = {"id", "type", "duration", "file_size", "filename", "category", "md5"}
+        required = {"id", "type", "filename", "md5", "custom_metadata"}
         for item in data:
             assert required.issubset(item.keys()), f"Missing keys: {required - item.keys()}"
+
+    def test_custom_metadata_is_dict(self):
+        resp = self.client.get("/api/medias")
+        data = resp.get_json()
+        for item in data:
+            assert isinstance(item["custom_metadata"], dict)
 
     def test_id_is_integer(self):
         resp = self.client.get("/api/medias")
@@ -43,12 +49,13 @@ class TestMediasContract:
         for item in data:
             assert isinstance(item["id"], int)
 
-    def test_file_size_is_positive_integer(self):
+    def test_file_size_in_custom_metadata(self):
         resp = self.client.get("/api/medias")
         data = resp.get_json()
         for item in data:
-            assert isinstance(item["file_size"], int)
-            assert item["file_size"] > 0
+            assert "File Size" in item["custom_metadata"]
+            assert isinstance(item["custom_metadata"]["File Size"], int)
+            assert item["custom_metadata"]["File Size"] > 0
 
     def test_md5_is_32_char_hex_string(self):
         resp = self.client.get("/api/medias")

--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -85,9 +85,14 @@ class TestListMedias:
         data = resp.get_json()
         for media in data:
             assert "id" in media
-            assert "frequency" in media
-            assert "duration" in media
-            assert "file_size" in media
+            assert "md5" in media
+            assert "filename" in media
+            assert "custom_metadata" in media
+            # Type-specific fields appear in custom_metadata
+            cm = media["custom_metadata"]
+            assert "Frequency" in cm
+            assert "Duration" in cm
+            assert "File Size" in cm
 
     def test_does_not_expose_media_bytes(self, client):
         resp = client.get("/api/medias")

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -63,6 +63,16 @@ class DatasetImporter(PluginBase):
     and expose a module-level ``IMPORTER = YourImporter()`` – the registry
     picks it up automatically.
 
+    Custom metadata
+    ---------------
+    Importers can attach arbitrary per-media display metadata by setting
+    ``media["custom_metadata"]`` to a ``dict[str, Any]`` mapping
+    human-readable labels to values.  For example, an S3 importer might
+    set ``{"Uploaded By": "alice", "Bucket": "my-data"}``.  These fields
+    are merged with the media type's built-in display fields and rendered
+    in the labeling UI.  The dict is also persisted through pickle
+    export/import.
+
     Content vectors
     ---------------
     Some importers provide pre-computed content vectors (embeddings) alongside

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -877,6 +877,9 @@ def load_dataset_from_pickle(
                 }
                 for field in _extra_fields.get(media_type, []):
                     media_data[field] = media_info.get(field)
+                cm = media_info.get("custom_metadata")
+                if cm:
+                    media_data["custom_metadata"] = cm
 
                 medias[media_id] = media_data
                 loaded_count += 1
@@ -950,6 +953,9 @@ def load_dataset_from_pickle(
                 }
                 for field in _extra_fields.get(media_type, []):
                     media_data[field] = media_info.get(field)
+                cm = media_info.get("custom_metadata")
+                if cm:
+                    media_data["custom_metadata"] = cm
 
                 medias[media_id] = media_data
                 loaded_count += 1
@@ -1065,6 +1071,9 @@ def load_dataset_from_pickle_chunked(
                 }
                 for field in _extra_fields.get(media_type, []):
                     media_data[field] = media_info.get(field)
+                cm = media_info.get("custom_metadata")
+                if cm:
+                    media_data["custom_metadata"] = cm
 
                 chunk_medias[new_id] = media_data
                 new_id += 1
@@ -1132,6 +1141,9 @@ def load_dataset_from_pickle_chunked(
                 }
                 for field in _extra_fields.get(media_type, []):
                     media_data[field] = media_info.get(field)
+                cm = media_info.get("custom_metadata")
+                if cm:
+                    media_data["custom_metadata"] = cm
 
                 chunk_medias[new_id] = media_data
                 new_id += 1
@@ -1307,6 +1319,7 @@ def export_dataset_to_file(
                 "character_count": media.get("character_count"),
                 "width": media.get("width"),
                 "height": media.get("height"),
+                "custom_metadata": media.get("custom_metadata"),
             }
             for cid, media in medias.items()
         }

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -85,6 +85,26 @@ class AudioMediaType(MediaType):
         return ["wav_bytes"]
 
     # ------------------------------------------------------------------
+    # Display metadata
+    # ------------------------------------------------------------------
+
+    def display_metadata(self, media: dict) -> dict:
+        result: dict = {}
+        freq = media.get("frequency")
+        if freq:
+            result["Frequency"] = freq
+        cat = media.get("category")
+        if cat and cat not in ("unknown", "custom"):
+            result["Category"] = cat
+        dur = media.get("duration")
+        if dur and dur > 0:
+            result["Duration"] = dur
+        fs = media.get("file_size")
+        if fs:
+            result["File Size"] = fs
+        return result
+
+    # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
 

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -294,6 +294,32 @@ class MediaType(ABC):
         return []
 
     # ------------------------------------------------------------------
+    # Display metadata
+    # ------------------------------------------------------------------
+
+    def display_metadata(self, media: dict) -> dict[str, Any]:
+        """Build an ordered dict of display-worthy metadata for *media*.
+
+        The returned dict maps human-readable labels to values.  These are
+        shown in the labeling UI's metadata grid.  The base implementation
+        includes **Category** and **File Size** when present.  Subclasses
+        override this to add type-specific fields (Duration, Dimensions,
+        Word Count, etc.).
+
+        Importers can additionally set ``media["custom_metadata"]`` to
+        supply per-item fields (e.g. ``{"Uploaded By": "alice"}``).  The
+        API route merges both sources before sending the response.
+        """
+        result: dict[str, Any] = {}
+        cat = media.get("category")
+        if cat and cat not in ("unknown", "custom"):
+            result["Category"] = cat
+        fs = media.get("file_size")
+        if fs:
+            result["File Size"] = fs
+        return result
+
+    # ------------------------------------------------------------------
     # Viewer behaviour
     # ------------------------------------------------------------------
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -120,6 +120,23 @@ class ImageMediaType(MediaType):
         return ["width", "height"]
 
     # ------------------------------------------------------------------
+    # Display metadata
+    # ------------------------------------------------------------------
+
+    def display_metadata(self, media: dict) -> dict:
+        result: dict = {}
+        cat = media.get("category")
+        if cat and cat not in ("unknown", "custom"):
+            result["Category"] = cat
+        w, h = media.get("width"), media.get("height")
+        if w and h:
+            result["Dimensions"] = f"{w}\u00d7{h}"
+        fs = media.get("file_size")
+        if fs:
+            result["File Size"] = fs
+        return result
+
+    # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
 

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -81,6 +81,26 @@ class TextMediaType(MediaType):
         return ["word_count", "character_count"]
 
     # ------------------------------------------------------------------
+    # Display metadata
+    # ------------------------------------------------------------------
+
+    def display_metadata(self, media: dict) -> dict:
+        result: dict = {}
+        cat = media.get("category")
+        if cat and cat not in ("unknown", "custom"):
+            result["Category"] = cat
+        wc = media.get("word_count")
+        if wc:
+            result["Word Count"] = wc
+        cc = media.get("character_count")
+        if cc:
+            result["Characters"] = cc
+        fs = media.get("file_size")
+        if fs:
+            result["File Size"] = fs
+        return result
+
+    # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -104,6 +104,23 @@ class VideoMediaType(MediaType):
         return ["video_bytes"]
 
     # ------------------------------------------------------------------
+    # Display metadata
+    # ------------------------------------------------------------------
+
+    def display_metadata(self, media: dict) -> dict:
+        result: dict = {}
+        cat = media.get("category")
+        if cat and cat not in ("unknown", "custom"):
+            result["Category"] = cat
+        dur = media.get("duration")
+        if dur and dur > 0:
+            result["Duration"] = dur
+        fs = media.get("file_size")
+        if fs:
+            result["File Size"] = fs
+        return result
+
+    # ------------------------------------------------------------------
     # Viewer
     # ------------------------------------------------------------------
 

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -59,29 +59,36 @@ def list_medias() -> Response:
     """Return metadata for all loaded medias as a JSON array.
 
     Excludes heavyweight fields (``embedding``, ``media_bytes``,
-    ``media_string``) from the response. Only includes the
-    ``frequency`` field when it is present (synthetic medias only).
+    ``media_string``) from the response.
+
+    Each item contains the required fields ``id``, ``type``, ``filename``,
+    ``md5``, and a ``custom_metadata`` dict of display-worthy key/value
+    pairs contributed by the media type and/or importer.
 
     Returns:
-        A JSON array of media metadata dicts, each containing: ``id``, ``type``,
-        ``duration``, ``file_size``, ``filename``, ``category``, ``md5``, and
-        optionally ``frequency``, ``width``, ``height``, ``word_count``.
+        A JSON array of media metadata dicts.
     """
+    from vtsearch.media import get as get_media_type  # noqa: PLC0415
+
     result: list[dict[str, Any]] = []
     for c in snapshot_medias().values():
+        media_type_id = c.get("type", "audio")
         media_data: dict[str, Any] = {
             "id": c["id"],
-            "type": c.get("type", "audio"),
-            "duration": c["duration"],
-            "file_size": c["file_size"],
+            "type": media_type_id,
             "filename": c.get("filename", f"media_{c['id']}.wav"),
-            "category": c.get("category", "unknown"),
             "md5": c["md5"],
         }
-        # Only include optional fields when present
-        for key in ("frequency", "width", "height", "word_count"):
-            if key in c:
-                media_data[key] = c[key]
+        # Build custom_metadata from media type + any importer-supplied fields
+        try:
+            mt = get_media_type(media_type_id)
+            custom: dict[str, Any] = mt.display_metadata(c)
+        except (KeyError, Exception):
+            custom = {}
+        importer_custom = c.get("custom_metadata")
+        if importer_custom:
+            custom.update(importer_custom)
+        media_data["custom_metadata"] = custom
         result.append(media_data)
     return jsonify(result)
 


### PR DESCRIPTION
## Summary
This PR refactors how media metadata is displayed in the UI and API by introducing a new `display_metadata()` method on media types. Instead of hardcoding field logic in the frontend and API route, each media type now defines which fields should be displayed and how they should be formatted.

## Key Changes

- **New `display_metadata()` method**: Added to `MediaType` base class and implemented in all media type subclasses (Audio, Video, Image, Text) to return an ordered dict of display-worthy metadata fields
- **Simplified API response**: The `/api/medias` endpoint now returns a single `custom_metadata` dict per media instead of individual top-level fields (`duration`, `file_size`, `category`, `frequency`, etc.)
- **Frontend refactoring**: Replaced hardcoded conditional rendering of metadata fields with a generic loop over `custom_metadata` entries, with special formatting for File Size, Duration, and Frequency
- **Importer support**: Importers can now set `media["custom_metadata"]` to contribute custom per-item fields (e.g., `{"Uploaded By": "alice"}`) that are merged with type-specific metadata
- **Persistence**: Custom metadata is now preserved through pickle export/import cycles
- **Updated tests**: API contract tests updated to reflect the new response structure with `custom_metadata` as a required field

## Implementation Details

- Each media type's `display_metadata()` method builds metadata from the media dict, filtering out "unknown" and "custom" categories
- The base `MediaType` class provides default handling for Category and File Size
- Subclasses override to add type-specific fields (Frequency for Audio, Dimensions for Image, Word Count for Text, etc.)
- The API route calls `display_metadata()` for each media type and merges results with any importer-supplied custom metadata
- Frontend formatting logic (KB conversion, Hz suffix, duration rounding) is preserved in the generic metadata rendering loop

https://claude.ai/code/session_01LUcXPeeAE7SeZ2kht1fFfi