### PR TITLE
Move sort progress indicator to progress-indicators component

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -20,8 +20,6 @@
     <div class="tab-panel-manual" role="tabpanel" aria-label="Manual mode">
       <vt-sort-bar
         [sortMode]="sortMode"
-        [busy]="sortBusy"
-        [status]="sortStatus"
         [loadSortLabel]="loadSortLabel"
         [hasGoodVotes]="goodVotes.size > 0"
         [hasBadVotes]="badVotes.size > 0"
@@ -43,6 +41,8 @@
 
       <vt-progress-indicators
         [labelingStatus]="labelingStatus"
+        [sortBusy]="sortBusy"
+        [sortStatus]="sortStatus"
         (indicatorClick)="indicatorClick.emit($event)"
       />
 

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -1,40 +1,49 @@
 <div class="progress-check-bar">
-  <button
-    class="labeling-indicator"
-    [attr.data-status]="smartStatus"
-    (click)="onClick('smart')"
-    aria-label="Smart indicator"
-  >
-    <span class="indicator-dot"></span>
-    <span class="indicator-label">Smart</span>
-    @if (smartSubtext) {
-      <span class="indicator-subtext">{{ smartSubtext }}</span>
-    }
-  </button>
+  @if (sortBusy) {
+    <div class="sort-overlay" aria-live="polite">
+      @if (sortStatus) {
+        <span class="sort-overlay-status">{{ sortStatus }}</span>
+      }
+      <vt-progress-bar [indeterminate]="true" />
+    </div>
+  } @else {
+    <button
+      class="labeling-indicator"
+      [attr.data-status]="smartStatus"
+      (click)="onClick('smart')"
+      aria-label="Smart indicator"
+    >
+      <span class="indicator-dot"></span>
+      <span class="indicator-label">Smart</span>
+      @if (smartSubtext) {
+        <span class="indicator-subtext">{{ smartSubtext }}</span>
+      }
+    </button>
 
-  <button
-    class="labeling-indicator"
-    [attr.data-status]="stableStatus"
-    (click)="onClick('stable')"
-    aria-label="Stable indicator"
-  >
-    <span class="indicator-dot"></span>
-    <span class="indicator-label">Stable</span>
-    @if (stableSubtext) {
-      <span class="indicator-subtext">{{ stableSubtext }}</span>
-    }
-  </button>
+    <button
+      class="labeling-indicator"
+      [attr.data-status]="stableStatus"
+      (click)="onClick('stable')"
+      aria-label="Stable indicator"
+    >
+      <span class="indicator-dot"></span>
+      <span class="indicator-label">Stable</span>
+      @if (stableSubtext) {
+        <span class="indicator-subtext">{{ stableSubtext }}</span>
+      }
+    </button>
 
-  <button
-    class="labeling-indicator"
-    [attr.data-status]="spanStatus"
-    (click)="onClick('span')"
-    aria-label="Diverse indicator"
-  >
-    <span class="indicator-dot"></span>
-    <span class="indicator-label">Diverse</span>
-    @if (spanSubtext) {
-      <span class="indicator-subtext">{{ spanSubtext }}</span>
-    }
-  </button>
+    <button
+      class="labeling-indicator"
+      [attr.data-status]="spanStatus"
+      (click)="onClick('span')"
+      aria-label="Diverse indicator"
+    >
+      <span class="indicator-dot"></span>
+      <span class="indicator-label">Diverse</span>
+      @if (spanSubtext) {
+        <span class="indicator-subtext">{{ spanSubtext }}</span>
+      }
+    </button>
+  }
 </div>

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -1,6 +1,26 @@
 .progress-check-bar {
   display: flex;
   gap: 4px;
+  min-height: 48px;
+  align-items: stretch;
+}
+
+.sort-overlay {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border: 1px solid var(--indicator-border);
+  border-radius: 4px;
+  background: var(--bg-panel);
+}
+
+.sort-overlay-status {
+  font-size: 0.75rem;
+  color: var(--text-muted);
 }
 
 .labeling-indicator {

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
@@ -74,6 +74,29 @@ describe('ProgressIndicatorsComponent', () => {
     expect(component.spanSubtext).toBe('2.5/4');
   });
 
+  it('should show sort overlay when sortBusy is true', () => {
+    component.sortBusy = true;
+    component.sortStatus = 'Sorting...';
+    fixture.detectChanges();
+    const overlay = fixture.nativeElement.querySelector('.sort-overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.textContent).toContain('Sorting...');
+    expect(fixture.nativeElement.querySelector('.labeling-indicator')).toBeNull();
+  });
+
+  it('should show progress bar inside sort overlay when busy', () => {
+    component.sortBusy = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.sort-overlay vt-progress-bar')).toBeTruthy();
+  });
+
+  it('should show indicators when sortBusy is false', () => {
+    component.sortBusy = false;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.sort-overlay')).toBeNull();
+    expect(fixture.nativeElement.querySelectorAll('.labeling-indicator').length).toBe(3);
+  });
+
   it('should set data-status attribute on indicators', () => {
     component.labelingStatus = {
       smart: { status: 'green' },

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,16 +1,19 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import { LabelingStatusResponse } from '../../../models/api.models';
 
 @Component({
   selector: 'vt-progress-indicators',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ProgressBarComponent],
   templateUrl: './progress-indicators.component.html',
   styleUrl: './progress-indicators.component.scss',
 })
 export class ProgressIndicatorsComponent {
   @Input() labelingStatus: LabelingStatusResponse | null = null;
+  @Input() sortBusy = false;
+  @Input() sortStatus = '';
 
   @Output() indicatorClick = new EventEmitter<string>();
 

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -67,11 +67,4 @@
     </div>
   }
 
-  @if (status) {
-    <div class="sort-status" aria-live="polite">{{ status }}</div>
-  }
-
-  @if (busy) {
-    <vt-progress-bar [indeterminate]="true" />
-  }
 </div>

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
@@ -51,8 +51,3 @@
   font-size: 0.78rem;
   color: var(--text-secondary);
 }
-
-.sort-status {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
@@ -82,18 +82,6 @@ describe('SortBarComponent', () => {
     expect(fixture.nativeElement.querySelector('.sort-hint')?.textContent).toContain('Need at least');
   });
 
-  it('should show status when provided', () => {
-    component.status = 'Sorting...';
-    fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('.sort-status')?.textContent).toContain('Sorting...');
-  });
-
-  it('should show progress bar when busy', () => {
-    component.busy = true;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('vt-progress-bar')).toBeTruthy();
-  });
-
   it('should show load sort label', () => {
     component.sortMode = 'load';
     component.loadSortLabel = 'Detector A';

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
@@ -3,20 +3,17 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import { SortMode } from '../left-panel.component';
 
 @Component({
   selector: 'vt-sort-bar',
   standalone: true,
-  imports: [CommonModule, FormsModule, ProgressBarComponent],
+  imports: [CommonModule, FormsModule],
   templateUrl: './sort-bar.component.html',
   styleUrl: './sort-bar.component.scss',
 })
 export class SortBarComponent implements OnDestroy {
   @Input() sortMode: SortMode = 'text';
-  @Input() busy = false;
-  @Input() status = '';
   @Input() loadSortLabel = '';
   @Input() hasGoodVotes = false;
   @Input() hasBadVotes = false;


### PR DESCRIPTION
## Summary
Refactored the sort progress UI by moving the busy state and status display from the sort-bar component to the progress-indicators component. This consolidates all progress/status indicators in one location and improves the visual hierarchy of the left panel.

## Key Changes
- **Moved sort progress UI**: Relocated the sort status message and progress bar from `sort-bar` to `progress-indicators` component
- **Updated progress-indicators**: 
  - Added `sortBusy` and `sortStatus` inputs
  - Imported `ProgressBarComponent` 
  - Added conditional rendering to show sort overlay when busy, hiding the indicator buttons
  - Styled the new `.sort-overlay` container with flex layout, border, and proper spacing
- **Cleaned up sort-bar**: 
  - Removed `busy` and `status` inputs
  - Removed progress bar and status message from template
  - Removed `ProgressBarComponent` import and related styles
- **Updated left-panel**: 
  - Removed `[busy]` and `[status]` bindings from sort-bar
  - Added `[sortBusy]` and `[sortStatus]` bindings to progress-indicators
- **Added test coverage**: Three new test cases for the sort overlay visibility and progress bar display

## Implementation Details
- The sort overlay uses `aria-live="polite"` for accessibility when status changes
- The overlay maintains consistent styling with the existing indicator buttons (border, border-radius, background)
- When sorting is active, the three indicator buttons are completely hidden and replaced with the progress overlay
- The progress bar is indeterminate to show ongoing activity without specific progress percentage

https://claude.ai/code/session_01EfqBG2iBN4zVcHZCxGKbB1