### PR TITLE
Add auto-seeding of good votes from model media examples

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -458,6 +458,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const model = this.models.find((m) => this.selectedModelIds.has(m.id));
     this.labelSession.textQuery = model?.text_query || '';
     this.labelSession.mediaExample = model?.media_example || '';
+    this.labelSession.examples = (model?.['examples'] as { type: string; value: string }[]) || [];
   }
 
   onLabel(): void {

--- a/frontend/src/app/services/label-session.service.ts
+++ b/frontend/src/app/services/label-session.service.ts
@@ -1,12 +1,19 @@
 import { Injectable } from '@angular/core';
 
+export interface ModelExample {
+  type: string;
+  value: string;
+}
+
 /**
  * Lightweight session state passed from dashboard to label view.
  * Holds the selected model's text_query or media_example so autopilot
- * can auto-sort on entry.
+ * can auto-sort on entry.  Also carries the full examples list so the
+ * label view can seed good votes from media examples.
  */
 @Injectable({ providedIn: 'root' })
 export class LabelSessionService {
   textQuery = '';
   mediaExample = '';
+  examples: ModelExample[] = [];
 }

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -562,6 +562,17 @@ class TestVoteSyncsToLoadedModel:
 class TestSeedVotesFromExamples:
     """When loading a model with media examples, matching medias get auto-labeled Good."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_medias(self):
+        """Remove any media items inserted by seeding after each test."""
+        from vtsearch.utils import medias
+
+        saved = dict(medias)
+        yield
+        # Remove items that were added, restore any that were modified
+        medias.clear()
+        medias.update(saved)
+
     def _create_example_file(self, media_bytes: bytes, filename: str = "ex.wav") -> str:
         """Write *media_bytes* into data/example_media/<filename> and return the filename."""
         from vtsearch.config import DATA_DIR
@@ -619,9 +630,14 @@ class TestSeedVotesFromExamples:
         assert data["seeded"] == 0
         assert data["skipped"] == 1
 
-    def test_seed_skips_unmatched_md5(self, client):
-        """A media example whose MD5 doesn't match any loaded media should be skipped."""
-        fname = self._create_example_file(b"random-unmatched-bytes", "unmatched.wav")
+    def test_seed_unmatched_inserts_new_media(self, client):
+        """A media example not in the dataset should be embedded and inserted as a new media."""
+        from vtsearch.utils import good_votes, medias
+
+        original_count = len(medias)
+
+        # Create a file whose content differs from all loaded medias
+        fname = self._create_example_file(b"novel-example-content", "novel.wav")
 
         res = client.post(
             "/api/votes/seed-from-examples",
@@ -629,8 +645,21 @@ class TestSeedVotesFromExamples:
         )
         assert res.status_code == 200
         data = res.get_json()
-        assert data["seeded"] == 0
-        assert data["skipped"] == 1
+        assert data["seeded"] == 1
+
+        # A new media should have been inserted
+        assert len(medias) == original_count + 1
+
+        # The new media should be in good_votes
+        new_id = max(medias.keys())
+        assert new_id in good_votes
+
+        # The new media should have the example_media origin (not a dataset origin)
+        new_media = medias[new_id]
+        assert new_media["origin"]["importer"] == "example_media"
+        assert new_media["origin"]["params"]["filename"] == fname
+        assert new_media["filename"] == fname
+        assert new_media["embedding"] is not None
 
     def test_seed_preserves_original_origins(self, client):
         """Seeded medias should keep their original dataset origins."""
@@ -675,6 +704,55 @@ class TestSeedVotesFromExamples:
         labels = res.get_json()["labels"]
         assert len(labels) >= 1
         assert any(lbl["label"] == "good" for lbl in labels)
+
+    def test_new_example_appears_in_label_export(self, client):
+        """A non-dataset example inserted by seeding should appear in label export."""
+        fname = self._create_example_file(b"export-novel-bytes", "export_novel.wav")
+
+        client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname}]},
+        )
+
+        res = client.get("/api/labels/export")
+        assert res.status_code == 200
+        labels = res.get_json()["labels"]
+        example_labels = [
+            lbl for lbl in labels if isinstance(lbl.get("origin"), dict) and lbl["origin"].get("importer") == "example_media"
+        ]
+        assert len(example_labels) == 1
+        assert example_labels[0]["label"] == "good"
+        assert example_labels[0]["origin"]["params"]["filename"] == fname
+
+    def test_new_example_usable_in_training(self, client):
+        """Inserted examples should have embeddings usable by learned-sort."""
+        from vtsearch.utils import good_votes, bad_votes, medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        # Seed a novel example as good
+        fname = self._create_example_file(b"training-novel-bytes", "train_novel.wav")
+        client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname}]},
+        )
+        assert len(good_votes) >= 1
+
+        # Add a bad vote on the first dataset media so we have both good+bad
+        first_id = next(iter(medias))
+        # Make sure we don't vote bad on the newly inserted item
+        new_id = max(medias.keys())
+        target_id = first_id if first_id != new_id else list(medias.keys())[1]
+        client.post(f"/api/medias/{target_id}/vote", json={"vote": "bad"})
+        assert len(bad_votes) >= 1
+
+        # Learned sort should work — it accesses the embedding from the inserted media
+        res = client.post("/api/learned-sort")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "results" in data
+        assert len(data["results"]) > 0
 
     # ---- Model load auto-seeding ----
 
