### PR TITLE
Fix media reselection when switching sort modes

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3301,6 +3301,10 @@
         sortStatus.textContent = "";
         if (!loadedDetector) {
           openLoadSortModal();
+        } else {
+          // Detector already loaded — reselect central media for current select mode
+          const nextClip = findNextClip();
+          if (nextClip) selectMedia(nextClip.id);
         }
         return;
       }
@@ -3312,7 +3316,19 @@
       sortStatus.textContent = "";
 
       if (sortMode === "text") {
-        onTextSortInput();
+        // Bypass debounce: when switching sort modes, fetch immediately
+        // so the central media is reselected without delay.
+        clearTimeout(sortTimer);
+        const text = textSortInput.value.trim();
+        if (text) {
+          fetchTextSort(text);
+        } else {
+          sortOrder = null;
+          sortStatus.textContent = "";
+          renderMediaList();
+          const nextClip = findNextClip();
+          if (nextClip) selectMedia(nextClip.id);
+        }
       } else if (sortMode === "learned") {
         updateLearnedSortDesc();
         fetchLearnedSort(true);


### PR DESCRIPTION
## Summary
Improved the sort mode switching behavior to properly reselect central media when changing between sort modes, particularly when a detector is already loaded or when switching to text sort mode.

## Key Changes
- **Detector already loaded**: When switching sort modes with a detector already loaded, the UI now reselects the central media for the current sort mode instead of opening the load modal again
- **Text sort mode**: Bypassed the debounce timer when switching to text sort mode to ensure immediate fetching and media reselection without delay
- **Empty text input**: Added handling for when text sort input is empty—clears the sort order and reselects media appropriately

## Implementation Details
- Added an `else` branch to handle the case where `loadedDetector` is already true, calling `findNextClip()` and `selectMedia()` to reselect appropriate media
- Explicitly `clearTimeout(sortTimer)` when entering text sort mode to bypass debounce and fetch immediately
- Consolidated text sort logic to handle both populated and empty input cases, ensuring media reselection occurs in both scenarios

https://claude.ai/code/session_01MDZ1v3nYw3jGYXRUjVcTLW