### PR TITLE
Fix input focus in rename mode for dataset and model cards

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -2,12 +2,12 @@
 <td>
   @if (editing) {
     <input
+      #renameInput
       class="form-input inline-edit"
       [(ngModel)]="editName"
       (keydown)="onRenameKeydown($event)"
       (blur)="confirmRename()"
       (click)="$event.stopPropagation()"
-      autofocus
     />
   } @else {
     <span class="name-cell">

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { DatasetCardComponent } from './dataset-card.component';
 
 describe('DatasetCardComponent', () => {
@@ -68,6 +68,16 @@ describe('DatasetCardComponent', () => {
     expect(component.editName).toBe('Test Dataset');
     expect(el.querySelector('.inline-edit')).toBeTruthy();
   });
+
+  it('should focus the rename input after clicking rename', fakeAsync(() => {
+    const el = fixture.nativeElement as HTMLElement;
+    const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
+    renameBtn.click();
+    fixture.detectChanges();
+    tick();
+    const input = el.querySelector('.inline-edit') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+  }));
 
   it('should emit rename on Enter key', () => {
     spyOn(component.rename, 'emit');

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -21,6 +21,8 @@ export class DatasetCardComponent {
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
 
+  @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
+
   editing = false;
   editName = '';
 
@@ -28,6 +30,7 @@ export class DatasetCardComponent {
     event.stopPropagation();
     this.editing = true;
     this.editName = this.dataset.name;
+    setTimeout(() => this.renameInput?.nativeElement.focus());
   }
 
   confirmRename(): void {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -1,12 +1,12 @@
 <td>
   @if (editing) {
     <input
+      #renameInput
       class="form-input inline-edit"
       [(ngModel)]="editName"
       (keydown)="onRenameKeydown($event)"
       (blur)="confirmRename()"
       (click)="$event.stopPropagation()"
-      autofocus
     />
   } @else {
     <span class="name-cell">

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ModelCardComponent } from './model-card.component';
 
 describe('ModelCardComponent', () => {
@@ -68,6 +68,16 @@ describe('ModelCardComponent', () => {
     expect(component.editing).toBeTrue();
     expect(el.querySelector('.inline-edit')).toBeTruthy();
   });
+
+  it('should focus the rename input after clicking rename', fakeAsync(() => {
+    const el = fixture.nativeElement as HTMLElement;
+    const renameBtn = el.querySelector('.edit-btn') as HTMLElement;
+    renameBtn.click();
+    fixture.detectChanges();
+    tick();
+    const input = el.querySelector('.inline-edit') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+  }));
 
   it('should emit rename on confirm', () => {
     spyOn(component.rename, 'emit');

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -21,6 +21,8 @@ export class ModelCardComponent {
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
 
+  @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
+
   editing = false;
   editName = '';
 
@@ -28,6 +30,7 @@ export class ModelCardComponent {
     event.stopPropagation();
     this.editing = true;
     this.editName = this.model.name;
+    setTimeout(() => this.renameInput?.nativeElement.focus());
   }
 
   confirmRename(): void {


### PR DESCRIPTION
## Summary
Replaced the `autofocus` HTML attribute with a programmatic focus approach using `ViewChild` and `setTimeout` to ensure the rename input field receives focus reliably after the edit button is clicked.

## Key Changes
- Added `@ViewChild('renameInput')` decorator to both `DatasetCardComponent` and `ModelCardComponent` to get a reference to the rename input element
- Replaced the `autofocus` HTML attribute with a `setTimeout(() => this.renameInput?.nativeElement.focus())` call in the `startRename()` method
- Updated component imports to include `ElementRef` and `ViewChild` from `@angular/core`
- Added template reference variable `#renameInput` to the input elements in both component templates
- Added comprehensive test cases using `fakeAsync` and `tick` to verify the input receives focus after the rename button is clicked

## Implementation Details
The `autofocus` attribute was unreliable because it executes before Angular's change detection completes. By using `setTimeout` with a `ViewChild` reference, we defer the focus operation until after the DOM has been updated and change detection has run, ensuring the input element is properly rendered and ready to receive focus.

https://claude.ai/code/session_01XPUAAijsMmG9jEHexzSmxL