### PR TITLE
Replace delete button with trash icon and custom styling

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -29,5 +29,13 @@
   }
 </td>
 <td>
-  <button class="btn btn--danger btn--xs" (click)="onDelete($event)" aria-label="Delete dataset">&#10005;</button>
+  <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="3 6 5 6 21 6"></polyline>
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+      <path d="M10 11v6"></path>
+      <path d="M14 11v6"></path>
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+    </svg>
+  </button>
 </td>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -57,3 +57,21 @@
   padding: 1px 6px;
   font-size: 0.75rem;
 }
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--color-bad);
+    background: var(--bad-bg);
+  }
+}

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -98,7 +98,7 @@ describe('DatasetCardComponent', () => {
   it('should emit delete on delete button click', () => {
     spyOn(component.delete, 'emit');
     const el = fixture.nativeElement as HTMLElement;
-    const deleteBtn = el.querySelector('.btn--danger') as HTMLElement;
+    const deleteBtn = el.querySelector('.delete-btn') as HTMLElement;
     deleteBtn.click();
     expect(component.delete.emit).toHaveBeenCalled();
   });

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -34,5 +34,13 @@
   }
 </td>
 <td>
-  <button class="btn btn--danger btn--xs" (click)="onDelete($event)" aria-label="Delete model">&#10005;</button>
+  <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="3 6 5 6 21 6"></polyline>
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+      <path d="M10 11v6"></path>
+      <path d="M14 11v6"></path>
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+    </svg>
+  </button>
 </td>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -55,3 +55,21 @@
   padding: 1px 6px;
   font-size: 0.75rem;
 }
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--color-bad);
+    background: var(--bad-bg);
+  }
+}

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
@@ -88,7 +88,7 @@ describe('ModelCardComponent', () => {
   it('should emit delete on delete button click', () => {
     spyOn(component.delete, 'emit');
     const el = fixture.nativeElement as HTMLElement;
-    const deleteBtn = el.querySelector('.btn--danger') as HTMLElement;
+    const deleteBtn = el.querySelector('.delete-btn') as HTMLElement;
     deleteBtn.click();
     expect(component.delete.emit).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
Replaced the generic danger button styling with a custom delete button component featuring a trash can icon and improved visual design across dataset and model cards.

## Key Changes
- **Button Styling**: Replaced `.btn--danger .btn--xs` classes with new `.delete-btn` class featuring:
  - Minimal design with no background by default
  - Muted text color that transitions to red on hover
  - Smooth color and background transitions (150ms)
  - Proper flexbox alignment and padding
  
- **Icon Update**: Replaced the text-based delete symbol (&#10005;) with an inline SVG trash can icon (14x14px) for better visual clarity and consistency

- **Styling Implementation**: Added identical `.delete-btn` styles to both `dataset-card.component.scss` and `model-card.component.scss`

- **Test Updates**: Updated selectors in unit tests from `.btn--danger` to `.delete-btn` to match the new button class

## Implementation Details
- The new delete button uses CSS custom properties (`--text-muted`, `--color-bad`, `--bad-bg`) for consistent theming
- SVG icon uses `currentColor` to inherit the button's text color, enabling the color transition effect on hover
- Button maintains accessibility with proper `aria-label` and `title` attributes

https://claude.ai/code/session_0124sirjnDVqCDt53ECz8mia