### PR TITLE
Add clipper selection support to demo dataset importer

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -255,7 +255,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.startProgressPolling();
   }
 
-  onDemoSelected(demo: { label: string; name: string; embedder?: string }): void {
+  onDemoSelected(demo: { label: string; name: string; embedder?: string; clipper?: string }): void {
     this.importerModalOpen = false;
     this.datasetState.setLoading(true);
     this.datasetState.setProgressMessage(`Loading demo: ${demo.label}...`);
@@ -263,6 +263,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const params: Record<string, string> = {};
     if (demo.embedder) {
       params['embedder'] = demo.embedder;
+    }
+    if (demo.clipper) {
+      params['clipper'] = demo.clipper;
     }
     this.datasetsApi.loadDemo(demo.name, params).subscribe({
       next: () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -42,19 +42,34 @@
           }
         </div>
 
-        @if (demoEmbedders.length > 1) {
+        @if (demoEmbedders.length > 1 || demoClippers.length > 1) {
           <div class="demo-embedder-row">
-            <label class="form-label" for="demo-embedder">Embedder:</label>
-            <select
-              id="demo-embedder"
-              class="form-select form-select--inline"
-              [ngModel]="selectedDemoEmbedder"
-              (ngModelChange)="onDemoEmbedderChange($event)"
-            >
-              @for (embedder of demoEmbedders; track embedder.name) {
-                <option [value]="embedder.name">{{ embedder.name }}</option>
-              }
-            </select>
+            @if (demoEmbedders.length > 1) {
+              <label class="form-label" for="demo-embedder">Embedder:</label>
+              <select
+                id="demo-embedder"
+                class="form-select form-select--inline"
+                [ngModel]="selectedDemoEmbedder"
+                (ngModelChange)="onDemoEmbedderChange($event)"
+              >
+                @for (embedder of demoEmbedders; track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </select>
+            }
+            @if (demoClippers.length > 1) {
+              <label class="form-label" for="demo-clipper">Clipper:</label>
+              <select
+                id="demo-clipper"
+                class="form-select form-select--inline"
+                [ngModel]="selectedDemoClipper"
+                (ngModelChange)="onDemoClipperChange($event)"
+              >
+                @for (clipper of demoClippers; track clipper.name) {
+                  <option [value]="clipper.name">{{ clipper.display_name || clipper.name }}</option>
+                }
+              </select>
+            }
           </div>
         }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -48,6 +48,8 @@ export class DatasetImporterModalComponent implements OnInit {
   demoEmbedders: EmbedderInfo[] = [];
   selectedDemoEmbedder = '';
   demoEmbedder = '';
+  demoClippers: ClipperInfo[] = [];
+  selectedDemoClipper = '';
 
   // Server folder browser state
   sfBrowseDirs: { name: string; path: string }[] = [];
@@ -223,6 +225,8 @@ export class DatasetImporterModalComponent implements OnInit {
     if (!mediaType) {
       this.demoEmbedders = [];
       this.selectedDemoEmbedder = '';
+      this.demoClippers = [];
+      this.selectedDemoClipper = '';
       return;
     }
     this.datasetsApi.getEmbedders(mediaType).subscribe({
@@ -231,11 +235,17 @@ export class DatasetImporterModalComponent implements OnInit {
         this.selectedDemoEmbedder = embedders.length > 0 ? embedders[0].name : '';
         this.demoEmbedder = this.selectedDemoEmbedder;
         this.updateDemoStatuses();
-        // The initial demo fetch had no embedder context, so re-fetch with the
-        // now-known default embedder for authoritative status values.
+        // The initial demo fetch had no embedder/clipper context, so re-fetch
+        // with the now-known defaults for authoritative status values.
         if (this.selectedDemoEmbedder) {
-          this.refetchDemoStatuses(this.selectedDemoEmbedder);
+          this.refetchDemoStatuses(this.selectedDemoEmbedder, this.selectedDemoClipper);
         }
+      },
+    });
+    this.datasetsApi.getClippers(mediaType).subscribe({
+      next: (clippers) => {
+        this.demoClippers = clippers;
+        this.selectedDemoClipper = clippers.length > 0 ? clippers[0].name : '';
       },
     });
   }
@@ -244,31 +254,32 @@ export class DatasetImporterModalComponent implements OnInit {
     this.selectedDemoEmbedder = embedder;
     this.demoEmbedder = embedder;
     this.updateDemoStatuses();
-    // Re-fetch from the server for authoritative status when the pkl_embedder
-    // is missing or the client-side heuristic might be wrong.
-    this.refetchDemoStatuses(embedder);
+    this.refetchDemoStatuses(embedder, this.selectedDemoClipper);
+  }
+
+  onDemoClipperChange(clipper: string): void {
+    this.selectedDemoClipper = clipper;
+    this.updateDemoStatuses();
+    this.refetchDemoStatuses(this.selectedDemoEmbedder, this.selectedDemoClipper);
   }
 
   /**
-   * Re-compute each demo's status client-side based on the selected embedder.
-   * A demo that has a cached pkl (`pkl_embedder` is set) is only "ready" when
-   * the pkl embedder matches the currently selected embedder; otherwise it
-   * downgrades to "needs_embedding" (source data is still present).
+   * Re-compute each demo's status client-side based on the selected embedder
+   * and clipper.  A demo that has a cached pkl is only "ready" when both the
+   * pkl embedder and clipper match the currently selected values; otherwise it
+   * downgrades to "needs_embedding".
    *
    * Only processes demos for the active tab to avoid accidentally changing
-   * statuses of demos from other media types (whose embedder names live in a
-   * different namespace).
+   * statuses of demos from other media types.
    */
   private updateDemoStatuses(): void {
     const emb = this.selectedDemoEmbedder;
+    const clip = this.selectedDemoClipper;
     for (const demo of this.demos) {
-      if (demo.media_type !== this.activeTab) continue;  // only touch current tab
-      if (demo.status === 'needs_download') continue;  // source data missing — can't re-embed
+      if (demo.media_type !== this.activeTab) continue;
+      if (demo.status === 'needs_download') continue;
 
       if (!demo.pkl_embedder) {
-        // pkl_embedder unknown — if the demo was marked "ready" by the server
-        // (no embedder param on initial fetch) we can't verify it matches the
-        // selected embedder, so conservatively downgrade.
         if (emb && demo.status === 'ready') {
           demo.status = 'needs_embedding';
           demo.ready = false;
@@ -276,22 +287,25 @@ export class DatasetImporterModalComponent implements OnInit {
         continue;
       }
 
-      if (emb && demo.pkl_embedder !== emb) {
-        demo.status = 'needs_embedding';
-        demo.ready = false;
-      } else {
+      const embedderMatch = !emb || demo.pkl_embedder === emb;
+      const clipperMatch = !clip || !demo.pkl_clipper || demo.pkl_clipper === clip;
+
+      if (embedderMatch && clipperMatch) {
         demo.status = 'ready';
         demo.ready = true;
+      } else {
+        demo.status = 'needs_embedding';
+        demo.ready = false;
       }
     }
   }
 
   /**
-   * Re-fetch the demo list from the server with the given embedder so the
-   * backend can authoritatively determine each demo's status.
+   * Re-fetch the demo list from the server with the given embedder and clipper
+   * so the backend can authoritatively determine each demo's status.
    */
-  private refetchDemoStatuses(embedder: string): void {
-    this.datasetsApi.getDemoList(embedder).subscribe({
+  private refetchDemoStatuses(embedder: string, clipper?: string): void {
+    this.datasetsApi.getDemoList(embedder, clipper).subscribe({
       next: (demoRes) => {
         this.demos = demoRes.datasets || [];
       },
@@ -371,7 +385,7 @@ export class DatasetImporterModalComponent implements OnInit {
   }
 
   selectDemo(demo: DemoDataset): void {
-    this.demoSelected.emit({ ...demo, embedder: this.selectedDemoEmbedder } as any);
+    this.demoSelected.emit({ ...demo, embedder: this.selectedDemoEmbedder, clipper: this.selectedDemoClipper } as any);
     this.closed.emit();
   }
 
@@ -380,6 +394,7 @@ export class DatasetImporterModalComponent implements OnInit {
     // Reset embedder selection for the new tab
     const embedders = this.allEmbedders.filter((e) => e.media_type_id === tab);
     this.demoEmbedder = embedders.length > 0 ? embedders[0].name : '';
+    // Clipper is reset by loadDemoEmbedders (called from selectDemoTab)
   }
 
   back(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -177,6 +177,7 @@ export interface DemoDataset {
   media_type: string;
   num_categories: number;
   pkl_embedder?: string;
+  pkl_clipper?: string;
 }
 
 export interface DemoListResponse {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -38,10 +38,13 @@ export class DatasetsApiService {
     return this.http.get<ImportersResponse>('/api/dataset/all-importers');
   }
 
-  getDemoList(embedder?: string): Observable<DemoListResponse> {
+  getDemoList(embedder?: string, clipper?: string): Observable<DemoListResponse> {
     const params: Record<string, string> = {};
     if (embedder) {
       params['embedder'] = embedder;
+    }
+    if (clipper) {
+      params['clipper'] = clipper;
     }
     return this.http.get<DemoListResponse>('/api/dataset/demo-list', { params });
   }

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -86,12 +86,14 @@ class DemoDatasetImporter(DatasetImporter):
 
         embedder_name = field_values.get("embedder", "") or ""
         converter_name = field_values.get("converter", "") or ""
+        clipper_name = field_values.get("clipper", "") or ""
 
         load_demo_dataset(
             dataset_name,
             medias,
             embedder_name=embedder_name,
             converter_name=converter_name,
+            clipper_name=clipper_name,
         )
 
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -68,8 +68,7 @@ class RestrictedUnpickler(pickle.Unpickler):
         if (module, name) in _PICKLE_SAFE_CLASSES:
             return super().find_class(module, name)
         raise pickle.UnpicklingError(
-            f"Forbidden pickle class: {module}.{name}. "
-            "Only plain Python types and numpy arrays are allowed."
+            f"Forbidden pickle class: {module}.{name}. Only plain Python types and numpy arrays are allowed."
         )
 
 
@@ -943,7 +942,9 @@ def load_dataset_from_pickle(
                 medias[media_id] = media_data
                 loaded_count += 1
                 if on_progress is not None and loaded_count % _progress_interval == 0:
-                    on_progress("loading", f"Processing {loaded_count} of {total_count} items…", loaded_count, total_count)
+                    on_progress(
+                        "loading", f"Processing {loaded_count} of {total_count} items…", loaded_count, total_count
+                    )
                 continue
 
             # ── Full mode (original behaviour) ──
@@ -1022,7 +1023,9 @@ def load_dataset_from_pickle(
                 medias[media_id] = media_data
                 loaded_count += 1
                 if on_progress is not None and loaded_count % _progress_interval == 0:
-                    on_progress("loading", f"Processing {loaded_count} of {total_count} items…", loaded_count, total_count)
+                    on_progress(
+                        "loading", f"Processing {loaded_count} of {total_count} items…", loaded_count, total_count
+                    )
     except MemoryError:
         medias.clear()
         del data
@@ -1256,6 +1259,24 @@ def _write_embedder_sidecar(pkl_path: Path, embedder_name: str) -> None:
     sidecar.write_text(embedder_name, encoding="utf-8")
 
 
+def _write_clipper_sidecar(pkl_path: Path, clipper_name: str) -> None:
+    """Write a small ``<name>.clipper`` file next to *pkl_path*."""
+    sidecar = pkl_path.with_suffix(".clipper")
+    sidecar.write_text(clipper_name, encoding="utf-8")
+
+
+def read_pkl_clipper(pkl_path: Path) -> str | None:
+    """Return the clipper name stored for *pkl_path*, or ``None`` if unknown.
+
+    Checks the lightweight ``.clipper`` sidecar.  Returns ``None`` if the
+    sidecar does not exist (legacy pickles created before clipper tracking).
+    """
+    sidecar = pkl_path.with_suffix(".clipper")
+    if sidecar.exists():
+        return sidecar.read_text(encoding="utf-8").strip()
+    return None
+
+
 def read_pkl_embedder(pkl_path: Path) -> str | None:
     """Return the embedder name stored for *pkl_path*, or ``None`` if unknown.
 
@@ -1292,6 +1313,7 @@ def load_demo_dataset(
     on_progress: Optional[ProgressCallback] = None,
     embedder_name: str = "",
     converter_name: str = "",
+    clipper_name: str = "",
 ) -> None:
     """Load a named demo dataset into the medias dict, downloading and embedding as needed.
 
@@ -1325,6 +1347,8 @@ def load_demo_dataset(
         converter_name: Optional name of a converter (e.g. ``"video2image"``).
             When given, the demo is loaded in its native type and then
             converted.
+        clipper_name: Optional name of a registered clipper.  Recorded in
+            a ``.clipper`` sidecar next to the pickle for status tracking.
 
     Raises:
         ValueError: If ``dataset_name`` is not in ``DEMO_DATASETS``, or if the
@@ -1354,6 +1378,7 @@ def load_demo_dataset(
             on_progress("loading", f"Media files missing, re-embedding {dataset_name}...", 0, 0)
             pkl_file.unlink()
             pkl_file.with_suffix(".embedder").unlink(missing_ok=True)
+            pkl_file.with_suffix(".clipper").unlink(missing_ok=True)
         else:
             on_progress("idle", f"Loaded {dataset_name} dataset")
             return
@@ -1437,6 +1462,9 @@ def load_demo_dataset(
     # Write a lightweight sidecar that records which embedder produced this pkl.
     resolved_name = getattr(embedder, "name", "") if embedder is not None else ""
     _write_embedder_sidecar(pkl_file, resolved_name)
+
+    # Write a clipper sidecar so the demo list can check readiness.
+    _write_clipper_sidecar(pkl_file, clipper_name)
 
     on_progress("idle", f"Loaded {dataset_name} dataset")
 

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -127,18 +127,27 @@ def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = 
         update_progress(status, message, current, total, step=step, total_steps=total_steps)
 
     update_progress(
-        "loading", "Loading embedding model…", 0, 0,
-        step=step, total_steps=total_steps,
+        "loading",
+        "Loading embedding model…",
+        0,
+        0,
+        step=step,
+        total_steps=total_steps,
     )
-    with intercept_tqdm_progress(_model_load_progress), intercept_weight_loading_progress(
-        _model_load_progress, "Loading model weights…"
+    with (
+        intercept_tqdm_progress(_model_load_progress),
+        intercept_weight_loading_progress(_model_load_progress, "Loading model weights…"),
     ):
         emb.load_models()
 
     # Warm up the text encoder so the first text sort is instant.
     update_progress(
-        "loading", "Warming up text encoder…", 0, 0,
-        step=step, total_steps=total_steps,
+        "loading",
+        "Warming up text encoder…",
+        0,
+        0,
+        step=step,
+        total_steps=total_steps,
     )
     try:
         emb.embed_text("warmup")
@@ -289,8 +298,13 @@ def _auto_register_dataset(
 
 
 def _run_origin_load_in_background(
-    load_fn, origin: dict, *, name: str = "", clipper: str = "",
-    clipper_params: dict | None = None, embedder: str = "",
+    load_fn,
+    origin: dict,
+    *,
+    name: str = "",
+    clipper: str = "",
+    clipper_params: dict | None = None,
+    embedder: str = "",
     created_by: str = "",
 ) -> None:
     """Run a dataset load in a background thread with standard error handling.
@@ -330,8 +344,12 @@ def _run_origin_load_in_background(
     def task():
         try:
             update_progress(
-                "loading", "Clearing previous dataset…", 0, 0,
-                step=1, total_steps=_TOTAL_LOAD_STEPS,
+                "loading",
+                "Clearing previous dataset…",
+                0,
+                0,
+                step=1,
+                total_steps=_TOTAL_LOAD_STEPS,
             )
             clear_dataset()
             gc.collect()
@@ -341,25 +359,33 @@ def _run_origin_load_in_background(
             # inner functions like load_demo_dataset cannot prematurely
             # signal completion to the frontend.
             update_progress(
-                "loading", "Removing duplicates…",
-                step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,
+                "loading",
+                "Removing duplicates…",
+                step=_TOTAL_LOAD_STEPS,
+                total_steps=_TOTAL_LOAD_STEPS,
             )
             _set_clip_origins(medias, origin)
             if clipper:
                 _apply_clipper(medias, clipper, clipper_params)
             collapse_duplicates(medias)
+
             def _diversity_progress(current: int, total: int) -> None:
                 update_progress(
-                    "loading", "Building diversity index…",
-                    current=current, total=total,
-                    step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,
+                    "loading",
+                    "Building diversity index…",
+                    current=current,
+                    total=total,
+                    step=_TOTAL_LOAD_STEPS,
+                    total_steps=_TOTAL_LOAD_STEPS,
                 )
 
             _diversity_progress(0, 0)
             build_diversity_tree(on_progress=_diversity_progress)
             update_progress(
-                "loading", "Saving to registry…",
-                step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,
+                "loading",
+                "Saving to registry…",
+                step=_TOTAL_LOAD_STEPS,
+                total_steps=_TOTAL_LOAD_STEPS,
             )
             origin_str = _origin_to_str(origin)
             _auto_register_dataset(
@@ -397,8 +423,11 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
     """Start *importer*.run() in a daemon thread after clearing the dataset."""
     created_by = get_current_user()
     origin = importer.build_origin(field_values)
-    clipper_name = field_values.pop("clipper", "")
+    clipper_name = field_values.pop("clipper", "") or ""
     clipper_params = field_values.pop("clipper_params", None)
+    # Keep clipper in field_values for importers that need it (e.g. demo
+    # importer writes a .clipper sidecar for readiness tracking).
+    field_values["clipper"] = clipper_name
     embedder_name = field_values.get("embedder", "")
 
     def _load():

--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify, request
 
 from vtsearch.config import EMBEDDINGS_DIR
 from vtsearch.datasets import DEMO_DATASETS
-from vtsearch.datasets.loader import read_pkl_embedder
+from vtsearch.datasets.loader import read_pkl_clipper, read_pkl_embedder
 from vtsearch.routes.datasets_loading import _origin_to_str
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.utils import (
@@ -43,9 +43,11 @@ def demo_dataset_list():
     from vtsearch.converters import list_converters_for_source
     from vtsearch.media import get as media_get
 
-    # Optional embedder filter: when the caller specifies an embedder, a cached
-    # pkl is only considered "ready" if it was produced by that same embedder.
+    # Optional embedder/clipper filters: when the caller specifies an embedder
+    # or clipper, a cached pkl is only considered "ready" if it was produced by
+    # those same values.
     requested_embedder = request.args.get("embedder", "").strip()
+    requested_clipper = request.args.get("clipper", "").strip()
 
     demos = []
     for name, dataset_info in DEMO_DATASETS.items():
@@ -84,6 +86,14 @@ def demo_dataset_list():
             if pkl_embedder is not None and pkl_embedder != requested_embedder:
                 status = "needs_embedding"
 
+        # Same check for clipper: if the pkl was created with a different
+        # clipper, it needs re-clipping (and re-embedding of the clips).
+        pkl_clipper: str | None = None
+        if status == "ready" and requested_clipper:
+            pkl_clipper = read_pkl_clipper(pkl_file)
+            if pkl_clipper is not None and pkl_clipper != requested_clipper:
+                status = "needs_embedding"
+
         # Calculate number of files from slice parameters
         num_categories = len(dataset_info["categories"])
         slice_start = dataset_info.get("slice_start", 0)
@@ -110,6 +120,10 @@ def demo_dataset_list():
         if pkl_embedder is None and has_pkl:
             pkl_embedder = read_pkl_embedder(pkl_file)
 
+        # Resolve pkl_clipper if not already read above.
+        if pkl_clipper is None and has_pkl:
+            pkl_clipper = read_pkl_clipper(pkl_file)
+
         demos.append(
             {
                 "name": name,
@@ -123,6 +137,7 @@ def demo_dataset_list():
                 "num_categories": num_categories,
                 "available_converters": available_converters,
                 "pkl_embedder": pkl_embedder or "",
+                "pkl_clipper": pkl_clipper or "",
             }
         )
     return jsonify({"datasets": demos})
@@ -245,11 +260,13 @@ def browse_media_files():
         if entry.is_dir():
             directories.append({"name": entry.name, "path": rel})
         elif entry.is_file() and entry.suffix.lower() in known_exts:
-            files.append({
-                "name": entry.name,
-                "path": rel,
-                "size_bytes": entry.stat().st_size,
-            })
+            files.append(
+                {
+                    "name": entry.name,
+                    "path": rel,
+                    "size_bytes": entry.stat().st_size,
+                }
+            )
 
     return jsonify({"directories": directories, "files": files, "root_path": str(root)})
 


### PR DESCRIPTION
## Summary
This PR extends the demo dataset importer to support clipper selection alongside embedder selection. Users can now choose which clipper to use when loading demo datasets, and the system tracks which clipper was used via a `.clipper` sidecar file for readiness status verification.

## Key Changes

**Frontend (Angular)**
- Added `demoClippers` and `selectedDemoClipper` state to track available clippers and user selection
- Added `onDemoClipperChange()` handler to update demo statuses when clipper selection changes
- Updated `updateDemoStatuses()` to verify both embedder and clipper match cached pickle files
- Modified `refetchDemoStatuses()` to pass both embedder and clipper to the backend
- Updated demo selection to emit both `embedder` and `clipper` parameters
- Added clipper dropdown UI in the importer modal (shown when multiple clippers available)
- Updated `DashboardComponent` to pass clipper parameter when loading demos

**Backend (Python)**
- Added `_write_clipper_sidecar()` and `read_pkl_clipper()` functions to manage `.clipper` sidecar files (parallel to existing embedder tracking)
- Extended `load_demo_dataset()` to accept `clipper_name` parameter and write clipper sidecar
- Updated `demo_dataset_list()` endpoint to accept optional `clipper` query parameter
- Added clipper readiness check: cached pickles are only "ready" if created with the matching clipper
- Modified `_run_importer_in_background()` to preserve clipper in field_values for importers that need it
- Updated API models to include `pkl_clipper` field in demo dataset responses

**Code Quality**
- Reformatted several function calls to follow multi-line parameter style for improved readability

## Implementation Details
- Clipper tracking mirrors the existing embedder tracking pattern using lightweight sidecar files
- Demo readiness now requires both embedder AND clipper to match (if specified)
- The system gracefully handles legacy pickles without clipper sidecars (returns empty string)
- Clipper selection is only shown in UI when multiple clippers are available for the media type

https://claude.ai/code/session_011CqbnuwtMCuyazfzc7qvYq