### PR TITLE
Improve spacing and layout in view settings modals

### DIFF
--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.scss
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.scss
@@ -40,11 +40,18 @@
 }
 
 .view-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
   padding: 0.75rem;
   border: 1px solid var(--border-color, #444);
   border-top: 1px solid var(--border-color, #444);
   border-radius: 0 0 6px 6px;
   background: var(--bg-primary, #1e1e2e);
+
+  .form-label {
+    margin-bottom: 0;
+  }
 }
 
 .radio-group {

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.scss
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.scss
@@ -40,11 +40,18 @@
 }
 
 .view-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
   padding: 0.75rem;
   border: 1px solid var(--border-color, #444);
   border-top: 1px solid var(--border-color, #444);
   border-radius: 0 0 6px 6px;
   background: var(--bg-primary, #1e1e2e);
+
+  .form-label {
+    margin-bottom: 0;
+  }
 }
 
 .radio-group {


### PR DESCRIPTION
## Summary
Updated the styling of view settings modals to improve spacing and layout consistency between form elements.

## Key Changes
- Added flexbox layout to `.view-tab-content` with column direction and 0.5rem gap spacing for better vertical alignment of form elements
- Removed default bottom margin from `.form-label` elements to prevent excessive spacing and work harmoniously with the flex gap
- Applied identical styling updates to both `left-view-settings-modal` and `view-settings-modal` components for consistency

## Implementation Details
The changes use CSS flexbox to create uniform spacing between form elements within the modal content area, replacing the need for individual margin management on labels. This approach provides better maintainability and visual consistency across both modal components.

https://claude.ai/code/session_013nVf2Nt6kJBYCst3pvooP3