### PR TITLE
Auto-start autopilot on component init and refactor UI flow

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -1,42 +1,35 @@
 <div class="autopilot-panel">
-  @if (!running) {
-    <div class="autopilot-idle">
-      <p class="autopilot-desc">
-        Autopilot guides you through labeling in phases: good examples, bad examples,
-        boundary refinement, and diversity exploration.
-      </p>
-      <button class="btn btn--primary" (click)="onStart()">Start Autopilot</button>
-    </div>
-  } @else {
-    <div class="autopilot-active">
-      <div class="autopilot-steps">
-        @for (step of steps; track step.phase) {
-          <div
-            class="ap-step"
-            [class.done]="step.state === 'done'"
-            [class.active]="step.state === 'active'"
-            [class.future]="step.state === 'future'"
-          >
-            <div class="ap-step-marker">
-              @if (step.state === 'done') {
-                <span class="ap-check" aria-label="Complete">&#10003;</span>
-              } @else if (step.state === 'active') {
-                <span class="ap-dot active-dot" aria-label="Current step"></span>
-              } @else {
-                <span class="ap-dot" aria-label="Upcoming step"></span>
-              }
-            </div>
-            <div class="ap-step-content">
-              <span class="ap-step-label">{{ step.label }}</span>
-              @if (step.detail) {
-                <span class="ap-step-detail">{{ step.detail }}</span>
-              }
-            </div>
-          </div>
-        }
-      </div>
+  <div class="autopilot-active">
+    <p class="autopilot-desc">
+      Autopilot guides you through labeling in phases: good examples, bad examples,
+      boundary refinement, and diversity exploration.
+    </p>
 
-      <button class="btn btn--secondary ap-stop-btn" (click)="onStop()">Stop Autopilot</button>
+    <div class="autopilot-steps">
+      @for (step of steps; track step.phase) {
+        <div
+          class="ap-step"
+          [class.done]="step.state === 'done'"
+          [class.active]="step.state === 'active'"
+          [class.future]="step.state === 'future'"
+        >
+          <div class="ap-step-marker">
+            @if (step.state === 'done') {
+              <span class="ap-check" aria-label="Complete">&#10003;</span>
+            } @else if (step.state === 'active') {
+              <span class="ap-dot active-dot" aria-label="Current step"></span>
+            } @else {
+              <span class="ap-dot" aria-label="Upcoming step"></span>
+            }
+          </div>
+          <div class="ap-step-content">
+            <span class="ap-step-label">{{ step.label }}</span>
+            @if (step.detail) {
+              <span class="ap-step-detail">{{ step.detail }}</span>
+            }
+          </div>
+        </div>
+      }
     </div>
-  }
+  </div>
 </div>

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -4,20 +4,13 @@
   gap: 12px;
 }
 
-.autopilot-idle {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  padding: 16px 8px;
-}
-
 .autopilot-desc {
   font-size: 0.82rem;
   color: var(--text-secondary);
   text-align: center;
   line-height: 1.4;
   margin: 0;
+  padding: 8px 8px 0;
 }
 
 .autopilot-active {
@@ -97,7 +90,3 @@
   color: var(--text-muted);
 }
 
