### PR TITLE
Add red status styling to progress indicators

### DIFF
--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -40,6 +40,22 @@
     background: var(--bg-hover);
   }
 
+  &[data-status="red"] {
+    border-color: var(--status-red-border);
+
+    .indicator-dot {
+      background: var(--status-red-dot);
+    }
+
+    .indicator-label {
+      color: var(--status-red-label);
+    }
+
+    .indicator-subtext {
+      color: var(--status-red-sub);
+    }
+  }
+
   &[data-status="green"] {
     border-color: var(--status-green-border);
 

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
@@ -101,12 +101,12 @@ describe('ProgressIndicatorsComponent', () => {
     component.labelingStatus = {
       smart: { status: 'green' },
       stable: { status: 'yellow' },
-      span: { status: '' },
+      span: { status: 'red' },
     };
     fixture.detectChanges();
     const buttons = fixture.nativeElement.querySelectorAll('.labeling-indicator');
     expect(buttons[0].getAttribute('data-status')).toBe('green');
     expect(buttons[1].getAttribute('data-status')).toBe('yellow');
-    expect(buttons[2].getAttribute('data-status')).toBe('');
+    expect(buttons[2].getAttribute('data-status')).toBe('red');
   });
 });


### PR DESCRIPTION
## Summary
Added support for a "red" status state in the progress indicators component with corresponding styling and test coverage.

## Key Changes
- **Styling**: Added new `[data-status="red"]` selector in the progress indicators SCSS with CSS variables for:
  - Border color (`--status-red-border`)
  - Indicator dot background (`--status-red-dot`)
  - Label text color (`--status-red-label`)
  - Subtext color (`--status-red-sub`)
- **Tests**: Updated the progress indicators component spec to test the red status state instead of an empty status string

## Implementation Details
The red status styling follows the same pattern as existing green and yellow status states, using CSS custom properties for theming consistency. The test was updated to verify that the red status is properly applied to the `data-status` attribute on indicator elements.

https://claude.ai/code/session_018qYKs8xNDZyZrLbsiw5qXh