### PR TITLE
Never auto-select on learned sort completion; always reselect immedia…

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -20,7 +20,7 @@
       (selectModeChange)="onSelectModeChange($event)"
       (inclusionChange)="onInclusionChange($event)"
       (textSort)="onTextSort($event)"
-      (learnedSort)="onLearnedSort()"
+      (learnedSort)="onLearnedSort(false)"
       (loadSort)="onLoadSort()"
       (mediaSelect)="onMediaSelect($event)"
       (indicatorClick)="onIndicatorClick($event)"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -268,8 +268,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onInclusionChange(value: number): void {
     this.sortState.setInclusion(value);
     this.sortingApi.setInclusion(value).pipe(takeUntil(this.destroy$)).subscribe();
+    this.autoSelectNext();
     if (this.sortState.sortMode === 'learned' && this.voteState.goodVotes.size > 0 && this.voteState.badVotes.size > 0) {
-      this.scheduleLearnedSort();
+      this.scheduleLearnedSort(false);
     }
   }
 


### PR DESCRIPTION
…tely on user action

All learned sort completions now pass autoSelect=false, since every call site already triggers an immediate autoSelectNext() at the point of user action:

- Sort mode change: immediate reselect in onSortModeChange()
- Vote: immediate reselect in onMediaVoted()
- Inclusion slider: added immediate reselect in onInclusionChange()
- Template learnedSort binding: passes false since onSortModeChange already handled the immediate reselect

This ensures the user is never ripped away from their current media by a background MLP training completion.

https://claude.ai/code/session_01KtbqYiP3hckT5RUQ9pEWsd