### PR TITLE
Move view button from label list to right panel header

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -2,7 +2,6 @@
   <h3 [class]="label">
     {{ label === 'good' ? 'Good' : 'Bad' }}
     <span class="label-count">({{ ids.length }})</span>
-    <button class="view-btn" (click)="viewButtonClicked.emit()">View</button>
   </h3>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-columns]="gridColumns">
     @for (entry of sortedEntries; track trackById($index, entry)) {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -42,26 +42,6 @@ h3 {
   font-weight: normal;
 }
 
-.view-btn {
-  margin-left: auto;
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 1px 8px;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-weight: normal;
-  text-transform: none;
-  letter-spacing: 0;
-  line-height: 1.4;
-
-  &:hover {
-    color: var(--text-primary);
-    border-color: var(--text-primary);
-  }
-}
-
 .vote-list {
   &.grid-layout {
     display: grid;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -30,7 +30,6 @@ export class LabelListComponent implements OnInit, OnChanges {
   @Input() focusMode: 'click' | 'hover' = 'click';
   @Output() mediaSelected = new EventEmitter<number>();
   @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
-  @Output() viewButtonClicked = new EventEmitter<void>();
 
   sortedEntries: LabelEntry[] = [];
 

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -14,6 +14,7 @@
       [mode]="sortMode"
       (modeChange)="onSortModeChange($event)"
     />
+    <button class="view-btn" (click)="onViewSettings()">View</button>
   </div>
 
   <vt-label-list
@@ -28,7 +29,6 @@
     [focusMode]="focusMode"
     (mediaSelected)="onMediaSelected($event)"
     (mediaVote)="onMediaVote($event)"
-    (viewButtonClicked)="onViewSettings()"
   />
 
   <vt-label-list
@@ -43,7 +43,6 @@
     [focusMode]="focusMode"
     (mediaSelected)="onMediaSelected($event)"
     (mediaVote)="onMediaVote($event)"
-    (viewButtonClicked)="onViewSettings()"
   />
 
   <div class="export-row">

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -37,6 +37,23 @@
   }
 }
 
+.view-btn {
+  margin-right: 12px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 8px;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  line-height: 1.4;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+  }
+}
+
 .export-row {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Summary
Refactored the view button UI by moving it from individual label list components to the right panel header, consolidating the control in a single location.

## Key Changes
- Removed `.view-btn` styling from `label-list.component.scss` and moved it to `right-panel.component.scss` with updated spacing (`margin-right: 12px` instead of `margin-left: auto`)
- Removed the view button HTML element and associated click handler from `label-list.component.html`
- Removed the `@Output() viewButtonClicked` event emitter from `label-list.component.ts`
- Added a single "View" button to the right panel header in `right-panel.component.html` that calls `onViewSettings()`
- Removed the `(viewButtonClicked)` event bindings from both label list instances in the right panel template

## Implementation Details
The view button is now positioned in the right panel's header section alongside the sort mode selector, providing a cleaner UI with a single control point instead of duplicate buttons in each label list section. The button styling remains consistent with the original design while being repositioned for better UX.

https://claude.ai/code/session_01VmVaWLA3RAkUhzwcryzxM7