### PR TITLE
Add detector export modal component to app

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -62,6 +62,9 @@
 <div class="main-content" role="main">
   <router-outlet />
 </div>
+@if (showDetectorExport) {
+  <vt-detector-export-modal (closed)="showDetectorExport = false" (exported)="showDetectorExport = false" />
+}
 @if (showSettings) {
   <vt-settings-modal (closed)="showSettings = false" />
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,18 +3,20 @@ import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
+import { DetectorExportModalComponent } from './components/modals/detector-export-modal/detector-export-modal.component';
 import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
 import { VtDialogService } from './services/dialog.service';
 
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, RouterOutlet, DialogHostComponent, SettingsModalComponent],
+  imports: [CommonModule, RouterOutlet, DialogHostComponent, DetectorExportModalComponent, SettingsModalComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
 export class AppComponent {
   title = 'VTSearch';
   menuOpen = false;
+  showDetectorExport = false;
   showSettings = false;
   isOnLabelView = false;
   labelsStatus = '';
@@ -96,7 +98,7 @@ export class AppComponent {
   onExportDetector(): void {
     if (!this.isOnLabelView) return;
     this.menuOpen = false;
-    this.dialog.alert('Detector export not yet available in the Angular frontend.', 'info');
+    this.showDetectorExport = true;
   }
 
   onExportLabels(): void {


### PR DESCRIPTION
## Summary
Implement the detector export modal functionality by integrating the `DetectorExportModalComponent` into the main app component, replacing the placeholder alert dialog.

## Key Changes
- Import and declare `DetectorExportModalComponent` in the app component's imports
- Add `showDetectorExport` boolean property to manage modal visibility state
- Replace the info alert in `onExportDetector()` method with modal display logic
- Add conditional rendering of the detector export modal in the app template with proper event handlers for `closed` and `exported` events

## Implementation Details
- The modal is conditionally rendered using Angular's `@if` control flow syntax
- Both `closed` and `exported` events dismiss the modal by setting `showDetectorExport` to false
- The modal is positioned alongside the existing settings modal in the template structure

https://claude.ai/code/session_017PVxXXgm3vFxzqSQu3Sjrz