### PR TITLE
Add resizable left panel divider to label view

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -1,4 +1,4 @@
-<div class="layout">
+<div class="layout" #layout>
   <div class="panel-left">
     <vt-left-panel
       [medias]="medias"
@@ -27,6 +27,10 @@
       (autopilotStop)="onAutopilotStop()"
     />
   </div>
+  <div
+    class="divider-left"
+    (mousedown)="onDividerMouseDown($event)"
+  ></div>
   <div class="panel-center">
     <div class="placeholder">
       @if (selectedId !== null) {

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -1,6 +1,6 @@
 .layout {
   display: grid;
-  grid-template-columns: 300px 1fr 300px;
+  grid-template-columns: var(--left-width, 300px) 4px 1fr 300px;
   height: 100%;
   overflow: hidden;
 }
@@ -9,6 +9,19 @@
   overflow: hidden;
   background: var(--bg-panel);
   border-right: 1px solid var(--border);
+  min-width: 180px;
+}
+
+.divider-left {
+  width: 4px;
+  cursor: col-resize;
+  background: var(--border);
+  transition: background 0.15s;
+
+  &:hover,
+  &.dragging {
+    background: var(--accent);
+  }
 }
 
 .panel-center {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject, timer, Subscription } from 'rxjs';
 import { takeUntil, switchMap } from 'rxjs/operators';
@@ -16,6 +16,8 @@ import { MediaItem, LabelingStatusResponse, AppSettings } from '../../models/api
   styleUrl: './label-view.component.scss',
 })
 export class LabelViewComponent implements OnInit, OnDestroy {
+  @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
+
   medias: MediaItem[] = [];
   sortOrder: SortedItem[] | null = null;
   threshold: number | null = null;
@@ -31,18 +33,26 @@ export class LabelViewComponent implements OnInit, OnDestroy {
   showThumbnails = true;
   loadSortLabel = '';
   settings: AppSettings | null = null;
+  leftWidth = 260;
 
+  private readonly LEFT_MIN = 180;
+  private readonly LEFT_MAX = 500;
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private learnedSortPending = false;
+  private dragging = false;
+  private boundMouseMove = this.onMouseMove.bind(this);
+  private boundMouseUp = this.onMouseUp.bind(this);
 
   constructor(
     private mediasApi: MediasApiService,
     private sortingApi: SortingApiService,
     private settingsApi: SettingsApiService,
+    private ngZone: NgZone,
   ) {}
 
   ngOnInit(): void {
+    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     this.loadMedias();
     this.loadVotes();
     this.loadSettings();
@@ -52,6 +62,36 @@ export class LabelViewComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    document.removeEventListener('mousemove', this.boundMouseMove);
+    document.removeEventListener('mouseup', this.boundMouseUp);
+  }
+
+  // --- Divider drag ---
+
+  onDividerMouseDown(event: MouseEvent): void {
+    event.preventDefault();
+    this.dragging = true;
+    this.ngZone.runOutsideAngular(() => {
+      document.addEventListener('mousemove', this.boundMouseMove);
+      document.addEventListener('mouseup', this.boundMouseUp);
+    });
+  }
+
+  private onMouseMove(event: MouseEvent): void {
+    if (!this.dragging) return;
+    const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
+    let newWidth = event.clientX - layoutRect.left;
+    newWidth = Math.max(this.LEFT_MIN, Math.min(this.LEFT_MAX, newWidth));
+    this.ngZone.run(() => {
+      this.leftWidth = newWidth;
+      this.layoutRef.nativeElement.style.setProperty('--left-width', `${newWidth}px`);
+    });
+  }
+
+  private onMouseUp(): void {
+    this.dragging = false;
+    document.removeEventListener('mousemove', this.boundMouseMove);
+    document.removeEventListener('mouseup', this.boundMouseUp);
   }
 
   // --- Data loading ---

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -1,6 +1,6 @@
 <div class="sort-bar">
   <div class="sort-mode-group">
-    <span class="sort-label">Sort</span>
+    <span class="sort-label">Sort:</span>
     <label class="sort-radio" [class.active]="sortMode === 'text'">
       <input
         type="radio"

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
@@ -6,15 +6,16 @@
 
 .sort-mode-group {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 4px 8px;
 }
 
 .sort-label {
   color: var(--text-secondary);
   font-size: 0.8rem;
   font-weight: 500;
-  min-width: 32px;
+  width: 100%;
 }
 
 .sort-radio {


### PR DESCRIPTION
## Summary
This PR adds a draggable divider between the left panel and center panel in the label view, allowing users to resize the left panel width dynamically within defined constraints.

## Key Changes
- **Label View Component**: 
  - Added `@ViewChild` reference to the layout element for DOM manipulation
  - Implemented divider drag functionality with `onDividerMouseDown()`, `onMouseMove()`, and `onMouseUp()` methods
  - Added `leftWidth` property (default 260px) with min/max constraints (180px-500px)
  - Used `NgZone` to optimize performance by running mouse move events outside Angular's change detection
  - Set CSS custom property `--left-width` dynamically during initialization and on resize

- **Label View Template**:
  - Added template reference `#layout` to the main layout div
  - Inserted new `.divider-left` element between left and center panels with mousedown event binding

- **Label View Styles**:
  - Updated grid layout to use CSS variable for left column width: `var(--left-width, 300px)`
  - Added 4px divider column between left and center panels
  - Styled `.divider-left` with `col-resize` cursor and hover/active state styling with accent color

- **Sort Bar Component**:
  - Updated sort label styling to wrap with full width and adjusted gap spacing for better responsive behavior
  - Changed "Sort" label to "Sort:" for clarity

## Implementation Details
- Mouse event listeners are bound to document level for smooth dragging outside component bounds
- `NgZone.runOutsideAngular()` is used during drag to prevent excessive change detection cycles
- Width constraints are enforced with `Math.max()` and `Math.min()` to keep the panel within usable bounds
- Event listeners are properly cleaned up in `ngOnDestroy()` to prevent memory leaks

https://claude.ai/code/session_01WwqKpqvegCU7aDB1K5G6gj