### PR TITLE
Add diversity_level and max_level fields to span_info output

### DIFF
--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -284,7 +284,9 @@ class DiversityTree:
             return {
                 "level": level,
                 "fractional_level": round(frac, 4),
+                "diversity_level": round(frac, 4),
                 "depth": d,
+                "max_level": d,
                 "next_level_seen": 0,
                 "next_level_total": 0,
             }
@@ -295,7 +297,9 @@ class DiversityTree:
         return {
             "level": level,
             "fractional_level": round(frac, 4),
+            "diversity_level": round(frac, 4),
             "depth": d,
+            "max_level": d,
             "next_level_seen": seen_count,
             "next_level_total": len(nodes_at_next),
         }


### PR DESCRIPTION
## Summary
Enhanced the `span_info()` method in the DiversityTree model to include two additional fields in the returned dictionary: `diversity_level` and `max_level`.

## Key Changes
- Added `diversity_level` field that mirrors the `fractional_level` value (rounded to 4 decimal places)
- Added `max_level` field that mirrors the `depth` value
- These fields are added to both code paths in the method (the early return case and the main return case)

## Implementation Details
The new fields provide alternative naming conventions for existing span information:
- `diversity_level` duplicates `fractional_level` to offer semantic clarity about what the fractional value represents
- `max_level` duplicates `depth` to provide consistency in naming conventions for level-related metrics

Both fields are populated in all return paths to ensure consistent output structure regardless of the tree traversal conditions.

https://claude.ai/code/session_01Smhg5KhUDhp682Ea2UoTks