### PR TITLE
Trigger learned sort when autopilot transitions to hard phase

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -295,6 +295,44 @@ describe('LabelViewComponent', () => {
     httpMock.expectNone('/api/sort');
   });
 
+  it('should trigger learned sort when autopilot transitions from bad to hard', fakeAsync(() => {
+    flushInitialRequests();
+
+    const autopilot = TestBed.inject(AutopilotStateService);
+    const sortState = TestBed.inject(SortStateService);
+
+    // Set up votes so learned sort will fire
+    component.voteState.loadVotes();
+    httpMock.expectOne('/api/votes').flush({ good: [1], bad: [2], click_times: {}, learned_scores: {} });
+
+    // Activate autopilot → good phase
+    autopilot.activate();
+    fixture.detectChanges();
+
+    // Transition good → bad
+    autopilot.checkPhaseTransition(3, 0);
+    fixture.detectChanges();
+    expect(autopilot.state.phase).toBe('bad');
+
+    // Transition bad → hard: should trigger learned sort
+    autopilot.checkPhaseTransition(3, 4);
+    fixture.detectChanges();
+    expect(autopilot.state.phase).toBe('hard');
+    expect(sortState.selectMode).toBe('hard');
+    expect(sortState.sortMode).toBe('learned');
+    expect(sortState.sortBusy).toBeTrue();
+
+    // Flush the learned sort request
+    const req = httpMock.expectOne('/api/learned-sort');
+    req.flush({
+      results: [{ id: 1, score: 0.8 }, { id: 2, score: 0.2 }],
+      threshold: 0.5,
+    });
+
+    expect(sortState.sortBusy).toBeFalse();
+    expect(sortState.threshold).toBe(0.5);
+  }));
+
   it('should clear stale autopilot state from previous session on init', () => {
     const autopilot = TestBed.inject(AutopilotStateService);
     // Simulate leftover state from a previous detector session

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -82,7 +82,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         if (prev.phase === curr.phase) return;
         if (curr.phase === 'good') this.sortState.setSelectMode('top');
         else if (curr.phase === 'bad') this.sortState.setSelectMode('bottom');
-        else if (curr.phase === 'hard') this.sortState.setSelectMode('hard');
+        else if (curr.phase === 'hard') {
+          this.sortState.setSelectMode('hard');
+          this.sortState.setSortMode('learned');
+          this.onLearnedSort();
+        }
         else if (curr.phase === 'new') this.sortState.setSelectMode('new');
       });
   }


### PR DESCRIPTION
## Summary
When the autopilot feature transitions from the "bad" phase to the "hard" phase, the application now automatically triggers a learned sort operation to re-rank items based on the learned scoring model.

## Key Changes
- Modified the autopilot phase transition logic in `LabelViewComponent` to detect when the phase changes to 'hard'
- When transitioning to 'hard' phase, the component now:
  - Sets the select mode to 'hard' (existing behavior)
  - Sets the sort mode to 'learned' (new)
  - Triggers the learned sort operation (new)
- Added comprehensive test coverage for this new behavior, including:
  - Verification that the phase transitions correctly
  - Confirmation that sort state is updated appropriately
  - Validation of the HTTP request to `/api/learned-sort`
  - Verification that results and threshold are properly applied

## Implementation Details
The change is minimal and focused, adding just 3 lines to the existing phase transition handler. The learned sort is triggered via the existing `onLearnedSort()` method, maintaining consistency with other sort operations in the component. The test validates the complete flow from phase transition through HTTP request handling and state updates.

https://claude.ai/code/session_01EKFvA2tVSJUt1cWYLCgRtX