### PR TITLE
Reuse trained models in progress cache to avoid retraining

### DIFF
--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -222,7 +222,7 @@ class TestTrainAndScoreGPU:
 
             clips_dict = _make_clips_dict(20, dim=64)
             good, bad = _make_votes([1, 2, 3], [18, 19, 20])
-            results, threshold = train_and_score(clips_dict, good, bad)
+            results, threshold, _model = train_and_score(clips_dict, good, bad)
 
             assert len(results) == 20
             assert isinstance(threshold, float)
@@ -242,7 +242,7 @@ class TestTrainAndScoreGPU:
 
             clips_dict = _make_clips_dict(20, dim=64)
             good, bad = _make_votes([1, 2, 3], [18, 19, 20])
-            results, _ = train_and_score(clips_dict, good, bad)
+            results, _, _m = train_and_score(clips_dict, good, bad)
             for entry in results:
                 assert 0.0 <= entry["score"] <= 1.0
         finally:
@@ -258,7 +258,7 @@ class TestTrainAndScoreGPU:
 
             clips_dict = _make_clips_dict(20, dim=64)
             good, bad = _make_votes([1, 2], [3, 4])
-            results, _ = train_and_score(clips_dict, good, bad)
+            results, _, _m = train_and_score(clips_dict, good, bad)
             scores = [e["score"] for e in results]
             assert scores == sorted(scores, reverse=True)
         finally:
@@ -281,7 +281,7 @@ class TestTrainAndScoreGPU:
                 clips_dict[i] = {"id": i, "embedding": emb, "type": "audio"}
 
             good, bad = _make_votes([1, 2, 3, 4, 5], [16, 17, 18, 19, 20])
-            results, _ = train_and_score(clips_dict, good, bad)
+            results, _, _m = train_and_score(clips_dict, good, bad)
             score_map = {e["id"]: e["score"] for e in results}
             avg_good = np.mean([score_map[i] for i in good])
             avg_bad = np.mean([score_map[i] for i in bad])
@@ -299,7 +299,7 @@ class TestTrainAndScoreGPU:
 
             clips_dict = _make_clips_dict(20, dim=64)
             good, bad = _make_votes([1, 2, 3], [18, 19, 20])
-            results, threshold = train_and_score(clips_dict, good, bad, inclusion_value=5)
+            results, threshold, _model = train_and_score(clips_dict, good, bad, inclusion_value=5)
             assert len(results) == 20
             assert isinstance(threshold, float)
         finally:

