### PR TITLE
Include exporters in base requirements and update docs

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -140,15 +140,9 @@ pip install -r requirements-cpu.txt
 pip install -r requirements-gpu.txt
 ```
 
-This installs Flask, NumPy, PyTorch, and other ML / media processing dependencies.
+This installs Flask, NumPy, PyTorch, and other ML / media processing dependencies (including importers and exporters).
 
-**For email, webhook, and GUI exporters** (optional):
-
-```bash
-pip install -r requirements-exporters.txt
-```
-
-**For development** (adds pytest and other dev tools — includes exporters):
+**For development** (adds pytest and other dev tools):
 
 ```bash
 pip install -r requirements-dev.txt

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -37,3 +37,9 @@ PyMuPDF
 # To add a new importer, create vtsearch/datasets/importers/<name>/requirements.txt,
 # then add a -r line to requirements-importers.txt.
 -r requirements-importers.txt
+
+# Per-exporter dependencies.
+# Each exporter declares its own requirements in its subdirectory.
+# To add a new exporter, create vtsearch/exporters/<name>/requirements.txt,
+# then add a -r line to requirements-exporters.txt.
+-r requirements-exporters.txt

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -35,3 +35,9 @@ PyMuPDF
 # To add a new importer, create vtsearch/datasets/importers/<name>/requirements.txt,
 # then add a -r line to requirements-importers.txt.
 -r requirements-importers.txt
+
+# Per-exporter dependencies.
+# Each exporter declares its own requirements in its subdirectory.
+# To add a new exporter, create vtsearch/exporters/<name>/requirements.txt,
+# then add a -r line to requirements-exporters.txt.
+-r requirements-exporters.txt


### PR DESCRIPTION
## Summary
This change consolidates the dependency installation process by including exporter requirements in the base CPU and GPU requirement files, eliminating the need for a separate installation step. The documentation has been updated to reflect this change.

## Key Changes
- Added `requirements-exporters.txt` to both `requirements-cpu.txt` and `requirements-gpu.txt` so exporters are installed by default
- Updated `SETUP.md` to remove the separate "For email, webhook, and GUI exporters" installation section
- Clarified that the base installation now includes "importers and exporters"
- Updated the "For development" section description to remove the note about exporters being included (since they're now in base)
- Added inline documentation in requirements files explaining the exporter dependency structure

## Implementation Details
- Exporters are now installed as part of the standard setup, making them available without requiring users to run an additional pip install command
- The modular structure is preserved: each exporter can still declare its own requirements in `vtsearch/exporters/<name>/requirements.txt`
- Documentation now clearly indicates that both importers and exporters are included in the base installation

https://claude.ai/code/session_01MwtmTUyRipC8JPo3Y5UwP5