### PR TITLE
Prevent Find operation on trainable models without training data

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -212,6 +212,27 @@ describe('DashboardComponent', () => {
       component.selectedModelIds.add('m2');
       expect(component.findEnabled).toBeTrue();
     });
+
+    it('should disable Find when a trainable model has 0 training', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: true, num_training: 0 }];
+      flushInitialRequests(datasets, models);
+      expect(component.findEnabled).toBeFalse();
+    });
+
+    it('should enable Find for a trainable model with training', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: true, num_training: 5 }];
+      flushInitialRequests(datasets, models);
+      expect(component.findEnabled).toBeTrue();
+    });
+
+    it('should enable Find for a non-trainable model with 0 training', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: false, num_training: 0 }];
+      flushInitialRequests(datasets, models);
+      expect(component.findEnabled).toBeTrue();
+    });
   });
 
   describe('label hints', () => {
@@ -299,6 +320,13 @@ describe('DashboardComponent', () => {
       const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
       expect(component.findHint).toBe('Score selected datasets with selected models');
+    });
+
+    it('should hint about untrained model', () => {
+      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: true, num_training: 0 }];
+      flushInitialRequests(datasets, models);
+      expect(component.findHint).toBe('Selected model has no training labels');
     });
   });
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -356,9 +356,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return types.size === 1;
   }
 
+  private hasUntrainedModel(): boolean {
+    const selectedModels = this.models.filter((m) => this.selectedModelIds.has(m.id));
+    return selectedModels.some((m) => m.trainable && (m.num_training ?? 0) === 0);
+  }
+
   get findEnabled(): boolean {
     if (this.selectedDatasetIds.size < 1 || this.selectedModelIds.size < 1) return false;
-    return this.findMediaTypesMatch();
+    if (!this.findMediaTypesMatch()) return false;
+    if (this.hasUntrainedModel()) return false;
+    return true;
   }
 
   get findHint(): string {
@@ -366,6 +373,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (this.selectedDatasetIds.size === 0) return 'Select a dataset';
     if (this.selectedModelIds.size === 0) return 'Select a model';
     if (!this.findMediaTypesMatch()) return 'Media type mismatch';
+    if (this.hasUntrainedModel()) return 'Selected model has no training labels';
     return 'Score selected datasets with selected models';
   }
 


### PR DESCRIPTION
## Summary
This PR adds validation to prevent users from running the Find operation on trainable models that have no training labels. The change ensures that only models with sufficient training data (or non-trainable models) can be used for scoring.

## Key Changes
- Added `hasUntrainedModel()` method to check if any selected model is trainable but has zero training labels
- Updated `findEnabled` getter to disable the Find button when an untrained model is selected
- Updated `findHint` getter to display "Selected model has no training labels" when this condition is detected
- Added three new test cases covering:
  - Disabling Find for trainable models with 0 training labels
  - Enabling Find for trainable models with training data
  - Enabling Find for non-trainable models regardless of training count

## Implementation Details
- The `hasUntrainedModel()` method filters selected models and checks if any are both trainable and have `num_training` equal to 0
- The validation is applied after media type matching to provide appropriate user feedback
- Non-trainable models bypass this check, allowing them to be used for scoring even without training data

https://claude.ai/code/session_01P2cnwaKhLbSgkWgks6jnVU