### PR TITLE
Remove "Loaded?" column from model dashboard table

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1528,7 +1528,6 @@
         <th data-sort="last_trained_at">Last Trained<span class="sort-arrow"></span></th>
         <th data-sort="created_at">Created<span class="sort-arrow"></span></th>
         <th>Autorun?</th>
-        <th>Loaded?</th>
         <th class="col-actions-header"></th>
       </tr></thead><tbody></tbody></table>`;
 
@@ -1550,7 +1549,6 @@
       sorted.forEach(m => {
         const icon = mediaIcons[m.media_type] || "";
         const isSelected = dashSelectedModelIds.includes(m.id);
-        const isLoaded = !!m.loaded;
         const trainingText = m.trainable ? String(m.num_training || 0) : "-";
         const tr = document.createElement("tr");
         tr.className = "dash-model-row" + (isSelected ? " dash-selected" : "");
@@ -1571,7 +1569,6 @@
           <td class="col-last-trained">${escapeHtml(mLastTrained)}</td>
           <td class="col-date">${escapeHtml(mCreated)}</td>
           <td class="col-autorun"><input type="checkbox" class="dash-autorun-cb" ${isAutorun ? "checked" : ""} title="Include in CLI autorun" aria-label="Autorun"></td>
-          <td class="col-loaded">${isLoaded ? '<span style="color:var(--color-good)">✓</span>' : ''}</td>
           <td class="col-actions"><button class="btn-icon dash-rename-btn" title="Rename" aria-label="Rename model">&#9998;</button><button class="btn-icon btn-icon-danger dash-delete-btn" title="Remove model" aria-label="Remove model">&#128465;</button></td>
         `);
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -356,7 +356,7 @@ class TestDashboardModelRegistryColumns:
         assert m["autodetect"] is True
 
     def test_model_registry_includes_loaded_field(self, client):
-        """Registered models include the loaded boolean (renamed to Loaded? in UI)."""
+        """Registered models include the loaded boolean (not shown in UI)."""
         register_model(name="ld-model", media_type="audio", trainable=True)
         resp = client.get("/api/models/registry")
         data = resp.get_json()


### PR DESCRIPTION
## Summary
Removes the "Loaded?" column from the model dashboard table UI, as this information is no longer needed in the user interface. The `loaded` field remains available in the API response for backend purposes.

## Changes
- Removed the "Loaded?" table header from the model dashboard table
- Removed the `isLoaded` variable calculation that checked the model's loaded status
- Removed the table cell that displayed the loaded status indicator (green checkmark)
- Updated test documentation to reflect that the loaded field is no longer displayed in the UI

## Details
The `loaded` boolean field continues to be included in the `/api/models/registry` API response, but is now hidden from the dashboard UI. This simplifies the model table display while maintaining the data availability for API consumers.

https://claude.ai/code/session_01BxCp9jwP7MfSUZXNhvwM3S