### PR TITLE
Replace Settings dialog with modal component

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -62,4 +62,7 @@
 <div class="main-content" role="main">
   <router-outlet />
 </div>
+@if (showSettings) {
+  <vt-settings-modal (closed)="showSettings = false" />
+}
 <vt-dialog-host />

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { AppComponent } from './app.component';
 import { provideRouter } from '@angular/router';
 import { VtDialogService } from './services/dialog.service';
@@ -17,6 +19,8 @@ describe('AppComponent', () => {
       imports: [AppComponent],
       providers: [
         provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: VtDialogService, useValue: dialogSpy },
       ],
     }).compileComponents();
@@ -153,11 +157,11 @@ describe('AppComponent', () => {
     expect(fixture.componentInstance.menuOpen).toBeFalse();
   });
 
-  it('should show Settings dialog when Settings clicked', () => {
+  it('should open Settings modal when Settings clicked', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.componentInstance.menuOpen = true;
     fixture.componentInstance.onSettings();
-    expect(dialogSpy.alert).toHaveBeenCalled();
+    expect(fixture.componentInstance.showSettings).toBeTrue();
     expect(fixture.componentInstance.menuOpen).toBeFalse();
   });
 });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,17 +3,19 @@ import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
+import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
 import { VtDialogService } from './services/dialog.service';
 
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, RouterOutlet, DialogHostComponent],
+  imports: [CommonModule, RouterOutlet, DialogHostComponent, SettingsModalComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
 export class AppComponent {
   title = 'VTSearch';
   menuOpen = false;
+  showSettings = false;
   isOnLabelView = false;
   labelsStatus = '';
   detectorStatus = '';
@@ -105,6 +107,6 @@ export class AppComponent {
 
   onSettings(): void {
     this.menuOpen = false;
-    this.dialog.alert('Settings not yet available in the Angular frontend.', 'info');
+    this.showSettings = true;
   }
 }


### PR DESCRIPTION
## Summary
Replaced the Settings dialog implementation with a dedicated modal component, improving the UI/UX for the settings interface in the Angular frontend.

## Key Changes
- Added `SettingsModalComponent` import and included it in `AppComponent` imports
- Introduced `showSettings` boolean flag to `AppComponent` to control modal visibility
- Updated `onSettings()` method to set `showSettings = true` instead of calling `dialog.alert()`
- Added conditional rendering of `<vt-settings-modal>` in the template with a `(closed)` event handler to toggle visibility
- Updated test to verify `showSettings` flag is set to `true` instead of checking for dialog service calls
- Updated test description from "should show Settings dialog" to "should open Settings modal"
- Added HTTP client providers (`provideHttpClient` and `provideHttpClientTesting`) to the test setup for proper dependency injection

## Implementation Details
- The settings modal is conditionally rendered using Angular's `@if` control flow syntax
- The modal emits a `closed` event that resets the `showSettings` flag, allowing users to close the modal
- The implementation follows Angular's standalone component pattern with proper imports

https://claude.ai/code/session_01KP1C53iZifT99tJeWWyJtT