### PR TITLE
Preserve optimistic votes during server sync delays

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -128,7 +128,6 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
     this.mediasApi.vote(this.media.id, vote).subscribe({
       next: () => {
-        this.voteState.loadVotes();
         if (this.swipeAnimation && this.media) {
           this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
           setTimeout(() => {

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -134,6 +134,68 @@ describe('VoteStateService', () => {
     expect(service.clickTimes['5']).toBe(2);
   });
 
+  it('applyVotes should preserve optimistic vote when server has not caught up', () => {
+    // Simulate optimistic vote
+    service.applyOptimisticVote(10, 'good');
+    expect(service.goodVotes.has(10)).toBeTrue();
+    expect(service.clickTimes['10']).toBe(1);
+
+    // Server response arrives WITHOUT the new vote (stale data)
+    service.loadVotes();
+    httpMock.expectOne('/api/votes').flush({
+      good: [1, 2],
+      bad: [3],
+      click_times: { '1': 100, '2': 200 },
+      learned_scores: {},
+    });
+
+    // Optimistic vote should be preserved
+    expect(service.goodVotes.has(10)).toBeTrue();
+    expect(service.clickTimes['10']).toBe(1);
+    // Server data should also be present
+    expect(service.goodVotes.has(1)).toBeTrue();
+    expect(service.goodVotes.has(2)).toBeTrue();
+  });
+
+  it('applyVotes should clear optimistic tracking once server confirms', () => {
+    // Simulate optimistic vote
+    service.applyOptimisticVote(10, 'good');
+
+    // Server response now includes the voted item
+    service.loadVotes();
+    httpMock.expectOne('/api/votes').flush({
+      good: [1, 2, 10],
+      bad: [3],
+      click_times: { '1': 100, '2': 200, '10': 300 },
+      learned_scores: {},
+    });
+
+    expect(service.goodVotes.has(10)).toBeTrue();
+    // Server's click time should be used now (not the optimistic one)
+    expect(service.clickTimes['10']).toBe(300);
+  });
+
+  it('stale polling should not remove optimistic bad vote', fakeAsync(() => {
+    service.startPolling(1000);
+    // Initial poll
+    httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+
+    // User votes bad optimistically
+    service.applyOptimisticVote(5, 'bad');
+    expect(service.badVotes.has(5)).toBeTrue();
+
+    // Next poll arrives with stale data (no vote for 5)
+    tick(1000);
+    httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+
+    // Optimistic bad vote should still be preserved
+    expect(service.badVotes.has(5)).toBeTrue();
+    expect(service.clickTimes['5']).toBe(1);
+
+    service.stopPolling();
+    discardPeriodicTasks();
+  }));
+
   it('goodVotes$ should emit on load', (done) => {
     const emissions: Set<number>[] = [];
     service.goodVotes$.subscribe((v) => emissions.push(v));

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -13,6 +13,8 @@ export class VoteStateService implements OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private readonly stopPolling$ = new Subject<void>();
   private polling = false;
+  /** Tracks optimistic votes not yet confirmed by the server. */
+  private pendingOptimistic = new Map<number, { vote: 'good' | 'bad'; clickTime: number }>();
 
   readonly goodVotes$ = this.goodVotesSubject.asObservable();
   readonly badVotes$ = this.badVotesSubject.asObservable();
@@ -73,17 +75,22 @@ export class VoteStateService implements OnDestroy {
       }
     }
 
-    this.goodVotesSubject.next(good);
-    this.badVotesSubject.next(bad);
-
     // Set an optimistic click time so the item sorts correctly immediately,
     // rather than appearing with time=-1 and then jumping when the server responds.
+    const times = { ...this.clickTimesSubject.value };
     if (isAdd) {
-      const times = { ...this.clickTimesSubject.value };
       const maxTime = Object.values(times).reduce((m, t) => Math.max(m, t), 0);
-      times[String(id)] = maxTime + 1;
-      this.clickTimesSubject.next(times);
+      const optimisticTime = maxTime + 1;
+      times[String(id)] = optimisticTime;
+      this.pendingOptimistic.set(id, { vote, clickTime: optimisticTime });
+    } else {
+      this.pendingOptimistic.delete(id);
     }
+
+    // Emit all changes together so Angular sees a single consistent state.
+    this.goodVotesSubject.next(good);
+    this.badVotesSubject.next(bad);
+    this.clickTimesSubject.next(times);
   }
 
   loadVotes(): void {
@@ -115,12 +122,39 @@ export class VoteStateService implements OnDestroy {
     this.badVotesSubject.next(new Set());
     this.clickTimesSubject.next({});
     this.learnedScoresSubject.next({});
+    this.pendingOptimistic.clear();
   }
 
   private applyVotes(votes: VotesResponse): void {
-    this.goodVotesSubject.next(new Set(votes.good));
-    this.badVotesSubject.next(new Set(votes.bad));
-    this.clickTimesSubject.next(votes.click_times);
+    const good = new Set(votes.good);
+    const bad = new Set(votes.bad);
+    const times = { ...votes.click_times };
+
+    // Preserve optimistic votes that the server hasn't acknowledged yet.
+    // Without this, a stale polling response (or a loadVotes() response that
+    // raced ahead of the vote POST) would remove the item from the grid,
+    // causing it to disappear and reappear (flicker).
+    for (const [id, opt] of this.pendingOptimistic) {
+      const serverHasIt = opt.vote === 'good' ? good.has(id) : bad.has(id);
+      if (serverHasIt) {
+        // Server caught up — stop preserving this optimistic vote.
+        this.pendingOptimistic.delete(id);
+      } else {
+        // Server hasn't processed the vote yet — keep optimistic state.
+        if (opt.vote === 'good') {
+          good.add(id);
+          bad.delete(id);
+        } else {
+          bad.add(id);
+          good.delete(id);
+        }
+        times[String(id)] = opt.clickTime;
+      }
+    }
+
+    this.goodVotesSubject.next(good);
+    this.badVotesSubject.next(bad);
+    this.clickTimesSubject.next(times);
     this.learnedScoresSubject.next(votes.learned_scores);
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes a UI flicker issue where optimistic votes would disappear and reappear when the server response lags behind the client-side vote submission. The solution preserves optimistic vote state until the server explicitly confirms the vote has been processed.

## Key Changes
- **Added optimistic vote tracking**: Introduced `pendingOptimistic` Map to track votes submitted optimistically but not yet confirmed by the server
- **Enhanced `applyVotes()` logic**: Modified to preserve optimistic votes when server responses don't yet include them, preventing items from disappearing from the grid during sync delays
- **Improved state consistency**: Ensured click times and vote sets are updated atomically to maintain a consistent UI state
- **Removed redundant server call**: Eliminated the `loadVotes()` call in `center-panel.component.ts` after voting, since polling will naturally sync the state
- **Added comprehensive test coverage**: Three new test cases covering:
  - Preserving optimistic votes when server data is stale
  - Clearing optimistic tracking once server confirms the vote
  - Preventing stale polling from removing optimistic bad votes

## Implementation Details
- Optimistic votes are tracked with their vote type ('good' or 'bad') and assigned click time
- When `applyVotes()` receives a server response, it checks if each pending optimistic vote has been acknowledged
- If the server hasn't processed a vote yet, the optimistic state is merged into the response data
- Once the server confirms a vote, the optimistic tracking is cleared and the server's click time is used
- All state updates (good votes, bad votes, click times) are emitted together to prevent intermediate inconsistent states

https://claude.ai/code/session_01N2ZuWPDKzvUJvGgWNNCug5