### PR TITLE
Add SSH key setup instructions to SETUP.md

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -44,8 +44,53 @@ brew install git
 
 ## Getting the code
 
+We recommend cloning over SSH so you don't have to enter your password on every push/pull.
+
+### Setting up an SSH key
+
+1. **Generate a key** (skip this if you already have one at `~/.ssh/id_ed25519`):
+
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com"
+   ```
+
+   Press Enter to accept the default file location, then choose a passphrase (or leave it empty).
+
+2. **Start the SSH agent and add your key**:
+
+   ```bash
+   eval "$(ssh-agent -s)"
+   ssh-add ~/.ssh/id_ed25519
+   ```
+
+3. **Copy the public key** to your clipboard:
+
+   Linux:
+
+   ```bash
+   cat ~/.ssh/id_ed25519.pub
+   ```
+
+   macOS:
+
+   ```bash
+   pbcopy < ~/.ssh/id_ed25519.pub
+   ```
+
+4. **Add the key to GitHub**: Go to [github.com/settings/ssh/new](https://github.com/settings/ssh/new), paste the public key, give it a title, and click **Add SSH key**.
+
+5. **Verify the connection**:
+
+   ```bash
+   ssh -T git@github.com
+   ```
+
+   You should see a message like *"Hi username! You've successfully authenticated…"*.
+
+### Clone the repository
+
 ```bash
-git clone https://github.com/samggreenberg/vtsearch.git
+git clone git@github.com:samggreenberg/vtsearch.git
 cd vtsearch
 ```
 


### PR DESCRIPTION
## Summary
Updated the setup documentation to include comprehensive SSH key configuration instructions and recommend SSH-based cloning over HTTPS.

## Key Changes
- Added a new "Setting up an SSH key" section with step-by-step instructions for:
  - Generating an Ed25519 SSH key
  - Starting the SSH agent and adding the key
  - Copying the public key to clipboard (with platform-specific commands for Linux and macOS)
  - Adding the key to GitHub
  - Verifying the SSH connection
- Updated the repository clone command from HTTPS (`https://github.com/samggreenberg/vtsearch.git`) to SSH (`git@github.com:samggreenberg/vtsearch.git`)
- Added a recommendation to use SSH cloning to avoid entering passwords on every push/pull

## Implementation Details
The instructions follow GitHub's recommended SSH setup workflow and use Ed25519 keys (modern, secure alternative to RSA). The guide includes platform-specific instructions for copying the public key, making it accessible to both Linux and macOS users.

https://claude.ai/code/session_01Jdy2Ksju1QCtjuMxWq2jau