### PR TITLE
Add collapsible autopilot panel with compact step indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - `vtsearch/config.py` — Constants (SAMPLE_RATE, NUM_MEDIAS, paths, model IDs)
 - `vtsearch/medias.py` — Test media generation and embedding cache management
 - `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detectors from settings, run inference, export results)
-- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_metadata, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, autopilot_top_greens, autopilot_hard_reds); auto-saves to `data/settings.json`
+- `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_metadata, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, hide_autopilot, autopilot_top_greens, autopilot_hard_reds); auto-saves to `data/settings.json`
 - `vtsearch/routes/` — Flask blueprints: `main.py`, `medias.py`, `sorting.py`, `detectors.py` (with sub-modules `detectors_crud.py`, `detectors_scoring.py`, `detectors_training.py`), `datasets.py` (with sub-modules `datasets_loading.py`, `datasets_ui.py`), `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`, `trainable_models.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking, diversity tree
 - `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/combine_datasets); auto-discovered via `IMPORTER` sentinel. Note: the `http_zip` directory registers as `http_archive` (its API/CLI name)
@@ -73,7 +73,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
   - `test_eval_visualize.py` — Evaluation visualisation chart generation
   - `test_eval_voting_iterations.py` — Voting iterations evaluation
   - `test_safe_thresholds.py` — Safe threshold blending
-  - `test_settings.py` — Settings persistence (volume, inclusion, theme, swipe_animation, show_metadata, show_thumbnails_left, show_thumbnails_right, autopilot_top_greens, autopilot_hard_reds, autorun processors)
+  - `test_settings.py` — Settings persistence (volume, inclusion, theme, swipe_animation, show_metadata, show_thumbnails_left, show_thumbnails_right, hide_autopilot, autopilot_top_greens, autopilot_hard_reds, autorun processors)
   - `test_thin_loading.py` — Thin (lazy) dataset loading mode for CLI
   - `test_chunked_loading.py` — Chunked (piecewise) dataset loading: folder/pickle chunked loaders, importer run_chunked interface, merge helper
   - `test_integration.py` — End-to-end user workflow simulations: chained API calls, state interactions, response format consistency
