### PR TITLE
Refactor border styling in right panel layout

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -14,10 +14,6 @@
   flex-direction: column;
 }
 
-:host + :host {
-  border-top: 1px solid var(--border);
-}
-
 h3 {
   font-size: 0.8rem;
   text-transform: uppercase;

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -31,6 +31,8 @@
     (mediaVote)="onMediaVote($event)"
   />
 
+  <div class="label-divider"></div>
+
   <vt-label-list
     label="bad"
     [ids]="badIds"

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -17,7 +17,6 @@
   display: flex;
   padding: 8px 16px;
   flex-shrink: 0;
-  border-bottom: 1px solid var(--border);
 }
 
 .sort-row {
@@ -52,6 +51,11 @@
     color: var(--text-primary);
     border-color: var(--text-primary);
   }
+}
+
+.label-divider {
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .export-row {


### PR DESCRIPTION
## Summary
Refactored the border divider styling between the sort section and label list in the right panel component. Moved from component-level borders to a dedicated divider element for better separation of concerns and more explicit layout control.

## Key Changes
- Removed `border-bottom` from `.sort-row` in right-panel component styles
- Removed `:host + :host` sibling selector styling from label-list component (which applied borders between consecutive label-list instances)
- Added new `.label-divider` class with `border-top` styling in right-panel component
- Inserted explicit `<div class="label-divider"></div>` element in the template between the sort section and label-list component

## Implementation Details
This change improves maintainability by:
- Making the visual divider explicit in the DOM rather than relying on CSS sibling selectors
- Centralizing border styling logic in the parent component (right-panel) rather than distributing it across child components
- Providing clearer intent about where dividers appear in the layout hierarchy

https://claude.ai/code/session_01BpJaLkU52eEbMDhERE5LNu