### PR TITLE
Require explicit media_type selection for trainable models

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6429,10 +6429,13 @@
       } catch (_) { /* ignore */ }
     }
 
-    // Build media type options from the registry
-    const mtOptions = Object.entries(mediaTypesMap).map(([id, mt]) =>
-      `<option value="${escapeHtml(id)}"${id === guessedMediaType ? " selected" : ""}>${escapeHtml(mt.icon || "")} ${escapeHtml(mt.name || id)}</option>`
-    ).join("");
+    // Build media type options from the registry (exclude "any" — users must pick a real type)
+    const mtEntries = Object.entries(mediaTypesMap).filter(([id]) => id !== "any");
+    const hasGuessed = guessedMediaType && mtEntries.some(([id]) => id === guessedMediaType);
+    const mtOptions = (hasGuessed ? "" : `<option value="" disabled selected>-- Select media type --</option>`) +
+      mtEntries.map(([id, mt]) =>
+        `<option value="${escapeHtml(id)}"${id === guessedMediaType ? " selected" : ""}>${escapeHtml(mt.icon || "")} ${escapeHtml(mt.name || id)}</option>`
+      ).join("");
 
     // Build example type options: built-in + importers
     let exTypeOptions = `<option value="text">Text description</option>`;
@@ -6483,6 +6486,7 @@
     const exampleTypeSelect = processorImporterFormDiv.querySelector("#new-model-example-type");
     const exampleAddBtn = processorImporterFormDiv.querySelector("#new-model-example-add");
     const nameInput = processorImporterFormDiv.querySelector("input[name='name']");
+    const mediaTypeSelect = processorImporterFormDiv.querySelector("select[name='media_type']");
 
     // Track examples locally
     let newModelExamples = [];
@@ -6497,10 +6501,12 @@
 
     function updateOkBtn() {
       const name = nameInput ? nameInput.value.trim() : "";
-      okBtn.disabled = !(name && newModelExamples.length > 0);
+      const mt = mediaTypeSelect ? mediaTypeSelect.value : "";
+      okBtn.disabled = !(name && mt && newModelExamples.length > 0);
     }
 
     if (nameInput) nameInput.addEventListener("input", updateOkBtn);
+    if (mediaTypeSelect) mediaTypeSelect.addEventListener("change", updateOkBtn);
 
     // Initial render
     refreshNewModelGrid();

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -24,7 +24,7 @@ class TestCreateTrainableModel:
     def test_create_success(self, client):
         res = client.post(
             "/api/trainable-models",
-            json={"name": "Dog Barks", "text_query": "sounds of dogs barking"},
+            json={"name": "Dog Barks", "media_type": "audio", "text_query": "sounds of dogs barking"},
         )
         assert res.status_code == 201
         data = res.get_json()
@@ -44,26 +44,42 @@ class TestCreateTrainableModel:
     def test_create_missing_text_query(self, client):
         res = client.post(
             "/api/trainable-models",
-            json={"name": "Test"},
+            json={"name": "Test", "media_type": "audio"},
         )
         assert res.status_code == 400
         assert "text_query" in res.get_json()["error"]
 
+    def test_create_missing_media_type(self, client):
+        res = client.post(
+            "/api/trainable-models",
+            json={"name": "Test", "text_query": "sounds"},
+        )
+        assert res.status_code == 400
+        assert "media_type" in res.get_json()["error"]
+
+    def test_create_rejects_any_media_type(self, client):
+        res = client.post(
+            "/api/trainable-models",
+            json={"name": "Test", "media_type": "any", "text_query": "sounds"},
+        )
+        assert res.status_code == 400
+        assert "media_type" in res.get_json()["error"]
+
     def test_create_duplicate(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "Dog Barks", "text_query": "dogs"},
+            json={"name": "Dog Barks", "media_type": "audio", "text_query": "dogs"},
         )
         res = client.post(
             "/api/trainable-models",
-            json={"name": "Dog Barks", "text_query": "dogs again"},
+            json={"name": "Dog Barks", "media_type": "audio", "text_query": "dogs again"},
         )
         assert res.status_code == 409
 
     def test_file_created_on_disk(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "Test Model", "text_query": "test"},
+            json={"name": "Test Model", "media_type": "audio", "text_query": "test"},
         )
         files = list(get_trainable_models_dir().glob("*.json"))
         assert len(files) == 1
