### PR TITLE
Replace inclusion range slider with number input

### DIFF
--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
@@ -1,15 +1,15 @@
-<div class="inclusion-slider">
-  <label class="inclusion-label" for="inclusion-slider" title="Adjust the inclusion bias. Positive values include more items (favor recall), negative values exclude more (favor precision). Triggers retraining of learned sort.">
+<div class="inclusion-selector">
+  <label class="inclusion-label" for="inclusion-input" title="Adjust the inclusion bias. Positive values include more items (favor recall), negative values exclude more (favor precision). Triggers retraining of learned sort.">
     Inclusion
-    <span class="inclusion-value">{{ displayValue }}</span>
   </label>
   <input
-    id="inclusion-slider"
-    type="range"
+    id="inclusion-input"
+    type="number"
     min="-10"
     max="10"
+    step="1"
     [value]="value"
     (input)="onInput($event)"
-    aria-label="Inclusion slider"
+    aria-label="Inclusion"
   />
 </div>

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
@@ -1,48 +1,27 @@
-.inclusion-slider {
+.inclusion-selector {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 8px;
 }
 
 .inclusion-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
   font-size: 0.8rem;
   color: var(--text-secondary);
+  white-space: nowrap;
 }
 
-.inclusion-value {
+input[type="number"] {
+  width: 56px;
+  padding: 2px 4px;
+  font-size: 0.8rem;
   color: var(--text-primary);
-  font-weight: 500;
-  font-size: 0.78rem;
-  min-width: 24px;
-}
-
-input[type="range"] {
-  width: 100%;
-  height: 4px;
-  appearance: none;
-  background: var(--border);
-  border-radius: 2px;
+  background: var(--bg-secondary, transparent);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  text-align: center;
   outline: none;
-  cursor: pointer;
 
-  &::-webkit-slider-thumb {
-    appearance: none;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: var(--accent);
-    cursor: pointer;
-  }
-
-  &::-moz-range-thumb {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: var(--accent);
-    cursor: pointer;
-    border: none;
+  &:focus {
+    border-color: var(--accent);
   }
 }

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
@@ -16,11 +16,8 @@ export class InclusionSliderComponent {
   onInput(event: Event): void {
     const target = event.target as HTMLInputElement;
     const val = parseInt(target.value, 10);
-    this.valueChange.emit(val);
-  }
-
-  get displayValue(): string {
-    if (this.value === 0) return '0';
-    return this.value > 0 ? `+${this.value}` : `${this.value}`;
+    if (!isNaN(val) && val >= -10 && val <= 10) {
+      this.valueChange.emit(val);
+    }
   }
 }


### PR DESCRIPTION
## Summary
Converted the inclusion slider component from a range input to a number input control, simplifying the UI and improving usability for precise value entry.

## Key Changes
- **Input Type**: Changed from `<input type="range">` to `<input type="number">` for more direct value control
- **Layout**: Updated flex layout from column to row with centered alignment, reducing vertical space
- **Styling**: 
  - Removed complex range slider styling (webkit/moz thumbs)
  - Added number input styling with fixed width (56px), padding, and border
  - Added focus state with accent color border
- **Component Structure**:
  - Renamed CSS class from `.inclusion-slider` to `.inclusion-selector`
  - Removed separate `.inclusion-value` span and display formatting
  - Simplified label to show only "Inclusion" text
- **Validation**: Added input validation to ensure values stay within -10 to 10 range before emitting changes
- **Accessibility**: Updated aria-label from "Inclusion slider" to "Inclusion"

## Implementation Details
- The number input includes `step="1"` to enforce integer increments
- Input validation now checks for NaN and range bounds before emitting the `valueChange` event
- Removed the `displayValue` getter that formatted positive values with a "+" prefix
- Styling uses CSS variables for theming consistency (accent, border, text colors)

https://claude.ai/code/session_01AJ1v1aWbGezzh4SF4ZYqtW