### PR TITLE
Add cancellation support for dataset loading operations

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -11,6 +11,7 @@
             [max]="progressTotal"
             [indeterminate]="progressIndeterminate"
           />
+          <button class="btn btn--cancel btn--sm" (click)="onCancelIngest()" title="Cancel dataset loading">Cancel</button>
         </div>
       }
       <div class="dashboard-section-actions">

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -51,6 +51,22 @@
   vt-progress-bar {
     flex: 1;
   }
+
+  .btn--cancel {
+    flex-shrink: 0;
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--text-secondary);
+    }
+  }
 }
 
 .dashboard-section-actions {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -293,6 +293,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetState.refresh();
   }
 
+  // --- Cancel ---
+
+  onCancelIngest(): void {
+    this.datasetsApi.cancelIngest().subscribe();
+  }
+
   // --- Progress polling ---
 
   startProgressPolling(onComplete?: () => void): void {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -152,6 +152,10 @@ export class DatasetsApiService {
     return this.http.post('/api/dataset/combine', params);
   }
 
+  cancelIngest(): Observable<OkResponse> {
+    return this.http.post<OkResponse>('/api/dataset/cancel', {});
+  }
+
   clearDataset(): Observable<OkResponse> {
     return this.http.post<OkResponse>('/api/dataset/clear', {});
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,6 +282,11 @@ def reset_state():
     _core.autorun_localizers.clear()
     clear_progress_cache()
 
+    # Reset the dataset progress cancellation flag
+    from vtsearch.utils.progress import dataset_progress
+
+    dataset_progress.reset_cancel()
+
     # Reset the login provider to DefaultLoginProvider
     from vtsearch.auth import DefaultLoginProvider, set_login_provider
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -321,7 +321,9 @@ class TestDemoDatasetReadiness:
         # Create the ESC-50 audio dir with a dummy file
         esc50_dir.mkdir(parents=True, exist_ok=True)
         dummy_wav = esc50_dir / "_test_dummy.wav"
-        already_populated = any(f.name != "_test_dummy.wav" for f in esc50_dir.iterdir()) if esc50_dir.exists() else False
+        already_populated = (
+            any(f.name != "_test_dummy.wav" for f in esc50_dir.iterdir()) if esc50_dir.exists() else False
+        )
         buf = io.BytesIO()
         with wave.open(buf, "wb") as wf:
             wf.setnchannels(1)
@@ -510,10 +512,12 @@ class TestDemoDatasetEmbedderStatus:
         sidecar = pkl_file.with_suffix(".embedder")
         # Write pkl with embedder info in media entries, no sidecar
         pkl_file.write_bytes(
-            pickle.dumps({
-                "name": demo_name,
-                "medias": {1: {"embedder": "FallbackEmb", "embedding": [0.1]}},
-            })
+            pickle.dumps(
+                {
+                    "name": demo_name,
+                    "medias": {1: {"embedder": "FallbackEmb", "embedding": [0.1]}},
+                }
+            )
         )
         sidecar.unlink(missing_ok=True)
         try:
@@ -877,17 +881,21 @@ class TestUCF101SubsetDownload:
         from vtsearch.datasets.config import DEMO_DATASETS
 
         subset_categories = {
-            "ApplyEyeMakeup", "ApplyLipstick", "Archery", "BabyCrawling",
-            "BalanceBeam", "BandMarching", "BaseballPitch", "Basketball",
-            "BasketballDunk", "BenchPress",
+            "ApplyEyeMakeup",
+            "ApplyLipstick",
+            "Archery",
+            "BabyCrawling",
+            "BalanceBeam",
+            "BandMarching",
+            "BaseballPitch",
+            "Basketball",
+            "BasketballDunk",
+            "BenchPress",
         }
         for name, info in DEMO_DATASETS.items():
             if info.get("media_type") == "video":
                 for cat in info["categories"]:
-                    assert cat in subset_categories, (
-                        f"Video demo '{name}' uses category '{cat}' "
-                        f"not in UCF-101 subset"
-                    )
+                    assert cat in subset_categories, f"Video demo '{name}' uses category '{cat}' not in UCF-101 subset"
 
 
 class TestLoadProgressRaceCondition:
@@ -980,8 +988,7 @@ class TestLoadProgressRaceCondition:
         # Progress must NOT have changed to idle
         progress = get_progress()
         assert progress["status"] == "loading", (
-            "_stepped_progress must filter out 'idle' to prevent "
-            "premature completion signals from cached dataset loads"
+            "_stepped_progress must filter out 'idle' to prevent premature completion signals from cached dataset loads"
         )
         assert progress["message"] == "In progress…"
 
@@ -1007,13 +1014,12 @@ class TestLoadProgressRaceCondition:
 
         with patch("vtsearch.routes.datasets_loading.threading.Thread"):
             _run_origin_load_in_background(
-                lambda: None, {"importer": "test", "params": {}},
+                lambda: None,
+                {"importer": "test", "params": {}},
             )
 
         progress = get_progress()
-        assert progress["error"] is None, (
-            "Starting a new load must clear the stale error from a previous load"
-        )
+        assert progress["error"] is None, "Starting a new load must clear the stale error from a previous load"
         assert progress["status"] == "loading"
 
     def test_load_embedder_sets_initial_progress(self):
@@ -1045,3 +1051,118 @@ class TestLoadProgressRaceCondition:
         assert any("Loading embedding model" in m for m in messages), (
             f"Expected 'Loading embedding model…' in progress messages, got: {messages}"
         )
+
+
+class TestCancelIngest:
+    """Tests for the POST /api/dataset/cancel endpoint."""
+
+    def test_cancel_endpoint_returns_ok(self, client):
+        """POST /api/dataset/cancel should return ok."""
+        resp = client.post("/api/dataset/cancel")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+
+    def test_cancel_sets_event(self, client):
+        """POST /api/dataset/cancel should set the cancellation event."""
+        from vtsearch.utils.progress import dataset_progress
+
+        dataset_progress.reset_cancel()
+        assert not dataset_progress.is_cancelled
+
+        client.post("/api/dataset/cancel")
+        assert dataset_progress.is_cancelled
+
+        # Clean up
+        dataset_progress.reset_cancel()
+
+    def test_cancel_clears_medias_on_background_load(self, client):
+        """Cancelling during a background load should clean up medias."""
+        import time
+
+        from vtsearch.utils.progress import dataset_progress, get_progress
+
+        saved = dict(app_module.medias)
+        try:
+            # Simulate a slow importer that checks cancellation via progress
+            def slow_load():
+                for i in range(100):
+                    dataset_progress.check_cancelled()
+                    time.sleep(0.05)
+
+            from vtsearch.routes.datasets_loading import _run_origin_load_in_background
+
+            _run_origin_load_in_background(
+                slow_load,
+                {"importer": "test", "params": {}},
+                created_by="test",
+            )
+
+            # Give the thread a moment to start
+            time.sleep(0.2)
+
+            # Cancel it
+            client.post("/api/dataset/cancel")
+
+            # Wait for the thread to notice the cancellation
+            for _ in range(40):
+                time.sleep(0.1)
+                progress = get_progress()
+                if progress["status"] == "idle":
+                    break
+
+            progress = get_progress()
+            assert progress["status"] == "idle"
+            assert progress["error"] == "Cancelled"
+        finally:
+            dataset_progress.reset_cancel()
+            app_module.medias.clear()
+            app_module.medias.update(saved)
+
+    def test_stepped_progress_raises_on_cancel(self):
+        """_stepped_progress should raise CancelledError when cancelled."""
+        from vtsearch.routes.datasets_loading import _stepped_progress
+        from vtsearch.utils.progress import CancelledError, dataset_progress
+
+        dataset_progress.reset_cancel()
+
+        # Should work normally when not cancelled
+        _stepped_progress("loading", "Test", 0, 0)
+
+        # Set cancel flag
+        dataset_progress.cancel()
+
+        # Should raise CancelledError
+        with pytest.raises(CancelledError):
+            _stepped_progress("loading", "Test", 0, 0)
+
+        dataset_progress.reset_cancel()
+
+    def test_new_load_resets_cancel_flag(self, client):
+        """Starting a new load should clear any previous cancellation."""
+        from unittest.mock import patch
+
+        from vtsearch.utils.progress import dataset_progress
+
+        # Set cancel from a previous operation
+        dataset_progress.cancel()
+        assert dataset_progress.is_cancelled
+
+        saved = dict(app_module.medias)
+        try:
+            # Start a new load — should reset the flag
+            from vtsearch.routes.datasets_loading import _run_origin_load_in_background
+
+            with patch("vtsearch.routes.datasets_loading._load_embedder_for_clips"):
+                _run_origin_load_in_background(
+                    lambda: None,
+                    {"importer": "test", "params": {}},
+                    created_by="test",
+                )
+
+            # Cancel flag should have been cleared
+            assert not dataset_progress.is_cancelled
+        finally:
+            dataset_progress.reset_cancel()
+            app_module.medias.clear()
+            app_module.medias.update(saved)

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -36,6 +36,7 @@ from vtsearch.datasets.registry import (
 from vtsearch.utils import (
     bad_votes,
     build_diversity_tree,
+    cancel_dataset_progress,
     collapse_duplicates,
     medias,
     get_dataset_display_name,
@@ -46,6 +47,8 @@ from vtsearch.utils import (
     snapshot_medias,
     update_progress,
 )
+from vtsearch.utils.progress import CancelledError
+from vtsearch.utils.progress import dataset_progress as _dataset_progress_tracker
 import vtsearch.utils.paths as _paths
 
 # Re-export loading helpers so existing importers keep working.
@@ -77,6 +80,7 @@ def _normalize_media_type_param(value: str) -> str:
         return get_by_folder_name(value).type_id
     except KeyError:
         return value  # assume it is already a type_id
+
 
 # Register the UI sub-blueprint.
 datasets_bp.register_blueprint(datasets_ui_bp)
@@ -200,6 +204,18 @@ def dataset_status():
 def dataset_progress():
     """Return the current progress of long-running operations."""
     return jsonify(get_progress())
+
+
+@datasets_bp.route("/api/dataset/cancel", methods=["POST"])
+def cancel_dataset_load():
+    """Cancel the currently running dataset load/import operation.
+
+    Sets a cancellation flag that is checked cooperatively by background
+    loading threads.  The thread will clean up partial state and set
+    progress to idle.
+    """
+    cancel_dataset_progress()
+    return jsonify({"ok": True})
 
 
 # ---------------------------------------------------------------------------
@@ -598,11 +614,16 @@ def load_registered_dataset(dataset_id: str):
 
     _LOAD_STEPS = 3  # read pickle + process items, build diversity index, warm up embedder
 
+    # Reset the cancellation flag so a previous cancel does not immediately
+    # abort this new operation.
+    _dataset_progress_tracker.reset_cancel()
+
     # Set progress to "loading" synchronously so the frontend never sees a
     # stale "idle" status from a previous operation before the thread starts.
     update_progress("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):
+        _dataset_progress_tracker.check_cancelled()
         update_progress(status, message, current, total, step=1, total_steps=_LOAD_STEPS)
 
     def load_task():
@@ -619,6 +640,7 @@ def load_registered_dataset(dataset_id: str):
             _reg_set_loaded(None)
             gc.collect()
             load_dataset_from_pickle(Path(pkl_path), medias, on_progress=_pickle_progress)
+            _dataset_progress_tracker.check_cancelled()
             update_progress(
                 "loading",
                 "Removing duplicates…",
@@ -630,6 +652,7 @@ def load_registered_dataset(dataset_id: str):
             collapse_duplicates(medias)
 
             def _diversity_progress(current: int, total: int) -> None:
+                _dataset_progress_tracker.check_cancelled()
                 update_progress(
                     "loading",
                     "Building diversity index…",
@@ -646,6 +669,10 @@ def load_registered_dataset(dataset_id: str):
             _reg_update(dataset_id, num_items=len(medias), num_dupes=get_dupe_count())
             set_dataset_display_name(entry.get("name", ""))
             _load_embedder_for_clips(step=_LOAD_STEPS, total_steps=_LOAD_STEPS)
+        except CancelledError:
+            medias.clear()
+            gc.collect()
+            update_progress("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
         except MemoryError:
             medias.clear()
             gc.collect()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -25,6 +25,7 @@ from vtsearch.utils import (
     snapshot_medias,
     update_progress,
 )
+from vtsearch.utils.progress import CancelledError, dataset_progress
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +58,11 @@ def _stepped_progress(status: str, message: str = "", current: int = 0, total: i
     ``"idle"`` before the wrapper overrides it, and a frontend poll during
     that window would stop polling prematurely — leaving the UI stuck on
     the progress overlay.
+
+    Also checks the cancellation flag on each callback so that long-running
+    loops (embedding, downloading) abort promptly when the user cancels.
     """
+    dataset_progress.check_cancelled()
     if status == "idle":
         return
     step = _STATUS_TO_STEP.get(status)
@@ -336,6 +341,10 @@ def _run_origin_load_in_background(
         the background thread starts (no Flask request context in thread).
     """
 
+    # Reset the cancellation flag so a previous cancel does not immediately
+    # abort this new operation.
+    dataset_progress.reset_cancel()
+
     # Set progress to "loading" synchronously so the frontend never sees a
     # stale "idle" status from a previous operation before the thread starts.
     # Clear the error field so stale errors from previous loads don't persist.
@@ -354,6 +363,7 @@ def _run_origin_load_in_background(
             clear_dataset()
             gc.collect()
             load_fn()
+            dataset_progress.check_cancelled()
             # _stepped_progress (the progress callback injected by
             # _run_importer_in_background) filters out "idle" so that
             # inner functions like load_demo_dataset cannot prematurely
@@ -370,6 +380,7 @@ def _run_origin_load_in_background(
             collapse_duplicates(medias)
 
             def _diversity_progress(current: int, total: int) -> None:
+                dataset_progress.check_cancelled()
                 update_progress(
                     "loading",
                     "Building diversity index…",
@@ -381,6 +392,7 @@ def _run_origin_load_in_background(
 
             _diversity_progress(0, 0)
             build_diversity_tree(on_progress=_diversity_progress)
+            dataset_progress.check_cancelled()
             update_progress(
                 "loading",
                 "Saving to registry…",
@@ -397,6 +409,18 @@ def _run_origin_load_in_background(
                 created_by=created_by,
             )
             _load_embedder_for_clips()
+        except CancelledError:
+            medias.clear()
+            gc.collect()
+            update_progress(
+                "idle",
+                "",
+                0,
+                0,
+                error="Cancelled",
+                step=None,
+                total_steps=None,
+            )
         except MemoryError:
             medias.clear()
             gc.collect()

--- a/vtsearch/utils/__init__.py
+++ b/vtsearch/utils/__init__.py
@@ -1,7 +1,16 @@
 """Utility modules for progress tracking and state management."""
 
 from vtsearch.utils.hits import build_media_hit
-from vtsearch.utils.progress import get_eval_progress, get_progress, get_sort_progress, update_eval_progress, update_progress, update_sort_progress
+from vtsearch.utils.progress import (
+    cancel_dataset_progress,
+    check_dataset_cancelled,
+    get_eval_progress,
+    get_progress,
+    get_sort_progress,
+    update_eval_progress,
+    update_progress,
+    update_sort_progress,
+)
 from vtsearch.utils.state import (
     _state_lock,
     add_autorun_detector,
@@ -79,6 +88,10 @@ __all__ = [
     "get_progress",
     "update_sort_progress",
     "get_sort_progress",
+    "update_eval_progress",
+    "get_eval_progress",
+    "cancel_dataset_progress",
+    "check_dataset_cancelled",
     # State lock
     "_state_lock",
     # State

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -6,12 +6,21 @@ from typing import Any, Optional
 _UNSET = object()  # sentinel for "caller did not provide this argument"
 
 
+class CancelledError(Exception):
+    """Raised when an operation is cancelled via :meth:`ProgressTracker.cancel`."""
+
+
 class ProgressTracker:
     """Thread-safe progress tracker for long-running operations.
 
     Each instance manages its own lock and data dict. The *extra_fields*
     parameter lets callers declare additional keys (e.g. ``"error"``,
     ``"staging_result"``) that are tracked alongside the base fields.
+
+    A :class:`threading.Event` is used for cooperative cancellation: call
+    :meth:`cancel` to set the flag and :meth:`check_cancelled` from inside
+    the background thread to raise :class:`CancelledError` when the flag is
+    set.
 
     Args:
         extra_fields: Mapping of extra field names to their default values.
@@ -22,6 +31,7 @@ class ProgressTracker:
     def __init__(self, extra_fields: Optional[dict[str, Any]] = None) -> None:
         self._lock = threading.Lock()
         self._extra_defaults = dict(extra_fields) if extra_fields else {}
+        self._cancel_event = threading.Event()
         self._data: dict[str, Any] = {
             "status": "idle",
             "message": "",
@@ -56,6 +66,36 @@ class ProgressTracker:
             for key in self._extra_defaults:
                 if key in kwargs:
                     self._data[key] = kwargs[key]
+
+    def cancel(self) -> None:
+        """Signal the background operation to stop.
+
+        This sets the internal cancel event.  The background thread must
+        cooperatively check it via :meth:`check_cancelled`.
+        """
+        self._cancel_event.set()
+
+    def check_cancelled(self) -> None:
+        """Raise :class:`CancelledError` if :meth:`cancel` has been called.
+
+        Call this periodically from inside the background thread (e.g. once
+        per loop iteration) to allow cooperative cancellation.
+        """
+        if self._cancel_event.is_set():
+            raise CancelledError("Operation cancelled by user")
+
+    @property
+    def is_cancelled(self) -> bool:
+        """Return ``True`` if cancellation has been requested."""
+        return self._cancel_event.is_set()
+
+    def reset_cancel(self) -> None:
+        """Clear the cancellation flag.
+
+        Called at the beginning of a new operation so that a previous
+        cancellation does not immediately abort the next run.
+        """
+        self._cancel_event.clear()
 
     def get(self) -> dict[str, Any]:
         """Return a snapshot of the current progress data.
@@ -122,6 +162,16 @@ def update_progress(
 def get_progress() -> dict[str, Any]:
     """Return a snapshot of the current dataset progress data."""
     return dataset_progress.get()
+
+
+def cancel_dataset_progress() -> None:
+    """Signal the current dataset operation to cancel."""
+    dataset_progress.cancel()
+
+
+def check_dataset_cancelled() -> None:
+    """Raise :class:`CancelledError` if the dataset operation was cancelled."""
+    dataset_progress.check_cancelled()
 
 
 def update_sort_progress(


### PR DESCRIPTION
## Summary
This PR adds cooperative cancellation support for long-running dataset loading and import operations. Users can now cancel in-progress loads via a new `/api/dataset/cancel` endpoint, with the operation cleaning up partial state and returning to idle status.

## Key Changes

**Backend (Python)**
- Added `CancelledError` exception class and cancellation methods to `ProgressTracker`:
  - `cancel()`: Sets the cancellation flag
  - `check_cancelled()`: Raises `CancelledError` if flag is set (called from background threads)
  - `is_cancelled` property: Checks current state
  - `reset_cancel()`: Clears flag for new operations
- New `/api/dataset/cancel` POST endpoint in `datasets.py` that signals cancellation
- Integrated `check_cancelled()` calls throughout loading pipelines:
  - In `load_registered_dataset()` at key checkpoints (after pickle load, after deduplication, during diversity index building)
  - In `_run_origin_load_in_background()` at similar checkpoints
  - In `_stepped_progress()` callback to abort long-running loops (embedding, downloading)
- Added exception handling for `CancelledError` that clears medias, triggers garbage collection, and sets progress to idle with error message "Cancelled"
- Reset cancellation flag at the start of new operations to prevent stale cancellations from aborting fresh loads
- Exported new utility functions: `cancel_dataset_progress()` and `check_dataset_cancelled()`

**Frontend (TypeScript/Angular)**
- Added `cancelIngest()` method to `DatasetsApiService` that calls the new cancel endpoint
- Added `onCancelIngest()` handler in `DashboardComponent` to trigger cancellation
- Added cancel button UI in dashboard template with styling

**Tests**
- Added comprehensive `TestCancelIngest` test class with 5 test cases:
  - Endpoint returns 200 OK
  - Cancellation flag is properly set
  - Background loads clean up medias on cancellation
  - `_stepped_progress` raises `CancelledError` when cancelled
  - New loads reset the cancellation flag
- Updated test fixtures to reset cancellation flag in `conftest.py`

**Code Quality**
- Applied consistent code formatting (line wrapping, multi-line constructs)
- Updated `__init__.py` exports to include new cancellation functions

## Implementation Details
- Uses `threading.Event` for thread-safe cancellation signaling
- Cancellation is cooperative: background threads must explicitly call `check_cancelled()` to abort
- Partial state (medias dict) is cleared on cancellation to prevent stale data
- Cancel flag is reset at operation start to ensure previous cancellations don't affect new loads
- Progress is set to idle with "Cancelled" error message when operation is aborted

https://claude.ai/code/session_01XUm99gWXYvCxg8MDwntnXL