### PR TITLE
Add configurable parameters to MediaClippers

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -171,13 +171,43 @@
           <select
             id="field-clipper"
             class="form-select"
-            [(ngModel)]="selectedClipper"
+            [ngModel]="selectedClipper"
+            (ngModelChange)="onClipperChange($event)"
           >
             @for (clipper of availableClippers; track clipper.name) {
               <option [value]="clipper.name">{{ clipper.name }}</option>
             }
           </select>
         </div>
+        @if (selectedClipperParams.length > 0) {
+          <div class="clipper-params">
+            @for (param of selectedClipperParams; track param.key) {
+              <div class="form-group">
+                <label class="form-label" [for]="'clipper-param-' + param.key">{{ param.label }}</label>
+                @if (param.type === 'number') {
+                  <input
+                    [id]="'clipper-param-' + param.key"
+                    type="number"
+                    class="form-input"
+                    [min]="param.min"
+                    [max]="param.max"
+                    [step]="param.step"
+                    [ngModel]="clipperParamValues[param.key]"
+                    (ngModelChange)="clipperParamValues[param.key] = $event"
+                  />
+                } @else {
+                  <input
+                    [id]="'clipper-param-' + param.key"
+                    type="text"
+                    class="form-input"
+                    [ngModel]="clipperParamValues[param.key]"
+                    (ngModelChange)="clipperParamValues[param.key] = $event"
+                  />
+                }
+              </div>
+            }
+          </div>
+        }
       }
 
       @if (error) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -87,6 +87,16 @@
   padding: 16px;
 }
 
+// --- Clipper parameters ---
+
+.clipper-params {
+  padding-left: 16px;
+  border-left: 2px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 // --- Demo picker ---
 
 .demo-picker {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
-import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo, EmbedderInfo } from '../../../models/api.models';
+import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 
 type ModalView = 'picker' | 'form' | 'demo';
 
@@ -30,6 +30,7 @@ export class DatasetImporterModalComponent implements OnInit {
   // Clipper state
   availableClippers: ClipperInfo[] = [];
   selectedClipper = '';
+  clipperParamValues: Record<string, number | string> = {};
 
   // Embedder state
   allEmbedders: EmbedderInfo[] = [];
@@ -76,6 +77,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.error = '';
     this.selectedClipper = '';
     this.availableClippers = [];
+    this.clipperParamValues = {};
     this.selectedEmbedder = '';
     this.availableEmbedders = [];
 
@@ -116,8 +118,26 @@ export class DatasetImporterModalComponent implements OnInit {
         this.availableClippers = clippers;
         // Default to the first clipper (the default/null clipper)
         this.selectedClipper = clippers.length > 0 ? clippers[0].name : '';
+        this.resetClipperParams();
       },
     });