-.ap-stop-btn {
-  align-self: center;
-  margin-top: 8px;
-}

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -19,34 +19,25 @@ describe('AutopilotPanelComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should start in idle state', () => {
-    expect(component.state.phase).toBe('idle');
-    expect(component.running).toBeFalse();
-  });
-
-  it('should show start button when idle', () => {
-    expect(fixture.nativeElement.querySelector('.autopilot-idle')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('.autopilot-active')).toBeNull();
-  });
-
-  it('should transition to good phase on start', () => {
-    spyOn(component.start, 'emit');
-    component.onStart();
+  it('should auto-start on init in good phase', () => {
     expect(component.state.phase).toBe('good');
     expect(component.running).toBeTrue();
-    expect(component.start.emit).toHaveBeenCalled();
   });
 
-  it('should show steps when running', () => {
-    component.onStart();
-    fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('.autopilot-active')).toBeTruthy();
+  it('should emit started on init', () => {
+    const fresh = TestBed.createComponent(AutopilotPanelComponent);
+    const comp = fresh.componentInstance;
+    spyOn(comp.started, 'emit');
+    fresh.detectChanges();
+    expect(comp.started.emit).toHaveBeenCalled();
+  });
+
+  it('should show steps immediately', () => {
     const steps = fixture.nativeElement.querySelectorAll('.ap-step');
     expect(steps.length).toBe(5);
   });
 
   it('should transition from good to bad phase', () => {
-    component.onStart();
     component.goodVotes = new Set([1, 2, 3]);
     component.ngOnChanges({
       goodVotes: { currentValue: component.goodVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
@@ -55,7 +46,6 @@ describe('AutopilotPanelComponent', () => {
   });
 
   it('should transition from bad to hard phase', () => {
-    component.onStart();
     component.state = { ...component.state, phase: 'bad' };
     component.badVotes = new Set([1, 2, 3, 4]);
     component.ngOnChanges({
@@ -65,7 +55,6 @@ describe('AutopilotPanelComponent', () => {
   });
 
   it('should transition from hard to new when smart+stable are green', () => {
-    component.onStart();
     component.state = { ...component.state, phase: 'hard' };
     component.labelingStatus = {
       smart: { status: 'green' },
@@ -79,7 +68,6 @@ describe('AutopilotPanelComponent', () => {
   });
 
   it('should transition from new to done when span is green', () => {
-    component.onStart();
     component.state = { ...component.state, phase: 'new', smartStatus: 'green', stableStatus: 'green' };
     component.labelingStatus = {
       smart: { status: 'green' },
@@ -92,17 +80,30 @@ describe('AutopilotPanelComponent', () => {
     expect(component.state.phase).toBe('done');
   });
 
-  it('should stop autopilot', () => {
-    spyOn(component.stop, 'emit');
-    component.onStart();
-    component.onStop();
+  it('should deactivate autopilot', () => {
+    spyOn(component.stopped, 'emit');
+    component.deactivate();
     expect(component.state.phase).toBe('idle');
     expect(component.running).toBeFalse();
-    expect(component.stop.emit).toHaveBeenCalled();
+    expect(component.stopped.emit).toHaveBeenCalled();
+  });
+
+  it('should re-activate after deactivate', () => {
+    component.deactivate();
+    spyOn(component.started, 'emit');
+    component.activate();
+    expect(component.state.phase).toBe('good');
+    expect(component.running).toBeTrue();
+    expect(component.started.emit).toHaveBeenCalled();
+  });
+
+  it('should not re-activate if already running', () => {
+    spyOn(component.started, 'emit');
+    component.activate();
+    expect(component.started.emit).not.toHaveBeenCalled();
   });
 
   it('should mark current step as active and future steps as future', () => {
-    component.onStart();
     const steps = component.steps;
     expect(steps[0].state).toBe('active');
     expect(steps[1].state).toBe('future');

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LabelingStatusResponse } from '../../../models/api.models';
 
@@ -28,13 +28,13 @@ interface StepDisplay {
   templateUrl: './autopilot-panel.component.html',
   styleUrl: './autopilot-panel.component.scss',
 })
-export class AutopilotPanelComponent implements OnChanges {
+export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   @Input() labelingStatus: LabelingStatusResponse | null = null;
 
-  @Output() start = new EventEmitter<void>();
-  @Output() stop = new EventEmitter<void>();
+  @Output() started = new EventEmitter<void>();
+  @Output() stopped = new EventEmitter<void>();
 
   state: AutopilotState = {
     phase: 'idle',
@@ -69,6 +69,10 @@ export class AutopilotPanelComponent implements OnChanges {
     });
   }
 
+  ngOnInit(): void {
+    this.activate();
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (!this.running) return;
 
@@ -86,7 +90,8 @@ export class AutopilotPanelComponent implements OnChanges {
     }
   }
 
-  onStart(): void {
+  activate(): void {
+    if (this.running) return;
     this.state = {
       ...this.state,
       phase: 'good',
@@ -95,12 +100,12 @@ export class AutopilotPanelComponent implements OnChanges {
       spanStatus: '',
       fracDiversity: 0,
     };
-    this.start.emit();
+    this.started.emit();
   }
 
-  onStop(): void {
+  deactivate(): void {
     this.state = { ...this.state, phase: 'idle' };
-    this.stop.emit();
+    this.stopped.emit();
   }
 
   private checkPhaseTransition(): void {

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -73,8 +73,8 @@
         [goodVotes]="goodVotes"
         [badVotes]="badVotes"
         [labelingStatus]="labelingStatus"
-        (start)="autopilotStart.emit()"
-        (stop)="autopilotStop.emit()"
+        (started)="autopilotStart.emit()"
+        (stopped)="autopilotStop.emit()"
       />
     </div>
   }

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -58,6 +58,25 @@ describe('LeftPanelComponent', () => {
     expect(tabsAfter[1].classList.contains('active')).toBeTrue();
   });
 
+  it('should emit autopilotStart when switching to autopilot tab', () => {
+    spyOn(component.autopilotStart, 'emit');
+    component.setTab('autopilot');
+    expect(component.autopilotStart.emit).toHaveBeenCalled();
+  });
+
+  it('should emit autopilotStop when switching from autopilot to manual tab', () => {
+    component.setTab('autopilot');
+    spyOn(component.autopilotStop, 'emit');
+    component.setTab('manual');
+    expect(component.autopilotStop.emit).toHaveBeenCalled();
+  });
+
+  it('should not emit when setting the same tab', () => {
+    spyOn(component.autopilotStart, 'emit');
+    component.setTab('manual');
+    expect(component.autopilotStart.emit).not.toHaveBeenCalled();
+  });
+
   it('should emit sortModeChange', () => {
     spyOn(component.sortModeChange, 'emit');
     component.sortModeChange.emit('learned');

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -63,6 +63,14 @@ export class LeftPanelComponent {
   activeTab: 'manual' | 'autopilot' = 'manual';
 
   setTab(tab: 'manual' | 'autopilot'): void {
+    if (tab === this.activeTab) return;
+    const previous = this.activeTab;
     this.activeTab = tab;
+    if (previous === 'autopilot') {
+      this.autopilotStop.emit();
+    }
+    if (tab === 'autopilot') {
+      this.autopilotStart.emit();
+    }
   }
 }


### PR DESCRIPTION
## Summary
This PR refactors the autopilot panel to auto-start on component initialization rather than requiring a manual "Start" button click. The UI now always displays the autopilot steps, and activation/deactivation is controlled programmatically through the parent component's tab switching logic.

## Key Changes

- **Auto-start behavior**: Autopilot now activates automatically in `ngOnInit()` instead of waiting for user interaction via a start button
- **Removed idle state UI**: Eliminated the conditional rendering between idle and active states; the panel now always displays the steps view
- **Refactored control methods**: Renamed `onStart()`/`onStop()` to `activate()`/`deactivate()` to better reflect their programmatic nature, with `activate()` now guarding against re-activation when already running
- **Updated event names**: Changed `start`/`stop` outputs to `started`/`stopped` for clarity
- **Tab-based lifecycle management**: The parent `LeftPanelComponent` now controls autopilot activation by emitting `autopilotStart` when switching to the autopilot tab and `autopilotStop` when switching away
- **Simplified styling**: Removed `.autopilot-idle` styles and the stop button styling since the UI is now always in the active state
- **Updated tests**: Adjusted test suite to reflect auto-start behavior and removed tests for the idle state UI

## Implementation Details

- The `activate()` method includes a guard (`if (this.running) return;`) to prevent re-initialization when already active
- Tab switching in `LeftPanelComponent` now prevents duplicate emissions by checking if the tab is already active
- The description text is now always visible as part of the active panel layout
- All phase transition logic remains unchanged; only the initialization and control flow have been refactored

https://claude.ai/code/session_01G18rwETx8TyxWY2877S1pK