### PR TITLE
Reorder sort modes and remove fixed width styling

### DIFF
--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.scss
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.scss
@@ -9,7 +9,6 @@
   color: var(--text-secondary);
   font-size: 0.8rem;
   font-weight: 500;
-  width: 100%;
 }
 
 .sort-radio {

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -11,6 +11,16 @@
       />
       Text
     </label>
+    <label class="sort-radio" [class.active]="sortMode === 'load'" title="Load a previously saved model or detector and rank items using its predictions.">
+      <input
+        type="radio"
+        name="sortMode"
+        value="load"
+        [checked]="sortMode === 'load'"
+        (change)="onSortModeChange('load')"
+      />
+      Load
+    </label>
     <label class="sort-radio" [class.active]="sortMode === 'learned'" title="Train a model on your good/bad votes and rank items by predicted score. Requires at least 1 good and 1 bad vote.">
       <input
         type="radio"
@@ -21,16 +31,6 @@
         (change)="onSortModeChange('learned')"
       />
       Learned
-    </label>
-    <label class="sort-radio" [class.active]="sortMode === 'load'" title="Load a previously saved model or detector and rank items using its predictions.">
-      <input
-        type="radio"
-        name="sortMode"
-        value="load"
-        [checked]="sortMode === 'load'"
-        (change)="onSortModeChange('load')"
-      />
-      Load
     </label>
   </div>
 

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
@@ -15,7 +15,6 @@
   color: var(--text-secondary);
   font-size: 0.8rem;
   font-weight: 500;
-  width: 100%;
 }
 
 .sort-radio {


### PR DESCRIPTION
## Summary
This PR reorders the sort mode options in the UI and removes unnecessary fixed width constraints from radio button labels.

## Key Changes
- **Reordered sort modes**: Moved the "Load" option to appear before "Learned" in the sort-bar component, changing the visual order from Text → Learned → Load to Text → Load → Learned
- **Removed fixed width styling**: Deleted `width: 100%` from the `.sort-radio` label styles in both sort-bar and select-mode components, allowing labels to size naturally based on content

## Implementation Details
- The "Load" radio button functionality remains unchanged; only its position in the DOM has been reordered
- The width removal affects the label container styling, enabling more flexible layout behavior for the radio button options
- All event handlers and bindings remain intact

https://claude.ai/code/session_015N5CHLk35mrQb1gn68yvyP