### PR TITLE
Add negative results and media_type to /api/find response

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -514,14 +514,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.progressIndeterminate = false;
 
         // Convert /api/find response to AutoDetectResultsData format
-        const hits = (response.results || []).map((r: any) => ({
+        const mapHit = (r: any) => ({
           md5: r.md5 || '',
           filename: r.filename || '',
           origin_name: r.origin_name || '',
           origin: r.origin,
           dataset_name: r.dataset_name || '',
           model_verdicts: r.model_verdicts || {},
-        }));
+        });
+
+        const hits = (response.results || []).map(mapHit);
+        const negativeHits = (response.negative_results || []).map(mapHit);
 
         const modelNames: string[] = response.models || [];
         const detectorResults: Record<string, any> = {};
@@ -533,6 +536,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             detector_name: label,
             total_hits: hits.length,
             hits,
+            negative_hits: negativeHits,
           };
         } else {
           // Multiple models: group hits by model
@@ -540,16 +544,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
             const modelHits = hits.filter(
               (h: any) => h.model_verdicts?.[name]?.verdict === 'Good',
             );
+            const modelNegHits = negativeHits.filter(
+              (h: any) => h.model_verdicts?.[name]?.verdict !== 'Good',
+            );
             detectorResults[name] = {
               detector_name: name,
               total_hits: modelHits.length,
               hits: modelHits,
+              negative_hits: modelNegHits,
             };
           }
         }
 
         this.findResultsData = {
-          media_type: `Find (${response.total_hits || 0} hits)`,
+          media_type: response.media_type || 'unknown',
           detectors_run: modelNames.length,
           results: detectorResults,
           models: modelNames,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -296,7 +296,6 @@ class TestMultiFindCrossDatasetFallback:
 
         from vtsearch.datasets.registry import register_dataset
         from vtsearch.models.registry import register_model
-        from vtsearch.utils import medias, snapshot_medias
 
         # Create a folder with media files for the trainable model's labels
         label_folder = tmp_path / "label_audio"
@@ -404,3 +403,171 @@ class TestMultiFindCrossDatasetFallback:
             verdicts = r["model_verdicts"]
             assert "Test Cross Detector" in verdicts
             assert verdicts["Test Cross Detector"]["verdict"] in ("Good", "Bad")
+
+    def test_find_returns_media_type(self, client, tmp_path):
+        """The /api/find response should include the media_type from the dataset."""
+        import json
+        import pickle
+        import time
+
+        from vtsearch.datasets.registry import register_dataset
+        from vtsearch.models.registry import register_model
+
+        # Create a target dataset pkl
+        target_medias = {}
+        for i in range(5):
+            emb = np.random.RandomState(i).randn(512).astype(np.float32)
+            target_medias[i] = {
+                "id": i,
+                "type": "audio",
+                "embedding": emb,
+                "md5": f"mt_md5_{i}",
+                "filename": f"mt_{i}.wav",
+                "origin_name": f"mt_{i}.wav",
+                "origin": {"importer": "folder", "params": {"path": "/mt/folder"}},
+            }
+
+        pkl_path = tmp_path / "mt_target.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": target_medias}, f)
+
+        ds = register_dataset(name="mt_ds", media_type="audio", num_items=5, pkl_path=str(pkl_path))
+
+        # Create a trainable model with labels
+        label_folder = tmp_path / "mt_label_audio"
+        label_folder.mkdir()
+        (label_folder / "good.wav").write_bytes(b"good_content")
+        (label_folder / "bad.wav").write_bytes(b"bad_content")
+
+        label_origin = {"importer": "folder", "params": {"path": str(label_folder)}}
+        from vtsearch.routes.trainable_models import _model_path, _write_model
+
+        tm_name = "test_mt_detector"
+        tm_data = {
+            "name": "Test MT Detector",
+            "text_query": "",
+            "media_type": "audio",
+            "examples": [],
+            "created_at": time.time(),
+            "labelset": {
+                "labels": [
+                    {"md5": "g_md5", "label": "good", "origin": label_origin, "origin_name": "good.wav", "filename": "good.wav"},
+                    {"md5": "b_md5", "label": "bad", "origin": label_origin, "origin_name": "bad.wav", "filename": "bad.wav"},
+                ]
+            },
+        }
+        _write_model(_model_path(tm_name), tm_data)
+
+        model_entry = register_model(
+            name="Test MT Detector",
+            media_type="audio",
+            trainable=True,
+            num_training=2,
+            trainable_model_name=tm_name,
+        )
+
+        good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
+        bad_emb = np.random.RandomState(200).randn(512).astype(np.float32)
+
+        def fake_embed(path, media_type):
+            return good_emb if "good" in Path(path).name else bad_emb
+
+        with patch("vtsearch.models.resolver.embed_file", side_effect=fake_embed):
+            resp = client.post(
+                "/api/find",
+                data=json.dumps({"dataset_ids": [ds["id"]], "model_ids": [model_entry["id"]]}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["media_type"] == "audio"
+
+    def test_find_returns_negative_results(self, client, tmp_path):
+        """The /api/find response should include negative_results for Bad verdicts."""
+        import json
+        import pickle
+        import time
+
+        from vtsearch.datasets.registry import register_dataset
+        from vtsearch.models.registry import register_model
+
+        # Create a target dataset pkl
+        target_medias = {}
+        for i in range(5):
+            emb = np.random.RandomState(i).randn(512).astype(np.float32)
+            target_medias[i] = {
+                "id": i,
+                "type": "image",
+                "embedding": emb,
+                "md5": f"nr_md5_{i}",
+                "filename": f"nr_{i}.jpg",
+                "origin_name": f"nr_{i}.jpg",
+                "origin": {"importer": "folder", "params": {"path": "/nr/folder"}},
+            }
+
+        pkl_path = tmp_path / "nr_target.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": target_medias}, f)
+
+        ds = register_dataset(name="nr_ds", media_type="image", num_items=5, pkl_path=str(pkl_path))
+
+        # Create a trainable model with labels
+        label_folder = tmp_path / "nr_label"
+        label_folder.mkdir()
+        (label_folder / "good.jpg").write_bytes(b"good_content")
+        (label_folder / "bad.jpg").write_bytes(b"bad_content")
+
+        label_origin = {"importer": "folder", "params": {"path": str(label_folder)}}
+        from vtsearch.routes.trainable_models import _model_path, _write_model
+
+        tm_name = "test_nr_detector"
+        tm_data = {
+            "name": "Test NR Detector",
+            "text_query": "",
+            "media_type": "image",
+            "examples": [],
+            "created_at": time.time(),
+            "labelset": {
+                "labels": [
+                    {"md5": "g_md5", "label": "good", "origin": label_origin, "origin_name": "good.jpg", "filename": "good.jpg"},
+                    {"md5": "b_md5", "label": "bad", "origin": label_origin, "origin_name": "bad.jpg", "filename": "bad.jpg"},
+                ]
+            },
+        }
+        _write_model(_model_path(tm_name), tm_data)
+
+        model_entry = register_model(
+            name="Test NR Detector",
+            media_type="image",
+            trainable=True,
+            num_training=2,
+            trainable_model_name=tm_name,
+        )
+
+        good_emb = np.random.RandomState(100).randn(512).astype(np.float32)
+        bad_emb = np.random.RandomState(200).randn(512).astype(np.float32)
+
+        def fake_embed(path, media_type):
+            return good_emb if "good" in Path(path).name else bad_emb
+
+        with patch("vtsearch.models.resolver.embed_file", side_effect=fake_embed):
+            resp = client.post(
+                "/api/find",
+                data=json.dumps({"dataset_ids": [ds["id"]], "model_ids": [model_entry["id"]]}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        # Should have both results and negative_results
+        assert "negative_results" in data
+        assert isinstance(data["negative_results"], list)
+
+        # Total of results + negative_results should equal the dataset size
+        total = len(data["results"]) + len(data["negative_results"])
+        assert total == 5
+
+        # media_type should be set correctly from the dataset
+        assert data["media_type"] == "image"

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -530,6 +530,8 @@ def multi_find():
 
     # Run Find across all datasets × models
     all_results = []
+    all_negative_results = []
+    detected_media_type = ""
     multiple_datasets = len(datasets) > 1
     multiple_models = len(model_configs) > 1
     model_names = [mc["name"] for mc in model_configs]
@@ -557,6 +559,11 @@ def multi_find():
 
         if not temp_medias:
             continue
+
+        # Detect media type from loaded dataset
+        if not detected_media_type:
+            first_media = next(iter(temp_medias.values()), {})
+            detected_media_type = first_media.get("type", "")
 
         # Build embeddings tensor
         all_ids = sorted(temp_medias.keys())
@@ -663,11 +670,13 @@ def multi_find():
                             "score": 0,
                         }
 
-        # Collect positive hits (Good for at least one model)
+        # Collect positive and negative hits
         for cid, mr in media_results.items():
             verdicts = mr["model_verdicts"]
             if any(v["verdict"] == "Good" for v in verdicts.values()):
                 all_results.append(mr)
+            elif any(v["verdict"] in ("Bad", "Error", "N/A") for v in verdicts.values()):
+                all_negative_results.append(mr)
 
         # Free memory
         del temp_medias, X_all
@@ -676,8 +685,10 @@ def multi_find():
     return jsonify(
         {
             "results": all_results,
+            "negative_results": all_negative_results,
             "datasets": [ds["name"] for ds in datasets],
             "models": model_names,
+            "media_type": detected_media_type,
             "multiple_datasets": multiple_datasets,
             "multiple_models": multiple_models,
             "total_hits": len(all_results),


### PR DESCRIPTION
## Summary
Enhanced the `/api/find` endpoint to return negative results (items with "Bad" verdicts) alongside positive results, and to include the detected media type from the dataset in the response. Updated the frontend to properly display and handle these negative results.

## Key Changes

**Backend (`vtsearch/routes/detectors_training.py`)**
- Modified `multi_find()` to track and return negative results separately from positive results
- Added detection of media type from the first loaded dataset and include it in the response
- Negative results are now collected for items with "Bad", "Error", or "N/A" verdicts
- Response now includes `negative_results`, `media_type` fields alongside existing `results`

**Frontend (`frontend/src/app/components/dashboard/dashboard.component.ts`)**
- Refactored hit mapping logic into a reusable `mapHit` function
- Added processing of `negative_results` from the API response
- Updated detector results to include `negative_hits` for each model
- Changed `media_type` display from showing hit count to showing the actual media type from the dataset

**Tests (`tests/test_resolver.py`)**
- Removed unused import of `medias` and `snapshot_medias`
- Added `test_find_returns_media_type()` to verify media_type is correctly returned in the response
- Added `test_find_returns_negative_results()` to verify negative results are properly collected and returned

## Implementation Details
- Negative results are filtered based on verdict values, capturing items that didn't match the "Good" criteria
- Media type detection happens on first dataset load to avoid redundant checks
- The frontend properly groups negative hits by model when multiple models are used
- Total results (positive + negative) should equal the dataset size when all items are processed

https://claude.ai/code/session_01X2Bn7d5yRrJrZda7enZukA