### PR TITLE
Implement Find/Auto-detect flow in dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -144,3 +144,10 @@
     (created)="onModelCreated()"
   />
 }
+
+@if (findResultsOpen) {
+  <vt-autodetect-results-modal
+    [data]="findResultsData"
+    (closed)="closeFindResults()"
+  />
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -4,11 +4,14 @@ import { Router } from '@angular/router';
 import { Subject, timer } from 'rxjs';
 import { takeUntil, switchMap } from 'rxjs/operators';
 import { DatasetsApiService } from '../../services/datasets-api.service';
+import { DetectorsApiService } from '../../services/detectors-api.service';
 import { TrainableModelsApiService } from '../../services/trainable-models-api.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { DatasetStateService } from '../../services/dataset-state.service';
+import { AutoDetectResultsData } from '../../models/api.models';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
@@ -20,6 +23,7 @@ import { NewModelModalComponent } from './new-model-modal/new-model-modal.compon
   imports: [
     CommonModule,
     ProgressBarComponent,
+    AutoDetectResultsModalComponent,
     DatasetCardComponent,
     ModelCardComponent,
     DatasetImporterModalComponent,
@@ -38,6 +42,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   importerModalOpen = false;
   newModelModalOpen = false;
+  findResultsOpen = false;
+  findResultsData: AutoDetectResultsData = { results: {} };
 
   datasetSortColumn = 'name';
   datasetSortAsc = true;
@@ -50,6 +56,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   constructor(
     private router: Router,
     private datasetsApi: DatasetsApiService,
+    private detectorsApi: DetectorsApiService,
     private modelsApi: TrainableModelsApiService,
     private dialog: VtDialogService,
     private labelSession: LabelSessionService,
@@ -408,6 +415,74 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   onFind(): void {
-    // Phase 7+ will implement the find/auto-detect flow
+    const datasetIds = [...this.selectedDatasetIds];
+    const modelIds = [...this.selectedModelIds];
+
+    this.datasetState.setLoading(true);
+    this.datasetState.setProgressMessage('Running Find...');
+    this.progressIndeterminate = true;
+
+    this.detectorsApi.find({ dataset_ids: datasetIds, model_ids: modelIds }).subscribe({
+      next: (response: any) => {
+        this.datasetState.setLoading(false);
+        this.progressIndeterminate = false;
+
+        // Convert /api/find response to AutoDetectResultsData format
+        const hits = (response.results || []).map((r: any) => ({
+          md5: r.md5 || '',
+          filename: r.filename || '',
+          origin_name: r.origin_name || '',
+          origin: r.origin,
+          dataset_name: r.dataset_name || '',
+          model_verdicts: r.model_verdicts || {},
+        }));
+
+        const modelNames: string[] = response.models || [];
+        const detectorResults: Record<string, any> = {};
+
+        if (modelNames.length <= 1) {
+          // Single model: one result group
+          const label = modelNames[0] || 'Find';
+          detectorResults[label] = {
+            detector_name: label,
+            total_hits: hits.length,
+            hits,
+          };
+        } else {
+          // Multiple models: group hits by model
+          for (const name of modelNames) {
+            const modelHits = hits.filter(
+              (h: any) => h.model_verdicts?.[name]?.verdict === 'Good',
+            );
+            detectorResults[name] = {
+              detector_name: name,
+              total_hits: modelHits.length,
+              hits: modelHits,
+            };
+          }
+        }
+
+        this.findResultsData = {
+          media_type: `Find (${response.total_hits || 0} hits)`,
+          detectors_run: modelNames.length,
+          results: detectorResults,
+          models: modelNames,
+          datasets: response.datasets || [],
+          multiple_datasets: response.multiple_datasets || false,
+          multiple_models: response.multiple_models || false,
+        } as AutoDetectResultsData;
+
+        this.findResultsOpen = true;
+      },
+      error: (err) => {
+        this.datasetState.setLoading(false);
+        this.progressIndeterminate = false;
+        this.dialog.alert(err.error?.error || 'Find failed.', 'error');
+      },
+    });
+  }
+
+  closeFindResults(): void {
+    this.findResultsOpen = false;
   }
 }


### PR DESCRIPTION
## Summary
This PR implements the Find/Auto-detect functionality in the dashboard component, allowing users to run detection queries across selected datasets and models, then view the results in a modal dialog.

## Key Changes
- **Added DetectorsApiService integration**: Imported and injected the service to call the `/api/find` endpoint
- **Implemented `onFind()` method**: Executes find operation with selected dataset and model IDs, handles the API response, and transforms it into the `AutoDetectResultsData` format
- **Added result grouping logic**: 
  - Single model: Creates one result group labeled with the model name
  - Multiple models: Groups hits by model, filtering for "Good" verdicts
- **Added modal state management**: Introduced `findResultsOpen` and `findResultsData` properties to control the results modal display
- **Integrated AutoDetectResultsModalComponent**: Added the modal component to imports and template to display find results
- **Added `closeFindResults()` method**: Handles closing the results modal
- **Updated template**: Added conditional rendering of the auto-detect results modal

## Implementation Details
- The API response is transformed to match the `AutoDetectResultsData` model structure, mapping fields like `md5`, `filename`, `origin_name`, and `model_verdicts`
- Progress indication is shown during the find operation with an indeterminate progress bar
- Error handling displays user-friendly error messages via the dialog service
- The implementation supports both single and multiple model scenarios with appropriate result grouping strategies

https://claude.ai/code/session_01PYXLYbBo8HEmQcg3USw4pY