### PR TITLE
Center-align numeric and action columns in dashboard tables

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -26,14 +26,14 @@
           <thead>
             <tr>
               <th (click)="sortDatasets('name')" class="sortable" title="Dataset display name (click to sort)">Name<span class="sort-indicator" [class.active]="isDatasetSortActive('name')">{{ datasetSortIndicator('name') }}</span></th>
-              <th (click)="sortDatasets('media_type')" class="sortable" title="Media type: audio, image, text, video, or document (click to sort)">Type<span class="sort-indicator" [class.active]="isDatasetSortActive('media_type')">{{ datasetSortIndicator('media_type') }}</span></th>
-              <th (click)="sortDatasets('num_items')" class="sortable" title="Number of media items in the dataset (click to sort)">Items<span class="sort-indicator" [class.active]="isDatasetSortActive('num_items')">{{ datasetSortIndicator('num_items') }}</span></th>
-              <th (click)="sortDatasets('num_dupes')" class="sortable" title="Number of duplicate items collapsed (click to sort)">Dupes<span class="sort-indicator" [class.active]="isDatasetSortActive('num_dupes')">{{ datasetSortIndicator('num_dupes') }}</span></th>
-              <th (click)="sortDatasets('created_at')" class="sortable" title="When the dataset was first imported (click to sort)">Created<span class="sort-indicator" [class.active]="isDatasetSortActive('created_at')">{{ datasetSortIndicator('created_at') }}</span></th>
+              <th (click)="sortDatasets('media_type')" class="sortable text-center" title="Media type: audio, image, text, video, or document (click to sort)">Type<span class="sort-indicator" [class.active]="isDatasetSortActive('media_type')">{{ datasetSortIndicator('media_type') }}</span></th>
+              <th (click)="sortDatasets('num_items')" class="sortable text-center" title="Number of media items in the dataset (click to sort)">Items<span class="sort-indicator" [class.active]="isDatasetSortActive('num_items')">{{ datasetSortIndicator('num_items') }}</span></th>
+              <th (click)="sortDatasets('num_dupes')" class="sortable text-center" title="Number of duplicate items collapsed (click to sort)">Dupes<span class="sort-indicator" [class.active]="isDatasetSortActive('num_dupes')">{{ datasetSortIndicator('num_dupes') }}</span></th>
+              <th (click)="sortDatasets('created_at')" class="sortable text-center" title="When the dataset was first imported (click to sort)">Created<span class="sort-indicator" [class.active]="isDatasetSortActive('created_at')">{{ datasetSortIndicator('created_at') }}</span></th>
               <th (click)="sortDatasets('origin')" class="sortable" title="Source or provenance of the dataset (click to sort)">Origin<span class="sort-indicator" [class.active]="isDatasetSortActive('origin')">{{ datasetSortIndicator('origin') }}</span></th>
-              <th (click)="sortDatasets('clipper')" class="sortable" title="MediaClipper used at creation (click to sort)">Clipper<span class="sort-indicator" [class.active]="isDatasetSortActive('clipper')">{{ datasetSortIndicator('clipper') }}</span></th>
-              <th title="Whether this dataset is currently loaded into memory">Loaded</th>
-              <th title="Available operations for this dataset">Actions</th>
+              <th (click)="sortDatasets('clipper')" class="sortable text-center" title="MediaClipper used at creation (click to sort)">Clipper<span class="sort-indicator" [class.active]="isDatasetSortActive('clipper')">{{ datasetSortIndicator('clipper') }}</span></th>
+              <th class="text-center" title="Whether this dataset is currently loaded into memory">Loaded</th>
+              <th class="text-center" title="Available operations for this dataset">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -69,12 +69,12 @@
           <thead>
             <tr>
               <th (click)="sortModels('name')" class="sortable" title="Model display name (click to sort)">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
-              <th (click)="sortModels('media_type')" class="sortable" title="Media type this model operates on (click to sort)">Type<span class="sort-indicator" [class.active]="isModelSortActive('media_type')">{{ modelSortIndicator('media_type') }}</span></th>
-              <th (click)="sortModels('num_training')" class="sortable" title="Number of labeled training examples (click to sort)"># Training<span class="sort-indicator" [class.active]="isModelSortActive('num_training')">{{ modelSortIndicator('num_training') }}</span></th>
-              <th title="Is this Model one we can load into the Labeling interface and improve?">Trainable</th>
-              <th (click)="sortModels('last_trained_at')" class="sortable" title="When the model was last trained (click to sort)">Last Trained<span class="sort-indicator" [class.active]="isModelSortActive('last_trained_at')">{{ modelSortIndicator('last_trained_at') }}</span></th>
-              <th (click)="sortModels('created_at')" class="sortable" title="When the model was created (click to sort)">Created<span class="sort-indicator" [class.active]="isModelSortActive('created_at')">{{ modelSortIndicator('created_at') }}</span></th>
-              <th title="Available operations for this model">Actions</th>
+              <th (click)="sortModels('media_type')" class="sortable text-center" title="Media type this model operates on (click to sort)">Type<span class="sort-indicator" [class.active]="isModelSortActive('media_type')">{{ modelSortIndicator('media_type') }}</span></th>
+              <th (click)="sortModels('num_training')" class="sortable text-center" title="Number of labeled training examples (click to sort)"># Training<span class="sort-indicator" [class.active]="isModelSortActive('num_training')">{{ modelSortIndicator('num_training') }}</span></th>
+              <th class="text-center" title="Is this Model one we can load into the Labeling interface and improve?">Trainable</th>
+              <th (click)="sortModels('last_trained_at')" class="sortable text-center" title="When the model was last trained (click to sort)">Last Trained<span class="sort-indicator" [class.active]="isModelSortActive('last_trained_at')">{{ modelSortIndicator('last_trained_at') }}</span></th>
+              <th (click)="sortModels('created_at')" class="sortable text-center" title="When the model was created (click to sort)">Created<span class="sort-indicator" [class.active]="isModelSortActive('created_at')">{{ modelSortIndicator('created_at') }}</span></th>
+              <th class="text-center" title="Available operations for this model">Actions</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -79,6 +79,10 @@
     text-align: left;
     border-bottom: 1px solid var(--border-subtle);
     white-space: nowrap;
