### PR TITLE
Standardize panel width settings to use pixels instead of percentages

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -36,8 +36,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private gridColumnsLeftDict: Record<string, number> = {};
   private focusModeLeftDict: Record<string, 'click' | 'hover'> = {};
   private focusModeRightDict: Record<string, 'click' | 'hover'> = {};
-  private panelPctLeftDict: Record<string, number | null> = {};
-  private panelPctRightDict: Record<string, number | null> = {};
+  private panelPxLeftDict: Record<string, number> = {};
+  private panelPxRightDict: Record<string, number> = {};
   private currentMediaType = '';
   leftWidth = 260;
   rightWidth = 300;
@@ -95,7 +95,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
             this.gridColumnsLeft = this.gridColumnsLeftDict[newType] ?? 2;
             this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
             this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
-            this.applyPanelPct(newType);
+            this.applyPanelPx(newType);
           }
         }
         if (this.autopilotTextSortPending && medias.length > 0) {
@@ -168,7 +168,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dragging = false;
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
-    this.savePanelPct('left');
+    this.savePanelPx('left');
   }
 
   // --- Right divider drag ---
@@ -197,7 +197,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.draggingRight = false;
     document.removeEventListener('mousemove', this.boundRightMouseMove);
     document.removeEventListener('mouseup', this.boundRightMouseUp);
-    this.savePanelPct('right');
+    this.savePanelPx('right');
   }
 
   // --- Data loading ---
