### PR TITLE
Reduce spacing and padding in center and left panel components

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -15,8 +15,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
+  gap: 2px;
+  padding: 2px 4px;
   overflow: hidden;
 
   &.empty {

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -62,8 +62,8 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: 8px;
-  gap: 8px;
+  padding: 4px;
+  gap: 4px;
 
   &.collapsed {
     padding: 4px 4px;


### PR DESCRIPTION
## Summary
This PR reduces the spacing and padding values in the center panel and left panel components to create a more compact UI layout.

## Key Changes
- **Center Panel Component**: Reduced gap from 4px to 2px and padding from 4px 8px to 2px 4px
- **Left Panel Component**: Reduced padding from 8px to 4px and gap from 8px to 4px

## Implementation Details
These changes affect the visual spacing within the panel layouts, making the components more space-efficient while maintaining the overall structure and functionality. The collapsed state padding in the left panel remains unchanged at 4px 4px.

https://claude.ai/code/session_01TMTTnWwL3qKXCLFxZ2xo5m