### PR TITLE
Add dashboard component with dataset and model management

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -8,15 +8,6 @@
   </nav>
   <h1>VTSearch</h1>
 </header>
-<div class="layout">
-  <div class="panel-left" role="region" aria-label="Media list">
-    <p class="placeholder">Left Panel — Sorting &amp; Media List</p>
-  </div>
-  <div class="panel-center" role="main" aria-label="Media viewer">
-    <router-outlet />
-    <p class="placeholder">Center Panel — Media Viewer &amp; Voting</p>
-  </div>
-  <div class="panel-right" role="region" aria-label="Labels">
-    <p class="placeholder">Right Panel — Labels &amp; Vote History</p>
-  </div>
+<div class="main-content" role="main">
+  <router-outlet />
 </div>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -36,6 +36,12 @@ header {
   }
 }
 
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+// Keep the 3-panel layout classes for future phases (4-6)
 .layout {
   display: grid;
   grid-template-columns: 300px 1fr 300px;

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -29,12 +29,10 @@ describe('AppComponent', () => {
     expect(compiled.querySelector('h1')?.textContent).toContain('VTSearch');
   });
 
-  it('should render three panels', () => {
+  it('should render main content area with router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.panel-left')).toBeTruthy();
-    expect(compiled.querySelector('.panel-center')).toBeTruthy();
-    expect(compiled.querySelector('.panel-right')).toBeTruthy();
+    expect(compiled.querySelector('.main-content')).toBeTruthy();
   });
 });

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,3 +1,7 @@
 import { Routes } from '@angular/router';
