### PR TITLE
Align dashboard table headers and cells to the left

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -673,7 +673,7 @@ video { max-width: 100%; }
 /* Dashboard dataset table */
 .dashboard-grid .dash-dataset-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
 .dashboard-grid .dash-dataset-table thead th {
-  text-align: center; padding: 5px 8px; color: var(--text-secondary);
+  text-align: left; padding: 5px 8px; color: var(--text-secondary);
   font-size: 0.7rem; font-weight: 600; border-bottom: 1px solid var(--border);
   cursor: pointer; user-select: none; white-space: nowrap;
 }
@@ -687,7 +687,7 @@ video { max-width: 100%; }
 .dashboard-grid .dash-dataset-table thead th:nth-child(6) { width: 16%; }
 .dashboard-grid .dash-dataset-table thead th:nth-child(7) { width: 10%; }
 .dashboard-grid .dash-dataset-table thead th:nth-child(8) { width: 32px; }
-.dash-dataset-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); text-align: center; }
+.dash-dataset-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); text-align: left; }
 .dash-dataset-row .col-name { font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dash-dataset-row .col-type { white-space: nowrap; }
 .dash-dataset-row .col-count { font-family: monospace; font-size: 0.72rem; color: var(--text-muted); }
@@ -699,7 +699,7 @@ video { max-width: 100%; }
 /* Dashboard model table */
 .dashboard-grid .dash-model-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; table-layout: fixed; }
 .dashboard-grid .dash-model-table thead th {
-  text-align: center; padding: 5px 8px; color: var(--text-secondary);
+  text-align: left; padding: 5px 8px; color: var(--text-secondary);
   font-size: 0.7rem; font-weight: 600; border-bottom: 1px solid var(--border);
   cursor: pointer; user-select: none; white-space: nowrap;
 }
@@ -714,7 +714,7 @@ video { max-width: 100%; }
 .dashboard-grid .dash-model-table thead th:nth-child(7) { width: 8%; }
 
 .dash-model-row { cursor: pointer; transition: background 0.15s; }
-.dash-model-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); text-align: center; }
+.dash-model-row td { padding: 6px 8px; border-bottom: 1px solid var(--border); text-align: left; }
 .dash-model-row:hover { background: var(--bg-subtle); }
 .dash-model-row .col-name { font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dash-model-row .col-type { white-space: nowrap; }


### PR DESCRIPTION
## Summary
Updated the text alignment for dashboard dataset and model tables from center to left alignment for improved readability and consistency with standard table layouts.

## Changes
- Changed dashboard dataset table headers (`dash-dataset-table thead th`) from `text-align: center` to `text-align: left`
- Changed dashboard dataset table cells (`.dash-dataset-row td`) from `text-align: center` to `text-align: left`
- Changed dashboard model table headers (`dash-model-table thead th`) from `text-align: center` to `text-align: left`
- Changed dashboard model table cells (`.dash-model-row td`) from `text-align: center` to `text-align: left`

## Details
This change affects both the dataset and model tables displayed in the dashboard grid. Left-aligning table content is a more conventional approach that typically improves scannability and readability, especially for text-heavy columns like names and types.

https://claude.ai/code/session_01Vg5ruUn2jqUMLswdiTgxvv