### PR TITLE
Hide scores in media list and widen stripe overview

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -56,6 +56,7 @@
           [goodVotes]="goodVotes"
           [badVotes]="badVotes"
           [showThumbnails]="showThumbnails"
+          [showScores]="false"
           (mediaSelect)="mediaSelect.emit($event)"
           (scrollUpdate)="onScrollUpdate($event)"
         />

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -19,6 +19,7 @@ export class MediaListComponent implements AfterViewChecked {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   @Input() showThumbnails = true;
+  @Input() showScores = true;
 
   @Output() mediaSelect = new EventEmitter<number>();
   @Output() scrollUpdate = new EventEmitter<{ scrollTop: number; scrollHeight: number; clientHeight: number }>();
@@ -43,7 +44,7 @@ export class MediaListComponent implements AfterViewChecked {
           thresholdInserted = true;
         }
 
-        items.push({ media, score: sorted.score, showThreshold });
+        items.push({ media, score: this.showScores ? sorted.score : null, showThreshold });
       }
     } else {
       for (const media of this.medias) {

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
@@ -4,7 +4,7 @@
 }
 
 .stripe-overview {
-  width: 12px;
+  width: 24px;
   height: 100%;
   position: relative;
   background: var(--bg-subtle);


### PR DESCRIPTION
## Summary
This PR adds the ability to hide scores in the media list component and increases the width of the stripe overview component for better visibility.

## Key Changes
- Added `showScores` input property to `MediaListComponent` to control score visibility (defaults to `true`)
- Modified score rendering logic to conditionally display scores based on the `showScores` flag
- Disabled score display in the left panel's media list by setting `showScores="false"`
- Increased stripe overview width from 12px to 24px for improved visual prominence

## Implementation Details
- The `showScores` input is a boolean flag that determines whether the score value is passed to list items or set to `null`
- When `showScores` is `false`, the score is explicitly set to `null` rather than omitted, allowing the template to handle the conditional rendering
- The stripe overview width change doubles the previous width, making the visual indicator more noticeable in the UI

https://claude.ai/code/session_01Sz6LB545P6oKE62WT2H4Bk