### PR TITLE
Fix media list scrolling and section header layout in grid mode

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.scss
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.scss
@@ -28,6 +28,10 @@
   padding: 2px 8px;
   margin: 2px 0;
 
+  .grid-layout & {
+    grid-column: 1 / -1;
+  }
+
   &::before,
   &::after {
     content: '';

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -98,10 +98,17 @@ export class MediaListComponent implements AfterViewChecked, OnChanges {
 
   scrollToIndex(index: number): void {
     if (!this.listContainer) return;
-    const items = this.listContainer.nativeElement.querySelectorAll('vt-media-item');
-    if (items[index]) {
-      items[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
-    }
+    const container = this.listContainer.nativeElement;
+    const items = container.querySelectorAll('vt-media-item');
+    const target = items[index] as HTMLElement | undefined;
+    if (!target) return;
+    const containerRect = container.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const offset = targetRect.top - containerRect.top + container.scrollTop;
+    container.scrollTo({
+      top: offset - containerRect.height / 2 + targetRect.height / 2,
+      behavior: 'smooth',
+    });
   }
 
   trackByMediaId(_index: number, item: { media: MediaItem }): number {


### PR DESCRIPTION
## Summary
This PR improves the media list component's scrolling behavior and fixes the layout of section headers when using grid display mode.

## Key Changes
- **Improved scroll-to-index implementation**: Replaced the native `scrollIntoView()` method with a custom scroll calculation that properly centers items within the scrollable container, accounting for container and target element dimensions
- **Fixed section header layout in grid mode**: Added CSS rule to make section headers span the full width (all columns) when the media list is displayed in grid layout mode

## Implementation Details
- The new `scrollToIndex()` method now:
  - Calculates the precise scroll offset by measuring the bounding rectangles of both the container and target element
  - Centers the target item vertically within the viewport by accounting for container height and target height
  - Uses `scrollTo()` with smooth behavior for consistent scrolling animation
  - Includes early return if target element is not found
  
- The section header styling now uses the `.grid-layout &` selector to apply `grid-column: 1 / -1`, ensuring headers span across all columns in grid layouts while maintaining their original behavior in other layouts

https://claude.ai/code/session_01F942cyfSCtT61yqVMY6dBN