### PR TITLE
Refactor importer UI modes to use plugin attributes instead of hardcoded lists

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2944,8 +2944,8 @@
       const res = await fetch("/api/exporters");
       if (res.ok) labelsetExporters = await res.json();
     } catch (_) { /* ignore */ }
-    // Filter out the GUI exporter (not useful for file-based export)
-    labelsetExporters = labelsetExporters.filter(e => e.name !== "gui");
+    // Filter out exporters that are hidden from picker (e.g. the GUI exporter)
+    labelsetExporters = labelsetExporters.filter(e => !e.hidden_from_picker);
 
     let html = `
       <div id="detector-export-browser-btn" class="option-card" role="button" tabindex="0">
@@ -5842,7 +5842,7 @@
 
     // Also add demo datasets as an option
     const options = importers.map(imp => `
-      <div class="dataset-importer-option option-card" data-name="${escapeHtml(imp.name)}" data-type="importer">
+      <div class="dataset-importer-option option-card" data-name="${escapeHtml(imp.name)}" data-type="importer" data-ui-mode="${escapeHtml(imp.ui_mode || 'form')}">
         <span class="option-card-icon">${escapeHtml(imp.icon || '\uD83D\uDD0C')}</span>
         <div>
           <div class="option-card-title">${escapeHtml(imp.display_name)}</div>
@@ -5870,15 +5870,16 @@
       el.setAttribute("tabindex", "0");
       const name = el.dataset.name;
       const type = el.dataset.type;