@@ -787,6 +865,43 @@ class TestSeedVotesFromExamples:
 
         # With default autopilot_top_greens=3, 4 good votes is enough to skip Good phase
         assert len(good_votes) >= 4
+
+    def test_load_model_seeds_novel_example(self, client):
+        """Loading a model with a non-dataset example should embed and insert it."""
+        from vtsearch.utils import good_votes, medias
+
+        original_count = len(medias)
+        fname = self._create_example_file(b"novel-load-bytes", "novel_load.wav")
+
+        client.post(
+            "/api/trainable-models",
+            json={
+                "name": "NovelSeed",
+                "media_type": "audio",
+                "examples": [{"type": "media", "value": fname}],
+            },
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={
+                "name": "NovelSeed",
+                "media_type": "audio",
+                "trainable": True,
+                "text_query": "",
+            },
+        )
+        model_id = res.get_json()["model"]["id"]
+
+        client.post("/api/votes/clear")
+        res = client.post("/api/models/registry/load", json={"model_id": model_id})
+        assert res.status_code == 200
+        assert res.get_json()["examples_seeded"] == 1
+
+        # A new media should have been inserted
+        assert len(medias) == original_count + 1
+        new_id = max(medias.keys())
+        assert new_id in good_votes
+        assert medias[new_id]["origin"]["importer"] == "example_media"
 
     def test_seed_directory_traversal_blocked(self, client):
         """Path traversal attempts in example filenames should be rejected."""

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -557,3 +557,244 @@ class TestVoteSyncsToLoadedModel:
 
         entry = get_model(model_id)
         assert entry["num_training"] == 1
