### PR TITLE
Add exporter configuration form support to export modal

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -1,36 +1,120 @@
-<vt-modal title="Export" [open]="true" (closed)="close()">
-  <div class="export-section">
-    <h3>Export Labels</h3>
-    @if (loading) {
-      <p class="empty-state">Loading exporters...</p>
-    } @else if (exporters.length === 0) {
-      <p class="empty-state">No exporters available.</p>
-    } @else {
-      <div class="exporter-picker">
-        @for (exp of exporters; track exp.name) {
-          <button class="exporter-card" (click)="exportLabelsWith(exp)">
-            <span class="exporter-name">{{ exp.label || exp.name }}</span>
-            @if (exp.description) {
-              <span class="exporter-desc">{{ exp.description }}</span>
-            }
-          </button>
-        }
-      </div>
-    }
-  </div>
-
-  <div class="export-section">
-    <h3>Export Detector Weights</h3>
-    <div class="export-options">
-      <button class="btn btn--primary" (click)="exportDetectorBrowser()">Browser Download</button>
-      <button class="btn btn--secondary" (click)="exportDetectorServer()">Save to Server</button>
+<vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
+  @if (view === 'picker') {
+    <div class="export-section">
+      <h3>Export Labels</h3>
+      @if (loading) {
+        <p class="empty-state">Loading exporters...</p>
+      } @else if (exporters.length === 0) {
+        <p class="empty-state">No exporters available.</p>
+      } @else {
+        <div class="exporter-picker">
+          @for (exp of exporters; track exp.name) {
+            <button class="exporter-card" (click)="selectExporter(exp)">
+              <span class="exporter-name">@if (exp.icon) {<span class="exporter-icon">{{ exp.icon }}</span> }{{ exp.display_name || exp.name }}</span>
+              @if (exp.description) {
+                <span class="exporter-desc">{{ exp.description }}</span>
+              }
+            </button>
+          }
+        </div>
+      }
     </div>
-  </div>
 
-  @if (status) {
-    <p class="status-text">{{ status }}</p>
+    <div class="export-section">
+      <h3>Export Detector Weights</h3>
+      <div class="export-options">
+        <button class="btn btn--primary" (click)="exportDetectorBrowser()">Browser Download</button>
+        <button class="btn btn--secondary" (click)="exportDetectorServer()">Save to Server</button>
+      </div>
+    </div>
   }
-  @if (error) {
-    <p class="error-text">{{ error }}</p>
+
+  @if (view === 'form' && selectedExporter) {
+    <div class="exporter-form">
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+
+      @if (selectedExporter.fields && selectedExporter.fields.length > 0) {
+        @for (field of selectedExporter.fields; track field.key) {
+          <div class="form-group">
+            <label class="form-label" [for]="'field-' + field.key">
+              {{ field.label || field.key }}
+              @if (field.required) {
+                <span class="required">*</span>
+              }
+            </label>
+
+            @if (field.field_type === 'password') {
+              <input
+                [id]="'field-' + field.key"
+                type="password"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
+            } @else if (field.field_type === 'email') {
+              <input
+                [id]="'field-' + field.key"
+                type="email"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
+            } @else if (field.field_type === 'url') {
+              <input
+                [id]="'field-' + field.key"
+                type="url"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
+            } @else if (field.field_type === 'select') {
+              <select
+                [id]="'field-' + field.key"
+                class="form-select"
+                [(ngModel)]="formValues[field.key]"
+              >
+                @for (opt of field.options || []; track opt) {
+                  <option [value]="opt">{{ opt }}</option>
+                }
+              </select>
+            } @else {
+              <input
+                [id]="'field-' + field.key"
+                type="text"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
+            }
+          </div>
+        }
+      } @else {
+        <p class="info-text">This exporter requires no additional configuration.</p>
+      }
+
+      @if (error) {
+        <p class="error-text">{{ error }}</p>
+      }
+
+      <div class="form-actions" modal-footer>
+        <button class="btn btn--secondary" (click)="back()">Cancel</button>
+        <button class="btn btn--primary" (click)="submitForm()" [disabled]="submitting">
+          @if (submitting) {
+            Exporting...
+          } @else {
+            Export
+          }
+        </button>
+      </div>
+    </div>
+  }
+
+  @if (view === 'picker') {
+    @if (status) {
+      <p class="status-text">{{ status }}</p>
+    }
+    @if (error) {
+      <p class="error-text">{{ error }}</p>
+    }
   }
 </vt-modal>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -11,3 +11,96 @@
   display: flex;
   gap: 0.5rem;
 }
+
+// --- Exporter picker cards (matches importer-card styling) ---
+
+.exporter-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.exporter-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px 16px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s, border-color 0.15s;
+  color: var(--text-primary);
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+  }
+}
+
+.exporter-name {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.exporter-icon {
+  margin-right: 4px;
+}
+
+.exporter-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+// --- Exporter form (matches importer form styling) ---
+
+.exporter-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.back-btn {
+  align-self: flex-start;
+  margin-bottom: 4px;
+}
+
+.btn--sm {
+  padding: 2px 10px;
+  font-size: 0.85rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.required {
+  color: var(--color-bad);
+}
+
+.info-text {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.error-text {
+  color: var(--color-bad);
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 16px;
+}

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
@@ -9,7 +10,7 @@ import { ExporterInfo } from '../../../models/api.models';
 @Component({
   selector: 'vt-export-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent],
+  imports: [CommonModule, FormsModule, ModalComponent],
   templateUrl: './export-modal.component.html',
   styleUrl: './export-modal.component.scss',
 })
@@ -23,6 +24,12 @@ export class ExportModalComponent implements OnInit {
   error = '';
   status = '';
 
+  /** Current view: picker list or field form for a selected exporter. */
+  view: 'picker' | 'form' = 'picker';
+  selectedExporter: ExporterInfo | null = null;
+  formValues: Record<string, string> = {};
+  submitting = false;
+
   constructor(
     private detectorsApi: DetectorsApiService,
     private exportersApi: ExportersApiService,
@@ -32,7 +39,7 @@ export class ExportModalComponent implements OnInit {
   ngOnInit(): void {
     this.exportersApi.getExporters().subscribe({
       next: (list) => {
-        this.exporters = list;
+        this.exporters = list.filter((e) => !e.hidden_from_picker);
         this.loading = false;
       },
       error: () => {
@@ -42,30 +49,72 @@ export class ExportModalComponent implements OnInit {
     });
   }
 
-  exportLabelsWith(exporter: ExporterInfo): void {
+  get modalTitle(): string {
+    if (this.view === 'form' && this.selectedExporter) {
+      return this.selectedExporter.display_name || this.selectedExporter.name;
+    }
+    return 'Export';
+  }
+
+  selectExporter(exporter: ExporterInfo): void {
+    const fields = exporter.fields || [];
+    if (fields.length === 0) {
+      // No fields needed — export immediately
+      this.exportLabelsWith(exporter, {});
+      return;
+    }
+    // Show form for this exporter
+    this.selectedExporter = exporter;
+    this.formValues = {};
+    for (const f of fields) {
+      this.formValues[f.key] = f.default || '';
+    }
+    this.view = 'form';
+    this.error = '';
+    this.status = '';
+  }
+
+  back(): void {
+    this.view = 'picker';
+    this.selectedExporter = null;
+    this.error = '';
+    this.status = '';
+  }
+
+  submitForm(): void {
+    if (!this.selectedExporter) return;
+    this.exportLabelsWith(this.selectedExporter, { ...this.formValues });
+  }
+
+  exportLabelsWith(exporter: ExporterInfo, fieldValues: Record<string, string>): void {
     this.status = 'Exporting labels...';
     this.error = '';
+    this.submitting = true;
     this.sortingApi.exportLabels().subscribe({
       next: (labelsData) => {
         this.exportersApi
           .runExport({
             exporter_name: exporter.name,
+            field_values: fieldValues,
             results: labelsData,
           })
           .subscribe({
             next: () => {
               this.status = 'Labels exported.';
+              this.submitting = false;
               this.exported.emit();
             },
             error: () => {
               this.status = '';
               this.error = 'Label export failed';
+              this.submitting = false;
             },
           });
       },
       error: () => {
         this.status = '';
         this.error = 'Failed to fetch labels';
+        this.submitting = false;
       },
     });
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -279,9 +279,12 @@ export interface AutorunProcessor {
 
 export interface ExporterInfo {
   name: string;
-  label?: string;
+  display_name?: string;
   description?: string;
+  icon?: string;
   fields?: ImporterField[];
+  ui_mode?: string;
+  hidden_from_picker?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
Enhanced the export modal to support exporters with configurable fields. Users can now fill out exporter-specific configuration forms before exporting labels, similar to the importer workflow.

## Key Changes
- **Multi-view modal**: Refactored export modal to support two views:
  - `picker` view: Lists available exporters (existing behavior)
  - `form` view: Displays configuration fields for selected exporter (new)

- **Exporter field support**: Added form rendering for various field types:
  - Text, password, email, URL inputs
  - Select dropdowns
  - Required field validation indicators
  - Default value population from exporter metadata

- **Navigation flow**: 
  - Users select an exporter from the picker
  - If exporter has no fields, export immediately
  - If exporter has fields, show form for configuration
  - Back button returns to picker view

- **API integration**: Updated `exportLabelsWith()` to accept and pass field values to the export API

- **UI improvements**:
  - Added exporter icon support (display_name, icon fields)
  - Styled exporter cards with hover effects
  - Added form styling matching importer modal patterns
  - Dynamic modal title based on current view/selected exporter
  - Loading state for form submission

- **Model updates**: Extended `ExporterInfo` interface with:
  - `display_name` (replaces `label`)
  - `icon`, `ui_mode`, `hidden_from_picker` fields
  - Support for filtering hidden exporters from picker

- **Dependencies**: Added `FormsModule` for two-way binding in form fields

https://claude.ai/code/session_01TN4kAgfSBHh25um862TPXM