### PR TITLE
Reorder header elements: move logo after title

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -6,8 +6,8 @@
       <span aria-hidden="true"></span>
     </button>
   </nav>
-  <img src="logo.png" alt="VTSearch logo" class="header-logo">
   <h1>VTSearch</h1>
+  <img src="logo.png" alt="VTSearch logo" class="header-logo">
 </header>
 <div class="main-content" role="main">
   <router-outlet />


### PR DESCRIPTION
## Summary
Reordered the header layout by moving the logo image element to appear after the h1 title instead of before it.

## Changes
- Moved `<img src="logo.png">` element from before `<h1>VTSearch</h1>` to after it in the header

## Details
This change affects the visual order of elements in the page header. The h1 title now appears first, followed by the logo image. This may improve semantic structure or better align with design requirements where the title should be the primary focus before the logo.

https://claude.ai/code/session_016pgQLBf96suLfw6FpAGzTi