### PR TITLE
Update chart threshold line to show green diversity indicator level

### DIFF
--- a/frontend/src/app/services/charts.service.ts
+++ b/frontend/src/app/services/charts.service.ts
@@ -193,7 +193,8 @@ export class ChartsService {
     const treeDepth = data[0].depth;
 
     const maxLabels = Math.max(...numLabels);
-    const maxLevel = Math.max(treeDepth, Math.max(...levels), 1);
+    const greenLevel = Math.min(4, treeDepth);
+    const maxLevel = Math.max(greenLevel, Math.max(...levels), 1);
     const minLevel = Math.min(0, Math.min(...levels));
 
     const xScale = (val: number) => left + (val / maxLabels) * chartWidth;
@@ -203,21 +204,21 @@ export class ChartsService {
     this.drawAxes(ctx, canvas.width, canvas.height);
     this.drawGrid(ctx, canvas.width, canvas.height);
 
-    // Draw tree depth target line
+    // Draw green threshold line (diversity indicator turns green at level 4)
     ctx.strokeStyle = this.themeColor('--color-good');
     ctx.lineWidth = 1;
     ctx.setLineDash([6, 4]);
-    const depthY = yScale(treeDepth);
+    const greenY = yScale(greenLevel);
     ctx.beginPath();
-    ctx.moveTo(left, depthY);
-    ctx.lineTo(left + chartWidth, depthY);
+    ctx.moveTo(left, greenY);
+    ctx.lineTo(left + chartWidth, greenY);
     ctx.stroke();
     ctx.setLineDash([]);
 
     ctx.fillStyle = this.themeColor('--color-good');
     ctx.font = '11px sans-serif';
     ctx.textAlign = 'left';
-    ctx.fillText(`depth ${treeDepth}`, left + chartWidth - 55, depthY - 5);
+    ctx.fillText(`green (${greenLevel})`, left + chartWidth - 70, greenY - 5);
 
     const xs = numLabels.map(xScale);
     const ys = levels.map(yScale);


### PR DESCRIPTION
## Summary
Updated the charts service to display a green threshold line at level 4 instead of the tree depth, better representing when the diversity indicator turns green in the UI.

## Key Changes
- Introduced `greenLevel` variable that caps at level 4 (or tree depth if smaller) to represent the diversity threshold
- Updated the threshold line label from "depth {treeDepth}" to "green ({greenLevel})" for clarity
- Adjusted label positioning and width to accommodate the new text format
- Updated comments to clarify that the line represents the green threshold rather than tree depth

## Implementation Details
- The `greenLevel` is calculated as `Math.min(4, treeDepth)`, ensuring the threshold never exceeds level 4
- The threshold line continues to use the "good" theme color and dashed line style
- This change makes the chart more intuitive by showing users the actual level at which their diversity metric is considered "good"

https://claude.ai/code/session_01SjXSFKEYcMTgWc6ucNRXjm