@@ -179,7 +179,7 @@ All mutable global state is reset automatically before each test via two autouse
 ## Key Details
 - Global state lives in `vtsearch/utils/state.py`: `medias`, `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `last_learned_scores`, `inclusion`, `textsort_suggestions`, `autorun_detectors`, `autorun_extractors`, `autorun_localizers`, `_dataset_display_name`, `_diversity_tree` are module-level dicts/lists; all protected by `_state_lock` (RLock)
 - Votes are `dict[int, None]` (not sets) — use `votes[id] = None` syntax
-- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_metadata, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, autopilot_top_greens, autopilot_hard_reds
+- Persistent settings live in `vtsearch/settings.py` (auto-saves to `data/settings.json`): volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_metadata, show_thumbnails_left, show_thumbnails_right, autoload_media_types, autorun_processors, hide_autopilot, autopilot_top_greens, autopilot_hard_reds
 - Each media item has `origin` (dict or None) and `origin_name` (str) for per-element provenance tracking
 - `Origin` class in `vtsearch/datasets/origin.py`; `LabelSet`/`LabeledElement` in `vtsearch/datasets/labelset.py`
 - Label export (`/api/labels/export`) returns a `LabelSet` with per-element origin info (superset of legacy format)

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -24,8 +24,10 @@
       (loadSort)="onLoadSort()"
       (mediaSelect)="onMediaSelect($event)"
       (indicatorClick)="onIndicatorClick($event)"
+      [autopilotCollapsed]="autopilotCollapsed"
       (autopilotStart)="onAutopilotStart()"
       (autopilotStop)="onAutopilotStop()"
+      (autopilotToggleCollapse)="onAutopilotToggleCollapse()"
     />
   </div>
   <div

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -9,7 +9,7 @@
   overflow: hidden;
   background: var(--bg-panel);
   border-right: 1px solid var(--border);
-  min-width: 180px;
+  min-width: 0;
 }
 
 .divider-left {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -30,8 +30,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   showThumbnails = true;
   leftWidth = 260;
   rightWidth = 300;
+  autopilotCollapsed = false;
   progressModalMetric: ProgressMetric | null = null;
 
+  private readonly COLLAPSED_WIDTH = 36;
+  private savedLeftWidth = 260;
   private readonly LEFT_MIN = 180;
   private readonly LEFT_MAX = 500;
   private readonly RIGHT_MIN = 150;
@@ -170,6 +173,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe((settings) => {
         if (!settings) return;
         this.showThumbnails = settings.show_thumbnails_left !== false;
+        if (settings.hide_autopilot && !this.autopilotCollapsed) {
+          this.setAutopilotCollapsed(true);
+        } else if (settings.hide_autopilot === false && this.autopilotCollapsed) {
+          this.setAutopilotCollapsed(false);
+        }
         if (settings.inclusion != null) {
           this.sortState.setInclusion(settings.inclusion);
         }
@@ -339,6 +347,23 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (textQuery) {
       this.onTextSort(textQuery);
     }
+  }
+
+  onAutopilotToggleCollapse(): void {
+    const newVal = !this.autopilotCollapsed;
+    this.setAutopilotCollapsed(newVal);
+    this.settingsState.update({ hide_autopilot: newVal }).subscribe();
+  }
+
+  private setAutopilotCollapsed(collapsed: boolean): void {
+    this.autopilotCollapsed = collapsed;
+    if (collapsed) {
+      this.savedLeftWidth = this.leftWidth;
+      this.leftWidth = this.COLLAPSED_WIDTH;
+    } else {
+      this.leftWidth = this.savedLeftWidth;
+    }
+    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
   }
 
   onAutopilotStop(): void {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -1,42 +1,66 @@
-<div class="autopilot-panel">
-  <div class="autopilot-active">
-    <div class="autopilot-steps">
+<div class="autopilot-panel" [class.collapsed]="collapsed">
+  @if (collapsed) {
+    <div class="collapsed-steps">
+      <button class="collapse-toggle" (click)="toggleCollapse.emit()" title="Show autopilot panel" aria-label="Show autopilot panel">&#9654;</button>
       @for (step of steps; track step.phase) {
         <div
-          class="ap-step"
+          class="collapsed-step"
           [class.done]="step.state === 'done'"
           [class.active]="step.state === 'active'"
           [class.future]="step.state === 'future'"
+          [title]="step.label"
         >
-          <div class="ap-step-marker">
-            @if (step.state === 'done') {
-              <span class="ap-check" aria-label="Complete">&#10003;</span>
-            } @else if (step.state === 'active') {
-              <span class="ap-dot active-dot" aria-label="Current step"></span>
-            } @else {
-              <span class="ap-dot" aria-label="Upcoming step"></span>
-            }
-          </div>
-          <div class="ap-step-content">
-            <span class="ap-step-label" [title]="step.helpText">
-              {{ step.label }}
-            </span>
-            @if (step.detail || step.statusIcons.length) {
-              <span class="ap-step-detail">
-                {{ step.detail }}
-                @for (icon of step.statusIcons; track icon.ariaLabel) {
-                  <span
-                    class="ap-status-icon"
-                    [attr.data-color]="icon.color"
-                    [attr.aria-label]="icon.ariaLabel"
-                    role="img"
-                  ></span>
-                }
-              </span>
-            }
-          </div>
+          @if (step.state === 'active') {
+            <span class="collapsed-step-label">{{ step.shortLabel }}</span>
+          } @else {
+            <span class="collapsed-step-number" [class.struck]="step.state === 'done'">{{ step.stepNumber }}</span>
+          }
         </div>
       }
     </div>
-  </div>
+  } @else {
+    <div class="autopilot-active">
+      <div class="autopilot-header">
+        <button class="collapse-toggle" (click)="toggleCollapse.emit()" title="Hide autopilot panel" aria-label="Hide autopilot panel">&#9664;</button>
+      </div>
+      <div class="autopilot-steps">
+        @for (step of steps; track step.phase) {
+          <div
+            class="ap-step"
+            [class.done]="step.state === 'done'"
+            [class.active]="step.state === 'active'"
+            [class.future]="step.state === 'future'"
+          >
+            <div class="ap-step-marker">
+              @if (step.state === 'done') {
+                <span class="ap-check" aria-label="Complete">&#10003;</span>
+              } @else if (step.state === 'active') {
+                <span class="ap-dot active-dot" aria-label="Current step"></span>
+              } @else {
+                <span class="ap-dot" aria-label="Upcoming step"></span>
+              }
+            </div>
+            <div class="ap-step-content">
+              <span class="ap-step-label" [title]="step.helpText">
+                {{ step.label }}
+              </span>
+              @if (step.detail || step.statusIcons.length) {
+                <span class="ap-step-detail">
+                  {{ step.detail }}
+                  @for (icon of step.statusIcons; track icon.ariaLabel) {
+                    <span
+                      class="ap-status-icon"
+                      [attr.data-color]="icon.color"
+                      [attr.aria-label]="icon.ariaLabel"
+                      role="img"
+                    ></span>
+                  }
+                </span>
+              }
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
 </div>

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -2,12 +2,40 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+
+  &.collapsed {
+    align-items: center;
+    padding: 4px 0;
+    gap: 0;
+  }
 }
 
 .autopilot-active {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.autopilot-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.collapse-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 2px 5px;
+  line-height: 1;
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+  }
 }
 
 .autopilot-steps {
@@ -102,3 +130,55 @@
   }
 }
 
+// --- Collapsed mode ---
+
+.collapsed-steps {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.collapsed-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+
+  &.done {
+    opacity: 0.5;
+  }
+
+  &.active {
+    background: var(--accent-highlight-bg);
+    border: 1px solid var(--accent-highlight-border);
+    border-radius: 3px;
+    padding: 4px 2px;
+  }
+
+  &.future {
+    opacity: 0.35;
+  }
+}
+
+.collapsed-step-number {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+
+  &.struck {
+    text-decoration: line-through;
+    color: var(--text-muted);
+  }
+}
+
+.collapsed-step-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-size: 0.72rem;
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -14,9 +14,11 @@ interface StatusIcon {
   ariaLabel: string;
 }
 
-interface StepDisplay {
+export interface StepDisplay {
   phase: AutopilotPhase;
   label: string;
+  shortLabel: string;
+  stepNumber: number;
   state: 'done' | 'active' | 'future';
   detail: string;
   statusIcons: StatusIcon[];
@@ -34,9 +36,11 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   @Input() labelingStatus: LabelingStatusResponse | null = null;
+  @Input() collapsed = false;
 
   @Output() started = new EventEmitter<void>();
   @Output() stopped = new EventEmitter<void>();
+  @Output() toggleCollapse = new EventEmitter<void>();
 
   constructor(public autopilotState: AutopilotStateService) {}
 
@@ -61,6 +65,8 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       return {
         phase,
         label: this.phaseLabel(phase),
+        shortLabel: this.phaseShortLabel(phase),
+        stepNumber: i + 1,
         state: stateStr,
         detail: stateStr === 'active' ? this.phaseDetail(phase) : '',
         statusIcons: stateStr === 'active' ? this.phaseStatusIcons(phase) : [],
@@ -102,6 +108,17 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       case 'bad': return 'Label Bad Examples';
       case 'hard': return 'Refine Boundary';
       case 'new': return 'Explore Diversity';
+      case 'done': return 'Done';
+      default: return '';
+    }
+  }
+
+  private phaseShortLabel(phase: AutopilotPhase): string {
+    switch (phase) {
+      case 'good': return 'Good';
+      case 'bad': return 'Bad';
+      case 'hard': return 'Boundary';
+      case 'new': return 'Diversity';
       case 'done': return 'Done';
       default: return '';
     }

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -1,21 +1,23 @@
-<div class="left-panel">
-  <div class="left-tabs" role="tablist" aria-label="Panel mode">
-    <button
-      class="left-tab"
-      role="tab"
-      [class.active]="activeTab === 'manual'"
-      [attr.aria-selected]="activeTab === 'manual'"
-      (click)="setTab('manual')"
-    >Manual</button>
-    <button
-      class="left-tab"
-      role="tab"
-      [class.active]="activeTab === 'autopilot'"
-      [attr.aria-selected]="activeTab === 'autopilot'"
-      (click)="setTab('autopilot')"
-      title="Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration."
-    >Autopilot</button>
-  </div>
+<div class="left-panel" [class.collapsed-autopilot]="activeTab === 'autopilot' && autopilotCollapsed">
+  @if (!(activeTab === 'autopilot' && autopilotCollapsed)) {
+    <div class="left-tabs" role="tablist" aria-label="Panel mode">
+      <button
+        class="left-tab"
+        role="tab"
+        [class.active]="activeTab === 'manual'"
+        [attr.aria-selected]="activeTab === 'manual'"
+        (click)="setTab('manual')"
+      >Manual</button>
+      <button
+        class="left-tab"
+        role="tab"
+        [class.active]="activeTab === 'autopilot'"
+        [attr.aria-selected]="activeTab === 'autopilot'"
+        (click)="setTab('autopilot')"
+        title="Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration."
+      >Autopilot</button>
+    </div>
+  }
 
   @if (activeTab === 'manual') {
     <div class="tab-panel-manual" role="tabpanel" aria-label="Manual mode">
@@ -72,13 +74,15 @@
       </div>
     </div>
   } @else {
-    <div class="tab-panel-autopilot" role="tabpanel" aria-label="Autopilot mode">
+    <div class="tab-panel-autopilot" [class.collapsed]="autopilotCollapsed" role="tabpanel" aria-label="Autopilot mode">
       <vt-autopilot-panel
         [goodVotes]="goodVotes"
         [badVotes]="badVotes"
         [labelingStatus]="labelingStatus"
+        [collapsed]="autopilotCollapsed"
         (started)="autopilotStart.emit()"
         (stopped)="autopilotStop.emit()"
+        (toggleCollapse)="autopilotToggleCollapse.emit()"
       />
     </div>
   }

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -33,6 +33,10 @@
   }
 }
 
+.left-panel.collapsed-autopilot {
+  align-items: center;
+}
+
 .tab-panel-manual,
 .tab-panel-autopilot {
   flex: 1;
@@ -41,6 +45,11 @@
   overflow: hidden;
   padding: 8px;
   gap: 8px;
+
+  &.collapsed {
+    padding: 4px 2px;
+    align-items: center;
+  }
 }
 
 .media-list-container {

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -44,6 +44,7 @@ export class LeftPanelComponent implements OnInit {
   @Input() showThumbnails = true;
   @Input() loadSortLabel = '';
   @Input() textQuery = '';
+  @Input() autopilotCollapsed = false;
 
   @Output() sortModeChange = new EventEmitter<SortMode>();
   @Output() selectModeChange = new EventEmitter<SelectMode>();
@@ -55,6 +56,7 @@ export class LeftPanelComponent implements OnInit {
   @Output() indicatorClick = new EventEmitter<string>();
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();
+  @Output() autopilotToggleCollapse = new EventEmitter<void>();
 
   @ViewChild(MediaListComponent) mediaListComponent!: MediaListComponent;
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -56,6 +56,10 @@
       <!-- Autopilot & Actions -->
       <div class="settings-section">
         <h3>Autopilot &amp; Actions</h3>
+        <label class="checkbox-row">
+          <input type="checkbox" [ngModel]="settings.hide_autopilot" (ngModelChange)="onToggle('hide_autopilot', $event)" />
+          Hide autopilot panel
+        </label>
         <div class="form-group">
           <label class="form-label"># Good to start</label>
           <input type="number" class="form-input" [ngModel]="settings.autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" />

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -254,6 +254,7 @@ export interface AppSettings {
   autoload_media_types?: string[];
   autoload_media_embedders?: string[];
   autorun_processors?: AutorunProcessor[];
+  hide_autopilot?: boolean;
   autopilot_top_greens?: number;
   autopilot_hard_reds?: number;
   [key: string]: unknown;

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -108,6 +108,9 @@ def update_settings():
     if "show_thumbnails_right" in body:
         settings.set_show_thumbnails_right(bool(body["show_thumbnails_right"]))
 
+    if "hide_autopilot" in body:
+        settings.set_hide_autopilot(bool(body["hide_autopilot"]))
+
     if "autopilot_top_greens" in body:
         try:
             val = body["autopilot_top_greens"]

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -51,6 +51,7 @@ _DEFAULTS: dict[str, Any] = {
     "autoload_media_types": [],
     "autoload_media_embedders": [],
     "autorun_processors": [],
+    "hide_autopilot": False,
     "autopilot_top_greens": 3,
     "autopilot_hard_reds": 4,
     "saved_datasets_dir": str(DATA_DIR / "saved_datasets"),
@@ -192,6 +193,7 @@ _SETTING_SPECS: list[tuple] = [
     ("show_metadata", bool, None),
     ("show_thumbnails_left", bool, None),
     ("show_thumbnails_right", bool, None),
+    ("hide_autopilot", bool, None),
     ("autopilot_top_greens", int, _clamp_min(int, 1)),
     ("autopilot_hard_reds", int, _clamp_min(int, 1)),
 ]


### PR DESCRIPTION
## Summary
This PR adds the ability to collapse the autopilot panel into a compact vertical indicator showing step numbers and the current active step label. When collapsed, the left panel width reduces to 36px, and the tabs are hidden. The collapsed state is persisted in user settings.

## Key Changes

- **Autopilot Panel Collapse UI**: Added toggle button and two layout modes:
  - Expanded mode: Full step details with labels, markers, and status icons
  - Collapsed mode: Compact vertical layout showing step numbers and abbreviated labels
  
- **State Management**: 
  - Added `autopilotCollapsed` state to `LabelViewComponent` with `COLLAPSED_WIDTH = 36px`
  - Saves/restores collapsed state via `hide_autopilot` setting
  - Dynamically adjusts left panel width when toggling collapse state

- **Settings Integration**:
  - Added `hide_autopilot` boolean setting (persisted to `data/settings.json`)
  - Added UI toggle in settings modal under "Autopilot & Actions" section
  - Backend route handler for updating the setting

- **Component Updates**:
  - `AutopilotPanelComponent`: Added `collapsed` input, `toggleCollapse` output, and new `shortLabel`/`stepNumber` properties to `StepDisplay`
  - `LeftPanelComponent`: Added `autopilotCollapsed` input and `autopilotToggleCollapse` output
  - `LabelViewComponent`: Added collapse/expand logic with width management and settings sync

- **Styling**:
  - New `.collapsed-steps` layout with centered flex column
  - Collapsed step indicators with state-based styling (done/active/future)
  - Collapse toggle button with hover effects
  - Responsive padding and gap adjustments for collapsed mode

## Implementation Details

- The collapsed panel hides the tab navigation and centers the autopilot indicator vertically
- Step numbers are struck-through when done; active step shows abbreviated label vertically
- Collapse state is synced bidirectionally with backend settings
- Left panel minimum width changed from 180px to 0 to allow full collapse

https://claude.ai/code/session_01CnBvP4w9CyskjztwAYrGv3