### PR TITLE
Fix layout shift in disabled button hints using visibility toggle

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -103,9 +103,7 @@
       >
         Label
       </button>
-      @if (!labelEnabled && labelHint) {
-        <span class="btn-disabled-reason">{{ labelHint }}</span>
-      }
+      <span class="btn-disabled-reason" [style.visibility]="(!labelEnabled && labelHint) ? 'visible' : 'hidden'">{{ labelHint || '&nbsp;' }}</span>
     </div>
     <div class="action-btn-group">
       <button
@@ -116,9 +114,7 @@
       >
         Find
       </button>
-      @if (!findEnabled && findHint) {
-        <span class="btn-disabled-reason">{{ findHint }}</span>
-      }
+      <span class="btn-disabled-reason" [style.visibility]="(!findEnabled && findHint) ? 'visible' : 'hidden'">{{ findHint || '&nbsp;' }}</span>
     </div>
   </div>
 </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -161,4 +161,5 @@
   font-size: 0.75rem;
   color: var(--text-muted);
   font-style: italic;
+  min-height: 1.2em;
 }


### PR DESCRIPTION
## Summary
Refactored the conditional rendering of disabled button hint messages to prevent layout shifts when hints appear or disappear. This improves the visual stability of the dashboard UI.

## Key Changes
- Replaced `@if` conditional blocks with CSS `visibility` binding for label and find button hint messages
- Changed from conditional DOM rendering to always-present elements with visibility toggling
- Added `min-height: 1.2em` to `.btn-disabled-reason` class to reserve space and prevent layout reflow
- Updated hint text binding to use `labelHint || '&nbsp;'` and `findHint || '&nbsp;'` to maintain consistent spacing

## Implementation Details
The previous implementation used Angular's `@if` directive to conditionally render hint spans only when needed. This caused the DOM to add/remove elements, resulting in layout shifts when hints became visible or hidden.

The new approach keeps the hint elements in the DOM at all times but controls their visibility with CSS. By setting `min-height: 1.2em` on the hint container, the space is always reserved, eliminating layout reflow. The visibility is toggled based on the same conditions (`!labelEnabled && labelHint` / `!findEnabled && findHint`), maintaining the same visual behavior while improving stability.

https://claude.ai/code/session_01Ar3EzHDyWmrbvAC6LrrR5H