### PR TITLE
Reduce spacing and padding in center panel and voting overlay

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -10,8 +10,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 16px;
+  gap: 4px;
+  padding: 4px 16px;
   overflow: hidden;
 
   &.empty {
@@ -59,7 +59,7 @@
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 8px;
   width: 100%;
-  padding: 8px 0;
+  padding: 2px 0;
   flex-shrink: 0;
 }
 

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   gap: 12px;
   justify-content: center;
-  padding: 8px 0;
+  padding: 2px 0;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
This PR reduces vertical spacing and adjusts padding in the center panel and voting overlay components to create a more compact layout.

## Key Changes
- **Center panel container**: Reduced gap from 10px to 4px and adjusted padding from 16px to 4px 16px (top/bottom to top/bottom)
- **Center panel grid**: Reduced vertical padding from 8px to 2px
- **Voting overlay**: Reduced vertical padding from 8px to 2px

## Details
These spacing adjustments make the UI more compact while maintaining visual hierarchy. The changes primarily affect vertical spacing, reducing gaps between elements and minimizing padding on the top and bottom of containers. Horizontal padding remains consistent at 16px for the center panel.

https://claude.ai/code/session_01MGQite64ok9x1UiiNihpKC