### PR TITLE
Add autopilot text sort on entry with session state

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { DashboardComponent } from './dashboard.component';
+import { LabelSessionService } from '../../services/label-session.service';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -352,6 +353,18 @@ describe('DashboardComponent', () => {
 
       expect(routerSpy).toHaveBeenCalledWith(['/label']);
       expect(component.loading).toBeFalse();
+    });
+
+    it('should store selected model text_query in session before navigating', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: true }];
+      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio', text_query: 'dog barking' }];
+      flushInitialRequests(datasets, models);
+
+      const session = TestBed.inject(LabelSessionService);
+      spyOn(component['router'], 'navigate');
+      component.onLabel();
+
+      expect(session.textQuery).toBe('dog barking');
     });
 
     it('should load dataset first when not loaded, then navigate', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import { takeUntil, switchMap } from 'rxjs/operators';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { TrainableModelsApiService } from '../../services/trainable-models-api.service';
 import { VtDialogService } from '../../services/dialog.service';
+import { LabelSessionService } from '../../services/label-session.service';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { ModelCardComponent } from './model-card/model-card.component';
@@ -54,6 +55,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private datasetsApi: DatasetsApiService,
     private modelsApi: TrainableModelsApiService,
     private dialog: VtDialogService,
+    private labelSession: LabelSessionService,
   ) {}
 
   ngOnInit(): void {
@@ -363,11 +365,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return '';
   }
 
