### PR TITLE
Add resizable right panel divider to label view

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -37,6 +37,10 @@
       (mediaVoted)="onMediaVoted($event)"
     />
   </div>
+  <div
+    class="divider-right"
+    (mousedown)="onRightDividerMouseDown($event)"
+  ></div>
   <div class="panel-right">
     <vt-right-panel
       [medias]="medias"

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -1,6 +1,6 @@
 .layout {
   display: grid;
-  grid-template-columns: var(--left-width, 300px) 4px 1fr 300px;
+  grid-template-columns: var(--left-width, 300px) 4px 1fr 4px var(--right-width, 300px);
   height: 100%;
   overflow: hidden;
 }
@@ -32,9 +32,22 @@
   justify-content: center;
 }
 
+.divider-right {
+  width: 4px;
+  cursor: col-resize;
+  background: var(--border);
+  transition: background 0.15s;
+
+  &:hover,
+  &.dragging {
+    background: var(--accent);
+  }
+}
+
 .panel-right {
-  overflow-y: auto;
+  overflow: hidden;
   background: var(--bg-panel);
   border-left: 1px solid var(--border);
+  min-width: 150px;
 }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -37,15 +37,21 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   loadSortLabel = '';
   settings: AppSettings | null = null;
   leftWidth = 260;
+  rightWidth = 300;
 
   private readonly LEFT_MIN = 180;
   private readonly LEFT_MAX = 500;
+  private readonly RIGHT_MIN = 150;
+  private readonly RIGHT_MAX = 500;
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private learnedSortPending = false;
   private dragging = false;
+  private draggingRight = false;
   private boundMouseMove = this.onMouseMove.bind(this);
   private boundMouseUp = this.onMouseUp.bind(this);
+  private boundRightMouseMove = this.onRightMouseMove.bind(this);
+  private boundRightMouseUp = this.onRightMouseUp.bind(this);
 
   constructor(
     private mediasApi: MediasApiService,
@@ -56,6 +62,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit(): void {
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
+    this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     this.loadMedias();
     this.loadVotes();
     this.loadSettings();
@@ -71,6 +78,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.destroy$.complete();
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
+    document.removeEventListener('mousemove', this.boundRightMouseMove);
+    document.removeEventListener('mouseup', this.boundRightMouseUp);
   }
 
   // --- Divider drag ---
@@ -99,6 +108,34 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dragging = false;
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
+  }
+
+  // --- Right divider drag ---
+
+  onRightDividerMouseDown(event: MouseEvent): void {
+    event.preventDefault();
+    this.draggingRight = true;
+    this.ngZone.runOutsideAngular(() => {
+      document.addEventListener('mousemove', this.boundRightMouseMove);
+      document.addEventListener('mouseup', this.boundRightMouseUp);
+    });
+  }
+
+  private onRightMouseMove(event: MouseEvent): void {
+    if (!this.draggingRight) return;
+    const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
+    let newWidth = layoutRect.right - event.clientX;
+    newWidth = Math.max(this.RIGHT_MIN, Math.min(this.RIGHT_MAX, newWidth));
+    this.ngZone.run(() => {
+      this.rightWidth = newWidth;
+      this.layoutRef.nativeElement.style.setProperty('--right-width', `${newWidth}px`);
+    });
+  }
+
+  private onRightMouseUp(): void {
+    this.draggingRight = false;
+    document.removeEventListener('mousemove', this.boundRightMouseMove);
+    document.removeEventListener('mouseup', this.boundRightMouseUp);
   }
 
   // --- Data loading ---

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -1,5 +1,13 @@
+:host {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .vote-section {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 12px 16px;
 }

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -5,10 +5,7 @@
 }
 
 .panel-right {
-  width: 220px;
-  border-left: 1px solid var(--border);
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   background: var(--bg-panel);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
This PR adds a draggable divider to the right panel in the label view component, allowing users to resize the right panel width dynamically between 150px and 500px.

## Key Changes
- **Label View Component**: Added right panel width state management and drag handlers
  - New `rightWidth` property to track right panel width (default 300px)
  - New `RIGHT_MIN` and `RIGHT_MAX` constants for width constraints
  - Implemented `onRightDividerMouseDown()`, `onRightMouseMove()`, and `onRightMouseUp()` methods to handle dragging
  - Added bound event listeners for right divider mouse events
  - Updated `ngOnInit()` to set CSS variable for right panel width
  - Updated `ngOnDestroy()` to clean up right divider event listeners

- **Label View Template**: Added draggable divider element
  - New divider div with `divider-right` class and mousedown handler

- **Label View Styles**: Updated grid layout and added divider styling
  - Modified grid template to include right divider: `grid-template-columns: var(--left-width, 300px) 4px 1fr 4px var(--right-width, 300px)`
  - Added `.divider-right` styles with hover/dragging visual feedback
  - Updated `.panel-right` to use `overflow: hidden` and set `min-width: 150px`

- **Right Panel Styles**: Simplified panel styling
  - Removed fixed width and border styling (now handled by parent layout)
  - Kept flex layout for proper content distribution

- **Label List Styles**: Enhanced scrollable content handling
  - Added `:host` styles for proper flex container setup
  - Added `min-height: 0` to enable proper flex scrolling behavior

## Implementation Details
- Uses `NgZone.runOutsideAngular()` for performance optimization during drag operations
- Calculates new width based on mouse position relative to layout bounds
- Applies CSS custom property (`--right-width`) for dynamic styling
- Follows same drag pattern as existing left divider implementation

https://claude.ai/code/session_011y9eUEiMNqFqfZmZFNsKMx