### PR TITLE
Implement label export modal in right panel

### DIFF
--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -41,6 +41,10 @@
   </div>
 </aside>
 
+@if (showLabelExport) {
+  <vt-label-exporter-modal (closed)="showLabelExport = false" (exportComplete)="showLabelExport = false" />
+}
+
 @if (showDetectorExport) {
   <vt-detector-export-modal (closed)="showDetectorExport = false" (exported)="showDetectorExport = false" />
 }

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -11,6 +11,7 @@ import { LabelSortComponent, LabelSortMode } from './label-sort/label-sort.compo
 import { LabelListComponent } from './label-list/label-list.component';
 import { DetectorContextBarComponent } from './detector-context-bar/detector-context-bar.component';
 import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
+import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
 
 export interface TrainModeContext {
   model: { name: string; registry_id?: string };
@@ -25,6 +26,7 @@ export interface TrainModeContext {
     LabelListComponent,
     DetectorContextBarComponent,
     DetectorExportModalComponent,
+    LabelExporterModalComponent,
   ],
   templateUrl: './right-panel.component.html',
   styleUrl: './right-panel.component.scss',
@@ -40,6 +42,7 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   learnedScores: Record<string, number> = {};
   sortMode: LabelSortMode = 'time-desc';
   showThumbnails = true;
+  showLabelExport = false;
   showDetectorExport = false;
 
   private destroy$ = new Subject<void>();
@@ -76,7 +79,7 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   }
 
   onExportLabels(): void {
-    this.dialog.alert('Label export not yet available in the Angular frontend.', 'info');
+    this.showLabelExport = true;
   }
 
   onExportDetector(): void {


### PR DESCRIPTION
## Summary
This PR implements the label export functionality in the Angular frontend by integrating a new `LabelExporterModalComponent` into the right panel component, replacing the previous placeholder alert dialog.

## Key Changes
- Added import and declaration of `LabelExporterModalComponent` in the right panel component
- Introduced `showLabelExport` boolean flag to control modal visibility
- Updated `onExportLabels()` method to display the modal instead of showing an info alert
- Added conditional rendering of the label exporter modal in the template with proper event bindings for `closed` and `exportComplete` events

## Implementation Details
- The modal follows the same pattern as the existing `DetectorExportModalComponent` for consistency
- Both `closed` and `exportComplete` events close the modal, allowing users to dismiss it either by canceling or completing the export
- The modal is conditionally rendered using Angular's `@if` control flow syntax

https://claude.ai/code/session_015rMAkWZuRpmkhXo7SD9X6x