### PR TITLE
Remove dataset and model loading functionality

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -43,7 +43,6 @@
                 (rowClick)="toggleDatasetSelection(dataset.id, $event)"
                 (rename)="renameDataset(dataset, $event)"
                 (delete)="deleteDataset(dataset)"
-                (load)="loadDataset(dataset)"
               />
             }
           </tbody>
@@ -74,7 +73,6 @@
               <th>Trainable</th>
               <th (click)="sortModels('last_trained_at')" class="sortable">Last Trained<span class="sort-indicator" [class.active]="isModelSortActive('last_trained_at')">{{ modelSortIndicator('last_trained_at') }}</span></th>
               <th (click)="sortModels('created_at')" class="sortable">Created<span class="sort-indicator" [class.active]="isModelSortActive('created_at')">{{ modelSortIndicator('created_at') }}</span></th>
-              <th>Loaded</th>
               <th>Actions</th>
             </tr>
           </thead>

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -298,26 +298,6 @@ describe('DashboardComponent', () => {
     httpMock.expectOne('/api/models/registry').flush({ models: [] });
   }));
 
-  it('should load a dataset and start progress polling', () => {
-    const datasets = [{ id: 'd1', name: 'ToLoad', loaded: false }];
-    flushInitialRequests(datasets);
-
-    component.loadDataset(datasets[0]);
-    expect(component.loading).toBeTrue();
-
-    const req = httpMock.expectOne('/api/datasets/registry/d1/load');
-    expect(req.request.method).toBe('POST');
-    req.flush({});
-
-    // Progress polling starts
-    const progressReq = httpMock.expectOne('/api/dataset/progress');
-    progressReq.flush({ status: 'idle' });
-
-    // After idle, it should refresh
-    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-    httpMock.expectOne('/api/models/registry').flush({ models: [] });
-  });
-
   it('should open and close importer modal', () => {
     flushInitialRequests();
     expect(component.importerModalOpen).toBeFalse();

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -167,21 +167,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  loadDataset(dataset: any): void {
-    this.datasetState.setLoading(true);
-    this.datasetState.setProgressMessage(`Loading ${dataset.name}...`);
-    this.progressIndeterminate = true;
-    this.datasetsApi.loadRegistered(dataset.id).subscribe({
-      next: () => {
-        this.startProgressPolling();
-      },
-      error: () => {
-        this.datasetState.setLoading(false);
-        this.progressIndeterminate = false;
-      },
-    });
-  }
-
   // --- Model actions ---
 
   renameModel(model: any, newName: string): void {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -24,7 +24,7 @@
   @if (dataset.loaded) {
     <span class="check" aria-label="Loaded">&#10003;</span>
   } @else {
-    <button class="btn btn--secondary btn--xs" (click)="onLoad($event)">Load</button>
+    <span class="dim">-</span>
   }
 </td>
 <td class="actions-cell">

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -51,12 +51,12 @@ describe('DatasetCardComponent', () => {
     expect(el.querySelector('.check')).toBeTruthy();
   });
 
-  it('should show Load button when not loaded', () => {
+  it('should show dash when not loaded', () => {
     component.dataset = { ...mockDataset, loaded: false };
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
-    const loadBtn = el.querySelector('button.btn--secondary');
-    expect(loadBtn?.textContent).toContain('Load');
+    const dims = el.querySelectorAll('.dim');
+    expect(dims.length).toBeGreaterThan(0);
   });
 
   it('should enter rename mode on rename button click', () => {
@@ -101,16 +101,6 @@ describe('DatasetCardComponent', () => {
     const deleteBtn = el.querySelector('.delete-btn') as HTMLElement;
     deleteBtn.click();
     expect(component.delete.emit).toHaveBeenCalled();
-  });
-
-  it('should emit load on load button click', () => {
-    spyOn(component.load, 'emit');
-    component.dataset = { ...mockDataset, loaded: false };
-    fixture.detectChanges();
-    const el = fixture.nativeElement as HTMLElement;
-    const loadBtn = el.querySelector('.btn--secondary') as HTMLElement;
-    loadBtn.click();
-    expect(component.load.emit).toHaveBeenCalled();
   });
 
   it('should format dates', () => {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -20,7 +20,6 @@ export class DatasetCardComponent {
   }
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
-  @Output() load = new EventEmitter<void>();
 
   editing = false;
   editName = '';
@@ -54,11 +53,6 @@ export class DatasetCardComponent {
   onDelete(event: MouseEvent): void {
     event.stopPropagation();
     this.delete.emit();
-  }
-
-  onLoad(event: MouseEvent): void {
-    event.stopPropagation();
-    this.load.emit();
   }
 
   formatDate(timestamp: number | null): string {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -25,13 +25,6 @@
 </td>
 <td>{{ formatDate(model.last_trained_at) }}</td>
 <td>{{ formatDate(model.created_at) }}</td>
-<td>
-  @if (model.loaded) {
-    <span class="check" aria-label="Loaded">&#10003;</span>
-  } @else {
-    <span class="dim">-</span>
-  }
-</td>
 <td class="actions-cell">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Summary
This PR removes the dataset and model loading features from the dashboard, including the load buttons, progress polling, and associated API calls.

## Key Changes
- **Removed `loadDataset()` method** from DashboardComponent that handled loading datasets and starting progress polling
- **Removed load button** from dataset cards - replaced with a dash indicator (`-`) for unloaded datasets, matching the visual treatment of unloaded models
- **Removed `load` event emitter** from DatasetCardComponent and its associated `onLoad()` handler
- **Removed "Loaded" column** from the models table in the dashboard
- **Removed loaded status display** from model cards (the checkmark/dash indicator)
- **Updated tests** to reflect the removal of load functionality:
  - Removed test for dataset loading and progress polling
  - Updated dataset card test to verify dash display instead of load button
  - Removed test for load button click emission

## Implementation Details
- The dataset card now displays a consistent visual indicator (`-`) for unloaded datasets instead of an interactive load button
- The models table no longer shows a "Loaded" column, simplifying the UI
- All related event handlers and API integration for the load feature have been removed
- Tests have been updated to verify the new behavior of displaying dashes for unloaded items

https://claude.ai/code/session_01UUi8wxpi3XoQVkNqBdngH6