@@ -238,16 +238,16 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         }
         const pplDict = settings.panel_pct_left;
         if (pplDict && typeof pplDict === 'object') {
-          this.panelPctLeftDict = pplDict as Record<string, number | null>;
+          this.panelPxLeftDict = pplDict as Record<string, number>;
           if (this.currentMediaType) {
-            this.applyPanelPct(this.currentMediaType);
+            this.applyPanelPx(this.currentMediaType);
           }
         }
         const pprDict = settings.panel_pct_right;
         if (pprDict && typeof pprDict === 'object') {
-          this.panelPctRightDict = pprDict as Record<string, number | null>;
+          this.panelPxRightDict = pprDict as Record<string, number>;
           if (this.currentMediaType) {
-            this.applyPanelPct(this.currentMediaType);
+            this.applyPanelPx(this.currentMediaType);
           }
         }
         if (settings.autopilot_enabled != null) {
@@ -513,31 +513,24 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Panel percentage helpers ---
 
-  private savePanelPct(side: 'left' | 'right'): void {
+  private savePanelPx(side: 'left' | 'right'): void {
     if (!this.currentMediaType) return;
-    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
-    if (layoutWidth <= 0) return;
     const px = side === 'left' ? this.leftWidth : this.rightWidth;
-    const pct = Math.round((px / layoutWidth) * 1000) / 1000; // 3 decimal places
     const key = side === 'left' ? 'panel_pct_left' : 'panel_pct_right';
-    const dict = side === 'left' ? this.panelPctLeftDict : this.panelPctRightDict;
-    dict[this.currentMediaType] = pct;
+    const dict = side === 'left' ? this.panelPxLeftDict : this.panelPxRightDict;
+    dict[this.currentMediaType] = px;
     this.settingsState.update({ [key]: { ...dict } }).subscribe();
   }
 
-  private applyPanelPct(mediaType: string): void {
-    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
-    if (layoutWidth <= 0) return;
-    const leftPct = this.panelPctLeftDict[mediaType];
-    if (leftPct != null && !this.autopilotCollapsed) {
-      const px = Math.round(leftPct * layoutWidth);
-      this.leftWidth = Math.max(this.LEFT_MIN, Math.min(this.LEFT_MAX, px));
+  private applyPanelPx(mediaType: string): void {
+    const leftPx = this.panelPxLeftDict[mediaType];
+    if (leftPx != null && !this.autopilotCollapsed) {
+      this.leftWidth = Math.max(this.LEFT_MIN, Math.min(this.LEFT_MAX, leftPx));
       this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     }
-    const rightPct = this.panelPctRightDict[mediaType];
-    if (rightPct != null) {
-      const px = Math.round(rightPct * layoutWidth);
-      this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(this.RIGHT_MAX, px));
+    const rightPx = this.panelPxRightDict[mediaType];
+    if (rightPx != null) {
+      this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(this.RIGHT_MAX, rightPx));
       this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     }
   }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -91,11 +91,8 @@
                   <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_left', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_left', activeViewTab, $event)" min="1" max="6" />
                 </div>
                 <div class="form-group">
-                  <label class="form-label">Panel %</label>
-                  <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_left', activeViewTab) }}</span>
-                  @if (getPanelPct('panel_pct_left', activeViewTab) != null) {
-                    <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_left', activeViewTab)">Reset</button>
-                  }
+                  <label class="form-label">Panel px</label>
+                  <span class="panel-pct-display">{{ getPanelPxDisplay('panel_pct_left', activeViewTab) }}</span>
                 </div>
               </div>
               <div class="view-side-section">
@@ -131,11 +128,8 @@
                   <input type="number" class="form-input" [ngModel]="getGridColumns('grid_columns_right', activeViewTab)" (ngModelChange)="onGridColumnsChange('grid_columns_right', activeViewTab, $event)" min="1" max="6" />
                 </div>
                 <div class="form-group">
-                  <label class="form-label">Panel %</label>
-                  <span class="panel-pct-display">{{ getPanelPctDisplay('panel_pct_right', activeViewTab) }}</span>
-                  @if (getPanelPct('panel_pct_right', activeViewTab) != null) {
-                    <button class="btn btn--small btn--secondary" (click)="clearPanelPct('panel_pct_right', activeViewTab)">Reset</button>
-                  }
+                  <label class="form-label">Panel px</label>
+                  <span class="panel-pct-display">{{ getPanelPxDisplay('panel_pct_right', activeViewTab) }}</span>
                 </div>
               </div>
             </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -116,27 +116,14 @@ export class SettingsModalComponent implements OnInit {
     return dict[typeId] ?? 'click';
   }
 
-  onPanelPctChange(side: 'panel_pct_left' | 'panel_pct_right', typeId: string, value: number | null): void {
-    const dict = (this.settings[side] as Record<string, number | null>) || {};
-    dict[typeId] = value;
-    (this.settings as Record<string, unknown>)[side] = { ...dict };
-    this.save();
-  }
-
-  getPanelPct(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): number | null {
+  getPanelPx(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): number {
     const dict = this.settings[side];
-    if (!dict) return null;
-    return dict[typeId] ?? null;
+    if (!dict) return side === 'panel_pct_left' ? 260 : 300;
+    return dict[typeId] ?? (side === 'panel_pct_left' ? 260 : 300);
   }
 
-  getPanelPctDisplay(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): string {
-    const pct = this.getPanelPct(side, typeId);
-    if (pct == null) return '—';
-    return Math.round(pct * 100) + '%';
-  }
-
-  clearPanelPct(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): void {
-    this.onPanelPctChange(side, typeId, null);
+  getPanelPxDisplay(side: 'panel_pct_left' | 'panel_pct_right', typeId: string): string {
+    return this.getPanelPx(side, typeId) + 'px';
   }
 
   onNumberChange(key: string, value: number): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -263,8 +263,8 @@ export interface AppSettings {
   grid_columns_right?: Record<string, number>;
   focus_mode_left?: Record<string, 'click' | 'hover'>;
   focus_mode_right?: Record<string, 'click' | 'hover'>;
-  panel_pct_left?: Record<string, number | null>;
-  panel_pct_right?: Record<string, number | null>;
+  panel_pct_left?: Record<string, number>;
+  panel_pct_right?: Record<string, number>;
   autoload_media_types?: string[];
   autoload_media_embedders?: string[];
   autorun_processors?: AutorunProcessor[];

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -422,62 +422,57 @@ class TestSettingsModule:
         result = settings_mod.get_panel_pct_left()
         assert isinstance(result, dict)
         for v in result.values():
-            assert v is None
+            assert v == 260
 
     def test_get_panel_pct_right_default(self):
         result = settings_mod.get_panel_pct_right()
         assert isinstance(result, dict)
         for v in result.values():
-            assert v is None
+            assert v == 300
 
     def test_set_panel_pct_left_per_type(self, isolated_settings):
-        settings_mod.set_panel_pct_left({"audio": 0.25, "image": 0.3})
+        settings_mod.set_panel_pct_left({"audio": 200, "image": 350})
         result = settings_mod.get_panel_pct_left()
-        assert result["audio"] == pytest.approx(0.25)
-        assert result["image"] == pytest.approx(0.3)
+        assert result["audio"] == 200
+        assert result["image"] == 350
 
         raw = json.loads(isolated_settings.read_text())
-        assert raw["panel_pct_left"]["audio"] == pytest.approx(0.25)
-        assert raw["panel_pct_left"]["image"] == pytest.approx(0.3)
+        assert raw["panel_pct_left"]["audio"] == 200
+        assert raw["panel_pct_left"]["image"] == 350
 
     def test_set_panel_pct_right_per_type(self, isolated_settings):
-        settings_mod.set_panel_pct_right({"audio": 0.2, "video": 0.35})
+        settings_mod.set_panel_pct_right({"audio": 250, "video": 400})
         result = settings_mod.get_panel_pct_right()
-        assert result["audio"] == pytest.approx(0.2)
-        assert result["video"] == pytest.approx(0.35)
+        assert result["audio"] == 250
+        assert result["video"] == 400
 
         raw = json.loads(isolated_settings.read_text())
-        assert raw["panel_pct_right"]["audio"] == pytest.approx(0.2)
+        assert raw["panel_pct_right"]["audio"] == 250
 
     def test_set_panel_pct_left_scalar(self, isolated_settings):
-        settings_mod.set_panel_pct_left(0.3)
+        settings_mod.set_panel_pct_left(300)
         result = settings_mod.get_panel_pct_left()
         for v in result.values():
-            assert v == pytest.approx(0.3)
-
-    def test_set_panel_pct_null_clears(self, isolated_settings):
-        settings_mod.set_panel_pct_left({"audio": 0.25})
-        settings_mod.set_panel_pct_left({"audio": None})
-        assert settings_mod.get_panel_pct_left()["audio"] is None
+            assert v == 300
 
     def test_panel_pct_persists_across_reset(self, isolated_settings):
-        settings_mod.set_panel_pct_left({"audio": 0.25})
+        settings_mod.set_panel_pct_left({"audio": 200})
         settings_mod.reset()
-        assert settings_mod.get_panel_pct_left()["audio"] == pytest.approx(0.25)
+        assert settings_mod.get_panel_pct_left()["audio"] == 200
 
     def test_panel_pct_out_of_range(self):
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left({"audio": 0.01})
+            settings_mod.set_panel_pct_left({"audio": 100})
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left({"audio": 0.95})
+            settings_mod.set_panel_pct_left({"audio": 600})
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left(0.01)
+            settings_mod.set_panel_pct_left(100)
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left(0.95)
+            settings_mod.set_panel_pct_left(600)
 
     def test_panel_pct_invalid_media_type(self):
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left({"nonexistent_type": 0.25})
+            settings_mod.set_panel_pct_left({"nonexistent_type": 250})
 
     def test_panel_pct_invalid_value(self):
         with pytest.raises(ValueError):
@@ -485,14 +480,24 @@ class TestSettingsModule:
 
     def test_panel_pct_clamped_on_read(self, isolated_settings):
         """Out-of-range values stored on disk are clamped when read."""
-        settings_mod.set_panel_pct_left({"audio": 0.5})
+        settings_mod.set_panel_pct_left({"audio": 300})
         # Manually write an out-of-range value to disk
         raw = json.loads(isolated_settings.read_text())
-        raw["panel_pct_left"]["audio"] = 0.99
+        raw["panel_pct_left"]["audio"] = 700
         isolated_settings.write_text(json.dumps(raw))
         settings_mod.reset()
         result = settings_mod.get_panel_pct_left()
-        assert result["audio"] == pytest.approx(0.80)
+        assert result["audio"] == 500
+
+    def test_panel_pct_legacy_percentage_replaced_with_default(self, isolated_settings):
+        """Legacy percentage values (< 2.0) are replaced with defaults on read."""
+        settings_mod.set_panel_pct_left({"audio": 300})
+        raw = json.loads(isolated_settings.read_text())
+        raw["panel_pct_left"]["audio"] = 0.25  # legacy percentage
+        isolated_settings.write_text(json.dumps(raw))
+        settings_mod.reset()
+        result = settings_mod.get_panel_pct_left()
+        assert result["audio"] == 260  # default for left
 
     def test_get_defaults(self):
         defaults = settings_mod.get_defaults()
@@ -522,10 +527,10 @@ class TestSettingsModule:
             assert v == "click"
         assert isinstance(defaults["panel_pct_left"], dict)
         for v in defaults["panel_pct_left"].values():
-            assert v is None
+            assert v == 260
         assert isinstance(defaults["panel_pct_right"], dict)
         for v in defaults["panel_pct_right"].values():
-            assert v is None
+            assert v == 300
         assert defaults["autoload_media_types"] == []
         assert defaults["autopilot_enabled"] is True
         assert defaults["autopilot_top_greens"] == 3
@@ -1092,41 +1097,36 @@ class TestSettingsAPI:
     # --- Panel percentage API tests ---
 
     def test_update_panel_pct_left_per_type(self, client):
-        res = client.put("/api/settings", json={"panel_pct_left": {"audio": 0.25, "image": 0.3}})
+        res = client.put("/api/settings", json={"panel_pct_left": {"audio": 200, "image": 350}})
         assert res.status_code == 200
         data = res.get_json()
-        assert data["panel_pct_left"]["audio"] == pytest.approx(0.25)
-        assert data["panel_pct_left"]["image"] == pytest.approx(0.3)
+        assert data["panel_pct_left"]["audio"] == 200
+        assert data["panel_pct_left"]["image"] == 350
 
         res2 = client.get("/api/settings")
-        assert res2.get_json()["panel_pct_left"]["audio"] == pytest.approx(0.25)
+        assert res2.get_json()["panel_pct_left"]["audio"] == 200
 
     def test_update_panel_pct_right_per_type(self, client):
-        res = client.put("/api/settings", json={"panel_pct_right": {"audio": 0.2, "video": 0.35}})
+        res = client.put("/api/settings", json={"panel_pct_right": {"audio": 250, "video": 400}})
         assert res.status_code == 200
         data = res.get_json()
-        assert data["panel_pct_right"]["audio"] == pytest.approx(0.2)
-        assert data["panel_pct_right"]["video"] == pytest.approx(0.35)
+        assert data["panel_pct_right"]["audio"] == 250
+        assert data["panel_pct_right"]["video"] == 400
 
     def test_update_panel_pct_left_scalar(self, client):
-        res = client.put("/api/settings", json={"panel_pct_left": 0.3})
+        res = client.put("/api/settings", json={"panel_pct_left": 300})
         assert res.status_code == 200
         for v in res.get_json()["panel_pct_left"].values():
-            assert v == pytest.approx(0.3)
-
-    def test_update_panel_pct_left_null(self, client):
-        res = client.put("/api/settings", json={"panel_pct_left": {"audio": None}})
-        assert res.status_code == 200
-        assert res.get_json()["panel_pct_left"]["audio"] is None
+            assert v == 300
 
     def test_update_panel_pct_left_invalid(self, client):
         res = client.put("/api/settings", json={"panel_pct_left": {"audio": "invalid"}})
         assert res.status_code == 400
 
     def test_update_panel_pct_left_out_of_range(self, client):
-        res = client.put("/api/settings", json={"panel_pct_left": 0.01})
+        res = client.put("/api/settings", json={"panel_pct_left": 100})
         assert res.status_code == 400
-        res = client.put("/api/settings", json={"panel_pct_left": 0.95})
+        res = client.put("/api/settings", json={"panel_pct_left": 600})
         assert res.status_code == 400
 
     def test_get_settings_includes_panel_pct(self, client):

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -133,8 +133,8 @@ def get_defaults() -> dict[str, Any]:
     result["focus_mode_left"] = {tid: _FOCUS_MODE_DEFAULTS["left"] for tid in valid_types}
     result["focus_mode_right"] = {tid: _FOCUS_MODE_DEFAULTS["right"] for tid in valid_types}
     # Expand panel percentage defaults to per-media-type dicts
-    result["panel_pct_left"] = {tid: _PANEL_PCT_DEFAULTS["left"] for tid in valid_types}
-    result["panel_pct_right"] = {tid: _PANEL_PCT_DEFAULTS["right"] for tid in valid_types}
+    result["panel_pct_left"] = {tid: _PANEL_PX_DEFAULTS["left"] for tid in valid_types}
+    result["panel_pct_right"] = {tid: _PANEL_PX_DEFAULTS["right"] for tid in valid_types}
     return result
 
 
@@ -248,8 +248,8 @@ del _key, _cast, _coerce, _g, _s
 _VIEW_MODE_DEFAULTS = {"left": "list", "right": "grid"}
 _GRID_COLUMNS_DEFAULT = 2
 _FOCUS_MODE_DEFAULTS = {"left": "click", "right": "click"}
-_PANEL_PCT_DEFAULTS: dict[str, float | None] = {"left": None, "right": None}
-VALID_PANEL_PCT = (0.05, 0.80)  # 5%–80% of window width
+_PANEL_PX_DEFAULTS: dict[str, int] = {"left": 260, "right": 300}
+VALID_PANEL_PX = (150, 500)  # pixel range matching frontend LEFT/RIGHT_MIN/MAX
 
 
 def _get_view_mode_dict(key: str) -> dict[str, str]:
@@ -477,86 +477,88 @@ def _set_focus_mode_dict(key: str, value: dict[str, str] | str) -> None:
 # -------------------------------------------------------------------
 
 
-def _get_panel_pct_dict(key: str) -> dict[str, float | None]:
-    """Return the per-media-type panel percentage dict for *key*.
+def _get_panel_pct_dict(key: str) -> dict[str, int]:
+    """Return the per-media-type panel width dict for *key*.
 
-    Values are floats in [0.05, 0.80] representing fraction of window width,
-    or ``None`` if not yet set (use default pixel widths).
+    Values are integers in [150, 500] representing pixel widths.
     """
     side = key.replace("panel_pct_", "")
-    default_val = _PANEL_PCT_DEFAULTS.get(side)
+    default_val = _PANEL_PX_DEFAULTS.get(side, 260)
     with _settings_lock:
         raw = _ensure_loaded().get(key, _DEFAULTS[key])
+    lo, hi = VALID_PANEL_PX
     if isinstance(raw, (int, float)):
-        # Legacy scalar — expand to all types
-        val = float(raw)
-        lo, hi = VALID_PANEL_PCT
-        val = max(lo, min(hi, val))
+        # Scalar — expand to all types
+        val = _coerce_panel_px(raw, default_val, lo, hi)
         return {tid: val for tid in _valid_media_types()}
     if isinstance(raw, dict):
-        result: dict[str, float | None] = {}
-        lo, hi = VALID_PANEL_PCT
+        result: dict[str, int] = {}
         for tid in _valid_media_types():
             v = raw.get(tid, default_val)
-            if v is None:
-                result[tid] = None
-            else:
-                try:
-                    fv = float(v)
-                    result[tid] = max(lo, min(hi, fv))
-                except (ValueError, TypeError):
-                    result[tid] = default_val
+            result[tid] = _coerce_panel_px(v, default_val, lo, hi)
         return result
     return {tid: default_val for tid in _valid_media_types()}
 
 
-def get_panel_pct_left() -> dict[str, float | None]:
-    """Return a dict mapping media type ID -> panel width fraction for the left panel."""
+def _coerce_panel_px(v: Any, default: int, lo: int, hi: int) -> int:
+    """Coerce a panel width value to a valid pixel integer.
+
+    Legacy percentage values (< 2.0) are replaced with *default*.
+    """
+    if v is None:
+        return default
+    try:
+        fv = float(v)
+    except (ValueError, TypeError):
+        return default
+    if fv < 2.0:
+        # Legacy percentage value — replace with default
+        return default
+    return max(lo, min(hi, int(round(fv))))
+
+
+def get_panel_pct_left() -> dict[str, int]:
+    """Return a dict mapping media type ID -> panel pixel width for the left panel."""
     return _get_panel_pct_dict("panel_pct_left")
 
 
-def get_panel_pct_right() -> dict[str, float | None]:
-    """Return a dict mapping media type ID -> panel width fraction for the right panel."""
+def get_panel_pct_right() -> dict[str, int]:
+    """Return a dict mapping media type ID -> panel pixel width for the right panel."""
     return _get_panel_pct_dict("panel_pct_right")
 
 
-def set_panel_pct_left(value: dict[str, float | None] | float | None) -> None:
-    """Set the left panel width fraction (per-media-type dict or scalar)."""
+def set_panel_pct_left(value: dict[str, int | float] | int | float) -> None:
+    """Set the left panel pixel width (per-media-type dict or scalar)."""
     _set_panel_pct_dict("panel_pct_left", value)
 
 
-def set_panel_pct_right(value: dict[str, float | None] | float | None) -> None:
-    """Set the right panel width fraction (per-media-type dict or scalar)."""
+def set_panel_pct_right(value: dict[str, int | float] | int | float) -> None:
+    """Set the right panel pixel width (per-media-type dict or scalar)."""
     _set_panel_pct_dict("panel_pct_right", value)
 
 
-def _set_panel_pct_dict(key: str, value: dict[str, float | None] | float | None) -> None:
-    """Persist the per-media-type panel percentage dict for *key*."""
+def _set_panel_pct_dict(key: str, value: dict[str, int | float] | int | float) -> None:
+    """Persist the per-media-type panel pixel width dict for *key*."""
     valid_types = _valid_media_types()
-    lo, hi = VALID_PANEL_PCT
-    if value is None:
-        value = {tid: None for tid in valid_types}
-    elif isinstance(value, (int, float)):
-        fv = float(value)
-        if not (lo <= fv <= hi):
-            raise ValueError(f"Invalid {key}: {fv!r} (must be between {lo} and {hi})")
-        value = {tid: fv for tid in valid_types}
+    lo, hi = VALID_PANEL_PX
+    if isinstance(value, (int, float)):
+        iv = int(round(float(value)))
+        if not (lo <= iv <= hi):
+            raise ValueError(f"Invalid {key}: {value!r} (must be between {lo} and {hi})")
+        value = {tid: iv for tid in valid_types}
     if not isinstance(value, dict):
-        raise ValueError(f"{key} must be a dict, number, or null")
-    coerced: dict[str, float | None] = {}
-    for tid, pct in value.items():
+        raise ValueError(f"{key} must be a dict or number")
+    coerced: dict[str, int] = {}
+    for tid, px in value.items():
         if tid not in valid_types:
             raise ValueError(f"Invalid media type: {tid!r}")
-        if pct is None:
-            coerced[tid] = None
-        else:
-            try:
-                fv = float(pct)
-            except (ValueError, TypeError):
-                raise ValueError(f"Invalid {key} value for {tid}: {pct!r}")
-            if not (lo <= fv <= hi):
-                raise ValueError(f"Invalid {key} value for {tid}: {fv!r} (must be between {lo} and {hi})")
-            coerced[tid] = fv
+        try:
+            iv = int(round(float(px)))
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid {key} value for {tid}: {px!r}")
+        if not (lo <= iv <= hi):
+            raise ValueError(f"Invalid {key} value for {tid}: {iv} (must be between {lo} and {hi})")
+        coerced[tid] = iv
     with _settings_lock:
         s = _ensure_loaded()
         s[key] = coerced


### PR DESCRIPTION
The panel_pct settings previously stored fractional percentages (0.0-1.0) but the GUI defaults were in pixels, causing a unit mismatch that required a special "—" display for the unset state. Now everything uses pixels (150-500 range), defaults match the GUI (260px left, 300px right), and legacy percentage values on disk are auto-replaced with defaults.

https://claude.ai/code/session_01Jq6teAhzrXUVAFHnPgHbhK