### PR TITLE
Add label import functionality with file upload support

### DIFF
--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -32,6 +32,7 @@ export class LabelImporterModalComponent implements OnInit {
   selectedImporter: LabelImporter | null = null;
   formValues: Record<string, string> = {};
   selectedFile: File | null = null;
+  selectedFileFieldKey: string | null = null;
   submitting = false;
   error = '';
   successMessage = '';
@@ -70,6 +71,7 @@ export class LabelImporterModalComponent implements OnInit {
     const input = event.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
       this.selectedFile = input.files[0];
+      this.selectedFileFieldKey = fieldName;
       this.formValues[fieldName] = input.files[0].name;
     }
   }
@@ -80,7 +82,12 @@ export class LabelImporterModalComponent implements OnInit {
     this.error = '';
     this.successMessage = '';
 
-    this.labelImportersApi.runImport(this.selectedImporter.name, this.formValues).subscribe({
+    this.labelImportersApi.runImport(
+      this.selectedImporter.name,
+      this.formValues,
+      this.selectedFile ?? undefined,
+      this.selectedFileFieldKey ?? undefined,
+    ).subscribe({
       next: (res: any) => {
         this.submitting = false;
         this.successMessage = res.message || `Applied ${res.applied ?? 0} labels`;

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -41,6 +41,10 @@
   </div>
 </aside>
 
+@if (showLabelImport) {
+  <vt-label-importer-modal (closed)="showLabelImport = false" (imported)="showLabelImport = false" />
+}
+
 @if (showLabelExport) {
   <vt-label-exporter-modal (closed)="showLabelExport = false" (exportComplete)="showLabelExport = false" />
 }

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -6,12 +6,13 @@ import { TrainableModelsApiService } from '../../services/trainable-models-api.s
 import { MediaItem } from '../../models/api.models';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
-import { VtDialogService } from '../../services/dialog.service';
+
 import { LabelSortComponent, LabelSortMode } from './label-sort/label-sort.component';
 import { LabelListComponent } from './label-list/label-list.component';
 import { DetectorContextBarComponent } from './detector-context-bar/detector-context-bar.component';
 import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
 import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
+import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 
 export interface TrainModeContext {
   model: { name: string; registry_id?: string };
@@ -27,6 +28,7 @@ export interface TrainModeContext {
     DetectorContextBarComponent,
     DetectorExportModalComponent,
     LabelExporterModalComponent,
+    LabelImporterModalComponent,
   ],
   templateUrl: './right-panel.component.html',
   styleUrl: './right-panel.component.scss',
@@ -42,6 +44,7 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   learnedScores: Record<string, number> = {};
   sortMode: LabelSortMode = 'time-desc';
   showThumbnails = true;
+  showLabelImport = false;
   showLabelExport = false;
   showDetectorExport = false;
 
@@ -51,7 +54,6 @@ export class RightPanelComponent implements OnInit, OnDestroy {
     private modelsApi: TrainableModelsApiService,
     public voteState: VoteStateService,
     private settingsState: SettingsStateService,
-    private dialog: VtDialogService,
   ) {}
 
   ngOnInit(): void {
@@ -75,7 +77,7 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   }
 
   onImportLabels(): void {
-    this.dialog.alert('Label import not yet available in the Angular frontend.', 'info');
+    this.showLabelImport = true;
   }
 
   onExportLabels(): void {

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -11,7 +11,17 @@ export class LabelImportersApiService {
     return this.http.get<LabelImporterInfo[]>('/api/label-importers');
   }
 
-  runImport(importerName: string, params: Record<string, unknown>): Observable<unknown> {
+  runImport(importerName: string, params: Record<string, unknown>, file?: File, fileFieldKey?: string): Observable<unknown> {
+    if (file && fileFieldKey) {
+      const formData = new FormData();
+      formData.append(fileFieldKey, file, file.name);
+      for (const [key, value] of Object.entries(params)) {
+        if (key !== fileFieldKey) {
+          formData.append(key, String(value ?? ''));
+        }
+      }
+      return this.http.post(`/api/label-importers/import/${importerName}`, formData);
+    }
     return this.http.post(`/api/label-importers/import/${importerName}`, params);
   }
 


### PR DESCRIPTION
## Summary
This PR implements the label import feature in the Angular frontend, allowing users to import labels from files through a modal dialog. Previously, the import functionality was not available and showed a placeholder alert message.

## Key Changes
- **Enhanced `LabelImportersApiService`**: Updated `runImport()` method to support file uploads via FormData when a file and field key are provided, while maintaining backward compatibility with parameter-only requests
- **Updated `LabelImporterModalComponent`**: Added file selection tracking with `selectedFileFieldKey` to properly identify which form field contains the file, and passed file data to the API service during import
- **Integrated import modal in `RightPanelComponent`**: 
  - Added `showLabelImport` flag to control modal visibility
  - Replaced placeholder alert with actual modal display in `onImportLabels()`
  - Imported and declared `LabelImporterModalComponent` in the component
  - Removed unused `VtDialogService` dependency
- **Updated `right-panel.component.html`**: Added conditional rendering of the label importer modal with proper event bindings

## Implementation Details
- File uploads are handled via FormData to properly encode multipart form data
- The service intelligently routes requests: uses FormData for file uploads, standard JSON for parameter-only imports
- File field key is tracked separately to ensure it's not duplicated in the form data
- Modal state is managed locally in the right panel component with proper cleanup on close/completion

https://claude.ai/code/session_01Xyi7Pcnx1A4G5LeZPhDnfU