### PR TITLE
Prevent flash when swiping to next media by hiding during render

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -59,6 +59,10 @@
   animation: swipe-left 0.18s cubic-bezier(0.4, 0, 1, 1) forwards;
 }
 
+.swipe-hidden {
+  opacity: 0;
+}
+
 // Image view controls (outside swipe wrapper so they stay fixed during swipe)
 .image-view-controls {
   display: flex;

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -124,6 +124,37 @@ describe('CenterPanelComponent', () => {
     expect(component.voteState.badVotes.has(3)).toBeTrue();
   });
 
+  it('should apply swipe-hidden class when media changes to prevent flash', () => {
+    component.media = mockMedia;
+    fixture.detectChanges();
+    // Simulate swipe ending
+    component.swipeClass = 'swipe-right';
+
+    // Change to new media (triggers ngOnChanges)
+    component.media = { ...mockMedia, id: 2, filename: 'next.wav' };
+    component.ngOnChanges({
+      media: { currentValue: component.media, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
+    });
+
+    expect(component.swipeClass).toBe('swipe-hidden');
+  });
+
+  it('should clear swipe-hidden after animation frame', (done) => {
+    component.media = mockMedia;
+    fixture.detectChanges();
+
+    component.media = { ...mockMedia, id: 2, filename: 'next.wav' };
+    component.ngOnChanges({
+      media: { currentValue: component.media, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
+    });
+
+    expect(component.swipeClass).toBe('swipe-hidden');
+    requestAnimationFrame(() => {
+      expect(component.swipeClass).toBe('');
+      done();
+    });
+  });
+
   it('should format metadata values', () => {
     expect(component.formatMetadataValue('File Size', 2048)).toBe('2.0 KB');
     expect(component.formatMetadataValue('Duration', 3.5)).toBe('3.5s');

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -53,7 +53,13 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media']) {
-      this.swipeClass = '';
+      // Keep the wrapper hidden while Angular renders the new media content.
+      // Without this, clearing swipeClass instantly snaps opacity back to 1,
+      // which can flash the OLD image for one frame before the new one paints.
+      this.swipeClass = 'swipe-hidden';
+      requestAnimationFrame(() => {
+        this.swipeClass = '';
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
This PR fixes a visual flash that occurs when swiping to the next media item. The issue was caused by the swipe animation class being cleared immediately, which snapped the opacity back to 1 before Angular had finished rendering the new media content, briefly showing the old image.

## Key Changes
- Modified `ngOnChanges()` to apply a `swipe-hidden` class (opacity: 0) when media changes, keeping the wrapper hidden during the render cycle
- Used `requestAnimationFrame()` to clear the `swipe-hidden` class after the browser has painted the new content, ensuring a smooth transition without flashing
- Added `.swipe-hidden` CSS class with `opacity: 0` to the component stylesheet
- Added comprehensive test coverage for the new behavior, including tests for class application and animation frame clearing

## Implementation Details
The fix leverages the browser's rendering pipeline by:
1. Immediately hiding the wrapper when media changes (preventing the old content from being visible)
2. Deferring the opacity reset to the next animation frame, allowing Angular to complete its change detection and DOM updates
3. This ensures the new media is fully rendered before the wrapper becomes visible again, eliminating the flash effect

https://claude.ai/code/session_01FSs2KsizS4b3VvupRnRUEr