### PR TITLE
Enhance label importer modal UI and form handling

### DIFF
--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -1,19 +1,19 @@
-<vt-modal [title]="view === 'picker' ? 'Import Labels' : selectedImporter?.display_name || selectedImporter?.name || 'Import'" [open]="true" (closed)="close()">
+<vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
   @if (view === 'picker') {
     <div class="importer-picker">
-      @if (importers.length === 0) {
+      @if (loading) {
         <p class="empty-state">Loading importers...</p>
-      }
-      @for (imp of importers; track imp.name) {
-        <button class="importer-card" (click)="selectImporter(imp)">
-          @if (imp.icon) {
-            <span class="importer-icon">{{ imp.icon }}</span>
-          }
-          <span class="importer-name">{{ imp.display_name || imp.label || imp.name }}</span>
-          @if (imp.description) {
-            <span class="importer-desc">{{ imp.description }}</span>
-          }
-        </button>
+      } @else if (importers.length === 0) {
+        <p class="empty-state">No label importers available.</p>
+      } @else {
+        @for (imp of importers; track imp.name) {
+          <button class="importer-card" (click)="selectImporter(imp)">
+            <span class="importer-name">@if (imp.icon) {<span class="importer-icon">{{ imp.icon }}</span> }{{ imp.display_name || imp.name }}</span>
+            @if (imp.description) {
+              <span class="importer-desc">{{ imp.description }}</span>
+            }
+          </button>
+        }
       }
     </div>
   }
@@ -31,16 +31,57 @@
                 <span class="required">*</span>
               }
             </label>
+
             @if (field.field_type === 'file') {
-              <input [id]="'lif-' + field.key" type="file" class="form-input" [accept]="field.accept || ''" (change)="onFileSelected($event, field.key)" />
+              <input
+                [id]="'lif-' + field.key"
+                type="file"
+                class="form-input"
+                [accept]="field.accept || ''"
+                (change)="onFileSelected($event, field.key)"
+              />
+            } @else if (field.field_type === 'password') {
+              <input
+                [id]="'lif-' + field.key"
+                type="password"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
+            } @else if (field.field_type === 'email') {
+              <input
+                [id]="'lif-' + field.key"
+                type="email"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
+            } @else if (field.field_type === 'url') {
+              <input
+                [id]="'lif-' + field.key"
+                type="url"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
             } @else if (field.field_type === 'select') {
-              <select [id]="'lif-' + field.key" class="form-select" [(ngModel)]="formValues[field.key]">
+              <select
+                [id]="'lif-' + field.key"
+                class="form-select"
+                [(ngModel)]="formValues[field.key]"
+              >
                 @for (opt of field.options || []; track opt) {
                   <option [value]="opt">{{ opt }}</option>
                 }
               </select>
             } @else {
-              <input [id]="'lif-' + field.key" type="text" class="form-input" [(ngModel)]="formValues[field.key]" [placeholder]="field.description || field.label || field.key" />
+              <input
+                [id]="'lif-' + field.key"
+                type="text"
+                class="form-input"
+                [(ngModel)]="formValues[field.key]"
+                [placeholder]="field.placeholder || field.description || field.label || field.key"
+              />
             }
           </div>
         }
@@ -56,9 +97,13 @@
       }
 
       <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="close()">Cancel</button>
