### PR TITLE
Sort embedders by media type and name in settings modal

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -106,6 +106,29 @@ describe('SettingsModalComponent', () => {
     expect(component.settings.theme).toBe('light');
   });
 
+  it('should sort embedders by media_type_id then name', () => {
+    fixture.detectChanges();
+    const settingsReq = httpMock.expectOne('/api/settings');
+    const embeddersReq = httpMock.expectOne('/api/embedders');
+    settingsReq.flush(mockSettings);
+    embeddersReq.flush({
+      embedders: [
+        { name: 'zebra', media_type_id: 'image' },
+        { name: 'alpha', media_type_id: 'text' },
+        { name: 'beta', media_type_id: 'audio' },
+        { name: 'alpha', media_type_id: 'audio' },
+        { name: 'clip', media_type_id: 'image' },
+      ],
+    });
+    expect(component.embedders.map((e) => `${e.media_type_id}:${e.name}`)).toEqual([
+      'audio:alpha',
+      'audio:beta',
+      'image:clip',
+      'image:zebra',
+      'text:alpha',
+    ]);
+  });
+
   it('should emit closed on close', () => {
     flushInit();
     spyOn(component.closed, 'emit');

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -34,7 +34,9 @@ export class SettingsModalComponent implements OnInit {
     }).subscribe({
       next: (res) => {
         this.settings = res.settings;
-        this.embedders = res.embedders.embedders || [];
+        this.embedders = (res.embedders.embedders || []).sort(
+          (a, b) => a.media_type_id.localeCompare(b.media_type_id) || a.name.localeCompare(b.name),
+        );
         this.loading = false;
       },
       error: () => {


### PR DESCRIPTION
## Summary
Added sorting functionality to the embedders list in the settings modal to improve organization and consistency of the displayed embedders.

## Key Changes
- Modified `SettingsModalComponent` to sort embedders by `media_type_id` first, then by `name` in ascending order
- Added comprehensive test case to verify the sorting behavior with multiple embedders across different media types

## Implementation Details
The embedders are now sorted using a comparator that:
1. Primarily sorts by `media_type_id` using `localeCompare()` for alphabetical ordering
2. Falls back to sorting by `name` when `media_type_id` values are equal
3. Sorting is applied immediately after fetching embedders from the API response

This ensures a predictable, organized display of embedders grouped by media type with consistent alphabetical ordering within each group.

https://claude.ai/code/session_01X2JHAeuLZZ3zDJY75opEpu