### PR TITLE
Add bottom select mode for autopilot bad phase

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject, timer, Subscription } from 'rxjs';
+import { Subject, timer, Subscription, pairwise } from 'rxjs';
 import { takeUntil, switchMap } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
@@ -11,6 +11,7 @@ import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService, SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import { AutopilotStateService } from '../../services/autopilot-state.service';
 import { LabelingStatusResponse } from '../../models/api.models';
 
 @Component({
@@ -52,6 +53,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     public voteState: VoteStateService,
     public sortState: SortStateService,
     private settingsState: SettingsStateService,
+    private autopilotStateService: AutopilotStateService,
   ) {}
 
   ngOnInit(): void {
@@ -69,6 +71,16 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.autopilotTextSortPending = false;
           this.triggerAutopilotTextSort();
         }
+      });
+
+    this.autopilotStateService.state$
+      .pipe(pairwise(), takeUntil(this.destroy$))
+      .subscribe(([prev, curr]) => {
+        if (prev.phase === curr.phase) return;
+        if (curr.phase === 'good') this.sortState.setSelectMode('top');
+        else if (curr.phase === 'bad') this.sortState.setSelectMode('bottom');
+        else if (curr.phase === 'hard') this.sortState.setSelectMode('hard');
+        else if (curr.phase === 'new') this.sortState.setSelectMode('new');
       });
   }
 
@@ -324,6 +336,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         (s) => !goodVotes.has(s.id) && !badVotes.has(s.id),
       );
       if (next) this.mediaState.selectMedia(next.id);
+    } else if (this.sortState.selectMode === 'bottom') {
+      for (let i = sortOrder.length - 1; i >= 0; i--) {
+        const s = sortOrder[i];
+        if (!goodVotes.has(s.id) && !badVotes.has(s.id)) {
+          this.mediaState.selectMedia(s.id);
+          break;
+        }
+      }
     } else if (this.sortState.selectMode === 'hard' && this.sortState.threshold !== null) {
       let best: SortedItem | null = null;
       let bestDist = Infinity;

--- a/frontend/src/app/services/sort-state.service.ts
+++ b/frontend/src/app/services/sort-state.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 export type SortMode = 'text' | 'learned' | 'load';
-export type SelectMode = 'top' | 'hard' | 'new';
+export type SelectMode = 'top' | 'bottom' | 'hard' | 'new';
 
 export interface SortedItem {
   id: number;

--- a/static/app.js
+++ b/static/app.js
@@ -11,7 +11,7 @@
   let selected = null;
   let sortOrder = null;   // null = default, or [{id, score}, ...]
   let sortMode = "text";  // "text" | "learned" | "load"
-  let selectMode = "top"; // "top" | "hard"
+  let selectMode = "top"; // "top" | "bottom" | "hard"
   let threshold = null;    // threshold for Good/Bad boundary
   let sortTimer = null;
   let inclusion = 0;       // Inclusion setting: -10 to +10
@@ -905,11 +905,12 @@
 
     if (st.phase === "good") {
       if (votes.good.length >= st.goodToStart) {
-        // Transition to Bad phase — switch select mode to Hard.
+        // Transition to Bad phase — switch select mode to Bottom so the user
+        // sees items least similar to the example (clear negatives).
         // Good→Bad only changes select mode (no sort change, no media jerk),
         // so apply immediately even mid-vote.
         st.phase = "bad";
-        _apSetSelectMode("hard");
+        _apSetSelectMode("bottom");
         checkAutopilotPhase(); // re-check in case bad threshold also met
         return;
       }
@@ -3722,6 +3723,9 @@
     if (selectMode === "top") {
       // Select highest scoring unlabeled media (or first in order for null sort)
       nextClip = unlabeled[0];
+    } else if (selectMode === "bottom") {
+      // Select lowest scoring unlabeled media (last in sort order)
+      nextClip = unlabeled[unlabeled.length - 1];
     } else {
       // Select unlabeled media closest to threshold by list position,
       // breaking ties by score distance


### PR DESCRIPTION
## Summary
This PR adds a new "bottom" select mode to support the autopilot bad phase, allowing users to review items least similar to positive examples during the labeling workflow.

## Key Changes
- Added `pairwise` operator import from rxjs to detect autopilot phase transitions
- Introduced `AutopilotStateService` dependency to monitor autopilot phase changes
- Added new `SelectMode` type: `'bottom'` alongside existing `'top'`, `'hard'`, and `'new'` modes
- Implemented autopilot phase-to-select-mode mapping:
  - `'good'` phase → `'top'` select mode
  - `'bad'` phase → `'bottom'` select mode
  - `'hard'` phase → `'hard'` select mode
  - `'new'` phase → `'new'` select mode
- Updated media selection logic to handle bottom mode by selecting the lowest-scoring unlabeled item
- Changed autopilot bad phase transition to use `'bottom'` mode instead of `'hard'` mode

## Implementation Details
- The autopilot phase subscription uses `pairwise()` to detect phase changes and only updates select mode when the phase actually transitions
- Bottom mode selection iterates through the sort order in reverse to find the first unlabeled item
- The bad phase now shows items least similar to positive examples, providing clearer negative examples for the labeling workflow

https://claude.ai/code/session_01QbJpiHBDrbNsiot2C95Utj