### PR TITLE
Improve "Trainable" column tooltip for clarity

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -70,7 +70,7 @@
               <th (click)="sortModels('name')" class="sortable" title="Model display name (click to sort)">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
               <th (click)="sortModels('media_type')" class="sortable" title="Media type this model operates on (click to sort)">Type<span class="sort-indicator" [class.active]="isModelSortActive('media_type')">{{ modelSortIndicator('media_type') }}</span></th>
               <th (click)="sortModels('num_training')" class="sortable" title="Number of labeled training examples (click to sort)"># Training<span class="sort-indicator" [class.active]="isModelSortActive('num_training')">{{ modelSortIndicator('num_training') }}</span></th>
-              <th title="Whether the model has enough labels to train">Trainable</th>
+              <th title="Is this Model one we can load into the Labeling interface and improve?">Trainable</th>
               <th (click)="sortModels('last_trained_at')" class="sortable" title="When the model was last trained (click to sort)">Last Trained<span class="sort-indicator" [class.active]="isModelSortActive('last_trained_at')">{{ modelSortIndicator('last_trained_at') }}</span></th>
               <th (click)="sortModels('created_at')" class="sortable" title="When the model was created (click to sort)">Created<span class="sort-indicator" [class.active]="isModelSortActive('created_at')">{{ modelSortIndicator('created_at') }}</span></th>
               <th title="Available operations for this model">Actions</th>


### PR DESCRIPTION
## Summary
Updated the tooltip text for the "Trainable" column in the models table to provide clearer guidance to users about what this column represents.

## Changes
- **Updated tooltip text**: Changed from "Whether the model has enough labels to train" to "Is this Model one we can load into the Labeling interface and improve?" to better communicate the practical meaning of the Trainable status from a user perspective.

## Details
The new tooltip text emphasizes the actionable aspect of the Trainable column—whether a model can be actively used and improved through the labeling interface—rather than just focusing on the technical requirement of having sufficient training labels. This should help users better understand when they can interact with a model to enhance it.

https://claude.ai/code/session_01AjD9gfdq56GiDmK2JLa7AM