### PR TITLE
Make dnspython an optional dependency with lazy import

### DIFF
--- a/vtsearch/exporters/email_smtp/__init__.py
+++ b/vtsearch/exporters/email_smtp/__init__.py
@@ -14,8 +14,6 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
 
-import dns.resolver
-
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 FROM_ADDRESS = "VTSearch@fake.ai"
@@ -77,6 +75,8 @@ def _build_html(results: dict[str, Any]) -> str:
 
 def _resolve_mx(domain: str) -> str:
     """Return the highest-priority MX host for *domain*."""
+    import dns.resolver  # lazy import – dnspython is optional
+
     answers = dns.resolver.resolve(domain, "MX")
     best = min(answers, key=lambda r: r.preference)
     return str(best.exchange).rstrip(".")


### PR DESCRIPTION
## Summary
This change makes `dnspython` an optional dependency by moving its import from the module level to a lazy import within the function that uses it. This allows the email SMTP exporter to be imported and used without requiring `dnspython` to be installed, as long as MX resolution is not needed.

## Key Changes
- Removed top-level `import dns.resolver` statement
- Moved `dns.resolver` import into the `_resolve_mx()` function as a lazy import
- Added clarifying comment indicating that `dnspython` is an optional dependency

## Implementation Details
The `dns.resolver` module is now only imported when `_resolve_mx()` is actually called, rather than when the module is loaded. This follows the lazy import pattern for optional dependencies and allows users who don't need MX resolution functionality to use the exporter without installing the `dnspython` package.

https://claude.ai/code/session_01W6LQKK4e9Z72NHf6Q5kHzu