### PR TITLE
Preserve text query state when switching between autopilot and manual

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -15,6 +15,7 @@
       [labelingStatus]="labelingStatus"
       [showThumbnails]="showThumbnails"
       [loadSortLabel]="sortState.loadSortLabel"
+      [textQuery]="sortState.textQuery"
       (sortModeChange)="onSortModeChange($event)"
       (selectModeChange)="onSelectModeChange($event)"
       (inclusionChange)="onInclusionChange($event)"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -189,6 +189,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onTextSort(text: string): void {
+    this.sortState.setTextQuery(text);
     this.sortState.setSortBusy(true);
     this.sortState.setSortStatus('Sorting...');
     this.sortingApi.sort({ text }).pipe(takeUntil(this.destroy$)).subscribe({
@@ -320,7 +321,21 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onAutopilotStop(): void {
-    // Reset to manual defaults
+    const phase = this.autopilotStateService.state.phase;
+
+    // Map autopilot phase to a valid Manual select mode.
+    // 'bottom' has no radio button in Manual UI, so map to 'top'.
+    if (phase === 'good' || phase === 'bad') {
+      this.sortState.setSelectMode('top');
+    } else if (phase === 'hard') {
+      this.sortState.setSelectMode('hard');
+    } else if (phase === 'new' || phase === 'done') {
+      this.sortState.setSelectMode('new');
+    }
+
+    // Keep sort mode as 'text' (what autopilot uses) so the sort bar
+    // shows the current text query and results carry over.
+    this.sortState.setSortMode('text');
   }
 
   // --- Helpers ---

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -21,6 +21,7 @@
       <vt-sort-bar
         [sortMode]="sortMode"
         [loadSortLabel]="loadSortLabel"
+        [initialTextQuery]="textQuery"
         [hasGoodVotes]="goodVotes.size > 0"
         [hasBadVotes]="badVotes.size > 0"
         (sortModeChange)="sortModeChange.emit($event)"

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -43,6 +43,7 @@ export class LeftPanelComponent implements OnInit {
   @Input() labelingStatus: LabelingStatusResponse | null = null;
   @Input() showThumbnails = true;
   @Input() loadSortLabel = '';
+  @Input() textQuery = '';
 
   @Output() sortModeChange = new EventEmitter<SortMode>();
   @Output() selectModeChange = new EventEmitter<SelectMode>();

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -12,9 +12,10 @@ import { SortMode } from '../left-panel.component';
   templateUrl: './sort-bar.component.html',
   styleUrl: './sort-bar.component.scss',
 })
-export class SortBarComponent implements OnDestroy {
+export class SortBarComponent implements OnInit, OnDestroy {
   @Input() sortMode: SortMode = 'text';
   @Input() loadSortLabel = '';
+  @Input() initialTextQuery = '';
   @Input() hasGoodVotes = false;
   @Input() hasBadVotes = false;
 
@@ -36,6 +37,12 @@ export class SortBarComponent implements OnDestroy {
           this.textSort.emit(text.trim());
         }
       });
+  }
+
+  ngOnInit(): void {
+    if (this.initialTextQuery) {
+      this.textQuery = this.initialTextQuery;
+    }
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/services/sort-state.service.ts
+++ b/frontend/src/app/services/sort-state.service.ts
@@ -19,6 +19,7 @@ export class SortStateService {
   private readonly sortStatusSubject = new BehaviorSubject<string>('');
   private readonly inclusionSubject = new BehaviorSubject<number>(0);
   private readonly loadSortLabelSubject = new BehaviorSubject<string>('');
+  private readonly textQuerySubject = new BehaviorSubject<string>('');
 
   readonly sortMode$ = this.sortModeSubject.asObservable();
   readonly selectMode$ = this.selectModeSubject.asObservable();
@@ -28,6 +29,7 @@ export class SortStateService {
   readonly sortStatus$ = this.sortStatusSubject.asObservable();
   readonly inclusion$ = this.inclusionSubject.asObservable();
   readonly loadSortLabel$ = this.loadSortLabelSubject.asObservable();
+  readonly textQuery$ = this.textQuerySubject.asObservable();
 
   get sortMode(): SortMode {
     return this.sortModeSubject.value;
@@ -61,6 +63,10 @@ export class SortStateService {
     return this.loadSortLabelSubject.value;
   }
 
+  get textQuery(): string {
+    return this.textQuerySubject.value;
+  }
+
   setSortMode(mode: SortMode): void {
     this.sortModeSubject.next(mode);
   }
@@ -90,6 +96,10 @@ export class SortStateService {
     this.loadSortLabelSubject.next(label);
   }
 
+  setTextQuery(query: string): void {
+    this.textQuerySubject.next(query);
+  }
+
   clear(): void {
     this.sortModeSubject.next('text');
     this.selectModeSubject.next('top');
@@ -99,5 +109,6 @@ export class SortStateService {
     this.sortStatusSubject.next('');
     this.inclusionSubject.next(0);
     this.loadSortLabelSubject.next('');
+    this.textQuerySubject.next('');
   }
 }


### PR DESCRIPTION
## Summary
This PR improves the user experience when transitioning from autopilot mode to manual sorting by preserving the text query that was used during autopilot sorting. Previously, switching to manual mode would lose the current search query, requiring users to re-enter it.

## Key Changes
- **SortStateService**: Added `textQuery` state management with getter, setter, and observable to track the current text search query
- **LabelViewComponent**: 
  - Store the text query when `onTextSort()` is called via `setTextQuery()`
  - Implement `onAutopilotStop()` to intelligently map autopilot phases to manual select modes while preserving the text sort mode and query
- **SortBarComponent**: Accept and initialize with `initialTextQuery` input to restore the previous search text when the component loads
- **LeftPanelComponent**: Pass through the `textQuery` state to the sort bar component
- **Template bindings**: Wire up `textQuery` from sort state through the component hierarchy to the sort bar

## Implementation Details
- When exiting autopilot mode, the select mode is intelligently mapped based on the current autopilot phase (e.g., 'good'/'bad' → 'top', 'hard' → 'hard', 'new'/'done' → 'new')
- The sort mode is explicitly set to 'text' to maintain the text query context and allow results to carry over
- The text query is initialized in `SortBarComponent.ngOnInit()` to restore the user's previous search when switching modes

https://claude.ai/code/session_01XVW3PBGF5KYTFW4h6z6i5F