### PR TITLE
Add root-level static file serving and SPA fallback routing

### DIFF
--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -181,9 +181,12 @@ class TestFavicon:
         resp = self.client.get("/favicon-angry.ico")
         assert resp.status_code == 404
 
-    def test_favicon_empty_variant_returns_404(self):
+    def test_favicon_empty_variant_returns_spa_fallback(self):
         resp = self.client.get("/favicon-.ico")
-        assert resp.status_code == 404
+        # Empty variant doesn't match the favicon-<variant>.ico route,
+        # so the catch-all serves the SPA (standard SPA fallback behavior).
+        assert resp.status_code == 200
+        assert b"<app-root>" in resp.data
 
     def test_favicon_content_type(self):
         resp = self.client.get("/favicon.ico")

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -117,6 +117,43 @@ class TestStaticFiles:
         assert resp.status_code == 404
 
 
+class TestRootStaticFiles:
+    """Static assets should also be accessible at root paths (no /static/ prefix).
+
+    The Angular build uses <base href="/"> so the browser requests main.js,
+    polyfills.js, and styles.css at the root.
+    """
+
+    def setup_method(self):
+        app_module.app.config["TESTING"] = True
+        self.client = app_module.app.test_client()
+
+    def test_main_js_at_root(self):
+        resp = self.client.get("/main.js")
+        assert resp.status_code == 200
+        assert "javascript" in resp.content_type
+
+    def test_polyfills_js_at_root(self):
+        resp = self.client.get("/polyfills.js")
+        assert resp.status_code == 200
+        assert "javascript" in resp.content_type
+
+    def test_styles_css_at_root(self):
+        resp = self.client.get("/styles.css")
+        assert resp.status_code == 200
+        assert "css" in resp.content_type
+
+    def test_logo_png_at_root(self):
+        resp = self.client.get("/logo.png")
+        assert resp.status_code == 200
+
+    def test_unknown_path_returns_spa(self):
+        """Unknown paths should return the Angular SPA for client-side routing."""
+        resp = self.client.get("/some/unknown/route")
+        assert resp.status_code == 200
+        assert b"<app-root>" in resp.data
+
+
 class TestFavicon:
     """Favicon routes should serve valid .ico files."""
 

--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -95,7 +95,15 @@ def catch_all(path: str) -> Response:
     route serves those files when they exist, and falls back to
     ``index.html`` for any other path so that Angular Router can handle
     client-side navigation.
+
+    Paths under ``/api/`` are excluded — unmatched API routes should
+    return 404, not the SPA page.
     """
+    # Don't intercept API routes; let Flask return its default 404.
+    if path.startswith("api/"):
+        from flask import abort
+
+        abort(404)
     static = _static_dir()
     # Resolve the candidate and ensure it stays within the static directory
     # to prevent path-traversal attacks (e.g. ../../etc/passwd).

--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -83,3 +83,26 @@ def logo() -> tuple[str, int] | Response:
     if not (static / "logo.svg").exists():
         return "", 204
     return send_from_directory(str(static), "logo.svg", mimetype="image/svg+xml")
+
+
+@main_bp.route("/<path:path>")
+def catch_all(path: str) -> Response:
+    """Serve static files at root paths and fall back to Angular SPA.
+
+    The Angular build output (main.js, polyfills.js, styles.css, etc.) is
+    referenced from index.html with ``<base href="/">``, so the browser
+    requests them at ``/main.js`` rather than ``/static/main.js``.  This
+    route serves those files when they exist, and falls back to
+    ``index.html`` for any other path so that Angular Router can handle
+    client-side navigation.
+    """
+    static = _static_dir()
+    # Resolve the candidate and ensure it stays within the static directory
+    # to prevent path-traversal attacks (e.g. ../../etc/passwd).
+    try:
+        candidate = (static / path).resolve()
+    except (OSError, ValueError):
+        return _serve_angular_index()
+    if candidate.is_file() and str(candidate).startswith(str(static.resolve())):
+        return send_from_directory(str(static), path)
+    return _serve_angular_index()


### PR DESCRIPTION
## Summary
This PR implements root-level static file serving and a catch-all route that falls back to the Angular SPA for client-side routing. This allows the Angular build output (main.js, polyfills.js, styles.css, etc.) to be served at root paths (e.g., `/main.js`) as expected by the `<base href="/">` configuration, while also enabling proper SPA fallback for unknown routes.

## Key Changes
- **Added catch-all route handler** (`catch_all()` in `main.py`): Implements a `/<path:path>` route that:
  - Serves static files from the root when they exist in the static directory
  - Falls back to serving `index.html` for unknown paths to enable Angular Router client-side navigation
  - Excludes `/api/` routes to ensure unmatched API requests return 404 instead of the SPA
  - Includes path-traversal attack prevention by validating that resolved paths stay within the static directory

- **Added comprehensive test coverage** (`TestRootStaticFiles` class):
  - Tests that key static assets (main.js, polyfills.js, styles.css, logo.png) are accessible at root paths
  - Tests that unknown routes return the SPA with proper fallback behavior
  - Updated existing favicon test to reflect new SPA fallback behavior for edge cases

## Implementation Details
- The catch-all route uses `resolve()` to safely handle path traversal attempts
- Static file serving is attempted first; if the file doesn't exist or the path is invalid, the SPA is served
- API routes are explicitly excluded from the catch-all to maintain proper API error handling
- The implementation maintains backward compatibility with existing `/static/` prefixed routes

https://claude.ai/code/session_01JAXpDVpgmuXRBaXMH3bBqd