### PR TITLE
Auto-select media type when dataset registry has single type

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -34,6 +34,16 @@ export class NewModelModalComponent implements OnInit {
         this.mediaTypes = (res.media_types || []).map((t) => t.type_id || t.name);
       },
     });
+    this.datasetsApi.getRegistry().subscribe({
+      next: (res) => {
+        const types = new Set(
+          (res.datasets || []).map((d) => d['media_type'] as string).filter(Boolean),
+        );
+        if (types.size === 1) {
+          this.mediaType = [...types][0];
+        }
+      },
+    });
   }
 
   submit(): void {


### PR DESCRIPTION
## Summary
Added logic to automatically select the media type in the new model modal when the dataset registry contains datasets with only a single media type.

## Key Changes
- Added a call to `datasetsApi.getRegistry()` in the `NewModelModalComponent` initialization
- Extracts unique media types from the dataset registry results
- Automatically sets `this.mediaType` to the single media type if only one type exists across all datasets
- Uses a Set to efficiently deduplicate media types and filter out empty/null values

## Implementation Details
- The new code subscribes to the registry API response and processes the `datasets` array
- Media types are extracted from the `media_type` property of each dataset
- Only sets the media type if exactly one unique type is found (size === 1)
- Maintains backward compatibility - no media type is selected if multiple types or no types are found

https://claude.ai/code/session_018YTMKiBwRmAVruMmMoZyYA