### PR TITLE
Disable Angular CLI analytics in production build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "build:prod": "ng build --configuration production",
+    "build:prod": "NG_CLI_ANALYTICS=false ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Summary
Disable Angular CLI analytics collection during production builds to improve build performance and reduce unnecessary telemetry data transmission.

## Key Changes
- Added `NG_CLI_ANALYTICS=false` environment variable to the `build:prod` npm script to opt out of Angular CLI analytics during production builds

## Implementation Details
The change sets the `NG_CLI_ANALYTICS` environment variable to `false` before executing the production build command. This prevents the Angular CLI from collecting and sending analytics data during the build process, which can slightly improve build times and avoid any potential network overhead from telemetry collection.

https://claude.ai/code/session_01R3zo719tMqgMiCvhJaKnZN