### PR TITLE
Report k-means progress during tree building, not just at leaf placement

### DIFF
--- a/tests/test_diversity_tree.py
+++ b/tests/test_diversity_tree.py
@@ -576,3 +576,75 @@ class TestWorkflow:
     def test_depth_empty_tree(self):
         tree = DiversityTree({})
         assert tree.depth() == -1
+
+
+# ---------------------------------------------------------------------------
+# Progress callback
+# ---------------------------------------------------------------------------
+
+
+class TestKmeansProgress:
+    """Progress should advance after each k-means call, not only at leaf placement."""
+
+    def test_progress_called_during_build(self):
+        """on_progress should fire multiple times, not just at the end."""
+        vecs = _make_vectors(200)
+        calls = []
+        DiversityTree(vecs, k=3, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
+        assert len(calls) >= 3, f"Expected multiple progress calls, got {len(calls)}"
+
+    def test_progress_starts_at_zero(self):
+        vecs = _make_vectors(100)
+        calls = []
+        DiversityTree(vecs, k=2, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
+        assert calls[0][0] == 0, "First progress call should have current=0"
+
+    def test_progress_ends_at_total(self):
+        vecs = _make_vectors(100)
+        calls = []
+        DiversityTree(vecs, k=2, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
+        last_current, last_total = calls[-1]
+        assert last_current == last_total, "Final progress call should have current == total"
+
+    def test_progress_monotonically_increases(self):
+        vecs = _make_vectors(300)
+        calls = []
+        DiversityTree(vecs, k=3, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
+        currents = [c for c, _ in calls]
+        for i in range(1, len(currents)):
+            assert currents[i] >= currents[i - 1], (
+                f"Progress went backwards at index {i}: {currents[i - 1]} -> {currents[i]}"
+            )
+
+    def test_progress_advances_after_root_kmeans(self):
+        """After the first (most expensive) k-means, progress should be > 0."""
+        vecs = _make_vectors(200)
+        calls = []
+        DiversityTree(vecs, k=2, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
+        # calls[0] is (0, total), calls[1] should be after root k-means
+        assert len(calls) >= 2
+        assert calls[1][0] > 0, "Progress should advance after root k-means"
+
+    def test_progress_total_reflects_estimated_work(self):
+        """Total should be based on N * num_levels, not just N."""
+        vecs = _make_vectors(200)
+        calls = []
+        DiversityTree(vecs, k=2, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
+        total = calls[0][1]
+        n = len(vecs)
+        assert total > n, f"Estimated total work ({total}) should exceed vector count ({n})"
+
+    def test_no_progress_for_small_input(self):
+        """Vectors below min_node_size should not trigger k-means progress."""
+        vecs = _make_vectors(5)
+        calls = []
+        DiversityTree(vecs, k=2, min_node_size=20, on_progress=lambda c, t: calls.append((c, t)))
+        # Should still get start (0) and end (total) calls
+        assert len(calls) >= 2
+        assert calls[-1][0] == calls[-1][1]
+
+    def test_progress_not_called_without_callback(self):
+        """Building without on_progress should not raise."""
+        vecs = _make_vectors(100)
+        tree = DiversityTree(vecs, k=2, min_node_size=10)
+        assert tree.depth() >= 1

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -13,6 +13,7 @@ The tree supports:
 
 from __future__ import annotations
 
+import math
 from collections import deque
 from collections.abc import Callable
 
@@ -71,12 +72,24 @@ class DiversityTree:
             ids = list(vectors.keys())
             total = len(ids)
             vecs = np.array([vectors[i] for i in ids], dtype=np.float32)
-            self._leaves_placed = 0
             self._on_progress = on_progress
-            self._total_vectors = total
+            # Estimate total k-means work: each tree level clusters ~N vectors
+            # total.  Number of levels ≈ log_k(N / min_node_size), capped at
+            # max_depth.  Progress is reported after each k-means call, weighted
+            # by the number of vectors in that call.
+            if total >= min_node_size and total >= 2 * k:
+                num_levels = max(1, math.ceil(math.log(total / min_node_size, k)))
+                num_levels = min(num_levels, max_depth)
+            else:
+                num_levels = 0
+            self._estimated_total_work = max(total * num_levels, 1)
+            self._work_done = 0
             if on_progress:
-                on_progress(0, total)
+                on_progress(0, self._estimated_total_work)
             self._build_node("0", ids, vecs, depth=0, parent=None)
+            # Ensure we hit 100% at the end
+            if on_progress:
+                on_progress(self._estimated_total_work, self._estimated_total_work)
             self._on_progress = None
 
     def _build_node(
@@ -100,14 +113,12 @@ class DiversityTree:
         if len(ids) < self.min_node_size or depth >= self.max_depth:
             for vid in ids:
                 self.vector_to_leaf[vid] = name
-            self._report_leaf_progress(len(ids))
             return
 
         actual_k = min(self.k, len(ids))
         if actual_k < 2:
             for vid in ids:
                 self.vector_to_leaf[vid] = name
-            self._report_leaf_progress(len(ids))
             return
 
         # Run k-means
@@ -115,6 +126,14 @@ class DiversityTree:
 
         kmeans = KMeans(n_clusters=actual_k, random_state=42, n_init=10)
         labels = kmeans.fit_predict(vecs)
+
+        # Report progress proportional to the number of vectors clustered
+        self._work_done += len(ids)
+        if self._on_progress:
+            self._on_progress(
+                min(self._work_done, self._estimated_total_work),
+                self._estimated_total_work,
+            )
 
         children = []
         for ci in range(actual_k):
@@ -133,13 +152,6 @@ class DiversityTree:
         if not children:
             for vid in ids:
                 self.vector_to_leaf[vid] = name
-            self._report_leaf_progress(len(ids))
-
-    def _report_leaf_progress(self, count: int) -> None:
-        """Report progress when vectors are assigned to a leaf node."""
-        self._leaves_placed += count
-        if self._on_progress:
-            self._on_progress(self._leaves_placed, self._total_vectors)
 
     def lookup(self, vector_id: int) -> str:
         """Return the name of the deepest (leaf) node containing this vector."""


### PR DESCRIPTION
## Summary
Changed the progress reporting mechanism in `DiversityTree` to fire after each k-means clustering operation during tree construction, rather than only when vectors are assigned to leaf nodes. This provides more granular and meaningful progress feedback during the most computationally expensive phase of tree building.

## Key Changes
- **Progress estimation**: Calculate estimated total work based on tree depth (log_k(N / min_node_size)) multiplied by vector count, rather than just the vector count
- **Progress reporting**: Report progress after each k-means call with work proportional to the number of vectors clustered, instead of waiting until leaf placement
- **Removed leaf-based tracking**: Eliminated `_leaves_placed` and `_report_leaf_progress()` method in favor of work-based tracking (`_work_done`)
- **Guaranteed completion**: Ensure final progress callback reaches 100% (current == total) at the end of tree construction
- **Graceful handling**: Progress is only reported when k-means actually runs; small inputs below `min_node_size` skip clustering entirely

## Implementation Details
- Uses `math.ceil(math.log(total / min_node_size, k))` to estimate tree depth, capped at `max_depth`
- Work is accumulated as vectors are processed through k-means, providing more accurate progress during the expensive clustering phase
- Progress callbacks are clamped to not exceed estimated total work to prevent overshoot
- Added comprehensive test suite covering multiple progress scenarios: monotonic increase, start/end values, behavior with small inputs, and callback-free operation

https://claude.ai/code/session_01PCEWy9qbhEYzMvpUvPFc9a