### PR TITLE
Improve progress bar accuracy across dataset load and sort flows

### DIFF
--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -596,20 +596,20 @@ def load_registered_dataset(dataset_id: str):
     if not pkl_path or not Path(pkl_path).is_file():
         return jsonify({"error": f"Saved dataset file not found: {pkl_path}"}), 404
 
-    _LOAD_STEPS = 4  # read pickle, process items, build diversity index, warm up embedder
+    _LOAD_STEPS = 3  # read pickle + process items, build diversity index, warm up embedder
 
     # Set progress to "loading" synchronously so the frontend never sees a
     # stale "idle" status from a previous operation before the thread starts.
     update_progress("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):
-        update_progress(status, message, current, total, step=2, total_steps=_LOAD_STEPS)
+        update_progress(status, message, current, total, step=1, total_steps=_LOAD_STEPS)
 
     def load_task():
         try:
             update_progress(
                 "loading",
-                "Clearing previous dataset…",
+                "Preparing…",
                 0,
                 0,
                 step=1,
@@ -624,7 +624,7 @@ def load_registered_dataset(dataset_id: str):
                 "Removing duplicates…",
                 0,
                 0,
-                step=3,
+                step=2,
                 total_steps=_LOAD_STEPS,
             )
             collapse_duplicates(medias)
@@ -635,7 +635,7 @@ def load_registered_dataset(dataset_id: str):
                     "Building diversity index…",
                     current=current,
                     total=total,
-                    step=3,
+                    step=2,
                     total_steps=_LOAD_STEPS,
                 )
 
@@ -645,7 +645,7 @@ def load_registered_dataset(dataset_id: str):
             # Update item count and dupe count in case they changed
             _reg_update(dataset_id, num_items=len(medias), num_dupes=get_dupe_count())
             set_dataset_display_name(entry.get("name", ""))
-            _load_embedder_for_clips()
+            _load_embedder_for_clips(step=_LOAD_STEPS, total_steps=_LOAD_STEPS)
         except MemoryError:
             medias.clear()
             gc.collect()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -90,7 +90,7 @@ def _get_embedder_for_clips():
     return avail[0] if avail else None
 
 
-def _load_embedder_for_clips() -> None:
+def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = None) -> None:
     """Eagerly load the embedder for the current dataset's media type.
 
     Called right after a dataset finishes loading so the first text sort
@@ -104,7 +104,18 @@ def _load_embedder_for_clips() -> None:
     media branch, leaving the text branch cold.  Without this warmup the
     first user-initiated text sort would stall on PyTorch's lazy
     initialisation for that branch.
+
+    Args:
+        step: The step number to report for this phase.  Defaults to
+            ``_TOTAL_LOAD_STEPS`` (the last step of the demo/importer flow).
+        total_steps: The total number of steps to report.  Defaults to
+            ``_TOTAL_LOAD_STEPS``.
     """
+    if step is None:
+        step = _TOTAL_LOAD_STEPS
+    if total_steps is None:
+        total_steps = _TOTAL_LOAD_STEPS
+
     from vtsearch.media.base import intercept_tqdm_progress, intercept_weight_loading_progress
 
     emb = _get_embedder_for_clips()
@@ -113,7 +124,7 @@ def _load_embedder_for_clips() -> None:
         return
 
     def _model_load_progress(status, message, current, total):
-        update_progress(status, message, current, total, step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS)
+        update_progress(status, message, current, total, step=step, total_steps=total_steps)
 
     with intercept_tqdm_progress(_model_load_progress), intercept_weight_loading_progress(
         _model_load_progress, "Loading model weights…"
@@ -123,7 +134,7 @@ def _load_embedder_for_clips() -> None:
     # Warm up the text encoder so the first text sort is instant.
     update_progress(
         "loading", "Warming up text encoder…", 0, 0,
-        step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,
+        step=step, total_steps=total_steps,
     )
     try:
         emb.embed_text("warmup")

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -157,10 +157,10 @@ def sort_clips():
     first = next(iter(snap.values()))
     media_type = first.get("type", "audio")
     embedder_name = first.get("embedder", "")
-    total_steps = 1 + len(snap) + 1
+    total_steps = 3  # load embedder, embed query, compute similarities
 
     _load_embedder_with_progress(media_type, total_steps)
-    update_sort_progress("sorting", "Embedding text query…", 0, total_steps)
+    update_sort_progress("sorting", "Embedding text query…", 1, total_steps)
 
     from vtsearch import settings
 
@@ -170,7 +170,7 @@ def sort_clips():
         update_sort_progress("idle")
         return jsonify({"error": f"Could not embed text for media type {media_type}"}), 500
 
-    update_sort_progress("sorting", "Computing similarities…", 1, total_steps)
+    update_sort_progress("sorting", "Computing similarities…", 2, total_steps)
     results, threshold = _cosine_sort(text_vec)
     update_sort_progress("idle")
     return jsonify({"results": results, "threshold": threshold})


### PR DESCRIPTION
- Sort progress: fix total_steps from `1 + len(medias) + 1` (which made the bar stuck near 0% for any real dataset) to 3 (load embedder, embed query, compute similarities) with proper current increments.

- Pickle registry load: reduce from 4 steps to 3 by merging the instant "Clearing previous dataset" into the first real step (read + process). Steps are now: (1) read pickle + process items, (2) dedup + diversity index, (3) warm up embedder.

- Parameterize _load_embedder_for_clips(step, total_steps) so both the demo/importer flow (4 steps) and pickle load flow (3 steps) report the correct final step number instead of hardcoding _TOTAL_LOAD_STEPS.

https://claude.ai/code/session_01WjNgMMQARipgWtog72VGzQ