### PR TITLE
Add disabled reason hints for Label and Find actions

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -96,21 +96,32 @@
 
   <!-- Action Buttons -->
   <div class="dashboard-actions">
-    <button
-      class="btn btn--primary"
-      [disabled]="!labelEnabled"
-      [title]="labelHint"
-      (click)="onLabel()"
-    >
-      Label
-    </button>
-    <button
-      class="btn btn--primary"
-      [disabled]="!findEnabled"
-      (click)="onFind()"
-    >
-      Find
-    </button>
+    <div class="action-btn-group">
+      <button
+        class="btn btn--primary"
+        [disabled]="!labelEnabled"
+        [title]="labelHint"
+        (click)="onLabel()"
+      >
+        Label
+      </button>
+      @if (!labelEnabled && labelHint) {
+        <span class="btn-disabled-reason">{{ labelHint }}</span>
+      }
+    </div>
+    <div class="action-btn-group">
+      <button
+        class="btn btn--primary"
+        [disabled]="!findEnabled"
+        [title]="findHint"
+        (click)="onFind()"
+      >
+        Find
+      </button>
+      @if (!findEnabled && findHint) {
+        <span class="btn-disabled-reason">{{ findHint }}</span>
+      }
+    </div>
   </div>
 </div>
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -121,3 +121,16 @@
     font-size: 1rem;
   }
 }
+
+.action-btn-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.btn-disabled-reason {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -191,6 +191,72 @@ describe('DashboardComponent', () => {
       component.selectedModelIds.clear();
       expect(component.labelHint).toBe('Select a model');
     });
+
+    it('should hint about multiple datasets', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.add('d1');
+      component.selectedDatasetIds.add('d2');
+      expect(component.labelHint).toBe('Select exactly 1 dataset');
+    });
+
+    it('should hint about multiple models', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.add('d1');
+      component.selectedModelIds.add('m1');
+      component.selectedModelIds.add('m2');
+      expect(component.labelHint).toBe('Select exactly 1 model');
+    });
+
+    it('should hint about non-trainable model', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: false, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      expect(component.labelHint).toBe('Model is not trainable');
+    });
+
+    it('should hint about media type mismatch', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'image' }];
+      flushInitialRequests(datasets, models);
+      expect(component.labelHint).toBe('Media type mismatch');
+    });
+
+    it('should return empty hint when label is enabled', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      expect(component.labelHint).toBe('');
+    });
+  });
+
+  describe('find hints', () => {
+    it('should hint about missing dataset and model', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.clear();
+      component.selectedModelIds.clear();
+      expect(component.findHint).toBe('Select a dataset and a model');
+    });
+
+    it('should hint about missing dataset', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.clear();
+      component.selectedModelIds.add('m1');
+      expect(component.findHint).toBe('Select a dataset');
+    });
+
+    it('should hint about missing model', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.add('d1');
+      component.selectedModelIds.clear();
+      expect(component.findHint).toBe('Select a model');
+    });
+
+    it('should return empty hint when find is enabled', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.add('d1');
+      component.selectedModelIds.add('m1');
+      expect(component.findHint).toBe('');
+    });
   });
 
   it('should rename a dataset', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -329,6 +329,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return true;
   }
 
+  get findHint(): string {
+    if (this.selectedDatasetIds.size === 0 && this.selectedModelIds.size === 0) return 'Select a dataset and a model';
+    if (this.selectedDatasetIds.size === 0) return 'Select a dataset';
+    if (this.selectedModelIds.size === 0) return 'Select a model';
+    return '';
+  }
+
   get labelHint(): string {
     if (this.selectedDatasetIds.size === 0) return 'Select a dataset';
     if (this.selectedDatasetIds.size > 1) return 'Select exactly 1 dataset';


### PR DESCRIPTION
## Summary
Enhanced the dashboard UI to display helpful hint messages below disabled action buttons, explaining why the Label and Find actions are unavailable. This improves user experience by providing clear feedback on what selections are needed.

## Key Changes
- **New `findHint` getter**: Added computed property to `DashboardComponent` that returns contextual messages for the Find button based on dataset and model selection state
- **Enhanced hint display**: Modified the template to show disabled reason messages below buttons when they are disabled and a hint is available
- **Improved styling**: Added `.action-btn-group` and `.btn-disabled-reason` CSS classes to properly layout and style the hint messages with muted text and italic styling
- **Comprehensive test coverage**: Added 8 new test cases covering:
  - Multiple dataset/model selection hints for Label action
  - Non-trainable model detection
  - Media type mismatch detection
  - All Find action hint scenarios (missing dataset, missing model, both missing)

## Implementation Details
- The `findHint` property follows the same pattern as the existing `labelHint` getter
- Hints are displayed conditionally using Angular's `@if` directive only when the button is disabled and a hint message exists
- The visual presentation uses flexbox column layout with small gap spacing and muted text color to avoid visual clutter while remaining helpful

https://claude.ai/code/session_01BrgZfHBhrAAstom1jDBCUi