### PR TITLE
Remove redundant vote state reload after voting

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -128,7 +128,6 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
     this.mediasApi.vote(this.media.id, vote).subscribe({
       next: () => {
-        this.voteState.loadVotes();
         if (this.swipeAnimation && this.media) {
           this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
           setTimeout(() => {


### PR DESCRIPTION
## Summary
Removed a redundant `loadVotes()` call from the vote submission handler in the center panel component. This call was being made immediately after a successful vote API request, but appears to be unnecessary for the current flow.

## Key Changes
- Removed `this.voteState.loadVotes()` call from the vote submission success handler in `CenterPanelComponent`

## Implementation Details
The vote state reload was being triggered synchronously after each vote submission. This change suggests that either:
- Vote state updates are now handled elsewhere in the application flow
- The vote state is updated through a different mechanism (e.g., reactive updates from the API response)
- The reload was redundant and not required for proper UI updates

The swipe animation logic and other vote handling behavior remain unchanged.

https://claude.ai/code/session_01Tz2AXyeJo48TBboX8eTxtb