### PR TITLE
Auto-select newly added datasets and models in dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -59,13 +59,51 @@ describe('DashboardComponent', () => {
     expect(component.selectedModelIds.has('m1')).toBeTrue();
   });
 
-  it('should not auto-select when multiple datasets', () => {
+  it('should not auto-select when multiple datasets on initial load', () => {
     const datasets = [
       { id: 'd1', name: 'First' },
       { id: 'd2', name: 'Second' },
     ];
     flushInitialRequests(datasets);
     expect(component.selectedDatasetIds.size).toBe(0);
+  });
+
+  it('should auto-select newly added dataset', () => {
+    const datasets = [{ id: 'd1', name: 'First' }];
+    flushInitialRequests(datasets);
+    expect(component.selectedDatasetIds.has('d1')).toBeTrue();
+
+    // Simulate adding a second dataset via refresh
+    component.refresh();
+    httpMock.expectOne('/api/datasets/registry').flush({
+      datasets: [
+        { id: 'd1', name: 'First' },
+        { id: 'd2', name: 'Second' },
+      ],
+    });
+    httpMock.expectOne('/api/models/registry').flush({ models: [] });
+
+    expect(component.selectedDatasetIds.has('d1')).toBeTrue();
+    expect(component.selectedDatasetIds.has('d2')).toBeTrue();
+  });
+
+  it('should auto-select newly added model', () => {
+    const models = [{ id: 'm1', name: 'First' }];
+    flushInitialRequests([], models);
+    expect(component.selectedModelIds.has('m1')).toBeTrue();
+
+    // Simulate adding a second model via refresh
+    component.refresh();
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/models/registry').flush({
+      models: [
+        { id: 'm1', name: 'First' },
+        { id: 'm2', name: 'Second' },
+      ],
+    });
+
+    expect(component.selectedModelIds.has('m1')).toBeTrue();
+    expect(component.selectedModelIds.has('m2')).toBeTrue();
   });
 
   it('should toggle dataset selection on click', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -52,6 +52,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   private polling$ = new Subject<void>();
+  private knownDatasetIds = new Set<string>();
+  private knownModelIds = new Set<string>();
 
   constructor(
     private router: Router,
@@ -64,6 +66,39 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    // Auto-select newly added items whenever the dataset/model lists change
+    this.datasetState.datasets$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((datasets) => {
+        const currentIds = new Set(datasets.map((d: any) => d.id));
+        const newIds = [...currentIds].filter((id) => !this.knownDatasetIds.has(id));
+        if (newIds.length > 0 && this.knownDatasetIds.size > 0) {
+          // Items were added after initial load — select the new ones
+          for (const id of newIds) {
+            this.selectedDatasetIds.add(id);
+          }
+        } else if (datasets.length === 1 && this.selectedDatasetIds.size === 0) {
+          // First load with exactly one item — auto-select it
+          this.selectedDatasetIds.add(datasets[0].id);
+        }
+        this.knownDatasetIds = currentIds;
+      });
+    this.datasetState.models$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((models) => {
+        const currentIds = new Set(models.map((m: any) => m.id));
+        const newIds = [...currentIds].filter((id) => !this.knownModelIds.has(id));
+        if (newIds.length > 0 && this.knownModelIds.size > 0) {
+          // Items were added after initial load — select the new ones
+          for (const id of newIds) {
+            this.selectedModelIds.add(id);
+          }
+        } else if (models.length === 1 && this.selectedModelIds.size === 0) {
+          // First load with exactly one item — auto-select it
+          this.selectedModelIds.add(models[0].id);
+        }
+        this.knownModelIds = currentIds;
+      });
     this.refresh();
   }
 
@@ -92,21 +127,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   refresh(): void {
     this.datasetState.refresh();
-    // Auto-select single items after refresh
-    this.datasetState.datasets$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((datasets) => {
-        if (datasets.length === 1 && this.selectedDatasetIds.size === 0) {
-          this.selectedDatasetIds.add(datasets[0].id);
-        }
-      });
-    this.datasetState.models$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((models) => {
-        if (models.length === 1 && this.selectedModelIds.size === 0) {
-          this.selectedModelIds.add(models[0].id);
-        }
-      });
   }
 
   // --- Dataset selection ---

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -11,8 +11,8 @@ describe('SettingsStateService', () => {
     volume: 0.8,
     theme: 'dark',
     swipe_animation: true,
-    view_mode_left: { audio: 'grid', image: 'grid' },
-    view_mode_right: { audio: 'list', image: 'list' },
+    view_mode_left: { audio: 'grid' as const, image: 'grid' as const },
+    view_mode_right: { audio: 'list' as const, image: 'list' as const },
     inclusion: 0.5,
   };
 


### PR DESCRIPTION
## Summary
Refactored the dashboard component to improve auto-selection behavior for datasets and models. The component now automatically selects newly added items when they appear in the list, not just on initial load.

## Key Changes
- **Moved auto-selection logic to `ngOnInit()`**: Subscriptions to dataset and model streams are now established once during component initialization rather than being recreated on every refresh
- **Track known items**: Added `knownDatasetIds` and `knownModelIds` sets to detect when new items are added to the lists
- **Enhanced auto-selection logic**: 
  - Auto-selects single items on initial load (existing behavior)
  - Auto-selects newly added items after initial load (new behavior)
- **Simplified `refresh()` method**: Removed redundant subscription logic that was creating multiple subscriptions
- **Added test coverage**: New tests verify auto-selection of newly added datasets and models after refresh
- **Minor type fix**: Added `as const` type assertions in settings state service tests for better type safety

## Implementation Details
The auto-selection now works in two scenarios:
1. **Initial load**: If exactly one dataset/model exists and nothing is selected, it's automatically selected
2. **After refresh**: If new items are added to an already-populated list, only the new items are selected

This prevents memory leaks from multiple subscriptions and provides a better user experience when items are dynamically added to the dashboard.

https://claude.ai/code/session_01AZhBY3ULuVHD6MxkTGH2Wp