### PR TITLE
Migrate frontend from vanilla JS to Angular SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-A media explorer web app. Browse collections of audio clips, images, text paragraphs, videos, or documents — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, CLIP, X-CLIP, or E5-base-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python) and vanilla JavaScript.
+A media explorer web app. Browse collections of audio clips, images, text paragraphs, videos, or documents — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, CLIP, X-CLIP, or E5-base-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python), Angular (TypeScript), and PyTorch.
 
 ## Setup and running tests
 
@@ -54,7 +54,7 @@ You can also load your own data from pickle files or folders via the same menu.
 │   ├── processors/importers/       # Processor importer plugins
 │   ├── audio/                      # Audio generation utility
 │   └── utils/                      # Global state (medias, votes) & progress helpers
-├── static/                         # Frontend (HTML, JS, CSS, assets)
+├── static/                         # Angular build output (HTML, JS, CSS, assets)
 ├── tests/                          # Test suite (pytest)
 ├── docs/                           # Extended documentation
 │   ├── HANDOFF.md                  # Project handoff & orientation guide

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ documents.  It combines:
   (video), E5-base-v2 (text) for embedding-based similarity search.
 - **Learned sorting** — a small MLP trained on user votes to predict
   good/bad labels.
-- **Flask web UI** — vanilla JS frontend with a REST API.
+- **Flask web UI** — Angular SPA frontend with a REST API.
 - **Plugin systems** — auto-discovered dataset importers, results
   exporters, label importers, and processor importers.
 
@@ -132,7 +132,7 @@ VTSearch/
 │   │
 │   └── audio/                      WAV/tone generation utilities
 │
