### PR TITLE
Refactor settings modal view controls to use radio buttons

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -39,55 +39,85 @@
             }
           </div>
           <div class="view-tab-content">
-            <div class="form-group">
-              <label class="form-label">Left panel view</label>
-              <select class="form-select" [ngModel]="getViewMode('view_mode_left', activeViewTab)" (ngModelChange)="onViewModeChange('view_mode_left', activeViewTab, $event)">
-                <option value="list">List View</option>
-                <option value="grid">Grid View</option>
-              </select>
+            <div class="view-side-section">
+              <h4>Left Side</h4>
+              <div class="form-group">
+                <label class="form-label">View</label>
+                <div class="radio-group">
+                  <label class="radio-row">
+                    <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_left', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'list')" />
+                    List
+                  </label>
+                  <label class="radio-row">
+                    <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'grid')" />
+                    Grid
+                  </label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Focus mode</label>
+                <div class="radio-group">
+                  <label class="radio-row">
+                    <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')" />
+                    Click
+                  </label>
+                  <label class="radio-row">
+                    <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')" />
+                    Hover
+                  </label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Grid columns</label>
+                <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_left', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_left', activeViewTab, $event)" min="1" max="6" />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Panel %</label>
+                <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_left', activeViewTab) }}</span>
+                @if (getPanelPct('panel_pct_left', activeViewTab) != null) {
+                  <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_left', activeViewTab)">Reset</button>
+                }
+              </div>
             </div>
-            <div class="form-group">
-              <label class="form-label">Right panel view</label>
-              <select class="form-select" [ngModel]="getViewMode('view_mode_right', activeViewTab)" (ngModelChange)="onViewModeChange('view_mode_right', activeViewTab, $event)">
-                <option value="list">List View</option>
-                <option value="grid">Grid View</option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label class="form-label">Left focus mode</label>
-              <select class="form-select" [ngModel]="getFocusMode('focus_mode_left', activeViewTab)" (ngModelChange)="onFocusModeChange('focus_mode_left', activeViewTab, $event)">
-                <option value="click">Click</option>
-                <option value="hover">Hover</option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label class="form-label">Right focus mode</label>
-              <select class="form-select" [ngModel]="getFocusMode('focus_mode_right', activeViewTab)" (ngModelChange)="onFocusModeChange('focus_mode_right', activeViewTab, $event)">
-                <option value="click">Click</option>
-                <option value="hover">Hover</option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label class="form-label">Left panel grid columns</label>
-              <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_left', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_left', activeViewTab, $event)" min="1" max="6" />
-            </div>
-            <div class="form-group">
-              <label class="form-label">Right panel grid columns</label>
-              <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_right', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_right', activeViewTab, $event)" min="1" max="6" />
-            </div>
-            <div class="form-group">
-              <label class="form-label">Left Panel %</label>
-              <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_left', activeViewTab) }}</span>
-              @if (getPanelPct('panel_pct_left', activeViewTab) != null) {
-                <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_left', activeViewTab)">Reset</button>
-              }
-            </div>
-            <div class="form-group">
-              <label class="form-label">Right Panel %</label>
-              <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_right', activeViewTab) }}</span>
-              @if (getPanelPct('panel_pct_right', activeViewTab) != null) {
-                <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_right', activeViewTab)">Reset</button>
-              }
+            <div class="view-side-section">
+              <h4>Right Side</h4>
+              <div class="form-group">
+                <label class="form-label">View</label>
+                <div class="radio-group">
+                  <label class="radio-row">
+                    <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_right', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'list')" />
+                    List
+                  </label>
+                  <label class="radio-row">
+                    <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'grid')" />
+                    Grid
+                  </label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Focus mode</label>
+                <div class="radio-group">
+                  <label class="radio-row">
+                    <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')" />
+                    Click
+                  </label>
+                  <label class="radio-row">
+                    <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')" />
+                    Hover
+                  </label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Grid columns</label>
+                <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_right', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_right', activeViewTab, $event)" min="1" max="6" />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Panel %</label>
+                <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_right', activeViewTab) }}</span>
+                @if (getPanelPct('panel_pct_right', activeViewTab) != null) {
+                  <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_right', activeViewTab)">Reset</button>
+                }
+              </div>
             </div>
           </div>
         }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -83,6 +83,29 @@
   background: var(--bg-primary, #1e1e2e);
 }
 
+.view-side-section {
+  h4 {
+    margin: 0 0 0.6rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-color, #444);
+    padding-bottom: 0.35rem;
+  }
+}
+
+.radio-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.radio-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
 .panel-pct-display {
   font-size: 0.85rem;
   color: var(--text-primary);


### PR DESCRIPTION
## Summary
Refactored the view settings controls in the settings modal from dropdown selects to radio button groups, improving the UI/UX with better visual organization and clearer option presentation.

## Key Changes
- **Replaced dropdown selects with radio buttons** for view mode (List/Grid) and focus mode (Click/Hover) options on both left and right panels
- **Reorganized layout** by grouping related settings under "Left Side" and "Right Side" sections with visual separators
- **Added new CSS classes** to support the radio button layout:
  - `.view-side-section` - Container for left/right panel settings with styled section headers
  - `.radio-group` - Flexbox container for horizontal radio button grouping
  - `.radio-row` - Individual radio button label styling with proper alignment and spacing
- **Simplified labels** by removing "Left/Right" prefixes from individual form labels (now handled by section headers)
- **Updated event binding** from `ngModelChange` to `change` events for radio inputs with explicit value passing

## Implementation Details
- Radio buttons use dynamic `name` attributes with `activeViewTab` to ensure proper grouping per tab
- Maintained all existing functionality and component method calls
- Grid columns and panel percentage controls remain as number inputs and display elements
- Styling uses CSS variables for theme consistency (text colors, borders, backgrounds)

https://claude.ai/code/session_01PA7RPXknYHAt9t83sLjv2j