### PR TITLE
Add media type validation for Find feature

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -173,10 +173,43 @@ describe('DashboardComponent', () => {
       expect(component.findEnabled).toBeFalse();
     });
 
-    it('should enable Find with any dataset + any model selected', () => {
-      flushInitialRequests();
-      component.selectedDatasetIds.add('d1');
-      component.selectedModelIds.add('m1');
+    it('should enable Find with matching media types', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      expect(component.findEnabled).toBeTrue();
+    });
+
+    it('should disable Find on media type mismatch', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'image' }];
+      flushInitialRequests(datasets, models);
+      expect(component.findEnabled).toBeFalse();
+    });
+
+    it('should disable Find when multiple datasets have different media types', () => {
+      const datasets = [
+        { id: 'd1', name: 'DS1', media_type: 'audio' },
+        { id: 'd2', name: 'DS2', media_type: 'image' },
+      ];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      component.selectedDatasetIds.add('d2');
+      expect(component.findEnabled).toBeFalse();
+    });
+
+    it('should enable Find when all selected items share media type', () => {
+      const datasets = [
+        { id: 'd1', name: 'DS1', media_type: 'image' },
+        { id: 'd2', name: 'DS2', media_type: 'image' },
+      ];
+      const models = [
+        { id: 'm1', name: 'M1', media_type: 'image' },
+        { id: 'm2', name: 'M2', media_type: 'image' },
+      ];
+      flushInitialRequests(datasets, models);
+      component.selectedDatasetIds.add('d2');
+      component.selectedModelIds.add('m2');
       expect(component.findEnabled).toBeTrue();
     });
   });
@@ -254,11 +287,18 @@ describe('DashboardComponent', () => {
       expect(component.findHint).toBe('Select a model');
     });
 
-    it('should return empty hint when find is enabled', () => {
-      flushInitialRequests();
-      component.selectedDatasetIds.add('d1');
-      component.selectedModelIds.add('m1');
-      expect(component.findHint).toBe('');
+    it('should hint about media type mismatch', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'image' }];
+      flushInitialRequests(datasets, models);
+      expect(component.findHint).toBe('Media type mismatch');
+    });
+
+    it('should return score hint when find is enabled', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
+      flushInitialRequests(datasets, models);
+      expect(component.findHint).toBe('Score selected datasets with selected models');
     });
   });
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -346,15 +346,26 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return true;
   }
 
+  private findMediaTypesMatch(): boolean {
+    const selectedDatasets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
+    const selectedModels = this.models.filter((m) => this.selectedModelIds.has(m.id));
+    const types = new Set([
+      ...selectedDatasets.map((d) => d.media_type),
+      ...selectedModels.map((m) => m.media_type),
+    ]);
+    return types.size === 1;
+  }
+
   get findEnabled(): boolean {
     if (this.selectedDatasetIds.size < 1 || this.selectedModelIds.size < 1) return false;
-    return true;
+    return this.findMediaTypesMatch();
   }
 
   get findHint(): string {
     if (this.selectedDatasetIds.size === 0 && this.selectedModelIds.size === 0) return 'Select a dataset and a model';
     if (this.selectedDatasetIds.size === 0) return 'Select a dataset';
     if (this.selectedModelIds.size === 0) return 'Select a model';
+    if (!this.findMediaTypesMatch()) return 'Media type mismatch';
     return 'Score selected datasets with selected models';
   }
 


### PR DESCRIPTION
## Summary
This PR adds media type validation to the Find feature in the Dashboard component. The Find operation now requires that all selected datasets and models share the same media type, preventing incompatible scoring operations.

## Key Changes
- **Media type matching validation**: Added `findMediaTypesMatch()` method that checks if all selected datasets and models have the same media type
- **Updated Find enablement logic**: The `findEnabled` getter now validates media type compatibility in addition to checking that at least one dataset and one model are selected
- **Enhanced user feedback**: Updated `findHint` to display "Media type mismatch" when selected items have incompatible media types, and changed the success hint to "Score selected datasets with selected models"
- **Comprehensive test coverage**: Replaced the generic "any dataset + any model" test with four specific test cases covering:
  - Matching media types (enabled)
  - Media type mismatch (disabled)
  - Multiple datasets with different media types (disabled)
  - Multiple items with matching media types (enabled)
  - Corresponding hint text validation tests

## Implementation Details
The validation uses a Set to collect all media types from selected datasets and models. If the Set size equals 1, all items share the same media type. This approach efficiently handles any number of selected items regardless of media type variety.

https://claude.ai/code/session_01QiNdcY9TLnZKaagr8BqLBL