### PR TITLE
Control auto-selection behavior in learned sort operations

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -188,6 +188,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onSortModeChange(mode: SortMode): void {
     this.sortState.setSortMode(mode);
+    this.autoSelectNext();
   }
 
   onTextSort(text: string): void {
@@ -211,7 +212,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
-  onLearnedSort(): void {
+  onLearnedSort(autoSelect = true): void {
     if (this.voteState.goodVotes.size === 0 || this.voteState.badVotes.size === 0) return;
     this.sortState.setSortBusy(true);
     this.sortState.setSortStatus('Training...');
@@ -223,7 +224,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         );
         this.sortState.setSortBusy(false);
         this.sortState.setSortStatus('');
-        this.autoSelectNext();
+        if (autoSelect) {
+          this.autoSelectNext();
+        }
       },
       error: () => {
         this.sortState.setSortBusy(false);
@@ -270,12 +273,12 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  private scheduleLearnedSort(): void {
+  private scheduleLearnedSort(autoSelect = true): void {
     if (this.learnedSortPending) return;
     this.learnedSortPending = true;
     setTimeout(() => {
       this.learnedSortPending = false;
-      this.onLearnedSort();
+      this.onLearnedSort(autoSelect);
     }, 300);
   }
 
@@ -289,7 +292,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.voteState.loadVotes();
     this.autoSelectNext();
     if (this.sortState.sortMode === 'learned' && this.voteState.goodVotes.size > 0 && this.voteState.badVotes.size > 0) {
-      this.scheduleLearnedSort();
+      this.scheduleLearnedSort(false);
     }
   }
 


### PR DESCRIPTION
## Summary
This PR adds fine-grained control over automatic item selection when performing learned sort operations, allowing callers to opt out of auto-selection when appropriate.

## Key Changes
- Added optional `autoSelect` parameter (default `true`) to `onLearnedSort()` method to conditionally trigger auto-selection after sorting completes
- Added optional `autoSelect` parameter (default `true`) to `scheduleLearnedSort()` method to propagate the auto-selection preference
- Updated `onSortModeChange()` to call `autoSelectNext()` when sort mode changes
- Modified vote state reset logic to pass `autoSelect: false` when scheduling learned sort, preventing double auto-selection

## Implementation Details
- The `autoSelect` parameter defaults to `true` to maintain backward compatibility with existing callers
- When votes are reset and learned sort is scheduled, auto-selection is disabled to avoid redundant selection since `autoSelectNext()` is already called during the reset process
- This prevents potential race conditions or unnecessary selection operations when the learned sort completes

https://claude.ai/code/session_01KtbqYiP3hckT5RUQ9pEWsd