### PR TITLE
Remove local detector file upload from load-sort modal

### DIFF
--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -88,20 +88,18 @@
       <!-- Sort by Detector -->
       <div class="sort-section">
         <h3>Sort by Detector</h3>
-        <label class="btn btn--secondary file-btn">
-          Local detector file
-          <input type="file" accept=".json,.pkl" (change)="onDetectorFileSelected($event)" hidden />
-        </label>
+        <h4>Server Detectors</h4>
         @if (serverDetectors.length > 0) {
-          <h4>Server Detectors</h4>
           <div class="file-list">
             @for (det of serverDetectors; track det.name) {
               <button class="file-item" (click)="loadServerDetector(det.name)">{{ det.name }}</button>
             }
           </div>
+        } @else {
+          <p class="empty-state">No server detector files found.</p>
         }
+        <h4>Dashboard Models</h4>
         @if (registryModels.length > 0) {
-          <h4>Dashboard Models</h4>
           <div class="file-list">
             @for (model of registryModels; track model.id) {
               <button class="file-item" (click)="loadRegistryModel(model)">
@@ -112,6 +110,8 @@
               </button>
             }
           </div>
+        } @else {
+          <p class="empty-state">No trained dashboard models found.</p>
         }
       </div>
 

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -88,23 +88,6 @@ export class LoadSortModalComponent implements OnInit {
 
   // --- Detector loading ---
 
-  onDetectorFileSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    if (!input.files || input.files.length === 0) return;
-    const file = input.files[0];
-    const reader = new FileReader();
-    reader.onload = () => {
-      try {
-        const data = JSON.parse(reader.result as string);
-        this.detectorLoaded.emit(data);
-        this.closed.emit();
-      } catch {
-        this.error = 'Invalid detector file';
-      }
-    };
-    reader.readAsText(file);
-  }
-
   loadServerDetector(name: string): void {
     this.status = 'Loading server detector...';
     this.detectorsApi.getServerFile(name).subscribe({


### PR DESCRIPTION
## Summary
This PR removes the local detector file upload functionality from the load-sort modal component and improves the UI/UX by reorganizing the detector loading options and adding empty state messages.

## Key Changes
- **Removed** `onDetectorFileSelected()` method that handled local `.json` and `.pkl` file uploads
- **Removed** the "Local detector file" upload button from the template
- **Reorganized** the "Sort by Detector" section to prioritize server detectors and dashboard models
- **Added** empty state messages when no server detectors or dashboard models are available
- **Improved** section structure by moving headers outside conditional blocks for better visual hierarchy

## Implementation Details
- The local file upload feature is completely removed from both the component class and template
- Users can now only load detectors from server detectors or dashboard models
- Empty state messages provide better feedback when no options are available in each category
- The UI now clearly separates "Server Detectors" and "Dashboard Models" sections with consistent styling

https://claude.ai/code/session_01CJDyxHdHCYj9619bmUMCz3