### PR TITLE
Refactor action buttons layout and styling in dashboard cards

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -12,7 +12,6 @@
   } @else {
     <span class="name-cell">
       {{ dataset.name }}
-      <button class="rename-btn" (click)="startRename($event)" title="Rename" aria-label="Rename dataset">&#9998;</button>
     </span>
   }
 </td>
@@ -28,7 +27,13 @@
     <button class="btn btn--secondary btn--xs" (click)="onLoad($event)">Load</button>
   }
 </td>
-<td>
+<td class="actions-cell">
+  <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+    </svg>
+  </button>
   <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="3 6 5 6 21 6"></polyline>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -18,22 +18,27 @@
   gap: 6px;
 }
 
-.rename-btn {
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.edit-btn {
   background: none;
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 0.85rem;
-  padding: 0 2px;
-  opacity: 0;
-  transition: opacity 0.15s;
-
-  :host:hover & {
-    opacity: 1;
-  }
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
 
   &:hover {
     color: var(--text-primary);
+    background: var(--bg-hover);
   }
 }
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -61,7 +61,7 @@ describe('DatasetCardComponent', () => {
 
   it('should enter rename mode on rename button click', () => {
     const el = fixture.nativeElement as HTMLElement;
-    const renameBtn = el.querySelector('.rename-btn') as HTMLElement;
+    const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
     fixture.detectChanges();
     expect(component.editing).toBeTrue();

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -11,7 +11,6 @@
   } @else {
     <span class="name-cell">
       {{ model.name }}
-      <button class="rename-btn" (click)="startRename($event)" title="Rename" aria-label="Rename model">&#9998;</button>
     </span>
   }
 </td>
@@ -33,7 +32,13 @@
     <span class="dim">-</span>
   }
 </td>
-<td>
+<td class="actions-cell">
+  <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+    </svg>
+  </button>
   <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="3 6 5 6 21 6"></polyline>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -18,22 +18,27 @@
   gap: 6px;
 }
 
-.rename-btn {
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.edit-btn {
   background: none;
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 0.85rem;
-  padding: 0 2px;
-  opacity: 0;
-  transition: opacity 0.15s;
-
-  :host:hover & {
-    opacity: 1;
-  }
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
 
   &:hover {
     color: var(--text-primary);
+    background: var(--bg-hover);
   }
 }
 

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
@@ -62,7 +62,7 @@ describe('ModelCardComponent', () => {
 
   it('should enter rename mode on rename button click', () => {
     const el = fixture.nativeElement as HTMLElement;
-    const renameBtn = el.querySelector('.rename-btn') as HTMLElement;
+    const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
     renameBtn.click();
     fixture.detectChanges();
     expect(component.editing).toBeTrue();


### PR DESCRIPTION
## Summary
Refactored the action buttons (rename/edit and delete) in dataset and model cards to use a dedicated actions cell with improved layout and visual design. The rename button has been moved from inline with the name to a dedicated actions column and redesigned with an SVG icon and enhanced hover states.

## Key Changes
- **Layout restructuring**: Moved rename button from inline name cell to a dedicated `actions-cell` table cell alongside the delete button
- **Button styling improvements**:
  - Renamed `.rename-btn` class to `.edit-btn` for semantic clarity
  - Changed from opacity-based visibility (hidden on hover) to always-visible buttons with improved affordance
  - Updated button styling with proper padding (4px), border-radius, and flexbox centering
  - Enhanced hover states with background color change using `--bg-hover` CSS variable
- **Icon replacement**: Replaced Unicode pencil character (&#9998;) with an SVG edit icon for better visual consistency and scalability
- **Actions cell styling**: Added new `.actions-cell` class with flexbox layout and 4px gap for proper button spacing
- **Test updates**: Updated selectors in component specs to reference the new `.edit-btn` class name

## Implementation Details
- Both dataset-card and model-card components received identical refactoring for consistency
- The actions are now grouped in a single table cell with flexbox layout, improving visual organization
- Button visibility is no longer dependent on parent hover state, making actions more discoverable
- SVG icons use `currentColor` to inherit the button's text color, simplifying color management

https://claude.ai/code/session_01TSWfGwZiWgkFbF9YKKGrw9