### PR TITLE
Remove swipe animation class reset in center panel

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -131,7 +131,6 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
         if (this.swipeAnimation && this.media) {
           this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
           setTimeout(() => {
-            this.swipeClass = '';
             this.mediaVoted.emit({ id: this.media!.id, vote });
             this.isVoting = false;
           }, 180);


### PR DESCRIPTION
## Summary
Removed the line that resets the swipe animation class after the animation completes in the center panel component.

## Key Changes
- Removed `this.swipeClass = '';` statement from the setTimeout callback in the swipe animation handler
- The swipe animation class now persists after the animation completes instead of being cleared

## Implementation Details
The swipe animation class (`swipe-right` or `swipe-left`) is set based on the vote direction, and after a 180ms delay, the media voted event is emitted and voting state is reset. Previously, the class was being cleared in this same callback, but this line has been removed. This change allows the animation class to remain applied to the element after the animation completes.

https://claude.ai/code/session_015zLQERMQeeekWCMx77ViL9