+
+
+class TestSeedVotesFromExamples:
+    """When loading a model with media examples, matching medias get auto-labeled Good."""
+
+    def _create_example_file(self, media_bytes: bytes, filename: str = "ex.wav") -> str:
+        """Write *media_bytes* into data/example_media/<filename> and return the filename."""
+        from vtsearch.config import DATA_DIR
+
+        example_dir = DATA_DIR / "example_media"
+        example_dir.mkdir(parents=True, exist_ok=True)
+        dest = example_dir / filename
+        dest.write_bytes(media_bytes)
+        return filename
+
+    # ---- POST /api/votes/seed-from-examples ----
+
+    def test_seed_endpoint_adds_good_votes(self, client):
+        """Media examples whose MD5 matches a loaded media should become good votes."""
+        from vtsearch.utils import good_votes, medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        media_bytes = media["media_bytes"]
+
+        fname = self._create_example_file(media_bytes, "seed_test.wav")
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname}]},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["seeded"] == 1
+        assert data["skipped"] == 0
+        assert first_id in good_votes
+
+    def test_seed_skips_text_examples(self, client):
+        """Text examples should be skipped (only media examples are seeded)."""
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "text", "value": "dog barking"}]},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["seeded"] == 0
+        assert data["skipped"] == 1
+
+    def test_seed_skips_nonexistent_file(self, client):
+        """A media example whose file doesn't exist should be skipped."""
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": "no_such_file.wav"}]},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["seeded"] == 0
+        assert data["skipped"] == 1
+
+    def test_seed_skips_unmatched_md5(self, client):
+        """A media example whose MD5 doesn't match any loaded media should be skipped."""
+        fname = self._create_example_file(b"random-unmatched-bytes", "unmatched.wav")
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname}]},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["seeded"] == 0
+        assert data["skipped"] == 1
+
+    def test_seed_preserves_original_origins(self, client):
+        """Seeded medias should keep their original dataset origins."""
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        original_origin = media.get("origin")
+        original_origin_name = media.get("origin_name", "")
+
+        fname = self._create_example_file(media["media_bytes"], "origin_test.wav")
+        client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname}]},
+        )
+
+        # Origin should be unchanged
+        assert medias[first_id].get("origin") == original_origin
+        assert medias[first_id].get("origin_name", "") == original_origin_name
+
+    def test_seed_appears_in_label_export(self, client):
+        """Seeded good votes should appear in the label export."""
+        from vtsearch.utils import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        fname = self._create_example_file(media["media_bytes"], "export_test.wav")
+
+        client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname}]},
+        )
+
+        res = client.get("/api/labels/export")
+        assert res.status_code == 200
+        labels = res.get_json()["labels"]
+        assert len(labels) >= 1
+        assert any(lbl["label"] == "good" for lbl in labels)
+
+    # ---- Model load auto-seeding ----
+
+    def test_load_model_seeds_from_media_examples(self, client):
+        """Loading a model with media examples should auto-seed good votes."""
+        from vtsearch.utils import good_votes, medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        fname = self._create_example_file(media["media_bytes"], "autoload.wav")
+
+        # Create model with a media example
+        client.post(
+            "/api/trainable-models",
+            json={
+                "name": "AutoSeed",
+                "media_type": "audio",
+                "examples": [{"type": "media", "value": fname}],
+            },
+        )
+        # Register in model registry
+        res = client.post(
+            "/api/models/registry",
+            json={
+                "name": "AutoSeed",
+                "media_type": "audio",
+                "trainable": True,
+                "text_query": "",
+                "media_example": fname,
+            },
+        )
+        model_id = res.get_json()["model"]["id"]
+
+        # Clear any prior votes
+        client.post("/api/votes/clear")
+        assert len(good_votes) == 0
+
+        # Load model — should auto-seed
+        res = client.post("/api/models/registry/load", json={"model_id": model_id})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["examples_seeded"] == 1
+        assert first_id in good_votes
+
+    def test_load_model_without_examples_seeds_nothing(self, client):
+        """Loading a text-only model should seed 0 examples."""
+        from vtsearch.utils import good_votes
+
+        client.post(
+            "/api/trainable-models",
+            json={"name": "TextOnly", "media_type": "audio", "text_query": "dogs"},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={
+                "name": "TextOnly",
+                "media_type": "audio",
+                "trainable": True,
+                "text_query": "dogs",
+            },
+        )
+        model_id = res.get_json()["model"]["id"]
+
+        client.post("/api/votes/clear")
+        res = client.post("/api/models/registry/load", json={"model_id": model_id})
+        assert res.status_code == 200
+        assert res.get_json()["examples_seeded"] == 0
+        assert len(good_votes) == 0
+
+    def test_seeded_examples_enable_autopilot_skip(self, client):
+        """If seeded examples meet the autopilot threshold, Good phase can be skipped.
+
+        This tests the backend side: enough media examples seed enough
+        good_votes that ``goodCount >= autopilot_top_greens``.
+        """
+        from vtsearch.utils import good_votes, medias
+
+        ids = list(medias.keys())
+        if len(ids) < 4:
+            pytest.skip("Need at least 4 medias")
+
+        # Create example files for 4 medias
+        fnames = []
+        for i, cid in enumerate(ids[:4]):
+            fname = self._create_example_file(medias[cid]["media_bytes"], f"skip_{i}.wav")
+            fnames.append(fname)
+
+        examples = [{"type": "media", "value": fn} for fn in fnames]
+        client.post(
+            "/api/trainable-models",
+            json={"name": "SkipGood", "media_type": "audio", "examples": examples},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={
+                "name": "SkipGood",
+                "media_type": "audio",
+                "trainable": True,
+                "text_query": "",
+            },
+        )
+        model_id = res.get_json()["model"]["id"]
+
+        client.post("/api/votes/clear")
+        res = client.post("/api/models/registry/load", json={"model_id": model_id})
+        assert res.get_json()["examples_seeded"] == 4
+
+        # With default autopilot_top_greens=3, 4 good votes is enough to skip Good phase
+        assert len(good_votes) >= 4
+
+    def test_seed_directory_traversal_blocked(self, client):
+        """Path traversal attempts in example filenames should be rejected."""
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": "../../etc/passwd"}]},
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["seeded"] == 0
+        assert data["skipped"] == 1

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -232,11 +232,9 @@ def seed_votes_from_examples():
     """Seed good votes from a model's media examples.
 
     For each ``type: "media"`` example, reads the file from
-    ``data/example_media/``, computes its MD5, and adds any matching
-    loaded media items to ``good_votes``.  This lets a detector that
-    was created with media examples start a labeling session with
-    those examples already counted as Good labels (preserving the
-    original dataset origins on each media item).
+    ``data/example_media/``, computes its MD5, and either marks the
+    matching loaded media as Good, or — if the example is new —
+    embeds it, inserts it into the ``medias`` dict, and votes it Good.
 
     Expects JSON::
 
@@ -246,7 +244,7 @@ def seed_votes_from_examples():
 
         {"seeded": 2, "skipped": 1}
     """
