### PR TITLE
Add per-media-type panel percentage settings

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -36,6 +36,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private gridColumnsLeftDict: Record<string, number> = {};
   private focusModeLeftDict: Record<string, 'click' | 'hover'> = {};
   private focusModeRightDict: Record<string, 'click' | 'hover'> = {};
+  private panelPctLeftDict: Record<string, number | null> = {};
+  private panelPctRightDict: Record<string, number | null> = {};
   private currentMediaType = '';
   leftWidth = 260;
   rightWidth = 300;
@@ -92,6 +94,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
             this.gridColumnsLeft = this.gridColumnsLeftDict[newType] ?? 2;
             this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
             this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
+            this.applyPanelPct(newType);
           }
         }
         if (this.autopilotTextSortPending && medias.length > 0) {
@@ -160,6 +163,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dragging = false;
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
+    this.savePanelPct('left');
   }
 
   // --- Right divider drag ---
@@ -188,6 +192,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.draggingRight = false;
     document.removeEventListener('mousemove', this.boundRightMouseMove);
     document.removeEventListener('mouseup', this.boundRightMouseUp);
+    this.savePanelPct('right');
   }
 
   // --- Data loading ---
@@ -224,6 +229,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.focusModeRightDict = fmRight as Record<string, 'click' | 'hover'>;
           if (this.currentMediaType) {
             this.focusModeRight = this.focusModeRightDict[this.currentMediaType] ?? 'click';
+          }
+        }
+        const pplDict = settings.panel_pct_left;
+        if (pplDict && typeof pplDict === 'object') {
+          this.panelPctLeftDict = pplDict as Record<string, number | null>;
+          if (this.currentMediaType) {
+            this.applyPanelPct(this.currentMediaType);
+          }
+        }
+        const pprDict = settings.panel_pct_right;
+        if (pprDict && typeof pprDict === 'object') {
+          this.panelPctRightDict = pprDict as Record<string, number | null>;
+          if (this.currentMediaType) {
+            this.applyPanelPct(this.currentMediaType);
           }
         }
         if (settings.autopilot_enabled != null) {
@@ -451,6 +470,37 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     } else if (phase === 'new' || phase === 'done') {
       this.sortState.setSortMode('learned');
       this.sortState.setSelectMode('new');
+    }
+  }
+
+  // --- Panel percentage helpers ---
+
+  private savePanelPct(side: 'left' | 'right'): void {
+    if (!this.currentMediaType) return;
+    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
+    if (layoutWidth <= 0) return;
+    const px = side === 'left' ? this.leftWidth : this.rightWidth;
+    const pct = Math.round((px / layoutWidth) * 1000) / 1000; // 3 decimal places
+    const key = side === 'left' ? 'panel_pct_left' : 'panel_pct_right';
+    const dict = side === 'left' ? this.panelPctLeftDict : this.panelPctRightDict;
+    dict[this.currentMediaType] = pct;
+    this.settingsState.update({ [key]: { ...dict } }).subscribe();
+  }
+
+  private applyPanelPct(mediaType: string): void {
+    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
+    if (layoutWidth <= 0) return;
+    const leftPct = this.panelPctLeftDict[mediaType];
+    if (leftPct != null && !this.autopilotCollapsed) {
+      const px = Math.round(leftPct * layoutWidth);
+      this.leftWidth = Math.max(this.LEFT_MIN, Math.min(this.LEFT_MAX, px));
+      this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
+    }
+    const rightPct = this.panelPctRightDict[mediaType];
+    if (rightPct != null) {
+      const px = Math.round(rightPct * layoutWidth);
+      this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(this.RIGHT_MAX, px));
+      this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     }
   }
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -75,6 +75,20 @@
               <label class="form-label">Right panel grid columns</label>
               <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_right', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_right', activeViewTab, $event)" min="1" max="6" />
             </div>
+            <div class="form-group">
+              <label class="form-label">Left Panel %</label>
+              <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_left', activeViewTab) }}</span>
+              @if (getPanelPct('panel_pct_left', activeViewTab) != null) {
+                <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_left', activeViewTab)">Reset</button>
+              }
+            </div>
+            <div class="form-group">
+              <label class="form-label">Right Panel %</label>
+              <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_right', activeViewTab) }}</span>
+              @if (getPanelPct('panel_pct_right', activeViewTab) != null) {
+                <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_right', activeViewTab)">Reset</button>
+              }
+            </div>
           </div>
         }
       </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -83,6 +83,12 @@
   background: var(--bg-primary, #1e1e2e);
 }
 
