### PR TITLE
Remove 'any' media type support from model validation

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -159,11 +159,11 @@ describe('DashboardComponent', () => {
       expect(component.labelEnabled).toBeFalse();
     });
 
-    it('should enable Label when model media_type is "any"', () => {
+    it('should disable Label when model media_type is "any" (not a valid type)', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
       const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'any' }];
       flushInitialRequests(datasets, models);
-      expect(component.labelEnabled).toBeTrue();
+      expect(component.labelEnabled).toBeFalse();
     });
 
     it('should disable Find with no selections', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -335,7 +335,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (!model || !model.trainable) return false;
     const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
     if (!dataset) return false;
-    if (model.media_type !== 'any' && model.media_type !== dataset.media_type) return false;
+    if (model.media_type !== dataset.media_type) return false;
     return true;
   }
 
@@ -359,7 +359,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const model = this.models.find((m) => this.selectedModelIds.has(m.id));
     if (model && !model.trainable) return 'Model is not trainable';
     const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
-    if (model && dataset && model.media_type !== 'any' && model.media_type !== dataset.media_type) {
+    if (model && dataset && model.media_type !== dataset.media_type) {
       return 'Media type mismatch';
     }
     return '';

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -31,9 +31,6 @@
     @case ('document') {
       <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
     }
-    @case ('any') {
-      <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-    }
   }
   {{ capitalizeType(model.media_type) }}
 </td>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -17,7 +17,6 @@
         @for (mt of mediaTypes; track mt) {
           <option [value]="mt">{{ mt }}</option>
         }
-        <option value="any">any</option>
       </select>
     </div>
 

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -87,7 +87,7 @@ def _list_all() -> list[dict]:
         models.append({
             "name": data["name"],
             "text_query": data.get("text_query", ""),
-            "media_type": data.get("media_type", "any"),
+            "media_type": data.get("media_type", ""),
             "examples": data.get("examples", []),
             "num_labels": len(labels),
             "created_at": data.get("created_at", 0),


### PR DESCRIPTION
## Summary
This PR removes support for the 'any' media type in model validation logic. Models with 'any' media type are no longer treated as compatible with any dataset media type. Instead, they must match the dataset's specific media type to be valid for labeling and training operations.

## Key Changes
- **Validation Logic**: Updated `isLabelEnabled()` and error message generation to require exact media type matching between models and datasets, removing the special case for 'any' media type
- **Backend Default**: Changed the default media_type from 'any' to empty string when creating new models
- **UI Updates**: 
  - Removed 'any' option from the new model modal media type dropdown
  - Removed the globe icon SVG that was used to represent 'any' media type in the model card
- **Tests**: Updated test expectations to reflect that models with 'any' media type should now disable the label feature

## Implementation Details
The changes enforce stricter media type compatibility requirements. Previously, a model with `media_type: 'any'` would be compatible with datasets of any media type. Now, models must have an explicit media type that matches the selected dataset's media type for labeling to be enabled.

https://claude.ai/code/session_01FZ1EsRw6LPhZBgqBtdubrB