-    import hashlib
+    from vtsearch.routes.trainable_models import _seed_good_votes_from_examples
 
     data = get_json_or_400()
     if not isinstance(data, dict):
@@ -256,45 +254,8 @@ def seed_votes_from_examples():
     if not isinstance(examples, list):
         return jsonify({"error": "examples must be a list"}), 400
 
-    snap = snapshot_medias()
-    if not snap:
-        return jsonify({"seeded": 0, "skipped": len(examples)})
-
-    _, md5_lookup = build_media_lookup(snap)
-
-    seeded = 0
-    skipped = 0
-    for ex in examples:
-        if not isinstance(ex, dict) or ex.get("type") != "media":
-            skipped += 1
-            continue
-
-        filename = ex.get("value", "").strip()
-        if not filename:
-            skipped += 1
-            continue
-
-        file_path = SERVER_MEDIA_DIR / filename
-        # Prevent directory traversal
-        try:
-            file_path.resolve().relative_to(SERVER_MEDIA_DIR.resolve())
-        except ValueError:
-            skipped += 1
-            continue
-
-        if not file_path.is_file():
-            skipped += 1
-            continue
-
-        file_md5 = hashlib.md5(file_path.read_bytes()).hexdigest()
-        cids = md5_lookup.get(file_md5, [])
-        if not cids:
-            skipped += 1
-            continue
-
-        for cid in cids:
-            apply_label(cid, "good")
-        seeded += 1
+    seeded = _seed_good_votes_from_examples(examples)
+    skipped = len(examples) - seeded
 
     if seeded > 0:
         from vtsearch.routes.trainable_models import sync_labels_to_loaded_model

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -227,6 +227,83 @@ def clear_votes_route():
     return jsonify({"ok": True})
 
 