@@ -83,11 +99,11 @@ class TestListTrainableModels:
     def test_list_after_create(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "Model A", "text_query": "a"},
+            json={"name": "Model A", "media_type": "audio", "text_query": "a"},
         )
         client.post(
             "/api/trainable-models",
-            json={"name": "Model B", "text_query": "b"},
+            json={"name": "Model B", "media_type": "audio", "text_query": "b"},
         )
         res = client.get("/api/trainable-models")
         data = res.get_json()
@@ -100,7 +116,7 @@ class TestGetTrainableModel:
     def test_get_existing(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "My Model", "text_query": "test query"},
+            json={"name": "My Model", "media_type": "audio", "text_query": "test query"},
         )
         res = client.get("/api/trainable-models/My%20Model")
         assert res.status_code == 200
@@ -118,7 +134,7 @@ class TestDeleteTrainableModel:
     def test_delete_existing(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "To Delete", "text_query": "test"},
+            json={"name": "To Delete", "media_type": "audio", "text_query": "test"},
         )
         res = client.delete("/api/trainable-models/To%20Delete")
         assert res.status_code == 200
@@ -137,7 +153,7 @@ class TestRenameTrainableModel:
     def test_rename_success(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "Old Name", "text_query": "test"},
+            json={"name": "Old Name", "media_type": "audio", "text_query": "test"},
         )
         res = client.put(
             "/api/trainable-models/Old%20Name/rename",
@@ -167,7 +183,7 @@ class TestRenameTrainableModel:
     def test_rename_missing_new_name(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "Test", "text_query": "test"},
+            json={"name": "Test", "media_type": "audio", "text_query": "test"},
         )
         res = client.put(
             "/api/trainable-models/Test/rename",
@@ -182,7 +198,7 @@ class TestRenameTrainableModel:
         # Create a trainable model and register it in the model registry
         client.post(
             "/api/trainable-models",
-            json={"name": "Original", "text_query": "test"},
+            json={"name": "Original", "media_type": "audio", "text_query": "test"},
         )
         res = client.post(
             "/api/models/registry",
@@ -213,11 +229,11 @@ class TestRenameTrainableModel:
     def test_rename_conflict(self, client):
         client.post(
             "/api/trainable-models",
-            json={"name": "Model A", "text_query": "a"},
+            json={"name": "Model A", "media_type": "audio", "text_query": "a"},
         )
         client.post(
             "/api/trainable-models",
-            json={"name": "Model B", "text_query": "b"},
+            json={"name": "Model B", "media_type": "audio", "text_query": "b"},
         )
         res = client.put(
             "/api/trainable-models/Model%20A/rename",
@@ -231,7 +247,7 @@ class TestSaveLabels:
         """Save labels when there are no votes — should produce empty labelset."""
         client.post(
             "/api/trainable-models",
-            json={"name": "Labeler", "text_query": "test"},
+            json={"name": "Labeler", "media_type": "audio", "text_query": "test"},
         )
         res = client.post("/api/trainable-models/Labeler/labels")
         assert res.status_code == 200
@@ -259,7 +275,7 @@ class TestSaveLabels:
 
         client.post(
             "/api/trainable-models",
-            json={"name": "Voted Model", "text_query": "test"},
+            json={"name": "Voted Model", "media_type": "audio", "text_query": "test"},
         )
         res = client.post("/api/trainable-models/Voted%20Model/labels")
         assert res.status_code == 200
@@ -308,7 +324,7 @@ class TestSaveLabels:
         }
         try:
             client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
-            client.post("/api/trainable-models", json={"name": "DupeTest", "text_query": "test"})
+            client.post("/api/trainable-models", json={"name": "DupeTest", "media_type": "audio", "text_query": "test"})
 
             res = client.post("/api/trainable-models/DupeTest/labels")
             assert res.status_code == 200
@@ -339,8 +355,8 @@ class TestLabelVoteIsolation:
             pytest.skip("Need at least 4 medias")
 
         # Create two trainable models
-        client.post("/api/trainable-models", json={"name": "Model A", "text_query": "a"})
-        client.post("/api/trainable-models", json={"name": "Model B", "text_query": "b"})
+        client.post("/api/trainable-models", json={"name": "Model A", "media_type": "audio", "text_query": "a"})
+        client.post("/api/trainable-models", json={"name": "Model B", "media_type": "audio", "text_query": "b"})
 
         # Simulate labeling with Model A: vote on ids[0] and ids[1]
         client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
@@ -369,7 +385,7 @@ class TestLabelVoteIsolation:
             pytest.skip("Need at least 4 medias")
 
         # Create model and label 2 items
-        client.post("/api/trainable-models", json={"name": "Target", "text_query": "t"})
+        client.post("/api/trainable-models", json={"name": "Target", "media_type": "audio", "text_query": "t"})
         client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
         client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
         client.post("/api/trainable-models/Target/labels")

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -107,7 +107,7 @@ def add_autorun_detector_route():
                 model_data = {
                     "name": name,
                     "text_query": text_query,
-                    "media_type": media_type or "any",
+                    "media_type": media_type,
                     "examples": examples or [],
                     "created_at": _time.time(),
                     "labelset": {"labels": []},

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -129,6 +129,8 @@ def create_trainable_model():
         return jsonify({"error": "name is required"}), 400
     if not text_query and not examples:
         return jsonify({"error": "text_query or examples is required"}), 400
+    if not media_type or media_type == "any":
+        return jsonify({"error": "media_type is required (must be a specific type, not 'any')"}), 400
 
     path = _model_path(name)
     if path.exists():
@@ -142,7 +144,7 @@ def create_trainable_model():
     model_data = {
         "name": name,
         "text_query": text_query,
-        "media_type": media_type or "any",
+        "media_type": media_type,
         "examples": examples or [],
         "created_at": time.time(),
         "labelset": {"labels": []},
@@ -153,7 +155,7 @@ def create_trainable_model():
         "success": True,
         "name": name,
         "text_query": text_query,
-        "media_type": media_type or "any",
+        "media_type": media_type,
         "examples": examples or [],
         "num_labels": 0,
     }), 201
@@ -353,6 +355,8 @@ def register_model_route():
 
     if not name:
         return jsonify({"error": "name is required"}), 400
+    if not media_type or media_type == "any":
+        return jsonify({"error": "media_type is required (must be a specific type, not 'any')"}), 400
 
     # If trainable, also create the trainable model file if needed
     if trainable and not trainable_model_name:
@@ -365,7 +369,7 @@ def register_model_route():
             model_data = {
                 "name": name,
                 "text_query": text_query,
-                "media_type": media_type or "any",
+                "media_type": media_type,
                 "examples": examples,
                 "created_at": time.time(),
                 "labelset": {"labels": []},
@@ -374,7 +378,7 @@ def register_model_route():
 
     entry = register_model(
         name=name,
-        media_type=media_type or "any",
+        media_type=media_type,
         trainable=trainable,
         text_query=text_query,
         detector_name=detector_name,


### PR DESCRIPTION
## Summary
This PR makes `media_type` a required field for trainable model creation and registration, preventing the use of the generic "any" type. Users must now explicitly select a specific media type (e.g., "audio", "video") when creating or registering models.

## Key Changes

- **Backend validation**: Added checks in `create_trainable_model()` and `register_model_route()` to reject requests where `media_type` is missing or set to "any", returning a 400 error with a descriptive message
- **Frontend UI improvements**:
  - Filtered out "any" from media type dropdown options
  - Added a disabled placeholder option ("-- Select media type --") when no media type is pre-selected
  - Made media type selection required for form submission by updating the OK button validation logic
  - Added event listener to media type select to trigger form validation on change
- **Test coverage**: Updated all test cases to include the required `media_type` field in POST requests, and added two new tests:
  - `test_create_missing_media_type`: Validates that missing media_type returns 400 error
  - `test_create_rejects_any_media_type`: Validates that "any" is rejected as invalid

## Implementation Details

- The validation happens at the API level before model creation, ensuring data consistency
- The frontend prevents submission of incomplete forms by disabling the OK button until all required fields (name, media_type, and at least one example) are filled
- Error messages clearly indicate that media_type must be a specific type, not "any"
- All existing tests were updated to comply with the new requirement, ensuring backward compatibility in test expectations

https://claude.ai/code/session_01CBVdzpzUsNtaYi1QTcRRbT