### PR TITLE
Refactor media type display and view button layout

### DIFF
--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
@@ -12,5 +12,4 @@
     (input)="onInput($event)"
     aria-label="Inclusion"
   />
-  <button class="view-btn" (click)="viewClicked.emit()">View</button>
 </div>

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
@@ -10,26 +10,6 @@
   white-space: nowrap;
 }
 
-.view-btn {
-  margin-left: auto;
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 1px 8px;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-weight: normal;
-  text-transform: none;
-  letter-spacing: 0;
-  line-height: 1.4;
-  white-space: nowrap;
-
-  &:hover {
-    color: var(--text-primary);
-    border-color: var(--text-primary);
-  }
-}
 
 input[type="number"] {
   width: 56px;

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.ts
@@ -12,7 +12,6 @@ export class InclusionSliderComponent {
   @Input() value = 0;
 
   @Output() valueChange = new EventEmitter<number>();
-  @Output() viewClicked = new EventEmitter<void>();
 
   onInput(event: Event): void {
     const target = event.target as HTMLInputElement;

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -50,8 +50,15 @@
       <vt-inclusion-slider
         [value]="inclusion"
         (valueChange)="inclusionChange.emit($event)"
-        (viewClicked)="showLeftViewSettings = true"
       />
+
+      <div class="images-header">
+        <h3 class="images-header-title">
+          {{ mediaTypeName }}
+          <span class="images-header-count">({{ medias.length }})</span>
+        </h3>
+        <button class="view-btn" (click)="showLeftViewSettings = true">View</button>
+      </div>
 
       <div class="media-list-container">
         <vt-media-list

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -71,6 +71,49 @@
   }
 }
 
+.images-header {
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+  flex-shrink: 0;
+}
+
+.images-header-title {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.images-header-count {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: normal;
+}
+
+.view-btn {
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 8px;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-weight: normal;
+  text-transform: none;
+  letter-spacing: 0;
+  line-height: 1.4;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+  }
+}
+
 .media-list-container {
   flex: 1;
   display: flex;

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SortBarComponent } from './sort-bar/sort-bar.component';
 import { SelectModeComponent } from './select-mode/select-mode.component';
@@ -8,7 +8,8 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { LeftViewSettingsModalComponent } from '../modals/left-view-settings-modal/left-view-settings-modal.component';
-import { MediaItem, LabelingStatusResponse } from '../../models/api.models';
+import { MediaItem, LabelingStatusResponse, MediaTypeInfo } from '../../models/api.models';
+import { DatasetsApiService } from '../../services/datasets-api.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 
 export type { SortMode, SelectMode, SortedItem };
@@ -30,7 +31,7 @@ export type { SortMode, SelectMode, SortedItem };
   templateUrl: './left-panel.component.html',
   styleUrl: './left-panel.component.scss',
 })
-export class LeftPanelComponent implements OnInit {
+export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() medias: MediaItem[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
@@ -71,11 +72,37 @@ export class LeftPanelComponent implements OnInit {
 
   activeTab: 'manual' | 'autopilot' = 'autopilot';
   showLeftViewSettings = false;
+  mediaTypeName = 'Media';
+  private mediaTypeInfos: MediaTypeInfo[] = [];
+  private currentTypeId = '';
+
+  constructor(private datasetsApi: DatasetsApiService) {}
 
   ngOnInit(): void {
+    this.datasetsApi.getMediaTypes().subscribe({
+      next: (resp) => {
+        this.mediaTypeInfos = resp.media_types;
+        this.updateMediaTypeName();
+      },
+    });
     this.activeTab = this.autopilotEnabled ? 'autopilot' : 'manual';
     if (this.autopilotEnabled) {
       this.autopilotStart.emit();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['medias']) {
+      this.updateMediaTypeName();
+    }
+  }
+
+  private updateMediaTypeName(): void {
+    const typeId = this.medias.length > 0 ? this.medias[0].type : '';
+    if (typeId && typeId !== this.currentTypeId) {
+      this.currentTypeId = typeId;
+      const info = this.mediaTypeInfos.find((mt) => mt.type_id === typeId);
+      this.mediaTypeName = info?.name ?? typeId.charAt(0).toUpperCase() + typeId.slice(1);
     }
   }
 


### PR DESCRIPTION
## Summary
This PR refactors the media type display and view button positioning in the left panel. The view button is moved from the inclusion slider component to a new dedicated header section that displays the media type name and item count.

## Key Changes
- **New images header section**: Added `.images-header`, `.images-header-title`, and `.images-header-count` styles to create a dedicated header displaying the media type name and count of items
- **View button relocation**: Moved the "View" button from the inclusion slider component to the new images header, with corresponding style migration to `left-panel.component.scss`
- **Dynamic media type naming**: Implemented logic in `LeftPanelComponent` to fetch media type information from the API and display the appropriate media type name (e.g., "Images", "Videos") instead of a generic "Media" label
- **Component lifecycle updates**: Added `OnChanges` implementation to update the media type name when the medias input changes
- **Removed unused output**: Removed the `viewClicked` output event from `InclusionSliderComponent` as the button is no longer part of that component

## Implementation Details
- The `LeftPanelComponent` now injects `DatasetsApiService` to fetch media type information on initialization
- Media type name is determined by matching the first media item's type ID against the fetched media type info
- The header displays both the media type name and the count of items in parentheses
- Fallback behavior: if media type info is not found, the type ID is capitalized and used as the display name

https://claude.ai/code/session_0112drNLT2bP3HzjhZhxVqDJ