### PR TITLE
Add server folder browser for dataset import

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -1,4 +1,4 @@
-<vt-modal [title]="view === 'picker' ? 'Add Dataset' : view === 'demo' ? 'Load Demo Dataset' : selectedImporter?.display_name || selectedImporter?.name || 'Import'" [open]="true" (closed)="close()">
+<vt-modal [title]="view === 'picker' ? 'Add Dataset' : view === 'demo' ? 'Load Demo Dataset' : view === 'server_folder' ? 'Import from Server Folder' : selectedImporter?.display_name || selectedImporter?.name || 'Import'" [open]="true" (closed)="close()">
   @if (view === 'picker') {
     <div class="importer-picker">
       @if (importers.length === 0) {
@@ -12,6 +12,10 @@
           }
         </button>
       }
+      <button class="importer-card" (click)="openServerFolderBrowser()">
+        <span class="importer-name"><span class="importer-icon">🖥️</span> Import from Server Folder</span>
+        <span class="importer-desc">Browse directories on the server and import media files</span>
+      </button>
       <button class="importer-card demo-card" (click)="openDemoPicker()">
         <span class="importer-name"><span class="importer-icon">🎓</span> Load Demo Dataset</span>
         <span class="importer-desc">Choose from a selection of pre-configured demo datasets</span>
@@ -213,17 +217,125 @@
       @if (error) {
         <p class="error-text">{{ error }}</p>
       }
+    </div>
+  }
 
-      <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="close()">Cancel</button>
-        <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
-          @if (submitting) {
-            Importing...
-          } @else {
-            Import
+  @if (view === 'form' && selectedImporter) {
+    <div class="form-actions" modal-footer>
+      <button class="btn btn--secondary" (click)="close()">Cancel</button>
+      <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
+        @if (submitting) {
+          Importing...
+        } @else {
+          Import
+        }
+      </button>
+    </div>
+  }
+
+  @if (view === 'server_folder') {
+    <div class="server-folder-browser">
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+
+      <div class="form-group">
+        <label class="form-label" for="sf-media-type">Media Type</label>
+        <select
+          id="sf-media-type"
+          class="form-select"
+          [ngModel]="sfMediaType"
+          (ngModelChange)="sfOnMediaTypeChange($event)"
+        >
+          @for (opt of sfMediaTypeOptions; track opt) {
+            <option [value]="opt">{{ opt }}</option>
           }
-        </button>
+        </select>
       </div>
+
+      <div class="sf-browse-section">
+        <label class="form-label">Select Folder</label>
+        <div class="sf-breadcrumbs">
+          <button class="sf-breadcrumb" [class.active]="!sfBrowsePath" (click)="sfLoadDirectory('')">Root</button>
+          @for (crumb of sfBreadcrumbs; track $index) {
+            <span class="sf-breadcrumb-sep">/</span>
+            <button class="sf-breadcrumb" [class.active]="$index === sfBreadcrumbs.length - 1" (click)="sfNavigateBreadcrumb($index)">{{ crumb }}</button>
+          }
+        </div>
+
+        <div class="sf-dir-list">
+          @if (sfBrowseLoading) {
+            <p class="empty-state">Loading...</p>
+          } @else if (sfBrowseError) {
+            <p class="error-text">{{ sfBrowseError }}</p>
+          } @else if (sfBrowseDirs.length === 0) {
+            <p class="sf-empty-dir">No subdirectories. This folder will be imported.</p>
+          }
+          @if (sfBrowsePath) {
+            <button class="sf-dir-item" (click)="sfGoUp()">
+              <span class="sf-dir-icon">⬆️</span>
+              <span class="sf-dir-name">..</span>
+            </button>
+          }
+          @for (dir of sfBrowseDirs; track dir.path) {
+            <button class="sf-dir-item" (click)="sfEnterDirectory(dir)">
+              <span class="sf-dir-icon">📁</span>
+              <span class="sf-dir-name">{{ dir.name }}</span>
+            </button>
+          }
+        </div>
+
+        <div class="sf-selected-path">
+          <span class="form-label">Path:</span>
+          <code class="sf-path-display">{{ sfAbsolutePath }}</code>
+        </div>
+      </div>
+
+      @if (sfEmbedders.length > 1) {
+        <div class="form-group">
+          <label class="form-label" for="sf-embedder">Embedder</label>
+          <select
+            id="sf-embedder"
+            class="form-select"
+            [(ngModel)]="sfSelectedEmbedder"
+          >
+            @for (embedder of sfEmbedders; track embedder.name) {
+              <option [value]="embedder.name">{{ embedder.name }}</option>
+            }
+          </select>
+        </div>
+      }
+
+      @if (sfClippers.length > 1) {
+        <div class="form-group">
+          <label class="form-label" for="sf-clipper">Clipper</label>
+          <select
+            id="sf-clipper"
+            class="form-select"
+            [ngModel]="sfSelectedClipper"
+            (ngModelChange)="sfOnClipperChange($event)"
+          >
+            @for (clipper of sfClippers; track clipper.name) {
+              <option [value]="clipper.name">{{ clipper.name }}</option>
+            }
+          </select>
+        </div>
+      }
+
+      @if (sfBrowseError && !sfBrowseLoading) {
+        <p class="error-text">{{ sfBrowseError }}</p>
+      }
+    </div>
+  }
+
+  @if (view === 'server_folder') {
+    <div class="form-actions" modal-footer>
+      <button class="btn btn--secondary" (click)="close()">Cancel</button>
+      <button class="btn btn--primary" (click)="sfSubmit()" [disabled]="sfSubmitting || !sfAbsolutePath">
+        @if (sfSubmitting) {
+          Importing...
+        } @else {
+          Import
+        }
+      </button>
     </div>
   }
 </vt-modal>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -263,3 +263,122 @@
   font-size: 0.7rem;
   border-radius: 3px;
 }
