### PR TITLE
Fix button layout shift when disabled hint text appears

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -92,7 +92,12 @@
     }
   </div>
 
-  <!-- Action Buttons -->
+  <!-- Action Buttons
+       DESIGN CONSTRAINT: Label/Find buttons must stay in the same position whether
+       their hint is visible or not. The btn-disabled-reason spans use visibility
+       (NOT display) toggling and have a fixed height in SCSS so they always reserve
+       the same space. Do NOT switch to *ngIf/display:none or remove the fixed-height
+       styles — that will cause the buttons to jump around. -->
   <div class="dashboard-actions">
     <div class="action-btn-group">
       <button

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -157,9 +157,20 @@
   gap: 4px;
 }
 
+// DESIGN CONSTRAINT: The Label/Find buttons must NOT move when their hint text
+// appears or disappears. This class uses visibility (not display) toggling in the
+// template, plus a fixed single-line height here, so the hint area always reserves
+// exactly the same space regardless of whether the hint is shown or hidden.
+// Do NOT remove white-space/overflow/height constraints or switch to display:none —
+// that will cause the buttons to jump around.
 .btn-disabled-reason {
   font-size: 0.75rem;
   color: var(--text-muted);
   font-style: italic;
-  min-height: 1.2em;
+  height: 1.2em;
+  line-height: 1.2em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
 }


### PR DESCRIPTION
## Summary
Fixed a layout stability issue where the Label/Find buttons would shift position when their disabled hint text appeared or disappeared. The buttons now maintain a fixed position regardless of hint visibility.

## Key Changes
- **SCSS (.btn-disabled-reason)**: Changed from `min-height: 1.2em` to fixed `height: 1.2em` with explicit `line-height: 1.2em`
- Added `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` to prevent text wrapping
- Set `max-width: 220px` to constrain hint text width
- **HTML (dashboard.component.html)**: Added design constraint documentation explaining the visibility toggle pattern

## Implementation Details
The hint text container now uses `visibility` toggling (not `display: none`) in the template, combined with a fixed single-line height in CSS. This ensures the hint area always reserves the same space whether the hint is shown or hidden, preventing the buttons from jumping around when the hint appears/disappears.

The `text-overflow: ellipsis` handles cases where hint text exceeds the max-width constraint, ensuring it truncates gracefully rather than causing layout shifts.

https://claude.ai/code/session_01PCNBHCKQrH1aeP7NvFXqHV