### PR TITLE
Add label resolution for cross-dataset detector training

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ _TEST_GROUPS = {
         "test_eval",
         "test_eval_visualize",
         "test_eval_voting_iterations",
+        "test_resolver",
     ],
     "downloads": [
         "test_ag_news_download",

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,357 @@
+"""Tests for vtsearch.models.resolver — media file resolution from origin trails."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vtsearch.models.resolver import (
+    ResolvedLabels,
+    resolve_file_from_origin,
+    resolve_label_embeddings,
+)
+
+
+class TestResolvedLabels:
+    def test_empty(self):
+        r = ResolvedLabels()
+        assert r.resolved_count == 0
+        assert r.total_count == 0
+        assert r.available_fraction == 0.0
+        assert not r.has_good_and_bad
+
+    def test_fraction(self):
+        r = ResolvedLabels(resolved_count=3, total_count=5)
+        assert r.available_fraction == pytest.approx(0.6)
+
+    def test_has_good_and_bad(self):
+        r = ResolvedLabels(labels=[1.0, 0.0])
+        assert r.has_good_and_bad
+
+    def test_only_good(self):
+        r = ResolvedLabels(labels=[1.0, 1.0])
+        assert not r.has_good_and_bad
+
+
+class TestResolveFolderOrigin:
+    def test_resolves_by_origin_name(self, tmp_path):
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "clip.wav").write_bytes(b"fake_audio")
+
+        origin = {"importer": "folder", "params": {"path": str(folder)}}
+        result = resolve_file_from_origin(origin, origin_name="clip.wav")
+        assert result == folder / "clip.wav"
+
+    def test_resolves_by_filename_fallback(self, tmp_path):
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "clip.wav").write_bytes(b"fake_audio")
+
+        origin = {"importer": "folder", "params": {"path": str(folder)}}
+        result = resolve_file_from_origin(origin, filename="clip.wav")
+        assert result == folder / "clip.wav"
+
+    def test_resolves_nested_path(self, tmp_path):
+        folder = tmp_path / "data"
+        subfolder = folder / "category"
+        subfolder.mkdir(parents=True)
+        (subfolder / "item.wav").write_bytes(b"data")
+
+        origin = {"importer": "folder", "params": {"path": str(folder)}}
+        result = resolve_file_from_origin(origin, origin_name="category/item.wav")
+        assert result == subfolder / "item.wav"
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        folder = tmp_path / "empty"
+        folder.mkdir()
+
+        origin = {"importer": "folder", "params": {"path": str(folder)}}
+        result = resolve_file_from_origin(origin, origin_name="nonexistent.wav")
+        assert result is None
+
+    def test_returns_none_for_missing_folder(self):
+        origin = {"importer": "folder", "params": {"path": "/nonexistent/path"}}
+        result = resolve_file_from_origin(origin, origin_name="clip.wav")
+        assert result is None
+
+    def test_returns_none_for_empty_path(self):
+        origin = {"importer": "folder", "params": {"path": ""}}
+        result = resolve_file_from_origin(origin, origin_name="clip.wav")
+        assert result is None
+
+
+class TestResolvePdfOrigin:
+    def test_resolves_existing_pdf(self, tmp_path):
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4 fake")
+
+        origin = {"importer": "pdf", "params": {"path": str(pdf)}}
+        result = resolve_file_from_origin(origin)
+        assert result == pdf
+
+    def test_returns_none_for_missing_pdf(self):
+        origin = {"importer": "pdf", "params": {"path": "/nonexistent/doc.pdf"}}
+        result = resolve_file_from_origin(origin)
+        assert result is None
+
+
+class TestResolveDupeSetOrigin:
+    def test_resolves_first_available_member(self, tmp_path):
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "b.wav").write_bytes(b"audio_b")
+
+        origin = {
+            "importer": "dupe_set",
+            "params": {"name": "a.wav"},
+            "members": [
+                {
+                    "origin": {"importer": "folder", "params": {"path": "/gone"}},
+                    "origin_name": "a.wav",
+                    "filename": "a.wav",
+                },
+                {
+                    "origin": {"importer": "folder", "params": {"path": str(folder)}},
+                    "origin_name": "b.wav",
+                    "filename": "b.wav",
+                },
+            ],
+        }
+        result = resolve_file_from_origin(origin)
+        assert result == folder / "b.wav"
+
+    def test_returns_none_when_no_members_resolve(self):
+        origin = {
+            "importer": "dupe_set",
+            "params": {"name": "x.wav"},
+            "members": [
+                {
+                    "origin": {"importer": "folder", "params": {"path": "/gone"}},
+                    "origin_name": "x.wav",
+                },
+            ],
+        }
+        result = resolve_file_from_origin(origin)
+        assert result is None
+
+
+class TestResolveConverterOrigin:
+    def test_resolves_folder_parent(self, tmp_path):
+        folder = tmp_path / "videos"
+        folder.mkdir()
+        (folder / "clip.mp4").write_bytes(b"video")
+
+        origin = {
+            "importer": "converter",
+            "params": {
+                "converter": "video2image",
+                "source_file": "clip.mp4",
+                "parent_importer": "folder",
+                "parent_path": str(folder),
+            },
+        }
+        result = resolve_file_from_origin(origin)
+        assert result == folder / "clip.mp4"
+
+
+class TestResolveNoneOrigin:
+    def test_none_origin(self):
+        assert resolve_file_from_origin(None) is None
+
+    def test_unknown_importer(self):
+        origin = {"importer": "unknown_thing", "params": {}}
+        assert resolve_file_from_origin(origin) is None
+
+
+class TestResolveLabelEmbeddings:
+    def test_resolves_folder_labels(self, tmp_path):
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "good1.wav").write_bytes(b"good_audio")
+        (folder / "bad1.wav").write_bytes(b"bad_audio")
+
+        origin = {"importer": "folder", "params": {"path": str(folder), "media_type": "sounds"}}
+        labels = [
+            {"label": "good", "origin": origin, "origin_name": "good1.wav", "md5": "aaa", "filename": "good1.wav"},
+            {"label": "bad", "origin": origin, "origin_name": "bad1.wav", "md5": "bbb", "filename": "bad1.wav"},
+        ]
+
+        fake_emb = np.zeros(512, dtype=np.float32)
+        with patch("vtsearch.models.resolver.embed_file", return_value=fake_emb):
+            result = resolve_label_embeddings(labels, "audio")
+
+        assert result.resolved_count == 2
+        assert result.total_count == 2
+        assert result.has_good_and_bad
+        assert len(result.embeddings) == 2
+        assert result.labels == [1.0, 0.0]
+        assert len(result.missing_entries) == 0
+
+    def test_skips_missing_files(self, tmp_path):
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "good1.wav").write_bytes(b"good_audio")
+
+        origin = {"importer": "folder", "params": {"path": str(folder), "media_type": "sounds"}}
+        labels = [
+            {"label": "good", "origin": origin, "origin_name": "good1.wav", "md5": "aaa", "filename": "good1.wav"},
+            {"label": "bad", "origin": origin, "origin_name": "missing.wav", "md5": "bbb", "filename": "missing.wav"},
+        ]
+
+        fake_emb = np.zeros(512, dtype=np.float32)
+        with patch("vtsearch.models.resolver.embed_file", return_value=fake_emb):
+            result = resolve_label_embeddings(labels, "audio")
+
+        assert result.resolved_count == 1
+        assert result.total_count == 2
+        assert not result.has_good_and_bad
+        assert len(result.missing_entries) == 1
+
+    def test_skips_invalid_labels(self):
+        labels = [
+            {"label": "neutral", "origin": None, "origin_name": "x.wav"},
+        ]
+        result = resolve_label_embeddings(labels, "audio")
+        assert result.total_count == 0
+        assert result.resolved_count == 0
+
+    def test_handles_embed_failure(self, tmp_path):
+        folder = tmp_path / "audio"
+        folder.mkdir()
+        (folder / "clip.wav").write_bytes(b"audio")
+
+        origin = {"importer": "folder", "params": {"path": str(folder)}}
+        labels = [
+            {"label": "good", "origin": origin, "origin_name": "clip.wav", "md5": "aaa", "filename": "clip.wav"},
+        ]
+
+        with patch("vtsearch.models.resolver.embed_file", return_value=None):
+            result = resolve_label_embeddings(labels, "audio")
+
+        assert result.resolved_count == 0
+        assert result.total_count == 1
+        assert len(result.missing_entries) == 1
+
+
+class TestMultiFindCrossDatasetFallback:
+    """Test that multi_find uses the resolver when labels don't match the target dataset."""
+
+    def test_trainable_model_falls_back_to_resolver(self, client, tmp_path):
+        """When a trainable model's labels don't match the target dataset,
+        multi_find should fall back to resolving labels from their origins."""
+        import json
+        import pickle
+        import time
+
+        from vtsearch.datasets.registry import register_dataset
+        from vtsearch.models.registry import register_model
+        from vtsearch.utils import medias, snapshot_medias
+
+        # Create a folder with media files for the trainable model's labels
+        label_folder = tmp_path / "label_audio"
+        label_folder.mkdir()
+        (label_folder / "good.wav").write_bytes(b"good_audio_content")
+        (label_folder / "bad.wav").write_bytes(b"bad_audio_content")
+
+        # Create a target dataset pkl with different medias (no overlap)
+        target_medias = {}
+        for i in range(5):
+            emb = np.random.RandomState(i).randn(512).astype(np.float32)
+            target_medias[i] = {
+                "id": i,
+                "type": "audio",
+                "embedding": emb,
+                "md5": f"target_md5_{i}",
+                "filename": f"target_{i}.wav",
+                "origin_name": f"target_{i}.wav",
+                "origin": {"importer": "folder", "params": {"path": "/other/folder"}},
+            }
+
+        pkl_path = tmp_path / "target.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": target_medias}, f)
+
+        # Register the target dataset
+        ds = register_dataset(
+            name="target_ds",
+            media_type="audio",
+            num_items=5,
+            pkl_path=str(pkl_path),
+        )
+
+        # Create a trainable model with labels from label_folder
+        label_origin = {"importer": "folder", "params": {"path": str(label_folder), "media_type": "sounds"}}
+        from vtsearch.routes.trainable_models import _model_path, _write_model
+
+        tm_name = "test_cross_detector"
+        tm_path = _model_path(tm_name)
+        tm_data = {
+            "name": "Test Cross Detector",
+            "text_query": "",
+            "media_type": "audio",
+            "examples": [],
+            "created_at": time.time(),
+            "labelset": {
+                "labels": [
+                    {
+                        "md5": "good_md5",
+                        "label": "good",
+                        "origin": label_origin,
+                        "origin_name": "good.wav",
+                        "filename": "good.wav",
+                    },
+                    {
+                        "md5": "bad_md5",
+                        "label": "bad",
+                        "origin": label_origin,
+                        "origin_name": "bad.wav",
+                        "filename": "bad.wav",
+                    },
+                ]
+            },
+        }
+        _write_model(tm_path, tm_data)
+
+        # Register the model
+        model_entry = register_model(
+            name="Test Cross Detector",
+            media_type="audio",
+            trainable=True,
+            num_training=2,
+            trainable_model_name=tm_name,
+        )
+
+        # Mock the embedder to return deterministic vectors
+        good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
+        bad_emb = np.random.RandomState(200).randn(512).astype(np.float32)
+
+        def fake_embed(path, media_type):
+            name = Path(path).name
+            if "good" in name:
+                return good_emb
+            return bad_emb
+
+        with patch("vtsearch.models.resolver.embed_file", side_effect=fake_embed):
+            resp = client.post(
+                "/api/find",
+                data=json.dumps(
+                    {
+                        "dataset_ids": [ds["id"]],
+                        "model_ids": [model_entry["id"]],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # The resolver should have kicked in — results should not all be N/A
+        assert "results" in data
+        # Every media should have a verdict from the model
+        # (either Good or Bad, not N/A since resolver found the files)
+        for r in data["results"]:
+            verdicts = r["model_verdicts"]
+            assert "Test Cross Detector" in verdicts
+            assert verdicts["Test Cross Detector"]["verdict"] in ("Good", "Bad")

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -1,0 +1,350 @@
+"""Resolve label entries to embeddings by following their origin trails.
+
+When a detector's training labels don't match a target dataset (cross-dataset
+scenario), we need to find the original media files, embed them, and use those
+embeddings for training.  This module handles that resolution:
+
+1. Given a label entry's origin info, resolve to an actual file on disk.
+2. Embed the file using the appropriate embedder for the media type.
+3. Return resolved embeddings with availability stats.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolvedLabels:
+    """Result of resolving label entries to embeddings."""
+
+    embeddings: list[np.ndarray] = field(default_factory=list)
+    labels: list[float] = field(default_factory=list)
+    resolved_count: int = 0
+    total_count: int = 0
+    missing_entries: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def available_fraction(self) -> float:
+        return self.resolved_count / self.total_count if self.total_count else 0.0
+
+    @property
+    def has_good_and_bad(self) -> bool:
+        return any(v == 1.0 for v in self.labels) and any(v == 0.0 for v in self.labels)
+
+
+def resolve_file_from_origin(
+    origin: dict[str, Any] | None,
+    origin_name: str = "",
+    filename: str = "",
+) -> Path | None:
+    """Resolve a media file from its origin information.
+
+    Follows the origin trail to find the actual file on disk:
+
+    - ``folder``: ``origin.params.path / origin_name``
+    - ``pdf``: ``origin.params.path`` (the PDF file itself)
+    - ``http_archive``: re-downloads and extracts if needed
+    - ``demo``: checks demo cache directory
+    - ``converter``: resolves parent origin, finds source file
+    - ``dupe_set``: tries each member until one resolves
+
+    Returns the file path if found, or ``None``.
+    """
+    if origin is None:
+        return None
+
+    importer = origin.get("importer", "")
+    params = origin.get("params", {})
+
+    if importer == "folder":
+        return _resolve_folder(params, origin_name, filename)
+
+    if importer == "pdf":
+        return _resolve_pdf(params)
+
+    if importer == "http_archive":
+        return _resolve_http_archive(params, origin_name, filename)
+
+    if importer == "demo":
+        return _resolve_demo(params, origin_name, filename)
+
+    if importer == "converter":
+        return _resolve_converter(params, origin_name, filename)
+
+    if importer == "dupe_set":
+        return _resolve_dupe_set(origin, origin_name, filename)
+
+    return None
+
+
+def _resolve_folder(
+    params: dict[str, str], origin_name: str, filename: str
+) -> Path | None:
+    folder = params.get("path", "")
+    if not folder:
+        return None
+    folder_path = Path(folder)
+    for name in [origin_name, filename]:
+        if name:
+            candidate = folder_path / name
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _resolve_pdf(params: dict[str, str]) -> Path | None:
+    path = params.get("path", "")
+    if path:
+        p = Path(path)
+        if p.is_file():
+            return p
+    return None
+
+
+def _resolve_http_archive(
+    params: dict[str, str], origin_name: str, filename: str
+) -> Path | None:
+    """Resolve a file from an http_archive origin.
+
+    Checks if the archive has already been downloaded to the data directory.
+    If found, extracts and searches for the file.  If not found, downloads
+    the archive first.
+    """
+    url = params.get("url", "")
+    if not url:
+        return None
+
+    from vtsearch.config import DATA_DIR
+
+    url_filename = url.rsplit("/", 1)[-1].split("?")[0]
+    download_path = DATA_DIR / f"http_archive_download_{url_filename}"
+    extract_dir = DATA_DIR / f"http_archive_resolve_{url_filename}"
+
+    # If already extracted, search there
+    if extract_dir.is_dir():
+        found = _search_dir_for_file(extract_dir, origin_name, filename)
+        if found:
+            return found
+
+    # If archive downloaded but not extracted (or extraction didn't find file)
+    if download_path.is_file() and not extract_dir.is_dir():
+        try:
+            from vtsearch.datasets.importers.http_zip import _extract_archive
+
+            extract_dir.mkdir(parents=True, exist_ok=True)
+            _extract_archive(download_path, extract_dir)
+            found = _search_dir_for_file(extract_dir, origin_name, filename)
+            if found:
+                return found
+        except Exception:
+            log.warning("Failed to extract %s", download_path, exc_info=True)
+
+    # Download the archive if not present
+    if not download_path.is_file():
+        try:
+            log.info("Downloading %s for label resolution...", url)
+            _download_url(url, download_path)
+            if download_path.is_file():
+                from vtsearch.datasets.importers.http_zip import _extract_archive
+
+                extract_dir.mkdir(parents=True, exist_ok=True)
+                _extract_archive(download_path, extract_dir)
+                found = _search_dir_for_file(extract_dir, origin_name, filename)
+                if found:
+                    return found
+        except Exception:
+            log.warning("Failed to download %s for label resolution", url, exc_info=True)
+
+    return None
+
+
+def _resolve_demo(
+    params: dict[str, str], origin_name: str, filename: str
+) -> Path | None:
+    """Resolve a file from a demo dataset origin.
+
+    Demo datasets may store files on disk (audio, video, document types keep
+    files in a type-specific directory).  Text and image demos often store
+    data in-memory only, so resolution may fail for those.
+    """
+    demo_name = params.get("name", "")
+    if not demo_name:
+        return None
+
+    from vtsearch.datasets.config import DEMO_DATASETS
+
+    demo_info = DEMO_DATASETS.get(demo_name)
+    if demo_info is None:
+        return None
+
+    media_type = demo_info.get("media_type", "")
+    source = demo_info.get("source", "")
+
+    # For demo datasets that download to a known directory,
+    # check common locations.  Audio demos (ESC-50, GTZAN, etc.)
+    # download to DATA_DIR / <source_folder>.
+    from vtsearch.config import DATA_DIR
+
+    # Try DATA_DIR-based paths (common for extracted archives)
+    for name in [origin_name, filename]:
+        if not name:
+            continue
+        # Direct path under data/
+        candidate = DATA_DIR / name
+        if candidate.is_file():
+            return candidate
+
+    # For audio/video/document types that use external directories,
+    # check the embeddings pkl for the stored dir_key path.
+    # But we can't open pkls per the design — instead check known
+    # download locations.
+    if source:
+        # Many demo sources download to DATA_DIR / <extracted_folder>
+        # Try to find the file by searching DATA_DIR recursively
+        # (bounded to avoid scanning huge trees)
+        for name in [origin_name, filename]:
+            if not name:
+                continue
+            basename = Path(name).name
+            for candidate_dir in DATA_DIR.iterdir():
+                if not candidate_dir.is_dir():
+                    continue
+                candidate = candidate_dir / name
+                if candidate.is_file():
+                    return candidate
+                # One level of rglob
+                matches = list(candidate_dir.rglob(basename))
+                if matches:
+                    return matches[0]
+
+    return None
+
+
+def _resolve_converter(
+    params: dict[str, str], origin_name: str, filename: str
+) -> Path | None:
+    """Resolve a file from a converter origin.
+
+    Converter origins track a parent importer and a source file within it.
+    """
+    source_file = params.get("source_file", "")
+    parent_importer = params.get("parent_importer", "")
+    parent_path = params.get("parent_path", "")
+    parent_url = params.get("parent_url", "")
+
+    # Try resolving via parent
+    if parent_importer == "folder" and parent_path and source_file:
+        candidate = Path(parent_path) / source_file
+        if candidate.is_file():
+            return candidate
+
+    if parent_importer == "http_archive" and parent_url:
+        return _resolve_http_archive({"url": parent_url}, source_file, "")
+
+    return None
+
+
+def _resolve_dupe_set(
+    origin: dict[str, Any], origin_name: str, filename: str
+) -> Path | None:
+    members = origin.get("members", [])
+    for m in members:
+        result = resolve_file_from_origin(
+            m.get("origin"),
+            m.get("origin_name", ""),
+            m.get("filename", ""),
+        )
+        if result is not None:
+            return result
+    return None
+
+
+def _search_dir_for_file(
+    directory: Path, origin_name: str, filename: str
+) -> Path | None:
+    """Search a directory for a file matching origin_name or filename."""
+    for name in [origin_name, filename]:
+        if not name:
+            continue
+        candidate = directory / name
+        if candidate.is_file():
+            return candidate
+        # Search recursively by basename
+        matches = list(directory.rglob(Path(name).name))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _download_url(url: str, dest: Path) -> None:
+    """Download a URL to a local file."""
+    import urllib.request
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(url, str(dest))  # noqa: S310
+
+
+def embed_file(file_path: Path, media_type: str) -> np.ndarray | None:
+    """Embed a media file using the appropriate embedder for the media type."""
+    from vtsearch.media import embedders_for_type
+
+    avail = embedders_for_type(media_type)
+    if not avail:
+        return None
+    return avail[0].embed_media(file_path)
+
+
+def resolve_label_embeddings(
+    labels: list[dict[str, Any]],
+    media_type: str,
+) -> ResolvedLabels:
+    """Resolve label entries to embeddings by following their origin trails.
+
+    For each label entry, attempts to:
+    1. Resolve the original media file from its origin info
+    2. Embed it using the appropriate embedder for *media_type*
+    3. Collect the embedding and label value
+
+    Args:
+        labels: List of label dicts (with origin, origin_name, filename, label keys).
+        media_type: The media type for embedding (e.g. "audio", "image").
+
+    Returns:
+        A :class:`ResolvedLabels` with resolved embeddings, stats, and missing entries.
+    """
+    result = ResolvedLabels()
+
+    for entry in labels:
+        label_val = entry.get("label", "")
+        if label_val not in ("good", "bad"):
+            continue
+
+        result.total_count += 1
+
+        origin = entry.get("origin")
+        origin_name = entry.get("origin_name", "")
+        filename = entry.get("filename", "")
+
+        file_path = resolve_file_from_origin(origin, origin_name, filename)
+        if file_path is None:
+            result.missing_entries.append(entry)
+            continue
+
+        embedding = embed_file(file_path, media_type)
+        if embedding is None:
+            result.missing_entries.append(entry)
+            continue
+
+        result.embeddings.append(embedding)
+        result.labels.append(1.0 if label_val == "good" else 0.0)
+        result.resolved_count += 1
+
+    return result

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -711,13 +711,23 @@ def multi_find():
                         bad_embs = [temp_medias[i]["embedding"] for i in bad_ids if i in temp_medias]
                         X_list = good_embs + bad_embs
                         y_list = [1.0] * len(good_embs) + [0.0] * len(bad_embs)
+                    else:
+                        # Labels didn't match this dataset — resolve from
+                        # original sources (cross-dataset scenario).
+                        from vtsearch.models.resolver import resolve_label_embeddings
 
-                        from vtsearch.models import calculate_cross_calibration_threshold, train_model
+                        media_type = tm_data.get("media_type", "audio")
+                        resolved = resolve_label_embeddings(labels, media_type)
+                        if resolved.has_good_and_bad:
+                            X_list = resolved.embeddings
+                            y_list = resolved.labels
+                        else:
+                            X_list = []
+                            y_list = []
 
+                    if X_list and any(v == 1.0 for v in y_list) and any(v == 0.0 for v in y_list):
                         input_dim = X_list[0].shape[0]
                         threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim, get_inclusion())
-
-                        import torch
 
                         X_train = torch.tensor(np.array(X_list), dtype=torch.float32)
                         y_train = torch.tensor([[v] for v in y_list], dtype=torch.float32)
@@ -733,7 +743,7 @@ def multi_find():
                                 "score": round(score, 4),
                             }
                     else:
-                        # Not enough labels matched this dataset
+                        # Not enough labels resolved
                         for cid in all_ids:
                             media_results[cid]["model_verdicts"][mc["name"]] = {
                                 "verdict": "N/A",


### PR DESCRIPTION
## Summary
This PR adds a new `resolver` module that enables training detectors on datasets different from where their labels originated. When a trainable model's labels don't match the target dataset, the resolver follows the origin trail to find the original media files, embeds them, and uses those embeddings for training.

## Key Changes

- **New module: `vtsearch/models/resolver.py`**
  - `ResolvedLabels` dataclass: Tracks resolved embeddings, labels, and availability statistics
  - `resolve_file_from_origin()`: Recursively resolves media files from various origin types (folder, PDF, HTTP archive, demo, converter, dupe_set)
  - `resolve_label_embeddings()`: Resolves a list of label entries to embeddings by following their origin trails
  - Support for multiple importer types with fallback chains (e.g., dupe_set tries each member until one resolves)

- **Updated: `vtsearch/routes/detectors_training.py`**
  - Modified `multi_find()` endpoint to detect cross-dataset scenarios (when labels don't match target dataset)
  - Falls back to `resolve_label_embeddings()` when labels are from different origins
  - Only trains the model if both good and bad labels are available after resolution

- **New test suite: `tests/test_resolver.py`**
  - Comprehensive tests for all origin types (folder, PDF, dupe_set, converter)
  - Tests for `ResolvedLabels` properties and statistics
  - Integration test demonstrating cross-dataset detector training with file resolution
  - Edge cases: missing files, invalid labels, embedding failures

## Implementation Details

- The resolver gracefully handles missing files and failed embeddings by tracking them in `missing_entries`
- Supports nested paths and recursive directory searching for flexible file location
- HTTP archives are downloaded and cached in the data directory for reuse
- Demo datasets check multiple known locations for resolved files
- The cross-dataset fallback only trains if both good and bad examples are available after resolution

https://claude.ai/code/session_011WxXjBWqTju2s3xQjKysiU