### PR TITLE
Convert LabelSet format to display format in GUI exporter

### DIFF
--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -270,6 +270,35 @@ class TestDisplayLabelsetExporter:
         assert "No items predicted as Good" in captured.out
         assert "message" in result
 
+    def test_export_converts_labelset_to_display_format(self):
+        """When results come from /api/labels/export (LabelSet format),
+        the GUI exporter should convert them to the display format."""
+        from vtsearch.exporters import get_exporter
+
+        labelset_data = {
+            "labels": [
+                {"md5": "aaa", "label": "good", "origin_name": "file1.wav", "filename": "file1.wav"},
+                {"md5": "bbb", "label": "bad", "origin_name": "file2.wav", "filename": "file2.wav"},
+                {"md5": "ccc", "label": "good", "origin_name": "file3.wav", "filename": "file3.wav"},
+            ]
+        }
+        exp = get_exporter("gui")
+        result = exp.export(labelset_data, {})
+        assert "display_results" in result
+        dr = result["display_results"]
+        # Should have the autodetect-results structure
+        assert "results" in dr
+        assert "media_type" in dr
+        assert "detectors_run" in dr
+        # All 3 labels should appear as hits
+        hits = dr["results"]["labels"]["hits"]
+        assert len(hits) == 3
+        # Good labels come first
+        assert hits[0]["label"] == "good"
+        assert hits[1]["label"] == "good"
+        assert hits[2]["label"] == "bad"
+        assert "3" in result["message"]
+
 
 # ---------------------------------------------------------------------------
 # Server JSON file exporter

--- a/vtsearch/exporters/gui/__init__.py
+++ b/vtsearch/exporters/gui/__init__.py
@@ -40,10 +40,34 @@ class DisplayLabelsetExporter(LabelsetExporter):
     fields = []  # no questions to ask
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        # If results come from /api/labels/export (LabelSet format), convert
+        # to the display format expected by displayAutodetectResults().
+        if "labels" in results and "results" not in results:
+            results = self._labelset_to_display(results)
+
         total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
         return {
             "message": (f"Showing {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s)."),
             "display_results": results,
+        }
+
+    @staticmethod
+    def _labelset_to_display(labelset: dict[str, Any]) -> dict[str, Any]:
+        """Convert a LabelSet dict to the autodetect-results display format."""
+        labels = labelset.get("labels", [])
+        good_hits = [e for e in labels if e.get("label") == "good"]
+        bad_hits = [e for e in labels if e.get("label") == "bad"]
+        total = len(good_hits) + len(bad_hits)
+        return {
+            "media_type": f"labels ({len(good_hits)} good, {len(bad_hits)} bad)",
+            "detectors_run": 0,
+            "results": {
+                "labels": {
+                    "detector_name": "Labels",
+                    "total_hits": total,
+                    "hits": good_hits + bad_hits,
+                },
+            },
         }
 
     def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Added support for the GUI exporter to handle LabelSet format data from the `/api/labels/export` endpoint by automatically converting it to the display format expected by the frontend's `displayAutodetectResults()` function.

## Key Changes
- Added `_labelset_to_display()` static method to `DisplayLabelsetExporter` that converts LabelSet dictionaries to the autodetect-results display format
- Modified `export()` method to detect LabelSet format input (presence of "labels" key without "results" key) and automatically convert it before processing
- The conversion separates labels into "good" and "bad" categories, with good labels appearing first in the results
- Added comprehensive test case `test_export_converts_labelset_to_display_format()` to verify the conversion logic

## Implementation Details
- The conversion creates a structured response with `media_type`, `detectors_run`, and `results` fields matching the expected display format
- Good and bad hit counts are included in the media_type description for user visibility
- The detector name is set to "Labels" to indicate the source of the results
- All labels are included as hits with proper ordering (good labels first)

https://claude.ai/code/session_018gwiwpNBmaqPcr25nuwaLC