### PR TITLE
Rename autoload_media_types to autoload_media_embedders

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -21,6 +21,7 @@ describe('SettingsModalComponent', () => {
     autopilot_top_greens: 3,
     autopilot_hard_reds: 3,
     autoload_media_types: ['audio'],
+    autoload_media_embedders: ['audio'],
   };
 
   beforeEach(async () => {
@@ -83,17 +84,17 @@ describe('SettingsModalComponent', () => {
   it('should check if embedder is autoloaded', () => {
     flushInit();
     expect(component.isEmbedderAutoloaded({ name: 'audio', media_type_id: 'audio' })).toBeTrue();
-    expect(component.isEmbedderAutoloaded({ name: 'images', media_type_id: 'image' })).toBeFalse();
+    expect(component.isEmbedderAutoloaded({ name: 'clip', media_type_id: 'image' })).toBeFalse();
   });
 
   it('should toggle embedder in autoload list', () => {
     flushInit();
-    component.toggleEmbedder({ name: 'images', media_type_id: 'image' });
-    expect(component.settings.autoload_media_types).toContain('images');
+    component.toggleEmbedder({ name: 'clip', media_type_id: 'image' });
+    expect(component.settings.autoload_media_embedders).toContain('clip');
     httpMock.expectOne('/api/settings').flush(mockSettings);
 
     component.toggleEmbedder({ name: 'audio', media_type_id: 'audio' });
-    expect(component.settings.autoload_media_types).not.toContain('audio');
+    expect(component.settings.autoload_media_embedders).not.toContain('audio');
     httpMock.expectOne('/api/settings').flush(mockSettings);
   });
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -61,15 +61,15 @@ export class SettingsModalComponent implements OnInit {
   }
 
   isEmbedderAutoloaded(embedder: EmbedderInfo): boolean {
-    return (this.settings.autoload_media_types || []).includes(embedder.name);
+    return (this.settings.autoload_media_embedders || []).includes(embedder.name);
   }
 
   toggleEmbedder(embedder: EmbedderInfo): void {
-    const current = this.settings.autoload_media_types || [];
+    const current = this.settings.autoload_media_embedders || [];
     if (current.includes(embedder.name)) {
-      this.settings.autoload_media_types = current.filter((e) => e !== embedder.name);
+      this.settings.autoload_media_embedders = current.filter((e) => e !== embedder.name);
     } else {
-      this.settings.autoload_media_types = [...current, embedder.name];
+      this.settings.autoload_media_embedders = [...current, embedder.name];
     }
     this.save();
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -251,6 +251,7 @@ export interface AppSettings {
   show_thumbnails_left?: boolean;
   show_thumbnails_right?: boolean;
   autoload_media_types?: string[];
+  autoload_media_embedders?: string[];
   autorun_processors?: AutorunProcessor[];
   autopilot_top_greens?: number;
   autopilot_hard_reds?: number;


### PR DESCRIPTION
## Summary
Renamed the `autoload_media_types` setting to `autoload_media_embedders` to better reflect its actual purpose of tracking which embedders should be autoloaded, rather than media types.

## Key Changes
- Updated `AppSettings` interface to include new `autoload_media_embedders` property alongside the existing `autoload_media_types`
- Modified `SettingsModalComponent` to use `autoload_media_embedders` instead of `autoload_media_types` in:
  - `isEmbedderAutoloaded()` method
  - `toggleEmbedder()` method
- Updated unit tests to reflect the new property name and use more accurate test data (e.g., 'clip' embedder instead of 'images')

## Implementation Details
The change improves semantic clarity by distinguishing between media types (audio, image, video, etc.) and embedders (audio, clip, etc.). The `autoload_media_embedders` property now correctly represents which embedders should be automatically loaded rather than which media types should be loaded.

https://claude.ai/code/session_016iuN2CQsKDMq96KuT8MzB2