### PR TITLE
Add embedder selection support to dataset import workflow

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -32,6 +32,7 @@
               <th (click)="sortDatasets('created_at')" class="sortable" title="When the dataset was first imported (click to sort)">Created<span class="sort-indicator" [class.active]="isDatasetSortActive('created_at')">{{ datasetSortIndicator('created_at') }}</span></th>
               <th (click)="sortDatasets('origin')" class="sortable" title="Source or provenance of the dataset (click to sort)">Origin<span class="sort-indicator" [class.active]="isDatasetSortActive('origin')">{{ datasetSortIndicator('origin') }}</span></th>
               <th (click)="sortDatasets('clipper')" class="sortable" title="MediaClipper used at creation (click to sort)">Clipper<span class="sort-indicator" [class.active]="isDatasetSortActive('clipper')">{{ datasetSortIndicator('clipper') }}</span></th>
+              <th (click)="sortDatasets('embedder')" class="sortable" title="MediaEmbedder used for embedding (click to sort)">Embedder<span class="sort-indicator" [class.active]="isDatasetSortActive('embedder')">{{ datasetSortIndicator('embedder') }}</span></th>
               <th title="Whether this dataset is currently loaded into memory">Loaded</th>
               <th title="Available operations for this dataset">Actions</th>
             </tr>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -40,6 +40,7 @@
 <td>{{ formatDate(dataset.created_at) }}</td>
 <td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
 <td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
+<td class="embedder-cell">{{ dataset.embedder || '-' }}</td>
 <td>
   @if (dataset.loaded) {
     <span class="check" aria-label="Loaded">&#10003;</span>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -133,6 +133,21 @@
         <p class="info-text">This importer requires no additional configuration.</p>
       }
 
+      @if (availableEmbedders.length > 1) {
+        <div class="form-group">
+          <label class="form-label" for="field-embedder">Embedder</label>
+          <select
+            id="field-embedder"
+            class="form-select"
+            [(ngModel)]="selectedEmbedder"
+          >
+            @for (embedder of availableEmbedders; track embedder.name) {
+              <option [value]="embedder.name">{{ embedder.name }}</option>
+            }
+          </select>
+        </div>
+      }
+
       @if (availableClippers.length > 1) {
         <div class="form-group">
           <label class="form-label" for="field-clipper">Clipper</label>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
-import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo } from '../../../models/api.models';
+import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo, EmbedderInfo } from '../../../models/api.models';
 
 type ModalView = 'picker' | 'form' | 'demo';
 
