### PR TITLE
Skip stability recording when training data hasn't changed

### DIFF
--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -377,3 +377,71 @@ class TestStableIndicatorThresholds:
         result = _compute_stable_status(good=5, bad=5, total=10)
         # Only 4 real entries (indices 1, 2, 6, 7) → yellow
         assert result["status"] == "yellow", "Gap entries (None) should be excluded, leaving only 4 real entries"
+
+
+class TestStabilitySkipsUnchangedModel:
+    """Stability should not be recorded when the training data hasn't changed."""
+
+    def test_unchanged_training_data_skips_stability(self, client):
+        """When good/bad IDs don't change between steps, stability should be None."""
+        from vtsearch.models.progress import clear_progress_cache
+
+        clear_progress_cache()
+
+        # Build a minimal clips_dict with embeddings
+        import numpy as np
+
+        clips = {}
+        for i in range(10):
+            clips[i] = {"embedding": np.random.randn(8).astype(np.float32)}
+
+        # Label history: vote good on 0, bad on 1, then vote good on 0 AGAIN
+        # The third event doesn't change the training data (0 is already good).
+        history = [
+            (0, "good", 1.0),
+            (1, "bad", 2.0),
+            (0, "good", 3.0),  # no-op: 0 is already good
+        ]
+
+        _ensure_cache(clips, history, inclusion_value=0)
+
+        assert len(_cached_steps) == 3
+        # Steps 0 and 1 change the training data — they should attempt training.
+        # Step 2 has the same good/bad IDs as step 1 — stability should be None.
+        assert _cached_steps[2]["stability"] is None, (
+            "Stability should not be recorded when training data didn't change"
+        )
+
+    def test_changed_training_data_records_stability(self, client):
+        """When good/bad IDs DO change, stability should be computed (once a prior model exists)."""
+        from vtsearch.models.progress import clear_progress_cache
+
+        clear_progress_cache()
+
+        import numpy as np
+
+        clips = {}
+        for i in range(20):
+            clips[i] = {"embedding": np.random.randn(8).astype(np.float32)}
+
+        # Each step changes the training data
+        history = [
+            (0, "good", 1.0),
+            (1, "bad", 2.0),   # first model (both polarities)
+            (2, "good", 3.0),  # new model
+            (3, "bad", 4.0),   # new model
+            (4, "good", 5.0),  # new model
+        ]
+
+        _ensure_cache(clips, history, inclusion_value=0)
+
+        assert len(_cached_steps) == 5
+        # Step 0: only good votes, no model → stability None
+        assert _cached_steps[0]["stability"] is None
+        # Step 1: first model, no prior predictions → stability None
+        assert _cached_steps[1]["stability"] is None
+        # Steps 2-4: new model each time, prior predictions exist → stability recorded
+        for i in [2, 3, 4]:
+            assert _cached_steps[i]["stability"] is not None, (
+                f"Step {i} changed training data and should have stability"
+            )

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -251,7 +251,20 @@ def _ensure_cache(
         bad_ids = list(_cache_bad_ids)
         num_labels = len(good_ids) + len(bad_ids)
 
-        model, threshold, stability = _train_step(clips_dict, all_media_ids, t, num_labels, inclusion_value)
+        # Check whether the training data actually changed compared to the
+        # previous step.  If the good/bad ID sets are identical, the model
+        # would be the same — skip training and stability recording so the
+        # line graph and Stable indicator only reflect genuine model updates.
+        prev = _cached_steps[-1] if _cached_steps else None
+        training_data_changed = prev is None or set(good_ids) != set(prev["good_ids"]) or set(bad_ids) != set(prev["bad_ids"])
+
+        if training_data_changed:
+            model, threshold, stability = _train_step(clips_dict, all_media_ids, t, num_labels, inclusion_value)
+        else:
+            # Reuse previous model — no new training or stability entry.
+            model = prev["model"] if prev else None
+            threshold = prev["threshold"] if prev else None
+            stability = None
 
         _cached_steps.append(
             {


### PR DESCRIPTION
## Summary
This PR optimizes the model stability tracking by skipping redundant training and stability recording when the training data (good/bad label sets) hasn't changed between steps. This prevents artificial stability entries from appearing in the line graph and Stable indicator when no actual model update occurs.

## Key Changes
- **Training data change detection**: Added logic to compare the current good/bad ID sets with the previous step before training a new model
- **Conditional model training**: Only calls `_train_step()` when training data has actually changed, otherwise reuses the previous model and threshold
- **Stability skipping**: Sets `stability = None` when training data is unchanged, ensuring the stability metric only reflects genuine model updates
- **Test coverage**: Added comprehensive tests validating both scenarios:
  - `test_unchanged_training_data_skips_stability`: Verifies that duplicate votes don't create stability entries
  - `test_changed_training_data_records_stability`: Confirms that actual data changes still produce stability metrics

## Implementation Details
- The change detection compares sets of good and bad IDs from the current step against the previous cached step
- When training data hasn't changed, the previous model/threshold are reused to maintain consistency
- This optimization reduces unnecessary model training and keeps the stability graph focused on meaningful model changes

https://claude.ai/code/session_01HYXhWcrFiKsFskJpzFvmQv