--- a/tests/test_safe_thresholds.py
+++ b/tests/test_safe_thresholds.py
@@ -91,7 +91,7 @@ class TestTrainAndScoreWithSafeThresholds:
         """With safe_thresholds=True, threshold is still in [0, 1]."""
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        results, threshold = train_and_score(
+        results, threshold, _model = train_and_score(
             app_module.medias, app_module.good_votes, app_module.bad_votes, safe_thresholds=True
         )
         assert 0.0 <= threshold <= 1.0
@@ -105,10 +105,10 @@ class TestTrainAndScoreWithSafeThresholds:
         """
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        _, thresh_off = train_and_score(
+        _, thresh_off, _m1 = train_and_score(
             app_module.medias, app_module.good_votes, app_module.bad_votes, safe_thresholds=False
         )
-        _, thresh_on = train_and_score(
+        _, thresh_on, _m2 = train_and_score(
             app_module.medias, app_module.good_votes, app_module.bad_votes, safe_thresholds=True
         )
         # They CAN be equal but with 6 labels, safe thresholds should blend
@@ -329,7 +329,7 @@ class TestCalibrationFractionTrainAndScore:
     def test_custom_fraction_returns_valid_results(self):
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        results, threshold = train_and_score(
+        results, threshold, _model = train_and_score(
             app_module.medias,
             app_module.good_votes,
             app_module.bad_votes,

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -57,7 +57,7 @@ class TestTrainAndScore:
     def test_returns_list_of_scored_clips(self):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        results, threshold = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
+        results, threshold, _model = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
         assert len(results) == app_module.NUM_MEDIAS
         assert isinstance(threshold, float)
         for entry in results:
@@ -67,21 +67,21 @@ class TestTrainAndScore:
     def test_scores_between_zero_and_one(self):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        results, threshold = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
+        results, threshold, _model = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
         for entry in results:
             assert 0.0 <= entry["score"] <= 1.0
 
     def test_results_sorted_descending(self):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        results, threshold = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
+        results, threshold, _model = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
         scores = [e["score"] for e in results]
         assert scores == sorted(scores, reverse=True)
 
     def test_good_clips_scored_higher_than_bad(self):
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        results, threshold = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
+        results, threshold, _model = app_module.train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
         score_map = {e["id"]: e["score"] for e in results}
         avg_good = np.mean([score_map[i] for i in app_module.good_votes])
         avg_bad = np.mean([score_map[i] for i in app_module.bad_votes])
@@ -91,14 +91,14 @@ class TestTrainAndScore:
         """After adding a vote and retraining, the sort order should change."""
         app_module.good_votes.update({k: None for k in [1, 2, 3, 4, 5]})
         app_module.bad_votes.update({k: None for k in [16, 17, 18, 19, 20]})
-        results_before, _ = app_module.train_and_score(
+        results_before, _, _m = app_module.train_and_score(
             app_module.medias, app_module.good_votes, app_module.bad_votes
         )
         order_before = [e["id"] for e in results_before]
 
         # Add a new good vote on a media that was in the middle
         app_module.good_votes[10] = None
-        results_after, _ = app_module.train_and_score(
+        results_after, _, _m = app_module.train_and_score(
             app_module.medias, app_module.good_votes, app_module.bad_votes
         )
         order_after = [e["id"] for e in results_after]

--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -5,6 +5,8 @@ from vtsearch.models.progress import (
     _cached_steps,
     _compute_stable_status,
     _ensure_cache,
+    _live_models,
+    inject_live_model,
 )
 from vtsearch.utils import medias, label_history
 
@@ -445,3 +447,159 @@ class TestStabilitySkipsUnchangedModel:
             assert _cached_steps[i]["stability"] is not None, (
                 f"Step {i} changed training data and should have stability"
             )
+
+
+class TestLiveModelReuse:
+    """Progress cache should reuse models injected by train_and_score."""
+
+    def test_injected_model_is_used(self, client):
+        """When a live model matches the label set, _ensure_cache should use it."""
+        import numpy as np
+        import torch
+
+        from vtsearch.models.progress import clear_progress_cache
+        from vtsearch.models.training import train_model
+
+        clear_progress_cache()
+
+        rng = np.random.RandomState(99)
+        clips = {}
+        for i in range(10):
+            clips[i] = {"embedding": rng.randn(8).astype(np.float32)}
+
+        # Train a live model for good={0,2}, bad={1}
+        good = {0: None, 2: None}
+        bad = {1: None}
+        X = torch.tensor(np.array([clips[0]["embedding"], clips[2]["embedding"], clips[1]["embedding"]]), dtype=torch.float32)
+        y = torch.tensor([1.0, 1.0, 0.0]).unsqueeze(1)
+        live_model = train_model(X, y, 8)
+        live_threshold = 0.42
+
+        inject_live_model(good, bad, live_model, live_threshold)
+
+        # Now run _ensure_cache with a history that leads to {0,2} good, {1} bad
+        history = [
+            (0, "good", 1.0),
+            (1, "bad", 2.0),
+            (2, "good", 3.0),
+        ]
+
+        _ensure_cache(clips, history, inclusion_value=0)
+
+        # Step 2 should have used the injected model (same label set)
+        step = _cached_steps[2]
+        assert step["model"] is live_model, "Should reuse the injected live model"
+        assert step["threshold"] == live_threshold, "Should use the injected threshold"
+
+    def test_non_matching_label_set_retrains(self, client):
+        """When no live model matches, _ensure_cache should train normally."""
+        import numpy as np
+        import torch
+
+        from vtsearch.models.progress import clear_progress_cache
+        from vtsearch.models.training import train_model
+
+        clear_progress_cache()
+
+        rng = np.random.RandomState(99)
+        clips = {}
+        for i in range(10):
+            clips[i] = {"embedding": rng.randn(8).astype(np.float32)}
+
+        # Inject a live model for a DIFFERENT label set
+        good = {5: None, 6: None}
+        bad = {7: None}
+        X = torch.tensor(np.array([clips[5]["embedding"], clips[6]["embedding"], clips[7]["embedding"]]), dtype=torch.float32)
+        y = torch.tensor([1.0, 1.0, 0.0]).unsqueeze(1)
+        live_model = train_model(X, y, 8)
+        inject_live_model(good, bad, live_model, 0.5)
+
+        # Ensure cache for a different label set
+        history = [
+            (0, "good", 1.0),
+            (1, "bad", 2.0),
+        ]
+
+        _ensure_cache(clips, history, inclusion_value=0)
+
+        # Step 1 should NOT use the injected model (different label set)
+        step = _cached_steps[1]
+        assert step["model"] is not live_model, "Should not use a live model with mismatched labels"
+
+    def test_clear_cache_removes_live_models(self, client):
+        """clear_progress_cache should also clear injected live models."""
+        import numpy as np
+        import torch
+
+        from vtsearch.models.progress import clear_progress_cache
+        from vtsearch.models.training import train_model
+
+        X = torch.tensor(np.random.randn(2, 8).astype(np.float32))
+        y = torch.tensor([1.0, 0.0]).unsqueeze(1)
+        model = train_model(X, y, 8)
+
+        inject_live_model({0: None}, {1: None}, model, 0.5)
+        assert len(_live_models) == 1
+
+        clear_progress_cache()
+        assert len(_live_models) == 0
+
+    def test_learned_sort_injects_model(self, client):
+        """The /api/learned-sort endpoint should inject the trained model."""
+        from vtsearch.models.progress import clear_progress_cache
+
+        clear_progress_cache()
+
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+
+        resp = client.post("/api/learned-sort")
+        assert resp.status_code == 200
+
+        # A live model should have been injected for the current vote set
+        key = (frozenset(app_module.good_votes), frozenset(app_module.bad_votes))
+        assert key in _live_models, "learned-sort should inject the live model"
+        model, threshold = _live_models[key]
+        assert model is not None
+        assert isinstance(threshold, float)
+
+    def test_live_model_stability_computed(self, client):
+        """When a live model is reused, stability should still be computed."""
+        import numpy as np
+        import torch
+
+        from vtsearch.models.progress import clear_progress_cache
+        from vtsearch.models.training import train_model
+
+        clear_progress_cache()
+
+        rng = np.random.RandomState(42)
+        clips = {}
+        for i in range(20):
+            clips[i] = {"embedding": rng.randn(8).astype(np.float32)}
+
+        # Build a history with enough steps to have prior predictions
+        history = [
+            (0, "good", 1.0),
+            (1, "bad", 2.0),
+            (2, "good", 3.0),
+            (3, "bad", 4.0),
+            (4, "good", 5.0),  # step 4: good={0,2,4}, bad={1,3}
+        ]
+
+        # Inject a live model for step 4's label set
+        good = {0: None, 2: None, 4: None}
+        bad = {1: None, 3: None}
+        embs = [clips[i]["embedding"] for i in [0, 2, 4, 1, 3]]
+        X = torch.tensor(np.array(embs), dtype=torch.float32)
+        y = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0]).unsqueeze(1)
+        live_model = train_model(X, y, 8)
+        inject_live_model(good, bad, live_model, 0.55)
+
+        _ensure_cache(clips, history, inclusion_value=0)
+
+        # Step 4 should use the live model
+        step4 = _cached_steps[4]
+        assert step4["model"] is live_model
+        # Stability should still be computed (not None) since prior predictions exist
+        assert step4["stability"] is not None, "Stability should be computed even with live model"

--- a/vtsearch/eval/runner.py
+++ b/vtsearch/eval/runner.py
@@ -174,7 +174,7 @@ def eval_learned_sort(
         bad_votes: dict[int, None] = {cid: None for cid in train_bad}
 
         # Run train_and_score
-        scored, threshold = train_and_score(
+        scored, threshold, _model = train_and_score(
             medias,
             good_votes,
             bad_votes,

--- a/vtsearch/models/__init__.py
+++ b/vtsearch/models/__init__.py
@@ -23,6 +23,7 @@ from vtsearch.models.progress import (
     calculate_prediction_stability_over_time,
     clear_progress_cache,
     compute_labeling_status,
+    inject_live_model,
 )
 from vtsearch.models.training import (
     build_model,
@@ -67,4 +68,5 @@ __all__ = [
     "calculate_prediction_stability_over_time",
     "clear_progress_cache",
     "compute_labeling_status",
+    "inject_live_model",
 ]

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -32,6 +32,12 @@ _cache_bad_ids: set[int] = set()
 _cache_prev_predictions: Optional[dict[int, int]] = None
 _cache_diversity_tree: Any = None  # DiversityTree | None
 
+# Live models injected by `train_and_score` during sorting.  Keyed by
+# ``(frozenset(good_ids), frozenset(bad_ids))`` so that ``_ensure_cache``
+# can look up the actual model that was used at each label step instead
+# of retraining from scratch.
+_live_models: dict[tuple[frozenset[int], frozenset[int]], tuple[Any, float]] = {}
+
 # Reentrant lock protecting all module-level cache variables.
 # RLock is used because public functions call _ensure_cache which may
 # call clear_progress_cache internally when the inclusion value changes.
@@ -52,6 +58,24 @@ def clear_progress_cache() -> None:
         _cache_prev_predictions = None
         _cache_inclusion = None
         _cache_diversity_tree = None
+        _live_models.clear()
+
+
+def inject_live_model(
+    good_votes: dict[int, None],
+    bad_votes: dict[int, None],
+    model: nn.Sequential,
+    threshold: float,
+) -> None:
+    """Register a live model from ``train_and_score`` for progress-cache reuse.
+
+    Called by the learned-sort route after each live training run.  The model
+    is stored keyed by its label set so ``_ensure_cache`` can look it up
+    instead of retraining from scratch.
+    """
+    key = (frozenset(good_votes), frozenset(bad_votes))
+    with _progress_lock:
+        _live_models[key] = (model, threshold)
 
 
 def _build_diversity_tree(clips_dict: dict[int, dict[str, Any]]) -> Any:
@@ -259,7 +283,16 @@ def _ensure_cache(
         training_data_changed = prev is None or set(good_ids) != set(prev["good_ids"]) or set(bad_ids) != set(prev["bad_ids"])
 
         if training_data_changed:
-            model, threshold, stability = _train_step(clips_dict, all_media_ids, t, num_labels, inclusion_value)
+            # Check whether train_and_score already produced a model for
+            # this exact label set during live sorting.  If so, reuse it
+            # (correct cross-calibrated threshold, zero compute cost).
+            live_key = (frozenset(_cache_good_ids), frozenset(_cache_bad_ids))
+            live = _live_models.get(live_key)
+            if live is not None:
+                model, threshold = live
+                stability = _compute_step_stability(model, threshold, clips_dict, all_media_ids, t, num_labels)
+            else:
+                model, threshold, stability = _train_step(clips_dict, all_media_ids, t, num_labels, inclusion_value)
         else:
             # Reuse previous model — no new training or stability entry.
             model = prev["model"] if prev else None

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -461,7 +461,7 @@ def train_and_score(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
-) -> tuple[list[dict[str, Any]], float]:
+) -> tuple[list[dict[str, Any]], float, nn.Sequential | None]:
     """Train a small MLP on voted media embeddings and score every media.
 
     Uses k-fold calibration to determine an appropriate decision threshold,
@@ -484,12 +484,14 @@ def train_and_score(
             20% Calibrate.
 
     Returns:
-        A tuple ``(results, threshold)`` where:
+        A tuple ``(results, threshold, model)`` where:
 
         - ``results`` is a list of ``{"id": int, "score": float}`` dicts, sorted
           by score in descending order (highest confidence first).
         - ``threshold`` is the decision boundary as a float (cross-calibrated,
           or blended with GMM when ``safe_thresholds`` is ``True``).
+        - ``model`` is the trained ``nn.Sequential`` model (``None`` when
+          training was not possible).
     """
     import torch  # noqa: PLC0415
 
@@ -508,7 +510,7 @@ def train_and_score(
     num_good = sum(1 for v in y_list if v == 1.0)
     num_bad = len(y_list) - num_good
     if len(X_list) < 2 or num_good == 0 or num_bad == 0:
-        return [], 0.5
+        return [], 0.5, None
 
     X = torch.tensor(np.array(X_list), dtype=torch.float32)
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
@@ -550,4 +552,4 @@ def train_and_score(
     # affect ordering.  Round only for the JSON response values.
     paired = sorted(zip(all_ids, scores), key=lambda x: x[1], reverse=True)
     results = [{"id": cid, "score": round(s, 4)} for cid, s in paired]
-    return results, threshold
+    return results, threshold, model

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -21,6 +21,7 @@ from vtsearch.models import (
     calculate_safe_threshold,
     compute_labeling_status,
     embed_text_query,
+    inject_live_model,
     train_and_score,
     train_model,
 )
@@ -180,7 +181,7 @@ def learned_sort():
     """Train MLP on voted medias, return all medias sorted by predicted score."""
     if not good_votes or not bad_votes:
         return jsonify({"error": "need at least one good and one bad vote"}), 400
-    results, threshold = train_and_score(
+    results, threshold, model = train_and_score(
         snapshot_medias(),
         good_votes,
         bad_votes,
@@ -191,6 +192,11 @@ def learned_sort():
     )
     # Store scores so the /api/votes endpoint can provide confidence info.
     update_learned_scores({r["id"]: r["score"] for r in results})
+    # Inject the live model into the progress cache so indicators and the
+    # progress line-graph use the actual model that guided sorting, rather
+    # than retraining an independent model from scratch.
+    if model is not None:
+        inject_live_model(good_votes, bad_votes, model, threshold)
     return jsonify({"results": results, "threshold": round(threshold, 4)})
 
 


### PR DESCRIPTION
## Summary
This PR adds model injection and reuse to the progress cache system. When `train_and_score` trains a model during live sorting, that model is now registered with the progress cache so that subsequent calls to `_ensure_cache` can reuse it instead of retraining from scratch. This improves performance and ensures consistency between the sorting results and the progress indicators.

## Key Changes

- **Model Injection System**: Added `inject_live_model()` function to register trained models in a module-level `_live_models` dictionary, keyed by the label set (good/bad vote IDs).

- **Progress Cache Reuse**: Modified `_ensure_cache()` to check for injected models before training. When a model exists for the current label set, it's reused with stability computed from prior predictions.

- **Return Value Update**: `train_and_score()` now returns a 3-tuple `(results, threshold, model)` instead of 2-tuple, exposing the trained model for injection.

- **Learned Sort Integration**: The `/api/learned-sort` endpoint now calls `inject_live_model()` after training to register the model for cache reuse.

- **Cache Cleanup**: `clear_progress_cache()` now also clears the `_live_models` dictionary.

- **Test Coverage**: Added comprehensive test suite (`TestLiveModelReuse`) covering:
  - Model reuse when label sets match
  - Training fallback when label sets don't match
  - Cache clearing behavior
  - Integration with learned-sort endpoint
  - Stability computation with reused models

## Implementation Details

- Live models are stored as `(model, threshold)` tuples keyed by `(frozenset(good_ids), frozenset(bad_ids))` for O(1) lookup.
- When a live model is reused, stability is still computed using `_compute_step_stability()` to maintain consistency with the progress cache contract.
- The model is only injected if training was successful (non-None return value).
- All module-level cache state is protected by the existing `_progress_lock` reentrant lock.

https://claude.ai/code/session_01XtXz8y1nx4DqbuLyVCuywG