+@sorting_bp.route("/api/votes/seed-from-examples", methods=["POST"])
+def seed_votes_from_examples():
+    """Seed good votes from a model's media examples.
+
+    For each ``type: "media"`` example, reads the file from
+    ``data/example_media/``, computes its MD5, and adds any matching
+    loaded media items to ``good_votes``.  This lets a detector that
+    was created with media examples start a labeling session with
+    those examples already counted as Good labels (preserving the
+    original dataset origins on each media item).
+
+    Expects JSON::
+
+        {"examples": [{"type": "media", "value": "abc123.wav"}, ...]}
+
+    Returns::
+
+        {"seeded": 2, "skipped": 1}
+    """
+    import hashlib
+
+    data = get_json_or_400()
+    if not isinstance(data, dict):
+        return data
+
+    examples = data.get("examples")
+    if not isinstance(examples, list):
+        return jsonify({"error": "examples must be a list"}), 400
+
+    snap = snapshot_medias()
+    if not snap:
+        return jsonify({"seeded": 0, "skipped": len(examples)})
+
+    _, md5_lookup = build_media_lookup(snap)
+
+    seeded = 0
+    skipped = 0
+    for ex in examples:
+        if not isinstance(ex, dict) or ex.get("type") != "media":
+            skipped += 1
+            continue
+
+        filename = ex.get("value", "").strip()
+        if not filename:
+            skipped += 1
+            continue
+
+        file_path = SERVER_MEDIA_DIR / filename
+        # Prevent directory traversal
+        try:
+            file_path.resolve().relative_to(SERVER_MEDIA_DIR.resolve())
+        except ValueError:
+            skipped += 1
+            continue
+
+        if not file_path.is_file():
+            skipped += 1
+            continue
+
+        file_md5 = hashlib.md5(file_path.read_bytes()).hexdigest()
+        cids = md5_lookup.get(file_md5, [])
+        if not cids:
+            skipped += 1
+            continue
+
+        for cid in cids:
+            apply_label(cid, "good")
+        seeded += 1
+
+    if seeded > 0:
+        from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+
+        sync_labels_to_loaded_model()
+
+    return jsonify({"seeded": seeded, "skipped": skipped})
+
+
 @sorting_bp.route("/api/textsort-suggestions")
 def get_textsort_suggestions_route():
     """Return stored text-sort suggestions (most recent last)."""

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -106,6 +106,61 @@ def sync_labels_to_loaded_model() -> None:
     update_model(entry["id"], num_training=len(labelset), last_trained_at=_time.time())
 
 
+def _seed_good_votes_from_examples(examples: list[dict]) -> int:
+    """Add loaded media items that match media-example files to good_votes.
+
+    For each ``type: "media"`` example, reads the file from
+    ``data/example_media/``, computes its MD5, and calls
+    :func:`~vtsearch.utils.apply_label` for every loaded media whose
+    MD5 matches.  The media items keep their original dataset origins.
+
+    Returns the number of example entries that matched at least one
+    loaded media item.
+    """
+    import hashlib
+
+    from vtsearch.config import DATA_DIR
+    from vtsearch.utils import apply_label, build_media_lookup, snapshot_medias
+
+    media_examples = [
+        ex
+        for ex in examples
+        if isinstance(ex, dict) and ex.get("type") == "media" and ex.get("value", "").strip()
+    ]
+    if not media_examples:
+        return 0
+
+    snap = snapshot_medias()
+    if not snap:
+        return 0
+
+    _, md5_lookup = build_media_lookup(snap)
+    server_media_dir = DATA_DIR / "example_media"
+
+    seeded = 0
+    for ex in media_examples:
+        filename = ex["value"].strip()
+        file_path = server_media_dir / filename
+        # Prevent directory traversal
+        try:
+            file_path.resolve().relative_to(server_media_dir.resolve())
+        except ValueError:
+            continue
+        if not file_path.is_file():
+            continue
+
+        file_md5 = hashlib.md5(file_path.read_bytes()).hexdigest()
+        cids = md5_lookup.get(file_md5, [])
+        if not cids:
+            continue
+
+        for cid in cids:
+            apply_label(cid, "good")
+        seeded += 1
+
+    return seeded
+
+
 def _list_all() -> list[dict]:
     """Return summary info for every trainable model on disk."""
     tm_dir = get_trainable_models_dir()
