### PR TITLE
Add text truncation to dashboard action button hints

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -736,6 +736,7 @@ video { max-width: 100%; }
 .dashboard-action-btn .dash-btn-hint {
   display: block; font-size: 0.68rem; font-weight: 400; opacity: 0.85;
   line-height: 1.2; min-height: 1.2em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .dashboard-action-btn:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
 .dashboard-action-btn:disabled { opacity: 0.35; cursor: not-allowed; }


### PR DESCRIPTION
## Summary
Added CSS text truncation styling to dashboard action button hints to prevent long text from overflowing and breaking the layout.

## Changes
- Added `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` properties to `.dashboard-action-btn .dash-btn-hint`
- This ensures long hint text is truncated with an ellipsis (...) instead of wrapping or overflowing

## Details
The dashboard action button hints now display truncated text on a single line when the content exceeds the available width, improving the visual consistency and preventing layout issues caused by unexpectedly long hint text.

https://claude.ai/code/session_01AbSH6LV2mpz9S2kpcULuid