### PR TITLE
Refactor progress indicator layout from vertical to horizontal

### DIFF
--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -7,19 +7,26 @@
 .sort-overlay {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 6px;
   padding: 3px 6px;
   border: 1px solid var(--indicator-border);
   border-radius: 4px;
   background: var(--bg-panel);
+
+  vt-progress-bar {
+    flex: 1;
+    min-width: 0;
+  }
 }
 
 .sort-overlay-status {
   font-size: 0.75rem;
   color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .labeling-indicator {


### PR DESCRIPTION
## Summary
Updated the progress indicators component layout to display horizontally instead of vertically, improving space utilization and visual presentation in the left panel.

## Key Changes
- Changed `.sort-overlay` flex direction from `column` to `row` to arrange items horizontally
- Increased gap spacing from `4px` to `6px` for better visual separation in horizontal layout
- Added flex styling to `vt-progress-bar` to allow it to expand and fill available space with `flex: 1` and `min-width: 0`
- Enhanced `.sort-overlay-status` styling with `white-space: nowrap` to prevent text wrapping and `flex-shrink: 0` to maintain fixed width for the status text

## Implementation Details
The changes ensure that the progress bar expands to fill available horizontal space while the status text remains fixed-width and doesn't wrap, creating a clean horizontal layout for the progress indicator component.

https://claude.ai/code/session_01H4XsS7YD9nbKNeJQQS3qSg