### PR TITLE
Update Docker builds to include webhook exporter and combine datasets importer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,13 @@ COPY vtsearch/datasets/importers/pickle/requirements.txt  vtsearch/datasets/impo
 COPY vtsearch/datasets/importers/folder/requirements.txt  vtsearch/datasets/importers/folder/requirements.txt
 COPY vtsearch/datasets/importers/http_zip/requirements.txt vtsearch/datasets/importers/http_zip/requirements.txt
 COPY vtsearch/exporters/gui/requirements.txt  vtsearch/exporters/gui/requirements.txt
-COPY vtsearch/exporters/file/requirements.txt vtsearch/exporters/file/requirements.txt
 COPY vtsearch/exporters/email_smtp/requirements.txt vtsearch/exporters/email_smtp/requirements.txt
+COPY vtsearch/exporters/webhook/requirements.txt vtsearch/exporters/webhook/requirements.txt
+COPY vtsearch/datasets/importers/combine_datasets/requirements.txt vtsearch/datasets/importers/combine_datasets/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r requirements-cpu.txt
+    pip install --no-cache-dir -r requirements-cpu.txt && \
+    pip install --no-cache-dir -r requirements-exporters.txt
 
 # ---------- application layer ----------
 COPY . .

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -34,11 +34,13 @@ COPY vtsearch/datasets/importers/pickle/requirements.txt  vtsearch/datasets/impo
 COPY vtsearch/datasets/importers/folder/requirements.txt  vtsearch/datasets/importers/folder/requirements.txt
 COPY vtsearch/datasets/importers/http_zip/requirements.txt vtsearch/datasets/importers/http_zip/requirements.txt
 COPY vtsearch/exporters/gui/requirements.txt  vtsearch/exporters/gui/requirements.txt
-COPY vtsearch/exporters/file/requirements.txt vtsearch/exporters/file/requirements.txt
 COPY vtsearch/exporters/email_smtp/requirements.txt vtsearch/exporters/email_smtp/requirements.txt
+COPY vtsearch/exporters/webhook/requirements.txt vtsearch/exporters/webhook/requirements.txt
+COPY vtsearch/datasets/importers/combine_datasets/requirements.txt vtsearch/datasets/importers/combine_datasets/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r requirements-gpu.txt
+    pip install --no-cache-dir -r requirements-gpu.txt && \
+    pip install --no-cache-dir -r requirements-exporters.txt
 
 # ---------- application layer ----------
 COPY . .


### PR DESCRIPTION
## Summary
Updated both CPU and GPU Dockerfiles to include new module dependencies and reorganize the dependency installation process.

## Key Changes
- Removed `vtsearch/exporters/file/requirements.txt` from COPY instructions
- Added `vtsearch/exporters/webhook/requirements.txt` to support the webhook exporter module
- Added `vtsearch/datasets/importers/combine_datasets/requirements.txt` to support the combine datasets importer module
- Introduced a new `requirements-exporters.txt` file that is installed alongside the base requirements (CPU/GPU-specific)

## Implementation Details
- Both Dockerfiles (standard and GPU variants) were updated consistently to maintain parity
- The pip install commands were chained with `&&` to install both base requirements and exporter requirements in a single RUN layer, maintaining Docker best practices for layer optimization
- The removal of the file exporter requirements suggests it may have been deprecated or consolidated into another module

https://claude.ai/code/session_01Y3K7o9wQ31WhCAERT9xpRy