@@ -30,6 +30,10 @@ export class DatasetImporterModalComponent implements OnInit {
   // Clipper state
   availableClippers: ClipperInfo[] = [];
   selectedClipper = '';
+
+  // Embedder state
+  availableEmbedders: EmbedderInfo[] = [];
+  selectedEmbedder = '';
 
   // Demo picker state
   demos: DemoDataset[] = [];
@@ -58,6 +62,8 @@ export class DatasetImporterModalComponent implements OnInit {
     this.error = '';
     this.selectedClipper = '';
     this.availableClippers = [];
+    this.selectedEmbedder = '';
+    this.availableEmbedders = [];
 
     // Pre-populate defaults
     if (importer.fields) {
@@ -68,10 +74,12 @@ export class DatasetImporterModalComponent implements OnInit {
       }
     }
 
-    // Load clippers for the default media type
+    // Load clippers and embedders for the default media type
     const mediaTypeField = importer.fields?.find((f) => f.key === 'media_type');
     if (mediaTypeField) {
-      this.loadClippers(this.formValues['media_type'] || mediaTypeField.default || '');
+      const defaultType = this.formValues['media_type'] || mediaTypeField.default || '';
+      this.loadClippers(defaultType);
+      this.loadEmbedders(defaultType);
     }
 
     this.view = 'form';
@@ -80,6 +88,7 @@ export class DatasetImporterModalComponent implements OnInit {
   onMediaTypeChange(mediaType: string): void {
     this.formValues['media_type'] = mediaType;
     this.loadClippers(mediaType);
+    this.loadEmbedders(mediaType);
   }
 
   private loadClippers(mediaType: string): void {
@@ -93,6 +102,21 @@ export class DatasetImporterModalComponent implements OnInit {
         this.availableClippers = clippers;
         // Default to the first clipper (the default/null clipper)
         this.selectedClipper = clippers.length > 0 ? clippers[0].name : '';
+      },
+    });
+  }
+
+  private loadEmbedders(mediaType: string): void {
+    if (!mediaType) {
+      this.availableEmbedders = [];
+      this.selectedEmbedder = '';
+      return;
+    }
+    this.datasetsApi.getEmbedders(mediaType).subscribe({
+      next: (embedders) => {
+        this.availableEmbedders = embedders;
+        // Default to the first embedder
+        this.selectedEmbedder = embedders.length > 0 ? embedders[0].name : '';
       },
     });
   }
@@ -226,10 +250,13 @@ export class DatasetImporterModalComponent implements OnInit {
     this.submitting = true;
     this.error = '';
 
-    // Include clipper in form values if one is selected
+    // Include clipper and embedder in form values if selected
     const submitValues = { ...this.formValues };
     if (this.selectedClipper) {
       submitValues['clipper'] = this.selectedClipper;
+    }
+    if (this.selectedEmbedder) {
+      submitValues['embedder'] = this.selectedEmbedder;
     }
 
     // If there's a file field, use loadFile; otherwise runImporter

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -13,6 +13,8 @@ import {
   ClippersResponse,
   ConverterInfo,
   ConvertersResponse,
+  EmbedderInfo,
+  EmbeddersResponse,
   OkResponse,
 } from '../models/api.models';
 
@@ -54,6 +56,16 @@ export class DatasetsApiService {
     );
   }
 
+  getEmbedders(mediaType?: string): Observable<EmbedderInfo[]> {
+    const params: Record<string, string> = {};
+    if (mediaType) {
+      params['media_type'] = mediaType;
+    }
+    return this.http.get<EmbeddersResponse>('/api/embedders', { params }).pipe(
+      map((res) => res.embedders),
+    );
+  }
+
   getConverters(target?: string): Observable<ConverterInfo[]> {
     const params: Record<string, string> = {};
     if (target) {
@@ -72,8 +84,8 @@ export class DatasetsApiService {
     return this.http.post(`/api/dataset/import/${importerName}`, params);
   }
 
-  loadDemo(name: string): Observable<unknown> {
-    return this.http.post('/api/dataset/load-demo', { name });
+  loadDemo(name: string, params?: Record<string, string>): Observable<unknown> {
+    return this.http.post('/api/dataset/load-demo', { name, ...params });
   }
 
   loadFile(file: File): Observable<unknown> {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -296,6 +296,93 @@ class TestDashboardDatasetDupesColumn:
         assert ds["num_dupes"] == 3
 
 
+class TestDashboardDatasetEmbedderColumn:
+    """Tests that the dataset registry API returns the embedder field."""
+
+    def test_dataset_registry_includes_embedder(self, client):
+        """Registered datasets include an embedder string."""
+        register_dataset(
+            name="emb-ds", media_type="audio", num_items=10,
+            pkl_path="/tmp/emb.pkl", embedder="clap",
+        )
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert "embedder" in ds
+        assert ds["embedder"] == "clap"
+
+    def test_dataset_registry_embedder_defaults_to_empty(self, client):
+        """Datasets registered without embedder default to empty string."""
+        register_dataset(name="no-emb", media_type="audio", num_items=5, pkl_path="/tmp/noemb.pkl")
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert ds["embedder"] == ""
+
+    def test_dataset_registry_stores_explicit_embedder(self, client):
+        """Datasets registered with explicit embedder retain the value."""
+        register_dataset(
+            name="clip-ds", media_type="image", num_items=20,
+            pkl_path="/tmp/clipemb.pkl", embedder="clip",
+        )
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert ds["embedder"] == "clip"
+
+
+class TestEmbeddersApiEndpoint:
+    """Tests for the /api/embedders endpoint with optional media_type filtering."""
+
+    def test_list_all_embedders(self, client):
+        """GET /api/embedders returns all registered embedders."""
+        resp = client.get("/api/embedders")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "embedders" in data
+        names = [e["name"] for e in data["embedders"]]
+        assert "clap" in names
+        assert "clip" in names
+        assert "e5" in names
+        assert "xclip" in names
+
+    def test_filter_by_type_id(self, client):
+        """GET /api/embedders?media_type=audio returns only audio embedders."""
+        resp = client.get("/api/embedders?media_type=audio")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        embedders = data["embedders"]
+        assert all(e["media_type_id"] == "audio" for e in embedders)
+        names = [e["name"] for e in embedders]
+        assert "clap" in names
+        assert "clip" not in names
+
+    def test_filter_by_folder_name(self, client):
+        """GET /api/embedders?media_type=images returns image embedders."""
+        resp = client.get("/api/embedders?media_type=images")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        embedders = data["embedders"]
+        assert all(e["media_type_id"] == "image" for e in embedders)
+        names = [e["name"] for e in embedders]
+        assert "clip" in names
+
+    def test_filter_unknown_type_returns_empty(self, client):
+        """GET /api/embedders?media_type=nonexistent returns empty list."""
+        resp = client.get("/api/embedders?media_type=nonexistent")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["embedders"] == []
+
+    def test_embedder_dict_has_required_keys(self, client):
+        """Each embedder dict has name and media_type_id keys."""
+        resp = client.get("/api/embedders")
+        data = resp.get_json()
+        for emb in data["embedders"]:
+            assert "name" in emb
+            assert "media_type_id" in emb
+
+
 class TestDashboardModelRegistryColumns:
     """Tests that the model registry API returns fields needed for new columns."""
 

--- a/vtsearch/datasets/registry.py
+++ b/vtsearch/datasets/registry.py
@@ -109,6 +109,7 @@ def register_dataset(
     source: dict[str, Any] | None = None,
     num_dupes: int = 0,
     clipper: str = "",
+    embedder: str = "",
 ) -> dict[str, Any]:
     """Add a new dataset to the registry and persist.
 
@@ -126,6 +127,7 @@ def register_dataset(
         "origin": origin,
         "source": source,
         "clipper": clipper,
+        "embedder": embedder,
         "created_at": time.time(),
     }
     with _lock:

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -81,10 +81,28 @@ def media_types_list():
 
 @datasets_bp.route("/api/embedders")
 def embedders_list():
-    """Return all registered embedders with their metadata."""
-    from vtsearch.media import all_embedders_dict
+    """Return all registered embedders, optionally filtered by media type.
 
-    return jsonify({"embedders": all_embedders_dict()})
+    Query parameters:
+        media_type: A ``type_id`` (e.g. ``"image"``) or ``folder_import_name``
+            (e.g. ``"images"``).  When provided, only embedders whose
+            ``media_type_id`` matches are returned.
+    """
+    from vtsearch.media import all_embedders_dict, embedders_for_type, get_by_folder_name
+
+    media_type = request.args.get("media_type", "").strip()
+    if media_type:
+        # Accept both type_id ("image") and folder_import_name ("images").
+        try:
+            mt = get_by_folder_name(media_type)
+            media_type = mt.type_id
+        except KeyError:
+            pass  # assume it is already a type_id
+        embedders = [e.to_dict() for e in embedders_for_type(media_type)]
+    else:
+        embedders = all_embedders_dict()
+
+    return jsonify({"embedders": embedders})
 
 
 # ---------------------------------------------------------------------------
@@ -459,6 +477,14 @@ def import_dataset(importer_name: str):
     if clipper_val:
         field_values["clipper"] = clipper_val
 
+    # Pass through the optional "embedder" key for embedder selection.
+    if file_keys:
+        embedder_val = request.form.get("embedder", "")
+    else:
+        embedder_val = (request.get_json(force=True) or {}).get("embedder", "")
+    if embedder_val:
+        field_values["embedder"] = embedder_val
+
     _run_importer_in_background(importer, field_values)
     return jsonify({"ok": True, "message": "Loading started"})
 
@@ -500,6 +526,7 @@ def load_demo_dataset_route():
         demo_origin,
         name=dataset_name,
         clipper=clipper_name,
+        embedder=embedder_name,
     )
 
     return jsonify({"ok": True, "message": "Loading started"})
@@ -605,6 +632,7 @@ def list_registered_datasets():
             entry["num_dupes"] = get_dupe_count()
         else:
             entry.setdefault("num_dupes", 0)
+        entry.setdefault("embedder", "")
     return jsonify({"datasets": entries})
 
 

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -166,6 +166,7 @@ def _auto_register_dataset(
     origin_str: str = "unknown",
     source: dict | None = None,
     clipper: str = "",
+    embedder: str = "",
 ) -> None:
     """Save the current medias as a pkl and register in the dataset registry.
 
@@ -180,6 +181,10 @@ def _auto_register_dataset(
     first = next(iter(snap.values()))
     media_type = first.get("type", "audio")
     num_items = len(snap)
+
+    # Derive embedder from medias if not explicitly provided
+    if not embedder:
+        embedder = first.get("embedder", "")
 
     # Derive name from display-name override, origin, or fallback
     if not name:
@@ -207,11 +212,14 @@ def _auto_register_dataset(
         origin=origin_str,
         source=source,
         clipper=clipper,
+        embedder=embedder,
     )
     _reg_set_loaded(entry["id"])
 
 
-def _run_origin_load_in_background(load_fn, origin: dict, *, name: str = "", clipper: str = "") -> None:
+def _run_origin_load_in_background(
+    load_fn, origin: dict, *, name: str = "", clipper: str = "", embedder: str = "",
+) -> None:
     """Run a dataset load in a background thread with standard error handling.
 
     *load_fn* is called after ``clear_dataset()`` / ``gc.collect()`` and should
@@ -230,6 +238,9 @@ def _run_origin_load_in_background(load_fn, origin: dict, *, name: str = "", cli
     clipper:
         Name of the clipper to apply after loading.  Empty string means
         no clipping.
+    embedder:
+        Name of the embedder used.  When empty, derived from the medias
+        at registration time.
     """
 
     # Set progress to "loading" synchronously so the frontend never sees a
@@ -258,6 +269,7 @@ def _run_origin_load_in_background(load_fn, origin: dict, *, name: str = "", cli
                 origin_str=origin_str,
                 source=origin,
                 clipper=clipper,
+                embedder=embedder,
             )
             _load_embedder_for_clips()
         except MemoryError:
@@ -284,11 +296,13 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
     """Start *importer*.run() in a daemon thread after clearing the dataset."""
     origin = importer.build_origin(field_values)
     clipper_name = field_values.pop("clipper", "")
+    embedder_name = field_values.get("embedder", "")
     _run_origin_load_in_background(
         lambda: importer.run(field_values, medias),
         origin,
         name=importer.display_name,
         clipper=clipper_name,
+        embedder=embedder_name,
     )
 
 


### PR DESCRIPTION
## Summary
This PR adds embedder selection functionality to the dataset import workflow, allowing users to choose which embedder to use when importing datasets. It mirrors the existing clipper selection pattern and includes backend support for storing and retrieving embedder metadata.

## Key Changes

### Backend (Python)
- **`vtsearch/routes/datasets.py`**: Enhanced `/api/embedders` endpoint to support optional `media_type` filtering (accepts both `type_id` and `folder_import_name` formats)
- **`vtsearch/routes/datasets.py`**: Modified `import_dataset()` to extract and pass through the `embedder` parameter from request data
- **`vtsearch/routes/datasets.py`**: Updated `load_demo_dataset_route()` to accept and forward `embedder_name` parameter
- **`vtsearch/routes/datasets.py`**: Added `embedder` field defaulting to empty string in `list_registered_datasets()` response
- **`vtsearch/datasets/registry.py`**: Added `embedder` parameter to `register_dataset()` function
- **`vtsearch/routes/datasets_loading.py`**: 
  - Added `embedder` parameter to `_auto_register_dataset()` with logic to derive from media if not explicitly provided
  - Added `embedder` parameter to `_run_origin_load_in_background()` with documentation
  - Updated `_run_importer_in_background()` to extract and pass embedder selection

### Frontend (Angular)
- **`dataset-importer-modal.component.ts`**: 
  - Added `availableEmbedders` and `selectedEmbedder` state properties
  - Implemented `loadEmbedders()` method to fetch embedders for selected media type
  - Updated form initialization and media type change handler to load embedders
  - Modified form submission to include selected embedder in request payload
- **`dataset-importer-modal.component.html`**: Added embedder selection dropdown (shown when multiple embedders available)
- **`datasets-api.service.ts`**: 
  - Added `getEmbedders()` method with optional media type filtering
  - Updated `loadDemo()` signature to accept optional parameters object
- **`dashboard.component.html` & `dataset-card.component.html`**: Added embedder column to dataset registry table display

### Tests
- **`tests/test_dashboard.py`**: Added comprehensive test suite:
  - `TestDashboardDatasetEmbedderColumn`: Tests for embedder field in dataset registry (inclusion, defaults, explicit values)
  - `TestEmbeddersApiEndpoint`: Tests for `/api/embedders` endpoint (listing all, filtering by media type, handling unknown types, required fields)

## Implementation Details
- Embedder selection follows the same UX pattern as clipper selection (dropdown shown only when multiple options available)
- Embedder defaults to empty string if not provided, with optional derivation from media metadata at registration time
- The `/api/embedders` endpoint supports flexible media type filtering to handle both internal type IDs and user-facing folder names
- Embedder metadata is persisted in the dataset registry and displayed in the dashboard table

https://claude.ai/code/session_01SsG3oFaSmD9LyaZ5KXXKYQ