### PR TITLE
Clear stale autopilot state on label view initialization

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -7,6 +7,7 @@ import { LabelSessionService } from '../../services/label-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
+import { AutopilotStateService } from '../../services/autopilot-state.service';
 
 describe('LabelViewComponent', () => {
   let component: LabelViewComponent;
@@ -292,5 +293,24 @@ describe('LabelViewComponent', () => {
 
     component.onAutopilotStart();
     httpMock.expectNone('/api/sort');
+  });
+
+  it('should clear stale autopilot state from previous session on init', () => {
+    const autopilot = TestBed.inject(AutopilotStateService);
+    // Simulate leftover state from a previous detector session
+    autopilot.activate();
+    autopilot.checkPhaseTransition(3, 0); // advance to 'bad'
+    expect(autopilot.state.phase).toBe('bad');
+
+    // Creating a new label-view should clear stale state
+    const freshFixture = TestBed.createComponent(LabelViewComponent);
+    freshFixture.detectChanges();
+
+    // After init, autopilot should be in 'good' phase (cleared then re-activated
+    // by the child autopilot panel), NOT stuck in 'bad' from the old session
+    expect(autopilot.state.phase).toBe('good');
+
+    freshFixture.componentInstance.ngOnDestroy();
+    httpMock.match(() => true);
   });
 });

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -59,6 +59,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.autopilotStateService.clear();
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     this.mediaState.loadMedias();


### PR DESCRIPTION
## Summary
This PR fixes a bug where autopilot state from a previous detector session would persist when initializing a new label view component, causing the autopilot to be stuck in an incorrect phase.

## Key Changes
- Added `this.autopilotStateService.clear()` call in `LabelViewComponent.ngOnInit()` to reset autopilot state when the component initializes
- Added test case to verify that stale autopilot state from a previous session is cleared on component initialization, ensuring the autopilot starts fresh in the 'good' phase

## Implementation Details
The fix ensures that each time a new label view is created, any leftover autopilot state (such as being stuck in the 'bad' phase) from a previous detector session is cleared before the component's child components (like the autopilot panel) re-initialize their own state. This prevents state pollution between sessions and ensures consistent behavior.

https://claude.ai/code/session_019Ka78vYdkncFQHC21dZS7B