### PR TITLE
Consolidate export modals into unified ExportModalComponent

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -1,0 +1,36 @@
+<vt-modal title="Export" [open]="true" (closed)="close()">
+  <div class="export-section">
+    <h3>Export Labels</h3>
+    @if (loading) {
+      <p class="empty-state">Loading exporters...</p>
+    } @else if (exporters.length === 0) {
+      <p class="empty-state">No exporters available.</p>
+    } @else {
+      <div class="exporter-picker">
+        @for (exp of exporters; track exp.name) {
+          <button class="exporter-card" (click)="exportLabelsWith(exp)">
+            <span class="exporter-name">{{ exp.label || exp.name }}</span>
+            @if (exp.description) {
+              <span class="exporter-desc">{{ exp.description }}</span>
+            }
+          </button>
+        }
+      </div>
+    }
+  </div>
+
+  <div class="export-section">
+    <h3>Export Detector Weights</h3>
+    <div class="export-options">
+      <button class="btn btn--primary" (click)="exportDetectorBrowser()">Browser Download</button>
+      <button class="btn btn--secondary" (click)="exportDetectorServer()">Save to Server</button>
+    </div>
+  </div>
+
+  @if (status) {
+    <p class="status-text">{{ status }}</p>
+  }
+  @if (error) {
+    <p class="error-text">{{ error }}</p>
+  }
+</vt-modal>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -1,0 +1,13 @@
+.export-section {
+  margin-bottom: 1.5rem;
+
+  h3 {
+    margin: 0 0 0.75rem;
+    font-size: 0.95rem;
+  }
+}
+
+.export-options {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -1,0 +1,113 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalComponent } from '../../modal/modal.component';
+import { DetectorsApiService } from '../../../services/detectors-api.service';
+import { ExportersApiService } from '../../../services/exporters-api.service';
+import { SortingApiService } from '../../../services/sorting-api.service';
+import { ExporterInfo } from '../../../models/api.models';
+
+@Component({
+  selector: 'vt-export-modal',
+  standalone: true,
+  imports: [CommonModule, ModalComponent],
+  templateUrl: './export-modal.component.html',
+  styleUrl: './export-modal.component.scss',
+})
+export class ExportModalComponent implements OnInit {
+  @Input() detectorName = '';
+  @Output() closed = new EventEmitter<void>();
+  @Output() exported = new EventEmitter<void>();
+
+  exporters: ExporterInfo[] = [];
+  loading = true;
+  error = '';
+  status = '';
+
+  constructor(
+    private detectorsApi: DetectorsApiService,
+    private exportersApi: ExportersApiService,
+    private sortingApi: SortingApiService,
+  ) {}
+
+  ngOnInit(): void {
+    this.exportersApi.getExporters().subscribe({
+      next: (list) => {
+        this.exporters = list;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.error = 'Failed to load exporters';
+      },
+    });
+  }
+
+  exportLabelsWith(exporter: ExporterInfo): void {
+    this.status = 'Exporting labels...';
+    this.error = '';
+    this.sortingApi.exportLabels().subscribe({
+      next: (labelsData) => {
+        this.exportersApi
+          .runExport({
+            exporter_name: exporter.name,
+            results: labelsData,
+          })
+          .subscribe({
+            next: () => {
+              this.status = 'Labels exported.';
+              this.exported.emit();
+            },
+            error: () => {
+              this.status = '';
+              this.error = 'Label export failed';
+            },
+          });
+      },
+      error: () => {
+        this.status = '';
+        this.error = 'Failed to fetch labels';
+      },
+    });
+  }
+
+  exportDetectorBrowser(): void {
+    this.status = 'Exporting...';
+    this.error = '';
+    this.detectorsApi.exportDetector(this.detectorName).subscribe({
+      next: (data: any) => {
+        const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${this.detectorName || 'detector'}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+        this.status = 'Downloaded.';
+        this.exported.emit();
+      },
+      error: () => {
+        this.error = 'Export failed';
+        this.status = '';
+      },
+    });
+  }
+
+  exportDetectorServer(): void {
+    this.status = 'Saving to server...';
+    this.error = '';
+    this.detectorsApi.exportDetectorToServer(this.detectorName).subscribe({
+      next: () => {
+        this.status = 'Saved to server.';
+        this.exported.emit();
+      },
+      error: () => {
+        this.error = 'Failed to save to server';
+        this.status = '';
+      },
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -42,8 +42,7 @@
   />
 
   <div class="export-row">
-    <button class="panel-btn export-btn" (click)="onExportLabels()">Export Labels</button>
-    <button class="panel-btn export-btn" (click)="onExportDetector()">Export Detector</button>
+    <button class="panel-btn export-btn" (click)="onExport()">Export</button>
   </div>
 </aside>
 
@@ -51,10 +50,10 @@
   <vt-label-importer-modal (closed)="showLabelImport = false" (imported)="showLabelImport = false" />
 }
 
-@if (showLabelExport) {
-  <vt-label-exporter-modal (closed)="showLabelExport = false" (exportComplete)="showLabelExport = false" />
-}
-
-@if (showDetectorExport) {
-  <vt-detector-export-modal (closed)="showDetectorExport = false" (exported)="showDetectorExport = false" />
+@if (showExport) {
+  <vt-export-modal
+    [detectorName]="trainMode?.model?.name ?? ''"
+    (closed)="showExport = false"
+    (exported)="showExport = false"
+  />
 }

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -62,4 +62,5 @@
 
 .export-btn {
   flex: 1;
+  text-align: center;
 }

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -10,8 +10,7 @@ import { SettingsStateService } from '../../services/settings-state.service';
 import { LabelSortComponent, LabelSortMode } from './label-sort/label-sort.component';
 import { LabelListComponent } from './label-list/label-list.component';
 import { DetectorContextBarComponent } from './detector-context-bar/detector-context-bar.component';
-import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
-import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
+import { ExportModalComponent } from '../modals/export-modal/export-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 
 export interface TrainModeContext {
@@ -26,8 +25,7 @@ export interface TrainModeContext {
     LabelSortComponent,
     LabelListComponent,
     DetectorContextBarComponent,
-    DetectorExportModalComponent,
-    LabelExporterModalComponent,
+    ExportModalComponent,
     LabelImporterModalComponent,
   ],
   templateUrl: './right-panel.component.html',
@@ -48,8 +46,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   viewMode: 'grid' | 'list' = 'grid';
   gridColumns: number = 2;
   showLabelImport = false;
-  showLabelExport = false;
-  showDetectorExport = false;
+  showExport = false;
 
   private viewModeRightDict: Record<string, 'grid' | 'list'> = {};
   private gridColumnsRightDict: Record<string, number> = {};
@@ -101,12 +98,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
     this.showLabelImport = true;
   }
 
-  onExportLabels(): void {
-    this.showLabelExport = true;
-  }
-
-  onExportDetector(): void {
-    this.showDetectorExport = true;
+  onExport(): void {
+    this.showExport = true;
   }
 
   onDetectorRenamed(newName: string): void {


### PR DESCRIPTION
## Summary
Refactored the export functionality by consolidating two separate export modals (`DetectorExportModalComponent` and `LabelExporterModalComponent`) into a single unified `ExportModalComponent`. This simplifies the UI and reduces code duplication while maintaining all existing export capabilities.

## Key Changes
- **New unified export modal**: Created `ExportModalComponent` that handles both label and detector exports in a single interface
  - Displays available exporters for label export
  - Provides detector export options (browser download and server save)
  - Manages loading states, errors, and status messages
  
- **Simplified right panel**: Updated `RightPanelComponent` to use the new unified modal
  - Replaced separate `showLabelExport` and `showDetectorExport` flags with single `showExport` flag
  - Consolidated `onExportLabels()` and `onExportDetector()` methods into single `onExport()` method
  - Merged two export buttons into one "Export" button
  
- **Removed old modals**: Eliminated `DetectorExportModalComponent` and `LabelExporterModalComponent` imports and usage

## Implementation Details
- The new modal accepts `detectorName` as an input to support detector export functionality
- Maintains all original export features: label export via exporters, detector browser download, and server save
- Uses Angular's new control flow syntax (`@if`, `@for`) for template rendering
- Properly handles async operations with loading, error, and success states
- Emits `closed` and `exported` events for parent component communication

https://claude.ai/code/session_0137QR9MxKMrNAcDZLa1disP