+        <button class="btn btn--secondary" (click)="back()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
-          {{ submitting ? 'Importing...' : 'Import' }}
+          @if (submitting) {
+            Importing...
+          } @else {
+            Import
+          }
         </button>
       </div>
     </div>

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -1,1 +1,88 @@
-// Styles inherited from global _components.scss
+.importer-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.importer-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px 16px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s, border-color 0.15s;
+  color: var(--text-primary);
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+  }
+}
+
+.importer-name {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.importer-icon {
+  margin-right: 4px;
+}
+
+.importer-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.importer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.back-btn {
+  align-self: flex-start;
+  margin-bottom: 4px;
+}
+
+.btn--sm {
+  padding: 2px 10px;
+  font-size: 0.85rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.required {
+  color: var(--color-bad);
+}
+
+.info-text {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.error-text {
+  color: var(--color-bad);
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.empty-state {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 16px;
+}

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -5,13 +5,14 @@ import { ModalComponent } from '../../modal/modal.component';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { ImporterField } from '../../../models/api.models';
 
-interface LabelImporter {
+interface LabelImporterInfo {
   name: string;
-  label?: string;
   display_name?: string;
   description?: string;
   icon?: string;
   fields?: ImporterField[];
+  ui_mode?: string;
+  hidden_from_picker?: boolean;
 }
 
 type ModalView = 'picker' | 'form';
@@ -28,8 +29,9 @@ export class LabelImporterModalComponent implements OnInit {
   @Output() imported = new EventEmitter<void>();
 
   view: ModalView = 'picker';
-  importers: LabelImporter[] = [];
-  selectedImporter: LabelImporter | null = null;
+  importers: LabelImporterInfo[] = [];
+  loading = true;
+  selectedImporter: LabelImporterInfo | null = null;
   formValues: Record<string, string> = {};
   selectedFile: File | null = null;
   selectedFileFieldKey: string | null = null;
@@ -39,17 +41,31 @@ export class LabelImporterModalComponent implements OnInit {
 
   constructor(private labelImportersApi: LabelImportersApiService) {}
 
+  get modalTitle(): string {
+    if (this.view === 'form' && this.selectedImporter) {
+      return this.selectedImporter.display_name || this.selectedImporter.name;
+    }
+    return 'Import Labels';
+  }
+
   ngOnInit(): void {
     this.labelImportersApi.list().subscribe({
       next: (list: any[]) => {
-        this.importers = list;
+        this.importers = list.filter((imp) => !imp.hidden_from_picker);
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.error = 'Failed to load label importers';
       },
     });
   }
 
-  selectImporter(importer: LabelImporter): void {
+  selectImporter(importer: LabelImporterInfo): void {
     this.selectedImporter = importer;
     this.formValues = {};
+    this.selectedFile = null;
+    this.selectedFileFieldKey = null;
     this.error = '';
     this.successMessage = '';
     if (importer.fields) {


### PR DESCRIPTION
## Summary
This PR improves the label importer modal component with enhanced styling, better form field support, improved UX flow, and refined loading states.

## Key Changes

- **Styling**: Added comprehensive SCSS styles for the importer picker and form components, replacing the previous reliance on global styles
  - Styled importer cards with hover effects and transitions
  - Added form group, button, and action layouts
  - Implemented error and info text styling

- **Form Field Support**: Extended input field type handling
  - Added support for `password`, `email`, and `url` field types
  - Improved placeholder handling with fallback chain: `placeholder` → `description` → `label` → `key`
  - Better formatted multi-line input elements for readability

- **Loading State**: Improved initial load experience
  - Added `loading` flag to distinguish between loading and empty states
  - Shows "Loading importers..." during API call
  - Shows "No label importers available" when list is empty
  - Filters out importers with `hidden_from_picker` flag

- **Modal Title**: Dynamic title based on current view
  - Added `modalTitle` getter that shows "Import Labels" in picker view
  - Shows selected importer name in form view

- **Navigation**: Enhanced back button functionality
  - Cancel button now calls `back()` method instead of `close()` to return to picker view
  - Properly resets form state when selecting a new importer

- **Code Quality**: Improved type naming and structure
  - Renamed `LabelImporter` interface to `LabelImporterInfo` for clarity
  - Removed unused `label` property from interface
  - Added `ui_mode` and `hidden_from_picker` properties to interface

## Notable Implementation Details

- Form state is properly reset when selecting a new importer (clears file selection and form values)
- Conditional rendering uses new control flow syntax with proper loading/empty state handling
- All input elements are properly formatted with consistent spacing and attributes

https://claude.ai/code/session_013vzkJyFNUruw6ryQPW3b5z