### PR TITLE
Refactor embedders to use structured EmbedderInfo objects

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -63,10 +63,10 @@
 
         @if (embedders.length > 0) {
           <h4>Autoload Embedders</h4>
-          @for (embedder of embedders; track embedder) {
+          @for (embedder of embedders; track embedder.name) {
             <label class="checkbox-row">
               <input type="checkbox" [checked]="isEmbedderAutoloaded(embedder)" (change)="toggleEmbedder(embedder)" />
-              {{ embedder }}
+              {{ embedder.name }} ({{ embedder.media_type_id }})
             </label>
           }
         }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -44,7 +44,7 @@ describe('SettingsModalComponent', () => {
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
     settingsReq.flush(mockSettings);
-    embeddersReq.flush({ embedders: ['audio', 'images', 'text'] });
+    embeddersReq.flush({ embedders: [{ name: 'audio', media_type_id: 'audio' }, { name: 'images', media_type_id: 'image' }, { name: 'text', media_type_id: 'text' }] });
   }
 
   it('should create', () => {
@@ -82,17 +82,17 @@ describe('SettingsModalComponent', () => {
 
   it('should check if embedder is autoloaded', () => {
     flushInit();
-    expect(component.isEmbedderAutoloaded('audio')).toBeTrue();
-    expect(component.isEmbedderAutoloaded('images')).toBeFalse();
+    expect(component.isEmbedderAutoloaded({ name: 'audio', media_type_id: 'audio' })).toBeTrue();
+    expect(component.isEmbedderAutoloaded({ name: 'images', media_type_id: 'image' })).toBeFalse();
   });
 
   it('should toggle embedder in autoload list', () => {
     flushInit();
-    component.toggleEmbedder('images');
+    component.toggleEmbedder({ name: 'images', media_type_id: 'image' });
     expect(component.settings.autoload_media_types).toContain('images');
     httpMock.expectOne('/api/settings').flush(mockSettings);
 
-    component.toggleEmbedder('audio');
+    component.toggleEmbedder({ name: 'audio', media_type_id: 'audio' });
     expect(component.settings.autoload_media_types).not.toContain('audio');
     httpMock.expectOne('/api/settings').flush(mockSettings);
   });

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { forkJoin } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
 import { SettingsApiService } from '../../../services/settings-api.service';
-import { AppSettings } from '../../../models/api.models';
+import { AppSettings, EmbedderInfo } from '../../../models/api.models';
 import { Theme, ThemeService } from '../../../services/theme.service';
 
 @Component({
@@ -18,7 +18,7 @@ export class SettingsModalComponent implements OnInit {
   @Output() closed = new EventEmitter<void>();
 
   settings: AppSettings = { volume: 50 };
-  embedders: string[] = [];
+  embedders: EmbedderInfo[] = [];
   loading = true;
   error = '';
 
@@ -60,16 +60,16 @@ export class SettingsModalComponent implements OnInit {
     this.save();
   }
 
-  isEmbedderAutoloaded(embedder: string): boolean {
-    return (this.settings.autoload_media_types || []).includes(embedder);
+  isEmbedderAutoloaded(embedder: EmbedderInfo): boolean {
+    return (this.settings.autoload_media_types || []).includes(embedder.name);
   }
 
-  toggleEmbedder(embedder: string): void {
+  toggleEmbedder(embedder: EmbedderInfo): void {
     const current = this.settings.autoload_media_types || [];
-    if (current.includes(embedder)) {
-      this.settings.autoload_media_types = current.filter((e) => e !== embedder);
+    if (current.includes(embedder.name)) {
+      this.settings.autoload_media_types = current.filter((e) => e !== embedder.name);
     } else {
-      this.settings.autoload_media_types = [...current, embedder];
+      this.settings.autoload_media_types = [...current, embedder.name];
     }
     this.save();
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -396,8 +396,13 @@ export interface AutoDetectResultsData {
 
 // --- Embedders ---
 
+export interface EmbedderInfo {
+  name: string;
+  media_type_id: string;
+}
+
 export interface EmbeddersResponse {
-  embedders: string[];
+  embedders: EmbedderInfo[];
 }
 
 // --- Export Result ---


### PR DESCRIPTION
## Summary
This PR refactors the embedders system to use structured `EmbedderInfo` objects instead of plain strings, providing richer metadata about each embedder including its media type identifier.

## Key Changes
- **New Model**: Added `EmbedderInfo` interface with `name` and `media_type_id` properties to replace simple string embedder names
- **Type Updates**: Changed `embedders` array type from `string[]` to `EmbedderInfo[]` throughout the settings modal component
- **Method Signatures**: Updated `isEmbedderAutoloaded()` and `toggleEmbedder()` methods to accept `EmbedderInfo` objects while maintaining string-based storage in `autoload_media_types`
- **UI Enhancement**: Updated template to display both embedder name and media type ID (e.g., "audio (audio)")
- **Tracking Optimization**: Changed template tracking from `track embedder` to `track embedder.name` for better change detection
- **Test Updates**: Updated all test cases to use the new `EmbedderInfo` structure with mock data

## Implementation Details
The refactoring maintains backward compatibility with the settings storage format (`autoload_media_types` remains a string array) while improving the internal representation. Methods now extract the `name` property when needed for comparisons and storage operations.

https://claude.ai/code/session_01BPsu8QUi2JG9fVay3YLBBK