### PR TITLE
Improve progress reporting for k-means clustering in DiversityTree

### DIFF
--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -22,6 +22,7 @@ import numpy as np
 DIVERSITY_TREE_DEFAULT_K = 2
 DIVERSITY_TREE_MAX_DEPTH = 10
 DIVERSITY_TREE_MIN_NODE_SIZE = 20
+_N_INIT = 10  # number of k-means initialisations per node
 
 
 class DiversityTree:
@@ -82,7 +83,7 @@ class DiversityTree:
                 num_levels = min(num_levels, max_depth)
             else:
                 num_levels = 0
-            self._estimated_total_work = max(total * num_levels, 1)
+            self._estimated_total_work = max(total * num_levels * _N_INIT, 1)
             self._work_done = 0
             if on_progress:
                 on_progress(0, self._estimated_total_work)
@@ -121,19 +122,34 @@ class DiversityTree:
                 self.vector_to_leaf[vid] = name
             return
 
-        # Run k-means
+        # Run k-means in individual inits for granular progress reporting.
+        # Each of the N_INIT runs reports progress separately, so the UI
+        # updates during the expensive root clustering instead of sitting
+        # at 0% until it finishes.
         from sklearn.cluster import KMeans  # noqa: PLC0415
 
-        kmeans = KMeans(n_clusters=actual_k, random_state=42, n_init=10)
-        labels = kmeans.fit_predict(vecs)
-
-        # Report progress proportional to the number of vectors clustered
-        self._work_done += len(ids)
-        if self._on_progress:
-            self._on_progress(
-                min(self._work_done, self._estimated_total_work),
-                self._estimated_total_work,
+        best_labels = None
+        best_inertia = float("inf")
+        for init_i in range(_N_INIT):
+            km = KMeans(
+                n_clusters=actual_k,
+                random_state=42 + init_i,
+                n_init=1,
             )
+            candidate_labels = km.fit_predict(vecs)
+            if km.inertia_ < best_inertia:
+                best_inertia = km.inertia_
+                best_labels = candidate_labels
+
+            # Report progress after each init
+            self._work_done += len(ids)
+            if self._on_progress:
+                self._on_progress(
+                    min(self._work_done, self._estimated_total_work),
+                    self._estimated_total_work,
+                )
+
+        labels = best_labels
 
         children = []
         for ci in range(actual_k):


### PR DESCRIPTION
## Summary
Refactored k-means clustering in `DiversityTree._build_node()` to run multiple initializations sequentially with granular progress reporting, rather than delegating all initializations to scikit-learn's internal implementation.

## Key Changes
- Added `_N_INIT` constant (10) to control the number of k-means initializations per node
- Updated `_estimated_total_work` calculation to account for multiple k-means initializations (`total * num_levels * _N_INIT`)
- Refactored k-means clustering to manually iterate through `_N_INIT` runs with `n_init=1` instead of using scikit-learn's `n_init=10`
- Moved progress reporting inside the initialization loop so UI updates incrementally during clustering instead of remaining at 0% until completion
- Implemented manual tracking of best clustering result (lowest inertia) across all initializations

## Implementation Details
- Each k-means initialization uses a different random seed (`42 + init_i`) to ensure diversity
- Progress is reported after each initialization completes, providing more responsive UI feedback during expensive root clustering operations
- The best clustering result across all initializations is selected based on inertia value

https://claude.ai/code/session_011kvhnTPaDZioxSdz2pZk5z