### PR TITLE
Add resolve_display_name method for dynamic dataset labels

### DIFF
--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -70,6 +70,15 @@ class DemoDatasetImporter(DatasetImporter):
                 f.options = list(DEMO_DATASETS.keys())
                 break
 
+    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        dataset_name = field_values.get("name", "")
+        entry = DEMO_DATASETS.get(dataset_name)
+        if entry:
+            return entry.get("label", self.display_name)
+        return self.display_name
+
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         dataset_name = field_values.get("name", "")
         if not dataset_name:

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -296,7 +296,7 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
     _run_origin_load_in_background(
         lambda: importer.run(field_values, medias),
         origin,
-        name=importer.display_name,
+        name=importer.resolve_display_name(field_values),
         clipper=clipper_name,
         embedder=embedder_name,
     )
@@ -330,7 +330,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
             first = next(iter(temp_medias.values()))
             media_type = first.get("type", "audio")
             count = len(temp_medias)
-            name = label or importer.display_name
+            name = label or importer.resolve_display_name(field_values)
 
             data_bytes = export_dataset_to_file(temp_medias)
             del temp_medias

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -129,6 +129,14 @@ class PluginBase:
     #: a dedicated code path (e.g. the GUI exporter).
     hidden_from_picker: bool = False
 
+    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+        """Return a human-readable name for a dataset loaded with *field_values*.
+
+        The default returns :attr:`display_name`.  Subclasses (e.g. the demo
+        importer) can override this to return a dataset-specific label.
+        """
+        return self.display_name
+
     # -- CLI support --------------------------------------------------------
 
     def add_cli_arguments(self, parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
## Summary
This PR introduces a new `resolve_display_name()` method to allow plugins to provide dynamic, dataset-specific display names instead of using a static `display_name` attribute.

## Key Changes
- Added `resolve_display_name(field_values)` method to `PluginBase` class that returns a human-readable name for a dataset based on its configuration
  - Default implementation returns the static `display_name` attribute
  - Can be overridden by subclasses to provide custom logic
- Implemented `resolve_display_name()` in the demo importer to return dataset-specific labels from the `DEMO_DATASETS` configuration
- Updated dataset loading routes to use `resolve_display_name()` instead of the static `display_name`:
  - In `_run_importer_in_background()` when setting the origin name
  - In `stage_task()` when exporting datasets

## Implementation Details
The `resolve_display_name()` method accepts `field_values` (a dictionary of field values from the importer form) to allow plugins to look up dataset-specific metadata. The demo importer uses this to fetch the "label" from the `DEMO_DATASETS` configuration, falling back to the default `display_name` if not found.

https://claude.ai/code/session_01X4fQhZdfsZnwR1Qb7oiFGQ