### PR TITLE
Add media example support to trainable models

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -457,6 +457,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private storeSelectedModelTextQuery(): void {
     const model = this.models.find((m) => this.selectedModelIds.has(m.id));
     this.labelSession.textQuery = model?.text_query || '';
+    this.labelSession.mediaExample = model?.media_example || '';
   }
 
   onLabel(): void {

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -1,48 +1,120 @@
-<vt-modal [open]="true" title="New Model" [showCloseButton]="false" (closed)="close()">
-  <form class="new-model-form" (ngSubmit)="submit()">
-    <div class="form-group">
-      <label for="model-name" title="A short name to identify this model">Model Name <span class="required">*</span></label>
-      <input
-        id="model-name"
-        class="form-input"
-        [(ngModel)]="name"
-        name="name"
-        placeholder="e.g. Dog Barks"
-        title="A short name to identify this model"
-        autofocus
-      />
+<vt-modal [open]="true" [title]="view === 'main' ? 'New Model' : 'Select Media Example'" [showCloseButton]="false" (closed)="close()">
+  @if (view === 'main') {
+    <form class="new-model-form" (ngSubmit)="submit()">
+      <div class="form-group">
+        <label for="model-name" title="A short name to identify this model">Model Name <span class="required">*</span></label>
+        <input
+          id="model-name"
+          class="form-input"
+          [(ngModel)]="name"
+          name="name"
+          placeholder="e.g. Dog Barks"
+          title="A short name to identify this model"
+          autofocus
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="model-media-type" title="The type of media this model will process">Media Type</label>
+        <select id="model-media-type" class="form-input" [(ngModel)]="mediaType" name="mediaType" title="The type of media this model will process">
+          @for (mt of mediaTypes; track mt) {
+            <option [value]="mt">{{ mt }}</option>
+          }
+        </select>
+      </div>
+
+      <div class="example-columns">
+        <div class="example-col">
+          <label class="col-label">Add Text Example</label>
+          <div class="text-input-row">
+            <input
+              class="form-input"
+              [(ngModel)]="pendingText"
+              name="pendingText"
+              placeholder="e.g. dog barking sounds"
+              title="A text description of what this model should find"
+              (keydown.enter)="$event.preventDefault(); addTextExample()"
+            />
+            <button type="button" class="btn btn--primary btn--sm" (click)="addTextExample()" [disabled]="!pendingText.trim()">Add</button>
+          </div>
+        </div>
+        <div class="example-col">
+          <label class="col-label">Add Media Example</label>
+          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()">Browse Media...</button>
+          <input
+            #fileInput
+            type="file"
+            class="hidden-file-input"
+            (change)="onLocalFileSelected($event)"
+          />
+          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()">Upload File...</button>
+        </div>
+      </div>
+
+      @if (examples.length > 0) {
+        <div class="examples-section">
+          <label class="col-label">Examples</label>
+          <div class="examples-grid">
+            @for (ex of examples; track $index) {
+              <div class="example-chip" [class.text-chip]="ex.type === 'text'" [class.media-chip]="ex.type === 'media'">
+                <span class="chip-icon">{{ ex.type === 'text' ? 'T' : 'M' }}</span>
+                <span class="chip-label" [title]="ex.display">{{ ex.display }}</span>
+                <button type="button" class="chip-remove" (click)="removeExample($index)" title="Remove">&times;</button>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      @if (error) {
+        <p class="error-text">{{ error }}</p>
+      }
+    </form>
+
+    <div modal-footer>
+      <button class="btn btn--secondary" (click)="close()">Cancel</button>
+      <button class="btn btn--primary" [disabled]="submitting" (click)="submit()">
+        {{ submitting ? 'Creating...' : 'Create' }}
+      </button>
     </div>
+  }
 
-    <div class="form-group">
-      <label for="model-media-type" title="The type of media this model will process">Media Type</label>
-      <select id="model-media-type" class="form-input" [(ngModel)]="mediaType" name="mediaType" title="The type of media this model will process">
-        @for (mt of mediaTypes; track mt) {
-          <option [value]="mt">{{ mt }}</option>
-        }
-      </select>
+  @if (view === 'media-picker') {
+    <div class="media-picker">
+      <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()">&larr; Back</button>
+
+      @if (!selectedSource) {
+        <p class="picker-instructions">Choose a source to browse media from:</p>
+        <div class="source-list">
+          @for (src of mediaSources; track src.name) {
+            <button class="importer-card" (click)="selectSource(src)">
+              <span class="importer-name">@if (src.icon) {<span class="importer-icon">{{ src.icon }}</span> }{{ src.display_name || src.name }}</span>
+              @if (src.description) {
+                <span class="importer-desc">{{ src.description }}</span>
+              }
+            </button>
+          }
+        </div>
+      }
+
+      @if (selectedSource && !browseLoading && browseItems.length > 0) {
+        <p class="picker-instructions">Select an item from <strong>{{ selectedSource.display_name || selectedSource.name }}</strong>:</p>
+        <div class="browse-list">
+          @for (item of browseItems; track item.key) {
+            <button class="browse-item" (click)="selectBrowseItem(item)" [title]="item.key">
+              {{ item.display || item.key }}
+            </button>
+          }
+        </div>
+      }
+
+      @if (browseLoading) {
+        <p class="empty-state">Loading items...</p>
+      }
+
+      @if (selectedSource && !browseLoading && browseItems.length === 0) {
+        <p class="empty-state">No items found in this source.</p>
+      }
     </div>
-
-    <div class="form-group">
-      <label for="model-query" title="A text description or example of what this model should find">Text Query / Example <span class="required">*</span></label>
-      <input
-        id="model-query"
-        class="form-input"
-        [(ngModel)]="textQuery"
-        name="textQuery"
-        placeholder="e.g. dog barking sounds"
-        title="A text description or example of what this model should find"
-      />
-    </div>
-
-    @if (error) {
-      <p class="error-text">{{ error }}</p>
-    }
-  </form>
-
-  <div modal-footer>
-    <button class="btn btn--secondary" (click)="close()">Cancel</button>
-    <button class="btn btn--primary" [disabled]="submitting" (click)="submit()">
-      {{ submitting ? 'Creating...' : 'Create' }}
-    </button>
-  </div>
+  }
 </vt-modal>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -23,3 +23,188 @@
   color: var(--color-bad);
   font-size: 0.85rem;
 }
+
+// Two-column layout for text vs media example input
+.example-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 4px;
+}
+
+.example-col {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.col-label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-secondary, var(--text-muted));
+}
+
+.text-input-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+
+  .form-input {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.media-btn {
+  width: 100%;
+  text-align: center;
+}
+
+.hidden-file-input {
+  display: none;
+}
+
+// Examples grid
+.examples-section {
+  margin-top: 4px;
+}
+
+.examples-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.example-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  max-width: 240px;
+  border: 1px solid var(--border-color, #ccc);
+  background: var(--bg-secondary, #f5f5f5);
+}
+
+.text-chip .chip-icon {
+  color: var(--color-good, #4caf50);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.media-chip .chip-icon {
+  color: var(--color-primary, #2196f3);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.chip-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--text-muted);
+  padding: 0 2px;
+
+  &:hover {
+    color: var(--color-bad);
+  }
+}
+
+// Media picker view
+.media-picker {
+  min-height: 200px;
+}
+
+.back-btn {
+  margin-bottom: 12px;
+}
+
+.picker-instructions {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+}
+
+.source-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.importer-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  background: var(--bg-secondary, #f5f5f5);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s;
+
+  &:hover {
+    border-color: var(--color-primary, #2196f3);
+  }
+}
+
+.importer-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.importer-icon {
+  margin-right: 4px;
+}
+
+.importer-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.browse-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.browse-item {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 4px;
+  background: var(--bg-secondary, #f5f5f5);
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.85rem;
+  transition: border-color 0.15s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    border-color: var(--color-primary, #2196f3);
+    background: var(--bg-hover, #e8e8e8);
+  }
+}
+
+.empty-state {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 16px 0;
+}

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -4,6 +4,21 @@ import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { TrainableModelsApiService } from '../../../services/trainable-models-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { SortingApiService } from '../../../services/sorting-api.service';
+import { ImporterInfo } from '../../../models/api.models';
+
+interface ModelExample {
+  type: 'text' | 'media';
+  value: string;
+  display: string;
+}
+
+interface BrowseItem {
+  key: string;
+  display: string;
+}
+
+type ModalView = 'main' | 'media-picker';
 
 @Component({
   selector: 'vt-new-model-modal',
@@ -16,16 +31,25 @@ export class NewModelModalComponent implements OnInit {
   @Output() closed = new EventEmitter<void>();
   @Output() created = new EventEmitter<void>();
 
+  view: ModalView = 'main';
   name = '';
   mediaType = 'audio';
-  textQuery = '';
+  pendingText = '';
   mediaTypes: string[] = [];
+  examples: ModelExample[] = [];
   submitting = false;
   error = '';
+
+  // Media picker state
+  mediaSources: ImporterInfo[] = [];
+  selectedSource: ImporterInfo | null = null;
+  browseItems: BrowseItem[] = [];
+  browseLoading = false;
 
   constructor(
     private modelsApi: TrainableModelsApiService,
     private datasetsApi: DatasetsApiService,
+    private sortingApi: SortingApiService,
   ) {}
 
   ngOnInit(): void {
@@ -46,27 +70,150 @@ export class NewModelModalComponent implements OnInit {
     });
   }
 
+  // --- Text examples ---
+
+  addTextExample(): void {
+    const text = this.pendingText.trim();
+    if (!text) return;
+    this.examples.push({ type: 'text', value: text, display: text });
+    this.pendingText = '';
+  }
+
+  // --- Media examples ---
+
+  openMediaPicker(): void {
+    this.view = 'media-picker';
+    this.selectedSource = null;
+    this.browseItems = [];
+    this.loadMediaSources();
+  }
+
+  private loadMediaSources(): void {
+    this.datasetsApi.getAllImporters().subscribe({
+      next: (res) => {
+        this.mediaSources = (res.importers || []).filter(
+          (imp) => !imp['hidden_from_picker'],
+        );
+      },
+    });
+  }
+
+  selectSource(source: ImporterInfo): void {
+    this.selectedSource = source;
+    this.browseLoading = true;
+    this.browseItems = [];
+
+    // For demo importer, list demo datasets
+    if (source.name === 'demo') {
+      this.datasetsApi.getDemoList().subscribe({
+        next: (res) => {
+          this.browseItems = (res.datasets || []).map((d) => ({
+            key: d.name,
+            display: `${d.label} (${d.media_type}, ${d.num_files} items)`,
+          }));
+          this.browseLoading = false;
+        },
+        error: () => { this.browseLoading = false; },
+      });
+    } else if (source.name === 'folder') {
+      // List available files on the server
+      this.datasetsApi.getAvailableFiles().subscribe({
+        next: (res) => {
+          this.browseItems = (res.files || []).map((f) => ({
+            key: f.path || f.name,
+            display: `${f.name} (${f.size_mb?.toFixed(1) || '?'} MB)`,
+          }));
+          this.browseLoading = false;
+        },
+        error: () => { this.browseLoading = false; },
+      });
+    } else {
+      // For other importers, list server media files as a fallback
+      this.sortingApi.getServerMediaFiles().subscribe({
+        next: (res) => {
+          this.browseItems = (res.files || []).map((f) => ({
+            key: f.filename || f.name,
+            display: f.name,
+          }));
+          this.browseLoading = false;
+        },
+        error: () => { this.browseLoading = false; },
+      });
+    }
+  }
+
+  selectBrowseItem(item: BrowseItem): void {
+    this.examples.push({
+      type: 'media',
+      value: item.key,
+      display: item.display || item.key,
+    });
+    this.view = 'main';
+  }
+
+  onLocalFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    const file = input.files[0];
+    this.sortingApi.uploadServerMediaFile(file).subscribe({
+      next: (res) => {
+        this.examples.push({
+          type: 'media',
+          value: res.filename,
+          display: res.original_name || res.filename,
+        });
+      },
+      error: () => {
+        this.error = 'Failed to upload file';
+      },
+    });
+    input.value = '';
+  }
+
+  backToMain(): void {
+    this.view = 'main';
+  }
+
+  // --- Examples grid ---
+
+  removeExample(index: number): void {
+    this.examples.splice(index, 1);
+  }
+
+  // --- Submit ---
+
   submit(): void {
     const trimmedName = this.name.trim();
-    const trimmedQuery = this.textQuery.trim();
     if (!trimmedName) {
       this.error = 'Name is required';
       return;
     }
-    if (!trimmedQuery) {
-      this.error = 'At least one text query or example is required';
+    if (this.examples.length === 0) {
+      this.error = 'At least one example (text or media) is required';
       return;
     }
 
     this.submitting = true;
     this.error = '';
 
+    // Derive text_query and media_example from first example for autopilot
+    const firstExample = this.examples[0];
+    const textQuery = firstExample.type === 'text' ? firstExample.value : '';
+    const mediaExample = firstExample.type === 'media' ? firstExample.value : '';
+
+    const examplesPayload = this.examples.map((ex) => ({
+      type: ex.type,
+      value: ex.value,
+    }));
+
     this.modelsApi
       .registerModel({
         name: trimmedName,
         media_type: this.mediaType,
         trainable: true,
-        text_query: trimmedQuery,
+        text_query: textQuery,
+        media_example: mediaExample,
+        examples: examplesPayload,
       })
       .subscribe({
         next: () => {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -55,6 +55,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private statusPolling$: Subscription | null = null;
   private learnedSortPending = false;
   private autopilotTextSortPending = false;
+  private autopilotMediaSortPending = false;
   private dragging = false;
   private draggingRight = false;
   private boundMouseMove = this.onMouseMove.bind(this);
@@ -100,6 +101,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         if (this.autopilotTextSortPending && medias.length > 0) {
           this.autopilotTextSortPending = false;
           this.triggerAutopilotTextSort();
+        }
+        if (this.autopilotMediaSortPending && medias.length > 0) {
+          this.autopilotMediaSortPending = false;
+          this.triggerAutopilotMediaSort();
         }
       });
 
@@ -417,11 +422,18 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onAutopilotStart(): void {
     this.sortState.setSelectMode('top');
     const textQuery = this.labelSession.textQuery;
+    const mediaExample = this.labelSession.mediaExample;
     if (textQuery) {
       if (this.mediaState.medias.length > 0) {
         this.triggerAutopilotTextSort();
       } else {
         this.autopilotTextSortPending = true;
+      }
+    } else if (mediaExample) {
+      if (this.mediaState.medias.length > 0) {
+        this.triggerAutopilotMediaSort();
+      } else {
+        this.autopilotMediaSortPending = true;
       }
     }
   }
@@ -430,6 +442,30 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const textQuery = this.labelSession.textQuery;
     if (textQuery) {
       this.onTextSort(textQuery);
+    }
+  }
+
+  private triggerAutopilotMediaSort(): void {
+    const mediaExample = this.labelSession.mediaExample;
+    if (mediaExample) {
+      this.sortState.setSortBusy(true);
+      this.sortState.setSortStatus('Sorting by example...');
+      this.sortingApi.exampleSortServer({ filename: mediaExample }).pipe(takeUntil(this.destroy$)).subscribe({
+        next: (response) => {
+          this.sortState.setSortResults(
+            response.results.map((r) => ({ id: r.id, score: r.similarity })),
+            response.threshold,
+          );
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus('');
+          this.sortState.setSortMode('load');
+          this.autoSelectNext();
+        },
+        error: () => {
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus('Example sort failed');
+        },
+      });
     }
   }
 
@@ -457,13 +493,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onAutopilotStop(): void {
     const phase = this.autopilotStateService.state.phase;
+    const isMediaBased = !!this.labelSession.mediaExample && !this.labelSession.textQuery;
 
     // Map autopilot phase to the same Sort + Select that autopilot was using.
     if (phase === 'good') {
-      this.sortState.setSortMode('text');
+      this.sortState.setSortMode(isMediaBased ? 'load' : 'text');
       this.sortState.setSelectMode('top');
     } else if (phase === 'bad') {
-      this.sortState.setSortMode('text');
+      this.sortState.setSortMode(isMediaBased ? 'load' : 'text');
       this.sortState.setSelectMode('hard');
     } else if (phase === 'hard') {
       this.sortState.setSortMode('learned');

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -311,6 +311,7 @@ export interface ModelRegistryEntry {
   trainable?: boolean;
   num_training?: number;
   text_query?: string;
+  media_example?: string;
   detector_name?: string;
   [key: string]: unknown;
 }

--- a/frontend/src/app/services/label-session.service.ts
+++ b/frontend/src/app/services/label-session.service.ts
@@ -2,9 +2,11 @@ import { Injectable } from '@angular/core';
 
 /**
  * Lightweight session state passed from dashboard to label view.
- * Holds the selected model's text_query so autopilot can auto-sort on entry.
+ * Holds the selected model's text_query or media_example so autopilot
+ * can auto-sort on entry.
  */
 @Injectable({ providedIn: 'root' })
 export class LabelSessionService {
   textQuery = '';
+  mediaExample = '';
 }

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -96,6 +96,12 @@ export class SortingApiService {
     return this.http.post<SortResponse>('/api/example-sort-server', params);
   }
 
+  uploadServerMediaFile(file: File): Observable<{ filename: string; original_name: string }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<{ filename: string; original_name: string }>('/api/server-media-files/upload', formData);
+  }
+
   labelFileSort(file: File): Observable<LearnedSortResponse> {
     const formData = new FormData();
     formData.append('file', file);

--- a/vtsearch/models/registry.py
+++ b/vtsearch/models/registry.py
@@ -99,6 +99,7 @@ def register_model(
     detector_name: str = "",
     trainable_model_name: str = "",
     text_query: str = "",
+    media_example: str = "",
     created_by: str = "default",
 ) -> dict[str, Any]:
     """Add a new model to the registry and persist.
@@ -127,6 +128,7 @@ def register_model(
         "detector_name": detector_name,
         "trainable_model_name": trainable_model_name,
         "text_query": text_query,
+        "media_example": media_example,
         "created_by": created_by,
         "created_at": time.time(),
     }

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -530,6 +530,27 @@ def example_sort():
 SERVER_MEDIA_DIR = DATA_DIR / "example_media"
 
 
+@sorting_bp.route("/api/server-media-files/upload", methods=["POST"])
+def upload_server_media_file():
+    """Upload a media file to data/example_media/ and return its filename."""
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if not file.filename:
+        return jsonify({"error": "No file selected"}), 400
+
+    import uuid
+
+    suffix = Path(file.filename).suffix or ".bin"
+    safe_name = f"{uuid.uuid4().hex}{suffix}"
+    SERVER_MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+    dest = SERVER_MEDIA_DIR / safe_name
+    file.save(dest)
+
+    return jsonify({"filename": safe_name, "original_name": file.filename}), 201
+
+
 @sorting_bp.route("/api/server-media-files", methods=["GET"])
 def list_server_media_files():
     """List media files saved on the server in data/example_media/."""

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -122,6 +122,7 @@ def _list_all() -> list[dict]:
         models.append({
             "name": data["name"],
             "text_query": data.get("text_query", ""),
+            "media_example": data.get("media_example", ""),
             "media_type": data.get("media_type", ""),
             "examples": data.get("examples", []),
             "num_labels": len(labels),
@@ -157,13 +158,14 @@ def create_trainable_model():
     data = request.get_json(force=True, silent=True) or {}
     name = data.get("name", "").strip()
     text_query = data.get("text_query", "").strip()
+    media_example = data.get("media_example", "").strip()
     media_type = data.get("media_type", "").strip()
     examples = data.get("examples")
 
     if not name:
         return jsonify({"error": "name is required"}), 400
-    if not text_query and not examples:
-        return jsonify({"error": "text_query or examples is required"}), 400
+    if not text_query and not media_example and not examples:
+        return jsonify({"error": "text_query, media_example, or examples is required"}), 400
     if not media_type or media_type == "any":
         return jsonify({"error": "media_type is required (must be a specific type, not 'any')"}), 400
 
@@ -171,14 +173,17 @@ def create_trainable_model():
     if path.exists():
         return jsonify({"error": f"A trainable model named '{name}' already exists"}), 409
 
-    # Build examples list; if text_query provided without explicit examples,
-    # create a single text example from it for backward compatibility.
+    # Build examples list; if text_query/media_example provided without
+    # explicit examples, create a single example from it for backward compat.
     if examples is None and text_query:
         examples = [{"type": "text", "value": text_query}]
+    elif examples is None and media_example:
+        examples = [{"type": "media", "value": media_example}]
 
     model_data = {
         "name": name,
         "text_query": text_query,
+        "media_example": media_example,
         "media_type": media_type,
         "examples": examples or [],
         "created_at": time.time(),
@@ -190,6 +195,7 @@ def create_trainable_model():
         "success": True,
         "name": name,
         "text_query": text_query,
+        "media_example": media_example,
         "media_type": media_type,
         "examples": examples or [],
         "num_labels": 0,
@@ -385,6 +391,7 @@ def register_model_route():
     media_type = data.get("media_type", "").strip()
     trainable = data.get("trainable", True)
     text_query = data.get("text_query", "")
+    media_example = data.get("media_example", "")
     detector_name = data.get("detector_name", "")
     trainable_model_name = data.get("trainable_model_name", "")
 
@@ -398,12 +405,15 @@ def register_model_route():
         trainable_model_name = name
         tm_path = _model_path(name)
         if not tm_path.exists():
-            examples = []
-            if text_query:
+            examples = data.get("examples", [])
+            if not examples and text_query:
                 examples = [{"type": "text", "value": text_query}]
+            if not examples and media_example:
+                examples = [{"type": "media", "value": media_example}]
             model_data = {
                 "name": name,
                 "text_query": text_query,
+                "media_example": media_example,
                 "media_type": media_type,
                 "examples": examples,
                 "created_at": time.time(),
@@ -416,6 +426,7 @@ def register_model_route():
         media_type=media_type,
         trainable=trainable,
         text_query=text_query,
+        media_example=media_example,
         detector_name=detector_name,
         trainable_model_name=trainable_model_name,
         created_by=get_current_user(),


### PR DESCRIPTION
## Summary
Extended trainable model creation to support media-based examples in addition to text queries. Users can now add both text and media examples when creating a new model, and autopilot will use media examples for sorting when available.

## Key Changes

**Frontend - New Model Modal:**
- Redesigned modal with two-column layout for adding text vs. media examples
- Added media picker UI with source selection (demo datasets, folder, server files)
- Implemented file upload capability for local media files
- Added examples grid to display and manage added examples (text and media)
- Extended styling with comprehensive SCSS for new UI components

**Frontend - Autopilot Integration:**
- Added `mediaExample` field to label session state
- Implemented `triggerAutopilotMediaSort()` to handle media-based sorting
- Modified autopilot start logic to use media examples when text query is unavailable
- Updated sort mode selection to use 'load' mode for media-based sorts

**Backend - Model Registration:**
- Added `media_example` field to trainable model creation endpoint
- Updated validation to accept either `text_query`, `media_example`, or `examples`
- Modified model listing to include `media_example` in response
- Updated model registry to store and track media examples

**Backend - Media File Management:**
- Added `/api/server-media-files/upload` endpoint for uploading media files
- Files are stored in `data/example_media/` with UUID-based naming for safety
- Returns both the safe filename and original filename to client

**API Service Updates:**
- Added `uploadServerMediaFile()` method to SortingApiService
- Extended model interfaces to include `media_example` field

## Implementation Details
- Media examples are stored alongside text examples in a unified `examples` array with type discrimination
- The first example (text or media) is used as the primary example for autopilot initialization
- Media file uploads use UUID-based naming to prevent collisions and security issues
- The media picker supports multiple sources: demo datasets, local folders, and server files
- UI gracefully handles loading states and empty results in the media picker

https://claude.ai/code/session_01EnWa9Pt1yNqA5564SWUWih