### PR TITLE
Refactor settings modal to use tabbed navigation layout

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -2,171 +2,200 @@
   @if (loading) {
     <p class="empty-state">Loading settings...</p>
   } @else {
-    <div class="settings-grid">
-      <!-- Appearance -->
-      <div class="settings-section">
-        <h3>Appearance</h3>
-        <div class="form-group">
-          <label class="form-label">Theme</label>
-          <select class="form-select" [ngModel]="settings.theme" (ngModelChange)="onThemeChange($event)">
-            <option value="dark">Dark</option>
-            <option value="light">Light</option>
-            <option value="highviz">High Visibility</option>
-          </select>
-        </div>
-        <label class="checkbox-row">
-          <input type="checkbox" [ngModel]="settings.swipe_animation" (ngModelChange)="onToggle('swipe_animation', $event)" />
-          Swipe animation
-        </label>
-        <label class="checkbox-row">
-          <input type="checkbox" [ngModel]="settings.show_metadata" (ngModelChange)="onToggle('show_metadata', $event)" />
-          Show metadata panel
-        </label>
-      </div>
+    <div class="settings-layout">
+      <nav class="settings-tabs">
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'appearance'"
+          (click)="activeSettingsTab = 'appearance'">
+          Appearance
+        </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'media'"
+          (click)="activeSettingsTab = 'media'">
+          Media Types
+        </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'sorting'"
+          (click)="activeSettingsTab = 'sorting'">
+          Sorting
+        </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'autopilot'"
+          (click)="activeSettingsTab = 'autopilot'">
+          Autopilot
+        </button>
+      </nav>
 
-      <!-- Media Type Settings (per-media-type) -->
-      <div class="settings-section settings-section--wide">
-        <h3>Media Type Settings</h3>
-        @if (mediaTypes.length > 0) {
-          <div class="view-tabs">
-            @for (mt of mediaTypes; track mt.type_id) {
-              <button
-                class="view-tab"
-                [class.view-tab--active]="activeViewTab === mt.type_id"
-                (click)="activeViewTab = mt.type_id">
-                {{ mt.name }}
-              </button>
-            }
+      <div class="settings-panel">
+        <!-- Appearance -->
+        @if (activeSettingsTab === 'appearance') {
+          <h3>Appearance</h3>
+          <div class="form-group">
+            <label class="form-label">Theme</label>
+            <select class="form-select" [ngModel]="settings.theme" (ngModelChange)="onThemeChange($event)">
+              <option value="dark">Dark</option>
+              <option value="light">Light</option>
+              <option value="highviz">High Visibility</option>
+            </select>
           </div>
-          <div class="view-tab-content">
-            <div class="view-side-section">
-              <h4>Left Side</h4>
-              <div class="form-group">
-                <label class="form-label">View</label>
-                <div class="radio-group">
-                  <label class="radio-row">
-                    <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_left', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'list')" />
-                    List
-                  </label>
-                  <label class="radio-row">
-                    <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'grid')" />
-                    Grid
-                  </label>
+          <label class="checkbox-row">
+            <input type="checkbox" [ngModel]="settings.swipe_animation" (ngModelChange)="onToggle('swipe_animation', $event)" />
+            Swipe animation
+          </label>
+          <label class="checkbox-row">
+            <input type="checkbox" [ngModel]="settings.show_metadata" (ngModelChange)="onToggle('show_metadata', $event)" />
+            Show metadata panel
+          </label>
+        }
+
+        <!-- Media Type Settings (per-media-type) -->
+        @if (activeSettingsTab === 'media') {
+          <h3>Media Type Settings</h3>
+          @if (mediaTypes.length > 0) {
+            <div class="view-tabs">
+              @for (mt of mediaTypes; track mt.type_id) {
+                <button
+                  class="view-tab"
+                  [class.view-tab--active]="activeViewTab === mt.type_id"
+                  (click)="activeViewTab = mt.type_id">
+                  {{ mt.name }}
+                </button>
+              }
+            </div>
+            <div class="view-tab-content">
+              <div class="view-side-section">
+                <h4>Left Side</h4>
+                <div class="form-group">
+                  <label class="form-label">View</label>
+                  <div class="radio-group">
+                    <label class="radio-row">
+                      <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_left', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'list')" />
+                      List
+                    </label>
+                    <label class="radio-row">
+                      <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'grid')" />
+                      Grid
+                    </label>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Focus mode</label>
+                  <div class="radio-group">
+                    <label class="radio-row">
+                      <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')" />
+                      Click
+                    </label>
+                    <label class="radio-row">
+                      <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')" />
+                      Hover
+                    </label>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Grid columns</label>
+                  <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_left', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_left', activeViewTab, $event)" min="1" max="6" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Panel %</label>
+                  <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_left', activeViewTab) }}</span>
+                  @if (getPanelPct('panel_pct_left', activeViewTab) != null) {
+                    <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_left', activeViewTab)">Reset</button>
+                  }
                 </div>
               </div>
-              <div class="form-group">
-                <label class="form-label">Focus mode</label>
-                <div class="radio-group">
-                  <label class="radio-row">
-                    <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')" />
-                    Click
-                  </label>
-                  <label class="radio-row">
-                    <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')" />
-                    Hover
-                  </label>
+              <div class="view-side-section">
+                <h4>Right Side</h4>
+                <div class="form-group">
+                  <label class="form-label">View</label>
+                  <div class="radio-group">
+                    <label class="radio-row">
+                      <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_right', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'list')" />
+                      List
+                    </label>
+                    <label class="radio-row">
+                      <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'grid')" />
+                      Grid
+                    </label>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">Grid columns</label>
-                <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_left', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_left', activeViewTab, $event)" min="1" max="6" />
-              </div>
-              <div class="form-group">
-                <label class="form-label">Panel %</label>
-                <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_left', activeViewTab) }}</span>
-                @if (getPanelPct('panel_pct_left', activeViewTab) != null) {
-                  <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_left', activeViewTab)">Reset</button>
-                }
+                <div class="form-group">
+                  <label class="form-label">Focus mode</label>
+                  <div class="radio-group">
+                    <label class="radio-row">
+                      <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')" />
+                      Click
+                    </label>
+                    <label class="radio-row">
+                      <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')" />
+                      Hover
+                    </label>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Grid columns</label>
+                  <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_right', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_right', activeViewTab, $event)" min="1" max="6" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Panel %</label>
+                  <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_right', activeViewTab) }}</span>
+                  @if (getPanelPct('panel_pct_right', activeViewTab) != null) {
+                    <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_right', activeViewTab)">Reset</button>
+                  }
+                </div>
               </div>
             </div>
