### PR TITLE
Pass false parameter to onLearnedSort in hard phase

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -128,7 +128,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         else if (curr.phase === 'hard') {
           this.sortState.setSelectMode('hard');
           this.sortState.setSortMode('learned');
-          this.onLearnedSort();
+          this.onLearnedSort(false);
         }
         else if (curr.phase === 'new') this.sortState.setSelectMode('new');
       });


### PR DESCRIPTION
## Summary
Updated the `onLearnedSort()` method call in the hard phase handler to explicitly pass `false` as a parameter.

## Changes
- Modified the hard phase condition in `LabelViewComponent` to pass `false` argument when calling `this.onLearnedSort()`
- This ensures the learned sort operation in hard phase is executed with the intended parameter value

## Details
When the component transitions to the 'hard' phase, it now calls `onLearnedSort(false)` instead of `onLearnedSort()` without arguments. This change likely controls a specific behavior flag in the sort operation, ensuring consistent and explicit handling of the learned sort functionality during hard phase transitions.

https://claude.ai/code/session_013KJG659BwobsR5K1z2KrYB