### PR TITLE
Add resizable column handles for left and right panels

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -7051,4 +7051,37 @@
     }
   }
 
+  // ---- Column resize handles ----
+  function initResizeHandle(handleId, panel, side) {
+    const handle = document.getElementById(handleId);
+    if (!handle || !panel) return;
+    let startX, startWidth;
+    handle.addEventListener("mousedown", function (e) {
+      e.preventDefault();
+      startX = e.clientX;
+      startWidth = panel.getBoundingClientRect().width;
+      handle.classList.add("active");
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      function onMouseMove(e) {
+        const dx = e.clientX - startX;
+        const newWidth = side === "left" ? startWidth + dx : startWidth - dx;
+        const clamped = Math.max(100, Math.min(newWidth, window.innerWidth * 0.4));
+        panel.style.width = clamped + "px";
+        panel.style.minWidth = clamped + "px";
+      }
+      function onMouseUp() {
+        handle.classList.remove("active");
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", onMouseUp);
+      }
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", onMouseUp);
+    });
+  }
+  initResizeHandle("resize-handle-left", leftPanel, "left");
+  initResizeHandle("resize-handle-right", rightPanel, "right");
+
 })();

--- a/static/index.html
+++ b/static/index.html
@@ -116,6 +116,9 @@
     </div>
   </div>
 
+  <!-- Left resize handle -->
+  <div class="resize-handle resize-handle-left" id="resize-handle-left" title="Drag to resize left panel"></div>
+
   <!-- Center panel -->
   <main class="panel-center" id="center">
     <!-- Dashboard view — select dataset + model, then dispatch to Label or Detect -->
@@ -202,6 +205,9 @@
     </div>
   </main>
   <input type="file" id="file-input" accept=".pkl" style="display:none" aria-label="Dataset file">
+
+  <!-- Right resize handle -->
+  <div class="resize-handle resize-handle-right" id="resize-handle-right" title="Drag to resize right panel"></div>
 
   <!-- Right panel -->
   <aside class="panel-right" aria-label="Labels">

--- a/static/styles.css
+++ b/static/styles.css
@@ -242,7 +242,12 @@ header h1 { margin-left: 0; }
 .ap-step-detail .ap-indicator-dot[data-status="green"] { background: #2ecc71; border-color: #27ae60; }
 
 /* Left panel – media list */
-.panel-left { width: 185px; min-width: 185px; border-right: 1px solid var(--border); overflow-y: auto; background: var(--bg-panel); display: flex; flex-direction: column; position: relative; }
+.panel-left { width: 185px; min-width: 100px; border-right: none; overflow-y: auto; background: var(--bg-panel); display: flex; flex-direction: column; position: relative; }
+
+/* Resize handles between panels */
+.resize-handle { width: 5px; cursor: col-resize; background: var(--border); flex-shrink: 0; position: relative; z-index: 10; }
+.resize-handle:hover, .resize-handle.active { background: var(--accent); }
+.resize-handle-right { border-left: none; }
 .sort-bar { padding: 8px 28px 12px 10px; border-bottom: 1px solid var(--border); }
 .sort-mode { display: flex; flex-wrap: nowrap; gap: 10px; margin-bottom: 6px; white-space: nowrap; }
 .sort-mode label { font-size: 0.75rem; color: var(--text-secondary); cursor: pointer; display: flex; align-items: center; gap: 3px; }
@@ -340,7 +345,7 @@ video { max-width: 100%; }
 .train-context-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* Right panel – votes */
-.panel-right { width: 220px; overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
+.panel-right { width: 220px; min-width: 100px; overflow-y: auto; overflow-x: hidden; background: var(--bg-panel); display: flex; flex-direction: column; }
 .label-sort-bar { padding: 8px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .vote-section { flex: 1; overflow-y: auto; padding: 12px 16px; }
 .vote-section + .vote-section { border-top: 1px solid var(--border); }


### PR DESCRIPTION
## Summary
This PR adds interactive resize handles that allow users to dynamically adjust the width of the left and right sidebar panels in the application interface.

## Key Changes
- **JavaScript (app.js)**: Added `initResizeHandle()` function that implements drag-to-resize functionality with:
  - Mouse event listeners for mousedown, mousemove, and mouseup
  - Width clamping between 100px and 40% of viewport width
  - Visual feedback (cursor change, active state styling)
  - Proper cleanup of event listeners on mouse release
  - Initialization of resize handles for both left and right panels

- **HTML (index.html)**: Added two resize handle elements:
  - Left resize handle between the left panel and center panel
  - Right resize handle between the center panel and right panel
  - Both include descriptive titles for accessibility

- **CSS (styles.css)**: Added styling for resize handles:
  - 5px wide draggable elements with `col-resize` cursor
  - Border color matches theme variables
  - Hover and active states highlight with accent color
  - Updated left panel to have `min-width: 100px` (was 185px)
  - Updated right panel to have `min-width: 100px` (new constraint)
  - Removed border-right from left panel (now handled by resize handle)

## Implementation Details
- Resize handles use `flex-shrink: 0` to maintain their 5px width
- Width constraints prevent panels from becoming too small (100px minimum) or too large (40% of viewport maximum)
- The resize logic differentiates between left and right handles to expand/contract appropriately
- User selection is disabled during drag to prevent text selection artifacts

https://claude.ai/code/session_012pJooRxQuE3hGMKXt6x49t