### PR TITLE
Add frontend dependency installation to test setup hooks

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -53,5 +53,11 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu \
 # Install dev tools (linter + test runner)
 pip install pytest ruff -q
 
+# Install frontend (Angular) dependencies if not already present
+if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
+  echo "Installing frontend dependencies..."
+  (cd frontend && npm install --no-audit --no-fund -q)
+fi
+
 touch "$MARKER"
 echo "Dependencies installed."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'pytest'; then bash $CLAUDE_PROJECT_DIR/.claude/hooks/ensure-test-deps.sh; fi"
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE 'pytest|ng test|ng serve|npm run|npm test'; then bash $CLAUDE_PROJECT_DIR/.claude/hooks/ensure-test-deps.sh; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Extended the development environment setup to automatically install frontend (Angular) dependencies alongside backend test dependencies, and updated the hook trigger conditions to include frontend-related commands.

## Key Changes
- **Frontend dependency installation**: Added logic to `ensure-test-deps.sh` to detect and install npm dependencies in the `frontend/` directory if `package.json` exists and `node_modules` is not already present
- **Expanded hook triggers**: Updated `.claude/settings.json` to trigger the dependency installation hook for frontend commands (`ng test`, `ng serve`, `npm run`, `npm test`) in addition to the existing `pytest` trigger
- **Installation flags**: Used `--no-audit` and `--no-fund` flags with `npm install` to keep installation output clean and focused

## Implementation Details
- The frontend dependency check is conditional and only runs if the `frontend/` directory contains a `package.json` file and lacks a `node_modules` directory, avoiding unnecessary reinstalls
- The hook now uses extended regex matching (`grep -qE`) to support multiple command patterns, ensuring developers can run frontend tests and development servers without manual setup
- Installation output is suppressed with the `-q` flag to maintain consistency with backend dependency installation

https://claude.ai/code/session_01CMkSSxkz9NY9TK32hZXcL3