-            <div class="view-side-section">
-              <h4>Right Side</h4>
-              <div class="form-group">
-                <label class="form-label">View</label>
-                <div class="radio-group">
-                  <label class="radio-row">
-                    <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_right', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'list')" />
-                    List
-                  </label>
-                  <label class="radio-row">
-                    <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'grid')" />
-                    Grid
-                  </label>
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">Focus mode</label>
-                <div class="radio-group">
-                  <label class="radio-row">
-                    <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')" />
-                    Click
-                  </label>
-                  <label class="radio-row">
-                    <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')" />
-                    Hover
-                  </label>
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">Grid columns</label>
-                <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_right', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_right', activeViewTab, $event)" min="1" max="6" />
-              </div>
-              <div class="form-group">
-                <label class="form-label">Panel %</label>
-                <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_right', activeViewTab) }}</span>
-                @if (getPanelPct('panel_pct_right', activeViewTab) != null) {
-                  <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_right', activeViewTab)">Reset</button>
-                }
-              </div>
-            </div>
+          }
+        }
+
+        <!-- Sorting & Calibration -->
+        @if (activeSettingsTab === 'sorting') {
+          <h3>Sorting &amp; Calibration</h3>
+          <label class="checkbox-row">
+            <input type="checkbox" [ngModel]="settings.enrich_descriptions" (ngModelChange)="onToggle('enrich_descriptions', $event)" />
+            Enrich descriptions
+          </label>
+          <label class="checkbox-row">
+            <input type="checkbox" [ngModel]="settings.safe_thresholds" (ngModelChange)="onToggle('safe_thresholds', $event)" />
+            Safe thresholds
+          </label>
+          <div class="form-group">
+            <label class="form-label">Calibrate count</label>
+            <input type="number" class="form-input" [ngModel]="settings.calibrate_count" (ngModelChange)="onNumberChange('calibrate_count', $event)" min="0" />
+          </div>
+          <div class="form-group">
+            <label class="form-label">Calibration fraction</label>
+            <input type="number" class="form-input" [ngModel]="settings.calibration_fraction" (ngModelChange)="onNumberChange('calibration_fraction', $event)" min="0" max="1" step="0.05" />
           </div>
         }
