### PR TITLE
Improve image viewer zoom display and panel overflow handling

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -12,7 +12,7 @@
   justify-content: center;
   gap: 10px;
   padding: 16px;
-  overflow-y: auto;
+  overflow: hidden;
 
   &.empty {
     color: var(--text-placeholder);
@@ -51,10 +51,6 @@
 
 .swipe-left {
   animation: swipe-left 0.18s cubic-bezier(0.4, 0, 1, 1) forwards;
-}
-
-.center-panel:has(.swipe-right, .swipe-left) {
-  overflow: hidden;
 }
 
 // Metadata grid

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -24,7 +24,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   imageSrc = '';
   zoom = 1;
   rotation = 0;
-  zoomLabel = '1.0\u00d7';
+  zoomLabel = '1\u00d7';
 
   private panX = 0;
   private panY = 0;
@@ -36,7 +36,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   private mouseMoveHandler: ((e: MouseEvent) => void) | null = null;
   private mouseUpHandler: (() => void) | null = null;
 
-  readonly minZoom = 0.25;
+  readonly minZoom = 1;
   readonly maxZoom = 5;
   readonly zoomStep = 0.05;
 
@@ -117,7 +117,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const max = this.getMaxPan();
     this.panX = Math.max(-max.x, Math.min(max.x, this.panX));
     this.panY = Math.max(-max.y, Math.min(max.y, this.panY));
-    this.zoomLabel = this.zoom.toFixed(1) + '\u00d7';
+    const zoomVal = this.zoom;
+    this.zoomLabel = (zoomVal === Math.floor(zoomVal) ? zoomVal.toFixed(0) : zoomVal.toFixed(1)) + '\u00d7';
   }
 
   private clampZoom(val: number): number {


### PR DESCRIPTION
## Summary
This PR refines the image viewer component's zoom functionality and simplifies the center panel's overflow styling.

## Key Changes
- **Zoom label formatting**: Updated to display whole numbers without decimal points (e.g., "1×" instead of "1.0×") while keeping decimals for non-integer zoom levels (e.g., "1.5×")
- **Minimum zoom level**: Increased from 0.25 to 1, preventing the image from being zoomed out below its natural size
- **Overflow handling**: Simplified center panel overflow styling by changing from `overflow-y: auto` to `overflow: hidden` and removing the conditional overflow rule for swipe animations

## Implementation Details
- The zoom label now uses conditional formatting: `toFixed(0)` for whole numbers and `toFixed(1)` for decimals
- Removed the `.center-panel:has(.swipe-right, .swipe-left)` selector as the base `overflow: hidden` rule now handles both normal and animated states consistently

https://claude.ai/code/session_01Ybr6wmCxKBrXMEAw65yvUL