+
+    &.text-center {
+      text-align: center;
+    }
   }
 
   th {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -15,7 +15,7 @@
     </span>
   }
 </td>
-<td class="type-cell">
+<td class="type-cell text-center">
   @switch (dataset.media_type) {
     @case ('audio') {
       <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
@@ -35,19 +35,19 @@
   }
   {{ capitalizeType(dataset.media_type) }}
 </td>
-<td>{{ dataset.num_items ?? '-' }}</td>
-<td>{{ dataset.num_dupes ?? 0 }}</td>
-<td>{{ formatDate(dataset.created_at) }}</td>
+<td class="text-center">{{ dataset.num_items ?? '-' }}</td>
+<td class="text-center">{{ dataset.num_dupes ?? 0 }}</td>
+<td class="text-center">{{ formatDate(dataset.created_at) }}</td>
 <td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
-<td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
-<td>
+<td class="clipper-cell text-center">{{ dataset.clipper || '-' }}</td>
+<td class="text-center">
   @if (dataset.loaded) {
     <span class="check" aria-label="Loaded">&#10003;</span>
   } @else {
     <span class="dim">-</span>
   }
 </td>
-<td class="actions-cell">
+<td class="actions-cell text-center">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -21,6 +21,7 @@
 .actions-cell {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
 }
 
@@ -48,9 +49,14 @@
   font-size: 0.83rem;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .type-cell {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
 }
 

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -14,7 +14,7 @@
     </span>
   }
 </td>
-<td class="type-cell">
+<td class="type-cell text-center">
   @switch (model.media_type) {
     @case ('audio') {
       <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
@@ -34,17 +34,17 @@
   }
   {{ capitalizeType(model.media_type) }}
 </td>
-<td>{{ model.num_training ?? 0 }}</td>
-<td>
+<td class="text-center">{{ model.num_training ?? 0 }}</td>
+<td class="text-center">
   @if (model.trainable) {
     <span class="check" aria-label="Trainable">&#10003;</span>
   } @else {
     <span class="dim">-</span>
   }
 </td>
-<td>{{ formatDate(model.last_trained_at) }}</td>
-<td>{{ formatDate(model.created_at) }}</td>
-<td class="actions-cell">
+<td class="text-center">{{ formatDate(model.last_trained_at) }}</td>
+<td class="text-center">{{ formatDate(model.created_at) }}</td>
+<td class="actions-cell text-center">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -21,6 +21,7 @@
 .actions-cell {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
 }
 
@@ -48,9 +49,14 @@
   font-size: 0.83rem;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .type-cell {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
 }
 


### PR DESCRIPTION
## Summary
This PR improves the visual alignment and readability of the dashboard tables by center-aligning numeric columns, status indicators, and action buttons across both the Datasets and Models tables.

## Key Changes
- Added `text-center` class to table headers and cells for numeric data (Type, Items, Dupes, Created, Clipper, # Training, Last Trained, Trainable, Actions columns)
- Updated dashboard component template to apply `text-center` class to relevant `<th>` elements in both dataset and model tables
- Updated dataset-card and model-card components to apply `text-center` class to corresponding `<td>` elements
- Added `.text-center { text-align: center; }` CSS rule to both card component stylesheets
- Enhanced `.type-cell` and `.actions-cell` flexbox layouts with `justify-content: center` for proper centering of icon and button content
- Added `.text-center` style rule to dashboard component stylesheet for table header alignment

## Implementation Details
- The changes maintain consistency across both the Datasets and Models tables
- Numeric columns (Items, Dupes, # Training) and date columns (Created, Last Trained) are now center-aligned for better visual hierarchy
- Status indicator columns (Type, Trainable, Loaded) and action columns are center-aligned for improved scannability
- Flexbox centering ensures icons and buttons within cells are properly positioned
- All changes are CSS-based with no modifications to component logic or data handling

https://claude.ai/code/session_018h9fLKRL38KMoXaCqHszvZ