### PR TITLE
Filter idle status in _stepped_progress to prevent UI lockup

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -659,3 +659,36 @@ class TestLoadProgressRaceCondition:
             from vtsearch.datasets.registry import unregister_dataset
 
             unregister_dataset(dataset_id)
+
+    def test_stepped_progress_filters_idle(self):
+        """_stepped_progress must drop 'idle' so cached-pkl loads can't leak it.
+
+        When a demo dataset is already cached, load_demo_dataset() emits
+        ``on_progress("idle", ...)`` before the outer finalization wrapper
+        has finished.  If this leaks through to the global progress tracker,
+        a frontend poll can see 'idle' and stop polling — leaving the UI
+        stuck on the progress overlay.
+        """
+        from vtsearch.routes.datasets_loading import _stepped_progress
+        from vtsearch.utils.progress import get_progress, update_progress
+
+        # Set progress to a known non-idle state
+        update_progress("loading", "In progress…", step=2, total_steps=4)
+
+        # Simulate the inner load function signalling idle (e.g. cached pkl)
+        _stepped_progress("idle", "Loaded dataset")
+
+        # Progress must NOT have changed to idle
+        progress = get_progress()
+        assert progress["status"] == "loading", (
+            "_stepped_progress must filter out 'idle' to prevent "
+            "premature completion signals from cached dataset loads"
+        )
+        assert progress["message"] == "In progress…"
+
+        # Non-idle statuses must still pass through
+        _stepped_progress("downloading", "Fetching files…", 50, 100)
+        progress = get_progress()
+        assert progress["status"] == "downloading"
+        assert progress["message"] == "Fetching files…"
+        assert progress["step"] == 1  # downloading maps to step 1

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -48,7 +48,17 @@ def _stepped_progress(status: str, message: str = "", current: int = 0, total: i
     Translates the ``status`` value emitted by inner functions (downloader,
     media-type ``load_demo_source``, etc.) into a step number so the
     frontend can display "Step 1/4", "Step 2/4", etc.
+
+    ``"idle"`` signals are silently dropped because the outer
+    :func:`_run_origin_load_in_background` wrapper is responsible for
+    emitting the final ``"idle"`` after registration and embedder warm-up
+    are complete.  Without this filter a cached-pickle load can briefly set
+    ``"idle"`` before the wrapper overrides it, and a frontend poll during
+    that window would stop polling prematurely — leaving the UI stuck on
+    the progress overlay.
     """
+    if status == "idle":
+        return
     step = _STATUS_TO_STEP.get(status)
     update_progress(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
 
@@ -286,11 +296,10 @@ def _run_origin_load_in_background(
             clear_dataset()
             gc.collect()
             load_fn()
-            # Suppress any premature "idle" that load_fn may have emitted
-            # (e.g. load_demo_dataset signals idle before returning).
-            # The frontend must not see "idle" until registration and
-            # embedder warm-up are complete, otherwise the dashboard grid
-            # renders before the new entry exists in the registry.
+            # _stepped_progress (the progress callback injected by
+            # _run_importer_in_background) filters out "idle" so that
+            # inner functions like load_demo_dataset cannot prematurely
+            # signal completion to the frontend.
             update_progress(
                 "loading", "Finalizing…",
                 step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,


### PR DESCRIPTION
## Summary
This PR fixes a UI lockup issue where cached dataset loads could prematurely signal completion to the frontend, causing the progress overlay to disappear before the dataset is fully registered and ready.

## Key Changes
- **Added idle status filtering in `_stepped_progress()`**: The function now silently drops `"idle"` signals from inner load functions (like `load_demo_dataset`) to prevent premature completion signals from reaching the frontend
- **Updated progress finalization logic**: Clarified that `_stepped_progress` is responsible for filtering idle signals, allowing the outer wrapper to emit the final idle signal only after registration and embedder warm-up are complete
- **Added comprehensive test coverage**: New test `test_stepped_progress_filters_idle()` verifies that:
  - Idle signals are filtered out and don't change progress status
  - Non-idle statuses still pass through correctly
  - The filtering prevents the UI from getting stuck on the progress overlay

## Implementation Details
The fix addresses a race condition where cached pickle loads emit `"idle"` before the outer `_run_origin_load_in_background` wrapper finishes its finalization steps. Without filtering, a frontend poll during this window would see the idle status and stop polling, leaving the UI stuck on the progress overlay. By filtering idle signals at the `_stepped_progress` level, only the final idle signal from the wrapper reaches the frontend, ensuring proper UI state transitions.

https://claude.ai/code/session_019YryUKzqKuQk4pNKfcCwwm