### PR TITLE
Hide media type tabs when only one type is available

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -95,5 +95,5 @@
 </div>
 
 @if (showLeftViewSettings) {
-  <vt-left-view-settings-modal (closed)="showLeftViewSettings = false" />
+  <vt-left-view-settings-modal [currentMediaType]="medias.length > 0 ? medias[0].type : ''" (closed)="showLeftViewSettings = false" />
 }

--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.html
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.html
@@ -3,16 +3,18 @@
     <p class="empty-state">Loading...</p>
   } @else {
     @if (mediaTypes.length > 0) {
-      <div class="view-tabs">
-        @for (mt of mediaTypes; track mt.type_id) {
-          <button
-            class="view-tab"
-            [class.view-tab--active]="activeViewTab === mt.type_id"
-            (click)="activeViewTab = mt.type_id">
-            {{ mt.name }}
-          </button>
-        }
-      </div>
+      @if (mediaTypes.length > 1) {
+        <div class="view-tabs">
+          @for (mt of mediaTypes; track mt.type_id) {
+            <button
+              class="view-tab"
+              [class.view-tab--active]="activeViewTab === mt.type_id"
+              (click)="activeViewTab = mt.type_id">
+              {{ mt.name }}
+            </button>
+          }
+        </div>
+      }
       <div class="view-tab-content">
         <div class="form-group">
           <label class="form-label">View</label>

--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.ts
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { forkJoin } from 'rxjs';
@@ -16,6 +16,7 @@ import { AppSettings, MediaTypeInfo } from '../../../models/api.models';
   styleUrl: './left-view-settings-modal.component.scss',
 })
 export class LeftViewSettingsModalComponent implements OnInit {
+  @Input() currentMediaType = '';
   @Output() closed = new EventEmitter<void>();
 
   settings: AppSettings = { volume: 50 };
@@ -38,6 +39,9 @@ export class LeftViewSettingsModalComponent implements OnInit {
       next: (res) => {
         this.settings = res.settings;
         this.mediaTypes = res.mediaTypes.media_types || [];
+        if (this.currentMediaType) {
+          this.mediaTypes = this.mediaTypes.filter(mt => mt.type_id === this.currentMediaType);
+        }
         if (this.mediaTypes.length > 0) {
           this.activeViewTab = this.mediaTypes[0].type_id;
         }

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.html
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.html
@@ -3,16 +3,18 @@
     <p class="empty-state">Loading...</p>
   } @else {
     @if (mediaTypes.length > 0) {
-      <div class="view-tabs">
-        @for (mt of mediaTypes; track mt.type_id) {
-          <button
-            class="view-tab"
-            [class.view-tab--active]="activeViewTab === mt.type_id"
-            (click)="activeViewTab = mt.type_id">
-            {{ mt.name }}
-          </button>
-        }
-      </div>
+      @if (mediaTypes.length > 1) {
+        <div class="view-tabs">
+          @for (mt of mediaTypes; track mt.type_id) {
+            <button
+              class="view-tab"
+              [class.view-tab--active]="activeViewTab === mt.type_id"
+              (click)="activeViewTab = mt.type_id">
+              {{ mt.name }}
+            </button>
+          }
+        </div>
+      }
       <div class="view-tab-content">
         <div class="form-group">
           <label class="form-label">View</label>

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.ts
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { forkJoin } from 'rxjs';
@@ -16,6 +16,7 @@ import { AppSettings, MediaTypeInfo } from '../../../models/api.models';
   styleUrl: './view-settings-modal.component.scss',
 })
 export class ViewSettingsModalComponent implements OnInit {
+  @Input() currentMediaType = '';
   @Output() closed = new EventEmitter<void>();
 
   settings: AppSettings = { volume: 50 };
@@ -38,6 +39,9 @@ export class ViewSettingsModalComponent implements OnInit {
       next: (res) => {
         this.settings = res.settings;
         this.mediaTypes = res.mediaTypes.media_types || [];
+        if (this.currentMediaType) {
+          this.mediaTypes = this.mediaTypes.filter(mt => mt.type_id === this.currentMediaType);
+        }
         if (this.mediaTypes.length > 0) {
           this.activeViewTab = this.mediaTypes[0].type_id;
         }

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -64,5 +64,5 @@
 }
 
 @if (showViewSettings) {
-  <vt-view-settings-modal (closed)="showViewSettings = false" />
+  <vt-view-settings-modal [currentMediaType]="currentMediaType" (closed)="showViewSettings = false" />
 }


### PR DESCRIPTION
## Summary
This PR improves the UX of the view settings modals by hiding the media type tab navigation when only a single media type is available, and adds support for filtering media types based on the currently selected media.

## Key Changes
- **Conditional tab rendering**: Added `@if (mediaTypes.length > 1)` check to hide the tab navigation container in both `left-view-settings-modal` and `view-settings-modal` components when there's only one media type available
- **Media type filtering**: Added `@Input() currentMediaType` property to both modal components to accept the currently selected media type
- **Filter logic**: Implemented filtering in the `ngOnInit` lifecycle to show only the media type matching the `currentMediaType` input when provided
- **Parent component updates**: Updated `left-panel.component.html` and `right-panel.component.html` to pass the current media type to their respective modal components

## Implementation Details
- The filtering is applied after fetching media types from the API, ensuring only relevant settings are displayed
- When `currentMediaType` is empty or not provided, all media types are shown (backward compatible)
- The tab UI is automatically hidden when the filtered result contains only one media type, providing a cleaner interface for single-media scenarios

https://claude.ai/code/session_01Ka8kftUCtyPa2YcCfPdx9C