### PR TITLE
Add clickable stripe overview for media list navigation

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -64,6 +64,7 @@
           [goodVotes]="goodVotes"
           [badVotes]="badVotes"
           [totalCount]="medias.length"
+          (stripeClick)="onStripeClick($event)"
         />
       </div>
     </div>

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SortBarComponent } from './sort-bar/sort-bar.component';
 import { SelectModeComponent } from './select-mode/select-mode.component';
@@ -55,10 +55,18 @@ export class LeftPanelComponent implements OnInit {
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();
 
+  @ViewChild(MediaListComponent) mediaListComponent!: MediaListComponent;
+
   activeTab: 'manual' | 'autopilot' = 'autopilot';
 
   ngOnInit(): void {
     this.autopilotStart.emit();
+  }
+
+  onStripeClick(index: number): void {
+    if (this.mediaListComponent) {
+      this.mediaListComponent.scrollToIndex(index);
+    }
   }
 
   setTab(tab: 'manual' | 'autopilot'): void {

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -84,6 +84,14 @@ export class MediaListComponent implements AfterViewChecked {
     }
   }
 
+  scrollToIndex(index: number): void {
+    if (!this.listContainer) return;
+    const items = this.listContainer.nativeElement.querySelectorAll('vt-media-item');
+    if (items[index]) {
+      items[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }
+
   trackByMediaId(_index: number, item: { media: MediaItem }): number {
     return item.media.id;
   }

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
@@ -1,5 +1,5 @@
 @if (visible) {
-  <div class="stripe-overview" aria-label="Media minimap">
+  <div class="stripe-overview" aria-label="Media minimap" (click)="onStripeClick($event)">
     <div class="stripe-container">
       @for (dot of dots; track $index) {
         <div

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
@@ -9,6 +9,7 @@
   position: relative;
   background: var(--bg-subtle);
   border-left: 1px solid var(--border-subtle);
+  cursor: pointer;
 }
 
 .stripe-container {

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SortedItem } from '../left-panel.component';
 
@@ -16,6 +16,18 @@ export class StripeOverviewComponent {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   @Input() totalCount = 0;
+
+  @Output() stripeClick = new EventEmitter<number>();
+
+  onStripeClick(event: MouseEvent): void {
+    if (!this.sortOrder || this.sortOrder.length === 0) return;
+    const el = event.currentTarget as HTMLElement;
+    const rect = el.getBoundingClientRect();
+    const y = event.clientY - rect.top;
+    const percentage = y / rect.height;
+    const index = Math.max(0, Math.min(Math.floor(percentage * this.sortOrder.length), this.sortOrder.length - 1));
+    this.stripeClick.emit(index);
+  }
 
   get visible(): boolean {
     return this.sortOrder !== null && this.sortOrder.length > 0;


### PR DESCRIPTION
## Summary
This PR adds interactive navigation functionality to the stripe overview component, allowing users to click on the minimap to jump to specific positions in the media list.

## Key Changes
- **StripeOverviewComponent**: Added click event handling that calculates the clicked position as a percentage of the stripe height and emits the corresponding media list index
  - Added `@Output() stripeClick` event emitter
  - Implemented `onStripeClick()` method to calculate index from mouse position
  - Updated template to bind click event
  - Added `cursor: pointer` styling to indicate interactivity

- **LeftPanelComponent**: Connected stripe click events to media list navigation
  - Added `@ViewChild` reference to `MediaListComponent`
  - Implemented `onStripeClick()` handler that delegates to media list's scroll method
  - Wired up stripe component's `stripeClick` output to the handler

- **MediaListComponent**: Added scroll-to-index functionality
  - Implemented `scrollToIndex()` method that smoothly scrolls a specific media item into view at the center of the viewport

## Implementation Details
The stripe click position is calculated by:
1. Getting the click event's Y coordinate relative to the stripe element
2. Converting to a percentage of the stripe's total height
3. Mapping that percentage to an index in the sorted media list
4. Clamping the index to valid bounds (0 to length-1)

This provides an intuitive way for users to navigate large media lists using the visual minimap representation.

https://claude.ai/code/session_0123Z8xw7chtDyCtcffXeh1F