@@ -443,6 +498,11 @@ def load_model_route():
         {"model_id": "abc123"}
 
     Pass ``model_id: null`` to unload.
+
+    When loading a model that has media examples, any example files whose
+    MD5 matches a loaded media item are automatically added to
+    ``good_votes`` so that the labeling session starts with those examples
+    pre-labeled as Good.
     """
     from vtsearch.models.registry import get_model, set_loaded_id
 
@@ -455,7 +515,19 @@ def load_model_route():
             return jsonify({"error": "Model not found"}), 404
 
     set_loaded_id(model_id)
-    return jsonify({"ok": True})
+
+    # Seed good votes from media examples on the loaded model.
+    examples_seeded = 0
+    if model_id is not None and entry is not None:
+        tm_name = entry.get("trainable_model_name", "")
+        if tm_name:
+            tm_data = _read_model(_model_path(tm_name))
+            if tm_data:
+                examples_seeded = _seed_good_votes_from_examples(
+                    tm_data.get("examples", [])
+                )
+
+    return jsonify({"ok": True, "examples_seeded": examples_seeded})
 
 
 @trainable_models_bp.route("/api/models/registry/<model_id>", methods=["DELETE"])

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -107,20 +107,32 @@ def sync_labels_to_loaded_model() -> None:
 
 
 def _seed_good_votes_from_examples(examples: list[dict]) -> int:
-    """Add loaded media items that match media-example files to good_votes.
+    """Seed good votes from a model's media examples.
 
     For each ``type: "media"`` example, reads the file from
-    ``data/example_media/``, computes its MD5, and calls
-    :func:`~vtsearch.utils.apply_label` for every loaded media whose
-    MD5 matches.  The media items keep their original dataset origins.
+    ``data/example_media/`` and adds it to ``good_votes``:
 
-    Returns the number of example entries that matched at least one
-    loaded media item.
+    * **Match by MD5** — if a loaded media has the same content hash,
+      that media is voted good (keeping its original dataset origin).
+    * **No match** — the example file is embedded using the dataset's
+      embedder, inserted into the ``medias`` dict as a new item with
+      an ``example_media`` origin, and voted good.  This makes it
+      available for training (its embedding is in the medias snapshot)
+      and for label export (LabelSet picks it up from medias + votes).
+
+    Returns the number of example entries successfully seeded.
     """
     import hashlib
 
     from vtsearch.config import DATA_DIR
