### PR TITLE
Simplify autopilot help UI by removing dedicated help icons

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -1,9 +1,5 @@
 <div class="autopilot-panel">
   <div class="autopilot-active">
-    <div class="autopilot-header">
-      <span class="ap-help-icon" [title]="overallHelp">?</span>
-    </div>
-
     <div class="autopilot-steps">
       @for (step of steps; track step.phase) {
         <div
@@ -22,9 +18,8 @@
             }
           </div>
           <div class="ap-step-content">
-            <span class="ap-step-label">
+            <span class="ap-step-label" [title]="step.helpText">
               {{ step.label }}
-              <span class="ap-help-icon small" [title]="step.helpText">?</span>
             </span>
             @if (step.detail || step.statusIcons.length) {
               <span class="ap-step-detail">

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -4,41 +4,6 @@
   gap: 12px;
 }
 
-.autopilot-header {
-  display: flex;
-  justify-content: flex-end;
-  padding: 4px 8px 0;
-}
-
-.ap-help-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 1px solid var(--text-muted);
-  color: var(--text-muted);
-  font-size: 0.7rem;
-  font-weight: 600;
-  cursor: help;
-  flex-shrink: 0;
-  line-height: 1;
-
-  &.small {
-    width: 14px;
-    height: 14px;
-    font-size: 0.6rem;
-    margin-left: 4px;
-    vertical-align: middle;
-  }
-
-  &:hover {
-    color: var(--text-primary);
-    border-color: var(--text-primary);
-  }
-}
-
 .autopilot-active {
   display: flex;
   flex-direction: column;
@@ -109,6 +74,7 @@
   font-size: 0.82rem;
   color: var(--text-primary);
   font-weight: 500;
+  cursor: help;
 }
 
 .ap-step-detail {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -128,18 +128,11 @@ describe('AutopilotPanelComponent', () => {
     expect(component.started.emit).not.toHaveBeenCalled();
   });
 
-  it('should show overall help icon with tooltip', () => {
-    const helpIcon = fixture.nativeElement.querySelector('.autopilot-header .ap-help-icon');
-    expect(helpIcon).toBeTruthy();
-    expect(helpIcon.textContent.trim()).toBe('?');
-    expect(helpIcon.title).toContain('Autopilot guides you');
-  });
-
-  it('should show help icon on each step with tooltip', () => {
-    const stepHelpIcons = fixture.nativeElement.querySelectorAll('.ap-step .ap-help-icon.small');
-    expect(stepHelpIcons.length).toBe(5);
-    expect(stepHelpIcons[0].title).toContain('good');
-    expect(stepHelpIcons[1].title).toContain('not what you want');
+  it('should show tooltip on each step label via title attribute', () => {
+    const stepLabels = fixture.nativeElement.querySelectorAll('.ap-step-label');
+    expect(stepLabels.length).toBe(5);
+    expect(stepLabels[0].title).toContain('good');
+    expect(stepLabels[1].title).toContain('not what you want');
   });
 
   it('should mark current step as active and future steps as future', () => {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -38,8 +38,6 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Output() started = new EventEmitter<void>();
   @Output() stopped = new EventEmitter<void>();
 
-  readonly overallHelp = 'Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration.';
-
   constructor(public autopilotState: AutopilotStateService) {}
 
   get state(): AutopilotState {

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -13,6 +13,7 @@
       [class.active]="activeTab === 'autopilot'"
       [attr.aria-selected]="activeTab === 'autopilot'"
       (click)="setTab('autopilot')"
+      title="Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration."
     >Autopilot</button>
   </div>
 


### PR DESCRIPTION
## Summary
Refactored the autopilot panel help system to use native HTML title attributes instead of custom help icon elements, reducing visual clutter and simplifying the component structure.

## Key Changes
- **Removed custom help icon elements**: Deleted `.autopilot-header` and `.ap-help-icon` styles and markup from the autopilot panel
- **Migrated help text to title attributes**: 
  - Moved overall autopilot help text from a dedicated header icon to the "Autopilot" tab button in the left panel
  - Moved per-step help text from small help icons to the step label's title attribute
- **Updated component logic**: Removed `overallHelp` property from AutopilotPanelComponent
- **Updated tests**: Changed test expectations to verify help text is accessible via title attributes on step labels rather than dedicated icon elements

## Implementation Details
- Help text remains accessible to users via native browser tooltips on hover
- Reduces DOM complexity by eliminating 6+ help icon elements
- Maintains all help content and functionality while improving visual simplicity
- The overall autopilot help is now shown on the tab button itself, providing context at the entry point

https://claude.ai/code/session_01SE3vkvX1yKsbNVwbyeY9Ku