### PR TITLE
Auto-sync votes to loaded trainable model

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -331,6 +331,12 @@ describe('DashboardComponent', () => {
       const routerSpy = spyOn(component['router'], 'navigate');
       component.onLabel();
 
+      // Flush the loadModel call
+      const loadModelReq = httpMock.expectOne('/api/models/registry/load');
+      expect(loadModelReq.request.method).toBe('POST');
+      expect(loadModelReq.request.body).toEqual({ model_id: 'm1' });
+      loadModelReq.flush({ ok: true });
+
       expect(routerSpy).toHaveBeenCalledWith(['/label']);
       expect(component.loading).toBeFalse();
     });
@@ -343,6 +349,9 @@ describe('DashboardComponent', () => {
       const session = TestBed.inject(LabelSessionService);
       spyOn(component['router'], 'navigate');
       component.onLabel();
+
+      const loadModelReq = httpMock.expectOne('/api/models/registry/load');
+      loadModelReq.flush({ ok: true });
 
       expect(session.textQuery).toBe('dog barking');
     });
@@ -367,6 +376,10 @@ describe('DashboardComponent', () => {
       // Progress polling returns idle -> should navigate
       const progressReq = httpMock.expectOne('/api/dataset/progress');
       progressReq.flush({ status: 'idle' });
+
+      // Flush the loadModel call triggered after progress completes
+      const loadModelReq = httpMock.expectOne('/api/models/registry/load');
+      loadModelReq.flush({ ok: true });
 
       expect(routerSpy).toHaveBeenCalledWith(['/label']);
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -374,9 +374,19 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const dataset = this.datasets.find((d) => this.selectedDatasetIds.has(d.id));
     if (!dataset) return;
 
-    if (dataset.loaded) {
+    const modelId = [...this.selectedModelIds][0] || null;
+
+    const navigateToLabel = (): void => {
       this.storeSelectedModelTextQuery();
-      this.router.navigate(['/label']);
+      // Tell the backend which model is loaded so votes auto-sync
+      this.modelsApi.loadModel(modelId).subscribe({
+        next: () => this.router.navigate(['/label']),
+        error: () => this.router.navigate(['/label']),
+      });
+    };
+
+    if (dataset.loaded) {
+      navigateToLabel();
       return;
     }
 
@@ -386,9 +396,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.progressIndeterminate = true;
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
       next: () => {
-        this.storeSelectedModelTextQuery();
         this.startProgressPolling(() => {
-          this.router.navigate(['/label']);
+          navigateToLabel();
         });
       },
       error: () => {

--- a/frontend/src/app/services/trainable-models-api.service.ts
+++ b/frontend/src/app/services/trainable-models-api.service.ts
@@ -52,4 +52,8 @@ export class TrainableModelsApiService {
   renameInRegistry(modelId: string, newName: string): Observable<unknown> {
     return this.http.put(`/api/models/registry/${modelId}/rename`, { name: newName });
   }
+
+  loadModel(modelId: string | null): Observable<unknown> {
+    return this.http.post('/api/models/registry/load', { model_id: modelId });
+  }
 }

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -405,3 +405,155 @@ class TestLabelVoteIsolation:
         assert len(good_votes) + len(bad_votes) == 2
         assert ids[2] not in good_votes, "Stale vote should be gone after clear+import"
         assert ids[3] not in bad_votes, "Stale vote should be gone after clear+import"
+
+
+class TestLoadModelEndpoint:
+    """Tests for POST /api/models/registry/load."""
+
+    def test_load_model(self, client):
+        from vtsearch.models.registry import get_loaded_id
+
+        res = client.post(
+            "/api/models/registry",
+            json={"name": "M", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        model_id = res.get_json()["model"]["id"]
+
+        res = client.post("/api/models/registry/load", json={"model_id": model_id})
+        assert res.status_code == 200
+        assert get_loaded_id() == model_id
+
+    def test_unload_model(self, client):
+        from vtsearch.models.registry import get_loaded_id, set_loaded_id
+
+        set_loaded_id("fake")
+        res = client.post("/api/models/registry/load", json={"model_id": None})
+        assert res.status_code == 200
+        assert get_loaded_id() is None
+
+    def test_load_nonexistent(self, client):
+        res = client.post("/api/models/registry/load", json={"model_id": "nope"})
+        assert res.status_code == 404
+
+
+class TestVoteSyncsToLoadedModel:
+    """Voting while a trainable model is loaded should auto-update the model's labelset."""
+
+    def test_vote_updates_model_labels(self, client):
+        """Casting a vote with a loaded model should persist labels and update registry stats."""
+        from vtsearch.models.registry import get_model
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        # Create and register a trainable model
+        client.post(
+            "/api/trainable-models",
+            json={"name": "AutoSync", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={"name": "AutoSync", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        model_id = res.get_json()["model"]["id"]
+
+        # Load the model
+        client.post("/api/models/registry/load", json={"model_id": model_id})
+
+        # Cast a vote
+        first_id = next(iter(medias))
+        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+
+        # Check that the model's labelset was updated
+        model_data = client.get("/api/trainable-models/AutoSync").get_json()
+        labels = model_data["labelset"]["labels"]
+        assert len(labels) == 1
+        assert labels[0]["label"] == "good"
+
+        # Check that the registry entry was updated
+        entry = get_model(model_id)
+        assert entry["num_training"] == 1
+        assert entry.get("last_trained_at") is not None
+
+    def test_vote_toggle_off_updates_model(self, client):
+        """Toggling a vote off should update the model labelset to reflect removal."""
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        client.post(
+            "/api/trainable-models",
+            json={"name": "ToggleSync", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={"name": "ToggleSync", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        model_id = res.get_json()["model"]["id"]
+        client.post("/api/models/registry/load", json={"model_id": model_id})
+
+        first_id = next(iter(medias))
+        # Vote good
+        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        model_data = client.get("/api/trainable-models/ToggleSync").get_json()
+        assert len(model_data["labelset"]["labels"]) == 1
+
+        # Toggle off (vote good again)
+        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+        model_data = client.get("/api/trainable-models/ToggleSync").get_json()
+        assert len(model_data["labelset"]["labels"]) == 0
+
+    def test_no_sync_without_loaded_model(self, client):
+        """Voting with no loaded model should not create/update any model files."""
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        client.post(
+            "/api/trainable-models",
+            json={"name": "NoSync", "media_type": "audio", "text_query": "test"},
+        )
+
+        first_id = next(iter(medias))
+        client.post(f"/api/medias/{first_id}/vote", json={"vote": "good"})
+
+        # Model should still have empty labelset
+        model_data = client.get("/api/trainable-models/NoSync").get_json()
+        assert len(model_data["labelset"]["labels"]) == 0
+
+    def test_label_import_syncs_to_loaded_model(self, client):
+        """Importing labels with a loaded model should persist to the model."""
+        from vtsearch.models.registry import get_model
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        client.post(
+            "/api/trainable-models",
+            json={"name": "ImportSync", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={"name": "ImportSync", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        model_id = res.get_json()["model"]["id"]
+        client.post("/api/models/registry/load", json={"model_id": model_id})
+
+        # Get an MD5 from the first media
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        md5 = media.get("md5", "")
+
+        # Import a label
+        client.post("/api/labels/import", json={"labels": [{"md5": md5, "label": "good"}]})
+
+        # Model should have the imported label
+        model_data = client.get("/api/trainable-models/ImportSync").get_json()
+        assert len(model_data["labelset"]["labels"]) == 1
+
+        entry = get_model(model_id)
+        assert entry["num_training"] == 1

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -308,4 +308,8 @@ def vote_media(media_id: int) -> tuple[Response, int] | Response:
 
     toggle_vote(media_id, vote)
 
+    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+
+    sync_labels_to_loaded_model()
+
     return jsonify({"ok": True})

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -285,6 +285,10 @@ def import_labels():
             apply_label(cid, label)
         applied += 1
 
+    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+
+    sync_labels_to_loaded_model()
+
     return jsonify({"applied": applied, "skipped": skipped})
 
 
@@ -394,6 +398,10 @@ def fill_labels_from_sort():
             },
         },
     }
+
+    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+
+    sync_labels_to_loaded_model()
 
     return jsonify({
         "good_applied": len(good_candidates),

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -71,6 +71,40 @@ def _write_model(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+def sync_labels_to_loaded_model() -> None:
+    """Persist the current votes into the loaded model's labelset (if any).
+
+    Called automatically after each vote so the dashboard's "# Training"
+    and "Last Trained" columns stay up to date without an explicit save.
+    """
+    from vtsearch.models.registry import get_loaded_id, get_model, update_model
+
+    loaded_id = get_loaded_id()
+    if not loaded_id:
+        return
+
+    entry = get_model(loaded_id)
+    if not entry or not entry.get("trainable") or not entry.get("trainable_model_name"):
+        return
+
+    tm_name = entry["trainable_model_name"]
+    path = _model_path(tm_name)
+    data = _read_model(path)
+    if data is None:
+        return
+
+    from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+
+    labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bad_votes, expand_dupes=False)
+    data["labelset"] = labelset.to_dict()
+    _write_model(path, data)
+
+    import time as _time
+
+    update_model(entry["id"], num_training=len(labelset), last_trained_at=_time.time())
+
+
 def _list_all() -> list[dict]:
     """Return summary info for every trainable model on disk."""
     tm_dir = get_trainable_models_dir()
@@ -385,6 +419,30 @@ def register_model_route():
         trainable_model_name=trainable_model_name,
     )
     return jsonify({"ok": True, "model": entry}), 201
+
+
+@trainable_models_bp.route("/api/models/registry/load", methods=["POST"])
+def load_model_route():
+    """Set the currently loaded model by ID.
+
+    Expects JSON::
+
+        {"model_id": "abc123"}
+
+    Pass ``model_id: null`` to unload.
+    """
+    from vtsearch.models.registry import get_model, set_loaded_id
+
+    data = request.get_json(force=True, silent=True) or {}
+    model_id = data.get("model_id")
+
+    if model_id is not None:
+        entry = get_model(model_id)
+        if entry is None:
+            return jsonify({"error": "Model not found"}), 404
+
+    set_loaded_id(model_id)
+    return jsonify({"ok": True})
 
 
 @trainable_models_bp.route("/api/models/registry/<model_id>", methods=["DELETE"])


### PR DESCRIPTION
## Summary
This PR implements automatic synchronization of votes and labels to a loaded trainable model. When a model is loaded via the new `/api/models/registry/load` endpoint, any subsequent votes or label imports will automatically update that model's labelset and training statistics without requiring an explicit save action.

## Key Changes

- **New Model Loading Endpoint**: Added `POST /api/models/registry/load` to set the currently active model by ID, with support for unloading via `model_id: null`

- **Auto-sync Mechanism**: Implemented `sync_labels_to_loaded_model()` function that:
  - Persists current votes into the loaded model's labelset
  - Updates registry statistics (`num_training`, `last_trained_at`)
  - Is called automatically after votes, label imports, and label fills

- **Vote Integration**: Modified vote endpoint to trigger sync after each vote, keeping the dashboard's training stats current in real-time

- **Label Import Integration**: Updated label import and fill operations to sync changes to the loaded model

- **Frontend Updates**: 
  - Added `loadModel()` method to trainable models API service
  - Modified dashboard navigation to call the load endpoint when transitioning to the label view
  - Updated component tests to expect the new load model HTTP requests

## Implementation Details

The sync function checks if a model is currently loaded and if so, reconstructs the model's labelset from the current vote state, persisting it back to disk. This ensures the model file always reflects the latest training data without manual intervention, improving the user experience when actively training a model.

https://claude.ai/code/session_01VE8n8dL1sAx91HVvDcQzLm