### PR TITLE
Refactor ImporterField model and update dataset importer modal

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -20,39 +20,40 @@
       <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
 
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
-        @for (field of selectedImporter.fields; track field.name) {
+        @for (field of selectedImporter.fields; track field.key) {
           <div class="form-group">
-            <label class="form-label" [for]="'field-' + field.name">
-              {{ field.label || field.name }}
+            <label class="form-label" [for]="'field-' + field.key">
+              {{ field.label || field.key }}
               @if (field.required) {
                 <span class="required">*</span>
               }
             </label>
 
-            @if (field.type === 'file') {
+            @if (field.field_type === 'file') {
               <input
-                [id]="'field-' + field.name"
+                [id]="'field-' + field.key"
                 type="file"
                 class="form-input"
-                (change)="onFileSelected($event, field.name)"
+                [accept]="field.accept || ''"
+                (change)="onFileSelected($event, field.key)"
               />
-            } @else if (field.type === 'select') {
+            } @else if (field.field_type === 'select') {
               <select
-                [id]="'field-' + field.name"
+                [id]="'field-' + field.key"
                 class="form-select"
-                [(ngModel)]="formValues[field.name]"
+                [(ngModel)]="formValues[field.key]"
               >
-                @if (field.default === undefined) {
-                  <option value="">-- Select --</option>
+                @for (opt of field.options || []; track opt) {
+                  <option [value]="opt">{{ opt }}</option>
                 }
               </select>
             } @else {
               <input
-                [id]="'field-' + field.name"
+                [id]="'field-' + field.key"
                 type="text"
                 class="form-input"
-                [(ngModel)]="formValues[field.name]"
-                [placeholder]="field.label || field.name"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.description || field.label || field.key"
               />
             }
           </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -45,7 +45,7 @@ export class DatasetImporterModalComponent implements OnInit {
     if (importer.fields) {
       for (const field of importer.fields) {
         if (field.default !== undefined) {
-          this.formValues[field.name] = field.default;
+          this.formValues[field.key] = field.default;
         }
       }
     }
@@ -73,7 +73,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.error = '';
 
     // If there's a file field, use loadFile; otherwise runImporter
-    const fileField = this.selectedImporter.fields?.find((f) => f.type === 'file');
+    const fileField = this.selectedImporter.fields?.find((f) => f.field_type === 'file');
     if (fileField && this.selectedFile) {
       this.datasetsApi.loadFile(this.selectedFile).subscribe({
         next: () => {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -150,11 +150,15 @@ export interface ImporterInfo {
 }
 
 export interface ImporterField {
-  name: string;
-  type: string;
+  key: string;
+  field_type: string;
   label?: string;
+  description?: string;
+  accept?: string;
+  options?: string[];
+  default?: string;
   required?: boolean;
-  default?: unknown;
+  placeholder?: string;
 }
 
 export interface ImportersResponse {


### PR DESCRIPTION
## Summary
Updated the `ImporterField` model to use more descriptive and consistent property names, and refactored the dataset importer modal component to align with the new model structure.

## Key Changes
- **Model Updates (`ImporterField`)**:
  - Renamed `name` → `key` for field identification
  - Renamed `type` → `field_type` for clarity
  - Added new optional properties: `description`, `accept`, `options[]`, and `placeholder`
  - Changed `default` type from `unknown` to `string` for consistency

- **Template Updates**:
  - Updated all field references to use `field.key` instead of `field.name`
  - Updated all field type checks to use `field.field_type` instead of `field.type`
  - Added `[accept]` binding for file input fields
  - Replaced hardcoded "-- Select --" option with dynamic option rendering from `field.options`
  - Enhanced input placeholder to use `field.description` as primary fallback

- **Component Updates**:
  - Updated form value initialization to use `field.key`
  - Updated file field detection to use `field.field_type`

## Implementation Details
The changes improve the API contract by using more semantic property names (`key` vs `name`, `field_type` vs `type`) and provide better support for field configuration through additional metadata properties like `description`, `accept`, and `options`. This allows for more flexible and maintainable importer field definitions.

https://claude.ai/code/session_01AAXS81UQpqYPrQar9yMdjy