-      </div>
 
-      <!-- Sorting & Calibration -->
-      <div class="settings-section">
-        <h3>Sorting &amp; Calibration</h3>
-        <label class="checkbox-row">
-          <input type="checkbox" [ngModel]="settings.enrich_descriptions" (ngModelChange)="onToggle('enrich_descriptions', $event)" />
-          Enrich descriptions
-        </label>
-        <label class="checkbox-row">
-          <input type="checkbox" [ngModel]="settings.safe_thresholds" (ngModelChange)="onToggle('safe_thresholds', $event)" />
-          Safe thresholds
-        </label>
-        <div class="form-group">
-          <label class="form-label">Calibrate count</label>
-          <input type="number" class="form-input" [ngModel]="settings.calibrate_count" (ngModelChange)="onNumberChange('calibrate_count', $event)" min="0" />
-        </div>
-        <div class="form-group">
-          <label class="form-label">Calibration fraction</label>
-          <input type="number" class="form-input" [ngModel]="settings.calibration_fraction" (ngModelChange)="onNumberChange('calibration_fraction', $event)" min="0" max="1" step="0.05" />
-        </div>
-      </div>
+        <!-- Autopilot & Actions -->
+        @if (activeSettingsTab === 'autopilot') {
+          <h3>Autopilot &amp; Actions</h3>
+          <label class="checkbox-row">
+            <input type="checkbox" [ngModel]="settings.hide_autopilot" (ngModelChange)="onToggle('hide_autopilot', $event)" />
+            Hide autopilot panel
+          </label>
+          <div class="form-group">
+            <label class="form-label"># Good to start</label>
+            <input type="number" class="form-input" [ngModel]="settings.autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" />
+          </div>
+          <div class="form-group">
+            <label class="form-label"># Bad to start</label>
+            <input type="number" class="form-input" [ngModel]="settings.autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" />
+          </div>
 
-      <!-- Autopilot & Actions -->
-      <div class="settings-section">
-        <h3>Autopilot &amp; Actions</h3>
-        <label class="checkbox-row">
-          <input type="checkbox" [ngModel]="settings.hide_autopilot" (ngModelChange)="onToggle('hide_autopilot', $event)" />
-          Hide autopilot panel
-        </label>
-        <div class="form-group">
-          <label class="form-label"># Good to start</label>
-          <input type="number" class="form-input" [ngModel]="settings.autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" />
-        </div>
-        <div class="form-group">
-          <label class="form-label"># Bad to start</label>
-          <input type="number" class="form-input" [ngModel]="settings.autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" />
-        </div>
-
-        @if (embedders.length > 0) {
-          <h4>Autoload Embedders</h4>
-          @for (embedder of embedders; track embedder.name) {
-            <label class="checkbox-row">
-              <input type="checkbox" [checked]="isEmbedderAutoloaded(embedder)" (change)="toggleEmbedder(embedder)" />
-              {{ embedder.name }} ({{ embedder.media_type_id }})
-            </label>
+          @if (embedders.length > 0) {
+            <h4>Autoload Embedders</h4>
+            @for (embedder of embedders; track embedder.name) {
+              <label class="checkbox-row">
+                <input type="checkbox" [checked]="isEmbedderAutoloaded(embedder)" (change)="toggleEmbedder(embedder)" />
+                {{ embedder.name }} ({{ embedder.media_type_id }})
+              </label>
+            }
           }
         }
       </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -12,12 +12,6 @@
         </button>
         <button
           class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab === 'media'"
-          (click)="activeSettingsTab = 'media'">
-          Media Types
-        </button>
-        <button
-          class="settings-tab"
           [class.settings-tab--active]="activeSettingsTab === 'sorting'"
           (click)="activeSettingsTab = 'sorting'">
           Sorting
@@ -50,12 +44,9 @@
             <input type="checkbox" [ngModel]="settings.show_metadata" (ngModelChange)="onToggle('show_metadata', $event)" />
             Show metadata panel
           </label>
-        }
 
-        <!-- Media Type Settings (per-media-type) -->
-        @if (activeSettingsTab === 'media') {
-          <h3>Media Type Settings</h3>
           @if (mediaTypes.length > 0) {
+            <h4>Per-Media-Type</h4>
             <div class="view-tabs">
               @for (mt of mediaTypes; track mt.type_id) {
                 <button

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -1,16 +1,53 @@
 :host {
   ::ng-deep .modal-content {
-    width: 720px;
+    width: 680px;
   }
 }
 
-.settings-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
+.settings-layout {
+  display: flex;
+  gap: 0;
+  min-height: 340px;
 }
 
-.settings-section {
+.settings-tabs {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 140px;
+  border-right: 1px solid var(--border-color, #444);
+  padding: 0.25rem 0;
+}
+
+.settings-tab {
+  background: none;
+  border: none;
+  border-left: 3px solid transparent;
+  padding: 0.6rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  }
+
+  &--active {
+    color: var(--text-primary);
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+    border-left-color: var(--accent-color, #6cf);
+  }
+}
+
+.settings-panel {
+  flex: 1;
+  padding: 0.75rem 1.25rem;
+  min-width: 0;
+
   h3 {
     margin: 0 0 0.75rem;
     font-size: 0.95rem;
@@ -21,10 +58,6 @@
     margin: 0.75rem 0 0.5rem;
     font-size: 0.85rem;
     color: var(--text-secondary);
-  }
-
-  &--wide {
-    grid-column: span 2;
   }
 }
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -164,6 +164,7 @@ describe('SettingsModalComponent', () => {
     component.preselectedViewTab = 'image';
     flushInit();
     expect(component.activeViewTab).toBe('image');
+    expect(component.activeSettingsTab).toBe('media');
   });
 
   it('should ignore preselectedViewTab when not in mediaTypes', () => {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -164,7 +164,7 @@ describe('SettingsModalComponent', () => {
     component.preselectedViewTab = 'image';
     flushInit();
     expect(component.activeViewTab).toBe('image');
-    expect(component.activeSettingsTab).toBe('media');
+    expect(component.activeSettingsTab).toBe('appearance');
   });
 
   it('should ignore preselectedViewTab when not in mediaTypes', () => {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -23,6 +23,7 @@ export class SettingsModalComponent implements OnInit {
   settings: AppSettings = { volume: 50 };
   embedders: EmbedderInfo[] = [];
   mediaTypes: MediaTypeInfo[] = [];
+  activeSettingsTab = 'appearance';
   activeViewTab = '';
   loading = true;
   error = '';
@@ -50,6 +51,7 @@ export class SettingsModalComponent implements OnInit {
           const preselected = this.preselectedViewTab;
           if (preselected && this.mediaTypes.some((mt) => mt.type_id === preselected)) {
             this.activeViewTab = preselected;
+            this.activeSettingsTab = 'media';
           } else {
             this.activeViewTab = this.mediaTypes[0].type_id;
           }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -51,7 +51,7 @@ export class SettingsModalComponent implements OnInit {
           const preselected = this.preselectedViewTab;
           if (preselected && this.mediaTypes.some((mt) => mt.type_id === preselected)) {
             this.activeViewTab = preselected;
-            this.activeSettingsTab = 'media';
+            this.activeSettingsTab = 'appearance';
           } else {
             this.activeViewTab = this.mediaTypes[0].type_id;
           }


### PR DESCRIPTION
## Summary
Restructured the settings modal from a grid-based layout to a tabbed interface with a sidebar navigation. This improves organization and reduces visual clutter by grouping related settings into distinct tabs.

## Key Changes
- **Layout restructuring**: Changed from 3-column grid layout (`settings-grid`) to a flex-based layout with sidebar tabs (`settings-layout`)
- **Tab navigation**: Added three main settings tabs (Appearance, Sorting, Autopilot) with active state styling
- **Conditional rendering**: Wrapped settings sections with `@if` directives to show/hide content based on `activeSettingsTab`
- **Sidebar styling**: Created new `.settings-tabs` and `.settings-tab` styles with hover and active states, including left border accent indicator
- **Content panel**: Introduced `.settings-panel` to contain the active tab's content with proper padding and flex layout
- **Modal width adjustment**: Reduced modal width from 720px to 680px to accommodate the new sidebar layout
- **Component state**: Added `activeSettingsTab` property to track the currently selected tab

## Implementation Details
- The per-media-type view settings (left/right side configurations) remain under the Appearance tab as a subsection
- Tab switching is handled via simple click handlers that update `activeSettingsTab`
- The sidebar uses a border-right divider and maintains consistent spacing with the content panel
- Active tab indicator uses a left border accent with the accent color for visual feedback
- All existing functionality is preserved; this is purely a UI/UX reorganization

https://claude.ai/code/session_01CJbrcwBVxFmD3JoyFy62PJ