### PR TITLE
Refactor embedder autoload UI with grid layout and media type icons

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -22,6 +22,12 @@
           (click)="activeSettingsTab = 'autopilot'">
           Autopilot
         </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'autoload'"
+          (click)="activeSettingsTab = 'autoload'">
+          Autoload
+        </button>
       </nav>
 
       <div class="settings-panel">
@@ -173,14 +179,29 @@
             <input type="number" class="form-input" [ngModel]="settings.autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" />
           </div>
 
+        }
+
+        <!-- Autoload -->
+        @if (activeSettingsTab === 'autoload') {
+          <h3>Autoload Embedders</h3>
           @if (embedders.length > 0) {
-            <h4>Autoload Embedders</h4>
-            @for (embedder of embedders; track embedder.name) {
-              <label class="checkbox-row">
-                <input type="checkbox" [checked]="isEmbedderAutoloaded(embedder)" (change)="toggleEmbedder(embedder)" />
-                {{ embedder.name }} ({{ embedder.media_type_id }})
-              </label>
-            }
+            <div class="embedder-grid">
+              <div class="embedder-grid-header">
+                <span>Embedder</span>
+                <span>Media Type</span>
+                <span></span>
+              </div>
+              @for (embedder of embedders; track embedder.name) {
+                <label class="embedder-row">
+                  <input type="checkbox" [checked]="isEmbedderAutoloaded(embedder)" (change)="toggleEmbedder(embedder)" />
+                  <span class="embedder-name">{{ embedder.name }}</span>
+                  <span class="embedder-media-type">{{ embedder.media_type_id }}</span>
+                  <span class="embedder-icon">{{ getMediaTypeIcon(embedder.media_type_id) }}</span>
+                </label>
+              }
+            </div>
+          } @else {
+            <p class="empty-state">No embedders available.</p>
           }
         }
       </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -149,6 +149,61 @@
   width: 4rem;
 }
 
+.embedder-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.embedder-grid-header {
+  display: grid;
+  grid-template-columns: 1fr 8rem 2.5rem;
+  gap: 0.5rem;
+  padding: 0 0 0.4rem calc(1.25rem + 0.5rem);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color, #444);
+  margin-bottom: 0.25rem;
+}
+
+.embedder-row {
+  display: grid;
+  grid-template-columns: auto 1fr 8rem 2.5rem;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.35rem 0;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.1s;
+
+  &:hover {
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  }
+
+  input[type='checkbox'] {
+    margin: 0;
+  }
+}
+
+.embedder-name {
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.embedder-media-type {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.embedder-icon {
+  text-align: center;
+  font-size: 1rem;
+}
+
 .settings-actions {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -26,8 +26,8 @@ describe('SettingsModalComponent', () => {
 
   const mockMediaTypes = {
     media_types: [
-      { type_id: 'audio', name: 'Sound' },
-      { type_id: 'image', name: 'Image' },
+      { type_id: 'audio', name: 'Sound', icon: '\uD83D\uDD0A' },
+      { type_id: 'image', name: 'Image', icon: '\uD83D\uDDBC\uFE0F' },
     ],
   };
 
@@ -177,6 +177,13 @@ describe('SettingsModalComponent', () => {
     component.preselectedViewTab = '';
     flushInit();
     expect(component.activeViewTab).toBe('audio');
+  });
+
+  it('should return media type icon for embedder', () => {
+    flushInit();
+    expect(component.getMediaTypeIcon('audio')).toBe('\uD83D\uDD0A');
+    expect(component.getMediaTypeIcon('image')).toBe('\uD83D\uDDBC\uFE0F');
+    expect(component.getMediaTypeIcon('unknown')).toBe('');
   });
 
   it('should emit closed on close', () => {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -136,6 +136,11 @@ export class SettingsModalComponent implements OnInit {
     this.save();
   }
 
+  getMediaTypeIcon(typeId: string): string {
+    const mt = this.mediaTypes.find((m) => m.type_id === typeId);
+    return mt?.icon || '';
+  }
+
   isEmbedderAutoloaded(embedder: EmbedderInfo): boolean {
     return (this.settings.autoload_media_embedders || []).includes(embedder.name);
   }


### PR DESCRIPTION
## Summary
Reorganized the embedder autoload settings into a dedicated tab with an improved grid-based layout that displays embedders alongside their media types and associated icons.

## Key Changes
- **New "Autoload" settings tab**: Moved embedder autoload configuration from the Autopilot tab to its own dedicated tab for better organization
- **Grid-based embedder list**: Replaced simple checkbox list with a structured grid layout featuring:
  - Column headers (Embedder, Media Type, Icon)
  - Proper alignment and spacing with consistent grid columns
  - Hover effects for better interactivity
- **Media type icons**: Added `getMediaTypeIcon()` method to retrieve and display icons for each embedder's media type
- **Enhanced styling**: Added comprehensive SCSS classes for the grid layout, rows, and individual elements with proper typography and color theming
- **Empty state handling**: Added fallback message when no embedders are available
- **Updated test data**: Modified mock media types to include icon data and added test coverage for the new `getMediaTypeIcon()` method

## Implementation Details
- The embedder grid uses CSS Grid with responsive column sizing (`1fr 8rem 2.5rem`)
- Media type icons are sourced from the media types data structure
- The layout maintains accessibility with proper label associations for checkboxes
- Styling uses CSS variables for theming consistency (`--text-primary`, `--bg-secondary`, etc.)

https://claude.ai/code/session_01GFqqwmaij8pvk4QoSmDTpv