### PR TITLE
Refactor sample rate configuration for clarity and specificity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,8 @@ _patch_embed_audio.start()
 import app as app_module
 
 # Import refactored modules and make them accessible through app_module
-from vtsearch.config import NUM_MEDIAS, SAMPLE_RATE
+from vtsearch.audio.generator import GENERATOR_SAMPLE_RATE
+from vtsearch.medias import NUM_MEDIAS
 from vtsearch.audio import generate_wav
 from vtsearch.models import initialize_models, train_and_score
 from vtsearch.models.progress import clear_progress_cache
@@ -177,7 +178,7 @@ from vtsearch.utils import (
 
 # Attach to app_module for backward compatibility with existing tests
 app_module.NUM_MEDIAS = NUM_MEDIAS
-app_module.SAMPLE_RATE = SAMPLE_RATE
+app_module.SAMPLE_RATE = GENERATOR_SAMPLE_RATE
 app_module.generate_wav = generate_wav
 app_module.train_and_score = train_and_score
 app_module.medias = medias

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -495,14 +495,14 @@ class TestCLAPEmbeddingGPU:
         import soundfile as sf
         from transformers import ClapModel, ClapProcessor
 
-        from vtsearch.config import CLAP_MODEL_ID, MODELS_CACHE_DIR, SAMPLE_RATE
+        from vtsearch.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
 
         # Generate a short sine wave
         duration = 1.0
-        t = np.linspace(0, duration, int(SAMPLE_RATE * duration), dtype=np.float32)
+        t = np.linspace(0, duration, int(CLAP_SAMPLE_RATE * duration), dtype=np.float32)
         audio = 0.5 * np.sin(2 * np.pi * 440 * t)
         wav_path = tmp_path / "test.wav"
-        sf.write(str(wav_path), audio, SAMPLE_RATE)
+        sf.write(str(wav_path), audio, CLAP_SAMPLE_RATE)
 
         cache_dir = str(MODELS_CACHE_DIR)
         model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir).to(device)
