### PR TITLE
Replace text chip icons with SVG icons

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -57,7 +57,11 @@
           <div class="examples-grid">
             @for (ex of examples; track $index) {
               <div class="example-chip" [class.text-chip]="ex.type === 'text'" [class.media-chip]="ex.type === 'media'">
-                <span class="chip-icon">{{ ex.type === 'text' ? 'T' : 'M' }}</span>
+                @if (ex.type === 'text') {
+                  <svg class="chip-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M3 1h10a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zm1 3v1.5h8V4H4zm0 3v1.5h8V7H4zm0 3v1.5h5V10H4z"/></svg>
+                } @else {
+                  <svg class="chip-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+                }
                 <span class="chip-label" [title]="ex.display">{{ ex.display }}</span>
                 <button type="button" class="chip-remove" (click)="removeExample($index)" title="Remove">&times;</button>
               </div>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -89,16 +89,18 @@
   color: var(--text-primary, #e0e0e0);
 }
 
+.chip-icon {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
 .text-chip .chip-icon {
   color: var(--color-good, #4caf50);
-  font-weight: 700;
-  font-size: 0.75rem;
 }
 
 .media-chip .chip-icon {
   color: var(--accent, #2196f3);
-  font-weight: 700;
-  font-size: 0.75rem;
 }
 
 .chip-label {


### PR DESCRIPTION
## Summary
Replaced text-based chip icons ('T' and 'M' characters) with semantic SVG icons in the new model modal component.

## Key Changes
- **HTML Template**: Replaced single character `<span>` elements with conditional SVG icons
  - Text chips now display a document/text icon
  - Media chips now display an image/media icon
  - Used Angular's `@if/@else` control flow for conditional rendering

- **Styles**: Refactored chip icon styling for better maintainability
  - Extracted common icon sizing rules into a shared `.chip-icon` class (12px × 12px with `flex-shrink: 0`)
  - Removed redundant `font-weight` and `font-size` properties from type-specific selectors
  - Retained color differentiation for text (green) and media (blue) chips

## Implementation Details
- SVG icons use `viewBox="0 0 16 16"` for scalability
- Icons inherit color via `fill="currentColor"` to respect CSS color variables
- Fixed icon dimensions prevent layout shifts and ensure consistent appearance

https://claude.ai/code/session_01BQkk3yuhwzBaTSHZGwxMDv