### PR TITLE
Add converter support for demo datasets and API filtering

### DIFF
--- a/tests/test_document_and_converters.py
+++ b/tests/test_document_and_converters.py
@@ -539,7 +539,7 @@ class TestConverterRegistrySourceFilter:
         results = list_converters_for_source("document")
         names = [c.name for c in results]
         assert "document2image" in names
-        assert "document2text" in names
+        assert "document2paragraph" in names
         assert "video2image" not in names
 
     def test_list_converters_for_source_nonexistent(self):

--- a/tests/test_document_and_converters.py
+++ b/tests/test_document_and_converters.py
@@ -516,3 +516,227 @@ class TestFolderImporterDocumentsOption:
         importer = FolderDatasetImporter()
         media_type_field = next(f for f in importer.fields if f.key == "media_type")
         assert "documents" in media_type_field.options
+
+
+# ===========================================================================
+# Converter registry: list_converters_for_source
+# ===========================================================================
+
+
+class TestConverterRegistrySourceFilter:
+    def test_list_converters_for_source_video(self):
+        from vtsearch.converters import list_converters_for_source
+
+        results = list_converters_for_source("video")
+        names = [c.name for c in results]
+        assert "video2image" in names
+        assert "video2audio" in names
+        assert "document2image" not in names
+
+    def test_list_converters_for_source_document(self):
+        from vtsearch.converters import list_converters_for_source
+
+        results = list_converters_for_source("document")
+        names = [c.name for c in results]
+        assert "document2image" in names
+        assert "document2text" in names
+        assert "video2image" not in names
+
+    def test_list_converters_for_source_nonexistent(self):
+        from vtsearch.converters import list_converters_for_source
+
+        results = list_converters_for_source("nonexistent_type")
+        assert results == []
+
+
+# ===========================================================================
+# /api/converters endpoint — source filter
+# ===========================================================================
+
+
+class TestConvertersAPISourceFilter:
+    def test_converters_no_filter(self, client):
+        resp = client.get("/api/converters")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "converters" in data
+        assert len(data["converters"]) >= 4
+
+    def test_converters_filter_by_target(self, client):
+        resp = client.get("/api/converters?target=image")
+        data = resp.get_json()
+        names = [c["name"] for c in data["converters"]]
+        assert "document2image" in names
+        assert "video2image" in names
+        assert "document2text" not in names
+
+    def test_converters_filter_by_source(self, client):
+        resp = client.get("/api/converters?source=video")
+        data = resp.get_json()
+        names = [c["name"] for c in data["converters"]]
+        assert "video2image" in names
+        assert "video2audio" in names
+        assert "document2image" not in names
+
+    def test_converters_filter_by_source_folder_name(self, client):
+        resp = client.get("/api/converters?source=videos")
+        data = resp.get_json()
+        names = [c["name"] for c in data["converters"]]
+        assert "video2image" in names
+
+    def test_converters_filter_by_source_no_results(self, client):
+        resp = client.get("/api/converters?source=paragraph")
+        data = resp.get_json()
+        assert data["converters"] == []
+
+
+# ===========================================================================
+# Demo list includes available converters
+# ===========================================================================
+
+
+class TestDemoListConverters:
+    def test_demo_list_includes_converters(self, client):
+        resp = client.get("/api/dataset/demo-list")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        demos = data["datasets"]
+        assert len(demos) > 0
+        for demo in demos:
+            assert "available_converters" in demo
+            assert isinstance(demo["available_converters"], list)
+
+    def test_demo_list_video_demo_has_video_converters(self, client):
+        """Video demos should list video2image and video2audio converters."""
+        resp = client.get("/api/dataset/demo-list")
+        demos = resp.get_json()["datasets"]
+        video_demos = [d for d in demos if d["media_type"] == "video"]
+        if not video_demos:
+            pytest.skip("No video demo datasets registered")
+        demo = video_demos[0]
+        conv_names = [c["name"] for c in demo["available_converters"]]
+        assert "video2image" in conv_names
+        assert "video2audio" in conv_names
+
+    def test_demo_list_audio_demo_has_no_source_converters(self, client):
+        """Audio demos should have no source converters (no audio→X converters exist)."""
+        resp = client.get("/api/dataset/demo-list")
+        demos = resp.get_json()["datasets"]
+        audio_demos = [d for d in demos if d["media_type"] == "audio"]
+        if not audio_demos:
+            pytest.skip("No audio demo datasets registered")
+        demo = audio_demos[0]
+        assert demo["available_converters"] == []
+
+
+# ===========================================================================
+# Importer to_dict includes available_converters_by_media_type
+# ===========================================================================
+
+
+class TestImporterConverterMetadata:
+    def test_folder_importer_to_dict_has_converters(self):
+        from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+        importer = FolderDatasetImporter()
+        d = importer.to_dict()
+        assert "available_converters_by_media_type" in d
+        by_mt = d["available_converters_by_media_type"]
+        assert isinstance(by_mt, dict)
+        # image type should have document2image and video2image
+        if "image" in by_mt:
+            names = [c["name"] for c in by_mt["image"]]
+            assert "document2image" in names
+            assert "video2image" in names
+
+    def test_http_archive_importer_to_dict_has_converters(self):
+        from vtsearch.datasets.importers.http_zip import HttpArchiveDatasetImporter
+
+        importer = HttpArchiveDatasetImporter()
+        d = importer.to_dict()
+        assert "available_converters_by_media_type" in d
+        by_mt = d["available_converters_by_media_type"]
+        # audio type should have video2audio
+        if "audio" in by_mt:
+            names = [c["name"] for c in by_mt["audio"]]
+            assert "video2audio" in names
+
+    def test_importers_endpoint_includes_converters(self, client):
+        resp = client.get("/api/dataset/importers")
+        assert resp.status_code == 200
+        importers = resp.get_json()["importers"]
+        folder_imp = next((i for i in importers if i["name"] == "folder"), None)
+        if folder_imp:
+            assert "available_converters_by_media_type" in folder_imp
+
+
+# ===========================================================================
+# Demo dataset loading with converter
+# ===========================================================================
+
+
+class TestLoadDemoWithConverter:
+    def test_load_demo_endpoint_accepts_converter(self, client):
+        """The load-demo endpoint should accept a converter parameter."""
+        resp = client.post(
+            "/api/dataset/load-demo",
+            json={"name": "nonexistent_demo", "converter": "video2image"},
+        )
+        # Should fail with "Invalid dataset name", not with a parameter error
+        assert resp.status_code == 400
+        assert "Invalid dataset" in resp.get_json()["error"]
+
+    def test_apply_converter_to_demo_unknown_converter(self):
+        """_apply_converter_to_demo should raise for unknown converters."""
+        from vtsearch.datasets.loader import _apply_converter_to_demo
+
+        with pytest.raises(ValueError, match="Unknown converter"):
+            _apply_converter_to_demo(
+                converter_name="nonexistent_converter",
+                dataset_name="test",
+                medias={},
+            )
+
+    def test_apply_converter_to_demo_empty_medias(self):
+        """_apply_converter_to_demo with empty medias should produce empty output."""
+        from vtsearch.datasets.loader import _apply_converter_to_demo
+
+        medias: dict = {}
+        _apply_converter_to_demo(
+            converter_name="document2image",
+            dataset_name="test",
+            medias=medias,
+        )
+        assert medias == {}
+
+    def test_apply_converter_to_demo_converts_documents(self):
+        """_apply_converter_to_demo should convert document medias to images."""
+        from vtsearch.datasets.loader import _apply_converter_to_demo
+
+        pdf_bytes = _make_minimal_pdf("Convert me")
+        medias = {
+            1: {
+                "id": 1,
+                "type": "document",
+                "filename": "test.pdf",
+                "media_bytes": pdf_bytes,
+                "media_path": "",
+                "category": "test_cat",
+            }
+        }
+        _apply_converter_to_demo(
+            converter_name="document2image",
+            dataset_name="test_demo",
+            medias=medias,
+        )
+        # Should have converted the document to image(s)
+        assert len(medias) >= 1
+        for m in medias.values():
+            assert m["type"] == "image"
+            assert m["origin"]["importer"] == "converter"
+            assert m["origin"]["params"]["converter"] == "document2image"
+            assert m["origin"]["params"]["parent_importer"] == "demo"
+            assert m["origin"]["params"]["parent_demo"] == "test_demo"
+            assert "test.pdf" in m["origin"]["params"]["source_file"]
+            # Category should be preserved from source
+            assert m["category"] == "test_cat"

