### PR TITLE
Add VideoSceneClipper for automatic scene detection in videos

### DIFF
--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -427,3 +427,162 @@ class TestTextSentenceClipper:
         media = {"id": 1, "type": "paragraph"}
         result = TextSentenceClipper().clip(media)
         assert result == [media]
+
+
+# ---------------------------------------------------------------------------
+# VideoSceneClipper
+# ---------------------------------------------------------------------------
+
+
+class TestVideoSceneClipper:
+    def test_identity(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        c = VideoSceneClipper()
+        assert c.name == "video_scene"
+        assert c.media_type == "video"
+        assert c.threshold == 0.3
+        assert c.min_scene_duration == 1.0
+        assert isinstance(c, MediaClipper)
+
+    def test_custom_params(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        c = VideoSceneClipper(threshold=0.5, min_scene_duration=2.0)
+        assert c.threshold == 0.5
+        assert c.min_scene_duration == 2.0
+
+    def test_rejects_invalid_threshold(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        with pytest.raises(ValueError):
+            VideoSceneClipper(threshold=-0.1)
+        with pytest.raises(ValueError):
+            VideoSceneClipper(threshold=1.1)
+
+    def test_rejects_non_positive_min_scene_duration(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        with pytest.raises(ValueError):
+            VideoSceneClipper(min_scene_duration=0)
+        with pytest.raises(ValueError):
+            VideoSceneClipper(min_scene_duration=-1)
+
+    def test_zero_duration_returns_unchanged(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        media = {"id": 1, "type": "video", "duration": 0}
+        result = VideoSceneClipper().clip(media)
+        assert result == [media]
+
+    def test_no_media_bytes_or_path_returns_unchanged(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        media = {"id": 1, "type": "video", "duration": 10.0}
+        result = VideoSceneClipper().clip(media)
+        assert result == [media]
+
+    def test_to_dict_includes_params(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        c = VideoSceneClipper(threshold=0.4, min_scene_duration=1.5)
+        d = c.to_dict()
+        assert d["name"] == "video_scene"
+        assert d["media_type"] == "video"
+        assert d["threshold"] == 0.4
+        assert d["min_scene_duration"] == 1.5
+
+    def test_detect_scene_boundaries_no_cv2(self, monkeypatch):
+        """When OpenCV is not available, clip returns the media unchanged."""
+        import builtins
+
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "cv2":
+                raise ImportError("no cv2")
+            return real_import(name, *args, **kwargs)
+
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = VideoSceneClipper().clip(media)
+        assert result == [media]
+
+    def test_detect_scene_boundaries_helper_empty(self, monkeypatch):
+        """When _detect_scene_boundaries returns no cuts, media is unchanged."""
+        from vtsearch.media.video import clipper as clipper_mod
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", lambda *a, **kw: [])
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        result = VideoSceneClipper().clip(media)
+        assert result == [media]
+
+    def test_splits_at_detected_boundaries(self, monkeypatch):
+        """When boundaries are found, the clipper produces the right scenes."""
+        from vtsearch.media.video import clipper as clipper_mod
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        # Simulate two scene boundaries at 3.0s and 7.0s in a 10s video.
+        monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", lambda *a, **kw: [3.0, 7.0])
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 10.0}
+        result = VideoSceneClipper().clip(media)
+
+        assert len(result) == 3
+
+        # Scene 0: [0, 3)
+        assert result[0]["clip_start"] == pytest.approx(0.0)
+        assert result[0]["clip_end"] == pytest.approx(3.0)
+        assert result[0]["duration"] == pytest.approx(3.0)
+        assert result[0]["clip_index"] == 0
+        assert result[0]["scene_index"] == 0
+
+        # Scene 1: [3, 7)
+        assert result[1]["clip_start"] == pytest.approx(3.0)
+        assert result[1]["clip_end"] == pytest.approx(7.0)
+        assert result[1]["duration"] == pytest.approx(4.0)
+        assert result[1]["clip_index"] == 1
+        assert result[1]["scene_index"] == 1
+
+        # Scene 2: [7, 10)
+        assert result[2]["clip_start"] == pytest.approx(7.0)
+        assert result[2]["clip_end"] == pytest.approx(10.0)
+        assert result[2]["duration"] == pytest.approx(3.0)
+        assert result[2]["clip_index"] == 2
+        assert result[2]["scene_index"] == 2
+
+    def test_single_boundary_produces_two_scenes(self, monkeypatch):
+        from vtsearch.media.video import clipper as clipper_mod
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", lambda *a, **kw: [5.0])
+        media = {"id": 1, "type": "video", "media_bytes": b"fake", "duration": 8.0}
+        result = VideoSceneClipper().clip(media)
+        assert len(result) == 2
+        assert result[0]["clip_start"] == pytest.approx(0.0)
+        assert result[0]["clip_end"] == pytest.approx(5.0)
+        assert result[1]["clip_start"] == pytest.approx(5.0)
+        assert result[1]["clip_end"] == pytest.approx(8.0)
+
+    def test_media_path_used_when_available(self, monkeypatch, tmp_path):
+        """When media_path exists, it's used instead of writing a temp file."""
+        from vtsearch.media.video import clipper as clipper_mod
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"fake video data")
+
+        paths_seen = []
+
+        def mock_detect(video_path, threshold, min_scene_duration):
+            paths_seen.append(video_path)
+            return [2.0]
+
+        monkeypatch.setattr(clipper_mod, "_detect_scene_boundaries", mock_detect)
+
+        media = {"id": 1, "type": "video", "media_path": str(video_file), "duration": 5.0}
+        result = VideoSceneClipper().clip(media)
+        assert len(result) == 2
+        assert paths_seen[0] == str(video_file)

--- a/vtsearch/media/video/clipper.py
+++ b/vtsearch/media/video/clipper.py
@@ -1,4 +1,4 @@
-"""Video clippers — tile or pass-through video media."""
+"""Video clippers — tile, scene-detect, or pass-through video media."""
 
 from __future__ import annotations
 
@@ -85,4 +85,193 @@ class VideoTilingClipper(MediaClipper):
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         d["duration"] = self._duration
+        return d
+
+
+def _detect_scene_boundaries(
+    video_path: str,
+    threshold: float,
+    min_scene_duration: float,
+) -> list[float]:
+    """Return a list of scene-boundary timestamps (in seconds) for *video_path*.
+
+    Scene changes are detected by comparing consecutive frames using
+    normalised histogram correlation.  When the correlation drops below
+    *threshold* (i.e. the frames look very different), a scene boundary is
+    recorded — provided at least *min_scene_duration* seconds have elapsed
+    since the previous boundary.
+
+    The function samples one frame per second to keep the cost manageable
+    for long videos.
+
+    Returns a sorted list of boundary timestamps **not** including 0 or
+    the video end.  An empty list means no scene changes were detected.
+    """
+    import cv2  # noqa: PLC0415
+    import numpy as np  # noqa: PLC0415
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        return []
+
+    try:
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        if fps <= 0:
+            return []
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if frame_count <= 0:
+            return []
+        total_duration = frame_count / fps
+
+        # Sample roughly one frame per second.
+        sample_interval = max(1, int(round(fps)))
+
+        prev_hist = None
+        boundaries: list[float] = []
+        last_boundary_time = 0.0
+
+        frame_idx = 0
+        while True:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            # Convert to HSV and compute a normalised hue-saturation histogram.
+            hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+            hist = cv2.calcHist([hsv], [0, 1], None, [50, 60], [0, 180, 0, 256])
+            cv2.normalize(hist, hist)
+
+            if prev_hist is not None:
+                corr = cv2.compareHist(prev_hist, hist, cv2.HISTCMP_CORREL)
+                current_time = frame_idx / fps
+                if corr < threshold and (current_time - last_boundary_time) >= min_scene_duration:
+                    boundaries.append(round(current_time, 6))
+                    last_boundary_time = current_time
+
+            prev_hist = hist
+            frame_idx += sample_interval
+            if frame_idx >= frame_count:
+                break
+
+        # Drop any boundary that would create a trailing scene shorter than
+        # min_scene_duration.
+        if boundaries and (total_duration - boundaries[-1]) < min_scene_duration:
+            boundaries.pop()
+
+        return boundaries
+    finally:
+        cap.release()
+
+
+class VideoSceneClipper(MediaClipper):
+    """Split a video into clips at detected scene boundaries.
+
+    Scene changes are found by comparing colour histograms of sampled
+    frames (one per second).  When consecutive frames differ significantly
+    (histogram correlation below *threshold*), a scene boundary is placed.
+
+    Like :class:`VideoTilingClipper`, this clipper records boundaries as
+    metadata (``clip_start``, ``clip_end``, ``clip_index``, ``scene_index``)
+    without transcoding the underlying bytes — downstream consumers use
+    these fields to seek or trim on playback.
+
+    Parameters
+    ----------
+    threshold : float
+        Histogram correlation threshold.  Lower values require a more
+        dramatic visual change to trigger a scene break.  Defaults to 0.3.
+    min_scene_duration : float
+        Minimum duration (seconds) for a scene.  Boundaries that would
+        produce shorter scenes are suppressed.  Defaults to 1.0.
+
+    If OpenCV is not installed, or if no scene boundaries are found, the
+    media is returned unchanged (single-element list).
+    """
+
+    def __init__(self, threshold: float = 0.3, min_scene_duration: float = 1.0) -> None:
+        if threshold < 0 or threshold > 1:
+            raise ValueError("threshold must be between 0 and 1")
+        if min_scene_duration <= 0:
+            raise ValueError("min_scene_duration must be positive")
+        self._threshold = threshold
+        self._min_scene_duration = min_scene_duration
+
+    @property
+    def name(self) -> str:
+        return "video_scene"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    @property
+    def min_scene_duration(self) -> float:
+        return self._min_scene_duration
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        import os  # noqa: PLC0415
+        import tempfile  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        total = media.get("duration", 0)
+        if total <= 0:
+            return [media]
+
+        # Resolve a file path that OpenCV can read.
+        media_path = media.get("media_path")
+        media_bytes = media.get("media_bytes")
+        tmp_file = None
+
+        if media_path and Path(media_path).exists():
+            video_path = str(media_path)
+        elif media_bytes:
+            filename = media.get("filename", "video.mp4")
+            ext = Path(filename).suffix or ".mp4"
+            tmp_file = tempfile.NamedTemporaryFile(suffix=ext, delete=False)
+            tmp_file.write(media_bytes)
+            tmp_file.close()
+            video_path = tmp_file.name
+        else:
+            return [media]
+
+        try:
+            try:
+                boundaries = _detect_scene_boundaries(
+                    video_path,
+                    self._threshold,
+                    self._min_scene_duration,
+                )
+            except ImportError:
+                return [media]
+
+            if not boundaries:
+                return [media]
+
+            # Build scene intervals: [0, b1), [b1, b2), ..., [bN, total)
+            starts = [0.0] + boundaries
+            ends = boundaries + [total]
+
+            results: list[dict[str, Any]] = []
+            for idx, (t0, t1) in enumerate(zip(starts, ends)):
+                scene = dict(media)
+                scene["duration"] = round(t1 - t0, 6)
+                scene["clip_index"] = idx
+                scene["scene_index"] = idx
+                scene["clip_start"] = round(t0, 6)
+                scene["clip_end"] = round(t1, 6)
+                results.append(scene)
+            return results
+        finally:
+            if tmp_file is not None:
+                os.unlink(tmp_file.name)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["threshold"] = self._threshold
+        d["min_scene_duration"] = self._min_scene_duration
         return d


### PR DESCRIPTION
## Summary
This PR adds automatic scene detection capabilities to the video clipping module. A new `VideoSceneClipper` class detects scene boundaries by analyzing color histogram differences between sampled video frames, allowing videos to be automatically split into clips at detected scene changes.

## Key Changes
- **New `_detect_scene_boundaries()` function**: Analyzes video frames using OpenCV to detect scene boundaries via histogram correlation. Samples one frame per second for efficiency and respects minimum scene duration constraints.
- **New `VideoSceneClipper` class**: A `MediaClipper` implementation that:
  - Detects scene boundaries in videos using the helper function
  - Splits videos into clips at detected boundaries without transcoding
  - Records clip metadata (`clip_start`, `clip_end`, `clip_index`, `scene_index`) for downstream consumers
  - Supports configurable `threshold` (histogram correlation sensitivity, 0–1) and `min_scene_duration` (minimum scene length in seconds)
  - Gracefully handles missing OpenCV or missing scene boundaries by returning media unchanged
  - Handles both file-based (`media_path`) and byte-based (`media_bytes`) video inputs
- **Comprehensive test coverage**: 12 new tests covering parameter validation, edge cases (zero duration, missing media), OpenCV availability, boundary detection, and file path handling.
- **Updated module docstring**: Reflects the new scene-detection capability.

## Implementation Details
- Scene detection uses HSV color space and normalized hue-saturation histograms for robust change detection
- Temporary files are created for byte-based media and cleaned up after processing
- Boundaries are validated to prevent trailing scenes shorter than `min_scene_duration`
- All timestamps are rounded to 6 decimal places for consistency
- OpenCV import is deferred to avoid hard dependency; graceful fallback if unavailable

https://claude.ai/code/session_01PoJ1gX8U3SUMCWD5N1J5LB