### PR TITLE
Add pluggable LoginProvider abstraction for multi-user support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,13 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - **Format**: `ruff format .`
 
 ## Architecture
-- `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing
+- `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing, per-request user context via `before_request` middleware
+- `vtsearch/auth/` — Authentication: `LoginProvider` ABC, `DefaultLoginProvider` (single-user, no-op), `get_current_user()`, `get_user_data_dir()`, `set_login_provider()`
 - `vtsearch/config.py` — Constants (SAMPLE_RATE, NUM_MEDIAS, paths, model IDs)
 - `vtsearch/medias.py` — Test media generation and embedding cache management
 - `vtsearch/cli.py` — CLI utilities: autodetect (load dataset + detectors from settings, run inference, export results)
 - `vtsearch/settings.py` — Persistent settings (volume, inclusion, theme, enrich_descriptions, safe_thresholds, calibrate_count, calibration_fraction, swipe_animation, show_metadata, view_mode_left, view_mode_right, focus_mode_left, focus_mode_right, autoload_media_types, autorun_processors, hide_autopilot, autopilot_top_greens, autopilot_hard_reds); auto-saves to `data/settings.json`
-- `vtsearch/routes/` — Flask blueprints: `main.py`, `medias.py`, `sorting.py`, `detectors.py` (with sub-modules `detectors_crud.py`, `detectors_scoring.py`, `detectors_training.py`), `datasets.py` (with sub-modules `datasets_loading.py`, `datasets_ui.py`), `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`, `trainable_models.py`
+- `vtsearch/routes/` — Flask blueprints: `auth.py`, `main.py`, `medias.py`, `sorting.py`, `detectors.py` (with sub-modules `detectors_crud.py`, `detectors_scoring.py`, `detectors_training.py`), `datasets.py` (with sub-modules `datasets_loading.py`, `datasets_ui.py`), `exporters.py`, `label_importers.py`, `processor_importers.py`, `settings.py`, `trainable_models.py`
 - `vtsearch/models/` — Embeddings, training, model loading, progress tracking, diversity tree
 - `vtsearch/datasets/` — Dataset loading, downloading, ingestion, origin tracking, labelsets, splitting, importers (folder/pickle/http_zip/combine_datasets); auto-discovered via `IMPORTER` sentinel. Note: the `http_zip` directory registers as `http_archive` (its API/CLI name)
 - `vtsearch/eval/` — Evaluation framework: runner, metrics, visualisation, voting iterations
@@ -92,6 +93,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
   - `test_imdb_download.py` — IMDB dataset download and load_demo_source integration
   - `test_load_sort_window.py` — Load Sort window endpoints: example-sort, server-media-files, detector server-files
   - `test_memory_errors.py` — Graceful MemoryError handling during dataset loading
+  - `test_multi_user_security.py` — LoginProvider ABC, DefaultLoginProvider, g.user middleware, created_by ownership, auth status endpoint, user data dir isolation
   - `test_pdf_import.py` — PDF-to-image import: render_pdf_pages conversion, folder importer PDF handling, origin tracking
   - `test_preload_progress.py` — Console progress output during embedding model preloading
   - `test_slow_integration.py` — Slow integration tests: chunked loading, detector scoring, export, label round-trips, settings persistence (marked slow)

