### PR TITLE
Add common Python/OS entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
 __pycache__/
 *.pyc
+*.pyo
+*.egg-info/
 .pytest_cache/
+.ruff_cache/
 .venv/
 .coverage
 coverage.json
 htmlcov/
+.env
+.DS_Store
 
 # Demo dataset files
 data/


### PR DESCRIPTION
Add *.pyo, *.egg-info/, .ruff_cache/, .env, and .DS_Store to prevent accidental commits of build artifacts, secrets, and OS metadata.

https://claude.ai/code/session_01NkLCjpiHn5NRVGBqgdWwUR