### PR TITLE
Replace multiplication symbols with trash can icons for remove buttons

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -365,7 +365,7 @@
       const removeBtn = document.createElement("button");
       removeBtn.className = "example-remove";
       removeBtn.setAttribute("aria-label", "Remove example");
-      removeBtn.textContent = "\u00D7";
+      removeBtn.textContent = "\uD83D\uDDD1\uFE0F";
       removeBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         const updated = examples.filter((_, j) => j !== i);
@@ -2405,7 +2405,7 @@
         html += `<div class="combine-item">`;
         html += `<span class="combine-item-name">${escapeHtml(ds.name)}</span>`;
         html += `<span class="combine-item-count">${ds.count} medias</span>`;
-        html += `<button type="button" data-combine-remove="${i}" class="combine-item-remove" title="Remove">&times;</button>`;
+        html += `<button type="button" data-combine-remove="${i}" class="combine-item-remove" title="Remove">&#128465;&#65039;</button>`;
         html += `</div>`;
       });
     }

--- a/static/styles.css
+++ b/static/styles.css
@@ -614,7 +614,8 @@ video { max-width: 100%; }
 .combine-item { display: flex; align-items: center; padding: 8px 10px; margin-bottom: 4px; background: var(--bg-hover); border-radius: 4px; }
 .combine-item-name { flex: 1; color: var(--text-primary); font-size: 0.9rem; }
 .combine-item-count { color: var(--text-dim); font-size: 0.75rem; margin-right: 10px; }
-.combine-item-remove { background: none; border: none; color: var(--color-bad); cursor: pointer; font-size: 1rem; padding: 0 4px; }
+.combine-item-remove { background: none; border: none; cursor: pointer; font-size: 0.85rem; padding: 0 4px; opacity: 0.5; transition: opacity 0.15s; }
+.combine-item-remove:hover { opacity: 1; }
 
 
 /* Missing elements prompt */
@@ -761,8 +762,8 @@ video { max-width: 100%; }
 .example-type-badge.type-detector { background: #4caf50; color: #fff; }
 .example-value { flex: 1; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .example-remove {
-  background: none; border: none; color: var(--color-bad); cursor: pointer;
-  font-size: 0.9rem; padding: 0 3px; opacity: 0.5; transition: opacity 0.15s;
+  background: none; border: none; cursor: pointer;
+  font-size: 0.8rem; padding: 0 3px; opacity: 0.5; transition: opacity 0.15s;
   flex-shrink: 0;
 }
 .example-remove:hover { opacity: 1; }


### PR DESCRIPTION
## Summary
Updated remove buttons throughout the application to use a trash can icon (🗑️) instead of the multiplication symbol (×), providing a more intuitive and visually consistent user interface.

## Key Changes
- **Example remove buttons**: Changed icon from `×` to trash can emoji (`🗑️`) in the examples section
- **Combine item remove buttons**: Changed icon from `×` to trash can emoji (`🗑️`) in the combine items section
- **Styling improvements**: 
  - Reduced font size for `.combine-item-remove` from `1rem` to `0.85rem` for better visual balance
  - Reduced font size for `.example-remove` from `0.9rem` to `0.8rem` for consistency
  - Removed explicit `color: var(--color-bad)` from both button styles, allowing the emoji to display naturally
  - Ensured both buttons maintain opacity transitions (0.5 → 1.0 on hover) for visual feedback

## Implementation Details
- The trash can emoji is rendered using HTML entity encoding (`&#128465;&#65039;`) in the HTML generation code
- Both remove button styles now follow a consistent pattern with reduced opacity by default and full opacity on hover
- The changes maintain accessibility with existing `aria-label` and `title` attributes

https://claude.ai/code/session_01Y7FM1ussJTb5v5v5chYM9A