### PR TITLE
Add optional close button control to modal component

### DIFF
--- a/frontend/src/app/components/dialog-host/dialog-host.component.html
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.html
@@ -1,4 +1,4 @@
-<vt-modal [open]="dialog.dialogOpen" [title]="dialog.getIcon() + ' ' + dialog.dialogTitle" (closed)="onClosed()">
+<vt-modal [open]="dialog.dialogOpen" [title]="dialog.getIcon() + ' ' + dialog.dialogTitle" [showCloseButton]="false" (closed)="onClosed()">
   <p>{{ dialog.dialogMessage }}</p>
   @if (dialog.dialogShowInput) {
     <input

--- a/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
@@ -43,6 +43,17 @@ describe('DialogHostComponent', () => {
     expect(result).toBeFalse();
   });
 
+  it('should not show close button on dialog modal', async () => {
+    const promise = dialogService.confirm('Delete?');
+    fixture.detectChanges();
+
+    const closeBtn = fixture.nativeElement.querySelector('.modal-close');
+    expect(closeBtn).toBeNull();
+
+    component.onButtonClick(true);
+    await promise;
+  });
+
   it('should render alert dialog', async () => {
     const promise = dialogService.alert('Something happened');
     fixture.detectChanges();

--- a/frontend/src/app/components/modal/modal.component.html
+++ b/frontend/src/app/components/modal/modal.component.html
@@ -11,7 +11,9 @@
   <div class="modal-content">
     <div class="modal-header">
       <h2>{{ title }}</h2>
-      <button class="modal-close" (click)="close()" aria-label="Close">&times;</button>
+      @if (showCloseButton) {
+        <button class="modal-close" (click)="close()" aria-label="Close">&times;</button>
+      }
     </div>
     <div class="modal-body">
       <ng-content />

--- a/frontend/src/app/components/modal/modal.component.spec.ts
+++ b/frontend/src/app/components/modal/modal.component.spec.ts
@@ -71,4 +71,19 @@ describe('ModalComponent', () => {
     fixture.nativeElement.querySelector('.modal-content').click();
     expect(host.closeCalled).toBeFalse();
   });
+
+  it('should hide close button when showCloseButton is false', () => {
+    host.isOpen = true;
+    fixture.detectChanges();
+    const modal = fixture.debugElement.children[0].componentInstance as ModalComponent;
+    modal.showCloseButton = false;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.modal-close')).toBeNull();
+  });
+
+  it('should show close button by default', () => {
+    host.isOpen = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.modal-close')).toBeTruthy();
+  });
 });

--- a/frontend/src/app/components/modal/modal.component.ts
+++ b/frontend/src/app/components/modal/modal.component.ts
@@ -9,6 +9,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class ModalComponent {
   @Input() title = '';
   @Input() open = false;
+  @Input() showCloseButton = true;
   @Output() closed = new EventEmitter<void>();
 
   onBackdropClick(event: MouseEvent): void {


### PR DESCRIPTION
## Summary
Added a configurable `showCloseButton` input property to the ModalComponent that allows consumers to control whether the close button is displayed in the modal header. This is useful for dialog modals where closing via the close button should not be permitted.

## Key Changes
- Added `@Input() showCloseButton = true` to ModalComponent to control close button visibility
- Updated modal template to conditionally render the close button using `@if` directive
- Disabled close button in DialogHostComponent by setting `[showCloseButton]="false"`
- Added unit tests to verify close button visibility behavior:
  - Test that close button is hidden when `showCloseButton` is false
  - Test that close button is shown by default
  - Test that dialog modals do not display the close button

## Implementation Details
- The close button defaults to visible (`true`) to maintain backward compatibility
- Dialog modals explicitly disable the close button to prevent unintended dismissal
- Uses Angular's new control flow syntax (`@if`) for conditional rendering

https://claude.ai/code/session_019GxniU7rfqNE9T4He794cG