-├── static/                         Frontend (HTML + CSS + JS)
+├── static/                         Angular build output (HTML + CSS + JS)
 └── tests/                          Comprehensive test suite
 ```
 
@@ -197,7 +197,10 @@ modules on the right.
 - **datasets/ functions accept an optional `on_progress` callback.**
   When `None`, they lazily resolve the app's `update_progress`; when
   provided, they use the caller's callback.
-- **Only `routes/*` imports global state** from `vtsearch.utils.state`.
+- **`routes/*` is the primary consumer of global state** from
+  `vtsearch.utils.state`.  A few non-route modules also import specific
+  helpers (e.g. `update_progress`, `next_media_id`) for progress
+  reporting and ID generation during dataset loading.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -69,6 +69,7 @@ UI. They are **not** downloaded at startup.
 | Food-101 | Image | ETH Zurich | ~170 MB |
 | EuroSAT | Image | Zenodo | ~170 MB |
 | Stanford Dogs | Image | Stanford | ~170 MB |
+| UCSF Industry Documents | Document | UCSF IDL | ~50 MB |
 | 20 Newsgroups | Text | scikit-learn | ~14 MB |
 | AG News | Text | HuggingFace | ~15 MB |
 | BBC News | Text | Internet | ~15 MB |

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -30,7 +30,7 @@ strategies:
 - **Learned sorting** — trains a small MLP neural network on user votes to
   predict good/bad labels.
 
-Built with Flask + vanilla JavaScript + PyTorch. Single-user, no auth,
+Built with Flask + Angular + PyTorch. Single-user, no auth,
 runs locally or in Docker.
 
 ---
@@ -165,15 +165,17 @@ argument parsing. Key startup sequence:
 | Dataset loading and downloading | `vtsearch/datasets/` |
 | Plugin registries | `vtsearch/datasets/importers/`, `vtsearch/exporters/`, `vtsearch/labels/importers/`, `vtsearch/processors/importers/` |
 | Constants and model IDs | `vtsearch/config.py` |
-| Frontend | `static/index.html`, `static/app.js`, `static/dialogs.js`, `static/charts.js`, `static/results.js`, `static/styles.css` |
+| Frontend | `static/index.html`, `static/main.js`, `static/polyfills.js`, `static/styles.css` (Angular build output) |
 | Tests | `tests/` (see test list in CLAUDE.md) |
 
 ### Architectural boundaries
 
 - **Media types, models, exporters, and importers do NOT import Flask.**
   They are standalone and can be used in scripts or notebooks.
-- **Only `vtsearch/routes/` imports global state.** All ML and dataset
-  functions accept state as parameters.
+- **`vtsearch/routes/` is the primary consumer of global state.** ML
+  and dataset functions generally accept state as parameters, though
+  some modules import specific helpers (e.g. `update_progress`,
+  `next_media_id`) for progress reporting and ID generation.
 - **Each plugin is self-contained** in its own subdirectory with its own
   `requirements.txt`.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -90,8 +90,8 @@ We recommend cloning over SSH so you don't have to enter your password on every 
 ### Clone the repository
 
 ```bash
-git clone git@github.com:samggreenberg/vtsearch.git
-cd vtsearch
+git clone git@github.com:samggreenberg/VTSearch.git
+cd VTSearch
 ```
 
 ## Setting up a virtual environment

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,20 +1,36 @@
-# Frontend
+# VTSearch Frontend
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.2.22.
+Angular SPA for the VTSearch media explorer. Built with Angular CLI 19.2 and TypeScript.
 
 ## Development server
 
-To start a local development server, run:
+Start the Flask backend first (`python app.py --local` from the project root), then:
 
 ```bash
-ng serve
+npm start
 ```
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+This starts the Angular dev server at `http://localhost:4200/` with a proxy that forwards `/api/*` requests to the Flask backend at `localhost:5000`. The application automatically reloads when source files change.
+
+## Building for production
+
+```bash
+npm run build:prod
+```
+
+This compiles the Angular app and outputs the build artifacts to `../static/` (the project root's `static/` directory), where Flask serves them. Output files: `index.html`, `main.js`, `polyfills.js`, `styles.css`.
+
+You must run `npm install` before the first build to install Angular CLI and other dependencies locally.
+
+## Running unit tests
+
+```bash
+ng test --watch=false
+```
+
+Uses [Karma](https://karma-runner.github.io) as the test runner.
 
 ## Code scaffolding
-
-Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
 
 ```bash
 ng generate component component-name
@@ -25,35 +41,3 @@ For a complete list of available schematics (such as `components`, `directives`,
 ```bash
 ng generate --help
 ```
-
-## Building
-
-To build the project run:
-
-```bash
-ng build
-```
-
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
-
-## Running unit tests
-
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
-
-```bash
-ng test
-```
-
-## Running end-to-end tests
-
-For end-to-end (e2e) testing, run:
-
-```bash
-ng e2e
-```
-
-Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
-
-## Additional Resources
-
-For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.


### PR DESCRIPTION
## Summary
This PR migrates the VTSearch frontend from vanilla JavaScript to an Angular Single Page Application (SPA), updating all documentation and build processes accordingly.

## Key Changes
- **Frontend framework migration**: Replaced vanilla JavaScript frontend with Angular 19.2 TypeScript SPA
- **Build output**: Frontend now compiles to `static/` directory with Angular build artifacts (`main.js`, `polyfills.js`, `styles.css`, `index.html`)
- **Development workflow**: Updated to use `npm start` which runs Angular dev server with API proxy to Flask backend at `localhost:5000`
- **Production build**: Added `npm run build:prod` command that outputs compiled Angular app to `../static/` for Flask to serve
- **Documentation updates**:
  - Updated `frontend/README.md` with Angular-specific setup and build instructions
  - Updated main `README.md` to reflect Angular + Flask + PyTorch stack
  - Updated `docs/ARCHITECTURE.md` to describe Angular SPA instead of vanilla JS
  - Updated `docs/HANDOFF.md` to reference Angular frontend
  - Updated `docs/DEPLOYMENT.md` to add UCSF Industry Documents dataset
  - Clarified architectural boundaries in `docs/HANDOFF.md` regarding global state imports
  - Fixed repository clone URL capitalization in `docs/SETUP.md`

## Implementation Details
- Angular dev server proxies `/api/*` requests to Flask backend at `localhost:5000`
- Flask backend must be started first with `python app.py --local` before running `npm start`
- Build artifacts are output to the project root's `static/` directory where Flask serves them
- Unit tests use Karma test runner with `ng test --watch=false` command
- Clarified that while `routes/` is the primary consumer of global state, some non-route modules import specific helpers (`update_progress`, `next_media_id`) for progress reporting during dataset loading

https://claude.ai/code/session_01KKZQvHkwEKAitcN16ZQXzn