### PR TITLE
Add multi-user file access restrictions via login providers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,7 +225,12 @@ def _allow_test_tmp_paths(monkeypatch):
         try:
             return _original(filepath_str, base_dir)
         except ValueError:
-            # Also allow the system temp directory (where pytest tmp_path lives).
+            # Also allow the system temp directory (where pytest tmp_path lives),
+            # but only when base_dir was not explicitly set (i.e. only for the
+            # default CWD fallback).  When a specific base_dir is given (e.g. in
+            # multi-user mode) we must honour that restriction.
+            if base_dir is not None:
+                raise
             return _original(filepath_str, Path(tempfile.gettempdir()))
 
     monkeypatch.setattr(paths_mod, "validate_server_filepath", _permissive)

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -2,15 +2,18 @@
 
 Covers:
 - validate_server_filepath: rejects path traversal, accepts safe paths
+- get_file_access_base_dir: returns None for DefaultLoginProvider, user dir otherwise
+- Multi-user file access restrictions via API endpoints
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from vtsearch.utils.paths import validate_server_filepath
+from vtsearch.utils.paths import get_file_access_base_dir, validate_server_filepath
 
 
 class TestValidateServerFilepath:
@@ -63,3 +66,257 @@ class TestValidateServerFilepath:
             pytest.skip("Cannot create symlinks in this environment")
         with pytest.raises(ValueError, match="must be within"):
             validate_server_filepath("escape_link/passwd", base_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# get_file_access_base_dir
+# ---------------------------------------------------------------------------
+
+
+class TestGetFileAccessBaseDir:
+    """Test that get_file_access_base_dir returns the correct base for each provider."""
+
+    def test_default_provider_returns_none(self):
+        """DefaultLoginProvider → None (unrestricted, falls back to CWD)."""
+        from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
+
+        original = get_login_provider()
+        try:
+            set_login_provider(DefaultLoginProvider())
+            assert get_file_access_base_dir() is None
+        finally:
+            set_login_provider(original)
+
+    def test_non_default_provider_returns_user_data_dir(self, tmp_path):
+        """Non-default provider → user data directory."""
+        from vtsearch.auth import LoginProvider, get_login_provider, set_login_provider
+
+        class MultiUserProvider(LoginProvider):
+            name = "multi"
+
+            def get_user(self, request):
+                return "alice"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return tmp_path / username
+
+        original = get_login_provider()
+        try:
+            set_login_provider(MultiUserProvider())
+            result = get_file_access_base_dir()
+            # Outside Flask context, get_current_user falls back to "default"
+            assert result == tmp_path / "default"
+        finally:
+            set_login_provider(original)
+
+    def test_trivial_provider_returns_user_data_dir(self):
+        """TrivialLoginProvider → user data directory (non-default provider)."""
+        from vtsearch.auth import TrivialLoginProvider, get_login_provider, set_login_provider
+
+        original = get_login_provider()
+        try:
+            set_login_provider(TrivialLoginProvider())
+            result = get_file_access_base_dir()
+            # Should return a Path, not None
+            assert result is not None
+            assert isinstance(result, Path)
+        finally:
+            set_login_provider(original)
+
+
+# ---------------------------------------------------------------------------
+# Multi-user file access restriction via API
+# ---------------------------------------------------------------------------
+
+
+class TestMultiUserFileRestriction:
+    """Verify that non-default login providers restrict file access to user data dir."""
+
+    def _setup_multi_user(self, client, user_data_dir):
+        """Set up a multi-user provider and return a cleanup function."""
+        from vtsearch.auth import LoginProvider, get_login_provider, set_login_provider
+
+        class TestMultiProvider(LoginProvider):
+            name = "test_multi"
+
+            def get_user(self, request):
+                return "testuser"
+
+            def is_authenticated(self, request):
+                return True
+
+            def get_user_data_dir(self, username, base_data_dir):
+                return user_data_dir
+
+        original = get_login_provider()
+        set_login_provider(TestMultiProvider())
+        return original
+
+    def test_exporter_rejects_path_outside_user_dir(self, client, tmp_path):
+        """Exporter filepath outside user data dir is rejected in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": "/etc/evil.json"},
+                },
+            )
+            assert resp.status_code == 400
+            assert "must be within" in resp.get_json()["error"]
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_exporter_accepts_path_inside_user_dir(self, client, tmp_path):
+        """Exporter filepath inside user data dir is accepted in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            target = user_dir / "results.json"
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": str(target)},
+                    "results": {},
+                },
+            )
+            # Should not get a path-validation 400 (may get other errors, but not path-related)
+            if resp.status_code == 400:
+                assert "must be within" not in resp.get_json().get("error", "")
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_label_importer_rejects_path_outside_user_dir(self, client, tmp_path):
+        """Label importer filepath outside user data dir is rejected in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            resp = client.post(
+                "/api/label-importers/import/server_json_file",
+                json={"filepath": "/etc/shadow"},
+            )
+            assert resp.status_code == 400
+            assert "must be within" in resp.get_json()["error"]
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_processor_importer_rejects_path_outside_user_dir(self, client, tmp_path):
+        """Processor importer filepath outside user data dir is rejected in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            resp = client.post(
+                "/api/processor-importers/import/server_detector_file",
+                json={"filepath": "/etc/shadow", "name": "evil"},
+            )
+            assert resp.status_code == 400
+            assert "must be within" in resp.get_json()["error"]
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_load_folder_rejects_path_outside_user_dir(self, client, tmp_path):
+        """Load folder path outside user data dir is rejected in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            resp = client.post(
+                "/api/dataset/load-folder",
+                json={"path": "/etc", "media_type": "sounds"},
+            )
+            assert resp.status_code == 400
+            assert "must be within" in resp.get_json()["error"]
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_combine_datasets_rejects_path_outside_user_dir(self, client, tmp_path):
+        """Combine datasets with paths outside user data dir is rejected in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            resp = client.post(
+                "/api/dataset/combine",
+                json={"datasets": ["/etc/a.pkl", "/etc/b.pkl"]},
+            )
+            assert resp.status_code == 400
+            assert "must be within" in resp.get_json()["error"]
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_settings_dir_rejects_path_outside_user_dir(self, client, tmp_path):
+        """Setting directory paths outside user data dir is rejected in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            resp = client.put(
+                "/api/settings",
+                json={"saved_datasets_dir": "/tmp/evil"},
+            )
+            assert resp.status_code == 400
+            assert "must be within" in resp.get_json()["error"]
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_settings_dir_accepts_path_inside_user_dir(self, client, tmp_path):
+        """Setting directory paths inside user data dir is accepted in multi-user mode."""
+        user_dir = tmp_path / "testuser"
+        user_dir.mkdir()
+        original = self._setup_multi_user(client, user_dir)
+        try:
+            target_dir = user_dir / "my_datasets"
+            resp = client.put(
+                "/api/settings",
+                json={"saved_datasets_dir": str(target_dir)},
+            )
+            assert resp.status_code == 200
+        finally:
+            from vtsearch.auth import set_login_provider
+
+            set_login_provider(original)
+
+    def test_default_provider_allows_any_path(self, client):
+        """DefaultLoginProvider allows any path within CWD (single-user mode)."""
+        from vtsearch.auth import DefaultLoginProvider, get_login_provider, set_login_provider
+
+        original = get_login_provider()
+        try:
+            set_login_provider(DefaultLoginProvider())
+            # Paths within CWD should be accepted (even if the file doesn't exist,
+            # the path validation itself should pass)
+            cwd = Path.cwd()
+            resp = client.post(
+                "/api/dataset/load-folder",
+                json={"path": str(cwd / "some_folder"), "media_type": "sounds"},
+            )
+            # Should not get a "must be within" error — may get "Invalid folder path"
+            # since the folder doesn't exist, but not a path-validation error
+            if resp.status_code == 400:
+                assert "must be within" not in resp.get_json().get("error", "")
+        finally:
+            set_login_provider(original)

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -259,9 +259,10 @@ def combine_datasets_route():
     if not isinstance(dataset_paths, list) or len(dataset_paths) < 2:
         return jsonify({"error": "Provide at least two dataset file paths."}), 400
 
+    _base = _paths.get_file_access_base_dir()
     for p in dataset_paths:
         try:
-            _paths.validate_server_filepath(str(p))
+            _paths.validate_server_filepath(str(p), base_dir=_base)
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
         if not Path(p).exists():
@@ -537,7 +538,7 @@ def load_dataset_folder():
         return jsonify({"error": "No folder path provided"}), 400
 
     try:
-        _paths.validate_server_filepath(str(folder_path))
+        _paths.validate_server_filepath(str(folder_path), base_dir=_paths.get_file_access_base_dir())
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -750,10 +751,11 @@ def _load_from_origin(source: dict):
         return jsonify({"error": f"Cannot reload from {importer_name} origin"}), 400
 
     # Validate any server file paths in the field values
+    _base = _paths.get_file_access_base_dir()
     for key, val in field_values.items():
         if isinstance(val, str) and ("/" in val or "\\" in val):
             try:
-                _paths.validate_server_filepath(val)
+                _paths.validate_server_filepath(val, base_dir=_base)
             except ValueError as exc:
                 return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -276,6 +276,7 @@ def import_detector_labels():
         loaded_count = 0
         skipped_count = 0
         detected_media_type: str | None = media_type_hint or None
+        _file_base = _paths.get_file_access_base_dir()
 
         for entry in labels:
             label = entry.get("label")
@@ -289,9 +290,9 @@ def import_detector_labels():
                 continue
 
             file_path = Path(file_path_str)
-            # Ensure the path doesn't escape the data directory
+            # Ensure the path doesn't escape the allowed directory
             try:
-                _paths.validate_server_filepath(file_path_str)
+                _paths.validate_server_filepath(file_path_str, base_dir=_file_base)
             except ValueError:
                 skipped_count += 1
                 continue
@@ -429,7 +430,7 @@ def train_from_label_import(importer_name: str):
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            _paths.validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/exporters.py
+++ b/vtsearch/routes/exporters.py
@@ -100,7 +100,7 @@ def run_export():
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            _paths.validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -145,7 +145,7 @@ def run_label_import(importer_name: str):
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            _paths.validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/processor_importers.py
+++ b/vtsearch/routes/processor_importers.py
@@ -104,7 +104,7 @@ def run_processor_import(importer_name: str):
     # Validate server file paths to prevent path traversal
     if "filepath" in field_values and str(field_values["filepath"]).strip():
         try:
-            _paths.validate_server_filepath(str(field_values["filepath"]))
+            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 

--- a/vtsearch/routes/settings.py
+++ b/vtsearch/routes/settings.py
@@ -196,6 +196,9 @@ def update_settings():
             return jsonify({"error": str(exc)}), 400
 
     # Directory path settings
+    import vtsearch.utils.paths as _paths
+
+    _dir_base = _paths.get_file_access_base_dir()
     for dir_key, setter in (
         ("saved_datasets_dir", settings.set_saved_datasets_dir),
         ("detectors_dir", settings.set_detectors_dir),
@@ -205,6 +208,12 @@ def update_settings():
             val = body[dir_key]
             if not isinstance(val, str) or not val.strip():
                 return jsonify({"error": f"{dir_key} must be a non-empty string"}), 400
+            # In multi-user mode, restrict directory paths to user's data dir
+            if _dir_base is not None:
+                try:
+                    _paths.validate_server_filepath(val.strip(), base_dir=_dir_base)
+                except ValueError as exc:
+                    return jsonify({"error": str(exc)}), 400
             setter(val.strip())
 
     return jsonify(settings.get_all())

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -610,6 +610,7 @@ def label_file_sort():
         y_list = []
         loaded_count = 0
         skipped_count = 0
+        _file_base = _paths.get_file_access_base_dir()
 
         for entry in labels:
             label = entry.get("label")
@@ -624,9 +625,9 @@ def label_file_sort():
                 continue
 
             media_path = Path(media_path)
-            # Ensure the path doesn't escape the data directory
+            # Ensure the path doesn't escape the allowed directory
             try:
-                _paths.validate_server_filepath(str(media_path))
+                _paths.validate_server_filepath(str(media_path), base_dir=_file_base)
             except ValueError:
                 skipped_count += 1
                 continue

--- a/vtsearch/utils/paths.py
+++ b/vtsearch/utils/paths.py
@@ -10,6 +10,26 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def get_file_access_base_dir() -> Path | None:
+    """Return the base directory for file-access validation.
+
+    In single-user mode (:class:`~vtsearch.auth.DefaultLoginProvider`) this
+    returns ``None``, which causes :func:`validate_server_filepath` to fall
+    back to ``Path.cwd()`` — giving the single user full access to any path
+    under the working directory.
+
+    In multi-user mode (any non-default provider) this returns the current
+    user's data directory so that each user is confined to their own
+    ``data/<username>/`` subtree.
+    """
+    from vtsearch.auth import DefaultLoginProvider, get_login_provider, get_user_data_dir
+
+    provider = get_login_provider()
+    if isinstance(provider, DefaultLoginProvider):
+        return None  # single-user: unrestricted (CWD)
+    return get_user_data_dir()
+
+
 def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) -> Path:
     """Validate that *filepath_str* resolves within *base_dir*.
 


