### PR TITLE
Remove meta text display from label list entries

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -30,9 +30,6 @@
           <span class="vote-name-grid">{{ entry.name }}</span>
         } @else {
           <span class="vote-name">{{ entry.name }}</span>
-          @if (metaText(entry)) {
-            <span class="vote-meta">{{ metaText(entry) }}</span>
-          }
         }
       </div>
     }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -145,9 +145,3 @@ h3 {
   line-height: 1.2;
   flex-shrink: 0;
 }
-
-.vote-meta {
-  display: block;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -137,50 +137,6 @@ describe('LabelListComponent', () => {
     });
   });
 
-  describe('meta text', () => {
-    it('should show click time when sorting by time', () => {
-      component.sortMode = 'time-desc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: 5, score: -1, confidence: -1 };
-      expect(component.metaText(entry)).toBe('#5');
-    });
-
-    it('should show imported when sorting by time with no click time', () => {
-      component.sortMode = 'time-asc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: -1, score: -1, confidence: -1 };
-      expect(component.metaText(entry)).toBe('imported');
-    });
-
-    it('should show confidence when sorting by confidence', () => {
-      component.sortMode = 'confidence-desc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: 3, score: 0.8, confidence: 0.8 };
-      expect(component.metaText(entry)).toBe('80%');
-    });
-
-    it('should show empty text when sorting by name', () => {
-      component.sortMode = 'name-asc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: 3, score: 0.8, confidence: 0.8 };
-      expect(component.metaText(entry)).toBe('');
-    });
-
-    it('should show empty text when sorting by id', () => {
-      component.sortMode = 'id-asc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: 3, score: 0.8, confidence: 0.8 };
-      expect(component.metaText(entry)).toBe('');
-    });
-
-    it('should not show confidence when sorting by time', () => {
-      component.sortMode = 'time-desc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: 3, score: 0.8, confidence: 0.8 };
-      expect(component.metaText(entry)).toBe('#3');
-    });
-
-    it('should not show click time when sorting by confidence', () => {
-      component.sortMode = 'confidence-asc';
-      const entry: LabelEntry = { id: 1, name: 'test', time: 3, score: 0.8, confidence: 0.8 };
-      expect(component.metaText(entry)).toBe('80%');
-    });
-  });
-
   describe('view modes and thumbnails', () => {
     beforeEach(() => {
       component.medias = sampleMedias;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -88,22 +88,6 @@ export class LabelListComponent implements OnInit, OnChanges {
     return sorted;
   }
 
-  metaText(entry: LabelEntry): string {
-    const parts: string[] = [];
-    if (this.sortMode === 'time-desc' || this.sortMode === 'time-asc') {
-      if (entry.time >= 0) {
-        parts.push(`#${entry.time}`);
-      } else {
-        parts.push('imported');
-      }
-    } else if (this.sortMode === 'confidence-desc' || this.sortMode === 'confidence-asc') {
-      if (entry.confidence >= 0) {
-        parts.push(`${(entry.confidence * 100).toFixed(0)}%`);
-      }
-    }
-    return parts.join(' \u00B7 ');
-  }
-
   get isGrid(): boolean {
     return this.viewMode === 'grid';
   }

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
@@ -1,5 +1,5 @@
 <div class="label-sort-bar">
-  <span class="sort-label">Sort labels</span>
+  <span class="sort-label">Sort:</span>
   <label for="label-sort-select" class="sr-only">Sort labels</label>
   <select
     id="label-sort-select"


### PR DESCRIPTION
## Summary
This PR removes the meta text feature that displayed additional information (click time or confidence) below label names in the label list component. The feature is being completely removed from the codebase.

## Key Changes
- Removed the `metaText()` method from `LabelListComponent` that generated contextual metadata based on the current sort mode
- Removed the conditional rendering of meta text in the label list template
- Removed the `.vote-meta` CSS styling that formatted the meta text display
- Updated the sort label text from "Sort labels" to "Sort:" for brevity
- Removed all 8 unit tests that validated the `metaText()` method behavior across different sort modes

## Implementation Details
The `metaText()` method previously displayed:
- Click time (e.g., "#5") when sorting by time, or "imported" for entries without a click time
- Confidence percentage (e.g., "80%") when sorting by confidence
- Empty string for other sort modes (name, id)

This metadata display has been entirely removed from the UI, simplifying the label list presentation.

https://claude.ai/code/session_019nMS33WFCbaxhAupLh6VEB