### PR TITLE
Add responsive container queries to left panel for compact labels

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -15,7 +15,7 @@
         [attr.aria-selected]="activeTab === 'autopilot'"
         (click)="setTab('autopilot')"
         title="Autopilot guides you through labeling in phases: good examples, bad examples, boundary refinement, and diversity exploration."
-      >Autopilot</button>
+      ><span class="label-full">Autopilot</span><span class="label-short">Auto</span></button>
     </div>
   }
 

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -3,6 +3,8 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  container-type: inline-size;
+  container-name: left-panel;
 }
 
 .left-tabs {
@@ -30,6 +32,19 @@
     background: var(--bg-surface);
     color: var(--text-primary);
     border-bottom: 2px solid var(--accent);
+  }
+}
+
+.label-short {
+  display: none;
+}
+
+@container left-panel (max-width: 140px) {
+  .label-full {
+    display: none;
+  }
+  .label-short {
+    display: inline;
   }
 }
 


### PR DESCRIPTION
## Summary
Implemented CSS container queries in the left panel component to display shortened labels when the panel width is constrained, improving space efficiency in narrow layouts.

## Key Changes
- Added `container-type: inline-size` and `container-name: left-panel` to the left panel root element to enable container query support
- Created responsive label display logic using `@container` queries that hides full-length labels and shows abbreviated versions when the left panel width is below 140px
- Updated the Autopilot button to display "Autopilot" in normal width and "Auto" in compact mode
- Added `.label-short` and `.label-full` CSS classes to control visibility based on container width

## Implementation Details
- Uses modern CSS container queries (inline-size) for responsive behavior without media queries
- The threshold of 140px targets narrow panel states (e.g., when the left panel is collapsed or on smaller screens)
- Maintains backward compatibility by defaulting to full labels with `display: none` on the short variant

https://claude.ai/code/session_01PYRyMDFNc3wFbrVkTVBJCg