### PR TITLE
Refactor: extract shared helpers to reduce route handler duplication

### DIFF
--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 from flask import Blueprint, jsonify, request, send_file
 
 from vtsearch.config import EMBEDDINGS_DIR
-from vtsearch.routes.helpers import get_json_or_400
+from vtsearch.routes.helpers import get_json_or_400, get_request_field
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtsearch.datasets.loader import load_dataset_from_pickle, safe_pickle_load
 from vtsearch.datasets.registry import (
@@ -65,6 +65,19 @@ from vtsearch.routes.datasets_ui import datasets_ui_bp  # noqa: F401
 
 datasets_bp = Blueprint("datasets", __name__)
 
+
+def _normalize_media_type_param(value: str) -> str:
+    """Accept both ``type_id`` (``"image"``) and ``folder_import_name`` (``"images"``)."""
+    value = value.strip()
+    if not value:
+        return ""
+    from vtsearch.media import get_by_folder_name
+
+    try:
+        return get_by_folder_name(value).type_id
+    except KeyError:
+        return value  # assume it is already a type_id
+
 # Register the UI sub-blueprint.
 datasets_bp.register_blueprint(datasets_ui_bp)
 
@@ -91,16 +104,10 @@ def embedders_list():
             (e.g. ``"images"``).  When provided, only embedders whose
             ``media_type_id`` matches are returned.
     """
-    from vtsearch.media import all_embedders_dict, embedders_for_type, get_by_folder_name
+    from vtsearch.media import all_embedders_dict, embedders_for_type
 
-    media_type = request.args.get("media_type", "").strip()
+    media_type = _normalize_media_type_param(request.args.get("media_type", ""))
     if media_type:
-        # Accept both type_id ("image") and folder_import_name ("images").
-        try:
-            mt = get_by_folder_name(media_type)
-            media_type = mt.type_id
-        except KeyError:
-            pass  # assume it is already a type_id
         embedders = [e.to_dict() for e in embedders_for_type(media_type)]
     else:
         embedders = all_embedders_dict()
@@ -122,16 +129,10 @@ def clippers_list():
             (e.g. ``"images"``).  When provided, only clippers whose
             ``media_type`` matches are returned.
     """
-    from vtsearch.media import all_clippers_dict, clippers_for_type, get_by_folder_name
+    from vtsearch.media import all_clippers_dict, clippers_for_type
 
-    media_type = request.args.get("media_type", "").strip()
+    media_type = _normalize_media_type_param(request.args.get("media_type", ""))
     if media_type:
-        # Accept both type_id ("image") and folder_import_name ("images").
-        try:
-            mt = get_by_folder_name(media_type)
-            media_type = mt.type_id
-        except KeyError:
-            pass  # assume it is already a type_id
         clippers = [c.to_dict() for c in clippers_for_type(media_type)]
     else:
         clippers = all_clippers_dict()
@@ -157,24 +158,13 @@ def converters_list():
             ``source_type`` matches are returned.
     """
     from vtsearch.converters import list_converters, list_converters_for_source, list_converters_for_target
-    from vtsearch.media import get_by_folder_name
 
-    target = request.args.get("target", "").strip()
-    source = request.args.get("source", "").strip()
+    target = _normalize_media_type_param(request.args.get("target", ""))
+    source = _normalize_media_type_param(request.args.get("source", ""))
 
     if target:
-        try:
-            mt = get_by_folder_name(target)
-            target = mt.type_id
-        except KeyError:
-            pass
         converters = list_converters_for_target(target)
     elif source:
-        try:
-            mt = get_by_folder_name(source)
-            source = mt.type_id
-        except KeyError:
-            pass
         converters = list_converters_for_source(source)
     else:
         converters = list_converters()
@@ -350,13 +340,11 @@ def stage_import(importer_name: str):
                 return jsonify({"error": f"Missing required field: {f.key!r}"}), 400
             field_values[f.key] = body.get(f.key, f.default)
 
-    # Pass through the optional "converters" key.
-    if file_keys:
-        conv = request.form.get("converters", "")
-    else:
-        conv = (request.get_json(force=True) or {}).get("converters", "")
-    if conv:
-        field_values["converters"] = conv
+    # Pass through optional keys not declared as plugin fields.
+    for key in ("converters",):
+        val = get_request_field(key, bool(file_keys))
+        if val:
+            field_values[key] = val
 
     _stage_importer_in_background(importer, field_values)
     return jsonify({"ok": True, "message": "Staging started"})
@@ -430,30 +418,11 @@ def import_dataset(importer_name: str):
                 return jsonify({"error": f"Missing required field: {f.key!r}"}), 400
             field_values[f.key] = body.get(f.key, f.default)
 
-    # Pass through the optional "converters" key for importers that support
-    # converter selection (e.g. folder, http_archive).
-    if file_keys:
-        converters_val = request.form.get("converters", "")
-    else:
-        converters_val = (request.get_json(force=True) or {}).get("converters", "")
-    if converters_val:
-        field_values["converters"] = converters_val
-
-    # Pass through the optional "clipper" key for post-import clipping.
-    if file_keys:
-        clipper_val = request.form.get("clipper", "")
-    else:
-        clipper_val = (request.get_json(force=True) or {}).get("clipper", "")
-    if clipper_val:
-        field_values["clipper"] = clipper_val
-
-    # Pass through the optional "embedder" key for embedder selection.
-    if file_keys:
-        embedder_val = request.form.get("embedder", "")
-    else:
-        embedder_val = (request.get_json(force=True) or {}).get("embedder", "")
-    if embedder_val:
-        field_values["embedder"] = embedder_val
+    # Pass through optional keys not declared as plugin fields.
+    for key in ("converters", "clipper", "embedder"):
+        val = get_request_field(key, bool(file_keys))
+        if val:
+            field_values[key] = val
 
     _run_importer_in_background(importer, field_values)
     return jsonify({"ok": True, "message": "Loading started"})

--- a/vtsearch/routes/detectors_helpers.py
+++ b/vtsearch/routes/detectors_helpers.py
@@ -1,0 +1,93 @@
+"""Shared helpers for detector training routes.
+
+Consolidates the repeated train → calibrate → safe-threshold → serialise
+pipeline that appears in ``export_detector``, ``import_detector_labels``,
+``train_from_label_import``, and ``multi_find``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def validate_good_bad_split(y_list: list[float]) -> tuple[int, int]:
+    """Check that *y_list* contains at least one good and one bad label.
+
+    Returns ``(num_good, num_bad)``.
+    Raises ``ValueError`` when either count is zero.
+    """
+    num_good = sum(1 for y in y_list if y == 1.0)
+    num_bad = len(y_list) - num_good
+    if num_good == 0 or num_bad == 0:
+        raise ValueError("Need at least one good and one bad labeled example")
+    return num_good, num_bad
+
+
+def train_and_threshold(
+    X_list: list,
+    y_list: list[float],
+    snap: dict | None = None,
+) -> tuple[Any, float]:
+    """Train an MLP and compute a calibrated threshold.
+
+    This is the canonical training pipeline used by all detector routes:
+
+    1. Cross-calibration threshold (respects ``calibrate_count`` /
+       ``calibration_fraction`` settings).
+    2. Full-data model training (respects ``inclusion`` setting).
+    3. Optional safe-threshold blending when ``get_safe_thresholds()`` is
+       enabled and *snap* is provided.
+
+    Args:
+        X_list: Embedding vectors (list of numpy arrays).
+        y_list: Binary labels (1.0 = good, 0.0 = bad).
+        snap: Optional media snapshot for safe-threshold scoring.
+
+    Returns:
+        ``(model, threshold)``
+    """
+    import torch
+
+    from vtsearch.models import (
+        calculate_cross_calibration_threshold,
+        calculate_safe_threshold,
+        train_model,
+    )
+    from vtsearch.utils import (
+        get_calibrate_count,
+        get_calibration_fraction,
+        get_inclusion,
+        get_safe_thresholds,
+    )
+
+    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+    input_dim = X.shape[1]
+
+    threshold = calculate_cross_calibration_threshold(
+        X_list,
+        y_list,
+        input_dim,
+        get_inclusion(),
+        calibrate_count=get_calibrate_count(),
+        calibration_fraction=get_calibration_fraction(),
+    )
+
+    model = train_model(X, y, input_dim, get_inclusion())
+
+    if get_safe_thresholds() and snap:
+        all_ids = sorted(snap.keys())
+        all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
+        X_all = torch.tensor(all_embs, dtype=torch.float32)
+        with torch.no_grad():
+            all_scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
+        threshold = calculate_safe_threshold(threshold, all_scores, len(y_list))
+
+    return model, threshold
+
+
+def serialize_weights(model) -> dict[str, list]:
+    """Convert a PyTorch model's state dict to JSON-serialisable nested lists."""
+    return {key: value.tolist() for key, value in model.state_dict().items()}

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -19,6 +19,14 @@ from vtsearch.routes.detectors_crud import _build_extractor, _build_localizer
 
 detectors_scoring_bp = Blueprint("detectors_scoring", __name__)
 
+# Keys excluded from API responses (large binary/vector data).
+_HEAVYWEIGHT_KEYS = ("embedding", "media_bytes", "media_string")
+
+
+def _media_info_for_response(media: dict) -> dict:
+    """Return a copy of *media* without heavyweight fields."""
+    return {k: v for k, v in media.items() if k not in _HEAVYWEIGHT_KEYS}
+
 
 # ---------------------------------------------------------------------------
 # Detector scoring
@@ -119,10 +127,7 @@ def auto_detect():
             positive_hits = []
             negative_hits = []
             for cid, score in zip(all_ids, scores):
-                clip_info = snap[cid].copy()
-                clip_info.pop("embedding", None)
-                clip_info.pop("media_bytes", None)
-                clip_info.pop("media_string", None)
+                clip_info = _media_info_for_response(snap[cid])
                 clip_info["score"] = round(score, 4)
                 if score >= threshold:
                     positive_hits.append(clip_info)
@@ -164,6 +169,69 @@ def auto_detect():
 
 
 # ---------------------------------------------------------------------------
+# Shared helper for extractor / localizer processing
+# ---------------------------------------------------------------------------
+
+
+def _apply_processor_to_medias(processor, snap: dict, method: str, result_key: str) -> list[dict]:
+    """Run a processor (extractor or localizer) on all medias, returning hits.
+
+    Args:
+        processor: An extractor or localizer instance with *method*.
+        snap: A snapshot of the medias dict.
+        method: The method name to call (``"extract"`` or ``"localize"``).
+        result_key: The key to store results under (``"extractions"`` or ``"localizations"``).
+    """
+    func = getattr(processor, method)
+    results = []
+    for media_id in sorted(snap.keys()):
+        media = snap[media_id]
+        hits = func(media)
+        if hits:
+            info = _media_info_for_response(media)
+            info[result_key] = hits
+            results.append(info)
+    return results
+
+
+def _auto_run_processors(snap: dict, processors: dict, build_fn, type_key: str, method: str, result_key: str, name_key: str) -> dict:
+    """Run multiple processors in parallel via ThreadPoolExecutor.
+
+    Args:
+        snap: A snapshot of the medias dict.
+        processors: ``{name: data_dict}`` of registered processors.
+        build_fn: Factory ``(name, type_str, config) -> processor``.
+        type_key: Key in *data_dict* holding the processor type string.
+        method: Method name (``"extract"`` or ``"localize"``).
+        result_key: Key for per-media results (``"extractions"`` or ``"localizations"``).
+        name_key: Key for the processor name in the result dict.
+    """
+
+    def _run_single(proc_name, proc_data):
+        try:
+            proc = build_fn(proc_name, proc_data[type_key], proc_data["config"])
+        except Exception:
+            return None
+
+        hits = _apply_processor_to_medias(proc, snap, method, result_key)
+        return proc_name, {
+            name_key: proc_name,
+            "total_medias_with_hits": len(hits),
+            "results": hits,
+        }
+
+    results = {}
+    with ThreadPoolExecutor(max_workers=min(len(processors), 8)) as pool:
+        futures = [pool.submit(_run_single, name, data) for name, data in processors.items()]
+        for future in futures:
+            outcome = future.result()
+            if outcome is not None:
+                name, result = outcome
+                results[name] = result
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Extractor execution
 # ---------------------------------------------------------------------------
 
@@ -200,14 +268,7 @@ def run_extract():
             400,
         )
 
