### PR TITLE
Detect selectedId changes via OnChanges instead of on select

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -1,4 +1,14 @@
-import { Component, Input, Output, EventEmitter, ElementRef, ViewChild, AfterViewChecked } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ElementRef,
+  ViewChild,
+  AfterViewChecked,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MediaItemComponent } from '../media-item/media-item.component';
 import { MediaItem } from '../../../models/api.models';
@@ -11,7 +21,7 @@ import { SortedItem } from '../left-panel.component';
   templateUrl: './media-list.component.html',
   styleUrl: './media-list.component.scss',
 })
-export class MediaListComponent implements AfterViewChecked {
+export class MediaListComponent implements AfterViewChecked, OnChanges {
   @Input() medias: MediaItem[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
@@ -27,6 +37,12 @@ export class MediaListComponent implements AfterViewChecked {
   @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
 
   private pendingScrollToSelected = false;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['selectedId'] && !changes['selectedId'].firstChange) {
+      this.pendingScrollToSelected = true;
+    }
+  }
 
   get orderedItems(): { media: MediaItem; score: number | null; showThreshold: boolean }[] {
     const mediaMap = new Map(this.medias.map((m) => [m.id, m]));
@@ -62,7 +78,6 @@ export class MediaListComponent implements AfterViewChecked {
   }
 
   onMediaSelect(id: number): void {
-    this.pendingScrollToSelected = true;
     this.mediaSelect.emit(id);
   }
 


### PR DESCRIPTION
## Summary
Refactored the media list component to detect changes to the `selectedId` input property using Angular's `OnChanges` lifecycle hook instead of setting a flag directly in the `onMediaSelect` method.

## Key Changes
- Added `OnChanges` and `SimpleChanges` to the component's imports
- Implemented the `OnChanges` interface on `MediaListComponent`
- Added `ngOnChanges` lifecycle hook that sets `pendingScrollToSelected` flag when `selectedId` input changes (excluding the initial change)
- Removed the `this.pendingScrollToSelected = true;` assignment from the `onMediaSelect` method

## Implementation Details
This change improves the separation of concerns by using Angular's built-in change detection mechanism rather than relying on the select event handler to manage scroll behavior. The `ngOnChanges` hook specifically watches for changes to the `selectedId` input property and only triggers the scroll behavior on subsequent changes (via the `!changes['selectedId'].firstChange` check), avoiding unnecessary scroll operations during component initialization.

https://claude.ai/code/session_01DMiEv3M5X36m4de294Nn3L