+import { DashboardComponent } from './components/dashboard/dashboard.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'dashboard', component: DashboardComponent },
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+];

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -1,0 +1,122 @@
+<div class="dashboard-view">
+  <!-- Dataset Section -->
+  <div class="dashboard-section">
+    <div class="dashboard-section-header">
+      <span class="dashboard-section-title">Datasets</span>
+      @if (loading) {
+        <div class="dashboard-progress">
+          <span class="progress-msg">{{ progressMessage }}</span>
+          <vt-progress-bar
+            [value]="progressValue"
+            [max]="progressTotal"
+            [indeterminate]="progressIndeterminate"
+          />
+        </div>
+      }
+      <div class="dashboard-section-actions">
+        <button class="btn btn--primary btn--sm" (click)="openImporterModal()">+</button>
+      </div>
+    </div>
+
+    @if (datasets.length === 0 && !loading) {
+      <p class="empty-state">No datasets yet. Click + to add one.</p>
+    } @else {
+      <div class="dashboard-grid">
+        <table class="dash-table">
+          <thead>
+            <tr>
+              <th (click)="sortDatasets('name')" class="sortable">Name{{ datasetSortIndicator('name') }}</th>
+              <th (click)="sortDatasets('media_type')" class="sortable">Type{{ datasetSortIndicator('media_type') }}</th>
+              <th (click)="sortDatasets('num_items')" class="sortable">Items{{ datasetSortIndicator('num_items') }}</th>
+              <th (click)="sortDatasets('num_dupes')" class="sortable">Dupes{{ datasetSortIndicator('num_dupes') }}</th>
+              <th (click)="sortDatasets('created_at')" class="sortable">Created{{ datasetSortIndicator('created_at') }}</th>
+              <th (click)="sortDatasets('origin')" class="sortable">Origin{{ datasetSortIndicator('origin') }}</th>
+              <th>Loaded</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (dataset of sortedDatasets; track dataset.id) {
+              <vt-dataset-card
+                [dataset]="dataset"
+                [selected]="isDatasetSelected(dataset.id)"
+                (rowClick)="toggleDatasetSelection(dataset.id, $event)"
+                (rename)="renameDataset(dataset, $event)"
+                (delete)="deleteDataset(dataset)"
+                (load)="loadDataset(dataset)"
+              />
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+
+  <!-- Model Section -->
+  <div class="dashboard-section">
+    <div class="dashboard-section-header">
+      <span class="dashboard-section-title">Models</span>
+      <div class="dashboard-section-actions">
+        <!-- Add model button — Phase 7 will implement the full picker -->
+      </div>
+    </div>
+
+    @if (models.length === 0) {
+      <p class="empty-state">No models yet.</p>
+    } @else {
+      <div class="dashboard-grid">
+        <table class="dash-table">
+          <thead>
+            <tr>
+              <th (click)="sortModels('name')" class="sortable">Name{{ modelSortIndicator('name') }}</th>
+              <th (click)="sortModels('media_type')" class="sortable">Type{{ modelSortIndicator('media_type') }}</th>
+              <th (click)="sortModels('num_training')" class="sortable"># Training{{ modelSortIndicator('num_training') }}</th>
+              <th>Trainable</th>
+              <th (click)="sortModels('last_trained_at')" class="sortable">Last Trained{{ modelSortIndicator('last_trained_at') }}</th>
+              <th (click)="sortModels('created_at')" class="sortable">Created{{ modelSortIndicator('created_at') }}</th>
+              <th>Loaded</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (model of sortedModels; track model.id) {
+              <vt-model-card
+                [model]="model"
+                [selected]="isModelSelected(model.id)"
+                (rowClick)="toggleModelSelection(model.id, $event)"
+                (rename)="renameModel(model, $event)"
+                (delete)="deleteModel(model)"
+              />
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+
+  <!-- Action Buttons -->
+  <div class="dashboard-actions">
+    <button
+      class="btn btn--primary"
+      [disabled]="!labelEnabled"
+      [title]="labelHint"
+      (click)="onLabel()"
+    >
+      Label
+    </button>
+    <button
+      class="btn btn--primary"
+      [disabled]="!findEnabled"
+      (click)="onFind()"
+    >
+      Find
+    </button>
+  </div>
+</div>
+
+@if (importerModalOpen) {
+  <vt-dataset-importer-modal
+    (closed)="closeImporterModal()"
+    (importStarted)="onImportComplete()"
+  />
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -1,0 +1,123 @@
+.dashboard-view {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.dashboard-section {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.dashboard-section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.dashboard-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.dashboard-progress {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .progress-msg {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+
+  vt-progress-bar {
+    flex: 1;
+  }
+}
+
+.dashboard-section-actions {
+  margin-left: auto;
+}
+
+.btn--sm {
+  padding: 2px 10px;
+  font-size: 1rem;
+  min-width: 28px;
+}
+
+.dashboard-grid {
+  overflow-x: auto;
+}
+
+.dash-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+
+  th, td {
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+    white-space: nowrap;
+  }
+
+  th {
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    user-select: none;
+
+    &.sortable {
+      cursor: pointer;
+
+      &:hover {
+        color: var(--text-primary);
+      }
+    }
+  }
+
+  tbody tr {
+    cursor: pointer;
+    transition: background 0.1s;
+
+    &:hover {
+      background: var(--bg-hover);
+    }
+
+    &.selected {
+      background: var(--accent-highlight-bg);
+      border-color: var(--accent-highlight-border);
+    }
+  }
+}
+
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 24px;
+  font-style: italic;
+}
+
+.dashboard-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+
+  .btn {
+    min-width: 120px;
+    padding: 10px 24px;
+    font-size: 1rem;
+  }
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,275 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { DashboardComponent } from './dashboard.component';
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function flushInitialRequests(
+    datasets: any[] = [],
+    models: any[] = [],
+  ): void {
+    fixture.detectChanges();
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets });
+    httpMock.expectOne('/api/models/registry').flush({ models });
+  }
+
+  it('should create', () => {
+    flushInitialRequests();
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch datasets and models on init', () => {
+    const datasets = [{ id: 'd1', name: 'Test Dataset', media_type: 'audio', num_items: 10 }];
+    const models = [{ id: 'm1', name: 'Test Model', trainable: true }];
+    flushInitialRequests(datasets, models);
+    expect(component.datasets.length).toBe(1);
+    expect(component.models.length).toBe(1);
+  });
+
+  it('should auto-select single dataset', () => {
+    const datasets = [{ id: 'd1', name: 'Only One' }];
+    flushInitialRequests(datasets);
+    expect(component.selectedDatasetIds.has('d1')).toBeTrue();
+  });
+
+  it('should auto-select single model', () => {
+    const models = [{ id: 'm1', name: 'Only One' }];
+    flushInitialRequests([], models);
+    expect(component.selectedModelIds.has('m1')).toBeTrue();
+  });
+
+  it('should not auto-select when multiple datasets', () => {
+    const datasets = [
+      { id: 'd1', name: 'First' },
+      { id: 'd2', name: 'Second' },
+    ];
+    flushInitialRequests(datasets);
+    expect(component.selectedDatasetIds.size).toBe(0);
+  });
+
+  it('should toggle dataset selection on click', () => {
+    flushInitialRequests();
+    const event = new MouseEvent('click');
+    component.toggleDatasetSelection('d1', event);
+    expect(component.isDatasetSelected('d1')).toBeTrue();
+    component.toggleDatasetSelection('d1', event);
+    expect(component.isDatasetSelected('d1')).toBeFalse();
+  });
+
+  it('should support multi-select with ctrl key', () => {
+    flushInitialRequests();
+    const ctrlEvent = new MouseEvent('click', { ctrlKey: true });
+    component.toggleDatasetSelection('d1', new MouseEvent('click'));
+    component.toggleDatasetSelection('d2', ctrlEvent);
+    expect(component.isDatasetSelected('d1')).toBeTrue();
+    expect(component.isDatasetSelected('d2')).toBeTrue();
+  });
+
+  it('should replace selection without ctrl key', () => {
+    flushInitialRequests();
+    component.toggleDatasetSelection('d1', new MouseEvent('click'));
+    component.toggleDatasetSelection('d2', new MouseEvent('click'));
+    expect(component.isDatasetSelected('d1')).toBeFalse();
+    expect(component.isDatasetSelected('d2')).toBeTrue();
+  });
+
+  it('should sort datasets by column', () => {
+    const datasets = [
+      { id: 'd1', name: 'Bravo', num_items: 5 },
+      { id: 'd2', name: 'Alpha', num_items: 10 },
+    ];
+    flushInitialRequests(datasets);
+
+    component.sortDatasets('name');
+    expect(component.sortedDatasets[0].name).toBe('Alpha');
+
+    component.sortDatasets('name');
+    expect(component.sortedDatasets[0].name).toBe('Bravo');
+  });
+
+  it('should sort models by column', () => {
+    const models = [
+      { id: 'm1', name: 'Zeta', num_training: 5 },
+      { id: 'm2', name: 'Alpha', num_training: 10 },
+    ];
+    flushInitialRequests([], models);
+
+    component.sortModels('name');
+    expect(component.sortedModels[0].name).toBe('Alpha');
+  });
+
+  it('should show sort indicators', () => {
+    flushInitialRequests();
+    component.sortDatasets('name');
+    expect(component.datasetSortIndicator('name')).toContain('\u25B2');
+    component.sortDatasets('name');
+    expect(component.datasetSortIndicator('name')).toContain('\u25BC');
+    expect(component.datasetSortIndicator('other')).toBe('');
+  });
+
+  describe('button state', () => {
+    it('should disable Label when nothing selected', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.clear();
+      component.selectedModelIds.clear();
+      expect(component.labelEnabled).toBeFalse();
+    });
+
+    it('should enable Label with 1 dataset + 1 trainable model', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      // Auto-selected since only 1 each
+      expect(component.labelEnabled).toBeTrue();
+    });
+
+    it('should disable Label when model is not trainable', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: false, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      expect(component.labelEnabled).toBeFalse();
+    });
+
+    it('should disable Label on media type mismatch', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'image' }];
+      flushInitialRequests(datasets, models);
+      expect(component.labelEnabled).toBeFalse();
+    });
+
+    it('should enable Label when model media_type is "any"', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'any' }];
+      flushInitialRequests(datasets, models);
+      expect(component.labelEnabled).toBeTrue();
+    });
+
+    it('should disable Find with no selections', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.clear();
+      component.selectedModelIds.clear();
+      expect(component.findEnabled).toBeFalse();
+    });
+
+    it('should enable Find with any dataset + any model selected', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.add('d1');
+      component.selectedModelIds.add('m1');
+      expect(component.findEnabled).toBeTrue();
+    });
+  });
+
+  describe('label hints', () => {
+    it('should hint about missing dataset', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.clear();
+      expect(component.labelHint).toBe('Select a dataset');
+    });
+
+    it('should hint about missing model', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.add('d1');
+      component.selectedModelIds.clear();
+      expect(component.labelHint).toBe('Select a model');
+    });
+  });
+
+  it('should rename a dataset', () => {
+    const datasets = [{ id: 'd1', name: 'Old' }];
+    flushInitialRequests(datasets);
+
+    component.renameDataset(datasets[0], 'New');
+    const req = httpMock.expectOne('/api/datasets/registry/d1/rename');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ name: 'New' });
+    req.flush({});
+
+    // Refresh calls
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/models/registry').flush({ models: [] });
+  });
+
+  it('should delete a dataset after confirmation', fakeAsync(() => {
+    const datasets = [{ id: 'd1', name: 'ToDelete' }];
+    flushInitialRequests(datasets);
+    component.selectedDatasetIds.add('d1');
+
+    // Mock dialog confirmation
+    spyOn(component['dialog'], 'confirm').and.returnValue(Promise.resolve(true));
+
+    component.deleteDataset(datasets[0]);
+    tick();
+
+    const req = httpMock.expectOne('/api/datasets/registry/d1');
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+
+    expect(component.selectedDatasetIds.has('d1')).toBeFalse();
+
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/models/registry').flush({ models: [] });
+  }));
+
+  it('should load a dataset and start progress polling', () => {
+    const datasets = [{ id: 'd1', name: 'ToLoad', loaded: false }];
+    flushInitialRequests(datasets);
+
+    component.loadDataset(datasets[0]);
+    expect(component.loading).toBeTrue();
+
+    const req = httpMock.expectOne('/api/datasets/registry/d1/load');
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+
+    // Progress polling starts
+    const progressReq = httpMock.expectOne('/api/dataset/progress');
+    progressReq.flush({ status: 'idle' });
+
+    // After idle, it should refresh
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/models/registry').flush({ models: [] });
+  });
+
+  it('should open and close importer modal', () => {
+    flushInitialRequests();
+    expect(component.importerModalOpen).toBeFalse();
+    component.openImporterModal();
+    expect(component.importerModalOpen).toBeTrue();
+    component.closeImporterModal();
+    expect(component.importerModalOpen).toBeFalse();
+  });
+
+  it('should render empty state when no datasets', () => {
+    flushInitialRequests();
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.empty-state')?.textContent).toContain('No datasets yet');
+  });
+
+  it('should render dataset table when datasets exist', () => {
+    const datasets = [{ id: 'd1', name: 'Test', media_type: 'audio', num_items: 5 }];
+    flushInitialRequests(datasets);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.dash-table')).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,0 +1,319 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject, forkJoin, timer } from 'rxjs';
+import { takeUntil, switchMap } from 'rxjs/operators';
+import { DatasetsApiService } from '../../services/datasets-api.service';
+import { TrainableModelsApiService } from '../../services/trainable-models-api.service';
+import { VtDialogService } from '../../services/dialog.service';
+import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { DatasetCardComponent } from './dataset-card/dataset-card.component';
+import { ModelCardComponent } from './model-card/model-card.component';
+import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
+
+@Component({
+  selector: 'vt-dashboard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ProgressBarComponent,
+    DatasetCardComponent,
+    ModelCardComponent,
+    DatasetImporterModalComponent,
+  ],
+  templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.scss',
+})
+export class DashboardComponent implements OnInit, OnDestroy {
+  datasets: any[] = [];
+  models: any[] = [];
+  selectedDatasetIds: Set<string> = new Set();
+  selectedModelIds: Set<string> = new Set();
+
+  loading = false;
+  progressMessage = '';
+  progressValue = 0;
+  progressTotal = 0;
+  progressIndeterminate = false;
+
+  importerModalOpen = false;
+
+  datasetSortColumn = 'name';
+  datasetSortAsc = true;
+  modelSortColumn = 'name';
+  modelSortAsc = true;
+
+  private destroy$ = new Subject<void>();
+  private polling$ = new Subject<void>();
+
+  constructor(
+    private datasetsApi: DatasetsApiService,
+    private modelsApi: TrainableModelsApiService,
+    private dialog: VtDialogService,
+  ) {}
+
+  ngOnInit(): void {
+    this.refresh();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.polling$.next();
+    this.polling$.complete();
+  }
+
+  refresh(): void {
+    forkJoin({
+      datasets: this.datasetsApi.getRegistry(),
+      models: this.modelsApi.getRegistry(),
+    }).subscribe({
+      next: ({ datasets, models }) => {
+        this.datasets = (datasets as any).datasets || [];
+        this.models = (models as any).models || [];
+        if (this.datasets.length === 1 && this.selectedDatasetIds.size === 0) {
+          this.selectedDatasetIds.add(this.datasets[0].id);
+        }
+        if (this.models.length === 1 && this.selectedModelIds.size === 0) {
+          this.selectedModelIds.add(this.models[0].id);
+        }
+      },
+    });
+  }
+
+  // --- Dataset selection ---
+
+  toggleDatasetSelection(id: string, event: MouseEvent): void {
+    if (event.ctrlKey || event.metaKey) {
+      if (this.selectedDatasetIds.has(id)) {
+        this.selectedDatasetIds.delete(id);
+      } else {
+        this.selectedDatasetIds.add(id);
+      }
+    } else {
+      if (this.selectedDatasetIds.has(id) && this.selectedDatasetIds.size === 1) {
+        this.selectedDatasetIds.clear();
+      } else {
+        this.selectedDatasetIds.clear();
+        this.selectedDatasetIds.add(id);
+      }
+    }
+  }
+
+  isDatasetSelected(id: string): boolean {
+    return this.selectedDatasetIds.has(id);
+  }
+
+  // --- Model selection ---
+
+  toggleModelSelection(id: string, event: MouseEvent): void {
+    if (event.ctrlKey || event.metaKey) {
+      if (this.selectedModelIds.has(id)) {
+        this.selectedModelIds.delete(id);
+      } else {
+        this.selectedModelIds.add(id);
+      }
+    } else {
+      if (this.selectedModelIds.has(id) && this.selectedModelIds.size === 1) {
+        this.selectedModelIds.clear();
+      } else {
+        this.selectedModelIds.clear();
+        this.selectedModelIds.add(id);
+      }
+    }
+  }
+
+  isModelSelected(id: string): boolean {
+    return this.selectedModelIds.has(id);
+  }
+
+  // --- Dataset actions ---
+
+  renameDataset(dataset: any, newName: string): void {
+    this.datasetsApi.renameRegistered(dataset.id, newName).subscribe({
+      next: () => this.refresh(),
+    });
+  }
+
+  async deleteDataset(dataset: any): Promise<void> {
+    const ok = await this.dialog.confirm(`Delete dataset "${dataset.name}"?`);
+    if (!ok) return;
+    this.datasetsApi.deleteRegistered(dataset.id).subscribe({
+      next: () => {
+        this.selectedDatasetIds.delete(dataset.id);
+        this.refresh();
+      },
+    });
+  }
+
+  loadDataset(dataset: any): void {
+    this.loading = true;
+    this.progressMessage = `Loading ${dataset.name}...`;
+    this.progressIndeterminate = true;
+    this.datasetsApi.loadRegistered(dataset.id).subscribe({
+      next: () => {
+        this.startProgressPolling();
+      },
+      error: () => {
+        this.loading = false;
+        this.progressIndeterminate = false;
+      },
+    });
+  }
+
+  // --- Model actions ---
+
+  renameModel(model: any, newName: string): void {
+    this.modelsApi.renameInRegistry(model.id, newName).subscribe({
+      next: () => this.refresh(),
+    });
+  }
+
+  async deleteModel(model: any): Promise<void> {
+    const ok = await this.dialog.confirm(`Delete model "${model.name}"?`);
+    if (!ok) return;
+    this.modelsApi.deleteFromRegistry(model.id).subscribe({
+      next: () => {
+        this.selectedModelIds.delete(model.id);
+        this.refresh();
+      },
+    });
+  }
+
+  // --- Importer modal ---
+
+  openImporterModal(): void {
+    this.importerModalOpen = true;
+  }
+
+  closeImporterModal(): void {
+    this.importerModalOpen = false;
+  }
+
+  onImportComplete(): void {
+    this.importerModalOpen = false;
+    this.startProgressPolling();
+  }
+
+  // --- Progress polling ---
+
+  startProgressPolling(): void {
+    this.loading = true;
+    this.progressIndeterminate = true;
+    this.polling$.next(); // cancel previous polling
+
+    timer(0, 1000)
+      .pipe(
+        takeUntil(this.polling$),
+        takeUntil(this.destroy$),
+        switchMap(() => this.datasetsApi.getProgress()),
+      )
+      .subscribe({
+        next: (progress: any) => {
+          if (progress.progress != null && progress.total != null) {
+            this.progressIndeterminate = false;
+            this.progressValue = progress.progress;
+            this.progressTotal = progress.total;
+          }
+          this.progressMessage = progress.message || 'Loading...';
+
+          if (progress.status === 'idle' || progress.status === 'error') {
+            this.loading = false;
+            this.progressIndeterminate = false;
+            this.polling$.next();
+            this.refresh();
+          }
+        },
+      });
+  }
+
+  // --- Sorting ---
+
+  sortDatasets(column: string): void {
+    if (this.datasetSortColumn === column) {
+      this.datasetSortAsc = !this.datasetSortAsc;
+    } else {
+      this.datasetSortColumn = column;
+      this.datasetSortAsc = true;
+    }
+  }
+
+  get sortedDatasets(): any[] {
+    const col = this.datasetSortColumn;
+    const asc = this.datasetSortAsc ? 1 : -1;
+    return [...this.datasets].sort((a, b) => {
+      const va = a[col] ?? '';
+      const vb = b[col] ?? '';
+      if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * asc;
+      return String(va).localeCompare(String(vb)) * asc;
+    });
+  }
+
+  sortModels(column: string): void {
+    if (this.modelSortColumn === column) {
+      this.modelSortAsc = !this.modelSortAsc;
+    } else {
+      this.modelSortColumn = column;
+      this.modelSortAsc = true;
+    }
+  }
+
+  get sortedModels(): any[] {
+    const col = this.modelSortColumn;
+    const asc = this.modelSortAsc ? 1 : -1;
+    return [...this.models].sort((a, b) => {
+      const va = a[col] ?? '';
+      const vb = b[col] ?? '';
+      if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * asc;
+      return String(va).localeCompare(String(vb)) * asc;
+    });
+  }
+
+  datasetSortIndicator(column: string): string {
+    if (this.datasetSortColumn !== column) return '';
+    return this.datasetSortAsc ? ' \u25B2' : ' \u25BC';
+  }
+
+  modelSortIndicator(column: string): string {
+    if (this.modelSortColumn !== column) return '';
+    return this.modelSortAsc ? ' \u25B2' : ' \u25BC';
+  }
+
+  // --- Button state ---
+
+  get labelEnabled(): boolean {
+    if (this.selectedDatasetIds.size !== 1 || this.selectedModelIds.size !== 1) return false;
+    const model = this.models.find((m) => this.selectedModelIds.has(m.id));
+    if (!model || !model.trainable) return false;
+    const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
+    if (!dataset) return false;
+    if (model.media_type !== 'any' && model.media_type !== dataset.media_type) return false;
+    return true;
+  }
+
+  get findEnabled(): boolean {
+    if (this.selectedDatasetIds.size < 1 || this.selectedModelIds.size < 1) return false;
+    return true;
+  }
+
+  get labelHint(): string {
+    if (this.selectedDatasetIds.size === 0) return 'Select a dataset';
+    if (this.selectedDatasetIds.size > 1) return 'Select exactly 1 dataset';
+    if (this.selectedModelIds.size === 0) return 'Select a model';
+    if (this.selectedModelIds.size > 1) return 'Select exactly 1 model';
+    const model = this.models.find((m) => this.selectedModelIds.has(m.id));
+    if (model && !model.trainable) return 'Model is not trainable';
+    const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
+    if (model && dataset && model.media_type !== 'any' && model.media_type !== dataset.media_type) {
+      return 'Media type mismatch';
+    }
+    return '';
+  }
+
+  onLabel(): void {
+    // Phase 4+ will implement the full labeling transition
+  }
+
+  onFind(): void {
+    // Phase 7+ will implement the find/auto-detect flow
+  }
+}

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -1,0 +1,33 @@
+<!-- Renders as a <tr> (host selector) inside the dashboard table -->
+<td>
+  @if (editing) {
+    <input
+      class="form-input inline-edit"
+      [(ngModel)]="editName"
+      (keydown)="onRenameKeydown($event)"
+      (blur)="confirmRename()"
+      (click)="$event.stopPropagation()"
+      autofocus
+    />
+  } @else {
+    <span class="name-cell">
+      {{ dataset.name }}
+      <button class="rename-btn" (click)="startRename($event)" title="Rename" aria-label="Rename dataset">&#9998;</button>
+    </span>
+  }
+</td>
+<td>{{ dataset.media_type || '-' }}</td>
+<td>{{ dataset.num_items ?? '-' }}</td>
+<td>{{ dataset.num_dupes ?? 0 }}</td>
+<td>{{ formatDate(dataset.created_at) }}</td>
+<td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
+<td>
+  @if (dataset.loaded) {
+    <span class="check" aria-label="Loaded">&#10003;</span>
+  } @else {
+    <button class="btn btn--secondary btn--xs" (click)="onLoad($event)">Load</button>
+  }
+</td>
+<td>
+  <button class="btn btn--danger btn--xs" (click)="onDelete($event)" aria-label="Delete dataset">&#10005;</button>
+</td>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -1,0 +1,59 @@
+:host {
+  display: table-row;
+  cursor: pointer;
+  transition: background 0.1s;
+
+  &:hover {
+    background: var(--bg-hover);
+  }
+
+  &.selected {
+    background: var(--accent-highlight-bg);
+  }
+}
+
+.name-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rename-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+
+  :host:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    color: var(--text-primary);
+  }
+}
+
+.inline-edit {
+  width: 140px;
+  padding: 2px 6px;
+  font-size: 0.83rem;
+}
+
+.origin-cell {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.check {
+  color: var(--color-good);
+}
+
+.btn--xs {
+  padding: 1px 6px;
+  font-size: 0.75rem;
+}

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DatasetCardComponent } from './dataset-card.component';
+
+describe('DatasetCardComponent', () => {
+  let component: DatasetCardComponent;
+  let fixture: ComponentFixture<DatasetCardComponent>;
+
+  const mockDataset = {
+    id: 'd1',
+    name: 'Test Dataset',
+    media_type: 'audio',
+    num_items: 100,
+    num_dupes: 5,
+    created_at: 1700000000,
+    origin: 'folder:/data/audio',
+    loaded: true,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DatasetCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasetCardComponent);
+    component = fixture.componentInstance;
+    component.dataset = { ...mockDataset };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display dataset name', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Test Dataset');
+  });
+
+  it('should display media type', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('audio');
+  });
+
+  it('should display item count', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('100');
+  });
+
+  it('should show checkmark when loaded', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.check')).toBeTruthy();
+  });
+
+  it('should show Load button when not loaded', () => {
+    component.dataset = { ...mockDataset, loaded: false };
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const loadBtn = el.querySelector('button.btn--secondary');
+    expect(loadBtn?.textContent).toContain('Load');
+  });
+
+  it('should enter rename mode on rename button click', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const renameBtn = el.querySelector('.rename-btn') as HTMLElement;
+    renameBtn.click();
+    fixture.detectChanges();
+    expect(component.editing).toBeTrue();
+    expect(component.editName).toBe('Test Dataset');
+    expect(el.querySelector('.inline-edit')).toBeTruthy();
+  });
+
+  it('should emit rename on Enter key', () => {
+    spyOn(component.rename, 'emit');
+    component.editing = true;
+    component.editName = 'New Name';
+    component.onRenameKeydown(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(component.rename.emit).toHaveBeenCalledWith('New Name');
+    expect(component.editing).toBeFalse();
+  });
+
+  it('should cancel rename on Escape key', () => {
+    spyOn(component.rename, 'emit');
+    component.editing = true;
+    component.editName = 'New Name';
+    component.onRenameKeydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(component.rename.emit).not.toHaveBeenCalled();
+    expect(component.editing).toBeFalse();
+  });
+
+  it('should not emit rename when name unchanged', () => {
+    spyOn(component.rename, 'emit');
+    component.editing = true;
+    component.editName = 'Test Dataset';
+    component.confirmRename();
+    expect(component.rename.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit delete on delete button click', () => {
+    spyOn(component.delete, 'emit');
+    const el = fixture.nativeElement as HTMLElement;
+    const deleteBtn = el.querySelector('.btn--danger') as HTMLElement;
+    deleteBtn.click();
+    expect(component.delete.emit).toHaveBeenCalled();
+  });
+
+  it('should emit load on load button click', () => {
+    spyOn(component.load, 'emit');
+    component.dataset = { ...mockDataset, loaded: false };
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const loadBtn = el.querySelector('.btn--secondary') as HTMLElement;
+    loadBtn.click();
+    expect(component.load.emit).toHaveBeenCalled();
+  });
+
+  it('should format dates', () => {
+    expect(component.formatDate(1700000000)).toMatch(/\d/);
+    expect(component.formatDate(null)).toBe('-');
+    expect(component.formatDate(0)).toBe('-');
+  });
+
+  it('should apply selected class via host binding', () => {
+    component.selected = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('selected')).toBeTrue();
+  });
+});

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,0 +1,68 @@
+import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'vt-dataset-card',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './dataset-card.component.html',
+  styleUrl: './dataset-card.component.scss',
+})
+export class DatasetCardComponent {
+  @Input() dataset: any;
+  @Input() @HostBinding('class.selected') selected = false;
+  @Output() rowClick = new EventEmitter<MouseEvent>();
+
+  @HostListener('click', ['$event'])
+  onClick(event: MouseEvent): void {
+    this.rowClick.emit(event);
+  }
+  @Output() rename = new EventEmitter<string>();
+  @Output() delete = new EventEmitter<void>();
+  @Output() load = new EventEmitter<void>();
+
+  editing = false;
+  editName = '';
+
+  startRename(event: MouseEvent): void {
+    event.stopPropagation();
+    this.editing = true;
+    this.editName = this.dataset.name;
+  }
+
+  confirmRename(): void {
+    const trimmed = this.editName.trim();
+    if (trimmed && trimmed !== this.dataset.name) {
+      this.rename.emit(trimmed);
+    }
+    this.editing = false;
+  }
+
+  cancelRename(): void {
+    this.editing = false;
+  }
+
+  onRenameKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      this.confirmRename();
+    } else if (event.key === 'Escape') {
+      this.cancelRename();
+    }
+  }
+
+  onDelete(event: MouseEvent): void {
+    event.stopPropagation();
+    this.delete.emit();
+  }
+
+  onLoad(event: MouseEvent): void {
+    event.stopPropagation();
+    this.load.emit();
+  }
+
+  formatDate(timestamp: number | null): string {
+    if (!timestamp) return '-';
+    return new Date(timestamp * 1000).toLocaleDateString();
+  }
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -1,0 +1,80 @@
+<vt-modal [title]="view === 'picker' ? 'Add Dataset' : selectedImporter?.name || 'Import'" [open]="true" (closed)="close()">
+  @if (view === 'picker') {
+    <div class="importer-picker">
+      @if (importers.length === 0) {
+        <p class="empty-state">Loading importers...</p>
+      }
+      @for (imp of importers; track imp.name) {
+        <button class="importer-card" (click)="selectImporter(imp)">
+          <span class="importer-name">{{ imp.label || imp.name }}</span>
+          @if (imp.description) {
+            <span class="importer-desc">{{ imp.description }}</span>
+          }
+        </button>
+      }
+    </div>
+  }
+
+  @if (view === 'form' && selectedImporter) {
+    <div class="importer-form">
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+
+      @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
+        @for (field of selectedImporter.fields; track field.name) {
+          <div class="form-group">
+            <label class="form-label" [for]="'field-' + field.name">
+              {{ field.label || field.name }}
+              @if (field.required) {
+                <span class="required">*</span>
+              }
+            </label>
+
+            @if (field.type === 'file') {
+              <input
+                [id]="'field-' + field.name"
+                type="file"
+                class="form-input"
+                (change)="onFileSelected($event, field.name)"
+              />
+            } @else if (field.type === 'select') {
+              <select
+                [id]="'field-' + field.name"
+                class="form-select"
+                [(ngModel)]="formValues[field.name]"
+              >
+                @if (field.default === undefined) {
+                  <option value="">-- Select --</option>
+                }
+              </select>
+            } @else {
+              <input
+                [id]="'field-' + field.name"
+                type="text"
+                class="form-input"
+                [(ngModel)]="formValues[field.name]"
+                [placeholder]="field.label || field.name"
+              />
+            }
+          </div>
+        }
+      } @else {
+        <p class="info-text">This importer requires no additional configuration.</p>
+      }
+
+      @if (error) {
+        <p class="error-text">{{ error }}</p>
+      }
+
+      <div class="form-actions" modal-footer>
+        <button class="btn btn--secondary" (click)="close()">Cancel</button>
+        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
+          @if (submitting) {
+            Importing...
+          } @else {
+            Import
+          }
+        </button>
+      </div>
+    </div>
+  }
+</vt-modal>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,0 +1,83 @@
+.importer-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.importer-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px 16px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s, border-color 0.15s;
+  color: var(--text-primary);
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+  }
+}
+
+.importer-name {
+  font-weight: 500;
+}
+
+.importer-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.importer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.back-btn {
+  align-self: flex-start;
+  margin-bottom: 4px;
+}
+
+.btn--sm {
+  padding: 2px 10px;
+  font-size: 0.85rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.required {
+  color: var(--color-bad);
+}
+
+.info-text {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.error-text {
+  color: var(--color-bad);
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 16px;
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -1,0 +1,147 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { DatasetImporterModalComponent } from './dataset-importer-modal.component';
+
+describe('DatasetImporterModalComponent', () => {
+  let component: DatasetImporterModalComponent;
+  let fixture: ComponentFixture<DatasetImporterModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockImporters = [
+    {
+      name: 'folder',
+      label: 'Load from Folder',
+      description: 'Import media files from a folder',
+      fields: [
+        { name: 'path', type: 'text', label: 'Folder Path', required: true },
+        { name: 'media_type', type: 'select', label: 'Media Type', default: 'audio' },
+      ],
+    },
+    {
+      name: 'pickle',
+      label: 'Load from File',
+      description: 'Load a .pkl dataset file',
+      fields: [{ name: 'file', type: 'file', label: 'Dataset File', required: true }],
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DatasetImporterModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasetImporterModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function flushImporters(): void {
+    fixture.detectChanges();
+    httpMock.expectOne('/api/dataset/all-importers').flush({ importers: mockImporters });
+  }
+
+  it('should create', () => {
+    flushImporters();
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch importers on init', () => {
+    flushImporters();
+    expect(component.importers.length).toBe(2);
+  });
+
+  it('should start in picker view', () => {
+    flushImporters();
+    expect(component.view).toBe('picker');
+  });
+
+  it('should render importer cards', () => {
+    flushImporters();
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const cards = el.querySelectorAll('.importer-card');
+    expect(cards.length).toBe(2);
+    expect(cards[0].textContent).toContain('Load from Folder');
+  });
+
+  it('should switch to form view on importer selection', () => {
+    flushImporters();
+    component.selectImporter(mockImporters[0]);
+    expect(component.view).toBe('form');
+    expect(component.selectedImporter).toBe(mockImporters[0]);
+  });
+
+  it('should pre-populate default values', () => {
+    flushImporters();
+    component.selectImporter(mockImporters[0]);
+    expect(component.formValues['media_type']).toBe('audio');
+  });
+
+  it('should go back to picker view', () => {
+    flushImporters();
+    component.selectImporter(mockImporters[0]);
+    component.back();
+    expect(component.view).toBe('picker');
+    expect(component.selectedImporter).toBeNull();
+  });
+
+  it('should submit form values via runImporter', () => {
+    flushImporters();
+    spyOn(component.importStarted, 'emit');
+
+    component.selectImporter(mockImporters[0]);
+    component.formValues['path'] = '/data/sounds';
+    component.submit();
+
+    const req = httpMock.expectOne('/api/dataset/import/folder');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body['path']).toBe('/data/sounds');
+    req.flush({});
+
+    expect(component.submitting).toBeFalse();
+    expect(component.importStarted.emit).toHaveBeenCalled();
+  });
+
+  it('should show error on import failure', () => {
+    flushImporters();
+    component.selectImporter(mockImporters[0]);
+    component.submit();
+
+    httpMock.expectOne('/api/dataset/import/folder').flush(
+      { error: 'Not found' },
+      { status: 404, statusText: 'Not Found' },
+    );
+
+    expect(component.submitting).toBeFalse();
+    expect(component.error).toBe('Not found');
+  });
+
+  it('should emit closed on close', () => {
+    flushImporters();
+    spyOn(component.closed, 'emit');
+    component.close();
+    expect(component.closed.emit).toHaveBeenCalled();
+  });
+
+  it('should use loadFile for file type fields', () => {
+    flushImporters();
+    spyOn(component.importStarted, 'emit');
+
+    component.selectImporter(mockImporters[1]);
+    const mockFile = new File(['data'], 'test.pkl');
+    component.selectedFile = mockFile;
+    component.submit();
+
+    const req = httpMock.expectOne('/api/dataset/load-file');
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+
+    expect(component.importStarted.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,0 +1,105 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../../modal/modal.component';
+import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { ImporterInfo } from '../../../models/api.models';
+
+type ModalView = 'picker' | 'form';
+
+@Component({
+  selector: 'vt-dataset-importer-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent],
+  templateUrl: './dataset-importer-modal.component.html',
+  styleUrl: './dataset-importer-modal.component.scss',
+})
+export class DatasetImporterModalComponent implements OnInit {
+  @Output() closed = new EventEmitter<void>();
+  @Output() importStarted = new EventEmitter<void>();
+
+  view: ModalView = 'picker';
+  importers: ImporterInfo[] = [];
+  selectedImporter: ImporterInfo | null = null;
+  formValues: Record<string, any> = {};
+  selectedFile: File | null = null;
+  submitting = false;
+  error = '';
+
+  constructor(private datasetsApi: DatasetsApiService) {}
+
+  ngOnInit(): void {
+    this.datasetsApi.getAllImporters().subscribe({
+      next: (res) => {
+        this.importers = res.importers || [];
+      },
+    });
+  }
+
+  selectImporter(importer: ImporterInfo): void {
+    this.selectedImporter = importer;
+    this.formValues = {};
+    this.error = '';
+
+    // Pre-populate defaults
+    if (importer.fields) {
+      for (const field of importer.fields) {
+        if (field.default !== undefined) {
+          this.formValues[field.name] = field.default;
+        }
+      }
+    }
+
+    this.view = 'form';
+  }
+
+  back(): void {
+    this.view = 'picker';
+    this.selectedImporter = null;
+    this.error = '';
+  }
+
+  onFileSelected(event: Event, fieldName: string): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.selectedFile = input.files[0];
+      this.formValues[fieldName] = input.files[0].name;
+    }
+  }
+
+  submit(): void {
+    if (!this.selectedImporter) return;
+    this.submitting = true;
+    this.error = '';
+
+    // If there's a file field, use loadFile; otherwise runImporter
+    const fileField = this.selectedImporter.fields?.find((f) => f.type === 'file');
+    if (fileField && this.selectedFile) {
+      this.datasetsApi.loadFile(this.selectedFile).subscribe({
+        next: () => {
+          this.submitting = false;
+          this.importStarted.emit();
+        },
+        error: (err) => {
+          this.submitting = false;
+          this.error = err.error?.error || 'Import failed';
+        },
+      });
+    } else {
+      this.datasetsApi.runImporter(this.selectedImporter.name, this.formValues).subscribe({
+        next: () => {
+          this.submitting = false;
+          this.importStarted.emit();
+        },
+        error: (err) => {
+          this.submitting = false;
+          this.error = err.error?.error || 'Import failed';
+        },
+      });
+    }
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -1,0 +1,38 @@
+<td>
+  @if (editing) {
+    <input
+      class="form-input inline-edit"
+      [(ngModel)]="editName"
+      (keydown)="onRenameKeydown($event)"
+      (blur)="confirmRename()"
+      (click)="$event.stopPropagation()"
+      autofocus
+    />
+  } @else {
+    <span class="name-cell">
+      {{ model.name }}
+      <button class="rename-btn" (click)="startRename($event)" title="Rename" aria-label="Rename model">&#9998;</button>
+    </span>
+  }
+</td>
+<td>{{ model.media_type || '-' }}</td>
+<td>{{ model.num_training ?? 0 }}</td>
+<td>
+  @if (model.trainable) {
+    <span class="check" aria-label="Trainable">&#10003;</span>
+  } @else {
+    <span class="dim">-</span>
+  }
+</td>
+<td>{{ formatDate(model.last_trained_at) }}</td>
+<td>{{ formatDate(model.created_at) }}</td>
+<td>
+  @if (model.loaded) {
+    <span class="check" aria-label="Loaded">&#10003;</span>
+  } @else {
+    <span class="dim">-</span>
+  }
+</td>
+<td>
+  <button class="btn btn--danger btn--xs" (click)="onDelete($event)" aria-label="Delete model">&#10005;</button>
+</td>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -1,0 +1,57 @@
+:host {
+  display: table-row;
+  cursor: pointer;
+  transition: background 0.1s;
+
+  &:hover {
+    background: var(--bg-hover);
+  }
+
+  &.selected {
+    background: var(--accent-highlight-bg);
+  }
+}
+
+.name-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rename-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+
+  :host:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    color: var(--text-primary);
+  }
+}
+
+.inline-edit {
+  width: 140px;
+  padding: 2px 6px;
+  font-size: 0.83rem;
+}
+
+.check {
+  color: var(--color-good);
+}
+
+.dim {
+  color: var(--text-dim);
+}
+
+.btn--xs {
+  padding: 1px 6px;
+  font-size: 0.75rem;
+}

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ModelCardComponent } from './model-card.component';
+
+describe('ModelCardComponent', () => {
+  let component: ModelCardComponent;
+  let fixture: ComponentFixture<ModelCardComponent>;
+
+  const mockModel = {
+    id: 'm1',
+    name: 'Test Model',
+    media_type: 'audio',
+    trainable: true,
+    num_training: 50,
+    last_trained_at: 1700000000,
+    created_at: 1699000000,
+    loaded: true,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ModelCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ModelCardComponent);
+    component = fixture.componentInstance;
+    component.model = { ...mockModel };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display model name', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Test Model');
+  });
+
+  it('should display media type', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('audio');
+  });
+
+  it('should display training count', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('50');
+  });
+
+  it('should show trainable checkmark', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const checks = el.querySelectorAll('.check');
+    expect(checks.length).toBeGreaterThan(0);
+  });
+
+  it('should show dash when not trainable', () => {
+    component.model = { ...mockModel, trainable: false };
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const dims = el.querySelectorAll('.dim');
+    expect(dims.length).toBeGreaterThan(0);
+  });
+
+  it('should enter rename mode on rename button click', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const renameBtn = el.querySelector('.rename-btn') as HTMLElement;
+    renameBtn.click();
+    fixture.detectChanges();
+    expect(component.editing).toBeTrue();
+    expect(el.querySelector('.inline-edit')).toBeTruthy();
+  });
+
+  it('should emit rename on confirm', () => {
+    spyOn(component.rename, 'emit');
+    component.editing = true;
+    component.editName = 'Renamed';
+    component.confirmRename();
+    expect(component.rename.emit).toHaveBeenCalledWith('Renamed');
+  });
+
+  it('should cancel rename on Escape', () => {
+    spyOn(component.rename, 'emit');
+    component.editing = true;
+    component.onRenameKeydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(component.rename.emit).not.toHaveBeenCalled();
+    expect(component.editing).toBeFalse();
+  });
+
+  it('should emit delete on delete button click', () => {
+    spyOn(component.delete, 'emit');
+    const el = fixture.nativeElement as HTMLElement;
+    const deleteBtn = el.querySelector('.btn--danger') as HTMLElement;
+    deleteBtn.click();
+    expect(component.delete.emit).toHaveBeenCalled();
+  });
+
+  it('should format dates', () => {
+    expect(component.formatDate(1700000000)).toMatch(/\d/);
+    expect(component.formatDate(null)).toBe('-');
+  });
+
+  it('should apply selected class via host binding', () => {
+    component.selected = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('selected')).toBeTrue();
+  });
+});

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -1,0 +1,62 @@
+import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'vt-model-card',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './model-card.component.html',
+  styleUrl: './model-card.component.scss',
+})
+export class ModelCardComponent {
+  @Input() model: any;
+  @Input() @HostBinding('class.selected') selected = false;
+  @Output() rowClick = new EventEmitter<MouseEvent>();
+
+  @HostListener('click', ['$event'])
+  onClick(event: MouseEvent): void {
+    this.rowClick.emit(event);
+  }
+  @Output() rename = new EventEmitter<string>();
+  @Output() delete = new EventEmitter<void>();
+
+  editing = false;
+  editName = '';
+
+  startRename(event: MouseEvent): void {
+    event.stopPropagation();
+    this.editing = true;
+    this.editName = this.model.name;
+  }
+
+  confirmRename(): void {
+    const trimmed = this.editName.trim();
+    if (trimmed && trimmed !== this.model.name) {
+      this.rename.emit(trimmed);
+    }
+    this.editing = false;
+  }
+
+  cancelRename(): void {
+    this.editing = false;
+  }
+
+  onRenameKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      this.confirmRename();
+    } else if (event.key === 'Escape') {
+      this.cancelRename();
+    }
+  }
+
+  onDelete(event: MouseEvent): void {
+    event.stopPropagation();
+    this.delete.emit();
+  }
+
+  formatDate(timestamp: number | null): string {
+    if (!timestamp) return '-';
+    return new Date(timestamp * 1000).toLocaleDateString();
+  }
+}


