### PR TITLE
Auto-select media when switching select modes

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -143,6 +143,42 @@ describe('LabelViewComponent', () => {
     expect(component.mediaState.selectedId).toBe(1);
   });
 
+  it('should reselect media when switching select mode to top', () => {
+    flushInitialRequests();
+
+    // Set up sort order so autoSelectNext has something to work with
+    component.sortState.setSortResults(
+      [{ id: 2, score: 0.9 }, { id: 1, score: 0.3 }],
+      0.5,
+    );
+
+    // Mark id 2 as voted so the top unlabeled is id 1... wait, need to set votes
+    component.voteState.loadVotes();
+    httpMock.expectOne('/api/votes').flush({ good: [2], bad: [], click_times: {}, learned_scores: {} });
+
+    // Switch to top mode
+    component.onSelectModeChange('top');
+    expect(component.sortState.selectMode).toBe('top');
+    // Should auto-select id 1 (first unlabeled in sort order)
+    expect(component.mediaState.selectedId).toBe(1);
+  });
+
+  it('should reselect media when switching select mode to hard', () => {
+    flushInitialRequests();
+
+    // Set up sort order with threshold
+    component.sortState.setSortResults(
+      [{ id: 2, score: 0.9 }, { id: 1, score: 0.4 }],
+      0.5,
+    );
+
+    // Switch to hard mode
+    component.onSelectModeChange('hard');
+    expect(component.sortState.selectMode).toBe('hard');
+    // id 1 (score 0.4) is closer to threshold 0.5 than id 2 (score 0.9)
+    expect(component.mediaState.selectedId).toBe(1);
+  });
+
   it('should handle inclusion change', fakeAsync(() => {
     flushInitialRequests();
     component.onInclusionChange(5);

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -240,9 +240,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onSelectModeChange(mode: SelectMode): void {
     this.sortState.setSelectMode(mode);
-    if (mode === 'new') {
-      this.fetchDiversityNext();
-    }
+    this.autoSelectNext();
   }
 
   private fetchDiversityNext(): void {


### PR DESCRIPTION
## Summary
Updated the select mode change handler to automatically reselect media for all modes, not just the 'new' mode. This ensures consistent behavior across all selection modes ('top', 'hard', and 'new').

## Key Changes
- Modified `onSelectModeChange()` to call `autoSelectNext()` for all select mode changes, replacing the previous conditional logic that only handled the 'new' mode
- Added test coverage for 'top' and 'hard' select modes to verify media is properly reselected when switching modes
- The 'new' mode continues to work as before, now using the generic `autoSelectNext()` method instead of the specific `fetchDiversityNext()` call

## Implementation Details
- The change simplifies the mode switching logic by using a single `autoSelectNext()` call that handles selection logic for all modes
- New tests verify that:
  - Switching to 'top' mode selects the first unlabeled item in sort order
  - Switching to 'hard' mode selects the item closest to the threshold score
- This ensures users always get a valid media selection when changing modes, improving the user experience

https://claude.ai/code/session_01JTJgogGoUnxbgv3DWmBpij