### PR TITLE
Fix layout jitter in progress indicators component

### DIFF
--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.scss
@@ -2,24 +2,34 @@
   display: flex;
   gap: 4px;
   align-items: stretch;
+  /* Fixed height prevents layout jitter when switching between indicators and progress bar */
+  height: 26px;
 }
 
 .sort-overlay {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 6px;
   padding: 3px 6px;
   border: 1px solid var(--indicator-border);
   border-radius: 4px;
   background: var(--bg-panel);
+  min-width: 0;
+
+  vt-progress-bar {
+    flex: 1;
+    min-width: 0;
+  }
 }
 
 .sort-overlay-status {
   font-size: 0.75rem;
   color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .labeling-indicator {


### PR DESCRIPTION
## Summary
Fixed layout instability in the progress indicators component that caused visual jitter when switching between different indicator states and the progress bar display.

## Key Changes
- Added fixed height (26px) to `.progress-indicators` container to prevent layout shifts during state transitions
- Changed `.sort-overlay` layout from column to row direction for horizontal alignment
- Increased gap spacing from 4px to 6px for better visual separation
- Added `min-width: 0` to `.sort-overlay` and `vt-progress-bar` to enable proper flex shrinking
- Made `vt-progress-bar` flex with `flex: 1` to fill available space
- Added `white-space: nowrap` and `flex-shrink: 0` to `.sort-overlay-status` to prevent text wrapping and maintain label width

## Implementation Details
The fixed height on the container ensures consistent spacing regardless of which child element is displayed, eliminating the jitter that occurred when switching between the indicator overlay and progress bar. The flex layout adjustments ensure proper horizontal alignment and responsive sizing of child elements.

https://claude.ai/code/session_01Lr1YrLSnLrCvvNHz6QKPfM