### PR DESCRIPTION
## Summary
This PR implements multi-user file access restrictions by introducing a new `get_file_access_base_dir()` function that returns the appropriate base directory for file validation depending on the active login provider. In single-user mode (DefaultLoginProvider), file access is unrestricted within the working directory. In multi-user mode (any non-default provider), file access is restricted to each user's data directory.

## Key Changes

- **New function `get_file_access_base_dir()`** in `vtsearch/utils/paths.py`:
  - Returns `None` for `DefaultLoginProvider` (single-user, unrestricted access)
  - Returns the current user's data directory for multi-user providers
  - Used throughout the codebase to enforce per-user file restrictions

- **Updated all file-access validation calls** across multiple route modules:
  - `routes/exporters.py`: Exporter filepath validation
  - `routes/label_importers.py`: Label importer filepath validation
  - `routes/processor_importers.py`: Processor importer filepath validation
  - `routes/datasets.py`: Dataset folder loading and combining
  - `routes/settings.py`: Directory path settings (saved_datasets_dir, detectors_dir, etc.)
  - `routes/detectors_training.py`: Training data file validation
  - `routes/sorting.py`: Label file sorting media path validation

- **Comprehensive test coverage** in `tests/test_path_validation.py`:
  - Tests for `get_file_access_base_dir()` behavior with different providers
  - Multi-user restriction tests for all affected API endpoints
  - Verification that paths outside user directory are rejected with 400 errors
  - Verification that paths inside user directory are accepted
  - Confirmation that DefaultLoginProvider allows unrestricted access

- **Test fixture update** in `tests/conftest.py`:
  - Modified `_permissive` wrapper to respect explicit `base_dir` restrictions
  - Ensures multi-user mode restrictions are properly tested even with temp directory fallback

## Implementation Details

- All `validate_server_filepath()` calls now pass `base_dir=_paths.get_file_access_base_dir()` to enforce the appropriate restriction level
- The implementation is backward compatible: single-user deployments continue to work as before
- Multi-user providers automatically get per-user file isolation without requiring changes to individual route handlers

https://claude.ai/code/session_01HioBgvmcMhqDpbtCwfnRsE