### PR TITLE
Add help tooltips to autopilot panel steps

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -1,9 +1,8 @@
 <div class="autopilot-panel">
   <div class="autopilot-active">
-    <p class="autopilot-desc">
-      Autopilot guides you through labeling in phases: good examples, bad examples,
-      boundary refinement, and diversity exploration.
-    </p>
+    <div class="autopilot-header">
+      <span class="ap-help-icon" [title]="overallHelp">?</span>
+    </div>
 
     <div class="autopilot-steps">
       @for (step of steps; track step.phase) {
@@ -23,7 +22,10 @@
             }
           </div>
           <div class="ap-step-content">
-            <span class="ap-step-label">{{ step.label }}</span>
+            <span class="ap-step-label">
+              {{ step.label }}
+              <span class="ap-help-icon small" [title]="step.helpText">?</span>
+            </span>
             @if (step.detail || step.statusIcons.length) {
               <span class="ap-step-detail">
                 {{ step.detail }}

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -4,13 +4,39 @@
   gap: 12px;
 }
 
-.autopilot-desc {
-  font-size: 0.82rem;
-  color: var(--text-secondary);
-  text-align: center;
-  line-height: 1.4;
-  margin: 0;
-  padding: 8px 8px 0;
+.autopilot-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px 0;
+}
+
+.ap-help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--text-muted);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: help;
+  flex-shrink: 0;
+  line-height: 1;
+
+  &.small {
+    width: 14px;
+    height: 14px;
+    font-size: 0.6rem;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+  }
 }
 
 .autopilot-active {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -128,6 +128,20 @@ describe('AutopilotPanelComponent', () => {
     expect(component.started.emit).not.toHaveBeenCalled();
   });
 
+  it('should show overall help icon with tooltip', () => {
+    const helpIcon = fixture.nativeElement.querySelector('.autopilot-header .ap-help-icon');
+    expect(helpIcon).toBeTruthy();
+    expect(helpIcon.textContent.trim()).toBe('?');
+    expect(helpIcon.title).toContain('Autopilot guides you');
+  });
+
+  it('should show help icon on each step with tooltip', () => {
+    const stepHelpIcons = fixture.nativeElement.querySelectorAll('.ap-step .ap-help-icon.small');
+    expect(stepHelpIcons.length).toBe(5);
+    expect(stepHelpIcons[0].title).toContain('good');
+    expect(stepHelpIcons[1].title).toContain('not what you want');
+  });
+
   it('should mark current step as active and future steps as future', () => {
     const steps = component.steps;
     expect(steps[0].state).toBe('active');

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -20,6 +20,7 @@ interface StepDisplay {
   state: 'done' | 'active' | 'future';
   detail: string;
   statusIcons: StatusIcon[];
+  helpText: string;
 }
 
 @Component({
@@ -36,6 +37,8 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
 
   @Output() started = new EventEmitter<void>();
   @Output() stopped = new EventEmitter<void>();
+
+  readonly overallHelp = 'Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration.';
 
   constructor(public autopilotState: AutopilotStateService) {}
 
@@ -63,6 +66,7 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
         state: stateStr,
         detail: stateStr === 'active' ? this.phaseDetail(phase) : '',
         statusIcons: stateStr === 'active' ? this.phaseStatusIcons(phase) : [],
+        helpText: this.phaseHelpText(phase),
       };
     });
   }
@@ -112,6 +116,17 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       { color: st.smartStatus === 'green' ? 'green' : 'yellow', ariaLabel: `Smart: ${st.smartStatus === 'green' ? 'green' : 'pending'}` },
       { color: st.stableStatus === 'green' ? 'green' : 'yellow', ariaLabel: `Stable: ${st.stableStatus === 'green' ? 'green' : 'pending'}` },
     ];
+  }
+
+  private phaseHelpText(phase: AutopilotPhase): string {
+    switch (phase) {
+      case 'good': return 'Label a few examples of what you are looking for so the system can learn what "good" looks like.';
+      case 'bad': return 'Label examples that are not what you want, helping the system learn the boundary between good and bad.';
+      case 'hard': return 'The system shows you items near the decision boundary. Labeling these improves accuracy where it matters most.';
+      case 'new': return 'Explore diverse items the system is less certain about, ensuring nothing important is missed.';
+      case 'done': return 'All quality indicators are green. You can continue labeling or export your results.';
+      default: return '';
+    }
   }
 
   private phaseDetail(phase: AutopilotPhase): string {


### PR DESCRIPTION
## Summary
Enhanced the autopilot panel UI with contextual help tooltips to guide users through each labeling phase. Replaced the static description text with an interactive help icon system that provides phase-specific guidance.

## Key Changes
- **Replaced static description with help icon**: Converted the centered description paragraph into a help icon (?) in the header that displays the overall autopilot guidance as a tooltip
- **Added phase-specific help text**: Implemented `phaseHelpText()` method that returns contextual help messages for each autopilot phase (good, bad, hard, new, done)
- **Added help icons to each step**: Each step now displays a small help icon next to its label with phase-specific tooltip text
- **Updated styling**: 
  - Created new `.autopilot-header` class for the header layout
  - Added `.ap-help-icon` class with styling for circular help icons with hover effects
  - Included `.small` variant for step-level help icons
- **Updated component interface**: Added `helpText` property to `StepDisplay` interface
- **Added test coverage**: Included tests verifying help icons render correctly with appropriate tooltip content

## Implementation Details
- Help icons use a circular design with a "?" character and muted color that brightens on hover
- Each phase has tailored help text explaining its purpose and what users should do
- The overall help text is stored as a readonly property for consistency
- Small help icons are vertically aligned with step labels using flexbox

https://claude.ai/code/session_01NwTNAcyLh5qUWMqMw39prT