-    results = []
-    for media_id in sorted(snap.keys()):
-        media = snap[media_id]
-        extractions = extractor.extract(media)
-        if extractions:
-            clip_info = {k: v for k, v in media.items() if k not in ("embedding", "media_bytes", "media_string")}
-            clip_info["extractions"] = extractions
-            results.append(clip_info)
+    results = _apply_processor_to_medias(extractor, snap, "extract", "extractions")
 
     return jsonify(
         {
@@ -232,39 +293,7 @@ def auto_extract():
     if not extractors:
         return jsonify({"error": f"No autorun extractors found for media type: {media_type}"}), 400
 
-    sorted_media_ids = sorted(snap.keys())
-
-    def _run_single_extractor(ext_name, ext_data):
-        """Run a single extractor on all medias and return (name, result_dict) or None."""
-        try:
-            extractor = _build_extractor(ext_name, ext_data["extractor_type"], ext_data["config"])
-        except Exception:
-            return None
-
-        ext_results = []
-        for media_id in sorted_media_ids:
-            media = snap[media_id]
-            extractions = extractor.extract(media)
-            if extractions:
-                clip_info = {k: v for k, v in media.items() if k not in ("embedding", "media_bytes", "media_string")}
-                clip_info["extractions"] = extractions
-                ext_results.append(clip_info)
-
-        return ext_name, {
-            "extractor_name": ext_name,
-            "total_medias_with_hits": len(ext_results),
-            "results": ext_results,
-        }
-
-    # Run all extractors in parallel
-    results = {}
-    with ThreadPoolExecutor(max_workers=min(len(extractors), 8)) as pool:
-        futures = [pool.submit(_run_single_extractor, name, data) for name, data in extractors.items()]
-        for future in futures:
-            outcome = future.result()
-            if outcome is not None:
-                name, result = outcome
-                results[name] = result
+    results = _auto_run_processors(snap, extractors, _build_extractor, "extractor_type", "extract", "extractions", "extractor_name")
 
     return jsonify(
         {
@@ -312,14 +341,7 @@ def run_localize():
             400,
         )
 
-    results = []
-    for media_id in sorted(snap.keys()):
-        media = snap[media_id]
-        localizations = localizer.localize(media)
-        if localizations:
-            media_info = {k: v for k, v in media.items() if k not in ("embedding", "media_bytes", "media_string")}
-            media_info["localizations"] = localizations
-            results.append(media_info)
+    results = _apply_processor_to_medias(localizer, snap, "localize", "localizations")
 
     return jsonify(
         {
@@ -344,37 +366,7 @@ def auto_localize():
     if not localizers:
         return jsonify({"error": f"No autorun localizers found for media type: {media_type}"}), 400
 
-    sorted_media_ids = sorted(snap.keys())
-
-    def _run_single_localizer(loc_name, loc_data):
-        try:
-            localizer = _build_localizer(loc_name, loc_data["localizer_type"], loc_data["config"])
-        except Exception:
-            return None
-
-        loc_results = []
-        for media_id in sorted_media_ids:
-            media = snap[media_id]
-            localizations = localizer.localize(media)
-            if localizations:
-                media_info = {k: v for k, v in media.items() if k not in ("embedding", "media_bytes", "media_string")}
-                media_info["localizations"] = localizations
-                loc_results.append(media_info)
-
-        return loc_name, {
-            "localizer_name": loc_name,
-            "total_medias_with_hits": len(loc_results),
-            "results": loc_results,
-        }
-
-    results = {}
-    with ThreadPoolExecutor(max_workers=min(len(localizers), 8)) as pool:
-        futures = [pool.submit(_run_single_localizer, name, data) for name, data in localizers.items()]
-        for future in futures:
-            outcome = future.result()
-            if outcome is not None:
-                name, result = outcome
-                results[name] = result
+    results = _auto_run_processors(snap, localizers, _build_localizer, "localizer_type", "localize", "localizations", "localizer_name")
 
     return jsonify(
         {

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -9,21 +9,16 @@ import numpy as np
 from flask import Blueprint, jsonify, request
 
 from vtsearch.auth import get_current_user
-from vtsearch.routes.helpers import get_json_or_400
+from vtsearch.routes.detectors_helpers import serialize_weights, train_and_threshold, validate_good_bad_split
+from vtsearch.routes.helpers import extract_plugin_fields, get_json_or_400, validate_filepath_field
 from vtsearch.models import (
     build_model_from_weights,
-    calculate_cross_calibration_threshold,
-    calculate_safe_threshold,
     collect_media_origins,
-    train_model,
 )
 from vtsearch.utils import (
     add_autorun_detector,
     get_autorun_detectors,
-    get_calibrate_count,
-    get_calibration_fraction,
     get_inclusion,
-    get_safe_thresholds,
     snapshot_medias,
 )
 import vtsearch.utils.paths as _paths
@@ -41,8 +36,6 @@ detectors_training_bp = Blueprint("detectors_training", __name__)
 @detectors_training_bp.route("/api/detector/export", methods=["POST"])
 def export_detector():
     """Train MLP on current votes and export the model weights."""
-    import torch  # noqa: PLC0415
-
     from vtsearch.utils import bad_votes, good_votes
 
     if not good_votes or not bad_votes:
@@ -65,43 +58,13 @@ def export_detector():
     if not X_list:
         return jsonify({"error": "voted medias no longer loaded — reload the dataset"}), 400
 
-    num_good = sum(1 for y_val in y_list if y_val == 1.0)
-    num_bad = len(y_list) - num_good
-    if num_good == 0 or num_bad == 0:
-        return jsonify({"error": "need at least one good and one bad vote with loaded medias"}), 400
+    try:
+        validate_good_bad_split(y_list)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
-    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-
-    input_dim = X.shape[1]
-
-    # Calculate threshold using k-fold calibration with inclusion
-    threshold = calculate_cross_calibration_threshold(
-        X_list,
-        y_list,
-        input_dim,
-        get_inclusion(),
-        calibrate_count=get_calibrate_count(),
-        calibration_fraction=get_calibration_fraction(),
-    )
-
-    # Train final model on all data with inclusion
-    model = train_model(X, y, input_dim, get_inclusion())
-
-    # Apply safe thresholds blending if enabled
-    if get_safe_thresholds():
-        all_ids = sorted(snap.keys())
-        all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
-        X_all = torch.tensor(all_embs, dtype=torch.float32)
-        with torch.no_grad():
-            all_scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
-        threshold = calculate_safe_threshold(threshold, all_scores, len(X_list))
-
-    # Extract model weights
-    state_dict = model.state_dict()
-    weights = {}
-    for key, value in state_dict.items():
-        weights[key] = value.tolist()
+    model, threshold = train_and_threshold(X_list, y_list, snap=snap)
+    weights = serialize_weights(model)
 
     # Collect origin info so the client can forward it when saving
     good_origins = collect_media_origins(good_votes, snap)
@@ -307,44 +270,14 @@ def import_detector_labels():
                 400,
             )
 
-        num_good = sum(1 for y in y_list if y == 1.0)
-        num_bad = len(y_list) - num_good
-        if num_good == 0 or num_bad == 0:
-            return (
-                jsonify({"error": "Need at least one good and one bad labeled example"}),
-                400,
-            )
+        try:
+            validate_good_bad_split(y_list)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
-        import torch  # noqa: PLC0415
-
-        X = torch.tensor(np.array(X_list), dtype=torch.float32)
-        y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-        input_dim = X.shape[1]
-
-        threshold = calculate_cross_calibration_threshold(
-            X_list,
-            y_list,
-            input_dim,
-            get_inclusion(),
-            calibrate_count=get_calibrate_count(),
-            calibration_fraction=get_calibration_fraction(),
-        )
-        model = train_model(X, y, input_dim, get_inclusion())
-
-        # Apply safe thresholds blending if enabled
         snap = snapshot_medias()
-        if get_safe_thresholds() and snap:
-            all_ids = sorted(snap.keys())
-            all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
-            X_all = torch.tensor(all_embs, dtype=torch.float32)
-            with torch.no_grad():
-                all_scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
-            threshold = calculate_safe_threshold(threshold, all_scores, len(y_list))
-
-        state_dict = model.state_dict()
-        weights = {}
-        for key, value in state_dict.items():
-            weights[key] = value.tolist()
+        model, threshold = train_and_threshold(X_list, y_list, snap=snap)
+        weights = serialize_weights(model)
 
         final_media_type = detected_media_type or "audio"
         add_autorun_detector(name, final_media_type, weights, threshold, created_by=get_current_user())
@@ -387,32 +320,21 @@ def train_from_label_import(importer_name: str):
     if not snap:
         return jsonify({"error": "No medias loaded. Load a dataset first."}), 400
 
-    # Build field_values from multipart form data
-    has_file_fields = any(f.field_type == "file" for f in importer.fields)
-    field_values: dict = {}
+    field_values = extract_plugin_fields(importer)
 
+    # name comes from form data or JSON body (not a plugin field)
+    has_file_fields = any(f.field_type == "file" for f in importer.fields)
     if has_file_fields:
-        for f in importer.fields:
-            if f.field_type == "file":
-                field_values[f.key] = request.files.get(f.key)
-            else:
-                field_values[f.key] = request.form.get(f.key, f.default if f.default is not None else "")
         name = request.form.get("name", "").strip()
     else:
-        body = request.get_json(force=True, silent=True) or {}
-        for f in importer.fields:
-            field_values[f.key] = body.get(f.key, f.default if f.default is not None else "")
-        name = body.get("name", "").strip()
+        name = (request.get_json(force=True, silent=True) or {}).get("name", "").strip()
 
     if not name:
         return jsonify({"error": "name is required"}), 400
 
-    # Validate server file paths to prevent path traversal
-    if "filepath" in field_values and str(field_values["filepath"]).strip():
-        try:
-            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+    err = validate_filepath_field(field_values)
+    if err:
+        return err
 
     try:
         label_entries = importer.run(field_values)
@@ -468,24 +390,13 @@ def train_from_label_import(importer_name: str):
             400,
         )
 
-    num_good = sum(1 for y in y_list if y == 1.0)
-    num_bad = len(y_list) - num_good
-    if num_good == 0 or num_bad == 0:
-        return jsonify({"error": "Need at least one good and one bad labeled example"}), 400
+    try:
+        validate_good_bad_split(y_list)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
-    import torch  # noqa: PLC0415
-
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
-    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-    input_dim = X.shape[1]
-
-    threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim, get_inclusion())
-    model = train_model(X, y, input_dim, get_inclusion())
-
-    state_dict = model.state_dict()
-    weights = {}
-    for key, value in state_dict.items():
-        weights[key] = value.tolist()
+    model, threshold = train_and_threshold(X_list, y_list, snap=snap)
+    weights = serialize_weights(model)
 
     media_type = next(iter(snap.values())).get("type", "audio")
     good_origins = collect_media_origins(good_cids, snap)
@@ -727,12 +638,7 @@ def multi_find():
                             y_list = []
 
                     if X_list and any(v == 1.0 for v in y_list) and any(v == 0.0 for v in y_list):
-                        input_dim = X_list[0].shape[0]
-                        threshold = calculate_cross_calibration_threshold(X_list, y_list, input_dim, get_inclusion())
-
-                        X_train = torch.tensor(np.array(X_list), dtype=torch.float32)
-                        y_train = torch.tensor([[v] for v in y_list], dtype=torch.float32)
-                        model = train_model(X_train, y_train, input_dim, get_inclusion())
+                        model, threshold = train_and_threshold(X_list, y_list)
 
                         with torch.no_grad():
                             scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()

--- a/vtsearch/routes/exporters.py
+++ b/vtsearch/routes/exporters.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.exporters import get_exporter, list_exporters
-import vtsearch.utils.paths as _paths
+from vtsearch.routes.helpers import validate_filepath_field
 
 exporters_bp = Blueprint("exporters", __name__)
 
@@ -97,12 +97,9 @@ def run_export():
             400,
         )
 
-    # Validate server file paths to prevent path traversal
-    if "filepath" in field_values and str(field_values["filepath"]).strip():
-        try:
-            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+    err = validate_filepath_field(field_values)
+    if err:
+        return err
 
     try:
         outcome = exporter.export(results, field_values)

--- a/vtsearch/routes/helpers.py
+++ b/vtsearch/routes/helpers.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flask import jsonify, request
+
+if TYPE_CHECKING:
+    from vtsearch.utils.registry import PluginBase
+
+import vtsearch.utils.paths as _paths
 
 
 def get_json_or_400():
@@ -26,3 +33,89 @@ def get_json_or_400():
     if data is None:
         return jsonify({"error": "Invalid request body"}), 400
     return data
+
+
+# ---------------------------------------------------------------------------
+# Plugin field extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_plugin_fields(plugin: PluginBase) -> dict:
+    """Build a ``field_values`` dict from the current Flask request.
+
+    Handles both ``multipart/form-data`` (when the plugin has ``"file"``
+    fields) and JSON request bodies.  File fields are populated from
+    ``request.files``; non-file fields come from ``request.form`` or the
+    JSON body, falling back to the field's default value.
+    """
+    has_file_fields = any(f.field_type == "file" for f in plugin.fields)
+    field_values: dict = {}
+
+    if has_file_fields:
+        for f in plugin.fields:
+            if f.field_type == "file":
+                field_values[f.key] = request.files.get(f.key)
+            else:
+                field_values[f.key] = request.form.get(f.key, f.default if f.default is not None else "")
+    else:
+        body = request.get_json(force=True, silent=True) or {}
+        for f in plugin.fields:
+            field_values[f.key] = body.get(f.key, f.default if f.default is not None else "")
+
+    return field_values
+
+
+def validate_required_fields(plugin: PluginBase, field_values: dict) -> tuple | None:
+    """Check that all required non-file fields have non-empty values.
+
+    Returns a ``(response, 400)`` tuple on failure, or ``None`` if all
+    required fields are present.
+    """
+    missing = [
+        f.key
+        for f in plugin.fields
+        if f.required and f.field_type != "file" and not str(field_values.get(f.key, "")).strip()
+    ]
+    if missing:
+        return (
+            jsonify({"error": f"Missing required field(s): {missing}", "missing_fields": missing}),
+            400,
+        )
+    return None
+
+
+def validate_filepath_field(field_values: dict) -> tuple | None:
+    """Validate the ``filepath`` field against path traversal attacks.
+
+    Returns a ``(response, 400)`` tuple on failure, or ``None`` if the
+    path is valid or absent.
+    """
+    if "filepath" in field_values and str(field_values["filepath"]).strip():
+        try:
+            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+    return None
+
+
+def run_plugin_or_error(plugin: PluginBase, method: str, *args):
+    """Call a plugin method, catching ValueError and unexpected exceptions.
+
+    Returns ``(result, None)`` on success or ``(None, (response, status))``
+    on failure.
+    """
+    try:
+        result = getattr(plugin, method)(*args)
+    except ValueError as exc:
+        return None, (jsonify({"error": str(exc)}), 400)
+    except Exception as exc:  # pragma: no cover
+        verb = method.replace("_", " ").capitalize()
+        return None, (jsonify({"error": f"{verb} failed: {exc}"}), 500)
+    return result, None
+
+
+def get_request_field(key: str, has_file_fields: bool) -> str:
+    """Read a single pass-through parameter from form data or JSON body."""
+    if has_file_fields:
+        return request.form.get(key, "")
+    return (request.get_json(force=True, silent=True) or {}).get(key, "")

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from flask import Blueprint, jsonify, request
 
 from vtsearch.labels.importers import get_label_importer, list_label_importers
-import vtsearch.utils.paths as _paths
+from vtsearch.routes.helpers import extract_plugin_fields, run_plugin_or_error, validate_filepath_field, validate_required_fields
 from vtsearch.utils import (
     apply_label,
     build_media_lookup,
@@ -115,46 +115,19 @@ def run_label_import(importer_name: str):
             404,
         )
 
-    # Build field_values from either multipart or JSON body
-    has_file_fields = any(f.field_type == "file" for f in importer.fields)
-    field_values: dict = {}
+    field_values = extract_plugin_fields(importer)
 
-    if has_file_fields:
-        for f in importer.fields:
-            if f.field_type == "file":
-                field_values[f.key] = request.files.get(f.key)
-            else:
-                field_values[f.key] = request.form.get(f.key, f.default if f.default is not None else "")
-    else:
-        body = request.get_json(force=True, silent=True) or {}
-        for f in importer.fields:
-            field_values[f.key] = body.get(f.key, f.default if f.default is not None else "")
+    err = validate_required_fields(importer, field_values)
+    if err:
+        return err
 
-    # Validate required fields (skip file fields — presence checked by importer)
-    missing_fields = [
-        f.key
-        for f in importer.fields
-        if f.required and f.field_type != "file" and not str(field_values.get(f.key, "")).strip()
-    ]
-    if missing_fields:
-        return (
-            jsonify({"error": f"Missing required field(s): {missing_fields}", "missing_fields": missing_fields}),
-            400,
-        )
+    err = validate_filepath_field(field_values)
+    if err:
+        return err
 
-    # Validate server file paths to prevent path traversal
-    if "filepath" in field_values and str(field_values["filepath"]).strip():
-        try:
-            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
-
-    try:
-        label_entries = importer.run(field_values)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
-    except Exception as exc:  # pragma: no cover
-        return jsonify({"error": f"Import failed: {exc}"}), 500
+    label_entries, err = run_plugin_or_error(importer, "run", field_values)
+    if err:
+        return err
 
     if not isinstance(label_entries, list):
         return jsonify({"error": "Importer did not return a list of label dicts."}), 500

--- a/vtsearch/routes/processor_importers.py
+++ b/vtsearch/routes/processor_importers.py
@@ -24,8 +24,8 @@ from flask import Blueprint, jsonify, request
 
 from vtsearch.auth import get_current_user
 from vtsearch.processors.importers import get_processor_importer, list_processor_importers
+from vtsearch.routes.helpers import extract_plugin_fields, run_plugin_or_error, validate_filepath_field, validate_required_fields
 from vtsearch.utils import add_autorun_detector
-import vtsearch.utils.paths as _paths
 
 processor_importers_bp = Blueprint("processor_importers", __name__)
 
@@ -68,52 +68,29 @@ def run_processor_import(importer_name: str):
             404,
         )
 
-    # Build field_values from either multipart or JSON body
-    has_file_fields = any(f.field_type == "file" for f in importer.fields)
-    field_values: dict = {}
+    field_values = extract_plugin_fields(importer)
 
+    # name comes from form data or JSON body (not a plugin field)
+    has_file_fields = any(f.field_type == "file" for f in importer.fields)
     if has_file_fields:
-        for f in importer.fields:
-            if f.field_type == "file":
-                field_values[f.key] = request.files.get(f.key)
-            else:
-                field_values[f.key] = request.form.get(f.key, f.default if f.default is not None else "")
-        # name comes from form data
         name = request.form.get("name", "").strip()
     else:
-        body = request.get_json(force=True, silent=True) or {}
-        for f in importer.fields:
-            field_values[f.key] = body.get(f.key, f.default if f.default is not None else "")
-        name = body.get("name", "").strip()
+        name = (request.get_json(force=True, silent=True) or {}).get("name", "").strip()
 
     if not name:
         return jsonify({"error": "name is required"}), 400
 
-    # Validate required fields (skip file fields — presence checked by importer)
-    missing = [
-        f.key
-        for f in importer.fields
-        if f.required and f.field_type != "file" and not str(field_values.get(f.key, "")).strip()
-    ]
-    if missing:
-        return (
-            jsonify({"error": f"Missing required field(s): {missing}", "missing_fields": missing}),
-            400,
-        )
+    err = validate_required_fields(importer, field_values)
+    if err:
+        return err
 
-    # Validate server file paths to prevent path traversal
-    if "filepath" in field_values and str(field_values["filepath"]).strip():
-        try:
-            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+    err = validate_filepath_field(field_values)
+    if err:
+        return err
 
-    try:
-        result = importer.run(field_values)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
-    except Exception as exc:  # pragma: no cover
-        return jsonify({"error": f"Import failed: {exc}"}), 500
+    result, err = run_plugin_or_error(importer, "run", field_values)
+    if err:
+        return err
 
     if not isinstance(result, dict):
         return jsonify({"error": "Importer did not return a dict."}), 500


### PR DESCRIPTION
- Extract plugin field extraction, validation, and filepath checks into shared helpers in routes/helpers.py (used by label_importers, processor_importers, detectors_training)
- Extract training pipeline (train_and_threshold, serialize_weights, validate_good_bad_split) into routes/detectors_helpers.py — fixes train_from_label_import missing calibrate_count/calibration_fraction/ safe_thresholds settings that other training routes respected
- Extract _media_info_for_response and _apply_processor_to_medias / _auto_run_processors in detectors_scoring.py to deduplicate extractor and localizer processing loops
- Deduplicate optional param pass-through (converters/clipper/embedder) in datasets.py using get_request_field helper
- Extract _normalize_media_type_param to deduplicate embedders/clippers/ converters list endpoints

https://claude.ai/code/session_01Dep3h9rzkpq9766y6KZxdP