### PR TITLE
Adjust modal positioning and content area height

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -125,7 +125,7 @@
 
 .demo-content-area {
   overflow-y: auto;
-  max-height: 400px;
+  height: 400px;
 }
 
 .demo-table {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -91,8 +91,9 @@
   inset: 0;
   background: var(--modal-backdrop);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
+  padding-top: 8vh;
   z-index: 1000;
 }
 


### PR DESCRIPTION
## Summary
Updated modal layout styling to position modals at the top of the viewport with padding, and adjusted the dataset importer modal content area to use fixed height instead of max-height.

## Key Changes
- Modified modal backdrop alignment from `center` to `flex-start` with `8vh` top padding to position modals near the top of the screen
- Changed dataset importer modal content area from `max-height: 400px` to `height: 400px` for consistent fixed height behavior

## Implementation Details
These changes improve the modal UX by:
- Reducing empty space above modals and making better use of viewport real estate
- Ensuring the dataset importer modal content area maintains a consistent height rather than expanding/contracting based on content

https://claude.ai/code/session_01XMNZHNfJGffzPrpPBcv7tB