### PR TITLE
Add cached indicator score history API and modal display

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -49,3 +49,11 @@
     />
   </div>
 </div>
+
+@if (progressModalMetric) {
+  <vt-progress-modal
+    [metric]="progressModalMetric"
+    [useCachedHistory]="true"
+    (closed)="onProgressModalClosed()"
+  />
+}

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -12,12 +12,13 @@ import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService, SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
+import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { LabelingStatusResponse } from '../../models/api.models';
 
 @Component({
   selector: 'vt-label-view',
   standalone: true,
-  imports: [CommonModule, LeftPanelComponent, CenterPanelComponent, RightPanelComponent],
+  imports: [CommonModule, LeftPanelComponent, CenterPanelComponent, RightPanelComponent, ProgressModalComponent],
   templateUrl: './label-view.component.html',
   styleUrl: './label-view.component.scss',
 })
@@ -29,6 +30,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   showThumbnails = true;
   leftWidth = 260;
   rightWidth = 300;
+  progressModalMetric: ProgressMetric | null = null;
 
   private readonly LEFT_MIN = 180;
   private readonly LEFT_MAX = 500;
@@ -295,8 +297,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Indicators ---
 
-  onIndicatorClick(_name: string): void {
-    // Will open progress modal in Phase 7
+  onIndicatorClick(name: string): void {
+    const metricMap: Record<string, ProgressMetric> = {
+      smart: 'smart',
+      stable: 'stable',
+      span: 'diverse',
+    };
+    const metric = metricMap[name];
+    if (metric) {
+      this.progressModalMetric = metric;
+    }
+  }
+
+  onProgressModalClosed(): void {
+    this.progressModalMetric = null;
   }
 
   // --- Autopilot ---

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -1,9 +1,17 @@
 <vt-modal [title]="title" [open]="true" (closed)="close()">
   @if (analyzing) {
     <div class="analysis-loading">
-      <p aria-live="polite">Training models over label history...</p>
-      <vt-progress-bar [value]="analysisProgress" [max]="100"></vt-progress-bar>
-      <p class="progress-text">{{ analysisProgress }}%</p>
+      @if (useCachedHistory) {
+        <p aria-live="polite">Loading indicator history...</p>
+      } @else {
+        <p aria-live="polite">Training models over label history...</p>
+        <vt-progress-bar [value]="analysisProgress" [max]="100"></vt-progress-bar>
+        <p class="progress-text">{{ analysisProgress }}%</p>
+      }
+    </div>
+  } @else if (emptyHistory) {
+    <div class="analysis-loading">
+      <p>No score history available yet. Label more items to build up history.</p>
     </div>
   } @else {
     <div class="chart-container">

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -22,6 +22,7 @@ export type ProgressMetric = 'smart' | 'stable' | 'diverse';
 })
 export class ProgressModalComponent implements OnInit, OnDestroy {
   @Input() metric: ProgressMetric = 'smart';
+  @Input() useCachedHistory = false;
   @Output() closed = new EventEmitter<void>();
 
   @ViewChild('chartCanvas') chartCanvas!: ElementRef<HTMLCanvasElement>;
@@ -29,6 +30,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   analyzing = true;
   analysisProgress = 0;
   chartData: ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[] = [];
+  emptyHistory = false;
 
   private destroy$ = new Subject<void>();
 
@@ -40,21 +42,43 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   get title(): string {
     switch (this.metric) {
       case 'smart':
-        return 'Smart: Error Cost Analysis';
+        return 'Smart: Error Cost Over Time';
       case 'stable':
-        return 'Stable: Prediction Flip Analysis';
+        return 'Stable: Prediction Flips Over Time';
       case 'diverse':
-        return 'Diverse: Diversity Coverage';
+        return 'Diverse: Diversity Coverage Over Time';
     }
   }
 
   ngOnInit(): void {
-    this.runAnalysis();
+    if (this.useCachedHistory) {
+      this.loadCachedHistory();
+    } else {
+      this.runAnalysis();
+    }
   }
 
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private loadCachedHistory(): void {
+    this.analyzing = true;
+    this.sortingApi.getIndicatorScoreHistory(this.metric).subscribe({
+      next: (res) => {
+        this.analyzing = false;
+        this.chartData = res.history || [];
+        this.emptyHistory = this.chartData.length === 0;
+        if (!this.emptyHistory) {
+          setTimeout(() => this.renderChart(), 50);
+        }
+      },
+      error: () => {
+        this.analyzing = false;
+        this.emptyHistory = true;
+      },
+    });
   }
 
   private runAnalysis(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -354,6 +354,11 @@ export interface TrainAndScoreResponse {
   [key: string]: unknown;
 }
 
+export interface IndicatorScoreHistoryResponse {
+  metric: string;
+  history: ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
+}
+
 export interface VotingIterationsResponse {
   progress: number;
   total: number;

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -20,6 +20,7 @@ import {
   ServerMediaFilesResponse,
   TrainAndScoreResponse,
   VotingIterationsResponse,
+  IndicatorScoreHistoryResponse,
 } from '../models/api.models';
 
 @Injectable({ providedIn: 'root' })
@@ -115,6 +116,12 @@ export class SortingApiService {
 
   getLabelingStatus(): Observable<LabelingStatusResponse> {
     return this.http.get<LabelingStatusResponse>('/api/labeling-status');
+  }
+
+  getIndicatorScoreHistory(metric: string): Observable<IndicatorScoreHistoryResponse> {
+    return this.http.get<IndicatorScoreHistoryResponse>('/api/indicator-score-history', {
+      params: { metric },
+    });
   }
 
   getDiversityTreeNext(scores?: Record<string, number>, threshold?: number): Observable<DiversityTreeNextResponse> {

--- a/vtsearch/models/__init__.py
+++ b/vtsearch/models/__init__.py
@@ -16,7 +16,14 @@ from vtsearch.models.loader import (
     initialize_models,
     preload_autoload_media_types,
 )
-from vtsearch.models.progress import analyze_labeling_progress, clear_progress_cache, compute_labeling_status
+from vtsearch.models.progress import (
+    analyze_labeling_progress,
+    calculate_diversity_level_over_time,
+    calculate_error_cost_over_time,
+    calculate_prediction_stability_over_time,
+    clear_progress_cache,
+    compute_labeling_status,
+)
 from vtsearch.models.training import (
     build_model,
     build_model_from_weights,
@@ -55,6 +62,9 @@ __all__ = [
     "calculate_cross_calibration_threshold",
     # Progress
     "analyze_labeling_progress",
+    "calculate_diversity_level_over_time",
+    "calculate_error_cost_over_time",
+    "calculate_prediction_stability_over_time",
     "clear_progress_cache",
     "compute_labeling_status",
 ]

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -14,7 +14,10 @@ import vtsearch.utils.paths as _paths
 from vtsearch.models import (
     analyze_labeling_progress,
     calculate_cross_calibration_threshold,
+    calculate_diversity_level_over_time,
+    calculate_error_cost_over_time,
     calculate_gmm_threshold,
+    calculate_prediction_stability_over_time,
     calculate_safe_threshold,
     compute_labeling_status,
     embed_text_query,
@@ -720,6 +723,36 @@ def labeling_status_indicator():
         span = tree.span_info() if tree is not None else None
         status = compute_labeling_status(snapshot_medias(), label_history, good_votes, bad_votes, get_inclusion(), span_info=span)
         return jsonify(status)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@sorting_bp.route("/api/indicator-score-history", methods=["GET"])
+def indicator_score_history():
+    """Return cached indicator score history for a given metric.
+
+    Query parameter ``metric`` must be one of ``smart``, ``stable``, or
+    ``diverse``.  Returns the cached per-step data without retraining
+    models — only data already computed by the labeling-status polling
+    is returned.
+    """
+    metric = request.args.get("metric", "").strip()
+    if metric not in ("smart", "stable", "diverse"):
+        return jsonify({"error": "metric must be one of: smart, stable, diverse"}), 400
+
+    clips = snapshot_medias()
+    inclusion = get_inclusion()
+
+    try:
+        if metric == "smart":
+            data = calculate_error_cost_over_time(clips, label_history, good_votes, bad_votes, inclusion)
+            return jsonify({"metric": "smart", "history": data})
+        elif metric == "stable":
+            data = calculate_prediction_stability_over_time(clips, label_history, inclusion)
+            return jsonify({"metric": "stable", "history": data})
+        else:
+            data = calculate_diversity_level_over_time(clips, label_history)
+            return jsonify({"metric": "diverse", "history": data})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 


### PR DESCRIPTION
## Summary
This PR adds the ability to display cached indicator score history without retraining models. Users can now click on indicator badges to view historical trends for smart (error cost), stable (prediction stability), and diverse (diversity coverage) metrics using previously computed data from the labeling-status polling system.

## Key Changes

- **Backend API**: Added `/api/indicator-score-history` endpoint that returns cached per-step indicator data for a specified metric (smart, stable, or diverse) without requiring model retraining
- **Progress Modal Enhancement**: Extended `ProgressModalComponent` with a `useCachedHistory` input flag to load cached data instead of running full analysis, with appropriate UI messaging for loading states and empty history
- **Label View Integration**: Connected indicator badge clicks to open the progress modal with cached history, mapping indicator names (smart, stable, span) to metric types
- **API Service**: Added `getIndicatorScoreHistory()` method to `SortingApiService` to fetch cached indicator data
- **Type Definitions**: Added `IndicatorScoreHistoryResponse` interface for the new API response format
- **Model Exports**: Exported three new calculation functions (`calculate_error_cost_over_time`, `calculate_prediction_stability_over_time`, `calculate_diversity_level_over_time`) from the progress module

## Implementation Details

- The cached history endpoint leverages data already computed during labeling-status polling, avoiding expensive model retraining
- Progress modal intelligently switches between full analysis mode and cached history mode based on the `useCachedHistory` flag
- UI provides appropriate feedback for loading states and handles empty history gracefully with a user-friendly message
- Metric mapping allows the frontend to use indicator names while the backend uses standardized metric identifiers

https://claude.ai/code/session_01GCde4xWUPMinsXJ2JobeZX