### PR TITLE
Remove scroll viewport indicator from stripe overview

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -59,7 +59,6 @@
           [showThumbnails]="showThumbnails"
           [showScores]="false"
           (mediaSelect)="mediaSelect.emit($event)"
-          (scrollUpdate)="onScrollUpdate($event)"
         />
         <vt-stripe-overview
           [sortOrder]="sortOrder"
@@ -68,7 +67,6 @@
           [goodVotes]="goodVotes"
           [badVotes]="badVotes"
           [totalCount]="medias.length"
-          [scrollInfo]="scrollInfo"
           (stripeClick)="onStripeClick($event)"
         />
       </div>

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -59,14 +59,9 @@ export class LeftPanelComponent implements OnInit {
   @ViewChild(MediaListComponent) mediaListComponent!: MediaListComponent;
 
   activeTab: 'manual' | 'autopilot' = 'autopilot';
-  scrollInfo: { scrollTop: number; scrollHeight: number; clientHeight: number } | null = null;
 
   ngOnInit(): void {
     this.autopilotStart.emit();
-  }
-
-  onScrollUpdate(info: { scrollTop: number; scrollHeight: number; clientHeight: number }): void {
-    this.scrollInfo = info;
   }
 
   onStripeClick(index: number): void {

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -1,4 +1,4 @@
-<div class="media-list" role="listbox" aria-label="Media items" #listContainer (scroll)="onScroll($event)">
+<div class="media-list" role="listbox" aria-label="Media items" #listContainer>
   @for (item of orderedItems; track trackByMediaId($index, item)) {
     @if (item.showThreshold) {
       <div class="media-threshold-line" aria-label="Good/Bad threshold">

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -22,8 +22,6 @@ export class MediaListComponent implements AfterViewChecked {
   @Input() showScores = true;
 
   @Output() mediaSelect = new EventEmitter<number>();
-  @Output() scrollUpdate = new EventEmitter<{ scrollTop: number; scrollHeight: number; clientHeight: number }>();
-
   @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
 
   private pendingScrollToSelected = false;
@@ -64,15 +62,6 @@ export class MediaListComponent implements AfterViewChecked {
   onMediaSelect(id: number): void {
     this.pendingScrollToSelected = true;
     this.mediaSelect.emit(id);
-  }
-
-  onScroll(event: Event): void {
-    const el = event.target as HTMLDivElement;
-    this.scrollUpdate.emit({
-      scrollTop: el.scrollTop,
-      scrollHeight: el.scrollHeight,
-      clientHeight: el.clientHeight,
-    });
   }
 
   ngAfterViewChecked(): void {

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
@@ -17,12 +17,6 @@
           [style.top.%]="thresholdPosition"
         ></div>
       }
-
-      <div
-        class="stripe-viewport"
-        [style.top.%]="viewportTop"
-        [style.height.%]="viewportHeight"
-      ></div>
     </div>
   </div>
 }

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
@@ -53,14 +53,3 @@
   background: var(--accent);
   opacity: 0.6;
 }
-
-.stripe-viewport {
-  position: absolute;
-  left: 0;
-  right: 0;
-  background: var(--text-primary);
-  opacity: 0.12;
-  border-top: 1px solid var(--text-primary);
-  border-bottom: 1px solid var(--text-primary);
-  pointer-events: none;
-}

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
@@ -16,8 +16,6 @@ export class StripeOverviewComponent {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   @Input() totalCount = 0;
-  @Input() scrollInfo: { scrollTop: number; scrollHeight: number; clientHeight: number } | null = null;
-
   @Output() stripeClick = new EventEmitter<number>();
 
   onStripeClick(event: MouseEvent): void {
@@ -56,16 +54,6 @@ export class StripeOverviewComponent {
     }
 
     return result;
-  }
-
-  get viewportTop(): number {
-    if (!this.scrollInfo || this.scrollInfo.scrollHeight === 0) return 0;
-    return (this.scrollInfo.scrollTop / this.scrollInfo.scrollHeight) * 100;
-  }
-
-  get viewportHeight(): number {
-    if (!this.scrollInfo || this.scrollInfo.scrollHeight === 0) return 100;
-    return (this.scrollInfo.clientHeight / this.scrollInfo.scrollHeight) * 100;
   }
 
   get thresholdPosition(): number | null {


### PR DESCRIPTION
## Summary
This PR removes the scroll viewport indicator feature from the stripe overview component. The viewport visualization that showed the current scroll position and visible area in the media list has been completely removed.

## Key Changes
- Removed `scrollInfo` input property from `StripeOverviewComponent` that tracked scroll position, height, and client height
- Removed `viewportTop` and `viewportHeight` computed properties that calculated viewport position percentages
- Removed the `.stripe-viewport` div element and its associated styling from the stripe overview template and stylesheet
- Removed `scrollUpdate` output event from `MediaListComponent` that emitted scroll information
- Removed `onScroll()` method from `MediaListComponent` that captured scroll events
- Removed scroll event binding from the media list container
- Removed `scrollInfo` property and `onScrollUpdate()` method from `LeftPanelComponent`
- Removed the scroll update event binding in the left panel template

## Implementation Details
The changes simplify the component hierarchy by eliminating the scroll synchronization mechanism between the media list and stripe overview. The stripe overview will no longer display a visual indicator of which portion of the media list is currently visible in the viewport.

https://claude.ai/code/session_01JmTeFcxJdqu1vJCp2woBY9