+  }
+
+  onClipperChange(clipperName: string): void {
+    this.selectedClipper = clipperName;
+    this.resetClipperParams();
+  }
+
+  get selectedClipperParams(): ClipperParameter[] {
+    const clipper = this.availableClippers.find((c) => c.name === this.selectedClipper);
+    return clipper?.parameters || [];
+  }
+
+  private resetClipperParams(): void {
+    this.clipperParamValues = {};
+    for (const param of this.selectedClipperParams) {
+      this.clipperParamValues[param.key] = param.default;
+    }
   }
 
   private loadEmbedders(mediaType: string): void {
@@ -361,6 +381,9 @@ export class DatasetImporterModalComponent implements OnInit {
     const submitValues = { ...this.formValues };
     if (this.selectedClipper) {
       submitValues['clipper'] = this.selectedClipper;
+      if (this.selectedClipperParams.length > 0 && Object.keys(this.clipperParamValues).length > 0) {
+        submitValues['clipper_params'] = { ...this.clipperParamValues };
+      }
     }
     if (this.selectedEmbedder) {
       submitValues['embedder'] = this.selectedEmbedder;

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -336,9 +336,20 @@ export interface ProcessorImporterInfo {
 
 // --- Clippers ---
 
+export interface ClipperParameter {
+  key: string;
+  label: string;
+  type: 'number' | 'string';
+  default: number | string;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
 export interface ClipperInfo {
   name: string;
   media_type: string;
+  parameters?: ClipperParameter[];
   [key: string]: unknown;
 }
 

--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -830,3 +830,206 @@ class TestDatasetRegistryClipperColumn:
         data = resp.get_json()
         ds = data["datasets"][0]
         assert ds["clipper"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Clipper parameters
+# ---------------------------------------------------------------------------
+
+
+class TestClipperParameters:
+    """Test the parameters property and with_params method on clippers."""
+
+    def test_default_clipper_has_no_parameters(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        assert c.parameters == []
+
+    def test_default_clipper_with_params_returns_self(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        assert c.with_params({"anything": 42}) is c
+
+    def test_sound_tiling_parameters(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        params = c.parameters
+        assert len(params) == 1
+        assert params[0]["key"] == "duration"
+        assert params[0]["type"] == "number"
+        assert params[0]["default"] == 2.0
+        assert params[0]["min"] == 0.1
+
+    def test_sound_tiling_with_params(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        c2 = c.with_params({"duration": 5.0})
+        assert isinstance(c2, SoundTilingClipper)
+        assert c2.duration == 5.0
+        assert c2 is not c
+        assert c.duration == 2.0  # original unchanged
+
+    def test_sound_tiling_with_params_ignores_unknown_keys(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        c2 = c.with_params({"unknown_key": 99})
+        assert c2.duration == 2.0  # falls back to current value
+
+    def test_video_tiling_parameters(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        c = VideoTilingClipper(2.0)
+        params = c.parameters
+        assert len(params) == 1
+        assert params[0]["key"] == "duration"
+        assert params[0]["default"] == 2.0
+
+    def test_video_tiling_with_params(self):
+        from vtsearch.media.video.clipper import VideoTilingClipper
+
+        c = VideoTilingClipper(2.0)
+        c2 = c.with_params({"duration": 10.0})
+        assert isinstance(c2, VideoTilingClipper)
+        assert c2.duration == 10.0
+        assert c.duration == 2.0
+
+    def test_video_scene_parameters(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        c = VideoSceneClipper()
+        params = c.parameters
+        assert len(params) == 2
+        keys = [p["key"] for p in params]
+        assert "threshold" in keys
+        assert "min_scene_duration" in keys
+        # Check defaults match constructor defaults
+        thresh_param = next(p for p in params if p["key"] == "threshold")
+        assert thresh_param["default"] == 0.3
+        min_dur_param = next(p for p in params if p["key"] == "min_scene_duration")
+        assert min_dur_param["default"] == 1.0
+
+    def test_video_scene_with_params(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        c = VideoSceneClipper()
+        c2 = c.with_params({"threshold": 0.5, "min_scene_duration": 2.5})
+        assert isinstance(c2, VideoSceneClipper)
+        assert c2.threshold == 0.5
+        assert c2.min_scene_duration == 2.5
+        assert c.threshold == 0.3  # original unchanged
+
+    def test_video_scene_with_partial_params(self):
+        from vtsearch.media.video.clipper import VideoSceneClipper
+
+        c = VideoSceneClipper(threshold=0.4, min_scene_duration=1.5)
+        c2 = c.with_params({"threshold": 0.6})
+        assert c2.threshold == 0.6
+        assert c2.min_scene_duration == 1.5  # kept from original
+
+    def test_to_dict_includes_parameters(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        d = c.to_dict()
+        assert "parameters" in d
+        assert len(d["parameters"]) == 1
+        assert d["parameters"][0]["key"] == "duration"
+
+    def test_to_dict_no_parameters_for_default_clipper(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        d = c.to_dict()
+        assert "parameters" not in d
+
+
+class TestClipperParametersApi:
+    """Test that the /api/clippers endpoint returns parameter info."""
+
+    def test_clippers_api_includes_parameters(self, client):
+        resp = client.get("/api/clippers?media_type=audio")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        clippers = data["clippers"]
+        # sound_tiling should have parameters
+        tiling = next(c for c in clippers if c["name"].startswith("sound_tiling"))
+        assert "parameters" in tiling
+        assert len(tiling["parameters"]) == 1
+        assert tiling["parameters"][0]["key"] == "duration"
+
+    def test_default_clipper_has_no_parameters_in_api(self, client):
+        resp = client.get("/api/clippers?media_type=audio")
+        data = resp.get_json()
+        default = next(c for c in data["clippers"] if c["name"] == "sound_default")
+        assert "parameters" not in default
+
+    def test_video_scene_clipper_in_registry(self, client):
+        resp = client.get("/api/clippers?media_type=video")
+        data = resp.get_json()
+        names = [c["name"] for c in data["clippers"]]
+        assert "video_scene" in names
+        scene = next(c for c in data["clippers"] if c["name"] == "video_scene")
+        assert "parameters" in scene
+        keys = [p["key"] for p in scene["parameters"]]
+        assert "threshold" in keys
+        assert "min_scene_duration" in keys
+
+
+class TestApplyClipperWithParams:
+    """Test _apply_clipper with custom clipper_params."""
+
+    def test_apply_clipper_with_custom_duration(self):
+        from vtsearch.audio import generate_wav
+        from vtsearch.routes.datasets_loading import _apply_clipper
+
+        # Generate a 10s audio clip
+        wav = generate_wav(440, 10.0)
+        media = {
+            "id": 1,
+            "type": "audio",
+            "media_bytes": wav,
+            "duration": 10.0,
+            "origin": {"importer": "test", "params": {}},
+        }
+        clips = {1: media}
+        # With default 2s duration: ceil(10/2) = 5 tiles
+        _apply_clipper(clips, "sound_tiling_2.0s")
+        assert len(clips) == 5
+
+    def test_apply_clipper_with_overridden_duration(self):
+        from vtsearch.audio import generate_wav
+        from vtsearch.routes.datasets_loading import _apply_clipper
+
+        wav = generate_wav(440, 10.0)
+        media = {
+            "id": 1,
+            "type": "audio",
+            "media_bytes": wav,
+            "duration": 10.0,
+            "origin": {"importer": "test", "params": {}},
+        }
+        clips = {1: media}
+        # Override to 5s duration: ceil(10/5) = 2 tiles
+        _apply_clipper(clips, "sound_tiling_2.0s", {"duration": 5.0})
+        assert len(clips) == 2
+
+    def test_apply_clipper_params_none_uses_defaults(self):
+        from vtsearch.audio import generate_wav
+        from vtsearch.routes.datasets_loading import _apply_clipper
+
+        wav = generate_wav(440, 10.0)
+        media = {
+            "id": 1,
+            "type": "audio",
+            "media_bytes": wav,
+            "duration": 10.0,
+            "origin": {"importer": "test", "params": {}},
+        }
+        clips = {1: media}
+        _apply_clipper(clips, "sound_tiling_2.0s", None)
+        assert len(clips) == 5  # default 2s → 5 tiles

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -258,7 +258,7 @@ from vtsearch.media.audio.clipper import SoundDefaultClipper, SoundTilingClipper
 from vtsearch.media.document.clipper import DocumentDefaultClipper  # noqa: E402
 from vtsearch.media.image.clipper import ImageDefaultClipper, ImageTilingClipper  # noqa: E402
 from vtsearch.media.text.clipper import TextDefaultClipper, TextSentenceClipper  # noqa: E402
-from vtsearch.media.video.clipper import VideoDefaultClipper, VideoTilingClipper  # noqa: E402
+from vtsearch.media.video.clipper import VideoDefaultClipper, VideoSceneClipper, VideoTilingClipper  # noqa: E402
 
 register_clipper(SoundDefaultClipper())
 register_clipper(SoundTilingClipper(2.0))
@@ -268,6 +268,7 @@ register_clipper(TextDefaultClipper())
 register_clipper(TextSentenceClipper())
 register_clipper(VideoDefaultClipper())
 register_clipper(VideoTilingClipper(2.0))
+register_clipper(VideoSceneClipper())
 register_clipper(DocumentDefaultClipper())
 
 

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -119,6 +119,24 @@ class SoundTilingClipper(MediaClipper):
             results.append(tile)
         return results
 
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "duration",
+                "label": "Clip length (seconds)",
+                "type": "number",
+                "default": self._duration,
+                "min": 0.1,
+                "max": 300,
+                "step": 0.1,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "SoundTilingClipper":
+        duration = float(params.get("duration", self._duration))
+        return SoundTilingClipper(duration)
+
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         d["duration"] = self._duration

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -1019,6 +1019,37 @@ class MediaClipper(ABC):
         """The media ``type_id`` this clipper operates on (e.g. ``"audio"``)."""
 
     # ------------------------------------------------------------------
+    # Parameters
+    # ------------------------------------------------------------------
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        """Return a list of user-configurable parameter descriptors.
+
+        Each descriptor is a dict with keys:
+
+        * ``key`` — parameter name (used in :meth:`with_params`).
+        * ``label`` — human-readable label for the UI.
+        * ``type`` — ``"number"`` or ``"string"``.
+        * ``default`` — current/default value.
+        * ``min`` / ``max`` / ``step`` — optional numeric constraints.
+
+        Clippers with no configurable parameters return ``[]`` (the default).
+        """
+        return []
+
+    def with_params(self, params: dict[str, Any]) -> "MediaClipper":
+        """Return a **new** clipper of the same type with overridden parameters.
+
+        *params* is a dict mapping parameter keys (as declared by
+        :attr:`parameters`) to their new values.  Unknown keys are ignored.
+
+        The default implementation returns ``self`` unchanged (suitable for
+        clippers that have no parameters).
+        """
+        return self
+
+    # ------------------------------------------------------------------
     # Clipping
     # ------------------------------------------------------------------
 
@@ -1042,7 +1073,11 @@ class MediaClipper(ABC):
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serialisable summary of this clipper's metadata."""
-        return {
+        d: dict[str, Any] = {
             "name": self.name,
             "media_type": self.media_type,
         }
+        params = self.parameters
+        if params:
+            d["parameters"] = params
+        return d

--- a/vtsearch/media/video/clipper.py
+++ b/vtsearch/media/video/clipper.py
@@ -82,6 +82,24 @@ class VideoTilingClipper(MediaClipper):
             results.append(tile)
         return results
 
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "duration",
+                "label": "Clip length (seconds)",
+                "type": "number",
+                "default": self._duration,
+                "min": 0.1,
+                "max": 300,
+                "step": 0.1,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "VideoTilingClipper":
+        duration = float(params.get("duration", self._duration))
+        return VideoTilingClipper(duration)
+
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         d["duration"] = self._duration
@@ -269,6 +287,34 @@ class VideoSceneClipper(MediaClipper):
         finally:
             if tmp_file is not None:
                 os.unlink(tmp_file.name)
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "threshold",
+                "label": "Sensitivity (0\u20131)",
+                "type": "number",
+                "default": self._threshold,
+                "min": 0,
+                "max": 1,
+                "step": 0.05,
+            },
+            {
+                "key": "min_scene_duration",
+                "label": "Min scene length (seconds)",
+                "type": "number",
+                "default": self._min_scene_duration,
+                "min": 0.1,
+                "max": 60,
+                "step": 0.1,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "VideoSceneClipper":
+        threshold = float(params.get("threshold", self._threshold))
+        min_scene_duration = float(params.get("min_scene_duration", self._min_scene_duration))
+        return VideoSceneClipper(threshold=threshold, min_scene_duration=min_scene_duration)
 
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -172,12 +172,15 @@ def _origin_to_str(origin: dict | None) -> str:
     return importer_name
 
 
-def _apply_clipper(clips_dict: dict, clipper_name: str) -> None:
+def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | None = None) -> None:
     """Apply a clipper to all medias in *clips_dict*, replacing them in-place.
 
     Each media is run through the clipper's ``clip()`` method.  The resulting
     clips are assigned fresh sequential IDs and their origins are annotated
     with the clipper name and clip index.
+
+    If *clipper_params* is provided, the registered clipper is customised via
+    its :meth:`~MediaClipper.with_params` method before clipping.
     """
     if not clipper_name:
         return
@@ -187,6 +190,9 @@ def _apply_clipper(clips_dict: dict, clipper_name: str) -> None:
         clipper = get_clipper(clipper_name)
     except KeyError:
         return
+
+    if clipper_params:
+        clipper = clipper.with_params(clipper_params)
 
     all_clipped: list[dict] = []
     for media in list(clips_dict.values()):
@@ -268,7 +274,8 @@ def _auto_register_dataset(
 
 
 def _run_origin_load_in_background(
-    load_fn, origin: dict, *, name: str = "", clipper: str = "", embedder: str = "",
+    load_fn, origin: dict, *, name: str = "", clipper: str = "",
+    clipper_params: dict | None = None, embedder: str = "",
     created_by: str = "",
 ) -> None:
     """Run a dataset load in a background thread with standard error handling.
@@ -289,6 +296,9 @@ def _run_origin_load_in_background(
     clipper:
         Name of the clipper to apply after loading.  Empty string means
         no clipping.
+    clipper_params:
+        Optional dict of parameter overrides for the clipper (e.g.
+        ``{"duration": 5.0}``).
     embedder:
         Name of the embedder used.  When empty, derived from the medias
         at registration time.
@@ -320,7 +330,7 @@ def _run_origin_load_in_background(
             )
             _set_clip_origins(medias, origin)
             if clipper:
-                _apply_clipper(medias, clipper)
+                _apply_clipper(medias, clipper, clipper_params)
             collapse_duplicates(medias)
             def _diversity_progress(current: int, total: int) -> None:
                 update_progress(
@@ -372,6 +382,7 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
     created_by = get_current_user()
     origin = importer.build_origin(field_values)
     clipper_name = field_values.pop("clipper", "")
+    clipper_params = field_values.pop("clipper_params", None)
     embedder_name = field_values.get("embedder", "")
 
     def _load():
@@ -397,6 +408,7 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
         origin,
         name=importer.resolve_display_name(field_values),
         clipper=clipper_name,
+        clipper_params=clipper_params,
         embedder=embedder_name,
         created_by=created_by,
     )


### PR DESCRIPTION
MediaClippers now expose a `parameters` property describing their user-configurable settings and a `with_params()` method to create customised instances. The frontend shows number inputs for these parameters when a clipper is selected during dataset import.

- SoundTilingClipper / VideoTilingClipper: clip length (seconds)
- VideoSceneClipper: sensitivity threshold and min scene duration
- VideoSceneClipper is now registered in the default clipper registry
- _apply_clipper accepts optional clipper_params dict for overrides
- Frontend displays parameter controls nested under the clipper dropdown

https://claude.ai/code/session_015UnmG9Q5awsqRhQrrCZsrH