-    from vtsearch.utils import apply_label, build_media_lookup, snapshot_medias
+    from vtsearch.utils import (
+        _state_lock,
+        apply_label,
+        build_media_lookup,
+        medias,
+        next_media_id,
+        snapshot_medias,
+    )
 
     media_examples = [
         ex
@@ -137,6 +149,13 @@ def _seed_good_votes_from_examples(examples: list[dict]) -> int:
     _, md5_lookup = build_media_lookup(snap)
     server_media_dir = DATA_DIR / "example_media"
 
+    # Determine the embedder and media type from the loaded dataset so we
+    # can embed example files that aren't already in the dataset.
+    first_media = next(iter(snap.values()))
+    dataset_media_type = first_media.get("type", "audio")
+    dataset_embedder_name = first_media.get("embedder", "")
+    embedder = None  # lazily loaded only when needed
+
     seeded = 0
     for ex in media_examples:
         filename = ex["value"].strip()
@@ -149,14 +168,57 @@ def _seed_good_votes_from_examples(examples: list[dict]) -> int:
         if not file_path.is_file():
             continue
 
-        file_md5 = hashlib.md5(file_path.read_bytes()).hexdigest()
+        file_bytes = file_path.read_bytes()
+        file_md5 = hashlib.md5(file_bytes).hexdigest()
         cids = md5_lookup.get(file_md5, [])
-        if not cids:
-            continue
 
-        for cid in cids:
-            apply_label(cid, "good")
-        seeded += 1
+        if cids:
+            # Example matches existing dataset media — just vote good.
+            for cid in cids:
+                apply_label(cid, "good")
+            seeded += 1
+        else:
+            # Example is NOT in the dataset — embed and insert as new media.
+            if embedder is None:
+                from vtsearch.media import embedders_for_type, get_embedder
+
+                if dataset_embedder_name:
+                    try:
+                        embedder = get_embedder(dataset_embedder_name)
+                    except KeyError:
+                        pass
+                if embedder is None:
+                    avail = embedders_for_type(dataset_media_type)
+                    embedder = avail[0] if avail else None
+                if embedder is None:
+                    # No embedder available; skip remaining examples.
+                    continue
+
+            embedding = embedder.embed_media(file_path)
+            if embedding is None:
+                continue
+
+            with _state_lock:
+                new_id = next_media_id(medias)
+                medias[new_id] = {
+                    "id": new_id,
+                    "type": dataset_media_type,
+                    "embedder": dataset_embedder_name,
+                    "md5": file_md5,
+                    "embedding": embedding,
+                    "media_bytes": file_bytes,
+                    "filename": filename,
+                    "file_size": len(file_bytes),
+                    "category": "",
+                    "origin": {
+                        "importer": "example_media",
+                        "params": {"filename": filename},
+                    },
+                    "origin_name": filename,
+                }
+
+            apply_label(new_id, "good")
+            seeded += 1
 
     return seeded
 


### PR DESCRIPTION
## Summary
This PR adds functionality to automatically seed good votes from media examples when loading a trainable model or via an explicit API endpoint. Media examples are matched against loaded datasets by MD5 hash, and unmatched examples are embedded and inserted as new media items.

## Key Changes

- **New endpoint `/api/votes/seed-from-examples`** — POST endpoint that accepts a list of examples and seeds good votes from media files. Returns counts of seeded and skipped examples.

- **Auto-seeding on model load** — When loading a trainable model via `/api/models/registry/load`, media examples from the model are automatically seeded as good votes. The response now includes an `examples_seeded` count.

- **MD5-based matching** — Media examples are matched against loaded dataset items by MD5 hash. Matching items are voted good while preserving their original dataset origins.

- **Novel example handling** — Media examples not found in the dataset are:
  - Embedded using the dataset's embedder
  - Inserted into the `medias` dict with an `example_media` origin
  - Voted good, making them available for training and label export

- **Security** — Path traversal attempts in example filenames are blocked by validating file paths stay within `data/example_media/`.

- **Frontend updates** — `LabelSessionService` now carries the full `examples` list to support seeding from the label view.

## Implementation Details

- The core seeding logic is in `_seed_good_votes_from_examples()` in `trainable_models.py`, which is reused by both the explicit endpoint and model load flow.
- Embedder selection falls back to the dataset's embedder, then to the first available embedder for the media type.
- State updates use the existing `_state_lock` to ensure thread-safe modifications to the `medias` dict.
- Label syncing is triggered after seeding to ensure votes are reflected in the model's training data.
- Comprehensive test coverage includes matching, skipping, novel insertion, origin preservation, export integration, and training usability.

https://claude.ai/code/session_017wQqS6knexLj1uXHmttSoa