### PR TITLE
Add voting functionality in hover focus mode

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -24,6 +24,7 @@
       (learnedSort)="onLearnedSort(false)"
       (loadSort)="onLoadSort()"
       (mediaSelect)="onMediaSelect($event)"
+      (mediaVote)="onHoverVote($event)"
       (indicatorClick)="onIndicatorClick($event)"
       [autopilotCollapsed]="autopilotCollapsed"
       (autopilotStart)="onAutopilotStart()"
@@ -50,6 +51,7 @@
       [medias]="mediaState.medias"
       [focusMode]="focusModeRight"
       (mediaSelected)="onMediaSelect($event)"
+      (mediaVoted)="onHoverVote($event)"
     />
   </div>
 </div>

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -6,6 +6,7 @@ import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
 import { SortingApiService } from '../../services/sorting-api.service';
+import { MediasApiService } from '../../services/medias-api.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
@@ -54,6 +55,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   constructor(
     private sortingApi: SortingApiService,
+    private mediasApi: MediasApiService,
     private ngZone: NgZone,
     private labelSession: LabelSessionService,
     public mediaState: MediaStateService,
@@ -309,6 +311,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onMediaSelect(id: number): void {
     this.mediaState.selectMedia(id);
+  }
+
+  onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
+    this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => {
+        this.onMediaVoted(event);
+      },
+    });
   }
 
   onMediaVoted(event: { id: number; vote: 'good' | 'bad' }): void {

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -62,6 +62,7 @@
           [focusMode]="focusMode"
           [showScores]="false"
           (mediaSelect)="mediaSelect.emit($event)"
+          (mediaVote)="mediaVote.emit($event)"
         />
         <vt-stripe-overview
           [sortOrder]="sortOrder"

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -54,6 +54,7 @@ export class LeftPanelComponent implements OnInit {
   @Output() learnedSort = new EventEmitter<void>();
   @Output() loadSort = new EventEmitter<void>();
   @Output() mediaSelect = new EventEmitter<number>();
+  @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
   @Output() indicatorClick = new EventEmitter<string>();
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -8,6 +8,7 @@
   [attr.aria-selected]="active"
   tabindex="0"
   (click)="onClick()"
+  (contextmenu)="onContextMenu($event)"
   (mouseenter)="onMouseEnter()"
   (keydown.enter)="onClick()"
   (keydown.space)="onClick()"

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -18,6 +18,7 @@ export class MediaItemComponent {
   @Input() focusMode: 'click' | 'hover' = 'click';
 
   @Output() select = new EventEmitter<number>();
+  @Output() vote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
   get isGrid(): boolean {
     return this.viewMode === 'grid';
@@ -44,7 +45,18 @@ export class MediaItemComponent {
   }
 
   onClick(): void {
-    this.select.emit(this.media.id);
+    if (this.focusMode === 'hover') {
+      this.vote.emit({ id: this.media.id, vote: 'bad' });
+    } else {
+      this.select.emit(this.media.id);
+    }
+  }
+
+  onContextMenu(event: MouseEvent): void {
+    if (this.focusMode === 'hover') {
+      event.preventDefault();
+      this.vote.emit({ id: this.media.id, vote: 'good' });
+    }
   }
 
   onMouseEnter(): void {

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -13,6 +13,7 @@
       [viewMode]="viewMode"
       [focusMode]="focusMode"
       (select)="onMediaSelect($event)"
+      (vote)="onMediaVote($event)"
     />
   }
 

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -23,6 +23,7 @@ export class MediaListComponent implements AfterViewChecked {
   @Input() showScores = true;
 
   @Output() mediaSelect = new EventEmitter<number>();
+  @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
   @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
 
   private pendingScrollToSelected = false;
@@ -63,6 +64,10 @@ export class MediaListComponent implements AfterViewChecked {
   onMediaSelect(id: number): void {
     this.pendingScrollToSelected = true;
     this.mediaSelect.emit(id);
+  }
+
+  onMediaVote(event: { id: number; vote: 'good' | 'bad' }): void {
+    this.mediaVote.emit(event);
   }
 
   ngAfterViewChecked(): void {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -12,6 +12,7 @@
         tabindex="0"
         [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name"
         (click)="onEntryClick(entry.id)"
+        (contextmenu)="onEntryContextMenu($event, entry.id)"
         (mouseenter)="onEntryMouseEnter(entry.id)"
         (keydown)="onEntryKeydown($event, entry.id)"
       >

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -28,6 +28,7 @@ export class LabelListComponent implements OnInit, OnChanges {
   @Input() viewMode: 'grid' | 'list' = 'grid';
   @Input() focusMode: 'click' | 'hover' = 'click';
   @Output() mediaSelected = new EventEmitter<number>();
+  @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
   sortedEntries: LabelEntry[] = [];
 
@@ -130,7 +131,18 @@ export class LabelListComponent implements OnInit, OnChanges {
   }
 
   onEntryClick(id: number): void {
-    this.mediaSelected.emit(id);
+    if (this.focusMode === 'hover') {
+      this.mediaVote.emit({ id, vote: 'bad' });
+    } else {
+      this.mediaSelected.emit(id);
+    }
+  }
+
+  onEntryContextMenu(event: MouseEvent, id: number): void {
+    if (this.focusMode === 'hover') {
+      event.preventDefault();
+      this.mediaVote.emit({ id, vote: 'good' });
+    }
   }
 
   onEntryMouseEnter(id: number): void {

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -23,6 +23,7 @@
     [viewMode]="viewMode"
     [focusMode]="focusMode"
     (mediaSelected)="onMediaSelected($event)"
+    (mediaVote)="onMediaVote($event)"
   />
 
   <vt-label-list
@@ -35,6 +36,7 @@
     [viewMode]="viewMode"
     [focusMode]="focusMode"
     (mediaSelected)="onMediaSelected($event)"
+    (mediaVote)="onMediaVote($event)"
   />
 
   <div class="export-row">

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -38,6 +38,7 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   @Input() trainMode: TrainModeContext | null = null;
   @Input() focusMode: 'click' | 'hover' = 'click';
   @Output() mediaSelected = new EventEmitter<number>();
+  @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
   goodIds: number[] = [];
   badIds: number[] = [];
@@ -75,6 +76,10 @@ export class RightPanelComponent implements OnInit, OnDestroy {
 
   onMediaSelected(id: number): void {
     this.mediaSelected.emit(id);
+  }
+
+  onMediaVote(event: { id: number; vote: 'good' | 'bad' }): void {
+    this.mediaVoted.emit(event);
   }
 
   onImportLabels(): void {


### PR DESCRIPTION
## Summary
This PR adds voting functionality that activates when the application is in 'hover' focus mode. Users can now vote on media items using click (bad vote) and right-click/context menu (good vote) interactions.

## Key Changes
- **Media Item Component**: Added `vote` output event and modified `onClick()` to emit votes in hover mode instead of selection. Added `onContextMenu()` handler for good votes via right-click.
- **Label List Component**: Added `mediaVote` output event with similar click/context-menu voting logic in `onEntryClick()` and new `onEntryContextMenu()` method.
- **Media List Component**: Added `mediaVote` output event and `onMediaVote()` passthrough method to propagate voting events up the component hierarchy.
- **Right Panel Component**: Added `mediaVoted` output event and `onMediaVote()` passthrough method.
- **Left Panel Component**: Added `mediaVote` output event and wired it through the template.
- **Label View Component**: 
  - Injected `MediasApiService` to handle vote API calls
  - Added `onHoverVote()` method that calls the API and triggers `onMediaVoted()` on success
  - Connected voting events from left and right panels to the new handler
- **Templates**: Added `(contextmenu)` event bindings to media items and label entries, and connected `(mediaVote)` and `(vote)` events through the component hierarchy.

## Implementation Details
- Voting only activates when `focusMode === 'hover'`; in 'click' mode, the original selection behavior is preserved
- Left-click emits a 'bad' vote, right-click emits a 'good' vote
- Context menu default behavior is prevented to avoid browser menus
- Vote API calls are made asynchronously with proper subscription cleanup using `takeUntil()`
- The voting event flows through multiple component layers (media-item → media-list → left-panel → label-view) to reach the API service

https://claude.ai/code/session_01RBtXgV4LqMhQuSktJ1CmvE