### PR TITLE
Add dataset loading before navigation to label view

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -341,6 +341,78 @@ describe('DashboardComponent', () => {
     expect(el.querySelector('.dash-table')).toBeTruthy();
   });
 
+  describe('onLabel', () => {
+    it('should navigate directly when dataset is already loaded', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: true }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+
+      const routerSpy = spyOn(component['router'], 'navigate');
+      component.onLabel();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/label']);
+      expect(component.loading).toBeFalse();
+    });
+
+    it('should load dataset first when not loaded, then navigate', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: false }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+
+      const routerSpy = spyOn(component['router'], 'navigate');
+      component.onLabel();
+
+      expect(component.loading).toBeTrue();
+      expect(component.progressMessage).toContain('DS');
+      expect(routerSpy).not.toHaveBeenCalled();
+
+      // Respond to load request
+      const loadReq = httpMock.expectOne('/api/datasets/registry/d1/load');
+      expect(loadReq.request.method).toBe('POST');
+      loadReq.flush({ ok: true });
+
+      // Progress polling returns idle -> should navigate
+      const progressReq = httpMock.expectOne('/api/dataset/progress');
+      progressReq.flush({ status: 'idle' });
+
+      expect(routerSpy).toHaveBeenCalledWith(['/label']);
+
+      // Refresh after completion
+      httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+      httpMock.expectOne('/api/models/registry').flush({ models: [] });
+    });
+
+    it('should not navigate on load error progress', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: false }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+
+      const routerSpy = spyOn(component['router'], 'navigate');
+      component.onLabel();
+
+      const loadReq = httpMock.expectOne('/api/datasets/registry/d1/load');
+      loadReq.flush({ ok: true });
+
+      // Progress polling returns error
+      const progressReq = httpMock.expectOne('/api/dataset/progress');
+      progressReq.flush({ status: 'error', message: 'Out of memory' });
+
+      expect(routerSpy).not.toHaveBeenCalled();
+
+      // Refresh after error
+      httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+      httpMock.expectOne('/api/models/registry').flush({ models: [] });
+    });
+
+    it('should do nothing when no dataset is selected', () => {
+      flushInitialRequests();
+      component.selectedDatasetIds.clear();
+      const routerSpy = spyOn(component['router'], 'navigate');
+      component.onLabel();
+      expect(routerSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('should load demo dataset on demoSelected', () => {
     flushInitialRequests();
     component.importerModalOpen = true;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -232,7 +232,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Progress polling ---
 
-  startProgressPolling(): void {
+  startProgressPolling(onComplete?: () => void): void {
     this.loading = true;
     this.progressIndeterminate = true;
     this.polling$.next(); // cancel previous polling
@@ -257,6 +257,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
             this.progressIndeterminate = false;
             this.polling$.next();
             this.refresh();
+            if (progress.status === 'idle' && onComplete) {
+              onComplete();
+            }
           }
         },
       });
@@ -361,7 +364,29 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   onLabel(): void {
-    this.router.navigate(['/label']);
+    const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
+    if (!dataset) return;
+
+    if (dataset.loaded) {
+      this.router.navigate(['/label']);
+      return;
+    }
+
+    // Dataset not loaded — load it first, then navigate
+    this.loading = true;
+    this.progressMessage = `Loading ${dataset.name}...`;
+    this.progressIndeterminate = true;
+    this.datasetsApi.loadRegistered(dataset.id).subscribe({
+      next: () => {
+        this.startProgressPolling(() => {
+          this.router.navigate(['/label']);
+        });
+      },
+      error: () => {
+        this.loading = false;
+        this.progressIndeterminate = false;
+      },
+    });
   }
 
   onFind(): void {


### PR DESCRIPTION
## Summary
Enhanced the `onLabel()` method to automatically load datasets before navigating to the label view, improving the user experience by ensuring datasets are ready before labeling begins.

## Key Changes
- **Modified `onLabel()` method**: Now checks if the selected dataset is loaded before navigating. If not loaded, it initiates a load operation and navigates only after the load completes successfully.
- **Enhanced `startProgressPolling()` method**: Added optional `onComplete` callback parameter that fires when the progress status reaches 'idle', enabling post-completion actions like navigation.
- **Added comprehensive test coverage**: Implemented four new test cases covering:
  - Direct navigation when dataset is already loaded
  - Dataset loading followed by navigation when not loaded
  - Error handling when dataset load fails
  - No-op behavior when no dataset is selected

## Implementation Details
- The `onLabel()` method now validates that a dataset is selected before proceeding
- If the dataset is not loaded, it calls `datasetsApi.loadRegistered()` and uses the new `onComplete` callback in `startProgressPolling()` to navigate after the load completes
- Error handling gracefully stops the loading state if the load operation fails
- The progress message displays the dataset name being loaded for better UX feedback

https://claude.ai/code/session_01JDoyhCGQCDnhxiBfKYBgDo