+.panel-pct-display {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  margin-right: 0.5rem;
+}
+
 .settings-actions {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -114,6 +114,29 @@ export class SettingsModalComponent implements OnInit {
     return dict[typeId] ?? 'click';
   }
 
+  onPanelPctChange(side: 'panel_pct_left' | 'panel_pct_right', typeId: string, value: number | null): void {
+    const dict = (this.settings[side] as Record<string, number | null>) || {};
+    dict[typeId] = value;
+    (this.settings as Record<string, unknown>)[side] = { ...dict };
+    this.save();
+  }
+
+  getPanelPct(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): number | null {
+    const dict = this.settings[side];
+    if (!dict) return null;
+    return dict[typeId] ?? null;
+  }
+
+  getPanelPctDisplay(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): string {
+    const pct = this.getPanelPct(side, typeId);
+    if (pct == null) return '—';
+    return Math.round(pct * 100) + '%';
+  }
+
+  clearPanelPct(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): void {
+    this.onPanelPctChange(side, typeId, null);
+  }
+
   onNumberChange(key: string, value: number): void {
     (this.settings as Record<string, unknown>)[key] = value;
     this.save();

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -257,6 +257,8 @@ export interface AppSettings {
   grid_columns_right?: Record<string, number>;
   focus_mode_left?: Record<string, 'click' | 'hover'>;
   focus_mode_right?: Record<string, 'click' | 'hover'>;
+  panel_pct_left?: Record<string, number | null>;
+  panel_pct_right?: Record<string, number | null>;
   autoload_media_types?: string[];
   autoload_media_embedders?: string[];
   autorun_processors?: AutorunProcessor[];

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -416,6 +416,84 @@ class TestSettingsModule:
         with pytest.raises(ValueError):
             settings_mod.set_focus_mode_left({"nonexistent_type": "hover"})
 
+    # --- Panel percentage settings ---
+
+    def test_get_panel_pct_left_default(self):
+        result = settings_mod.get_panel_pct_left()
+        assert isinstance(result, dict)
+        for v in result.values():
+            assert v is None
+
+    def test_get_panel_pct_right_default(self):
+        result = settings_mod.get_panel_pct_right()
+        assert isinstance(result, dict)
+        for v in result.values():
+            assert v is None
+
+    def test_set_panel_pct_left_per_type(self, isolated_settings):
+        settings_mod.set_panel_pct_left({"audio": 0.25, "image": 0.3})
+        result = settings_mod.get_panel_pct_left()
+        assert result["audio"] == pytest.approx(0.25)
+        assert result["image"] == pytest.approx(0.3)
+
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["panel_pct_left"]["audio"] == pytest.approx(0.25)
+        assert raw["panel_pct_left"]["image"] == pytest.approx(0.3)
+
+    def test_set_panel_pct_right_per_type(self, isolated_settings):
+        settings_mod.set_panel_pct_right({"audio": 0.2, "video": 0.35})
+        result = settings_mod.get_panel_pct_right()
+        assert result["audio"] == pytest.approx(0.2)
+        assert result["video"] == pytest.approx(0.35)
+
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["panel_pct_right"]["audio"] == pytest.approx(0.2)
+
+    def test_set_panel_pct_left_scalar(self, isolated_settings):
+        settings_mod.set_panel_pct_left(0.3)
+        result = settings_mod.get_panel_pct_left()
+        for v in result.values():
+            assert v == pytest.approx(0.3)
+
+    def test_set_panel_pct_null_clears(self, isolated_settings):
+        settings_mod.set_panel_pct_left({"audio": 0.25})
+        settings_mod.set_panel_pct_left({"audio": None})
+        assert settings_mod.get_panel_pct_left()["audio"] is None
+
+    def test_panel_pct_persists_across_reset(self, isolated_settings):
+        settings_mod.set_panel_pct_left({"audio": 0.25})
+        settings_mod.reset()
+        assert settings_mod.get_panel_pct_left()["audio"] == pytest.approx(0.25)
+
+    def test_panel_pct_out_of_range(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_panel_pct_left({"audio": 0.01})
+        with pytest.raises(ValueError):
+            settings_mod.set_panel_pct_left({"audio": 0.95})
+        with pytest.raises(ValueError):
+            settings_mod.set_panel_pct_left(0.01)
+        with pytest.raises(ValueError):
+            settings_mod.set_panel_pct_left(0.95)
+
+    def test_panel_pct_invalid_media_type(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_panel_pct_left({"nonexistent_type": 0.25})
+
+    def test_panel_pct_invalid_value(self):
+        with pytest.raises(ValueError):
+            settings_mod.set_panel_pct_left({"audio": "invalid"})
+
+    def test_panel_pct_clamped_on_read(self, isolated_settings):
+        """Out-of-range values stored on disk are clamped when read."""
+        settings_mod.set_panel_pct_left({"audio": 0.5})
+        # Manually write an out-of-range value to disk
+        raw = json.loads(isolated_settings.read_text())
+        raw["panel_pct_left"]["audio"] = 0.99
+        isolated_settings.write_text(json.dumps(raw))
+        settings_mod.reset()
+        result = settings_mod.get_panel_pct_left()
+        assert result["audio"] == pytest.approx(0.80)
+
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()
         assert defaults["volume"] == 1.0
@@ -442,6 +520,12 @@ class TestSettingsModule:
         assert isinstance(defaults["focus_mode_right"], dict)
         for v in defaults["focus_mode_right"].values():
             assert v == "click"
+        assert isinstance(defaults["panel_pct_left"], dict)
+        for v in defaults["panel_pct_left"].values():
+            assert v is None
+        assert isinstance(defaults["panel_pct_right"], dict)
+        for v in defaults["panel_pct_right"].values():
+            assert v is None
         assert defaults["autoload_media_types"] == []
         assert defaults["autopilot_enabled"] is True
         assert defaults["autopilot_top_greens"] == 3
@@ -1004,6 +1088,55 @@ class TestSettingsAPI:
         assert isinstance(data["focus_mode_left"], dict)
         assert "focus_mode_right" in data
         assert isinstance(data["focus_mode_right"], dict)
+
+    # --- Panel percentage API tests ---
+
+    def test_update_panel_pct_left_per_type(self, client):
+        res = client.put("/api/settings", json={"panel_pct_left": {"audio": 0.25, "image": 0.3}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["panel_pct_left"]["audio"] == pytest.approx(0.25)
+        assert data["panel_pct_left"]["image"] == pytest.approx(0.3)
+
+        res2 = client.get("/api/settings")
+        assert res2.get_json()["panel_pct_left"]["audio"] == pytest.approx(0.25)
+
+    def test_update_panel_pct_right_per_type(self, client):
+        res = client.put("/api/settings", json={"panel_pct_right": {"audio": 0.2, "video": 0.35}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["panel_pct_right"]["audio"] == pytest.approx(0.2)
+        assert data["panel_pct_right"]["video"] == pytest.approx(0.35)
+
+    def test_update_panel_pct_left_scalar(self, client):
+        res = client.put("/api/settings", json={"panel_pct_left": 0.3})
+        assert res.status_code == 200
+        for v in res.get_json()["panel_pct_left"].values():
+            assert v == pytest.approx(0.3)
+
+    def test_update_panel_pct_left_null(self, client):
+        res = client.put("/api/settings", json={"panel_pct_left": {"audio": None}})
+        assert res.status_code == 200
+        assert res.get_json()["panel_pct_left"]["audio"] is None
+
+    def test_update_panel_pct_left_invalid(self, client):
+        res = client.put("/api/settings", json={"panel_pct_left": {"audio": "invalid"}})
+        assert res.status_code == 400
+
+    def test_update_panel_pct_left_out_of_range(self, client):
+        res = client.put("/api/settings", json={"panel_pct_left": 0.01})
+        assert res.status_code == 400
+        res = client.put("/api/settings", json={"panel_pct_left": 0.95})
+        assert res.status_code == 400
+
+    def test_get_settings_includes_panel_pct(self, client):
+        res = client.get("/api/settings")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "panel_pct_left" in data
+        assert isinstance(data["panel_pct_left"], dict)
+        assert "panel_pct_right" in data
+        assert isinstance(data["panel_pct_right"], dict)
 
     def test_update_autoload_media_types(self, client):
         res = client.put("/api/settings", json={"autoload_media_types": ["audio", "video"]})

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -138,6 +138,18 @@ def update_settings():
         except (ValueError, TypeError) as exc:
             return jsonify({"error": str(exc)}), 400
 
+    if "panel_pct_left" in body:
+        try:
+            settings.set_panel_pct_left(body["panel_pct_left"])
+        except (ValueError, TypeError) as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    if "panel_pct_right" in body:
+        try:
+            settings.set_panel_pct_right(body["panel_pct_right"])
+        except (ValueError, TypeError) as exc:
+            return jsonify({"error": str(exc)}), 400
+
     if "autopilot_enabled" in body:
         settings.set_autopilot_enabled(bool(body["autopilot_enabled"]))
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -52,6 +52,8 @@ _DEFAULTS: dict[str, Any] = {
     "grid_columns_right": {},
     "focus_mode_left": {},
     "focus_mode_right": {},
+    "panel_pct_left": {},
+    "panel_pct_right": {},
     "autoload_media_types": [],
     "autoload_media_embedders": [],
     "autorun_processors": [],
@@ -129,6 +131,9 @@ def get_defaults() -> dict[str, Any]:
     # Expand focus mode defaults to per-media-type dicts
     result["focus_mode_left"] = {tid: _FOCUS_MODE_DEFAULTS["left"] for tid in valid_types}
     result["focus_mode_right"] = {tid: _FOCUS_MODE_DEFAULTS["right"] for tid in valid_types}
+    # Expand panel percentage defaults to per-media-type dicts
+    result["panel_pct_left"] = {tid: _PANEL_PCT_DEFAULTS["left"] for tid in valid_types}
+    result["panel_pct_right"] = {tid: _PANEL_PCT_DEFAULTS["right"] for tid in valid_types}
     return result
 
 
@@ -146,6 +151,9 @@ def get_all() -> dict[str, Any]:
         # Always return expanded per-media-type focus mode dicts
         result["focus_mode_left"] = get_focus_mode_left()
         result["focus_mode_right"] = get_focus_mode_right()
+        # Always return expanded per-media-type panel percentage dicts
+        result["panel_pct_left"] = get_panel_pct_left()
+        result["panel_pct_right"] = get_panel_pct_right()
         return result
 
 
@@ -238,6 +246,8 @@ del _key, _cast, _coerce, _g, _s
 _VIEW_MODE_DEFAULTS = {"left": "list", "right": "grid"}
 _GRID_COLUMNS_DEFAULT = 2
 _FOCUS_MODE_DEFAULTS = {"left": "click", "right": "click"}
+_PANEL_PCT_DEFAULTS: dict[str, float | None] = {"left": None, "right": None}
+VALID_PANEL_PCT = (0.05, 0.80)  # 5%–80% of window width
 
 
 def _get_view_mode_dict(key: str) -> dict[str, str]:
@@ -457,6 +467,97 @@ def _set_focus_mode_dict(key: str, value: dict[str, str] | str) -> None:
     with _settings_lock:
         s = _ensure_loaded()
         s[key] = dict(value)
+        _save(s)
+
+
+# -------------------------------------------------------------------
+# Per-media-type panel percentage settings
+# -------------------------------------------------------------------
+
+
+def _get_panel_pct_dict(key: str) -> dict[str, float | None]:
+    """Return the per-media-type panel percentage dict for *key*.
+
+    Values are floats in [0.05, 0.80] representing fraction of window width,
+    or ``None`` if not yet set (use default pixel widths).
+    """
+    side = key.replace("panel_pct_", "")
+    default_val = _PANEL_PCT_DEFAULTS.get(side)
+    with _settings_lock:
+        raw = _ensure_loaded().get(key, _DEFAULTS[key])
+    if isinstance(raw, (int, float)):
+        # Legacy scalar — expand to all types
+        val = float(raw)
+        lo, hi = VALID_PANEL_PCT
+        val = max(lo, min(hi, val))
+        return {tid: val for tid in _valid_media_types()}
+    if isinstance(raw, dict):
+        result: dict[str, float | None] = {}
+        lo, hi = VALID_PANEL_PCT
+        for tid in _valid_media_types():
+            v = raw.get(tid, default_val)
+            if v is None:
+                result[tid] = None
+            else:
+                try:
+                    fv = float(v)
+                    result[tid] = max(lo, min(hi, fv))
+                except (ValueError, TypeError):
+                    result[tid] = default_val
+        return result
+    return {tid: default_val for tid in _valid_media_types()}
+
+
+def get_panel_pct_left() -> dict[str, float | None]:
+    """Return a dict mapping media type ID -> panel width fraction for the left panel."""
+    return _get_panel_pct_dict("panel_pct_left")
+
+
+def get_panel_pct_right() -> dict[str, float | None]:
+    """Return a dict mapping media type ID -> panel width fraction for the right panel."""
+    return _get_panel_pct_dict("panel_pct_right")
+
+
+def set_panel_pct_left(value: dict[str, float | None] | float | None) -> None:
+    """Set the left panel width fraction (per-media-type dict or scalar)."""
+    _set_panel_pct_dict("panel_pct_left", value)
+
+
+def set_panel_pct_right(value: dict[str, float | None] | float | None) -> None:
+    """Set the right panel width fraction (per-media-type dict or scalar)."""
+    _set_panel_pct_dict("panel_pct_right", value)
+
+
+def _set_panel_pct_dict(key: str, value: dict[str, float | None] | float | None) -> None:
+    """Persist the per-media-type panel percentage dict for *key*."""
+    valid_types = _valid_media_types()
+    lo, hi = VALID_PANEL_PCT
+    if value is None:
+        value = {tid: None for tid in valid_types}
+    elif isinstance(value, (int, float)):
+        fv = float(value)
+        if not (lo <= fv <= hi):
+            raise ValueError(f"Invalid {key}: {fv!r} (must be between {lo} and {hi})")
+        value = {tid: fv for tid in valid_types}
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a dict, number, or null")
+    coerced: dict[str, float | None] = {}
+    for tid, pct in value.items():
+        if tid not in valid_types:
+            raise ValueError(f"Invalid media type: {tid!r}")
+        if pct is None:
+            coerced[tid] = None
+        else:
+            try:
+                fv = float(pct)
+            except (ValueError, TypeError):
+                raise ValueError(f"Invalid {key} value for {tid}: {pct!r}")
+            if not (lo <= fv <= hi):
+                raise ValueError(f"Invalid {key} value for {tid}: {fv!r} (must be between {lo} and {hi})")
+            coerced[tid] = fv
+    with _settings_lock:
+        s = _ensure_loaded()
+        s[key] = coerced
         _save(s)
 
 


### PR DESCRIPTION
## Summary
This PR adds support for saving and restoring panel width percentages on a per-media-type basis, allowing users to customize the left and right panel widths for different media types and have those preferences persist across sessions.

## Key Changes

**Backend (Python)**
- Added `panel_pct_left` and `panel_pct_right` settings to store panel width fractions (5%–80% of window width) per media type
- Implemented getter/setter functions (`get_panel_pct_left()`, `set_panel_pct_left()`, etc.) with support for both per-type dicts and scalar values
- Added validation to ensure values are within the valid range [0.05, 0.80] and clamp out-of-range values on read
- Integrated panel percentage settings into the settings API endpoint (`/api/settings`)
- Added comprehensive test coverage for all panel percentage operations

**Frontend (Angular)**
- Added `panelPctLeftDict` and `panelPctRightDict` properties to track panel percentages per media type
- Implemented `savePanelPct()` to persist panel widths when dividers are released, calculating the percentage relative to layout width
- Implemented `applyPanelPct()` to restore saved panel widths when switching media types
- Added UI controls in the settings modal to display and reset panel percentages per media type
- Updated API models to include the new panel percentage settings

## Implementation Details

- Panel percentages are stored as floats (e.g., 0.25 for 25% of window width) and validated to be between 5% and 80%
- When a user drags a divider, the new width is saved as a percentage relative to the current layout width
- When switching media types, the saved percentage for that type is applied by converting back to pixels
- Out-of-range values stored on disk are automatically clamped when read, ensuring graceful handling of invalid data
- The settings modal displays panel percentages as percentages (e.g., "25%") with a "Reset" button to clear per-type overrides
- Scalar values are expanded to apply to all media types for backward compatibility

https://claude.ai/code/session_0132z4K4EqYJEaTXPYNA1GLJ