### PR TITLE
Fix burger menu positioning in header layout

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -25,10 +25,7 @@ header {
 }
 
 .burger-menu {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
+  position: relative;
   z-index: 2000;
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -173,11 +173,11 @@
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: var(--bg-body); color: var(--text-primary); height: 100vh; display: flex; flex-direction: column; }
 header { background: var(--bg-surface); padding: 12px 24px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 12px; position: relative; }
 header h1 { font-size: 1.3rem; color: var(--accent); }
-.header-logo { height: 28px; width: auto; margin-left: 48px; }
+.header-logo { height: 28px; width: auto; }
 .layout { display: flex; flex: 1; overflow: hidden; }
 
 /* Burger menu */
-.burger-menu { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); z-index: 2000; }
+.burger-menu { position: relative; z-index: 2000; }
 .burger-btn { width: 32px; height: 32px; background: transparent; border: 1px solid var(--border); border-radius: 4px; cursor: pointer; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; padding: 0; transition: all 0.2s; }
 .burger-btn:hover { background: var(--bg-hover); border-color: var(--accent); }
 .burger-btn span { display: block; width: 18px; height: 2px; background: var(--text-secondary); transition: all 0.2s; }


### PR DESCRIPTION
## Summary
Refactored the burger menu positioning from absolute to relative positioning, and removed unnecessary left margin from the header logo. This simplifies the header layout and allows the burger menu to flow naturally within the flexbox header layout.

## Key Changes
- Changed `.burger-menu` from `position: absolute` with manual centering (`left: 12px; top: 50%; transform: translateY(-50%)`) to `position: relative`
- Removed `margin-left: 48px` from `.header-logo` to eliminate the spacing workaround that was needed for absolute positioning
- Updated both `frontend/src/app/app.component.scss` and `static/styles.css` to maintain consistency

## Implementation Details
The burger menu was previously positioned absolutely with manual left and vertical centering, which required compensating with a large left margin on the logo. By switching to relative positioning, the burger menu now participates in the header's flexbox layout naturally, eliminating the need for absolute positioning hacks and the associated margin compensation. This results in cleaner, more maintainable CSS and a more flexible layout.

https://claude.ai/code/session_01MDVUenSfeZw3pTWfzyZLrr