@@ -510,7 +510,7 @@ class TestCLAPEmbeddingGPU:
 
         inputs = processor(
             audio=audio,
-            sampling_rate=SAMPLE_RATE,
+            sampling_rate=CLAP_SAMPLE_RATE,
             return_tensors="pt",
             padding="max_length",
             max_length=480000,

--- a/vtsearch/audio/generator.py
+++ b/vtsearch/audio/generator.py
@@ -5,15 +5,14 @@ import math
 import struct
 import wave
 
-from vtsearch.config import SAMPLE_RATE
+GENERATOR_SAMPLE_RATE = 48000
 
 
 def generate_wav(frequency: float, duration: float) -> bytes:
     """Generate a mono PCM WAV file containing a pure sine-wave tone.
 
-    Produces a single-channel, 16-bit signed PCM WAV at the sample rate
-    defined by ``SAMPLE_RATE`` (typically 48 000 Hz). The amplitude is fixed
-    at 50 % of the maximum value (32767) to avoid clipping.
+    Produces a single-channel, 16-bit signed PCM WAV at 48 kHz. The amplitude
+    is fixed at 50 % of the maximum value (32767) to avoid clipping.
 
     Args:
         frequency: Frequency of the sine wave in Hz (e.g. 440.0 for concert A).
@@ -23,15 +22,15 @@ def generate_wav(frequency: float, duration: float) -> bytes:
         A ``bytes`` object containing a valid WAV file that can be written
         directly to disk or streamed as ``audio/wav``.
     """
-    num_samples = int(SAMPLE_RATE * duration)
+    num_samples = int(GENERATOR_SAMPLE_RATE * duration)
     buf = io.BytesIO()
     with wave.open(buf, "wb") as wf:
         wf.setnchannels(1)
         wf.setsampwidth(2)
-        wf.setframerate(SAMPLE_RATE)
+        wf.setframerate(GENERATOR_SAMPLE_RATE)
         samples = []
         for i in range(num_samples):
-            t = i / SAMPLE_RATE
+            t = i / GENERATOR_SAMPLE_RATE
             value = int(32767 * 0.5 * math.sin(2 * math.pi * frequency * t))
             samples.append(struct.pack("<h", value))
         wf.writeframes(b"".join(samples))

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -3,10 +3,6 @@
 import os
 from pathlib import Path
 
-# Audio settings
-SAMPLE_RATE = 48000
-NUM_MEDIAS = 20
-
 # Dataset paths
 DATA_DIR = Path("data")
 AUDIO_DIR = DATA_DIR / "audio"
@@ -72,6 +68,7 @@ MLP_DROPOUT = 0.5
 
 # Model IDs
 CLAP_MODEL_ID = "laion/clap-htsat-unfused"
+CLAP_SAMPLE_RATE = 48000  # CLAP model expected input sample rate
 XCLIP_MODEL_ID = "microsoft/xclip-base-patch32"
 CLIP_MODEL_ID = "openai/clip-vit-base-patch32"
 E5_MODEL_ID = "intfloat/e5-base-v2"

--- a/vtsearch/converters/video2audio.py
+++ b/vtsearch/converters/video2audio.py
@@ -88,9 +88,7 @@ class Video2AudioMediaConverter(MediaConverter):
             try:
                 import librosa  # noqa: PLC0415
 
-                from vtsearch.config import SAMPLE_RATE  # noqa: PLC0415
-
-                audio_data, sr = librosa.load(wav_path, sr=SAMPLE_RATE, mono=True)
+                audio_data, sr = librosa.load(wav_path, sr=None, mono=True)
                 duration = len(audio_data) / sr
             except Exception:
                 pass

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtsearch.config import CLAP_MODEL_ID, MODELS_CACHE_DIR, SAMPLE_RATE
+from vtsearch.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
 from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress
 
 if TYPE_CHECKING:
@@ -82,17 +82,17 @@ class AudioClapEmbedder(MediaEmbedder):
 
         import soundfile as sf  # noqa: PLC0415
 
-        _warmup_sr = 16000  # intentionally different from SAMPLE_RATE
+        _warmup_sr = 16000  # intentionally different from CLAP_SAMPLE_RATE
         _warmup_buf = io.BytesIO()
         sf.write(_warmup_buf, np.zeros(_warmup_sr, dtype=np.float32), _warmup_sr, format="WAV")
         _warmup_buf.seek(0)
-        librosa.load(_warmup_buf, sr=SAMPLE_RATE, mono=True)
+        librosa.load(_warmup_buf, sr=CLAP_SAMPLE_RATE, mono=True)
 
         self._on_progress("loading", "Warming up audio pipeline: preprocessing…", 3, 4)
-        dummy_audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        dummy_audio = np.zeros(CLAP_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
-            sampling_rate=SAMPLE_RATE,
+            sampling_rate=CLAP_SAMPLE_RATE,
             return_tensors="pt",
             padding="max_length",
             max_length=480000,
@@ -128,10 +128,10 @@ class AudioClapEmbedder(MediaEmbedder):
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            audio_data, _sr = librosa.load(file_path, sr=SAMPLE_RATE, mono=True)
+            audio_data, _sr = librosa.load(file_path, sr=CLAP_SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,
-                sampling_rate=SAMPLE_RATE,
+                sampling_rate=CLAP_SAMPLE_RATE,
                 return_tensors="pt",
                 padding="max_length",
                 max_length=480000,

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from vtsearch.config import CLAP_MUSIC_MODEL_ID, MODELS_CACHE_DIR, SAMPLE_RATE
+from vtsearch.config import CLAP_MUSIC_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
 from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress
 
 if TYPE_CHECKING:
@@ -74,10 +74,10 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         import torch  # noqa: PLC0415
 
         self._on_progress("loading", "Warming up CLAP Music pipeline: preprocessing…", 2, 3)
-        dummy_audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        dummy_audio = np.zeros(CLAP_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
-            sampling_rate=SAMPLE_RATE,
+            sampling_rate=CLAP_SAMPLE_RATE,
             return_tensors="pt",
             padding="max_length",
             max_length=480000,
@@ -113,10 +113,10 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415
 
-            audio_data, _sr = librosa.load(file_path, sr=SAMPLE_RATE, mono=True)
+            audio_data, _sr = librosa.load(file_path, sr=CLAP_SAMPLE_RATE, mono=True)
             inputs = self._processor(
                 audio=audio_data,
-                sampling_rate=SAMPLE_RATE,
+                sampling_rate=CLAP_SAMPLE_RATE,
                 return_tensors="pt",
                 padding="max_length",
                 max_length=480000,

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -11,7 +11,6 @@ from vtsearch.config import (
     DATA_DIR,
     ESC50_DOWNLOAD_SIZE_MB,
     GTZAN_DOWNLOAD_SIZE_MB,
-    SAMPLE_RATE,
     SPEECH_COMMANDS_V2_DOWNLOAD_SIZE_MB,
     URBANSOUND8K_DOWNLOAD_SIZE_MB,
 )
@@ -325,7 +324,7 @@ class AudioMediaType(MediaType):
         with open(file_path, "rb") as f:
             media_bytes = f.read()
         try:
-            audio_data, sr = librosa.load(file_path, sr=SAMPLE_RATE, mono=True)
+            audio_data, sr = librosa.load(file_path, sr=None, mono=True)
             duration = len(audio_data) / sr
         except Exception:
             duration = 0.0

--- a/vtsearch/medias.py
+++ b/vtsearch/medias.py
@@ -5,7 +5,9 @@ import hashlib
 import numpy as np
 
 from vtsearch.audio import generate_wav
-from vtsearch.config import DATA_DIR, NUM_MEDIAS
+from vtsearch.config import DATA_DIR
+
+NUM_MEDIAS = 20
 from vtsearch.models import embed_audio_file
 from vtsearch.utils import medias
 


### PR DESCRIPTION
## Summary
This PR refactors sample rate configuration across the codebase to improve clarity by distinguishing between different use cases: CLAP model processing and audio generation. The changes separate concerns and make the codebase more maintainable.

## Key Changes

- **Renamed `SAMPLE_RATE` to `CLAP_SAMPLE_RATE`** in `vtsearch/config.py` and updated all CLAP-related modules (`embedder.py`, `embedder_clap_music.py`) to use the new constant name, making it explicit that this sample rate is specific to CLAP model input requirements (48 kHz)

- **Introduced `GENERATOR_SAMPLE_RATE`** in `vtsearch/audio/generator.py` as a module-level constant (48 kHz) instead of importing from config, decoupling audio generation from global configuration

- **Moved `NUM_MEDIAS`** from `vtsearch/config.py` to `vtsearch/medias.py` where it's actually used, reducing unnecessary exports from the config module

- **Removed sample rate resampling** in `vtsearch/converters/video2audio.py` and `vtsearch/media/audio/media_type.py` by changing `librosa.load()` calls to use `sr=None`, allowing the original sample rate to be preserved during audio loading

- **Updated test fixtures** in `tests/conftest.py` to import from the new locations and maintain backward compatibility by aliasing `GENERATOR_SAMPLE_RATE` as `SAMPLE_RATE` on the app module

## Notable Implementation Details

- The CLAP model's expected input sample rate (48 kHz) is now explicitly documented in config with a clarifying comment
- Audio generation is now independent of global configuration, making it more self-contained
- The removal of forced resampling in converters and media type loaders allows for more flexible audio processing while preserving original audio characteristics
- All changes maintain backward compatibility through appropriate imports and aliases in test fixtures

https://claude.ai/code/session_01S6oaYRor32Uce322MKtbWA