### PR TITLE
Fix autopilot resort prompt logic and state cleanup

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -355,6 +355,69 @@ describe('LabelViewComponent', () => {
     expect(component.mediaState.selectedId).toBe(2);
   });
 
+  it('should deactivate autopilot state when switching to manual mode', () => {
+    flushInitialRequests();
+
+    const autopilot = TestBed.inject(AutopilotStateService);
+    autopilot.activate();
+    expect(autopilot.running).toBeTrue();
+    expect(autopilot.state.phase).toBe('good');
+
+    component.onAutopilotStop();
+    expect(autopilot.running).toBeFalse();
+    expect(autopilot.state.phase).toBe('idle');
+  });
+
+  it('should not show resort prompt after switching to manual mode', () => {
+    const session = TestBed.inject(LabelSessionService);
+    session.textQuery = 'test query';
+    flushInitialRequests();
+
+    const autopilot = TestBed.inject(AutopilotStateService);
+    autopilot.activate();
+    component.onAutopilotStart();
+
+    // Switch to manual mode
+    component.onAutopilotStop();
+
+    // Vote many times — resort prompt should never fire because autopilot is off
+    for (let i = 0; i < 15; i++) {
+      component.onMediaVoted({ id: 1, vote: 'good' });
+      httpMock.match('/api/votes').forEach(req =>
+        req.flush({ good: [1], bad: [], click_times: {}, learned_scores: {} }),
+      );
+    }
+
+    expect(component.showResortPrompt).toBeFalse();
+  });
+
+  it('should not show resort prompt after phase transitions past good', () => {
+    const session = TestBed.inject(LabelSessionService);
+    session.textQuery = 'test query';
+    flushInitialRequests();
+
+    const autopilot = TestBed.inject(AutopilotStateService);
+    autopilot.activate();
+    component.onAutopilotStart();
+
+    // Simulate optimistic votes that push good count past threshold
+    component.voteState.loadVotes();
+    httpMock.expectOne('/api/votes').flush({ good: [1, 2, 3], bad: [], click_times: {}, learned_scores: {} });
+
+    // Phase should transition to 'bad' when checkResortPrompt eagerly checks
+    // Vote 11 times (exceeding default resort interval of 10)
+    for (let i = 0; i < 11; i++) {
+      component.onMediaVoted({ id: 1, vote: 'bad' });
+      httpMock.match('/api/votes').forEach(req =>
+        req.flush({ good: [1, 2, 3], bad: [4], click_times: {}, learned_scores: {} }),
+      );
+    }
+
+    // Phase should have transitioned to 'bad', so no resort prompt
+    expect(autopilot.state.phase).toBe('bad');
+    expect(component.showResortPrompt).toBeFalse();
+  });
+
   it('should clear stale autopilot state from previous session on init', () => {
     const autopilot = TestBed.inject(AutopilotStateService);
     // Simulate leftover state from a previous detector session

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -533,6 +533,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private checkResortPrompt(): void {
     // Only show during autopilot's "good" phase (sorting by example in top mode)
     if (!this.autopilotStateService.running) return;
+    // Eagerly check phase transition so we don't show the prompt after the user
+    // has already found enough greens (the panel's ngOnChanges may not have run yet).
+    this.autopilotStateService.checkPhaseTransition(
+      this.voteState.goodVotes.size, this.voteState.badVotes.size,
+    );
     const phase = this.autopilotStateService.state.phase;
     if (phase !== 'good') return;
 
@@ -623,6 +628,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       this.sortState.setSortMode('learned');
       this.sortState.setSelectMode('new');
     }
+
+    // Deactivate autopilot state so resort prompt and phase logic stop firing.
+    this.autopilotStateService.deactivate();
+    this.showResortPrompt = false;
   }
 
   // --- Panel percentage helpers ---


### PR DESCRIPTION
## Summary
This PR fixes issues with the autopilot resort prompt appearing at incorrect times and ensures proper cleanup when switching from autopilot to manual mode.

## Key Changes
- **Eager phase transition check**: Added `checkPhaseTransition()` call in `checkResortPrompt()` to detect phase changes before the panel's change detection runs, preventing the resort prompt from showing after the user has already found enough good votes
- **Autopilot deactivation**: Implemented proper cleanup in `onAutopilotStop()` to:
  - Deactivate the autopilot state service
  - Reset the `showResortPrompt` flag to false
  - Prevent resort prompt and phase transition logic from firing after switching to manual mode
- **Test coverage**: Added three comprehensive test cases covering:
  - Autopilot state deactivation when switching to manual mode
  - Resort prompt suppression after manual mode activation
  - Resort prompt suppression after phase transitions past the "good" phase

## Implementation Details
The fix addresses a race condition where the resort prompt could appear even after the autopilot phase had transitioned away from "good". By eagerly checking phase transitions in `checkResortPrompt()`, we ensure the phase state is current before deciding whether to show the prompt. Additionally, properly deactivating autopilot state when the user switches to manual mode prevents stale autopilot logic from interfering with the labeling session.

https://claude.ai/code/session_01B8BKGRZ6HEzo8Xfk3RRKMd