### PR TITLE
Add optimistic click time updates to vote state service

### DIFF
--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -88,6 +88,52 @@ describe('VoteStateService', () => {
     expect(service.learnedScores).toEqual({});
   });
 
+  it('applyOptimisticVote should add to good and set click time', () => {
+    service.applyOptimisticVote(5, 'good');
+    expect(service.goodVotes.has(5)).toBeTrue();
+    expect(service.badVotes.has(5)).toBeFalse();
+    expect(service.clickTimes['5']).toBe(1);
+  });
+
+  it('applyOptimisticVote should add to bad and set click time', () => {
+    service.applyOptimisticVote(5, 'bad');
+    expect(service.badVotes.has(5)).toBeTrue();
+    expect(service.goodVotes.has(5)).toBeFalse();
+    expect(service.clickTimes['5']).toBe(1);
+  });
+
+  it('applyOptimisticVote click time should exceed existing max', () => {
+    // Load votes with existing click times
+    service.loadVotes();
+    httpMock.expectOne('/api/votes').flush(mockVotes);
+    // mockVotes has click_times: { '1': 100, '2': 200 }
+
+    service.applyOptimisticVote(7, 'good');
+    expect(service.clickTimes['7']).toBe(201);
+  });
+
+  it('applyOptimisticVote toggle-off should not set click time', () => {
+    service.applyOptimisticVote(5, 'good');
+    const timeAfterAdd = service.clickTimes['5'];
+    expect(timeAfterAdd).toBe(1);
+
+    // Toggle off
+    service.applyOptimisticVote(5, 'good');
+    expect(service.goodVotes.has(5)).toBeFalse();
+    // Click time should remain unchanged (no new time set on removal)
+    expect(service.clickTimes['5']).toBe(1);
+  });
+
+  it('applyOptimisticVote should move from bad to good with new click time', () => {
+    service.applyOptimisticVote(5, 'bad');
+    expect(service.clickTimes['5']).toBe(1);
+
+    service.applyOptimisticVote(5, 'good');
+    expect(service.goodVotes.has(5)).toBeTrue();
+    expect(service.badVotes.has(5)).toBeFalse();
+    expect(service.clickTimes['5']).toBe(2);
+  });
+
   it('goodVotes$ should emit on load', (done) => {
     const emissions: Set<number>[] = [];
     service.goodVotes$.subscribe((v) => emissions.push(v));

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -55,6 +55,8 @@ export class VoteStateService implements OnDestroy {
     const good = new Set(this.goodVotesSubject.value);
     const bad = new Set(this.badVotesSubject.value);
 
+    const isAdd = vote === 'good' ? !good.has(id) : !bad.has(id);
+
     if (vote === 'good') {
       if (good.has(id)) {
         good.delete(id);
@@ -73,6 +75,15 @@ export class VoteStateService implements OnDestroy {
 
     this.goodVotesSubject.next(good);
     this.badVotesSubject.next(bad);
+
+    // Set an optimistic click time so the item sorts correctly immediately,
+    // rather than appearing with time=-1 and then jumping when the server responds.
+    if (isAdd) {
+      const times = { ...this.clickTimesSubject.value };
+      const maxTime = Object.values(times).reduce((m, t) => Math.max(m, t), 0);
+      times[String(id)] = maxTime + 1;
+      this.clickTimesSubject.next(times);
+    }
   }
 
   loadVotes(): void {


### PR DESCRIPTION
## Summary
This PR adds optimistic click time updates to the `applyOptimisticVote` method in the VoteStateService. When a user votes on an item, the click time is now immediately updated locally to ensure correct sorting before the server response is received.

## Key Changes
- **Optimistic click time assignment**: When a vote is added (not toggled off), the service now assigns a click time that exceeds the current maximum, allowing the item to sort correctly in the UI immediately
- **Click time calculation**: The new click time is calculated as `max(existing times) + 1` to ensure it sorts above all previously voted items
- **Toggle-off behavior**: When removing a vote (toggling off), the click time is preserved and not updated
- **Vote switching**: When switching from one vote type to another (e.g., bad → good), a new click time is assigned to reflect the updated interaction

## Implementation Details
- Added `isAdd` flag to distinguish between adding a new vote and toggling off an existing vote
- Click time updates only occur when `isAdd` is true, preventing unnecessary updates on vote removal
- The implementation uses the existing `clickTimesSubject` to maintain consistency with the reactive architecture
- Comprehensive test coverage added to verify all voting scenarios: adding good/bad votes, exceeding existing max times, toggle-off behavior, and vote switching

https://claude.ai/code/session_01AfYxpnEzaBjBnxZ6nzg2qy