+
+// --- Server folder browser ---
+
+.server-folder-browser {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sf-browse-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sf-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.sf-breadcrumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 0.8rem;
+
+  &:hover {
+    background: var(--bg-subtle);
+  }
+
+  &.active {
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: default;
+
+    &:hover {
+      background: none;
+    }
+  }
+}
+
+.sf-breadcrumb-sep {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.sf-dir-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.sf-dir-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  transition: background 0.15s;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: var(--bg-subtle);
+  }
+}
+
+.sf-dir-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.sf-dir-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sf-empty-dir {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  padding: 12px;
+  text-align: center;
+}
+
+.sf-selected-path {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.sf-path-display {
+  font-size: 0.8rem;
+  color: var(--text-secondary, var(--text-muted));
+  background: var(--bg-subtle);
+  padding: 3px 8px;
+  border-radius: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -5,7 +5,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 
-type ModalView = 'picker' | 'form' | 'demo';
+type ModalView = 'picker' | 'form' | 'demo' | 'server_folder';
 
 @Component({
   selector: 'vt-dataset-importer-modal',
@@ -48,6 +48,22 @@ export class DatasetImporterModalComponent implements OnInit {
   demoEmbedders: EmbedderInfo[] = [];
   selectedDemoEmbedder = '';
   demoEmbedder = '';
+
+  // Server folder browser state
+  sfBrowseDirs: { name: string; path: string }[] = [];
+  sfBrowsePath = '';
+  sfBrowseRootPath = '';
+  sfBrowseLoading = false;
+  sfBrowseError = '';
+  sfMediaType = '';
+  sfMediaTypeOptions: string[] = [];
+  sfEmbedders: EmbedderInfo[] = [];
+  sfSelectedEmbedder = '';
+  sfClippers: ClipperInfo[] = [];
+  sfSelectedClipper = '';
+  sfClipperParams: ClipperParameter[] = [];
+  sfClipperParamValues: Record<string, number | string> = {};
+  sfSubmitting = false;
 
   constructor(private datasetsApi: DatasetsApiService) {}
 
@@ -362,6 +378,150 @@ export class DatasetImporterModalComponent implements OnInit {
     this.view = 'picker';
     this.selectedImporter = null;
     this.error = '';
+  }
+
+  // --- Server folder browser ---
+
+  openServerFolderBrowser(): void {
+    this.view = 'server_folder';
+    this.sfBrowsePath = '';
+    this.sfBrowseRootPath = '';
+    this.sfBrowseDirs = [];
+    this.sfBrowseError = '';
+    this.sfSubmitting = false;
+
+    // Load media type options from the folder importer's fields
+    const folderImporter = this.importers.find((imp) => imp.name === 'folder');
+    const mtField = folderImporter?.fields?.find((f) => f.key === 'media_type');
+    this.sfMediaTypeOptions = mtField?.options || [];
+    this.sfMediaType = mtField?.default || this.sfMediaTypeOptions[0] || 'sounds';
+
+    this.sfLoadEmbedders(this.sfMediaType);
+    this.sfLoadClippers(this.sfMediaType);
+    this.sfLoadDirectory('');
+  }
+
+  sfLoadDirectory(path: string): void {
+    this.sfBrowseLoading = true;
+    this.sfBrowseError = '';
+    this.datasetsApi.browseMediaFiles('folder', path).subscribe({
+      next: (res) => {
+        this.sfBrowseDirs = res.directories;
+        this.sfBrowsePath = path;
+        this.sfBrowseRootPath = res.root_path;
+        this.sfBrowseLoading = false;
+      },
+      error: (err) => {
+        this.sfBrowseError = err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
+        this.sfBrowseLoading = false;
+      },
+    });
+  }
+
+  sfEnterDirectory(dir: { name: string; path: string }): void {
+    this.sfLoadDirectory(dir.path);
+  }
+
+  sfGoUp(): void {
+    if (!this.sfBrowsePath) return;
+    const parts = this.sfBrowsePath.split('/');
+    parts.pop();
+    this.sfLoadDirectory(parts.join('/'));
+  }
+
+  get sfBreadcrumbs(): string[] {
+    if (!this.sfBrowsePath) return [];
+    return this.sfBrowsePath.split('/');
+  }
+
+  sfNavigateBreadcrumb(index: number): void {
+    const parts = this.sfBrowsePath.split('/');
+    this.sfLoadDirectory(parts.slice(0, index + 1).join('/'));
+  }
+
+  get sfAbsolutePath(): string {
+    if (!this.sfBrowseRootPath) return '';
+    if (!this.sfBrowsePath) return this.sfBrowseRootPath;
+    return this.sfBrowseRootPath + '/' + this.sfBrowsePath;
+  }
+
+  sfOnMediaTypeChange(mediaType: string): void {
+    this.sfMediaType = mediaType;
+    this.sfLoadEmbedders(mediaType);
+    this.sfLoadClippers(mediaType);
+  }
+
+  private sfLoadEmbedders(mediaType: string): void {
+    if (!mediaType) {
+      this.sfEmbedders = [];
+      this.sfSelectedEmbedder = '';
+      return;
+    }
+    this.datasetsApi.getEmbedders(mediaType).subscribe({
+      next: (embedders) => {
+        this.sfEmbedders = embedders;
+        this.sfSelectedEmbedder = embedders.length > 0 ? embedders[0].name : '';
+      },
+    });
+  }
+
+  private sfLoadClippers(mediaType: string): void {
+    if (!mediaType) {
+      this.sfClippers = [];
+      this.sfSelectedClipper = '';
+      return;
+    }
+    this.datasetsApi.getClippers(mediaType).subscribe({
+      next: (clippers) => {
+        this.sfClippers = clippers;
+        this.sfSelectedClipper = clippers.length > 0 ? clippers[0].name : '';
+        this.sfResetClipperParams();
+      },
+    });
+  }
+
+  sfOnClipperChange(clipperName: string): void {
+    this.sfSelectedClipper = clipperName;
+    this.sfResetClipperParams();
+  }
+
+  private sfResetClipperParams(): void {
+    const clipper = this.sfClippers.find((c) => c.name === this.sfSelectedClipper);
+    this.sfClipperParams = clipper?.parameters || [];
+    this.sfClipperParamValues = {};
+    for (const param of this.sfClipperParams) {
+      this.sfClipperParamValues[param.key] = param.default;
+    }
+  }
+
+  sfSubmit(): void {
+    this.sfSubmitting = true;
+    this.sfBrowseError = '';
+
+    const params: Record<string, unknown> = {
+      path: this.sfAbsolutePath,
+      media_type: this.sfMediaType,
+    };
+    if (this.sfSelectedEmbedder) {
+      params['embedder'] = this.sfSelectedEmbedder;
+    }
+    if (this.sfSelectedClipper) {
+      params['clipper'] = this.sfSelectedClipper;
+      if (this.sfClipperParams.length > 0 && Object.keys(this.sfClipperParamValues).length > 0) {
+        params['clipper_params'] = { ...this.sfClipperParamValues };
+      }
+    }
+
+    this.datasetsApi.runImporter('folder', params).subscribe({
+      next: () => {
+        this.sfSubmitting = false;
+        this.importStarted.emit();
+      },
+      error: (err) => {
+        this.sfSubmitting = false;
+        this.sfBrowseError = err.error?.error || 'Import failed';
+      },
+    });
   }
 
   onFileSelected(event: Event, fieldName: string): void {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -56,10 +56,12 @@ export class DatasetsApiService {
   ): Observable<{
     directories: { name: string; path: string }[];
     files: { name: string; path: string; size_bytes: number }[];
+    root_path: string;
   }> {
     return this.http.get<{
       directories: { name: string; path: string }[];
       files: { name: string; path: string; size_bytes: number }[];
+      root_path: string;
     }>('/api/browse-media-files', { params: { source, path } });
   }
 

--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -251,7 +251,7 @@ def browse_media_files():
                 "size_bytes": entry.stat().st_size,
             })
 
-    return jsonify({"directories": directories, "files": files})
+    return jsonify({"directories": directories, "files": files, "root_path": str(root)})
 
 
 @datasets_ui_bp.route("/api/browse-media-files/select", methods=["POST"])


### PR DESCRIPTION
## Summary
This PR adds a new "Import from Server Folder" feature to the dataset importer modal, allowing users to browse directories on the server and import media files directly without uploading.

## Key Changes

- **New Modal View**: Added `'server_folder'` view type to the dataset importer modal alongside existing 'picker', 'form', and 'demo' views

- **Server Folder Browser UI**: 
  - New folder browsing interface with breadcrumb navigation
  - Directory listing with up/parent directory navigation
  - Real-time path display showing absolute server path
  - Loading and error states

- **Server Folder State Management**:
  - Added comprehensive state properties for folder browsing (sfBrowseDirs, sfBrowsePath, sfBrowseRootPath, etc.)
  - Added state for media type, embedder, and clipper selection specific to server folder imports
  - Separate parameter tracking for clipper configuration

- **Server Folder Methods**:
  - `openServerFolderBrowser()`: Initialize and open the folder browser
  - `sfLoadDirectory()`: Fetch directory contents from server
  - `sfEnterDirectory()` / `sfGoUp()`: Navigate directory hierarchy
  - `sfNavigateBreadcrumb()`: Jump to specific breadcrumb location
  - `sfOnMediaTypeChange()`: Update embedders/clippers when media type changes
  - `sfOnClipperChange()`: Reset clipper parameters when clipper selection changes
  - `sfSubmit()`: Submit import request with selected path and configuration

- **API Integration**:
  - Updated `browseMediaFiles()` API call to include `root_path` in response
  - Uses existing `runImporter('folder', params)` endpoint with path-based parameters

- **UI Enhancements**:
  - Added "Import from Server Folder" button to importer picker (with 🖥️ icon)
  - Updated modal title to reflect server folder view
  - Styled folder browser with breadcrumbs, directory list, and path display
  - Conditional rendering of embedder/clipper selectors (only shown if multiple options available)

## Implementation Details

- Server folder import reuses the existing 'folder' importer backend with path-based parameters
- Embedders and clippers are dynamically loaded based on selected media type
- Clipper parameters are automatically initialized with default values
- The absolute path is computed from root_path and relative browse path
- Import submission is disabled until a valid path is selected

https://claude.ai/code/session_011YjYV1Dk4Z6r7nvJ3x5Gtp