### PR TITLE
Add librosa resampling JIT warmup to audio embedder initialization

### DIFF
--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -118,9 +118,10 @@ class TestPreloadConsoleOutput:
             mock_emb._on_progress("loading", "Loading CLAP model weights...", 0, 0)
             mock_emb._on_progress("loading", "model.safetensors", 50, 100)
             mock_emb._on_progress("loading", "model.safetensors", 100, 100)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: importing libraries...", 1, 3)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: preprocessing...", 2, 3)
-            mock_emb._on_progress("loading", "Warming up audio pipeline: running model...", 3, 3)
+            mock_emb._on_progress("loading", "Warming up audio pipeline: importing libraries...", 1, 4)
+            mock_emb._on_progress("loading", "Warming up audio pipeline: resampling JIT...", 2, 4)
+            mock_emb._on_progress("loading", "Warming up audio pipeline: preprocessing...", 3, 4)
+            mock_emb._on_progress("loading", "Warming up audio pipeline: running model...", 4, 4)
 
         mock_emb.load_models = fake_load_models
         mock_embedders_for_type.return_value = [mock_emb]

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -65,14 +65,30 @@ class AudioClapEmbedder(MediaEmbedder):
         with intercept_tqdm_progress(self._on_progress):
             self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
 
-        # Warmup: import librosa (heavy — pulls in numba, scipy, etc.) and
-        # run a single dummy forward pass so that the first real embed_media
-        # call runs at the same speed as every subsequent one.
-        self._on_progress("loading", "Warming up audio pipeline: importing libraries…", 1, 3)
+        # Warmup: import librosa (heavy — pulls in numba, scipy, etc.),
+        # trigger the numba JIT for audio resampling, and run a single
+        # dummy forward pass so that the first real embed_media call runs
+        # at the same speed as every subsequent one.
+        self._on_progress("loading", "Warming up audio pipeline: importing libraries…", 1, 4)
         import librosa  # noqa: F401, PLC0415
         import torch  # noqa: PLC0415
 
-        self._on_progress("loading", "Warming up audio pipeline: preprocessing…", 2, 3)
+        # Trigger librosa/soxr resampling JIT by loading a tiny WAV at a
+        # different sample rate.  Without this, the first embed_media()
+        # call stalls for 10-30 s while numba compiles resampling kernels,
+        # making the embedding progress bar appear frozen.
+        self._on_progress("loading", "Warming up audio pipeline: resampling JIT…", 2, 4)
+        import io  # noqa: PLC0415
+
+        import soundfile as sf  # noqa: PLC0415
+
+        _warmup_sr = 16000  # intentionally different from SAMPLE_RATE
+        _warmup_buf = io.BytesIO()
+        sf.write(_warmup_buf, np.zeros(_warmup_sr, dtype=np.float32), _warmup_sr, format="WAV")
+        _warmup_buf.seek(0)
+        librosa.load(_warmup_buf, sr=SAMPLE_RATE, mono=True)
+
+        self._on_progress("loading", "Warming up audio pipeline: preprocessing…", 3, 4)
         dummy_audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
@@ -82,7 +98,7 @@ class AudioClapEmbedder(MediaEmbedder):
             max_length=480000,
             truncation=True,
         )
-        self._on_progress("loading", "Warming up audio pipeline: running model…", 3, 3)
+        self._on_progress("loading", "Warming up audio pipeline: running model…", 4, 4)
         device = next(self._model.parameters()).device
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():


### PR DESCRIPTION
## Summary
This PR adds an additional warmup step to the audio embedder's model loading process to pre-compile librosa's resampling kernels via numba JIT compilation. This prevents the first `embed_media()` call from stalling for 10-30 seconds while numba compiles the resampling code.

## Key Changes
- **Added resampling JIT warmup step**: Creates a tiny WAV file at a different sample rate and loads it through librosa to trigger numba JIT compilation of resampling kernels before any real audio processing occurs
- **Updated progress tracking**: Increased the total warmup steps from 3 to 4 stages and added a new "resampling JIT" progress message
- **Updated test expectations**: Modified `test_preload_progress.py` to reflect the new 4-stage warmup sequence with the additional resampling JIT step

## Implementation Details
- The warmup creates a silent audio buffer at 16kHz (intentionally different from the standard SAMPLE_RATE) and resamples it using librosa
- This synthetic resampling operation triggers the numba JIT compilation without requiring actual audio files
- The progress callback now reports 4 stages instead of 3: importing libraries → resampling JIT → preprocessing → running model
- Uses `soundfile` to write the temporary WAV data to an in-memory BytesIO buffer for efficiency

https://claude.ai/code/session_018LdshYkBayeoo7mebM8NEj