### PR TITLE
Improve select-mode layout responsiveness with flex wrapping

### DIFF
--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.scss
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.scss
@@ -1,14 +1,15 @@
 .select-mode-group {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 4px 8px;
 }
 
 .sort-label {
   color: var(--text-secondary);
   font-size: 0.8rem;
   font-weight: 500;
-  min-width: 32px;
+  width: 100%;
 }
 
 .sort-radio {


### PR DESCRIPTION
## Summary
Updated the select-mode component styling to improve layout responsiveness and ensure proper text wrapping behavior on smaller screens.

## Key Changes
- Added `flex-wrap: wrap` to `.select-mode-group` to allow child elements to wrap to the next line when space is constrained
- Updated `gap` property from `8px` to `4px 8px` to provide different spacing for row and column gaps (4px vertical, 8px horizontal)
- Changed `.sort-label` width from `min-width: 32px` to `width: 100%` to ensure the label takes full width and forces subsequent elements to wrap below it

## Implementation Details
These changes ensure that the select-mode controls display properly on responsive layouts, with the sort label spanning the full width and radio buttons wrapping to a new line when needed, rather than being constrained by a minimum width constraint.

https://claude.ai/code/session_01DbkL2vFJ2y7wEku5ngZyMa