### PR TITLE
Track embedder used for demo dataset pickles

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -44,7 +44,8 @@
             <select
               id="demo-embedder"
               class="form-select form-select--inline"
-              [(ngModel)]="selectedDemoEmbedder"
+              [ngModel]="selectedDemoEmbedder"
+              (ngModelChange)="onDemoEmbedderChange($event)"
             >
               @for (embedder of demoEmbedders; track embedder.name) {
                 <option [value]="embedder.name">{{ embedder.name }}</option>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -141,8 +141,8 @@ export class DatasetImporterModalComponent implements OnInit {
     });
   }
 
-  private fetchDemos(): void {
-    this.datasetsApi.getDemoList().subscribe({
+  private fetchDemos(embedder?: string): void {
+    this.datasetsApi.getDemoList(embedder).subscribe({
       next: (demoRes) => {
         this.demos = demoRes.datasets || [];
         this.buildDemoTabs();
@@ -181,8 +181,36 @@ export class DatasetImporterModalComponent implements OnInit {
       next: (embedders) => {
         this.demoEmbedders = embedders;
         this.selectedDemoEmbedder = embedders.length > 0 ? embedders[0].name : '';
+        this.updateDemoStatuses();
       },
     });
+  }
+
+  onDemoEmbedderChange(embedder: string): void {
+    this.selectedDemoEmbedder = embedder;
+    this.updateDemoStatuses();
+  }
+
+  /**
+   * Re-compute each demo's status client-side based on the selected embedder.
+   * A demo that has a cached pkl (`pkl_embedder` is set) is only "ready" when
+   * the pkl embedder matches the currently selected embedder; otherwise it
+   * downgrades to "needs_embedding" (source data is still present).
+   */
+  private updateDemoStatuses(): void {
+    const emb = this.selectedDemoEmbedder;
+    for (const demo of this.demos) {
+      if (!demo.pkl_embedder) continue;  // no pkl or unknown embedder — keep server status
+      if (demo.status === 'needs_download') continue;  // source data missing — can't re-embed
+
+      if (emb && demo.pkl_embedder !== emb) {
+        demo.status = 'needs_embedding';
+        demo.ready = false;
+      } else {
+        demo.status = 'ready';
+        demo.ready = true;
+      }
+    }
   }
 
   get filteredDemos(): DemoDataset[] {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -176,6 +176,7 @@ export interface DemoDataset {
   description: string;
   media_type: string;
   num_categories: number;
+  pkl_embedder?: string;
 }
 
 export interface DemoListResponse {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -38,8 +38,12 @@ export class DatasetsApiService {
     return this.http.get<ImportersResponse>('/api/dataset/all-importers');
   }
 
-  getDemoList(): Observable<DemoListResponse> {
-    return this.http.get<DemoListResponse>('/api/dataset/demo-list');
+  getDemoList(embedder?: string): Observable<DemoListResponse> {
+    const params: Record<string, string> = {};
+    if (embedder) {
+      params['embedder'] = embedder;
+    }
+    return this.http.get<DemoListResponse>('/api/dataset/demo-list', { params });
   }
 
   getMediaTypes(): Observable<MediaTypesResponse> {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -236,6 +236,169 @@ class TestDemoDatasetReadiness:
             assert ds["status"] in ("ready", "needs_embedding", "needs_download")
 
 
+class TestDemoDatasetEmbedderStatus:
+    """Demo dataset status respects which embedder produced the cached pkl."""
+
+    def test_ready_with_matching_embedder(self, client):
+        """pkl with sidecar matching requested embedder → ready."""
+        import pickle
+
+        from vtsearch.config import EMBEDDINGS_DIR
+        from vtsearch.datasets import DEMO_DATASETS
+
+        # Pick a demo that has no required_folder (e.g. a text or image demo).
+        demo_name = None
+        for name, info in DEMO_DATASETS.items():
+            if info.get("required_folder") is None:
+                demo_name = name
+                break
+        if demo_name is None:
+            pytest.skip("No demo dataset without required_folder found")
+
+        EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+        pkl_file = EMBEDDINGS_DIR / f"{demo_name}.pkl"
+        sidecar = pkl_file.with_suffix(".embedder")
+        pkl_file.write_bytes(pickle.dumps({"name": demo_name, "medias": {}}))
+        sidecar.write_text("TestEmbedder", encoding="utf-8")
+        try:
+            resp = client.get("/api/dataset/demo-list?embedder=TestEmbedder")
+            data = resp.get_json()
+            ds = next((d for d in data["datasets"] if d["name"] == demo_name), None)
+            assert ds is not None
+            assert ds["status"] == "ready"
+            assert ds["ready"] is True
+            assert ds["pkl_embedder"] == "TestEmbedder"
+        finally:
+            pkl_file.unlink(missing_ok=True)
+            sidecar.unlink(missing_ok=True)
+            try:
+                EMBEDDINGS_DIR.rmdir()
+            except OSError:
+                pass
+
+    def test_needs_embedding_with_mismatched_embedder(self, client):
+        """pkl with sidecar NOT matching requested embedder → needs_embedding."""
+        import pickle
+
+        from vtsearch.config import EMBEDDINGS_DIR
+        from vtsearch.datasets import DEMO_DATASETS
+
+        demo_name = None
+        for name, info in DEMO_DATASETS.items():
+            if info.get("required_folder") is None:
+                demo_name = name
+                break
+        if demo_name is None:
+            pytest.skip("No demo dataset without required_folder found")
+
+        EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+        pkl_file = EMBEDDINGS_DIR / f"{demo_name}.pkl"
+        sidecar = pkl_file.with_suffix(".embedder")
+        pkl_file.write_bytes(pickle.dumps({"name": demo_name, "medias": {}}))
+        sidecar.write_text("OldEmbedder", encoding="utf-8")
+        try:
+            resp = client.get("/api/dataset/demo-list?embedder=NewEmbedder")
+            data = resp.get_json()
+            ds = next((d for d in data["datasets"] if d["name"] == demo_name), None)
+            assert ds is not None
+            assert ds["status"] == "needs_embedding"
+            assert ds["ready"] is False
+            assert ds["pkl_embedder"] == "OldEmbedder"
+        finally:
+            pkl_file.unlink(missing_ok=True)
+            sidecar.unlink(missing_ok=True)
+            try:
+                EMBEDDINGS_DIR.rmdir()
+            except OSError:
+                pass
+
+    def test_no_embedder_param_ignores_check(self, client):
+        """Without embedder query param, pkl existence alone means ready."""
+        import pickle
+
+        from vtsearch.config import EMBEDDINGS_DIR
+        from vtsearch.datasets import DEMO_DATASETS
+
+        demo_name = None
+        for name, info in DEMO_DATASETS.items():
+            if info.get("required_folder") is None:
+                demo_name = name
+                break
+        if demo_name is None:
+            pytest.skip("No demo dataset without required_folder found")
+
+        EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+        pkl_file = EMBEDDINGS_DIR / f"{demo_name}.pkl"
+        sidecar = pkl_file.with_suffix(".embedder")
+        pkl_file.write_bytes(pickle.dumps({"name": demo_name, "medias": {}}))
+        sidecar.write_text("SomeEmbedder", encoding="utf-8")
+        try:
+            resp = client.get("/api/dataset/demo-list")
+            data = resp.get_json()
+            ds = next((d for d in data["datasets"] if d["name"] == demo_name), None)
+            assert ds is not None
+            assert ds["status"] == "ready"
+            assert ds["ready"] is True
+        finally:
+            pkl_file.unlink(missing_ok=True)
+            sidecar.unlink(missing_ok=True)
+            try:
+                EMBEDDINGS_DIR.rmdir()
+            except OSError:
+                pass
+
+    def test_pkl_embedder_field_present(self, client):
+        """Every demo in the response should have a pkl_embedder field."""
+        resp = client.get("/api/dataset/demo-list")
+        data = resp.get_json()
+        for ds in data["datasets"]:
+            assert "pkl_embedder" in ds, f"Dataset '{ds['name']}' missing pkl_embedder field"
+
+    def test_fallback_reads_embedder_from_pkl_medias(self, client):
+        """When no sidecar file exists, embedder is read from the pkl medias and cached."""
+        import pickle
+
+        from vtsearch.config import EMBEDDINGS_DIR
+        from vtsearch.datasets import DEMO_DATASETS
+
+        demo_name = None
+        for name, info in DEMO_DATASETS.items():
+            if info.get("required_folder") is None:
+                demo_name = name
+                break
+        if demo_name is None:
+            pytest.skip("No demo dataset without required_folder found")
+
+        EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+        pkl_file = EMBEDDINGS_DIR / f"{demo_name}.pkl"
+        sidecar = pkl_file.with_suffix(".embedder")
+        # Write pkl with embedder info in media entries, no sidecar
+        pkl_file.write_bytes(
+            pickle.dumps({
+                "name": demo_name,
+                "medias": {1: {"embedder": "FallbackEmb", "embedding": [0.1]}},
+            })
+        )
+        sidecar.unlink(missing_ok=True)
+        try:
+            resp = client.get("/api/dataset/demo-list?embedder=FallbackEmb")
+            data = resp.get_json()
+            ds = next((d for d in data["datasets"] if d["name"] == demo_name), None)
+            assert ds is not None
+            assert ds["pkl_embedder"] == "FallbackEmb"
+            assert ds["status"] == "ready"
+            # Sidecar should have been created as a cache
+            assert sidecar.exists(), "Sidecar should be written as cache after fallback read"
+            assert sidecar.read_text(encoding="utf-8").strip() == "FallbackEmb"
+        finally:
+            pkl_file.unlink(missing_ok=True)
+            sidecar.unlink(missing_ok=True)
+            try:
+                EMBEDDINGS_DIR.rmdir()
+            except OSError:
+                pass
+
+
 class TestImporterMetadata:
     """Importer to_dict() must include the icon field."""
 

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -1233,6 +1233,46 @@ def embed_image_file_from_pil(image: Image.Image, embedder_name: str = "") -> Op
     return emb.embed_pil_image(image)
 
 
+def _write_embedder_sidecar(pkl_path: Path, embedder_name: str) -> None:
+    """Write a small ``<name>.embedder`` file next to *pkl_path*.
+
+    The file stores the embedder name used to produce the pickle so that
+    ``demo_dataset_list`` can cheaply check whether the cached embeddings
+    match the user's current embedder selection without loading the full pkl.
+    """
+    sidecar = pkl_path.with_suffix(".embedder")
+    sidecar.write_text(embedder_name, encoding="utf-8")
+
+
+def read_pkl_embedder(pkl_path: Path) -> str | None:
+    """Return the embedder name stored for *pkl_path*, or ``None`` if unknown.
+
+    Checks the lightweight ``.embedder`` sidecar first.  Falls back to loading
+    the pickle and inspecting the first media entry's ``"embedder"`` field,
+    then writes the sidecar for future fast lookups.
+    """
+    sidecar = pkl_path.with_suffix(".embedder")
+    if sidecar.exists():
+        return sidecar.read_text(encoding="utf-8").strip()
+
+    # Fallback: peek into the pkl itself.
+    if not pkl_path.exists():
+        return None
+    try:
+        with open(pkl_path, "rb") as f:
+            data = pickle.load(f)  # noqa: S301
+        medias_dict = data.get("medias", {}) if isinstance(data, dict) else {}
+        for media in medias_dict.values():
+            name = media.get("embedder", "")
+            if name:
+                # Cache it for next time.
+                _write_embedder_sidecar(pkl_path, name)
+                return name
+    except Exception:
+        pass
+    return None
+
+
 def load_demo_dataset(
     dataset_name: str,
     medias: dict[int, dict[str, Any]],
@@ -1301,6 +1341,7 @@ def load_demo_dataset(
             # Pickle file exists but media files are missing, delete and re-embed
             on_progress("loading", f"Media files missing, re-embedding {dataset_name}...", 0, 0)
             pkl_file.unlink()
+            pkl_file.with_suffix(".embedder").unlink(missing_ok=True)
         else:
             on_progress("idle", f"Loaded {dataset_name} dataset")
             return
@@ -1380,6 +1421,10 @@ def load_demo_dataset(
     EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
     with open(pkl_file, "wb") as f:
         pickle.dump(pkl_data, f)
+
+    # Write a lightweight sidecar that records which embedder produced this pkl.
+    resolved_name = getattr(embedder, "name", "") if embedder is not None else ""
+    _write_embedder_sidecar(pkl_file, resolved_name)
 
     on_progress("idle", f"Loaded {dataset_name} dataset")
 

--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.config import EMBEDDINGS_DIR
-from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.datasets import DEMO_DATASETS
+from vtsearch.datasets.loader import read_pkl_embedder
 from vtsearch.routes.datasets_loading import _origin_to_str
+from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.utils import (
     get_dataset_display_name,
     get_dupe_count,
@@ -42,6 +43,10 @@ def demo_dataset_list():
     from vtsearch.converters import list_converters_for_source
     from vtsearch.media import get as media_get
 
+    # Optional embedder filter: when the caller specifies an embedder, a cached
+    # pkl is only considered "ready" if it was produced by that same embedder.
+    requested_embedder = request.args.get("embedder", "").strip()
+
     demos = []
     for name, dataset_info in DEMO_DATASETS.items():
         media_type = dataset_info.get("media_type", "audio")
@@ -71,6 +76,14 @@ def demo_dataset_list():
             else:
                 status = "needs_download"
 
+        # If the pkl exists but was embedded with a different embedder than
+        # the one the user selected, downgrade from "ready" to "needs_embedding".
+        pkl_embedder: str | None = None
+        if status == "ready" and requested_embedder:
+            pkl_embedder = read_pkl_embedder(pkl_file)
+            if pkl_embedder is not None and pkl_embedder != requested_embedder:
+                status = "needs_embedding"
+
         # Calculate number of files from slice parameters
         num_categories = len(dataset_info["categories"])
         slice_start = dataset_info.get("slice_start", 0)
@@ -93,6 +106,10 @@ def demo_dataset_list():
         # Converters that consume this demo's media type (M→N converters).
         available_converters = [c.to_dict() for c in list_converters_for_source(media_type)]
 
+        # Resolve pkl_embedder if not already read above.
+        if pkl_embedder is None and has_pkl:
+            pkl_embedder = read_pkl_embedder(pkl_file)
+
         demos.append(
             {
                 "name": name,
@@ -105,6 +122,7 @@ def demo_dataset_list():
                 "media_type": media_type,
                 "num_categories": num_categories,
                 "available_converters": available_converters,
+                "pkl_embedder": pkl_embedder or "",
             }
         )
     return jsonify({"datasets": demos})


### PR DESCRIPTION
## Summary
This PR adds embedder tracking for cached demo dataset pickles. When a demo dataset is embedded and cached, the system now records which embedder was used. This allows the UI to intelligently downgrade a cached dataset's status from "ready" to "needs_embedding" when the user selects a different embedder, enabling re-embedding with the new embedder while preserving the source data.

## Key Changes

**Backend (Python)**
- Added `_write_embedder_sidecar()` to write a lightweight `.embedder` sidecar file next to each pickle, storing the embedder name used to produce it
- Added `read_pkl_embedder()` to efficiently read the embedder from the sidecar file, with fallback to inspecting the pickle's media entries and caching the result
- Modified `demo_dataset_list()` endpoint to:
  - Accept optional `embedder` query parameter
  - Check if a cached pickle's embedder matches the requested embedder
  - Downgrade status from "ready" to "needs_embedding" when embedders don't match
  - Include `pkl_embedder` field in response for each demo
- Updated `load_demo_dataset()` to write the sidecar file after embedding completes
- Clean up sidecar files when pickles are deleted due to missing media

**Frontend (Angular)**
- Modified `getDemoList()` in `DatasetsApiService` to accept and pass optional `embedder` parameter
- Added `onDemoEmbedderChange()` handler to trigger status updates when embedder selection changes
- Added `updateDemoStatuses()` to recompute demo statuses client-side based on selected embedder:
  - Downgrades "ready" to "needs_embedding" when pkl_embedder doesn't match selected embedder
  - Preserves "needs_download" status (source data missing)
  - Skips updates for demos without cached pickles
- Updated template to call `onDemoEmbedderChange()` when embedder dropdown changes
- Added `pkl_embedder` field to `DemoDataset` interface

## Implementation Details
- The sidecar approach provides fast status checks without loading full pickles
- Fallback mechanism reads embedder from pickle media entries and caches it for future lookups
- Client-side status updates provide immediate UI feedback without server round-trips
- Comprehensive test coverage validates all scenarios: matching embedder, mismatched embedder, missing sidecar, and fallback behavior

https://claude.ai/code/session_0141S5f1Dj1zMJocLAxy9AbA