### PR TITLE
Reorder settings modal form groups for better UX

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -47,26 +47,10 @@
               </select>
             </div>
             <div class="form-group">
-              <label class="form-label">Left panel grid item size</label>
-              <select class="form-select" [ngModel]="getGridItemSize('grid_item_size_left', activeViewTab)" (ngModelChange)="onGridItemSizeChange('grid_item_size_left', activeViewTab, $event)">
-                <option value="small">Small</option>
-                <option value="medium">Medium</option>
-                <option value="large">Large</option>
-              </select>
-            </div>
-            <div class="form-group">
               <label class="form-label">Right panel view</label>
               <select class="form-select" [ngModel]="getViewMode('view_mode_right', activeViewTab)" (ngModelChange)="onViewModeChange('view_mode_right', activeViewTab, $event)">
                 <option value="list">List View</option>
                 <option value="grid">Grid View</option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label class="form-label">Right panel grid item size</label>
-              <select class="form-select" [ngModel]="getGridItemSize('grid_item_size_right', activeViewTab)" (ngModelChange)="onGridItemSizeChange('grid_item_size_right', activeViewTab, $event)">
-                <option value="small">Small</option>
-                <option value="medium">Medium</option>
-                <option value="large">Large</option>
               </select>
             </div>
             <div class="form-group">
@@ -81,6 +65,22 @@
               <select class="form-select" [ngModel]="getFocusMode('focus_mode_right', activeViewTab)" (ngModelChange)="onFocusModeChange('focus_mode_right', activeViewTab, $event)">
                 <option value="click">Click</option>
                 <option value="hover">Hover</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Left panel grid item size</label>
+              <select class="form-select" [ngModel]="getGridItemSize('grid_item_size_left', activeViewTab)" (ngModelChange)="onGridItemSizeChange('grid_item_size_left', activeViewTab, $event)">
+                <option value="small">Small</option>
+                <option value="medium">Medium</option>
+                <option value="large">Large</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Right panel grid item size</label>
+              <select class="form-select" [ngModel]="getGridItemSize('grid_item_size_right', activeViewTab)" (ngModelChange)="onGridItemSizeChange('grid_item_size_right', activeViewTab, $event)">
+                <option value="small">Small</option>
+                <option value="medium">Medium</option>
+                <option value="large">Large</option>
               </select>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Reorganized the settings modal form groups to improve the logical flow and user experience. The grid item size settings have been moved to appear after the focus mode settings, creating a more intuitive grouping of related options.

## Changes
- Moved "Left panel grid item size" setting from appearing immediately after "Left panel view" to after "Left focus mode"
- Moved "Right panel grid item size" setting from appearing immediately after "Right panel view" to after "Right focus mode"
- This reordering groups view mode settings together, followed by focus mode settings, and finally grid item size settings

## Details
The form now presents settings in a more logical order:
1. View mode options (left and right panels)
2. Focus mode options (left and right panels)
3. Grid item size options (left and right panels)

This grouping makes it easier for users to understand the relationship between settings and reduces cognitive load when navigating the settings modal.

https://claude.ai/code/session_01QRe3XASy2BNqmXxUFvhYjE