### PR TITLE
Fix stale error persistence and progress polling resilience

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -525,6 +525,32 @@ describe('DashboardComponent', () => {
     });
   });
 
+  it('should continue polling after HTTP error on progress endpoint', fakeAsync(() => {
+    flushInitialRequests();
+    component.onDemoSelected({ name: 'gtzan', label: 'GTZAN' });
+
+    const demoReq = httpMock.expectOne('/api/dataset/load-demo');
+    demoReq.flush({});
+
+    // First progress poll fails with a server error
+    const failedReq = httpMock.expectOne('/api/dataset/progress');
+    failedReq.error(new ProgressEvent('error'), { status: 500, statusText: 'Internal Server Error' });
+
+    // Component should still be in loading state
+    expect(component.loading).toBeTrue();
+
+    // Advance timer to trigger next poll — polling should survive the error
+    tick(1000);
+    const retryReq = httpMock.expectOne('/api/dataset/progress');
+    retryReq.flush({ status: 'idle' });
+
+    expect(component.loading).toBeFalse();
+
+    // Refresh after completion
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/models/registry').flush({ models: [] });
+  }));
+
   it('should load demo dataset on demoSelected', () => {
     flushInitialRequests();
     component.importerModalOpen = true;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { Subject, timer } from 'rxjs';
-import { takeUntil, switchMap } from 'rxjs/operators';
+import { EMPTY, Subject, timer } from 'rxjs';
+import { catchError, takeUntil, switchMap } from 'rxjs/operators';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
 import { TrainableModelsApiService } from '../../services/trainable-models-api.service';
@@ -301,7 +301,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
       .pipe(
         takeUntil(this.polling$),
         takeUntil(this.destroy$),
-        switchMap(() => this.datasetsApi.getProgress()),
+        switchMap(() => this.datasetsApi.getProgress().pipe(
+          catchError(() => EMPTY),
+        )),
       )
       .subscribe({
         next: (progress: any) => {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -856,3 +856,56 @@ class TestLoadProgressRaceCondition:
         assert progress["status"] == "downloading"
         assert progress["message"] == "Fetching files…"
         assert progress["step"] == 1  # downloading maps to step 1
+
+    def test_origin_load_clears_stale_error(self):
+        """_run_origin_load_in_background must clear old error on new load."""
+        from unittest.mock import patch
+
+        from vtsearch.utils.progress import get_progress, update_progress
+
+        # Simulate a previous load that left a stale error
+        update_progress("idle", "", error="Previous load failed", step=None, total_steps=None)
+        assert get_progress()["error"] == "Previous load failed"
+
+        # Start a new load (mock the thread so it doesn't actually run)
+        from vtsearch.routes.datasets_loading import _run_origin_load_in_background
+
+        with patch("vtsearch.routes.datasets_loading.threading.Thread"):
+            _run_origin_load_in_background(
+                lambda: None, {"importer": "test", "params": {}},
+            )
+
+        progress = get_progress()
+        assert progress["error"] is None, (
+            "Starting a new load must clear the stale error from a previous load"
+        )
+        assert progress["status"] == "loading"
+
+    def test_load_embedder_sets_initial_progress(self):
+        """_load_embedder_for_clips must set progress before loading starts."""
+        from unittest.mock import patch
+
+        from vtsearch.media import embedders_for_type
+        from vtsearch.routes.datasets import _load_embedder_for_clips
+        from vtsearch.utils.progress import get_progress, update_progress
+
+        # Set a stale progress message from the previous phase
+        update_progress("loading", "Saving to registry…", step=3, total_steps=4)
+
+        emb = embedders_for_type("audio")[0]
+        messages: list[str] = []
+
+        orig_update = update_progress.__wrapped__ if hasattr(update_progress, "__wrapped__") else None
+
+        def _capture_update(status, message="", **kw):
+            messages.append(message)
+
+        with patch("vtsearch.routes.datasets_loading.update_progress", side_effect=_capture_update):
+            with patch.object(emb, "load_models"):
+                with patch.object(emb, "embed_text"):
+                    _load_embedder_for_clips()
+
+        # Should have set "Loading embedding model…" before calling load_models
+        assert any("Loading embedding model" in m for m in messages), (
+            f"Expected 'Loading embedding model…' in progress messages, got: {messages}"
+        )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -882,28 +882,29 @@ class TestLoadProgressRaceCondition:
         assert progress["status"] == "loading"
 
     def test_load_embedder_sets_initial_progress(self):
-        """_load_embedder_for_clips must set progress before loading starts."""
+        """_load_embedder_for_clips must set progress before loading starts.
+
+        The function should emit 'Loading embedding model…' so the frontend
+        knows the embedder warm-up phase has begun (rather than staying stuck
+        on the previous phase's message like 'Saving to registry…').
+        """
         from unittest.mock import patch
 
-        from vtsearch.media import embedders_for_type
         from vtsearch.routes.datasets import _load_embedder_for_clips
-        from vtsearch.utils.progress import get_progress, update_progress
+        from vtsearch.utils.progress import update_progress
 
-        # Set a stale progress message from the previous phase
+        # _load_embedder_for_clips inspects medias to find the embedder.
+        # The conftest-populated medias dict provides this automatically.
+        # Set a stale progress message from the previous phase.
         update_progress("loading", "Saving to registry…", step=3, total_steps=4)
 
-        emb = embedders_for_type("audio")[0]
         messages: list[str] = []
 
-        orig_update = update_progress.__wrapped__ if hasattr(update_progress, "__wrapped__") else None
-
-        def _capture_update(status, message="", **kw):
+        def _capture_update(status, message="", current=0, total=0, **kw):
             messages.append(message)
 
         with patch("vtsearch.routes.datasets_loading.update_progress", side_effect=_capture_update):
-            with patch.object(emb, "load_models"):
-                with patch.object(emb, "embed_text"):
-                    _load_embedder_for_clips()
+            _load_embedder_for_clips()
 
         # Should have set "Loading embedding model…" before calling load_models
         assert any("Loading embedding model" in m for m in messages), (

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -655,7 +655,8 @@ def load_registered_dataset(dataset_id: str):
 
     # Signal "loading" before the thread starts so frontend polling never
     # sees a stale "idle" from a previous load and prematurely stops.
-    update_progress("loading", "Preparing to load dataset…", 0, 0, step=1, total_steps=_LOAD_STEPS)
+    # Clear stale error from any previous load.
+    update_progress("loading", "Preparing to load dataset…", 0, 0, error=None, step=1, total_steps=_LOAD_STEPS)
 
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -126,6 +126,10 @@ def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = 
     def _model_load_progress(status, message, current, total):
         update_progress(status, message, current, total, step=step, total_steps=total_steps)
 
+    update_progress(
+        "loading", "Loading embedding model…", 0, 0,
+        step=step, total_steps=total_steps,
+    )
     with intercept_tqdm_progress(_model_load_progress), intercept_weight_loading_progress(
         _model_load_progress, "Loading model weights…"
     ):
@@ -320,7 +324,8 @@ def _run_origin_load_in_background(
 
     # Set progress to "loading" synchronously so the frontend never sees a
     # stale "idle" status from a previous operation before the thread starts.
-    update_progress("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)
+    # Clear the error field so stale errors from previous loads don't persist.
+    update_progress("loading", "Preparing dataset...", error=None, step=1, total_steps=_TOTAL_LOAD_STEPS)
 
     def task():
         try:
@@ -383,7 +388,7 @@ def _run_origin_load_in_background(
 
     # Signal "loading" before the thread starts so frontend polling never
     # sees a stale "idle" from a previous load and prematurely stops.
-    update_progress("loading", "Preparing to load dataset…", 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
+    update_progress("loading", "Preparing to load dataset…", 0, 0, error=None, step=1, total_steps=_TOTAL_LOAD_STEPS)
 
     threading.Thread(target=task, daemon=True).start()
 


### PR DESCRIPTION
## Summary
This PR addresses two issues in the dataset loading workflow:
1. Stale error messages persisting across multiple load attempts
2. Frontend progress polling stopping after HTTP errors

## Key Changes

**Backend (Python)**
- Clear the `error` field when initiating new dataset loads in `_run_origin_load_in_background()` and `load_demo_dataset()` to prevent stale errors from previous failed loads from persisting
- Set initial progress message "Loading embedding model…" in `_load_embedder_for_clips()` before the embedder warm-up phase begins, ensuring the frontend sees the correct status instead of stale messages from previous phases

**Frontend (Angular)**
- Add error handling to the progress polling observable using `catchError()` operator to gracefully handle HTTP errors (e.g., 500 responses) without stopping the polling loop
- Return `EMPTY` on progress endpoint errors so the polling timer continues and retries on the next interval

## Implementation Details

- The backend now explicitly passes `error=None` when calling `update_progress()` at the start of load operations, ensuring any previous error state is cleared
- The frontend's progress polling now uses RxJS `catchError()` to catch HTTP errors and return an empty observable, allowing the `switchMap()` to continue polling without interruption
- Tests added to verify stale errors are cleared on new loads and that progress polling survives HTTP errors

https://claude.ai/code/session_017r8XWsB1Ugi2SRTGjfLiWt