### PR TITLE
Adjust dataset importer table layout and remove description truncation

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -80,7 +80,7 @@
                   <td class="col-name">{{ demo.label }}</td>
                   <td class="col-num">{{ demo.num_files }}</td>
                   <td class="col-num">{{ demo.num_categories }}</td>
-                  <td class="col-desc" [title]="demo.description">{{ demo.description.length > 60 ? demo.description.slice(0, 57) + '...' : demo.description }}</td>
+                  <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
                   <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
                 </tr>
               }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -188,10 +188,10 @@
     }
   }
 
-  thead th:nth-child(1) { width: 22%; }
-  thead th:nth-child(2) { width: 11%; }
-  thead th:nth-child(3) { width: 10%; }
-  thead th:nth-child(5) { width: 14%; }
+  thead th:nth-child(1) { width: 18%; }
+  thead th:nth-child(2) { width: 7%; }
+  thead th:nth-child(3) { width: 6%; }
+  thead th:nth-child(5) { width: 10%; }
 }
 
 .col-num {


### PR DESCRIPTION
## Summary
Updated the dataset importer modal table to improve layout and display full dataset descriptions without truncation.

## Key Changes
- **Table column widths**: Adjusted `thead th` width percentages to better accommodate content:
  - Column 1 (name): 22% → 18%
  - Column 2 (num_files): 11% → 7%
  - Column 3 (num_categories): 10% → 6%
  - Column 5 (status): 14% → 10%
- **Description display**: Removed character limit truncation (57 chars) and now displays full description text
- **Tooltip**: Retained `[title]` attribute for full description on hover, providing better UX for long descriptions

## Implementation Details
The changes optimize the table layout by reducing column widths for numeric and status columns, freeing up more space for the description column. The full description is now visible in the table cell while still providing a tooltip for accessibility.

https://claude.ai/code/session_01P1qzC8axmjSvFWQKHRfxJp