### PR TITLE
Reorganize settings modal layout and improve spacing

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -531,7 +531,7 @@
 
 <!-- Settings Modal -->
 <div id="settings-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="settings-modal-title">
-  <div class="modal-content" style="max-width: 800px;">
+  <div class="modal-content settings-modal-wide">
     <div class="modal-header">
       <h2 id="settings-modal-title">Settings</h2>
       <button class="modal-close" id="settings-modal-close" aria-label="Close">&times;</button>
@@ -564,30 +564,15 @@
             </div>
           </div>
           <div class="settings-section">
-            <div class="settings-section-title">Storage Locations</div>
-            <div class="settings-row">
-              <label for="saved-datasets-dir-input" class="settings-label">Saved Datasets</label>
-              <input type="text" id="saved-datasets-dir-input" class="settings-path-input" placeholder="data/saved_datasets">
-            </div>
-            <div class="settings-row">
-              <label for="detectors-dir-input" class="settings-label">Detectors</label>
-              <input type="text" id="detectors-dir-input" class="settings-path-input" placeholder="data/detectors">
-            </div>
-            <div class="settings-row">
-              <label for="trainable-models-dir-input" class="settings-label">Trainable Models</label>
-              <input type="text" id="trainable-models-dir-input" class="settings-path-input" placeholder="data/trainable_models">
-            </div>
-          </div>
-        </div>
-        <!-- Column 2: Sorting + Calibration -->
-        <div>
-          <div class="settings-section">
             <div class="settings-section-title">Sorting</div>
             <div class="settings-row">
               <label for="enrich-descriptions-checkbox" class="settings-label">Enrich Sort Descriptions</label>
               <input type="checkbox" id="enrich-descriptions-checkbox" style="accent-color:var(--accent)">
             </div>
           </div>
+        </div>
+        <!-- Column 2: Calibration + Autopilot -->
+        <div>
           <div class="settings-section">
             <div class="settings-section-title">Calibration</div>
             <div class="settings-row">
@@ -603,9 +588,6 @@
               <input type="checkbox" id="safe-thresholds-checkbox" style="accent-color:var(--accent)">
             </div>
           </div>
-        </div>
-        <!-- Column 3: Autopilot + Autoload Media Types + Actions -->
-        <div>
           <div class="settings-section">
             <div class="settings-section-title">Autopilot</div>
             <div class="settings-row">
@@ -615,6 +597,24 @@
             <div class="settings-row">
               <label for="autopilot-hard-reds-input" class="settings-label">#BadToStart</label>
               <input type="number" id="autopilot-hard-reds-input" min="1" value="4" step="1" class="settings-number-input">
+            </div>
+          </div>
+        </div>
+        <!-- Column 3: Storage Locations + Autoload + Actions -->
+        <div>
+          <div class="settings-section">
+            <div class="settings-section-title">Storage Locations</div>
+            <div class="settings-row">
+              <label for="saved-datasets-dir-input" class="settings-label">Saved Datasets</label>
+              <input type="text" id="saved-datasets-dir-input" class="settings-path-input" placeholder="data/saved_datasets">
+            </div>
+            <div class="settings-row">
+              <label for="detectors-dir-input" class="settings-label">Detectors</label>
+              <input type="text" id="detectors-dir-input" class="settings-path-input" placeholder="data/detectors">
+            </div>
+            <div class="settings-row">
+              <label for="trainable-models-dir-input" class="settings-label">Trainable Models</label>
+              <input type="text" id="trainable-models-dir-input" class="settings-path-input" placeholder="data/trainable_models">
             </div>
           </div>
           <div class="settings-section">

--- a/static/styles.css
+++ b/static/styles.css
@@ -489,11 +489,12 @@ video { max-width: 100%; }
 .vt-dialog-btn.secondary:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* Settings modal */
-.settings-columns { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0 24px; }
+.settings-modal-wide { max-width: 1100px; }
+.settings-columns { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0 28px; }
 .settings-columns > div { display: flex; flex-direction: column; }
-.settings-section { margin-bottom: 16px; }
-.settings-section-title { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 10px; }
-.settings-row { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; }
+.settings-section { margin-bottom: 12px; }
+.settings-section-title { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 6px; }
+.settings-row { display: flex; align-items: center; justify-content: space-between; padding: 5px 0; }
 .settings-row + .settings-row { border-top: 1px solid var(--border-subtle); }
 .settings-label { font-size: 0.85rem; color: var(--text-secondary); cursor: pointer; }
 .settings-number-input { width: 72px; padding: 5px 8px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg-panel); color: var(--text-primary); font-size: 0.85rem; text-align: center; outline: none; }


### PR DESCRIPTION
## Summary
Reorganized the settings modal to improve information hierarchy and visual balance by moving the "Storage Locations" section to the third column and adjusting spacing throughout.

## Key Changes
- **Modal width**: Increased from inline `max-width: 800px` to a new CSS class `settings-modal-wide` with `max-width: 1100px` to accommodate the three-column layout better
- **Column reorganization**: 
  - Moved "Storage Locations" section from Column 1 to Column 3
  - Reordered sections so Column 1 contains Display settings and Sorting
  - Column 2 now contains Calibration and Autopilot settings
  - Column 3 contains Storage Locations, Autoload Media Embedders, and Actions
- **Spacing refinements**:
  - Increased gap between columns from `24px` to `28px` for better visual separation
  - Reduced `settings-section` margin-bottom from `16px` to `12px`
  - Reduced `settings-section-title` margin-bottom from `10px` to `6px`
  - Reduced `settings-row` padding from `8px 0` to `5px 0` for more compact rows

## Implementation Details
The reorganization groups related settings more logically: display/sorting preferences in the first column, detection/automation settings in the second, and storage/data management in the third. The increased modal width and adjusted spacing ensure the layout remains readable and well-proportioned with the new arrangement.

https://claude.ai/code/session_018hYbwDoUjiAvxBYfxwWiCU