+  private storeSelectedModelTextQuery(): void {
+    const model = this.models.find((m) => this.selectedModelIds.has(m.id));
+    this.labelSession.textQuery = model?.text_query || '';
+  }
+
   onLabel(): void {
     const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
     if (!dataset) return;
 
     if (dataset.loaded) {
+      this.storeSelectedModelTextQuery();
       this.router.navigate(['/label']);
       return;
     }
@@ -378,6 +386,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.progressIndeterminate = true;
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
       next: () => {
+        this.storeSelectedModelTextQuery();
         this.startProgressPolling(() => {
           this.router.navigate(['/label']);
         });

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { LabelViewComponent } from './label-view.component';
+import { LabelSessionService } from '../../services/label-session.service';
 
 describe('LabelViewComponent', () => {
   let component: LabelViewComponent;
@@ -185,5 +186,62 @@ describe('LabelViewComponent', () => {
 
     // Should auto-select id 1 (first unlabeled)
     expect(component.selectedId).toBe(1);
+  });
+
+  it('should trigger text sort on autopilot start when session has text query', () => {
+    const session = TestBed.inject(LabelSessionService);
+    session.textQuery = 'dog barking';
+    flushInitialRequests();
+
+    // onAutopilotStart is called by left-panel ngOnInit; simulate it
+    component.onAutopilotStart();
+
+    const req = httpMock.expectOne('/api/sort');
+    expect(req.request.body).toEqual({ text: 'dog barking' });
+    req.flush({
+      results: [{ id: 1, similarity: 0.9 }, { id: 2, similarity: 0.3 }],
+      threshold: 0.5,
+    });
+
+    expect(component.sortOrder).toBeTruthy();
+    expect(component.selectedId).toBe(1);
+  });
+
+  it('should defer autopilot text sort until medias are loaded', () => {
+    const session = TestBed.inject(LabelSessionService);
+    session.textQuery = 'cat meowing';
+
+    // Call onAutopilotStart before medias are loaded
+    component.onAutopilotStart();
+    // No sort request yet (no medias)
+    httpMock.expectNone('/api/sort');
+
+    // Now trigger init which loads medias
+    fixture.detectChanges();
+    httpMock.expectOne('/api/medias').flush([
+      { id: 1, type: 'audio', duration: 5, file_size: 1024, filename: 'a.wav', category: '', md5: 'a1' },
+    ]);
+    httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+    httpMock.expectOne('/api/settings').flush({ volume: 80 });
+    httpMock.expectOne('/api/labeling-status').flush({});
+
+    // Now the deferred sort should fire
+    const req = httpMock.expectOne('/api/sort');
+    expect(req.request.body).toEqual({ text: 'cat meowing' });
+    req.flush({
+      results: [{ id: 1, similarity: 0.8 }],
+      threshold: 0.5,
+    });
+
+    expect(component.selectedId).toBe(1);
+  });
+
+  it('should not trigger text sort on autopilot start when no text query', () => {
+    const session = TestBed.inject(LabelSessionService);
+    session.textQuery = '';
+    flushInitialRequests();
+
+    component.onAutopilotStart();
+    httpMock.expectNone('/api/sort');
   });
 });

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -8,6 +8,7 @@ import { MediasApiService } from '../../services/medias-api.service';
 import { SortingApiService } from '../../services/sorting-api.service';
 import { SettingsApiService } from '../../services/settings-api.service';
 import { MediaItem, LabelingStatusResponse, AppSettings } from '../../models/api.models';
+import { LabelSessionService } from '../../services/label-session.service';
 
 @Component({
   selector: 'vt-label-view',
@@ -42,6 +43,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private learnedSortPending = false;
+  private autopilotTextSortPending = false;
   private dragging = false;
   private boundMouseMove = this.onMouseMove.bind(this);
   private boundMouseUp = this.onMouseUp.bind(this);
@@ -51,6 +53,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private sortingApi: SortingApiService,
     private settingsApi: SettingsApiService,
     private ngZone: NgZone,
+    private labelSession: LabelSessionService,
   ) {}
 
   ngOnInit(): void {
@@ -106,6 +109,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.mediasApi.getMedias().pipe(takeUntil(this.destroy$)).subscribe({
       next: (medias) => {
         this.medias = medias;
+        if (this.autopilotTextSortPending) {
+          this.autopilotTextSortPending = false;
+          this.triggerAutopilotTextSort();
+        }
       },
     });
   }
@@ -267,6 +274,21 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onAutopilotStart(): void {
     this.selectMode = 'top';
+    const textQuery = this.labelSession.textQuery;
+    if (textQuery) {
+      if (this.medias.length > 0) {
+        this.triggerAutopilotTextSort();
+      } else {
+        this.autopilotTextSortPending = true;
+      }
+    }
+  }
+
+  private triggerAutopilotTextSort(): void {
+    const textQuery = this.labelSession.textQuery;
+    if (textQuery) {
+      this.onTextSort(textQuery);
+    }
   }
 
   onAutopilotStop(): void {

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -22,50 +22,59 @@ describe('LeftPanelComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should default to manual tab', () => {
-    expect(component.activeTab).toBe('manual');
-  });
-
-  it('should switch to autopilot tab', () => {
-    component.setTab('autopilot');
+  it('should default to autopilot tab', () => {
     expect(component.activeTab).toBe('autopilot');
   });
 
-  it('should render manual tab content by default', () => {
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.tab-panel-manual')).toBeTruthy();
-    expect(el.querySelector('.tab-panel-autopilot')).toBeNull();
+  it('should emit autopilotStart on init', () => {
+    const fresh = TestBed.createComponent(LeftPanelComponent);
+    const comp = fresh.componentInstance;
+    spyOn(comp.autopilotStart, 'emit');
+    fresh.detectChanges();
+    expect(comp.autopilotStart.emit).toHaveBeenCalled();
   });
 
-  it('should render autopilot tab content when switched', () => {
-    component.setTab('autopilot');
-    fixture.detectChanges();
+  it('should switch to manual tab', () => {
+    component.setTab('manual');
+    expect(component.activeTab).toBe('manual');
+  });
+
+  it('should render autopilot tab content by default', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.tab-panel-autopilot')).toBeTruthy();
     expect(el.querySelector('.tab-panel-manual')).toBeNull();
   });
 
+  it('should render manual tab content when switched', () => {
+    component.setTab('manual');
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.tab-panel-manual')).toBeTruthy();
+    expect(el.querySelector('.tab-panel-autopilot')).toBeNull();
+  });
+
   it('should show active class on selected tab', () => {
     const el = fixture.nativeElement as HTMLElement;
     const tabs = el.querySelectorAll('.left-tab');
-    expect(tabs[0].classList.contains('active')).toBeTrue();
-    expect(tabs[1].classList.contains('active')).toBeFalse();
+    // Default: autopilot is active (second tab)
+    expect(tabs[0].classList.contains('active')).toBeFalse();
+    expect(tabs[1].classList.contains('active')).toBeTrue();
 
-    component.setTab('autopilot');
+    component.setTab('manual');
     fixture.detectChanges();
     const tabsAfter = el.querySelectorAll('.left-tab');
-    expect(tabsAfter[0].classList.contains('active')).toBeFalse();
-    expect(tabsAfter[1].classList.contains('active')).toBeTrue();
+    expect(tabsAfter[0].classList.contains('active')).toBeTrue();
+    expect(tabsAfter[1].classList.contains('active')).toBeFalse();
   });
 
   it('should emit autopilotStart when switching to autopilot tab', () => {
+    component.setTab('manual');
     spyOn(component.autopilotStart, 'emit');
     component.setTab('autopilot');
     expect(component.autopilotStart.emit).toHaveBeenCalled();
   });
 
   it('should emit autopilotStop when switching from autopilot to manual tab', () => {
-    component.setTab('autopilot');
     spyOn(component.autopilotStop, 'emit');
     component.setTab('manual');
     expect(component.autopilotStop.emit).toHaveBeenCalled();
@@ -73,7 +82,7 @@ describe('LeftPanelComponent', () => {
 
   it('should not emit when setting the same tab', () => {
     spyOn(component.autopilotStart, 'emit');
-    component.setTab('manual');
+    component.setTab('autopilot');
     expect(component.autopilotStart.emit).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SortBarComponent } from './sort-bar/sort-bar.component';
 import { SelectModeComponent } from './select-mode/select-mode.component';
@@ -33,7 +33,7 @@ export interface SortedItem {
   templateUrl: './left-panel.component.html',
   styleUrl: './left-panel.component.scss',
 })
-export class LeftPanelComponent {
+export class LeftPanelComponent implements OnInit {
   @Input() medias: MediaItem[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
@@ -60,7 +60,11 @@ export class LeftPanelComponent {
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();
 
-  activeTab: 'manual' | 'autopilot' = 'manual';
+  activeTab: 'manual' | 'autopilot' = 'autopilot';
+
+  ngOnInit(): void {
+    this.autopilotStart.emit();
+  }
 
   setTab(tab: 'manual' | 'autopilot'): void {
     if (tab === this.activeTab) return;

--- a/frontend/src/app/services/label-session.service.ts
+++ b/frontend/src/app/services/label-session.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Lightweight session state passed from dashboard to label view.
+ * Holds the selected model's text_query so autopilot can auto-sort on entry.
+ */
+@Injectable({ providedIn: 'root' })
+export class LabelSessionService {
+  textQuery = '';
+}


### PR DESCRIPTION
## Summary
This PR implements automatic text-based sorting when entering the label view in autopilot mode. It introduces a lightweight session service to pass the selected model's text query from the dashboard to the label view, enabling autopilot to automatically trigger sorting based on text similarity.

## Key Changes
- **New `LabelSessionService`**: Created a lightweight injectable service to store the selected model's `text_query` across navigation from dashboard to label view
- **Dashboard integration**: Modified `DashboardComponent.onLabel()` to store the selected model's text query in the session before navigating to the label view
- **Autopilot text sort logic**: Enhanced `LabelViewComponent.onAutopilotStart()` to trigger text-based sorting when a text query is available
- **Deferred sorting**: Implemented deferred text sort that waits for medias to load if `onAutopilotStart()` is called before media initialization
- **Default tab change**: Changed `LeftPanelComponent` to default to the autopilot tab and emit `autopilotStart` on initialization
- **Comprehensive test coverage**: Added tests for text sort triggering, deferred sorting, and edge cases (no text query, etc.)

## Implementation Details
- The `autopilotTextSortPending` flag ensures text sorting is deferred until medias are loaded, preventing premature API calls
- The session service uses a simple string property (`textQuery`) to avoid tight coupling between components
- Text sorting only triggers when both a text query exists and medias are available
- The autopilot tab is now the default entry point, with the text sort automatically executing on component initialization if a query is present

https://claude.ai/code/session_01JQYSCbUgNtrKDccY8NCPeF