--- a/app.py
+++ b/app.py
@@ -22,12 +22,14 @@ warnings.filterwarnings("ignore", message=".*unauthenticated requests.*HF Hub.*"
 # Visual feedback for startup
 print("⏳ Initializing VTSearch...", flush=True)
 
-from flask import Flask
+from flask import Flask, g
 
 # Import refactored modules
+from vtsearch.auth import get_login_provider  # noqa: E402
 from vtsearch.medias import init_medias  # noqa: E402, F401 — used by tests via app_module.init_medias()
 from vtsearch.models import initialize_models, preload_autoload_media_types  # noqa: E402
 from vtsearch.routes import (  # noqa: E402
+    auth_bp,
     medias_bp,
     datasets_bp,
     detectors_bp,
@@ -49,10 +51,26 @@ set_progress_callback(update_progress)
 
 app = Flask(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Per-request user context
+# ---------------------------------------------------------------------------
+
+
+@app.before_request
+def _set_user_context():
+    """Populate ``g.user`` from the active LoginProvider on every request."""
+    from flask import request
+
+    provider = get_login_provider()
+    g.user = provider.get_user(request)
+
+
 # ---------------------------------------------------------------------------
 # Register Blueprints
 # ---------------------------------------------------------------------------
 
+app.register_blueprint(auth_bp)
 app.register_blueprint(main_bp)
 app.register_blueprint(medias_bp)
 app.register_blueprint(sorting_bp)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ _TEST_GROUPS = {
         "test_error_recovery",
         "test_dashboard",
         "test_path_validation",
+        "test_multi_user_security",
     ],
     "sorting": [
         "test_sorting",
@@ -272,6 +273,11 @@ def reset_state():
     _core.autorun_extractors.clear()
     _core.autorun_localizers.clear()
     clear_progress_cache()
+
+    # Reset the login provider to DefaultLoginProvider
+    from vtsearch.auth import DefaultLoginProvider, set_login_provider
+
+    set_login_provider(DefaultLoginProvider())
 
     # Reset the dataset and model registries
     from vtsearch.datasets.registry import reset_for_tests as _reset_ds_reg

--- a/tests/test_multi_user_security.py
+++ b/tests/test_multi_user_security.py
@@ -1,0 +1,352 @@
+"""Tests for multi-user security: LoginProvider abstraction and user isolation.
+
+Verifies that:
+- The LoginProvider ABC and DefaultLoginProvider work correctly
+- ``g.user`` is set on every request via the before_request middleware
+- Dataset, model, and detector entries include ``created_by``
+- The ``/api/auth/status`` endpoint returns correct information
+- get_current_user() falls back to "default" outside Flask context
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vtsearch.auth import (
+    DefaultLoginProvider,
+    LoginProvider,
+    get_current_user,
+    get_login_provider,
+    get_user_data_dir,
+    set_login_provider,
+)
+
+
+# ---------------------------------------------------------------------------
+# LoginProvider abstraction
+# ---------------------------------------------------------------------------
+
+
+class TestLoginProviderABC:
+    """Test the LoginProvider base class and DefaultLoginProvider."""
+
+    def test_default_provider_returns_default_user(self):
+        provider = DefaultLoginProvider()
+        assert provider.get_user(None) == "default"
+
+    def test_default_provider_always_authenticated(self):
+        provider = DefaultLoginProvider()
+        assert provider.is_authenticated(None) is True
+
+    def test_default_provider_no_login_required(self):
+        provider = DefaultLoginProvider()
+        assert provider.login_required() is False
+
+    def test_default_provider_name(self):
+        provider = DefaultLoginProvider()
+        assert provider.name == "default"
+
+    def test_default_provider_data_dir_unchanged(self):
+        """DefaultLoginProvider uses DATA_DIR directly (no subdirectory)."""
+        provider = DefaultLoginProvider()
+        base = Path("/some/data")
+        assert provider.get_user_data_dir("default", base) == base
+        # Even with a different username, default provider returns base unchanged
+        assert provider.get_user_data_dir("alice", base) == base
+
+    def test_default_provider_status_dict(self):
+        provider = DefaultLoginProvider()
+        status = provider.status_dict(None)
+        assert status["provider"] == "default"
+        assert status["user"] == "default"
+        assert status["authenticated"] is True
+        assert status["login_required"] is False
+
+    def test_cannot_instantiate_abc_directly(self):
+        """LoginProvider is abstract and cannot be instantiated."""
+        with pytest.raises(TypeError):
+            LoginProvider()  # type: ignore[abstract]
+
+
+class TestCustomLoginProvider:
+    """Test that a custom LoginProvider implementation works correctly."""
+
+    def test_custom_provider(self):
+        class TestProvider(LoginProvider):
+            name = "test"
+
+            def get_user(self, request):
+                return "alice"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return base_data_dir / username
+
+        provider = TestProvider()
+        assert provider.get_user(None) == "alice"
+        assert provider.is_authenticated(None) is True
+        assert provider.login_required() is False  # default
+        data_dir = provider.get_user_data_dir("alice", Path("/data"))
+        assert data_dir == Path("/data/alice")
+
+    def test_custom_provider_with_login_required(self):
+        class SecureProvider(LoginProvider):
+            name = "secure"
+
+            def get_user(self, request):
+                return "bob"
+
+            def is_authenticated(self, request):
+                return False
+
+            def login_required(self):
+                return True
+
+        provider = SecureProvider()
+        assert provider.login_required() is True
+        assert provider.is_authenticated(None) is False
+        status = provider.status_dict(None)
+        assert status["login_required"] is True
+        assert status["authenticated"] is False
+
+
+# ---------------------------------------------------------------------------
+# Module-level provider management
+# ---------------------------------------------------------------------------
+
+
+class TestProviderManagement:
+    """Test set_login_provider / get_login_provider / get_current_user."""
+
+    def test_default_provider_is_set_initially(self):
+        provider = get_login_provider()
+        assert isinstance(provider, DefaultLoginProvider)
+
+    def test_set_and_get_provider(self):
+        class Custom(LoginProvider):
+            name = "custom"
+
+            def get_user(self, request):
+                return "custom_user"
+
+            def is_authenticated(self, request):
+                return True
+
+        original = get_login_provider()
+        try:
+            set_login_provider(Custom())
+            assert get_login_provider().name == "custom"
+        finally:
+            set_login_provider(original)
+
+    def test_get_current_user_outside_flask_context(self):
+        """Outside a Flask request context, get_current_user returns 'default'."""
+        # The reset_state fixture already resets to DefaultLoginProvider
+        user = get_current_user()
+        assert user == "default"
+
+    def test_get_user_data_dir_default(self):
+        """get_user_data_dir returns DATA_DIR for the default provider."""
+        from vtsearch.config import DATA_DIR
+
+        data_dir = get_user_data_dir("default")
+        assert data_dir == DATA_DIR
+
+
+# ---------------------------------------------------------------------------
+# Flask integration
+# ---------------------------------------------------------------------------
+
+
+class TestFlaskAuthMiddleware:
+    """Test that g.user is set on Flask requests."""
+
+    def test_auth_status_endpoint(self, client):
+        """GET /api/auth/status returns provider info."""
+        resp = client.get("/api/auth/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["provider"] == "default"
+        assert data["user"] == "default"
+        assert data["authenticated"] is True
+        assert data["login_required"] is False
+
+    def test_g_user_set_on_api_requests(self, client):
+        """Verify g.user is set via the before_request middleware."""
+        # Any API call should work without errors — the middleware sets g.user
+        resp = client.get("/api/medias")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Ownership metadata
+# ---------------------------------------------------------------------------
+
+
+class TestOwnershipMetadata:
+    """Test that created_by is recorded on detectors, datasets, and models."""
+
+    def test_autorun_detector_has_created_by(self):
+        from vtsearch.utils import add_autorun_detector, get_autorun_detectors
+
+        add_autorun_detector("test_det", "audio", created_by="alice")
+        dets = get_autorun_detectors()
+        assert dets["test_det"]["created_by"] == "alice"
+
+    def test_autorun_detector_default_created_by(self):
+        from vtsearch.utils import add_autorun_detector, get_autorun_detectors
+
+        add_autorun_detector("test_det2", "audio")
+        dets = get_autorun_detectors()
+        assert dets["test_det2"]["created_by"] == "default"
+
+    def test_dataset_registry_has_created_by(self):
+        from vtsearch.datasets.registry import register_dataset
+
+        entry = register_dataset(
+            name="test_ds",
+            media_type="audio",
+            num_items=10,
+            pkl_path="/tmp/test.pkl",
+            created_by="bob",
+        )
+        assert entry["created_by"] == "bob"
+
+    def test_dataset_registry_default_created_by(self):
+        from vtsearch.datasets.registry import register_dataset
+
+        entry = register_dataset(
+            name="test_ds2",
+            media_type="audio",
+            num_items=5,
+            pkl_path="/tmp/test2.pkl",
+        )
+        assert entry["created_by"] == "default"
+
+    def test_model_registry_has_created_by(self):
+        from vtsearch.models.registry import register_model
+
+        entry = register_model(
+            name="test_model",
+            media_type="audio",
+            trainable=True,
+            created_by="carol",
+        )
+        assert entry["created_by"] == "carol"
+
+    def test_model_registry_default_created_by(self):
+        from vtsearch.models.registry import register_model
+
+        entry = register_model(
+            name="test_model2",
+            media_type="audio",
+            trainable=False,
+        )
+        assert entry["created_by"] == "default"
+
+
+# ---------------------------------------------------------------------------
+# User data directory isolation
+# ---------------------------------------------------------------------------
+
+
+class TestUserDataDirIsolation:
+    """Test per-user data directory logic for different providers."""
+
+    def test_default_provider_no_subdirectory(self):
+        """DefaultLoginProvider maps all users to DATA_DIR directly."""
+        provider = DefaultLoginProvider()
+        base = Path("/app/data")
+        assert provider.get_user_data_dir("default", base) == base
+        assert provider.get_user_data_dir("alice", base) == base
+
+    def test_multi_user_provider_uses_subdirectory(self):
+        """A multi-user provider scopes each user to their own subdirectory."""
+
+        class MultiUserProvider(LoginProvider):
+            name = "multiuser"
+
+            def get_user(self, request):
+                return "alice"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return base_data_dir / username
+
+        provider = MultiUserProvider()
+        base = Path("/app/data")
+        assert provider.get_user_data_dir("alice", base) == Path("/app/data/alice")
+        assert provider.get_user_data_dir("bob", base) == Path("/app/data/bob")
+
+    def test_get_user_data_dir_uses_active_provider(self):
+        """get_user_data_dir() delegates to the active provider."""
+        from vtsearch.config import DATA_DIR
+
+        # Default provider should return DATA_DIR unchanged
+        result = get_user_data_dir("anything")
+        assert result == DATA_DIR
+
+
+# ---------------------------------------------------------------------------
+# Provider swap safety
+# ---------------------------------------------------------------------------
+
+
+class TestProviderSwapSafety:
+    """Test that swapping providers doesn't break existing functionality."""
+
+    def test_swap_provider_and_back(self, client):
+        """Swapping to a custom provider and back doesn't break the app."""
+
+        class TempProvider(LoginProvider):
+            name = "temp"
+
+            def get_user(self, request):
+                return "temp_user"
+
+            def is_authenticated(self, request):
+                return True
+
+        set_login_provider(TempProvider())
+        resp = client.get("/api/auth/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["user"] == "temp_user"
+        assert data["provider"] == "temp"
+
+        # Swap back
+        set_login_provider(DefaultLoginProvider())
+        resp = client.get("/api/auth/status")
+        data = resp.get_json()
+        assert data["user"] == "default"
+
+    def test_api_works_after_provider_swap(self, client):
+        """Core API endpoints still work after a provider swap."""
+
+        class AnotherProvider(LoginProvider):
+            name = "another"
+
+            def get_user(self, request):
+                return "test_user"
+
+            def is_authenticated(self, request):
+                return True
+
+        set_login_provider(AnotherProvider())
+
+        # These should all return 200 regardless of provider
+        resp = client.get("/api/medias")
+        assert resp.status_code == 200
+
+        resp = client.get("/api/auth/status")
+        assert resp.status_code == 200
+
+        # Restore default
+        set_login_provider(DefaultLoginProvider())

--- a/vtsearch/auth/__init__.py
+++ b/vtsearch/auth/__init__.py
@@ -1,0 +1,158 @@
+"""Authentication and user management for VTSearch.
+
+Provides a pluggable login-provider abstraction so VTSearch can run in
+single-user mode (DefaultLoginProvider) or multi-user mode (e.g.
+UserPassLoginProvider, PKILoginProvider) without changing route code.
+
+Routes call :func:`get_current_user` to learn who is making the request.
+The active provider is set once at startup via :func:`set_login_provider`.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# LoginProvider ABC
+# ---------------------------------------------------------------------------
+
+
+class LoginProvider(ABC):
+    """Abstract base for authentication providers.
+
+    Subclasses must implement :meth:`get_user` and :meth:`is_authenticated`.
+    The default implementations of the other methods are suitable for
+    single-user deployments; multi-user providers should override them.
+    """
+
+    #: Short identifier for this provider (e.g. ``"default"``, ``"userpass"``).
+    name: str = ""
+
+    @abstractmethod
+    def get_user(self, request: Any) -> str:
+        """Return the username for the current request.
+
+        Args:
+            request: The Flask request object.
+
+        Returns:
+            A non-empty string identifying the user.
+        """
+
+    @abstractmethod
+    def is_authenticated(self, request: Any) -> bool:
+        """Return ``True`` if the request carries valid credentials.
+
+        For providers that don't require authentication (e.g.
+        :class:`DefaultLoginProvider`) this should always return ``True``.
+        """
+
+    def login_required(self) -> bool:
+        """Whether the frontend should show a login screen at startup."""
+        return False
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
+        """Return the data directory for *username*.
+
+        The default implementation returns *base_data_dir* unchanged, which
+        is correct for single-user deployments.  Multi-user providers should
+        return ``base_data_dir / username`` (or similar) so each user's
+        datasets, detectors, and settings are stored separately.
+        """
+        return base_data_dir
+
+    def status_dict(self, request: Any) -> dict[str, Any]:
+        """Return a JSON-serialisable dict describing the auth state.
+
+        Used by the ``/api/auth/status`` endpoint.
+        """
+        return {
+            "provider": self.name,
+            "user": self.get_user(request),
+            "authenticated": self.is_authenticated(request),
+            "login_required": self.login_required(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# DefaultLoginProvider — single-user, no authentication
+# ---------------------------------------------------------------------------
+
+
+class DefaultLoginProvider(LoginProvider):
+    """No-op provider for single-user deployments.
+
+    Every request is treated as coming from the ``"default"`` user.
+    No login screen is shown, and the data directory is used as-is
+    (no per-user subdirectory).
+    """
+
+    name = "default"
+
+    def get_user(self, request: Any) -> str:  # noqa: ARG002
+        return "default"
+
+    def is_authenticated(self, request: Any) -> bool:  # noqa: ARG002
+        return True
+
+    def login_required(self) -> bool:
+        return False
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:  # noqa: ARG002
+        # Single-user: no subdirectory — use data/ directly.
+        return base_data_dir
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_login_provider: LoginProvider = DefaultLoginProvider()
+
+
+def set_login_provider(provider: LoginProvider) -> None:
+    """Set the active login provider (called once at app startup)."""
+    global _login_provider
+    _login_provider = provider
+    logger.info("Login provider set to %r", provider.name)
+
+
+def get_login_provider() -> LoginProvider:
+    """Return the active login provider."""
+    return _login_provider
+
+
+def get_current_user() -> str:
+    """Return the username for the current request.
+
+    Inside a Flask request context this reads ``g.user`` (set by the
+    ``before_request`` middleware in ``app.py``).  Outside a request
+    context (e.g. CLI, tests) it falls back to ``"default"``.
+    """
+    try:
+        from flask import g
+
+        return g.user  # type: ignore[attr-defined]
+    except (AttributeError, RuntimeError):
+        # No Flask request context (CLI mode, background thread, etc.)
+        return "default"
+
+
+def get_user_data_dir(username: str | None = None) -> Path:
+    """Return the data directory for a user.
+
+    If *username* is ``None``, the current request user is used.  For
+    :class:`DefaultLoginProvider` this always returns ``DATA_DIR``
+    unchanged.
+    """
+    from vtsearch.config import DATA_DIR
+
+    if username is None:
+        username = get_current_user()
+    return _login_provider.get_user_data_dir(username, DATA_DIR)

--- a/vtsearch/datasets/registry.py
+++ b/vtsearch/datasets/registry.py
@@ -110,8 +110,12 @@ def register_dataset(
     num_dupes: int = 0,
     clipper: str = "",
     embedder: str = "",
+    created_by: str = "default",
 ) -> dict[str, Any]:
     """Add a new dataset to the registry and persist.
+
+    Args:
+        created_by: Username of the user who created this dataset.
 
     Returns the newly created entry (with a generated ``id``).
     """
@@ -128,6 +132,7 @@ def register_dataset(
         "source": source,
         "clipper": clipper,
         "embedder": embedder,
+        "created_by": created_by,
         "created_at": time.time(),
     }
     with _lock:

--- a/vtsearch/models/registry.py
+++ b/vtsearch/models/registry.py
@@ -99,6 +99,7 @@ def register_model(
     detector_name: str = "",
     trainable_model_name: str = "",
     text_query: str = "",
+    created_by: str = "default",
 ) -> dict[str, Any]:
     """Add a new model to the registry and persist.
 
@@ -110,6 +111,7 @@ def register_model(
         detector_name: The key used in ``autorun_detectors`` (for non-trainable).
         trainable_model_name: The key used in ``data/trainable_models/`` (for trainable).
         text_query: Text-sort query associated with the model.
+        created_by: Username of the user who created this model.
 
     Returns:
         The newly created entry dict.
@@ -125,6 +127,7 @@ def register_model(
         "detector_name": detector_name,
         "trainable_model_name": trainable_model_name,
         "text_query": text_query,
+        "created_by": created_by,
         "created_at": time.time(),
     }
     with _lock:

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -1,5 +1,6 @@
 """Flask blueprints for organizing application routes."""
 
+from vtsearch.routes.auth import auth_bp
 from vtsearch.routes.medias import medias_bp
 from vtsearch.routes.datasets import datasets_bp
 from vtsearch.routes.detectors import detectors_bp
@@ -12,6 +13,7 @@ from vtsearch.routes.sorting import sorting_bp
 from vtsearch.routes.trainable_models import trainable_models_bp
 
 __all__ = [
+    "auth_bp",
     "main_bp",
     "medias_bp",
     "sorting_bp",

--- a/vtsearch/routes/auth.py
+++ b/vtsearch/routes/auth.py
@@ -1,0 +1,26 @@
+"""Authentication status routes."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from vtsearch.auth import get_login_provider
+
+auth_bp = Blueprint("auth", __name__)
+
+
+@auth_bp.route("/api/auth/status", methods=["GET"])
+def auth_status():
+    """Return the current authentication state.
+
+    Response shape::
+
+        {
+            "provider": "default",
+            "user": "default",
+            "authenticated": true,
+            "login_required": false
+        }
+    """
+    provider = get_login_provider()
+    return jsonify(provider.status_dict(request))

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -7,6 +7,7 @@ import threading
 from pathlib import Path
 from uuid import uuid4
 
+from vtsearch.auth import get_current_user
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets import export_dataset_to_file
 from vtsearch.datasets.registry import (
@@ -211,6 +212,7 @@ def _auto_register_dataset(
     source: dict | None = None,
     clipper: str = "",
     embedder: str = "",
+    created_by: str = "",
 ) -> None:
     """Save the current medias as a pkl and register in the dataset registry.
 
@@ -258,12 +260,14 @@ def _auto_register_dataset(
         source=source,
         clipper=clipper,
         embedder=embedder,
+        created_by=created_by,
     )
     _reg_set_loaded(entry["id"])
 
 
 def _run_origin_load_in_background(
     load_fn, origin: dict, *, name: str = "", clipper: str = "", embedder: str = "",
+    created_by: str = "",
 ) -> None:
     """Run a dataset load in a background thread with standard error handling.
 
@@ -286,6 +290,9 @@ def _run_origin_load_in_background(
     embedder:
         Name of the embedder used.  When empty, derived from the medias
         at registration time.
+    created_by:
+        Username of the user who initiated the load.  Captured before
+        the background thread starts (no Flask request context in thread).
     """
 
     # Set progress to "loading" synchronously so the frontend never sees a
@@ -333,6 +340,7 @@ def _run_origin_load_in_background(
                 source=origin,
                 clipper=clipper,
                 embedder=embedder,
+                created_by=created_by,
             )
             _load_embedder_for_clips()
         except MemoryError:
@@ -359,6 +367,7 @@ def _run_origin_load_in_background(
 
 def _run_importer_in_background(importer, field_values: dict) -> None:
     """Start *importer*.run() in a daemon thread after clearing the dataset."""
+    created_by = get_current_user()
     origin = importer.build_origin(field_values)
     clipper_name = field_values.pop("clipper", "")
     embedder_name = field_values.get("embedder", "")
@@ -387,6 +396,7 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
         name=importer.resolve_display_name(field_values),
         clipper=clipper_name,
         embedder=embedder_name,
+        created_by=created_by,
     )
 
 

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 
+from vtsearch.auth import get_current_user
 from vtsearch.config import DATA_DIR
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.utils import (
@@ -85,7 +86,8 @@ def add_autorun_detector_route():
         return jsonify({"error": "media_type is required"}), 400
 
     add_autorun_detector(
-        name, media_type, weights, threshold, autodetect=autodetect, examples=examples, num_labels=num_labels
+        name, media_type, weights, threshold, autodetect=autodetect, examples=examples, num_labels=num_labels,
+        created_by=get_current_user(),
     )
 
     # Extract text_query from examples (first text example) for the registry
@@ -129,6 +131,7 @@ def add_autorun_detector_route():
             detector_name=name,
             text_query=text_query,
             trainable_model_name=trainable_model_name,
+            created_by=get_current_user(),
         )
 
     return jsonify({"success": True, "name": name})
@@ -317,7 +320,7 @@ def import_detector_pkl():
             else:
                 media_type = "audio"
 
-        add_autorun_detector(name, media_type, weights, threshold)
+        add_autorun_detector(name, media_type, weights, threshold, created_by=get_current_user())
         return jsonify({"success": True, "name": name, "media_type": media_type})
 
     except Exception as e:

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 from flask import Blueprint, jsonify, request
 
+from vtsearch.auth import get_current_user
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.models import (
     build_model_from_weights,
@@ -368,7 +369,7 @@ def import_detector_labels():
             weights[key] = value.tolist()
 
         final_media_type = detected_media_type or "audio"
-        add_autorun_detector(name, final_media_type, weights, threshold)
+        add_autorun_detector(name, final_media_type, weights, threshold, created_by=get_current_user())
         return jsonify(
             {
                 "success": True,
@@ -500,7 +501,7 @@ def train_from_label_import(importer_name: str):
         weights[key] = value.tolist()
 
     media_type = next(iter(snap.values())).get("type", "audio")
-    add_autorun_detector(name, media_type, weights, threshold)
+    add_autorun_detector(name, media_type, weights, threshold, created_by=get_current_user())
 
     # Register in the persistent model registry for the dashboard grid.
     from vtsearch.models.registry import find_by_detector_name, register_model
@@ -512,6 +513,7 @@ def train_from_label_import(importer_name: str):
             trainable=False,
             num_training=loaded_count,
             detector_name=name,
+            created_by=get_current_user(),
         )
 
     return jsonify(

--- a/vtsearch/routes/processor_importers.py
+++ b/vtsearch/routes/processor_importers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from flask import Blueprint, jsonify, request
 
+from vtsearch.auth import get_current_user
 from vtsearch.processors.importers import get_processor_importer, list_processor_importers
 from vtsearch.utils import add_autorun_detector
 import vtsearch.utils.paths as _paths
@@ -126,7 +127,7 @@ def run_processor_import(importer_name: str):
 
     # Use suggested name from the importer if the user didn't provide one
     # (already checked above that name is non-empty, but importer may suggest)
-    add_autorun_detector(name, media_type, weights, threshold)
+    add_autorun_detector(name, media_type, weights, threshold, created_by=get_current_user())
 
     # Register in the persistent model registry for the dashboard grid.
     from vtsearch.models.registry import find_by_detector_name, register_model
@@ -137,6 +138,7 @@ def run_processor_import(importer_name: str):
             media_type=media_type,
             trainable=False,
             detector_name=name,
+            created_by=get_current_user(),
         )
 
     response: dict = {

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 
+from vtsearch.auth import get_current_user
 from vtsearch.config import DATA_DIR
 
 trainable_models_bp = Blueprint("trainable_models", __name__)
@@ -417,6 +418,7 @@ def register_model_route():
         text_query=text_query,
         detector_name=detector_name,
         trainable_model_name=trainable_model_name,
+        created_by=get_current_user(),
     )
     return jsonify({"ok": True, "model": entry}), 201
 

--- a/vtsearch/utils/state_processors.py
+++ b/vtsearch/utils/state_processors.py
@@ -26,6 +26,7 @@ def add_autorun_detector(
     autodetect: bool = False,
     examples: list[dict[str, str]] | None = None,
     num_labels: int = 0,
+    created_by: str = "default",
 ) -> None:
     """Add or overwrite a named autorun detector in the global store.
 
@@ -46,6 +47,7 @@ def add_autorun_detector(
             (``"text"``, ``"media"``, or ``"detector"``) and ``"value"`` (str).
         num_labels: Number of training labels used when this detector was last
             trained.  Defaults to ``0`` for untrained stubs.
+        created_by: Username of the user who created this detector.
     """
     import time
 
@@ -59,6 +61,7 @@ def add_autorun_detector(
             "autodetect": autodetect,
             "examples": examples or [],
             "num_labels": num_labels,
+            "created_by": created_by,
         }
 
 


### PR DESCRIPTION
## Summary
Introduces a pluggable authentication abstraction layer that allows VTSearch to run in both single-user mode (default) and multi-user mode without changing route code. This enables future integration with authentication systems like username/password, PKI, or LDAP.

## Key Changes

- **New `vtsearch/auth/` module** with:
  - `LoginProvider` ABC defining the authentication interface (`get_user()`, `is_authenticated()`, `login_required()`, `get_user_data_dir()`, `status_dict()`)
  - `DefaultLoginProvider` implementation for single-user deployments (always returns "default" user, no login required)
  - Module-level provider management (`set_login_provider()`, `get_login_provider()`, `get_current_user()`)
  - `get_user_data_dir()` helper that delegates to the active provider for per-user data isolation

- **Flask integration in `app.py`**:
  - Added `before_request` middleware that populates `g.user` from the active provider on every request
  - Registered new `auth_bp` blueprint

- **New `/api/auth/status` endpoint** (`vtsearch/routes/auth.py`):
  - Returns JSON with provider name, current user, authentication status, and login requirement flag
  - Enables frontend to adapt UI based on auth configuration

- **Ownership tracking**:
  - Added `created_by` parameter (defaults to "default") to:
    - `register_dataset()` in `vtsearch/datasets/registry.py`
    - `register_model()` in `vtsearch/models/registry.py`
    - `add_autorun_detector()` in `vtsearch/utils/state_processors.py`
  - Updated all callers to pass `created_by=get_current_user()` where appropriate

- **Comprehensive test suite** (`tests/test_multi_user_security.py`):
  - Tests for `LoginProvider` ABC and `DefaultLoginProvider`
  - Custom provider implementation examples
  - Provider management and swapping
  - Flask middleware integration
  - Ownership metadata recording
  - User data directory isolation logic
  - Provider swap safety

## Implementation Details

- The `LoginProvider` ABC uses abstract methods for `get_user()` and `is_authenticated()`, with sensible defaults for `login_required()` and `get_user_data_dir()` suitable for single-user deployments
- `get_current_user()` gracefully falls back to "default" outside Flask request context (CLI, tests, background threads)
- Single-user deployments (default) use `DATA_DIR` directly; multi-user providers can override `get_user_data_dir()` to return `base_data_dir / username` for isolation
- All existing functionality remains unchanged; the default provider maintains backward compatibility

https://claude.ai/code/session_019Z19C87kuYwBS83jepUdr9