--- a/vtsearch/converters/__init__.py
+++ b/vtsearch/converters/__init__.py
@@ -48,6 +48,11 @@ def list_converters_for_target(target_type: str) -> list[MediaConverter]:
     return [c for c in _ALL_CONVERTERS if c.target_type == target_type]
 
 
+def list_converters_for_source(source_type: str) -> list[MediaConverter]:
+    """Return converters that consume *source_type* (a ``type_id``)."""
+    return [c for c in _ALL_CONVERTERS if c.source_type == source_type]
+
+
 __all__ = [
     "MediaConverter",
     "Document2ImageMediaConverter",
@@ -57,4 +62,5 @@ __all__ = [
     "list_converters",
     "get_converter",
     "list_converters_for_target",
+    "list_converters_for_source",
 ]

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -185,6 +185,23 @@ class FolderDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        from vtsearch.converters import list_converters_for_target
+        from vtsearch.media import all_types_dict
+
+        # For each media type the user can select, list N→M converters
+        # that produce that type — so the UI can show a datagrid of
+        # available converters dynamically.
+        converters_by_target: dict[str, list[dict]] = {}
+        for mt_info in all_types_dict():
+            type_id = mt_info["type_id"]
+            convs = list_converters_for_target(type_id)
+            if convs:
+                converters_by_target[type_id] = [c.to_dict() for c in convs]
+        d["available_converters_by_media_type"] = converters_by_target
+        return d
+
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         folder = Path(field_values["path"])
         media_type = field_values.get("media_type", "sounds")

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -183,6 +183,20 @@ class HttpArchiveDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        from vtsearch.converters import list_converters_for_target
+        from vtsearch.media import all_types_dict
+
+        converters_by_target: dict[str, list[dict]] = {}
+        for mt_info in all_types_dict():
+            type_id = mt_info["type_id"]
+            convs = list_converters_for_target(type_id)
+            if convs:
+                converters_by_target[type_id] = [c.to_dict() for c in convs]
+        d["available_converters_by_media_type"] = converters_by_target
+        return d
+
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         url = field_values["url"]
         validate_url(url)

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -1229,6 +1229,7 @@ def load_demo_dataset(
     e5_model: Any = None,
     on_progress: Optional[ProgressCallback] = None,
     embedder_name: str = "",
+    converter_name: str = "",
 ) -> None:
     """Load a named demo dataset into the medias dict, downloading and embedding as needed.
 
@@ -1240,6 +1241,11 @@ def load_demo_dataset(
     :meth:`~vtsearch.media.base.MediaType.load_demo_source` method that
     handles downloading, embedding, and populating clips for its demo sources.
     This function simply orchestrates pickle caching around that delegation.
+
+    When *converter_name* is given (e.g. ``"video2image"``), the demo data is
+    loaded using its original media type, then each media is converted via the
+    named converter.  The resulting dataset contains the *target* type and
+    is cached under a separate pickle key.
 
     Progress throughout the operation is reported via :func:`update_progress`.
 
@@ -1254,6 +1260,9 @@ def load_demo_dataset(
         embedder_name: Optional name of a registered embedder to use.
             When empty, the first registered embedder for the media type
             is used.
+        converter_name: Optional name of a converter (e.g. ``"video2image"``).
+            When given, the demo is loaded in its native type and then
+            converted.
 
     Raises:
         ValueError: If ``dataset_name`` is not in ``DEMO_DATASETS``, or if the
@@ -1268,8 +1277,11 @@ def load_demo_dataset(
     dataset_info = DEMO_DATASETS[dataset_name]
     media_type_id = dataset_info.get("media_type", "audio")
 
+    # When a converter is specified, use a separate pickle cache key.
+    cache_key = f"{dataset_name}__{converter_name}" if converter_name else dataset_name
+
     # Check if already embedded
-    pkl_file = EMBEDDINGS_DIR / f"{dataset_name}.pkl"
+    pkl_file = EMBEDDINGS_DIR / f"{cache_key}.pkl"
     if pkl_file.exists():
         on_progress("loading", f"Loading {dataset_name} dataset...", 0, 0)
         load_dataset_from_pickle(pkl_file, medias)
@@ -1316,13 +1328,28 @@ def load_demo_dataset(
     )
 
     # Stamp the demo origin on all medias (fresh dict per media to avoid shared-reference mutation bugs)
+    demo_origin_params: dict[str, str] = {"name": dataset_name}
+    if converter_name:
+        demo_origin_params["converter"] = converter_name
     for media in medias.values():
-        media["origin"] = {"importer": "demo", "params": {"name": dataset_name}}
+        media["origin"] = {"importer": "demo", "params": dict(demo_origin_params)}
+
+    # --- Apply converter if requested ---
+    if converter_name:
+        _apply_converter_to_demo(
+            converter_name=converter_name,
+            dataset_name=dataset_name,
+            medias=medias,
+            embedder_name=embedder_name,
+            on_progress=on_progress,
+        )
 
     # Build the pickle cache payload
     # For types with external media dirs (audio, video), exclude media_bytes
     # from the pickle and store the dir path so reloading can find the files.
-    if external_dir is not None:
+    # When a converter was applied, external_dir is no longer relevant (the
+    # converted medias carry their own bytes/strings).
+    if external_dir is not None and not converter_name:
         pkl_data: dict[str, Any] = {
             "name": dataset_name,
             "medias": {
@@ -1345,6 +1372,129 @@ def load_demo_dataset(
         pickle.dump(pkl_data, f)
 
     on_progress("idle", f"Loaded {dataset_name} dataset")
+
+
+def _apply_converter_to_demo(
+    converter_name: str,
+    dataset_name: str,
+    medias: dict[int, dict[str, Any]],
+    embedder_name: str = "",
+    on_progress: Optional[ProgressCallback] = None,
+) -> None:
+    """Convert all medias in-place using the named converter.
+
+    After conversion, *medias* contains the converted outputs (target type)
+    instead of the original source-type medias.  Each converted media's
+    origin records the demo dataset and the converter used.
+    """
+    from vtsearch.converters import get_converter
+    from vtsearch.converters.runner import _compute_md5, _embed_converted_output
+    from vtsearch.media import embedders_for_type, get_embedder
+
+    converter = get_converter(converter_name)
+    if converter is None:
+        raise ValueError(f"Unknown converter: {converter_name}")
+
+    if on_progress is None:
+        on_progress = _default_progress()
+
+    # Resolve embedder for the *target* type.
+    target_emb = None
+    if embedder_name:
+        try:
+            target_emb = get_embedder(embedder_name)
+        except KeyError:
+            pass
+    if target_emb is None:
+        avail = embedders_for_type(converter.target_type)
+        if avail:
+            target_emb = avail[0]
+    if target_emb is not None and getattr(target_emb, "_model", None) is None:
+        target_emb.load_models()
+
+    # Convert each original media and collect the outputs.
+    source_items = list(medias.items())
+    converted: dict[int, dict[str, Any]] = {}
+    new_id = 1
+
+    on_progress(
+        "converting",
+        f"Converting {len(source_items)} items via {converter.display_name or converter.name}...",
+        0,
+        len(source_items),
+    )
+
+    for idx, (_, src) in enumerate(source_items):
+        on_progress(
+            "converting",
+            f"Converting {src.get('filename', '')} via {converter.display_name or converter.name}...",
+            idx + 1,
+            len(source_items),
+        )
+
+        try:
+            outputs = converter.convert(src)
+        except Exception:
+            continue
+        if not outputs:
+            continue
+
+        origin = {
+            "importer": "converter",
+            "params": {
+                "converter": converter_name,
+                "source_file": src.get("filename", ""),
+                "parent_importer": "demo",
+                "parent_demo": dataset_name,
+            },
+        }
+
+        for output in outputs:
+            output_filename = output.get("filename", f"converted_{new_id}")
+            source_name = src.get("filename", str(src.get("id", "")))
+            origin_name = f"{source_name}\u2192{output_filename}"
+
+            embedding = _embed_converted_output(target_emb, output)
+            if embedding is None:
+                continue
+
+            md5 = _compute_md5(output)
+
+            media_data: dict[str, Any] = {
+                "id": new_id,
+                "type": converter.target_type,
+                "embedder": target_emb.name if target_emb else "",
+                "file_size": len(output.get("media_bytes", b"") or output.get("media_string", "").encode()),
+                "md5": md5,
+                "embedding": embedding,
+                "filename": origin_name,
+                "category": src.get("category", "custom"),
+                "origin": origin,
+                "origin_name": origin_name,
+                "media_bytes": None,
+                "media_string": None,
+                "media_path": src.get("media_path", ""),
+                "duration": output.get("duration", 0),
+            }
+
+            if "media_bytes" in output:
+                media_data["media_bytes"] = output["media_bytes"]
+            if "media_string" in output:
+                media_data["media_string"] = output["media_string"]
+            if "width" in output:
+                media_data["width"] = output["width"]
+            if "height" in output:
+                media_data["height"] = output["height"]
+            if "word_count" in output:
+                media_data["word_count"] = output["word_count"]
+            if "character_count" in output:
+                media_data["character_count"] = output["character_count"]
+
+            converted[new_id] = media_data
+            new_id += 1
+
+    medias.clear()
+    medias.update(converted)
 
 
 def export_dataset_to_file(

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -125,25 +125,36 @@ def clippers_list():
 
 @datasets_bp.route("/api/converters")
 def converters_list():
-    """Return all converters, optionally filtered by target media type.
+    """Return all converters, optionally filtered by source or target media type.
 
     Query parameters:
         target: A ``type_id`` (e.g. ``"image"``) or ``folder_import_name``
             (e.g. ``"images"``).  When provided, only converters whose
             ``target_type`` matches are returned.
+        source: A ``type_id`` (e.g. ``"video"``) or ``folder_import_name``
+            (e.g. ``"videos"``).  When provided, only converters whose
+            ``source_type`` matches are returned.
     """
-    from vtsearch.converters import list_converters, list_converters_for_target
+    from vtsearch.converters import list_converters, list_converters_for_source, list_converters_for_target
     from vtsearch.media import get_by_folder_name
 
     target = request.args.get("target", "").strip()
+    source = request.args.get("source", "").strip()
+
     if target:
-        # Accept both type_id ("image") and folder_import_name ("images").
         try:
             mt = get_by_folder_name(target)
             target = mt.type_id
         except KeyError:
-            pass  # assume it is already a type_id
+            pass
         converters = list_converters_for_target(target)
+    elif source:
+        try:
+            mt = get_by_folder_name(source)
+            source = mt.type_id
+        except KeyError:
+            pass
+        converters = list_converters_for_source(source)
     else:
         converters = list_converters()
 
@@ -334,10 +345,13 @@ def stage_demo(name: str):
     if name not in DEMO_DATASETS:
         return jsonify({"error": "Invalid dataset name"}), 400
 
+    body = request.get_json(force=True, silent=True) or {}
+    converter_name = body.get("converter", "")
+
     def stage_task():
         try:
             temp_medias: dict = {}
-            load_demo_dataset(name, temp_medias)
+            load_demo_dataset(name, temp_medias, converter_name=converter_name)
 
             if not temp_medias:
                 update_progress("idle", "", 0, 0, "Demo produced no medias.")
@@ -456,7 +470,13 @@ def import_dataset(importer_name: str):
 
 @datasets_bp.route("/api/dataset/load-demo", methods=["POST"])
 def load_demo_dataset_route():
-    """Load a demo dataset in a background thread."""
+    """Load a demo dataset in a background thread.
+
+    When a ``converter`` is specified, the demo data is loaded using its
+    original media type, then converted to the converter's target type.
+    The resulting dataset has the *target* type, not the demo's original
+    type.
+    """
     data = get_json_or_400()
     if not isinstance(data, dict):
         return data
@@ -464,13 +484,19 @@ def load_demo_dataset_route():
     dataset_name = data.get("name")
     embedder_name = data.get("embedder", "")
     clipper_name = data.get("clipper", "")
+    converter_name = data.get("converter", "")
 
     if not dataset_name or dataset_name not in DEMO_DATASETS:
         return jsonify({"error": "Invalid dataset name"}), 400
 
     demo_origin = {"importer": "demo", "params": {"name": dataset_name}}
+    if converter_name:
+        demo_origin["params"]["converter"] = converter_name
+
     _run_origin_load_in_background(
-        lambda: load_demo_dataset(dataset_name, medias, embedder_name=embedder_name),
+        lambda: load_demo_dataset(
+            dataset_name, medias, embedder_name=embedder_name, converter_name=converter_name,
+        ),
         demo_origin,
         name=dataset_name,
         clipper=clipper_name,
@@ -698,11 +724,14 @@ def _load_from_origin(source: dict):
 
     if importer_name == "demo":
         demo_name = params.get("name", "")
+        converter_name = params.get("converter", "")
         if demo_name not in DEMO_DATASETS:
             return jsonify({"error": f"Unknown demo dataset: {demo_name}"}), 400
         origin = {"importer": "demo", "params": {"name": demo_name}}
+        if converter_name:
+            origin["params"]["converter"] = converter_name
         _run_origin_load_in_background(
-            lambda: load_demo_dataset(demo_name, medias),
+            lambda: load_demo_dataset(demo_name, medias, converter_name=converter_name),
             origin,
             name=demo_name,
         )

--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -39,6 +39,7 @@ def demo_dataset_list():
     * ``"needs_download"`` – source data must be downloaded (and then embedded).
     """
     # Only include demo datasets whose media type is currently registered.
+    from vtsearch.converters import list_converters_for_source
     from vtsearch.media import get as media_get
 
     demos = []
@@ -89,6 +90,9 @@ def demo_dataset_list():
             # Use the download_size_mb from DemoDataset metadata
             download_size_mb = dataset_info.get("download_size_mb", 0)
 
+        # Converters that consume this demo's media type (M→N converters).
+        available_converters = [c.to_dict() for c in list_converters_for_source(media_type)]
+
         demos.append(
             {
                 "name": name,
@@ -100,6 +104,7 @@ def demo_dataset_list():
                 "description": dataset_info.get("description", ""),
                 "media_type": media_type,
                 "num_categories": num_categories,
+                "available_converters": available_converters,
             }
         )
     return jsonify({"datasets": demos})


### PR DESCRIPTION
## Summary
This PR adds support for applying media converters to demo datasets and introduces source-type filtering for the converters API. Users can now load a demo dataset and automatically convert its media to a different type (e.g., convert videos to images), with proper origin tracking and embedding of converted outputs.

## Key Changes

- **Demo dataset converter support**: Added `converter_name` parameter to `load_demo_dataset()` that allows converting loaded demo media to a target type. Converted media is cached separately and includes origin metadata tracking the converter used.

- **Converter application logic**: Implemented `_apply_converter_to_demo()` function that:
  - Converts each source media using the specified converter
  - Embeds converted outputs using the target type's embedder
  - Preserves source metadata (category, filename) in converted media
  - Records converter origin with parent demo and converter name

- **API source filtering**: Added `list_converters_for_source()` function and source-type query parameter to `/api/converters` endpoint, allowing clients to filter converters by input media type (e.g., `?source=video`).

- **Importer metadata**: Extended `FolderDatasetImporter` and `HttpArchiveDatasetImporter` with `to_dict()` methods that include `available_converters_by_media_type` mapping, exposing available converters for each media type to the UI.

- **Demo list enhancements**: Updated `/api/dataset/demo-list` to include `available_converters` for each demo, showing which converters can process that demo's media type.

- **Load-demo endpoint**: Extended `/api/dataset/load-demo` to accept optional `converter` parameter in request body, enabling converter application during demo loading.

## Implementation Details

- Converted media uses separate pickle cache keys (`dataset_name__converter_name`) to avoid conflicts with unconverted demos
- Origin tracking distinguishes between "demo" importer and "converter" importer, with nested parent references
- External media directories are excluded from pickle cache when converters are applied (converted media carries its own bytes/strings)
- Comprehensive test coverage for converter registry, API filtering, demo list integration, and end-to-end conversion workflows

https://claude.ai/code/session_015V2fKdgoMT7cgkYpF8VApc