### PR TITLE
Fix delete buttons and add model creation UI

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -11,3 +11,4 @@
 <div class="main-content" role="main">
   <router-outlet />
 </div>
+<vt-dialog-host />

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, DialogHostComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -57,12 +57,12 @@
     <div class="dashboard-section-header">
       <span class="dashboard-section-title">Models</span>
       <div class="dashboard-section-actions">
-        <!-- Add model button — Phase 7 will implement the full picker -->
+        <button class="btn btn--primary btn--sm" (click)="openNewModelModal()">+</button>
       </div>
     </div>
 
     @if (models.length === 0) {
-      <p class="empty-state">No models yet.</p>
+      <p class="empty-state">No models yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
         <table class="dash-table">
@@ -118,5 +118,12 @@
   <vt-dataset-importer-modal
     (closed)="closeImporterModal()"
     (importStarted)="onImportComplete()"
+  />
+}
+
+@if (newModelModalOpen) {
+  <vt-new-model-modal
+    (closed)="closeNewModelModal()"
+    (created)="onModelCreated()"
   />
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -9,6 +9,7 @@ import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
+import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
 
 @Component({
   selector: 'vt-dashboard',
@@ -19,6 +20,7 @@ import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-
     DatasetCardComponent,
     ModelCardComponent,
     DatasetImporterModalComponent,
+    NewModelModalComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
@@ -36,6 +38,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   progressIndeterminate = false;
 
   importerModalOpen = false;
+  newModelModalOpen = false;
 
   datasetSortColumn = 'name';
   datasetSortAsc = true;
@@ -192,6 +195,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
   onImportComplete(): void {
     this.importerModalOpen = false;
     this.startProgressPolling();
+  }
+
+  // --- New model modal ---
+
+  openNewModelModal(): void {
+    this.newModelModalOpen = true;
+  }
+
+  closeNewModelModal(): void {
+    this.newModelModalOpen = false;
+  }
+
+  onModelCreated(): void {
+    this.newModelModalOpen = false;
+    this.refresh();
   }
 
   // --- Progress polling ---

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -1,0 +1,46 @@
+<vt-modal [open]="true" title="New Model" (closed)="close()">
+  <div class="new-model-form">
+    <div class="form-group">
+      <label for="model-name">Model Name <span class="required">*</span></label>
+      <input
+        id="model-name"
+        class="form-input"
+        [(ngModel)]="name"
+        placeholder="e.g. Dog Barks"
+        autofocus
+      />
+    </div>
+
+    <div class="form-group">
+      <label for="model-media-type">Media Type</label>
+      <select id="model-media-type" class="form-input" [(ngModel)]="mediaType">
+        @for (mt of mediaTypes; track mt) {
+          <option [value]="mt">{{ mt }}</option>
+        }
+        <option value="any">any</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <label for="model-query">Text Query / Example <span class="required">*</span></label>
+      <input
+        id="model-query"
+        class="form-input"
+        [(ngModel)]="textQuery"
+        placeholder="e.g. dog barking sounds"
+      />
+      <span class="info-text">Describes what this model should find.</span>
+    </div>
+
+    @if (error) {
+      <p class="error-text">{{ error }}</p>
+    }
+  </div>
+
+  <div modal-footer>
+    <button class="btn btn--secondary" (click)="close()">Cancel</button>
+    <button class="btn btn--primary" [disabled]="submitting" (click)="submit()">
+      {{ submitting ? 'Creating...' : 'Create' }}
+    </button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -1,0 +1,25 @@
+.new-model-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.required {
+  color: var(--color-bad);
+}
+
+.info-text {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.error-text {
+  color: var(--color-bad);
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { NewModelModalComponent } from './new-model-modal.component';
+
+describe('NewModelModalComponent', () => {
+  let component: NewModelModalComponent;
+  let fixture: ComponentFixture<NewModelModalComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NewModelModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewModelModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    // Flush the media types request from ngOnInit
+    httpMock.expectOne('/api/media-types').flush({
+      media_types: [
+        { type_id: 'audio', name: 'Audio' },
+        { type_id: 'image', name: 'Image' },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should populate media types from API', () => {
+    expect(component.mediaTypes).toEqual(['audio', 'image']);
+  });
+
+  it('should show error when name is empty', () => {
+    component.name = '';
+    component.textQuery = 'test';
+    component.submit();
+    expect(component.error).toBe('Name is required');
+  });
+
+  it('should show error when query is empty', () => {
+    component.name = 'Test Model';
+    component.textQuery = '';
+    component.submit();
+    expect(component.error).toBe('At least one text query or example is required');
+  });
+
+  it('should submit to models registry API', () => {
+    spyOn(component.created, 'emit');
+
+    component.name = 'Dog Barks';
+    component.mediaType = 'audio';
+    component.textQuery = 'dog barking sounds';
+    component.submit();
+
+    const req = httpMock.expectOne('/api/models/registry');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.name).toBe('Dog Barks');
+    expect(req.request.body.media_type).toBe('audio');
+    expect(req.request.body.text_query).toBe('dog barking sounds');
+    expect(req.request.body.trainable).toBe(true);
+    req.flush({ id: '123', name: 'Dog Barks' });
+
+    expect(component.created.emit).toHaveBeenCalled();
+  });
+
+  it('should show server error on failure', () => {
+    component.name = 'Test';
+    component.textQuery = 'test';
+    component.submit();
+
+    httpMock.expectOne('/api/models/registry').flush(
+      { error: 'Model already exists' },
+      { status: 409, statusText: 'Conflict' },
+    );
+
+    expect(component.error).toBe('Model already exists');
+  });
+
+  it('should emit closed on close', () => {
+    spyOn(component.closed, 'emit');
+    component.close();
+    expect(component.closed.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -1,0 +1,76 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../../modal/modal.component';
+import { TrainableModelsApiService } from '../../../services/trainable-models-api.service';
+import { DatasetsApiService } from '../../../services/datasets-api.service';
+
+@Component({
+  selector: 'vt-new-model-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent],
+  templateUrl: './new-model-modal.component.html',
+  styleUrl: './new-model-modal.component.scss',
+})
+export class NewModelModalComponent implements OnInit {
+  @Output() closed = new EventEmitter<void>();
+  @Output() created = new EventEmitter<void>();
+
+  name = '';
+  mediaType = 'audio';
+  textQuery = '';
+  mediaTypes: string[] = [];
+  submitting = false;
+  error = '';
+
+  constructor(
+    private modelsApi: TrainableModelsApiService,
+    private datasetsApi: DatasetsApiService,
+  ) {}
+
+  ngOnInit(): void {
+    this.datasetsApi.getMediaTypes().subscribe({
+      next: (res) => {
+        this.mediaTypes = (res.media_types || []).map((t) => t.type_id || t.name);
+      },
+    });
+  }
+
+  submit(): void {
+    const trimmedName = this.name.trim();
+    const trimmedQuery = this.textQuery.trim();
+    if (!trimmedName) {
+      this.error = 'Name is required';
+      return;
+    }
+    if (!trimmedQuery) {
+      this.error = 'At least one text query or example is required';
+      return;
+    }
+
+    this.submitting = true;
+    this.error = '';
+
+    this.modelsApi
+      .registerModel({
+        name: trimmedName,
+        media_type: this.mediaType,
+        trainable: true,
+        text_query: trimmedQuery,
+      })
+      .subscribe({
+        next: () => {
+          this.submitting = false;
+          this.created.emit();
+        },
+        error: (err) => {
+          this.submitting = false;
+          this.error = err.error?.error || 'Failed to create model';
+        },
+      });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/components/dialog-host/dialog-host.component.html
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.html
@@ -1,0 +1,23 @@
+<vt-modal [open]="dialog.dialogOpen" [title]="dialog.getIcon() + ' ' + dialog.dialogTitle" (closed)="onClosed()">
+  <p>{{ dialog.dialogMessage }}</p>
+  @if (dialog.dialogShowInput) {
+    <input
+      class="form-input"
+      [(ngModel)]="dialog.dialogInputValue"
+      (keydown.enter)="onButtonClick('__input__')"
+      autofocus
+    />
+  }
+  <div modal-footer>
+    @for (btn of dialog.dialogButtons; track btn.label) {
+      <button
+        class="btn"
+        [class.btn--primary]="btn.primary"
+        [class.btn--secondary]="!btn.primary"
+        (click)="onButtonClick(btn.value)"
+      >
+        {{ btn.label }}
+      </button>
+    }
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/dialog-host/dialog-host.component.scss
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.scss
@@ -1,0 +1,5 @@
+// Dialog host uses global modal styles. Component-specific overrides only.
+.form-input {
+  width: 100%;
+  margin-top: 8px;
+}

--- a/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogHostComponent } from './dialog-host.component';
+import { VtDialogService } from '../../services/dialog.service';
+
+describe('DialogHostComponent', () => {
+  let component: DialogHostComponent;
+  let fixture: ComponentFixture<DialogHostComponent>;
+  let dialogService: VtDialogService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DialogHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DialogHostComponent);
+    component = fixture.componentInstance;
+    dialogService = TestBed.inject(VtDialogService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should resolve dialog on button click', async () => {
+    const promise = dialogService.confirm('Are you sure?');
+    fixture.detectChanges();
+
+    expect(dialogService.dialogOpen).toBeTrue();
+
+    component.onButtonClick(true);
+    const result = await promise;
+    expect(result).toBeTrue();
+    expect(dialogService.dialogOpen).toBeFalse();
+  });
+
+  it('should resolve with false on close', async () => {
+    const promise = dialogService.confirm('Delete?');
+    fixture.detectChanges();
+
+    component.onClosed();
+    const result = await promise;
+    expect(result).toBeFalse();
+  });
+
+  it('should render alert dialog', async () => {
+    const promise = dialogService.alert('Something happened');
+    fixture.detectChanges();
+
+    expect(dialogService.dialogOpen).toBeTrue();
+    expect(dialogService.dialogMessage).toBe('Something happened');
+
+    component.onButtonClick(true);
+    await promise;
+  });
+});

--- a/frontend/src/app/components/dialog-host/dialog-host.component.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../modal/modal.component';
+import { VtDialogService } from '../../services/dialog.service';
+
+@Component({
+  selector: 'vt-dialog-host',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent],
+  templateUrl: './dialog-host.component.html',
+  styleUrl: './dialog-host.component.scss',
+})
+export class DialogHostComponent {
+  constructor(public dialog: VtDialogService) {}
+
+  onButtonClick(value: unknown): void {
+    this.dialog.resolve(value);
+  }
+
+  onClosed(): void {
+    this.dialog.resolve(false);
+  }
+}


### PR DESCRIPTION
- Add DialogHostComponent that renders VtDialogService's confirm/alert dialogs, fixing delete buttons that previously hung on unresolved promises
- Add NewModelModalComponent with name, media type, and text query fields
- Add "+" button to Models section header
- Add unit tests for dialog host and new model modal

https://claude.ai/code/session_01Vj2JS8Rrbi1LWyH5ucXsxu