### PR TITLE
Make focus modes per-media-type like view modes

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -32,6 +32,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   focusModeLeft: 'click' | 'hover' = 'click';
   focusModeRight: 'click' | 'hover' = 'click';
   private viewModeLeftDict: Record<string, 'grid' | 'list'> = {};
+  private focusModeLeftDict: Record<string, 'click' | 'hover'> = {};
+  private focusModeRightDict: Record<string, 'click' | 'hover'> = {};
   private currentMediaType = '';
   leftWidth = 260;
   rightWidth = 300;
@@ -84,6 +86,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           if (newType !== this.currentMediaType) {
             this.currentMediaType = newType;
             this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
+            this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
+            this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
           }
         }
         if (this.autopilotTextSortPending && medias.length > 0) {
@@ -197,8 +201,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
             this.viewModeLeft = this.viewModeLeftDict[this.currentMediaType] ?? 'list';
           }
         }
-        this.focusModeLeft = settings.focus_mode_left === 'hover' ? 'hover' : 'click';
-        this.focusModeRight = settings.focus_mode_right === 'hover' ? 'hover' : 'click';
+        const fmLeft = settings.focus_mode_left;
+        if (fmLeft && typeof fmLeft === 'object') {
+          this.focusModeLeftDict = fmLeft as Record<string, 'click' | 'hover'>;
+          if (this.currentMediaType) {
+            this.focusModeLeft = this.focusModeLeftDict[this.currentMediaType] ?? 'click';
+          }
+        }
+        const fmRight = settings.focus_mode_right;
+        if (fmRight && typeof fmRight === 'object') {
+          this.focusModeRightDict = fmRight as Record<string, 'click' | 'hover'>;
+          if (this.currentMediaType) {
+            this.focusModeRight = this.focusModeRightDict[this.currentMediaType] ?? 'click';
+          }
+        }
         if (settings.hide_autopilot && !this.autopilotCollapsed) {
           this.setAutopilotCollapsed(true);
         } else if (settings.hide_autopilot === false && this.autopilotCollapsed) {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -22,25 +22,11 @@
           <input type="checkbox" [ngModel]="settings.show_metadata" (ngModelChange)="onToggle('show_metadata', $event)" />
           Show metadata panel
         </label>
-        <div class="form-group">
-          <label class="form-label">Focus mode (left panel)</label>
-          <select class="form-select" [ngModel]="settings.focus_mode_left" (ngModelChange)="onStringChange('focus_mode_left', $event)">
-            <option value="click">Click</option>
-            <option value="hover">Hover</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label class="form-label">Focus mode (right panel)</label>
-          <select class="form-select" [ngModel]="settings.focus_mode_right" (ngModelChange)="onStringChange('focus_mode_right', $event)">
-            <option value="click">Click</option>
-            <option value="hover">Hover</option>
-          </select>
-        </div>
       </div>
 
-      <!-- View (per-media-type) -->
+      <!-- Media Type Settings (per-media-type) -->
       <div class="settings-section settings-section--wide">
-        <h3>View</h3>
+        <h3>Media Type Settings</h3>
         @if (mediaTypes.length > 0) {
           <div class="view-tabs">
             @for (mt of mediaTypes; track mt.type_id) {
@@ -65,6 +51,20 @@
               <select class="form-select" [ngModel]="getViewMode('view_mode_right', activeViewTab)" (ngModelChange)="onViewModeChange('view_mode_right', activeViewTab, $event)">
                 <option value="list">List View</option>
                 <option value="grid">Grid View</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Left focus mode</label>
+              <select class="form-select" [ngModel]="getFocusMode('focus_mode_left', activeViewTab)" (ngModelChange)="onFocusModeChange('focus_mode_left', activeViewTab, $event)">
+                <option value="click">Click</option>
+                <option value="hover">Hover</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Right focus mode</label>
+              <select class="form-select" [ngModel]="getFocusMode('focus_mode_right', activeViewTab)" (ngModelChange)="onFocusModeChange('focus_mode_right', activeViewTab, $event)">
+                <option value="click">Click</option>
+                <option value="hover">Hover</option>
               </select>
             </div>
           </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -40,26 +40,34 @@
 .view-tabs {
   display: flex;
   gap: 0;
-  border-bottom: 1px solid var(--border-color, #444);
-  margin-bottom: 0.75rem;
+  margin-bottom: 0;
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border-radius: 6px 6px 0 0;
+  border: 1px solid var(--border-color, #444);
+  border-bottom: none;
+  padding: 0.25rem 0.25rem 0;
 }
 
 .view-tab {
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
-  padding: 0.4rem 0.75rem;
+  border-radius: 4px 4px 0 0;
+  padding: 0.45rem 0.85rem;
   font-size: 0.8rem;
+  font-weight: 500;
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
 
   &:hover {
     color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.04);
   }
 
   &--active {
     color: var(--text-primary);
+    background: var(--bg-primary, #1e1e2e);
     border-bottom-color: var(--accent-color, #6cf);
   }
 }
@@ -68,6 +76,11 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color, #444);
+  border-top: 1px solid var(--border-color, #444);
+  border-radius: 0 0 6px 6px;
+  background: var(--bg-primary, #1e1e2e);
 }
 
 .settings-actions {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -81,6 +81,19 @@ export class SettingsModalComponent implements OnInit {
     return dict[typeId] ?? (side === 'view_mode_left' ? 'list' : 'grid');
   }
 
+  onFocusModeChange(side: 'focus_mode_left' | 'focus_mode_right', typeId: string, value: string): void {
+    const dict = (this.settings[side] as Record<string, string>) || {};
+    dict[typeId] = value;
+    (this.settings as Record<string, unknown>)[side] = { ...dict };
+    this.save();
+  }
+
+  getFocusMode(side: 'focus_mode_left' | 'focus_mode_right', typeId: string): string {
+    const dict = this.settings[side];
+    if (!dict) return 'click';
+    return dict[typeId] ?? 'click';
+  }
+
   onNumberChange(key: string, value: number): void {
     (this.settings as Record<string, unknown>)[key] = value;
     this.save();

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -253,8 +253,8 @@ export interface AppSettings {
   show_metadata?: boolean;
   view_mode_left?: Record<string, 'grid' | 'list'>;
   view_mode_right?: Record<string, 'grid' | 'list'>;
-  focus_mode_left?: 'click' | 'hover';
-  focus_mode_right?: 'click' | 'hover';
+  focus_mode_left?: Record<string, 'click' | 'hover'>;
+  focus_mode_right?: Record<string, 'click' | 'hover'>;
   autoload_media_types?: string[];
   autoload_media_embedders?: string[];
   autorun_processors?: AutorunProcessor[];

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -257,43 +257,78 @@ class TestSettingsModule:
         with pytest.raises(ValueError):
             settings_mod.set_view_mode_left({"nonexistent_type": "grid"})
 
-    def test_get_set_focus_mode_left(self, isolated_settings):
-        settings_mod.set_focus_mode_left("hover")
-        assert settings_mod.get_focus_mode_left() == "hover"
+    def test_get_focus_mode_left_default(self):
+        result = settings_mod.get_focus_mode_left()
+        assert isinstance(result, dict)
+        # All types default to "click"
+        for v in result.values():
+            assert v == "click"
+
+    def test_get_focus_mode_right_default(self):
+        result = settings_mod.get_focus_mode_right()
+        assert isinstance(result, dict)
+        # All types default to "click"
+        for v in result.values():
+            assert v == "click"
+
+    def test_set_focus_mode_left_per_type(self, isolated_settings):
+        settings_mod.set_focus_mode_left({"audio": "hover", "image": "click"})
+        result = settings_mod.get_focus_mode_left()
+        assert result["audio"] == "hover"
+        assert result["image"] == "click"
 
         raw = json.loads(isolated_settings.read_text())
-        assert raw["focus_mode_left"] == "hover"
+        assert raw["focus_mode_left"]["audio"] == "hover"
+        assert raw["focus_mode_left"]["image"] == "click"
 
-    def test_focus_mode_left_default(self):
-        assert settings_mod.get_focus_mode_left() == "click"
+    def test_set_focus_mode_right_per_type(self, isolated_settings):
+        settings_mod.set_focus_mode_right({"audio": "hover", "video": "click"})
+        result = settings_mod.get_focus_mode_right()
+        assert result["audio"] == "hover"
+        assert result["video"] == "click"
 
-    def test_focus_mode_left_invalid(self):
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["focus_mode_right"]["audio"] == "hover"
+
+    def test_focus_mode_left_legacy_scalar(self, isolated_settings):
+        """Legacy string value is accepted and expanded to all types."""
+        settings_mod.set_focus_mode_left("hover")
+        result = settings_mod.get_focus_mode_left()
+        for v in result.values():
+            assert v == "hover"
+
+    def test_focus_mode_right_legacy_scalar(self, isolated_settings):
+        """Legacy string value is accepted and expanded to all types."""
+        settings_mod.set_focus_mode_right("hover")
+        result = settings_mod.get_focus_mode_right()
+        for v in result.values():
+            assert v == "hover"
+
+    def test_focus_mode_left_persists_across_reset(self, isolated_settings):
+        settings_mod.set_focus_mode_left({"audio": "hover"})
+        settings_mod.reset()
+        assert settings_mod.get_focus_mode_left()["audio"] == "hover"
+
+    def test_focus_mode_right_persists_across_reset(self, isolated_settings):
+        settings_mod.set_focus_mode_right({"audio": "hover"})
+        settings_mod.reset()
+        assert settings_mod.get_focus_mode_right()["audio"] == "hover"
+
+    def test_focus_mode_left_invalid_mode(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_focus_mode_left({"audio": "invalid"})
+
+    def test_focus_mode_right_invalid_mode(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_focus_mode_right({"audio": "invalid"})
+
+    def test_focus_mode_invalid_scalar(self):
         with pytest.raises(ValueError):
             settings_mod.set_focus_mode_left("invalid")
 
-    def test_focus_mode_left_persists_across_reset(self, isolated_settings):
-        settings_mod.set_focus_mode_left("hover")
-        settings_mod.reset()
-        assert settings_mod.get_focus_mode_left() == "hover"
-
-    def test_get_set_focus_mode_right(self, isolated_settings):
-        settings_mod.set_focus_mode_right("hover")
-        assert settings_mod.get_focus_mode_right() == "hover"
-
-        raw = json.loads(isolated_settings.read_text())
-        assert raw["focus_mode_right"] == "hover"
-
-    def test_focus_mode_right_default(self):
-        assert settings_mod.get_focus_mode_right() == "click"
-
-    def test_focus_mode_right_invalid(self):
+    def test_focus_mode_invalid_media_type(self):
         with pytest.raises(ValueError):
-            settings_mod.set_focus_mode_right("invalid")
-
-    def test_focus_mode_right_persists_across_reset(self, isolated_settings):
-        settings_mod.set_focus_mode_right("hover")
-        settings_mod.reset()
-        assert settings_mod.get_focus_mode_right() == "hover"
+            settings_mod.set_focus_mode_left({"nonexistent_type": "hover"})
 
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()
@@ -309,8 +344,12 @@ class TestSettingsModule:
         assert isinstance(defaults["view_mode_right"], dict)
         for v in defaults["view_mode_right"].values():
             assert v == "grid"
-        assert defaults["focus_mode_left"] == "click"
-        assert defaults["focus_mode_right"] == "click"
+        assert isinstance(defaults["focus_mode_left"], dict)
+        for v in defaults["focus_mode_left"].values():
+            assert v == "click"
+        assert isinstance(defaults["focus_mode_right"], dict)
+        for v in defaults["focus_mode_right"].values():
+            assert v == "click"
         assert defaults["autoload_media_types"] == []
         assert defaults["autopilot_top_greens"] == 3
         assert defaults["autopilot_hard_reds"] == 4
@@ -649,8 +688,12 @@ class TestSettingsAPI:
         assert data["calibrate_count"] == 2
         assert data["calibration_fraction"] == 0.5
         assert data["safe_thresholds"] is False
-        assert data["focus_mode_left"] == "click"
-        assert data["focus_mode_right"] == "click"
+        assert isinstance(data["focus_mode_left"], dict)
+        for v in data["focus_mode_left"].values():
+            assert v == "click"
+        assert isinstance(data["focus_mode_right"], dict)
+        for v in data["focus_mode_right"].values():
+            assert v == "click"
         assert data["autoload_media_types"] == []
         assert "autorun_processors" not in data
         assert "saved_datasets_dir" not in data
@@ -744,42 +787,53 @@ class TestSettingsAPI:
         assert "view_mode_left" in data
         assert "view_mode_right" in data
 
-    def test_update_focus_mode_left(self, client):
-        res = client.put("/api/settings", json={"focus_mode_left": "hover"})
+    def test_update_focus_mode_left_per_type(self, client):
+        res = client.put("/api/settings", json={"focus_mode_left": {"audio": "hover", "image": "click"}})
         assert res.status_code == 200
-        assert res.get_json()["focus_mode_left"] == "hover"
+        data = res.get_json()
+        assert data["focus_mode_left"]["audio"] == "hover"
+        assert data["focus_mode_left"]["image"] == "click"
 
         # Verify it persisted
         res2 = client.get("/api/settings")
-        assert res2.get_json()["focus_mode_left"] == "hover"
+        assert res2.get_json()["focus_mode_left"]["audio"] == "hover"
 
-    def test_update_focus_mode_left_click(self, client):
-        client.put("/api/settings", json={"focus_mode_left": "hover"})
-        res = client.put("/api/settings", json={"focus_mode_left": "click"})
+    def test_update_focus_mode_left_legacy_scalar(self, client):
+        res = client.put("/api/settings", json={"focus_mode_left": "hover"})
         assert res.status_code == 200
-        assert res.get_json()["focus_mode_left"] == "click"
+        data = res.get_json()
+        # All types should now be "hover"
+        for v in data["focus_mode_left"].values():
+            assert v == "hover"
 
     def test_update_focus_mode_left_invalid(self, client):
+        res = client.put("/api/settings", json={"focus_mode_left": {"audio": "invalid"}})
+        assert res.status_code == 400
+
+    def test_update_focus_mode_left_invalid_scalar(self, client):
         res = client.put("/api/settings", json={"focus_mode_left": "invalid"})
         assert res.status_code == 400
 
-    def test_update_focus_mode_right(self, client):
-        res = client.put("/api/settings", json={"focus_mode_right": "hover"})
+    def test_update_focus_mode_right_per_type(self, client):
+        res = client.put("/api/settings", json={"focus_mode_right": {"audio": "hover", "video": "click"}})
         assert res.status_code == 200
-        assert res.get_json()["focus_mode_right"] == "hover"
+        data = res.get_json()
+        assert data["focus_mode_right"]["audio"] == "hover"
+        assert data["focus_mode_right"]["video"] == "click"
 
         # Verify it persisted
         res2 = client.get("/api/settings")
-        assert res2.get_json()["focus_mode_right"] == "hover"
+        assert res2.get_json()["focus_mode_right"]["audio"] == "hover"
 
-    def test_update_focus_mode_right_click(self, client):
-        client.put("/api/settings", json={"focus_mode_right": "hover"})
-        res = client.put("/api/settings", json={"focus_mode_right": "click"})
+    def test_update_focus_mode_right_legacy_scalar(self, client):
+        res = client.put("/api/settings", json={"focus_mode_right": "hover"})
         assert res.status_code == 200
-        assert res.get_json()["focus_mode_right"] == "click"
+        data = res.get_json()
+        for v in data["focus_mode_right"].values():
+            assert v == "hover"
 
     def test_update_focus_mode_right_invalid(self, client):
-        res = client.put("/api/settings", json={"focus_mode_right": "invalid"})
+        res = client.put("/api/settings", json={"focus_mode_right": {"audio": "invalid"}})
         assert res.status_code == 400
 
     def test_get_settings_includes_focus_modes(self, client):
@@ -787,7 +841,9 @@ class TestSettingsAPI:
         assert res.status_code == 200
         data = res.get_json()
         assert "focus_mode_left" in data
+        assert isinstance(data["focus_mode_left"], dict)
         assert "focus_mode_right" in data
+        assert isinstance(data["focus_mode_right"], dict)
 
     def test_update_autoload_media_types(self, client):
         res = client.put("/api/settings", json={"autoload_media_types": ["audio", "video"]})

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -116,15 +116,15 @@ def update_settings():
 
     if "focus_mode_left" in body:
         try:
-            settings.set_focus_mode_left(str(body["focus_mode_left"]))
-        except ValueError:
-            return jsonify({"error": "focus_mode_left must be 'click' or 'hover'"}), 400
+            settings.set_focus_mode_left(body["focus_mode_left"])
+        except (ValueError, TypeError) as exc:
+            return jsonify({"error": str(exc)}), 400
 
     if "focus_mode_right" in body:
         try:
-            settings.set_focus_mode_right(str(body["focus_mode_right"]))
-        except ValueError:
-            return jsonify({"error": "focus_mode_right must be 'click' or 'hover'"}), 400
+            settings.set_focus_mode_right(body["focus_mode_right"])
+        except (ValueError, TypeError) as exc:
+            return jsonify({"error": str(exc)}), 400
 
     if "hide_autopilot" in body:
         settings.set_hide_autopilot(bool(body["hide_autopilot"]))

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -48,8 +48,8 @@ _DEFAULTS: dict[str, Any] = {
     "show_metadata": True,
     "view_mode_left": {},
     "view_mode_right": {},
-    "focus_mode_left": "click",
-    "focus_mode_right": "click",
+    "focus_mode_left": {},
+    "focus_mode_right": {},
     "autoload_media_types": [],
     "autoload_media_embedders": [],
     "autorun_processors": [],
@@ -121,6 +121,9 @@ def get_defaults() -> dict[str, Any]:
     valid_types = _valid_media_types()
     result["view_mode_left"] = {tid: _VIEW_MODE_DEFAULTS["left"] for tid in valid_types}
     result["view_mode_right"] = {tid: _VIEW_MODE_DEFAULTS["right"] for tid in valid_types}
+    # Expand focus mode defaults to per-media-type dicts
+    result["focus_mode_left"] = {tid: _FOCUS_MODE_DEFAULTS["left"] for tid in valid_types}
+    result["focus_mode_right"] = {tid: _FOCUS_MODE_DEFAULTS["right"] for tid in valid_types}
     return result
 
 
@@ -133,6 +136,9 @@ def get_all() -> dict[str, Any]:
         # Always return expanded per-media-type view mode dicts
         result["view_mode_left"] = get_view_mode_left()
         result["view_mode_right"] = get_view_mode_right()
+        # Always return expanded per-media-type focus mode dicts
+        result["focus_mode_left"] = get_focus_mode_left()
+        result["focus_mode_right"] = get_focus_mode_right()
         return result
 
 
@@ -203,8 +209,6 @@ _SETTING_SPECS: list[tuple] = [
     ("calibration_fraction", float, _clamp(float, 0.0, 1.0)),
     ("swipe_animation", bool, None),
     ("show_metadata", bool, None),
-    ("focus_mode_left", str, _one_of("focus_mode_left", VALID_FOCUS_MODES)),
-    ("focus_mode_right", str, _one_of("focus_mode_right", VALID_FOCUS_MODES)),
     ("hide_autopilot", bool, None),
     ("autopilot_top_greens", int, _clamp_min(int, 1)),
     ("autopilot_hard_reds", int, _clamp_min(int, 1)),
@@ -223,6 +227,7 @@ del _key, _cast, _coerce, _g, _s
 # -------------------------------------------------------------------
 
 _VIEW_MODE_DEFAULTS = {"left": "list", "right": "grid"}
+_FOCUS_MODE_DEFAULTS = {"left": "click", "right": "click"}
 
 
 def _get_view_mode_dict(key: str) -> dict[str, str]:
@@ -294,6 +299,76 @@ def _valid_media_types() -> tuple[str, ...]:
     from vtsearch.media import all_type_ids
 
     return tuple(all_type_ids())
+
+
+# -------------------------------------------------------------------
+# Per-media-type focus mode settings
+# -------------------------------------------------------------------
+
+
+def _get_focus_mode_dict(key: str) -> dict[str, str]:
+    """Return the per-media-type focus mode dict for *key* (``focus_mode_left`` or ``focus_mode_right``).
+
+    Handles backward compatibility: if the stored value is a plain string
+    (old format), it is treated as the mode for all known media types.
+    """
+    side = key.replace("focus_mode_", "")
+    default_mode = _FOCUS_MODE_DEFAULTS.get(side, "click")
+    with _settings_lock:
+        raw = _ensure_loaded().get(key, _DEFAULTS[key])
+    if isinstance(raw, str):
+        # Legacy scalar value — expand to dict for all known types
+        mode = raw if raw in VALID_FOCUS_MODES else default_mode
+        return {tid: mode for tid in _valid_media_types()}
+    if isinstance(raw, dict):
+        # Fill in missing types with the side default
+        result = {}
+        for tid in _valid_media_types():
+            val = raw.get(tid, default_mode)
+            result[tid] = val if val in VALID_FOCUS_MODES else default_mode
+        return result
+    return {tid: default_mode for tid in _valid_media_types()}
+
+
+def get_focus_mode_left() -> dict[str, str]:
+    """Return a dict mapping media type ID -> focus mode for the left panel."""
+    return _get_focus_mode_dict("focus_mode_left")
+
+
+def get_focus_mode_right() -> dict[str, str]:
+    """Return a dict mapping media type ID -> focus mode for the right panel."""
+    return _get_focus_mode_dict("focus_mode_right")
+
+
+def set_focus_mode_left(value: dict[str, str] | str) -> None:
+    """Set the left panel focus mode (per-media-type dict or legacy scalar)."""
+    _set_focus_mode_dict("focus_mode_left", value)
+
+
+def set_focus_mode_right(value: dict[str, str] | str) -> None:
+    """Set the right panel focus mode (per-media-type dict or legacy scalar)."""
+    _set_focus_mode_dict("focus_mode_right", value)
+
+
+def _set_focus_mode_dict(key: str, value: dict[str, str] | str) -> None:
+    """Persist the per-media-type focus mode dict for *key*."""
+    valid_types = _valid_media_types()
+    if isinstance(value, str):
+        # Legacy scalar — expand to all types
+        if value not in VALID_FOCUS_MODES:
+            raise ValueError(f"Invalid {key}: {value!r}")
+        value = {tid: value for tid in valid_types}
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a dict or string")
+    for tid, mode in value.items():
+        if tid not in valid_types:
+            raise ValueError(f"Invalid media type: {tid!r}")
+        if mode not in VALID_FOCUS_MODES:
+            raise ValueError(f"Invalid {key} value for {tid}: {mode!r}")
+    with _settings_lock:
+        s = _ensure_loaded()
+        s[key] = dict(value)
+        _save(s)
 
 
 def get_autoload_media_types() -> list[str]:


### PR DESCRIPTION
## Summary
This PR refactors focus mode settings to be per-media-type dictionaries (similar to view modes) instead of global scalar values. This allows users to configure different focus behaviors (click vs. hover) for different media types.

## Key Changes

**Backend (Python)**
- Changed `focus_mode_left` and `focus_mode_right` from scalar strings to per-media-type dictionaries in settings storage
- Added `_get_focus_mode_dict()` and `_set_focus_mode_dict()` functions to handle per-media-type focus mode management
- Implemented backward compatibility: legacy scalar string values are automatically expanded to all known media types
- Updated `get_defaults()` to expand focus mode defaults to per-media-type dicts
- Updated `get_all()` to always return expanded per-media-type focus mode dicts
- Removed focus mode validation from the generic settings coercion rules (now handled by dedicated setters)
- Updated API error handling to accept both dict and string inputs with proper validation

**Frontend (TypeScript/Angular)**
- Updated `AppSettings` interface to define `focus_mode_left` and `focus_mode_right` as `Record<string, 'click' | 'hover'>` instead of scalar strings
- Modified settings modal to display per-media-type focus mode controls alongside view mode controls
- Added `getFocusMode()` and `onFocusModeChange()` methods to handle per-media-type focus mode updates
- Updated `LabelViewComponent` to store and use per-media-type focus mode dictionaries, switching modes when the active media type changes
- Reorganized settings modal UI: moved focus mode controls from global appearance section to per-media-type "Media Type Settings" section

**Tests**
- Refactored test suite to verify per-media-type focus mode behavior
- Added tests for default values, per-type setting/getting, and persistence
- Added tests for backward compatibility with legacy scalar values
- Added tests for invalid media types and invalid mode values
- Updated API endpoint tests to work with dict-based focus modes
- Updated default settings tests to verify focus modes are dicts with correct defaults

**UI/Styling**
- Enhanced settings modal styling for the media type tabs section with better visual hierarchy
- Added padding, borders, and background colors to improve tab appearance and content grouping

## Implementation Details
- Focus mode defaults are defined in `_FOCUS_MODE_DEFAULTS` (left: "click", right: "click")
- When a legacy scalar value is encountered, it's automatically expanded to apply to all known media types
- Missing media types in partial dicts default to the side-specific default mode
- The implementation maintains full backward compatibility with existing settings files

https://claude.ai/code/session_017989qa6s4Y69uwhyUaXuJ1