### PR TITLE
Make view modes per-media-type instead of global

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -28,6 +28,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   labelingStatus: LabelingStatusResponse | null = null;
   viewModeLeft: 'grid' | 'list' = 'list';
+  private viewModeLeftDict: Record<string, 'grid' | 'list'> = {};
+  private currentMediaType = '';
   leftWidth = 260;
   rightWidth = 300;
   autopilotCollapsed = false;
@@ -73,6 +75,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.mediaState.medias$
       .pipe(takeUntil(this.destroy$))
       .subscribe((medias) => {
+        if (medias.length > 0) {
+          const newType = medias[0].type;
+          if (newType !== this.currentMediaType) {
+            this.currentMediaType = newType;
+            this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
+          }
+        }
         if (this.autopilotTextSortPending && medias.length > 0) {
           this.autopilotTextSortPending = false;
           this.triggerAutopilotTextSort();
@@ -177,7 +186,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((settings) => {
         if (!settings) return;
-        this.viewModeLeft = settings.view_mode_left ?? 'list';
+        const dict = settings.view_mode_left;
+        if (dict && typeof dict === 'object') {
+          this.viewModeLeftDict = dict as Record<string, 'grid' | 'list'>;
+          if (this.currentMediaType) {
+            this.viewModeLeft = this.viewModeLeftDict[this.currentMediaType] ?? 'list';
+          }
+        }
         if (settings.hide_autopilot && !this.autopilotCollapsed) {
           this.setAutopilotCollapsed(true);
         } else if (settings.hide_autopilot === false && this.autopilotCollapsed) {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -22,20 +22,39 @@
           <input type="checkbox" [ngModel]="settings.show_metadata" (ngModelChange)="onToggle('show_metadata', $event)" />
           Show metadata panel
         </label>
-        <div class="form-group">
-          <label class="form-label">Left panel view</label>
-          <select class="form-select" [ngModel]="settings.view_mode_left" (ngModelChange)="onViewModeChange('view_mode_left', $event)">
-            <option value="list">List View</option>
-            <option value="grid">Grid View</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label class="form-label">Right panel view</label>
-          <select class="form-select" [ngModel]="settings.view_mode_right" (ngModelChange)="onViewModeChange('view_mode_right', $event)">
-            <option value="list">List View</option>
-            <option value="grid">Grid View</option>
-          </select>
-        </div>
+      </div>
+
+      <!-- View (per-media-type) -->
+      <div class="settings-section settings-section--wide">
+        <h3>View</h3>
+        @if (mediaTypes.length > 0) {
+          <div class="view-tabs">
+            @for (mt of mediaTypes; track mt.type_id) {
+              <button
+                class="view-tab"
+                [class.view-tab--active]="activeViewTab === mt.type_id"
+                (click)="activeViewTab = mt.type_id">
+                {{ mt.name }}
+              </button>
+            }
+          </div>
+          <div class="view-tab-content">
+            <div class="form-group">
+              <label class="form-label">Left panel view</label>
+              <select class="form-select" [ngModel]="getViewMode('view_mode_left', activeViewTab)" (ngModelChange)="onViewModeChange('view_mode_left', activeViewTab, $event)">
+                <option value="list">List View</option>
+                <option value="grid">Grid View</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Right panel view</label>
+              <select class="form-select" [ngModel]="getViewMode('view_mode_right', activeViewTab)" (ngModelChange)="onViewModeChange('view_mode_right', activeViewTab, $event)">
+                <option value="list">List View</option>
+                <option value="grid">Grid View</option>
+              </select>
+            </div>
+          </div>
+        }
       </div>
 
       <!-- Sorting & Calibration -->

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -22,6 +22,10 @@
     font-size: 0.85rem;
     color: var(--text-secondary);
   }
+
+  &--wide {
+    grid-column: span 2;
+  }
 }
 
 .checkbox-row {
@@ -31,6 +35,39 @@
   margin-bottom: 0.5rem;
   font-size: 0.85rem;
   cursor: pointer;
+}
+
+.view-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-color, #444);
+  margin-bottom: 0.75rem;
+}
+
+.view-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+  }
+
+  &--active {
+    color: var(--text-primary);
+    border-bottom-color: var(--accent-color, #6cf);
+  }
+}
+
+.view-tab-content {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
 }
 
 .settings-actions {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -12,8 +12,8 @@ describe('SettingsModalComponent', () => {
     volume: 50,
     theme: 'dark',
     swipe_animation: true,
-    view_mode_left: 'grid',
-    view_mode_right: 'list',
+    view_mode_left: { audio: 'list', image: 'grid' },
+    view_mode_right: { audio: 'grid', image: 'list' },
     enrich_descriptions: false,
     safe_thresholds: false,
     calibrate_count: 50,
@@ -22,6 +22,13 @@ describe('SettingsModalComponent', () => {
     autopilot_hard_reds: 3,
     autoload_media_types: ['audio'],
     autoload_media_embedders: ['audio'],
+  };
+
+  const mockMediaTypes = {
+    media_types: [
+      { type_id: 'audio', name: 'Sound' },
+      { type_id: 'image', name: 'Image' },
+    ],
   };
 
   beforeEach(async () => {
@@ -41,11 +48,13 @@ describe('SettingsModalComponent', () => {
 
   function flushInit(): void {
     fixture.detectChanges();
-    // forkJoin makes both requests in parallel
+    // forkJoin makes all requests in parallel
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
+    const mediaTypesReq = httpMock.expectOne('/api/media-types');
     settingsReq.flush(mockSettings);
     embeddersReq.flush({ embedders: [{ name: 'audio', media_type_id: 'audio' }, { name: 'images', media_type_id: 'image' }, { name: 'text', media_type_id: 'text' }] });
+    mediaTypesReq.flush(mockMediaTypes);
   }
 
   it('should create', () => {
@@ -58,6 +67,12 @@ describe('SettingsModalComponent', () => {
     expect(component.settings.theme).toBe('dark');
     expect(component.embedders.length).toBe(3);
     expect(component.loading).toBeFalse();
+  });
+
+  it('should load media types and set active view tab', () => {
+    flushInit();
+    expect(component.mediaTypes.length).toBe(2);
+    expect(component.activeViewTab).toBe('audio');
   });
 
   it('should update theme and save', () => {
@@ -79,6 +94,20 @@ describe('SettingsModalComponent', () => {
     component.onNumberChange('calibrate_count', 100);
     expect(component.settings.calibrate_count).toBe(100);
     httpMock.expectOne('/api/settings').flush(mockSettings);
+  });
+
+  it('should update per-media-type view mode and save', () => {
+    flushInit();
+    component.onViewModeChange('view_mode_left', 'audio', 'grid');
+    const dict = component.settings.view_mode_left as Record<string, string>;
+    expect(dict['audio']).toBe('grid');
+    httpMock.expectOne('/api/settings').flush(mockSettings);
+  });
+
+  it('should get view mode for a media type', () => {
+    flushInit();
+    expect(component.getViewMode('view_mode_left', 'audio')).toBe('list');
+    expect(component.getViewMode('view_mode_right', 'audio')).toBe('grid');
   });
 
   it('should check if embedder is autoloaded', () => {
@@ -110,6 +139,7 @@ describe('SettingsModalComponent', () => {
     fixture.detectChanges();
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
+    const mediaTypesReq = httpMock.expectOne('/api/media-types');
     settingsReq.flush(mockSettings);
     embeddersReq.flush({
       embedders: [
@@ -120,6 +150,7 @@ describe('SettingsModalComponent', () => {
         { name: 'clip', media_type_id: 'image' },
       ],
     });
+    mediaTypesReq.flush(mockMediaTypes);
     expect(component.embedders.map((e) => `${e.media_type_id}:${e.name}`)).toEqual([
       'audio:alpha',
       'audio:beta',
@@ -140,8 +171,10 @@ describe('SettingsModalComponent', () => {
     fixture.detectChanges();
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
+    const mediaTypesReq = httpMock.expectOne('/api/media-types');
     settingsReq.flush({}, { status: 500, statusText: 'Error' });
     embeddersReq.flush({ embedders: [] });
+    mediaTypesReq.flush({ media_types: [] });
     expect(component.loading).toBeFalse();
     expect(component.error).toBe('Failed to load settings');
   });

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -4,7 +4,8 @@ import { FormsModule } from '@angular/forms';
 import { forkJoin } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
 import { SettingsApiService } from '../../../services/settings-api.service';
-import { AppSettings, EmbedderInfo } from '../../../models/api.models';
+import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { AppSettings, EmbedderInfo, MediaTypeInfo } from '../../../models/api.models';
 import { Theme, ThemeService } from '../../../services/theme.service';
 
 @Component({
@@ -19,11 +20,14 @@ export class SettingsModalComponent implements OnInit {
 
   settings: AppSettings = { volume: 50 };
   embedders: EmbedderInfo[] = [];
+  mediaTypes: MediaTypeInfo[] = [];
+  activeViewTab = '';
   loading = true;
   error = '';
 
   constructor(
     private settingsApi: SettingsApiService,
+    private datasetsApi: DatasetsApiService,
     private themeService: ThemeService,
   ) {}
 
@@ -31,12 +35,17 @@ export class SettingsModalComponent implements OnInit {
     forkJoin({
       settings: this.settingsApi.getSettings(),
       embedders: this.settingsApi.getEmbedders(),
+      mediaTypes: this.datasetsApi.getMediaTypes(),
     }).subscribe({
       next: (res) => {
         this.settings = res.settings;
         this.embedders = (res.embedders.embedders || []).sort(
           (a, b) => a.media_type_id.localeCompare(b.media_type_id) || a.name.localeCompare(b.name),
         );
+        this.mediaTypes = res.mediaTypes.media_types || [];
+        if (this.mediaTypes.length > 0) {
+          this.activeViewTab = this.mediaTypes[0].type_id;
+        }
         this.loading = false;
       },
       error: () => {
@@ -57,9 +66,17 @@ export class SettingsModalComponent implements OnInit {
     this.save();
   }
 
-  onViewModeChange(key: string, value: string): void {
-    (this.settings as Record<string, unknown>)[key] = value;
+  onViewModeChange(side: 'view_mode_left' | 'view_mode_right', typeId: string, value: string): void {
+    const dict = (this.settings[side] as Record<string, string>) || {};
+    dict[typeId] = value;
+    (this.settings as Record<string, unknown>)[side] = { ...dict };
     this.save();
+  }
+
+  getViewMode(side: 'view_mode_left' | 'view_mode_right', typeId: string): string {
+    const dict = this.settings[side];
+    if (!dict) return side === 'view_mode_left' ? 'list' : 'grid';
+    return dict[typeId] ?? (side === 'view_mode_left' ? 'list' : 'grid');
   }
 
   onNumberChange(key: string, value: number): void {

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -34,7 +34,7 @@ describe('RightPanelComponent', () => {
     // Settings request
     httpMock.expectOne('/api/settings').flush({
       volume: 1,
-      view_mode_right: 'grid',
+      view_mode_right: { audio: 'grid', image: 'grid' },
     });
     // First votes poll
     httpMock.expectOne('/api/votes').flush({
@@ -52,10 +52,13 @@ describe('RightPanelComponent', () => {
   }));
 
   it('should load view mode from settings on init', fakeAsync(() => {
+    component.medias = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
     fixture.detectChanges();
     tick();
-    httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: 'list' });
+    httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
     httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+    // Trigger ngOnChanges by setting medias via input
+    component.ngOnChanges({ medias: { currentValue: component.medias, previousValue: [], firstChange: true, isFirstChange: () => true } });
     expect(component.viewMode).toBe('list');
     cleanup();
   }));

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -33,7 +33,7 @@ export interface TrainModeContext {
   templateUrl: './right-panel.component.html',
   styleUrl: './right-panel.component.scss',
 })
-export class RightPanelComponent implements OnInit, OnDestroy {
+export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Input() medias: MediaItem[] = [];
   @Input() trainMode: TrainModeContext | null = null;
   @Output() mediaSelected = new EventEmitter<number>();
@@ -48,6 +48,8 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   showLabelExport = false;
   showDetectorExport = false;
 
+  private viewModeRightDict: Record<string, 'grid' | 'list'> = {};
+  private currentMediaType = '';
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -61,6 +63,16 @@ export class RightPanelComponent implements OnInit, OnDestroy {
     this.loadSettings();
     this.voteState.startPolling();
     this.subscribeToVotes();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['medias'] && this.medias.length > 0) {
+      const newType = this.medias[0].type;
+      if (newType !== this.currentMediaType) {
+        this.currentMediaType = newType;
+        this.viewMode = this.viewModeRightDict[newType] ?? 'grid';
+      }
+    }
   }
 
   ngOnDestroy(): void {
@@ -105,7 +117,13 @@ export class RightPanelComponent implements OnInit, OnDestroy {
       .subscribe({
         next: settings => {
           if (!settings) return;
-          this.viewMode = settings.view_mode_right ?? 'grid';
+          const dict = settings.view_mode_right;
+          if (dict && typeof dict === 'object') {
+            this.viewModeRightDict = dict as Record<string, 'grid' | 'list'>;
+            if (this.currentMediaType) {
+              this.viewMode = this.viewModeRightDict[this.currentMediaType] ?? 'grid';
+            }
+          }
         },
       });
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -251,8 +251,8 @@ export interface AppSettings {
   calibration_fraction?: number;
   swipe_animation?: boolean;
   show_metadata?: boolean;
-  view_mode_left?: 'grid' | 'list';
-  view_mode_right?: 'grid' | 'list';
+  view_mode_left?: Record<string, 'grid' | 'list'>;
+  view_mode_right?: Record<string, 'grid' | 'list'>;
   autoload_media_types?: string[];
   autoload_media_embedders?: string[];
   autorun_processors?: AutorunProcessor[];

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -11,8 +11,8 @@ describe('SettingsStateService', () => {
     volume: 0.8,
     theme: 'dark',
     swipe_animation: true,
-    view_mode_left: 'grid',
-    view_mode_right: 'list',
+    view_mode_left: { audio: 'grid', image: 'grid' },
+    view_mode_right: { audio: 'list', image: 'list' },
     inclusion: 0.5,
   };
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -184,43 +184,78 @@ class TestSettingsModule:
         settings_mod.reset()
         assert settings_mod.get_show_metadata() is False
 
-    def test_get_set_view_mode_left(self, isolated_settings):
-        settings_mod.set_view_mode_left("grid")
-        assert settings_mod.get_view_mode_left() == "grid"
+    def test_get_view_mode_left_default(self):
+        result = settings_mod.get_view_mode_left()
+        assert isinstance(result, dict)
+        # All types default to "list"
+        for v in result.values():
+            assert v == "list"
+
+    def test_get_view_mode_right_default(self):
+        result = settings_mod.get_view_mode_right()
+        assert isinstance(result, dict)
+        # All types default to "grid"
+        for v in result.values():
+            assert v == "grid"
+
+    def test_set_view_mode_left_per_type(self, isolated_settings):
+        settings_mod.set_view_mode_left({"audio": "grid", "image": "list"})
+        result = settings_mod.get_view_mode_left()
+        assert result["audio"] == "grid"
+        assert result["image"] == "list"
 
         raw = json.loads(isolated_settings.read_text())
-        assert raw["view_mode_left"] == "grid"
+        assert raw["view_mode_left"]["audio"] == "grid"
+        assert raw["view_mode_left"]["image"] == "list"
 
-    def test_view_mode_left_default(self):
-        assert settings_mod.get_view_mode_left() == "list"
+    def test_set_view_mode_right_per_type(self, isolated_settings):
+        settings_mod.set_view_mode_right({"audio": "list", "video": "grid"})
+        result = settings_mod.get_view_mode_right()
+        assert result["audio"] == "list"
+        assert result["video"] == "grid"
+
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["view_mode_right"]["audio"] == "list"
+
+    def test_view_mode_left_legacy_scalar(self, isolated_settings):
+        """Legacy string value is accepted and expanded to all types."""
+        settings_mod.set_view_mode_left("grid")
+        result = settings_mod.get_view_mode_left()
+        for v in result.values():
+            assert v == "grid"
+
+    def test_view_mode_right_legacy_scalar(self, isolated_settings):
+        """Legacy string value is accepted and expanded to all types."""
+        settings_mod.set_view_mode_right("list")
+        result = settings_mod.get_view_mode_right()
+        for v in result.values():
+            assert v == "list"
 
     def test_view_mode_left_persists_across_reset(self, isolated_settings):
-        settings_mod.set_view_mode_left("grid")
+        settings_mod.set_view_mode_left({"audio": "grid"})
         settings_mod.reset()
-        assert settings_mod.get_view_mode_left() == "grid"
+        assert settings_mod.get_view_mode_left()["audio"] == "grid"
 
-    def test_view_mode_left_invalid(self):
+    def test_view_mode_right_persists_across_reset(self, isolated_settings):
+        settings_mod.set_view_mode_right({"audio": "list"})
+        settings_mod.reset()
+        assert settings_mod.get_view_mode_right()["audio"] == "list"
+
+    def test_view_mode_left_invalid_mode(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_view_mode_left({"audio": "invalid"})
+
+    def test_view_mode_right_invalid_mode(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_view_mode_right({"audio": "invalid"})
+
+    def test_view_mode_invalid_scalar(self):
         with pytest.raises(ValueError):
             settings_mod.set_view_mode_left("invalid")
 
-    def test_get_set_view_mode_right(self, isolated_settings):
-        settings_mod.set_view_mode_right("list")
-        assert settings_mod.get_view_mode_right() == "list"
-
-        raw = json.loads(isolated_settings.read_text())
-        assert raw["view_mode_right"] == "list"
-
-    def test_view_mode_right_default(self):
-        assert settings_mod.get_view_mode_right() == "grid"
-
-    def test_view_mode_right_persists_across_reset(self, isolated_settings):
-        settings_mod.set_view_mode_right("list")
-        settings_mod.reset()
-        assert settings_mod.get_view_mode_right() == "list"
-
-    def test_view_mode_right_invalid(self):
+    def test_view_mode_invalid_media_type(self):
         with pytest.raises(ValueError):
-            settings_mod.set_view_mode_right("invalid")
+            settings_mod.set_view_mode_left({"nonexistent_type": "grid"})
 
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()
@@ -230,8 +265,12 @@ class TestSettingsModule:
         assert defaults["calibration_fraction"] == 0.5
         assert defaults["safe_thresholds"] is False
         assert defaults["show_metadata"] is True
-        assert defaults["view_mode_left"] == "list"
-        assert defaults["view_mode_right"] == "grid"
+        assert isinstance(defaults["view_mode_left"], dict)
+        for v in defaults["view_mode_left"].values():
+            assert v == "list"
+        assert isinstance(defaults["view_mode_right"], dict)
+        for v in defaults["view_mode_right"].values():
+            assert v == "grid"
         assert defaults["autoload_media_types"] == []
         assert defaults["autopilot_top_greens"] == 3
         assert defaults["autopilot_hard_reds"] == 4
@@ -606,42 +645,53 @@ class TestSettingsAPI:
         assert res.status_code == 200
         assert res.get_json()["show_metadata"] is True
 
-    def test_update_view_mode_left(self, client):
-        res = client.put("/api/settings", json={"view_mode_left": "grid"})
+    def test_update_view_mode_left_per_type(self, client):
+        res = client.put("/api/settings", json={"view_mode_left": {"audio": "grid", "image": "list"}})
         assert res.status_code == 200
-        assert res.get_json()["view_mode_left"] == "grid"
+        data = res.get_json()
+        assert data["view_mode_left"]["audio"] == "grid"
+        assert data["view_mode_left"]["image"] == "list"
 
         # Verify it persisted
         res2 = client.get("/api/settings")
-        assert res2.get_json()["view_mode_left"] == "grid"
+        assert res2.get_json()["view_mode_left"]["audio"] == "grid"
 
-    def test_update_view_mode_left_list(self, client):
-        client.put("/api/settings", json={"view_mode_left": "grid"})
-        res = client.put("/api/settings", json={"view_mode_left": "list"})
+    def test_update_view_mode_left_legacy_scalar(self, client):
+        res = client.put("/api/settings", json={"view_mode_left": "grid"})
         assert res.status_code == 200
-        assert res.get_json()["view_mode_left"] == "list"
+        data = res.get_json()
+        # All types should now be "grid"
+        for v in data["view_mode_left"].values():
+            assert v == "grid"
 
     def test_update_view_mode_left_invalid(self, client):
+        res = client.put("/api/settings", json={"view_mode_left": {"audio": "invalid"}})
+        assert res.status_code == 400
+
+    def test_update_view_mode_left_invalid_scalar(self, client):
         res = client.put("/api/settings", json={"view_mode_left": "invalid"})
         assert res.status_code == 400
 
-    def test_update_view_mode_right(self, client):
-        res = client.put("/api/settings", json={"view_mode_right": "list"})
+    def test_update_view_mode_right_per_type(self, client):
+        res = client.put("/api/settings", json={"view_mode_right": {"audio": "list", "video": "grid"}})
         assert res.status_code == 200
-        assert res.get_json()["view_mode_right"] == "list"
+        data = res.get_json()
+        assert data["view_mode_right"]["audio"] == "list"
+        assert data["view_mode_right"]["video"] == "grid"
 
         # Verify it persisted
         res2 = client.get("/api/settings")
-        assert res2.get_json()["view_mode_right"] == "list"
+        assert res2.get_json()["view_mode_right"]["audio"] == "list"
 
-    def test_update_view_mode_right_grid(self, client):
-        client.put("/api/settings", json={"view_mode_right": "list"})
-        res = client.put("/api/settings", json={"view_mode_right": "grid"})
+    def test_update_view_mode_right_legacy_scalar(self, client):
+        res = client.put("/api/settings", json={"view_mode_right": "list"})
         assert res.status_code == 200
-        assert res.get_json()["view_mode_right"] == "grid"
+        data = res.get_json()
+        for v in data["view_mode_right"].values():
+            assert v == "list"
 
     def test_update_view_mode_right_invalid(self, client):
-        res = client.put("/api/settings", json={"view_mode_right": "invalid"})
+        res = client.put("/api/settings", json={"view_mode_right": {"audio": "invalid"}})
         assert res.status_code == 400
 
     def test_get_settings_includes_view_modes(self, client):

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -104,15 +104,15 @@ def update_settings():
 
     if "view_mode_left" in body:
         try:
-            settings.set_view_mode_left(str(body["view_mode_left"]))
-        except ValueError:
-            return jsonify({"error": "view_mode_left must be 'grid' or 'list'"}), 400
+            settings.set_view_mode_left(body["view_mode_left"])
+        except (ValueError, TypeError) as exc:
+            return jsonify({"error": str(exc)}), 400
 
     if "view_mode_right" in body:
         try:
-            settings.set_view_mode_right(str(body["view_mode_right"]))
-        except ValueError:
-            return jsonify({"error": "view_mode_right must be 'grid' or 'list'"}), 400
+            settings.set_view_mode_right(body["view_mode_right"])
+        except (ValueError, TypeError) as exc:
+            return jsonify({"error": str(exc)}), 400
 
     if "hide_autopilot" in body:
         settings.set_hide_autopilot(bool(body["hide_autopilot"]))

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -46,8 +46,8 @@ _DEFAULTS: dict[str, Any] = {
     "calibration_fraction": 0.5,
     "swipe_animation": True,
     "show_metadata": True,
-    "view_mode_left": "list",
-    "view_mode_right": "grid",
+    "view_mode_left": {},
+    "view_mode_right": {},
     "autoload_media_types": [],
     "autoload_media_embedders": [],
     "autorun_processors": [],
@@ -114,7 +114,12 @@ def _ensure_loaded() -> dict[str, Any]:
 
 def get_defaults() -> dict[str, Any]:
     """Return a copy of the default settings (excluding infrastructure keys)."""
-    return {k: v for k, v in _DEFAULTS.items() if k not in _EXCLUDE_FROM_DEFAULTS}
+    result = {k: v for k, v in _DEFAULTS.items() if k not in _EXCLUDE_FROM_DEFAULTS}
+    # Expand view mode defaults to per-media-type dicts
+    valid_types = _valid_media_types()
+    result["view_mode_left"] = {tid: _VIEW_MODE_DEFAULTS["left"] for tid in valid_types}
+    result["view_mode_right"] = {tid: _VIEW_MODE_DEFAULTS["right"] for tid in valid_types}
+    return result
 
 
 def get_all() -> dict[str, Any]:
@@ -123,6 +128,9 @@ def get_all() -> dict[str, Any]:
         s = _ensure_loaded()
         result = dict(_DEFAULTS)
         result.update(s)
+        # Always return expanded per-media-type view mode dicts
+        result["view_mode_left"] = get_view_mode_left()
+        result["view_mode_right"] = get_view_mode_right()
         return result
 
 
@@ -192,8 +200,6 @@ _SETTING_SPECS: list[tuple] = [
     ("calibration_fraction", float, _clamp(float, 0.0, 1.0)),
     ("swipe_animation", bool, None),
     ("show_metadata", bool, None),
-    ("view_mode_left", str, _one_of("view_mode_left", VALID_VIEW_MODES)),
-    ("view_mode_right", str, _one_of("view_mode_right", VALID_VIEW_MODES)),
     ("hide_autopilot", bool, None),
     ("autopilot_top_greens", int, _clamp_min(int, 1)),
     ("autopilot_hard_reds", int, _clamp_min(int, 1)),
@@ -205,6 +211,77 @@ for _key, _cast, _coerce in _SETTING_SPECS:
     globals()[f"set_{_key}"] = _s
 
 del _key, _cast, _coerce, _g, _s
+
+
+# -------------------------------------------------------------------
+# Per-media-type view mode settings
+# -------------------------------------------------------------------
+
+_VIEW_MODE_DEFAULTS = {"left": "list", "right": "grid"}
+
+
+def _get_view_mode_dict(key: str) -> dict[str, str]:
+    """Return the per-media-type view mode dict for *key* (``view_mode_left`` or ``view_mode_right``).
+
+    Handles backward compatibility: if the stored value is a plain string
+    (old format), it is treated as the mode for all known media types.
+    """
+    side = key.replace("view_mode_", "")
+    default_mode = _VIEW_MODE_DEFAULTS.get(side, "list")
+    with _settings_lock:
+        raw = _ensure_loaded().get(key, _DEFAULTS[key])
+    if isinstance(raw, str):
+        # Legacy scalar value — expand to dict for all known types
+        return {tid: raw for tid in _valid_media_types()}
+    if isinstance(raw, dict):
+        # Fill in missing types with the side default
+        result = {}
+        for tid in _valid_media_types():
+            val = raw.get(tid, default_mode)
+            result[tid] = val if val in VALID_VIEW_MODES else default_mode
+        return result
+    return {tid: default_mode for tid in _valid_media_types()}
+
+
+def get_view_mode_left() -> dict[str, str]:
+    """Return a dict mapping media type ID -> view mode for the left panel."""
+    return _get_view_mode_dict("view_mode_left")
+
+
+def get_view_mode_right() -> dict[str, str]:
+    """Return a dict mapping media type ID -> view mode for the right panel."""
+    return _get_view_mode_dict("view_mode_right")
+
+
+def set_view_mode_left(value: dict[str, str] | str) -> None:
+    """Set the left panel view mode (per-media-type dict or legacy scalar)."""
+    _set_view_mode_dict("view_mode_left", value)
+
+
+def set_view_mode_right(value: dict[str, str] | str) -> None:
+    """Set the right panel view mode (per-media-type dict or legacy scalar)."""
+    _set_view_mode_dict("view_mode_right", value)
+
+
+def _set_view_mode_dict(key: str, value: dict[str, str] | str) -> None:
+    """Persist the per-media-type view mode dict for *key*."""
+    valid_types = _valid_media_types()
+    if isinstance(value, str):
+        # Legacy scalar — expand to all types
+        if value not in VALID_VIEW_MODES:
+            raise ValueError(f"Invalid {key}: {value!r}")
+        value = {tid: value for tid in valid_types}
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a dict or string")
+    for tid, mode in value.items():
+        if tid not in valid_types:
+            raise ValueError(f"Invalid media type: {tid!r}")
+        if mode not in VALID_VIEW_MODES:
+            raise ValueError(f"Invalid {key} value for {tid}: {mode!r}")
+    with _settings_lock:
+        s = _ensure_loaded()
+        s[key] = dict(value)
+        _save(s)
 
 
 def _valid_media_types() -> tuple[str, ...]:


### PR DESCRIPTION
## Summary
This PR refactors the view mode settings (left and right panel) from global scalar values to per-media-type dictionaries, allowing different view modes for different media types (audio, image, video, etc.).

## Key Changes

**Backend (vtsearch/settings.py)**
- Changed `view_mode_left` and `view_mode_right` from scalar strings to dictionaries mapping media type IDs to view modes
- Added `_get_view_mode_dict()` helper to handle backward compatibility with legacy scalar values
- Implemented `get_view_mode_left()`, `get_view_mode_right()`, `set_view_mode_left()`, and `set_view_mode_right()` functions that work with per-media-type dicts
- Added `_set_view_mode_dict()` to validate and persist view mode changes with proper error handling for invalid media types and modes
- Updated `get_defaults()` to expand view mode defaults to all known media types
- Updated `get_all()` to always return expanded per-media-type view mode dicts
- Removed old scalar view mode validation from the generic settings coercion system

**Frontend (Angular)**
- Updated `AppSettings` model to use `Record<string, 'grid' | 'list'>` for view modes instead of scalar strings
- Modified `SettingsModalComponent` to:
  - Load media types from the API
  - Display tabbed interface for selecting view mode per media type
  - Track active view tab and update view modes per media type
  - Added `getViewMode()` and updated `onViewModeChange()` to handle per-media-type logic
- Updated `LabelViewComponent` and `RightPanelComponent` to:
  - Store the full view mode dictionary
  - Track current media type and switch view mode when media type changes
  - Implement `ngOnChanges` to detect media type changes and apply appropriate view mode
- Updated component specs and styling to support the new tabbed view mode interface

**API Route (vtsearch/routes/settings.py)**
- Updated error handling to accept both dict and string values for view mode settings
- Improved error messages to be more descriptive

## Implementation Details

- **Backward Compatibility**: Legacy scalar view mode values are automatically expanded to apply to all known media types
- **Dynamic Media Types**: View modes are populated based on the actual registered media types in the system
- **Validation**: Invalid media type IDs and view mode values are properly validated with clear error messages
- **UI/UX**: The settings modal now displays tabs for each media type, allowing users to configure view modes independently per type
- **Auto-switching**: When users navigate between different media types, the view mode automatically switches to the configured mode for that type

https://claude.ai/code/session_013ZTEk738TDhFnSE8czixfD