### PR TITLE
Add sorting support for "Loaded?" column in datasets table

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1327,7 +1327,7 @@
         <th data-sort="created_at">Created<span class="sort-arrow"></span></th>
         <th data-sort="origin">Origin<span class="sort-arrow"></span></th>
         <th>Details</th>
-        <th>Loaded?</th>
+        <th data-sort="loaded">Loaded?<span class="sort-arrow"></span></th>
         <th class="col-actions-header"></th>
       </tr></thead>
       <tbody></tbody></table>`;
@@ -1338,6 +1338,10 @@
     function renderDatasetRows() {
       const sorted = [...dashRegisteredDatasets].sort((a, b) => {
         let va = a[datasetSort.key], vb = b[datasetSort.key];
+        if (datasetSort.key === "loaded") {
+          va = a.loaded ? 1 : 0; vb = b.loaded ? 1 : 0;
+          return datasetSort.asc ? (va - vb) : (vb - va);
+        }
         if (datasetSort.key === "num_items" || datasetSort.key === "num_dupes" || datasetSort.key === "created_at") {
           return datasetSort.asc ? ((va || 0) - (vb || 0)) : ((vb || 0) - (va || 0));
         }


### PR DESCRIPTION
## Summary
Added sorting functionality to the "Loaded?" column in the datasets table, allowing users to sort datasets by their loaded status.

## Changes
- Made the "Loaded?" table header sortable by adding `data-sort="loaded"` attribute and sort arrow indicator
- Implemented sorting logic for the `loaded` boolean field that converts boolean values to numeric (1/0) for comparison
- Sorting respects the ascending/descending direction toggle like other sortable columns

## Implementation Details
The loaded status is a boolean field, so the sorting logic converts `true` to `1` and `false` to `0` before performing numeric comparison. This ensures proper ascending (unloaded first) and descending (loaded first) sort order.

https://claude.ai/code/session_017sCEfGTAEV9xeLbzSdexsm