### PR DESCRIPTION
## Summary
Implements the dashboard view for VTSearch, providing a centralized interface for managing datasets and trainable models. This includes dataset import functionality, selection/sorting capabilities, and progress tracking for long-running operations.

## Key Changes

### Dashboard Component (`dashboard.component.ts`)
- Main dashboard controller managing datasets and models registries
- Multi-select support for datasets and models with Ctrl/Cmd+click
- Sorting functionality for both datasets and models by multiple columns
- Progress polling system for tracking import/load operations
- Dataset operations: rename, delete, load
- Model operations: rename, delete
- Auto-selection of single items when only one dataset/model exists
- Button state management for Label and Find actions based on selections

### Dataset Importer Modal (`dataset-importer-modal/`)
- Modal interface for importing datasets via multiple importers
- Two-view system: importer picker and dynamic form generation
- Support for different field types (text, select, file)
- Pre-population of default field values
- File upload handling and form submission
- Error handling and user feedback

### Card Components
- **DatasetCardComponent**: Renders dataset rows with inline rename, delete, and load actions
- **ModelCardComponent**: Renders model rows with inline rename and delete actions
- Both support selection state and hover interactions

### Styling
- Dashboard layout with sections for datasets and models
- Table-based presentation with sortable headers
- Responsive grid with progress bar integration
- Card-based styling for importer selection
- Form styling for import configuration

### Routing & Integration
- Added dashboard route to app routes
- Updated app component layout to support main content area
- Integrated with existing API services (DatasetsApiService, TrainableModelsApiService)

## Notable Implementation Details

- Uses RxJS `forkJoin` for parallel API requests and `timer` with `switchMap` for polling
- Implements proper cleanup with `takeUntil` and destroy subjects
- Selection state managed via `Set<string>` for efficient lookups
- Sorting uses generic comparison logic supporting both numeric and string values
- Modal uses standalone component architecture with FormsModule for two-way binding
- Comprehensive test coverage for all major functionality

https://claude.ai/code/session_01Vj2JS8Rrbi1LWyH5ucXsxu