### PR TITLE
Remove left border from right panel

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -339,7 +339,7 @@ video { max-width: 100%; }
 .train-context-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* Right panel – votes */
-.panel-right { width: 220px; border-left: 1px solid var(--border); overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
+.panel-right { width: 220px; overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
 .label-sort-bar { padding: 8px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .vote-section { flex: 1; overflow-y: auto; padding: 12px 16px; }
 .vote-section + .vote-section { border-top: 1px solid var(--border); }


### PR DESCRIPTION
## Summary
Removed the left border styling from the right panel element to update the visual design of the votes panel.

## Changes
- Removed `border-left: 1px solid var(--border);` from `.panel-right` CSS rule
- The right panel now relies on other visual separation methods instead of an explicit left border

## Details
This is a minor CSS adjustment that simplifies the right panel styling while maintaining its layout and functionality. The panel will still be visually distinct through its background color and other existing styles.

https://claude.ai/code/session_01VfYUDzRRXM3P1Ph3zk1LfP