+      const uiMode = el.dataset.uiMode || "form";
       el.addEventListener("click", () => {
         if (type === "demo") {
           showDashDemoDatasetPicker();
-        } else if (name === "pickle") {
-          // Pickle = file upload — close modal and trigger file input
+        } else if (uiMode === "file_upload") {
+          // File upload importers — close modal and trigger file input
           datasetImporterModal.classList.remove("show");
           dashFileInput.click();
-        } else if (name === "combine_datasets") {
-          // Combine = close modal and go to welcome screen combine flow
+        } else if (uiMode === "custom") {
+          // Custom UI importers — close modal and show dedicated UI
           datasetImporterModal.classList.remove("show");
           showCombineDatasetsForm();
           datasetWelcome.style.display = "flex";

--- a/tests/test_combine_datasets.py
+++ b/tests/test_combine_datasets.py
@@ -133,10 +133,12 @@ class TestCombineDatasetsMetadata:
 
 
 class TestCombineDatasetsBuiltinExclusion:
-    def test_combine_datasets_in_builtin_names(self):
-        from vtsearch.routes.datasets import _BUILTIN_IMPORTER_NAMES
+    def test_combine_datasets_has_custom_ui_mode(self):
+        from vtsearch.datasets.importers import get_importer
 
-        assert "combine_datasets" in _BUILTIN_IMPORTER_NAMES
+        imp = get_importer("combine_datasets")
+        assert imp is not None
+        assert imp.ui_mode == "custom"
 
     def test_combine_datasets_not_in_extended_list(self, client):
         resp = client.get("/api/dataset/importers")

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -309,15 +309,19 @@ class TestFolderImporterMetadata:
 
 
 class TestBuiltinImporterNames:
-    def test_folder_not_in_builtin_names(self):
-        from vtsearch.routes.datasets import _BUILTIN_IMPORTER_NAMES
+    def test_folder_has_form_ui_mode(self):
+        from vtsearch.datasets.importers import get_importer
 
-        assert "folder" not in _BUILTIN_IMPORTER_NAMES
+        imp = get_importer("folder")
+        assert imp is not None
+        assert imp.ui_mode == "form"
 
-    def test_pickle_still_in_builtin_names(self):
-        from vtsearch.routes.datasets import _BUILTIN_IMPORTER_NAMES
+    def test_pickle_has_file_upload_ui_mode(self):
+        from vtsearch.datasets.importers import get_importer
 
-        assert "pickle" in _BUILTIN_IMPORTER_NAMES
+        imp = get_importer("pickle")
+        assert imp is not None
+        assert imp.ui_mode == "file_upload"
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -273,3 +273,46 @@ class DatasetImporter(PluginBase):
             if val:
                 params[f.key] = str(val)
         return {"importer": self.name, "params": params}
+
+    # ------------------------------------------------------------------
+    # Origin display and reload
+    # ------------------------------------------------------------------
+
+    def origin_display(self, origin: dict[str, Any]) -> str:
+        """Return a human-readable string for an origin dict from this importer.
+
+        The default implementation returns ``"<name>:<first_param_value>"``
+        or just ``"<name>"`` when there are no params.  Subclasses may
+        override for a more descriptive representation.
+        """
+        params = origin.get("params", {})
+        if params:
+            first_val = next(iter(params.values()))
+            return f"{self.name}:{first_val}"
+        return self.name
+
+    def can_reload_from_origin(self, origin: dict[str, Any]) -> bool:
+        """Return whether this importer can re-load data from *origin*.
+
+        The default implementation returns ``True`` — most importers can
+        reload from their stored params.  Importers that require browser
+        uploads (e.g. pickle) should return ``False`` unless the params
+        contain enough info to reload (e.g. a server file path).
+
+        Subclasses should override when their reload capability depends on
+        the specific origin params (e.g. checking if a file still exists).
+        """
+        return True
+
+    def reload_from_origin(self, origin: dict[str, Any]) -> dict[str, Any] | None:
+        """Extract field_values from an origin dict suitable for :meth:`run`.
+
+        Returns a field_values dict that can be passed to
+        :meth:`run` / ``_run_importer_in_background()``, or ``None`` if
+        the origin cannot be reloaded.
+
+        The default implementation returns the origin's ``params`` dict
+        directly, which works for importers whose fields accept plain
+        strings.
+        """
+        return dict(origin.get("params", {}))

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -44,6 +44,7 @@ class CombineDatasetsImporter(DatasetImporter):
     display_name = "Combine Existing Datasets"
     description = "Merge multiple .pkl datasets into one, skipping duplicates."
     icon = "\U0001f500"  # twisted rightwards arrows
+    ui_mode = "custom"
     fields = [
         ImporterField(
             key="datasets",

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -246,5 +246,14 @@ class FolderDatasetImporter(DatasetImporter):
             origin["params"]["converters"] = converters
         return origin
 
+    def origin_display(self, origin: dict[str, Any]) -> str:
+        params = origin.get("params", {})
+        return f"folder:{params.get('path', '')}"
+
+    def can_reload_from_origin(self, origin: dict[str, Any]) -> bool:
+        params = origin.get("params", {})
+        folder_path = params.get("path", "")
+        return bool(folder_path) and Path(folder_path).is_dir()
+
 
 IMPORTER = FolderDatasetImporter()

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -32,6 +32,7 @@ class PickleDatasetImporter(DatasetImporter):
     name = "pickle"
     display_name = "Pickle File"
     description = "Load a previously exported .pkl dataset file."
+    ui_mode = "file_upload"
     fields = [
         ImporterField(
             key="file",
@@ -78,6 +79,23 @@ class PickleDatasetImporter(DatasetImporter):
         if not file_path.exists():
             raise FileNotFoundError(f"Dataset file not found: {file_path}")
         yield from load_dataset_from_pickle_chunked(file_path, chunk_size, thin=thin)
+
+    def origin_display(self, origin: dict[str, Any]) -> str:
+        params = origin.get("params", {})
+        filename = params.get("filename", params.get("path", ""))
+        return f"file:{filename}" if filename else "pickle"
+
+    def can_reload_from_origin(self, origin: dict[str, Any]) -> bool:
+        params = origin.get("params", {})
+        pkl_path = params.get("path", "")
+        return bool(pkl_path) and Path(pkl_path).is_file()
+
+    def reload_from_origin(self, origin: dict[str, Any]) -> dict[str, Any] | None:
+        params = origin.get("params", {})
+        pkl_path = params.get("path", "")
+        if not pkl_path or not Path(pkl_path).is_file():
+            return None
+        return {"file": pkl_path}
 
 
 IMPORTER = PickleDatasetImporter()

--- a/vtsearch/exporters/gui/__init__.py
+++ b/vtsearch/exporters/gui/__init__.py
@@ -37,6 +37,7 @@ class DisplayLabelsetExporter(LabelsetExporter):
     display_name = "Display Results"
     description = "Display the results in the browser (GUI) or print to console (CLI)."
     icon = "🖥️"
+    hidden_from_picker = True
     fields = []  # no questions to ask
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -63,10 +63,6 @@ datasets_bp = Blueprint("datasets", __name__)
 # Register the UI sub-blueprint.
 datasets_bp.register_blueprint(datasets_ui_bp)
 
-# Names of importers that have dedicated, hand-crafted UI sections in the
-# frontend.  They are excluded from the generic /api/dataset/importers list
-# so the frontend doesn't render a duplicate panel for them.
-_BUILTIN_IMPORTER_NAMES = {"pickle", "combine_datasets"}
 
 
 # ---------------------------------------------------------------------------
@@ -150,8 +146,8 @@ def dataset_progress():
 
 @datasets_bp.route("/api/dataset/importers")
 def dataset_importers():
-    """List all registered importers (excluding those with dedicated UI)."""
-    extended = [imp.to_dict() for imp in list_importers() if imp.name not in _BUILTIN_IMPORTER_NAMES]
+    """List all registered importers (excluding those with non-form UI)."""
+    extended = [imp.to_dict() for imp in list_importers() if imp.ui_mode == "form"]
     return jsonify({"importers": extended})
 
 
@@ -630,9 +626,16 @@ def load_dataset_from_source():
 
 
 def _load_from_origin(source: dict):
-    """Start loading a dataset from a raw origin dict (internal helper)."""
+    """Start loading a dataset from a raw origin dict (internal helper).
+
+    Special pseudo-origins (``"dupe_set"``, ``"demo"``) are handled inline.
+    All real importers are dispatched generically via
+    :meth:`~DatasetImporter.reload_from_origin`.
+    """
     importer_name = source.get("importer", "")
     params = source.get("params", {})
+
+    # --- pseudo-origins (not real importers) ---
 
     if importer_name == "dupe_set":
         members = source.get("members", [])
@@ -654,44 +657,26 @@ def _load_from_origin(source: dict):
         )
         return jsonify({"ok": True, "message": "Loading started"})
 
-    if importer_name == "pickle":
-        pkl_path = params.get("path", "")
-        try:
-            _paths.validate_server_filepath(str(pkl_path)) if pkl_path else None
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
-        if not pkl_path or not Path(pkl_path).is_file():
-            return jsonify({"error": f"Pickle file not found: {pkl_path}"}), 400
-        origin = {"importer": "pickle", "params": params}
+    # --- real importers: generic dispatch ---
 
-        def load_pkl():
-            update_progress("loading", "Loading dataset from file...", 0, 0)
-            load_dataset_from_pickle(Path(pkl_path), medias)
-
-        _run_origin_load_in_background(load_pkl, origin)
-        return jsonify({"ok": True, "message": "Loading started"})
-
-    if importer_name == "folder":
-        folder_path = params.get("path", "")
-        try:
-            _paths.validate_server_filepath(str(folder_path)) if folder_path else None
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
-        if not folder_path or not Path(folder_path).is_dir():
-            return jsonify({"error": f"Folder not found: {folder_path}"}), 400
-        importer = get_importer("folder")
-        if importer is None:
-            return jsonify({"error": "folder importer not available"}), 500
-        field_values = {"path": folder_path}
-        media_type = params.get("media_type", "")
-        if media_type:
-            field_values["media_type"] = media_type
-        _run_importer_in_background(importer, field_values)
-        return jsonify({"ok": True, "message": "Loading started"})
-
-    # Generic fallback: try the named importer with the stored params
     importer = get_importer(importer_name)
     if importer is None:
         return jsonify({"error": f"Unknown importer: {importer_name}"}), 400
-    _run_importer_in_background(importer, params)
+
+    if not importer.can_reload_from_origin(source):
+        return jsonify({"error": f"Cannot reload from {importer_name} origin (source not available)"}), 400
+
+    field_values = importer.reload_from_origin(source)
+    if field_values is None:
+        return jsonify({"error": f"Cannot reload from {importer_name} origin"}), 400
+
+    # Validate any server file paths in the field values
+    for key, val in field_values.items():
+        if isinstance(val, str) and ("/" in val or "\\" in val):
+            try:
+                _paths.validate_server_filepath(val)
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 400
+
+    _run_importer_in_background(importer, field_values)
     return jsonify({"ok": True, "message": "Loading started"})

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -81,20 +81,33 @@ def _set_clip_origins(clips_dict: dict, origin: dict) -> None:
 
 
 def _origin_to_str(origin: dict | None) -> str:
-    """Convert an origin dict to a human-readable string."""
+    """Convert an origin dict to a human-readable string.
+
+    Delegates to the importer's :meth:`origin_display` when available,
+    falling back to a generic ``"<importer_name>:<first_param>"`` format.
+    """
     if not origin:
         return "unknown"
-    importer = origin.get("importer", "")
+    importer_name = origin.get("importer", "")
+    if not importer_name:
+        return "unknown"
+
+    # Special pseudo-origins that are not real importers
     params = origin.get("params", {})
-    if importer == "demo":
+    if importer_name == "demo":
         return f"demo:{params.get('name', '')}"
-    elif importer == "pickle":
-        return f"file:{params.get('filename', '')}"
-    elif importer == "folder":
-        return f"folder:{params.get('path', '')}"
-    elif importer:
-        return importer
-    return "unknown"
+
+    from vtsearch.datasets.importers import get_importer
+
+    importer = get_importer(importer_name)
+    if importer is not None:
+        return importer.origin_display(origin)
+
+    # Unknown importer — generic fallback
+    if params:
+        first_val = next(iter(params.values()))
+        return f"{importer_name}:{first_val}"
+    return importer_name
 
 
 def _auto_register_dataset(name: str = "", origin_str: str = "unknown", source: dict | None = None) -> None:

--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -7,6 +7,7 @@ from flask import Blueprint, jsonify, request
 from vtsearch.config import EMBEDDINGS_DIR
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.datasets import DEMO_DATASETS
+from vtsearch.routes.datasets_loading import _origin_to_str
 from vtsearch.utils import (
     get_dataset_display_name,
     get_dupe_count,
@@ -129,17 +130,7 @@ def dashboard_dataset_info():
     for m in snap.values():
         o = m.get("origin")
         if o:
-            importer = o.get("importer", "")
-            params = o.get("params", {})
-            # Build a human-readable origin string
-            if importer == "demo":
-                origin = f"demo:{params.get('name', '')}"
-            elif importer == "pickle":
-                origin = f"file:{params.get('filename', '')}"
-            elif importer == "folder":
-                origin = f"folder:{params.get('path', '')}"
-            elif importer:
-                origin = importer
+            origin = _origin_to_str(o)
             break
 
     # Use display name override if set, otherwise derive from origin

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -116,6 +116,19 @@ class PluginBase:
     #: Ordered list of fields the user must fill.
     fields: list[PluginField]
 
+    #: How the frontend should render this plugin's UI.
+    #: ``"form"`` — generic form built from :attr:`fields` (default).
+    #: ``"file_upload"`` — the frontend should use its native file picker.
+    #: ``"custom"`` — the plugin has a dedicated UI section in the frontend.
+    #: ``"none"`` — no user-facing UI (e.g. the GUI exporter is handled
+    #:   automatically by the frontend results view).
+    ui_mode: str = "form"
+
+    #: When ``True``, this plugin is excluded from the generic picker list
+    #: in the frontend.  Useful for plugins that are always invoked through
+    #: a dedicated code path (e.g. the GUI exporter).
+    hidden_from_picker: bool = False
+
     # -- CLI support --------------------------------------------------------
 
     def add_cli_arguments(self, parser: argparse.ArgumentParser) -> None:
@@ -154,6 +167,8 @@ class PluginBase:
             "description": self.description,
             "icon": self.icon,
             "fields": [f.to_dict() for f in self.fields],
+            "ui_mode": self.ui_mode,
+            "hidden_from_picker": self.hidden_from_picker,
         }
 
 


### PR DESCRIPTION
## Summary
This PR refactors how the system determines which importers have dedicated UI sections in the frontend. Instead of maintaining a hardcoded `_BUILTIN_IMPORTER_NAMES` list, the system now uses a `ui_mode` attribute on each importer to declaratively specify how its UI should be rendered.

## Key Changes

- **Added `ui_mode` and `hidden_from_picker` attributes to `PluginBase`**: These new attributes allow plugins to declare their UI rendering strategy (`"form"`, `"file_upload"`, `"custom"`, or `"none"`) and whether they should be excluded from generic picker lists.

- **Removed hardcoded `_BUILTIN_IMPORTER_NAMES` list**: The `/api/dataset/importers` endpoint now filters importers by `ui_mode == "form"` instead of checking against a static list.

- **Added origin reload methods to `DatasetImporter`**:
  - `origin_display()`: Returns a human-readable string representation of an origin dict
  - `can_reload_from_origin()`: Checks if an origin can be reloaded (e.g., file still exists)
  - `reload_from_origin()`: Extracts field values from an origin dict for re-running the importer

- **Refactored `_load_from_origin()` in datasets.py**: Replaced special-case handling for `pickle` and `folder` importers with a generic dispatch mechanism that uses the new `reload_from_origin()` method.

- **Consolidated origin display logic**: Moved origin-to-string conversion to use the importer's `origin_display()` method, eliminating duplicate hardcoded formatting logic in multiple places.

- **Updated specific importers**:
  - `PickleDatasetImporter`: Set `ui_mode = "file_upload"` and implemented origin reload methods
  - `FolderDatasetImporter`: Implemented origin reload methods
  - `CombineDatasetsImporter`: Set `ui_mode = "custom"`
  - `DisplayLabelsetExporter`: Set `hidden_from_picker = True`

- **Updated frontend (app.js)**: Changed importer selection logic to use `ui_mode` attribute instead of hardcoded importer names, and updated exporter filtering to use `hidden_from_picker` attribute.

- **Updated tests**: Changed test assertions to verify `ui_mode` attributes instead of checking hardcoded lists.

## Implementation Details

The refactoring makes the system more extensible by allowing new importers to declare their UI behavior through attributes rather than requiring code changes to maintain a central list. The origin reload mechanism enables importers to validate and transform stored origin parameters before re-running, which is particularly important for file-based importers that need to verify file existence.

https://claude.ai/code/session_01QfxJGzUExZAzEKmdfZk5th