### PR TITLE
Partially invalidate progress cache on vote polarity switches

### DIFF
--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -7,6 +7,7 @@ from vtsearch.models.progress import (
     _ensure_cache,
     _live_models,
     inject_live_model,
+    invalidate_progress_cache_from,
 )
 from vtsearch.utils import medias, label_history
 
@@ -272,33 +273,50 @@ class TestProgressCacheWithLabelChanges:
 
 
 class TestProgressCacheInvalidatedOnVoteSwitch:
-    """Progress cache must be cleared when a vote switches polarity (good→bad or bad→good).
+    """Progress cache is partially invalidated when a vote switches polarity.
 
-    Old cached models were trained with the now-incorrect label, and their
-    stability/evaluation metrics are stale.
+    Only cached steps from the point where the affected media first appeared
+    in the training data are discarded.  Earlier steps are preserved.
     """
 
-    def test_good_to_bad_clears_cache(self, client):
-        """Switching a vote from good to bad should clear the progress cache."""
+    def test_good_to_bad_truncates_from_first_appearance(self, client):
+        """Switching good→bad should keep steps before the media first appeared."""
+        # Steps: 0=(3,good), 1=(4,bad), 2=(1,good), 3=(2,bad)
+        # Media 1 first appears at step 2.
+        client.post("/api/medias/3/vote", json={"vote": "good"})
+        client.post("/api/medias/4/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 4
+
+        # Switch media 1 from good to bad — steps 0-1 preserved, 2-3 discarded
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert len(_cached_steps) == 2, "Steps before media 1's first appearance should be kept"
+
+    def test_bad_to_good_truncates_from_first_appearance(self, client):
+        """Switching bad→good should keep steps before the media first appeared."""
+        client.post("/api/medias/3/vote", json={"vote": "good"})
+        client.post("/api/medias/4/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/2/vote", json={"vote": "good"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 4
+
+        # Switch media 1 from bad to good — steps 0-1 preserved, 2-3 discarded
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        assert len(_cached_steps) == 2, "Steps before media 1's first appearance should be kept"
+
+    def test_first_vote_switch_clears_entire_cache(self, client):
+        """If the switched media was in the very first step, full clear occurs."""
         client.post("/api/medias/1/vote", json={"vote": "good"})
         client.post("/api/medias/2/vote", json={"vote": "bad"})
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == 2
 
-        # Switch media 1 from good to bad — cache should be cleared
+        # Switch media 1 (present from step 0) — full clear
         client.post("/api/medias/1/vote", json={"vote": "bad"})
-        assert len(_cached_steps) == 0, "Cache should be cleared on good→bad switch"
-
-    def test_bad_to_good_clears_cache(self, client):
-        """Switching a vote from bad to good should clear the progress cache."""
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
-        client.post("/api/medias/2/vote", json={"vote": "good"})
-        _ensure_cache(medias, label_history, 0)
-        assert len(_cached_steps) == 2
-
-        # Switch media 1 from bad to good — cache should be cleared
-        client.post("/api/medias/1/vote", json={"vote": "good"})
-        assert len(_cached_steps) == 0, "Cache should be cleared on bad→good switch"
+        assert len(_cached_steps) == 0, "Cache should be fully cleared when media was in step 0"
 
     def test_toggle_off_does_not_clear_cache(self, client):
         """Toggling a vote OFF (unlabeling) should NOT clear the progress cache."""
@@ -334,18 +352,37 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
         client.post("/api/medias/1/vote", json={"vote": "bad"})
         assert len(_live_models) == 0, "Live models should be cleared on vote switch"
 
-    def test_cache_rebuilds_correctly_after_switch(self, client):
-        """After a cache invalidation from a vote switch, rebuilding should work."""
+    def test_running_ids_restored_after_truncation(self, client):
+        """After partial truncation, _cache_good_ids/_cache_bad_ids match the last kept step."""
+        client.post("/api/medias/3/vote", json={"vote": "good"})
+        client.post("/api/medias/4/vote", json={"vote": "bad"})
         client.post("/api/medias/1/vote", json={"vote": "good"})
         client.post("/api/medias/2/vote", json={"vote": "bad"})
         _ensure_cache(medias, label_history, 0)
+
+        # Switch media 1 — truncates to 2 steps (steps 0-1)
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert len(_cached_steps) == 2
+        # Running ID sets should match step 1's state: good={3}, bad={4}
+        assert 3 in _cache_good_ids
+        assert 4 in _cache_bad_ids
+        assert 1 not in _cache_good_ids
+        assert 1 not in _cache_bad_ids
+
+    def test_cache_rebuilds_correctly_after_partial_truncation(self, client):
+        """After partial invalidation, _ensure_cache replays from the truncation point."""
+        client.post("/api/medias/3/vote", json={"vote": "good"})
+        client.post("/api/medias/4/vote", json={"vote": "bad"})
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 4
+
+        # Switch media 1 from good to bad — truncates to 2 steps
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
         assert len(_cached_steps) == 2
 
-        # Switch media 1 from good to bad (clears cache)
-        client.post("/api/medias/1/vote", json={"vote": "bad"})
-        assert len(_cached_steps) == 0
-
-        # Rebuild cache — should process entire label_history from scratch
+        # Rebuild cache — should replay from step 2 onward
         _ensure_cache(medias, label_history, 0)
         assert len(_cached_steps) == len(label_history)
         # After replay, media 1 should be in bad_ids (final state)
@@ -367,6 +404,17 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
 
         resp = client.post("/api/labeling-progress")
         assert resp.status_code == 200
+
+    def test_invalidate_noop_when_media_not_in_cache(self, client):
+        """invalidate_progress_cache_from should be a no-op for unknown media."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 2
+
+        # Invalidate a media that never appeared in the cache
+        invalidate_progress_cache_from(999)
+        assert len(_cached_steps) == 2, "Cache should not change for unknown media"
 
 
 class TestStableIndicatorThresholds:

--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -359,13 +359,13 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
         for i in range(6, 11):
             client.post(f"/api/medias/{i}/vote", json={"vote": "bad"})
 
-        resp = client.get("/api/labeling-progress")
+        resp = client.post("/api/labeling-progress")
         assert resp.status_code == 200
 
         # Switch a vote
         client.post("/api/medias/1/vote", json={"vote": "bad"})
 
-        resp = client.get("/api/labeling-progress")
+        resp = client.post("/api/labeling-progress")
         assert resp.status_code == 200
 
 

--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -271,6 +271,104 @@ class TestProgressCacheWithLabelChanges:
         assert data["bad_count"] == 4  # lost 1
 
 
+class TestProgressCacheInvalidatedOnVoteSwitch:
+    """Progress cache must be cleared when a vote switches polarity (good→bad or bad→good).
+
+    Old cached models were trained with the now-incorrect label, and their
+    stability/evaluation metrics are stale.
+    """
+
+    def test_good_to_bad_clears_cache(self, client):
+        """Switching a vote from good to bad should clear the progress cache."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 2
+
+        # Switch media 1 from good to bad — cache should be cleared
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert len(_cached_steps) == 0, "Cache should be cleared on good→bad switch"
+
+    def test_bad_to_good_clears_cache(self, client):
+        """Switching a vote from bad to good should clear the progress cache."""
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        client.post("/api/medias/2/vote", json={"vote": "good"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 2
+
+        # Switch media 1 from bad to good — cache should be cleared
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        assert len(_cached_steps) == 0, "Cache should be cleared on bad→good switch"
+
+    def test_toggle_off_does_not_clear_cache(self, client):
+        """Toggling a vote OFF (unlabeling) should NOT clear the progress cache."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 2
+
+        # Toggle off media 1 (good→unlabel) — cache should NOT be cleared
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        assert len(_cached_steps) > 0, "Cache should not be cleared on simple toggle-off"
+
+    def test_new_vote_does_not_clear_cache(self, client):
+        """Adding a brand-new vote (no prior label) should NOT clear the cache."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 2
+
+        # Add a new good vote on media 3 (no prior label)
+        client.post("/api/medias/3/vote", json={"vote": "good"})
+        assert len(_cached_steps) == 2, "Cache should not be cleared when adding a new vote"
+
+    def test_live_models_cleared_on_switch(self, client):
+        """Live models from learned-sort should also be cleared on a vote switch."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        resp = client.post("/api/learned-sort")
+        assert resp.status_code == 200
+        assert len(_live_models) > 0
+
+        # Switch media 1 from good to bad — live models should be cleared
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert len(_live_models) == 0, "Live models should be cleared on vote switch"
+
+    def test_cache_rebuilds_correctly_after_switch(self, client):
+        """After a cache invalidation from a vote switch, rebuilding should work."""
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post("/api/medias/2/vote", json={"vote": "bad"})
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == 2
+
+        # Switch media 1 from good to bad (clears cache)
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert len(_cached_steps) == 0
+
+        # Rebuild cache — should process entire label_history from scratch
+        _ensure_cache(medias, label_history, 0)
+        assert len(_cached_steps) == len(label_history)
+        # After replay, media 1 should be in bad_ids (final state)
+        assert 1 in _cache_bad_ids
+        assert 1 not in _cache_good_ids
+
+    def test_labeling_progress_works_after_switch(self, client):
+        """The /api/labeling-progress endpoint should work after a vote switch."""
+        for i in range(1, 6):
+            client.post(f"/api/medias/{i}/vote", json={"vote": "good"})
+        for i in range(6, 11):
+            client.post(f"/api/medias/{i}/vote", json={"vote": "bad"})
+
+        resp = client.get("/api/labeling-progress")
+        assert resp.status_code == 200
+
+        # Switch a vote
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+
+        resp = client.get("/api/labeling-progress")
+        assert resp.status_code == 200
+
+
 class TestStableIndicatorThresholds:
     """The Stable indicator should not turn green prematurely."""
 

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -61,6 +61,55 @@ def clear_progress_cache() -> None:
         _live_models.clear()
 
 
+def invalidate_progress_cache_from(media_id: int) -> None:
+    """Truncate the progress cache to just before *media_id* first appeared.
+
+    Called when a vote switches polarity (good→bad or bad→good).  Steps
+    before the media was first labeled are still valid — their models never
+    included this media in training data.  Only steps from the first
+    appearance onward are discarded so they can be retrained and their
+    stability/evaluation metrics recomputed.
+    """
+    global _cache_prev_predictions, _cache_diversity_tree
+    with _progress_lock:
+        # Find the first cached step that includes media_id in its training data.
+        truncate_at = None
+        for i, step in enumerate(_cached_steps):
+            if media_id in step["good_ids"] or media_id in step["bad_ids"]:
+                truncate_at = i
+                break
+
+        if truncate_at is None:
+            # Media never appeared in any cached step — nothing to invalidate.
+            return
+
+        if truncate_at == 0:
+            # Media was present from the very first step — full clear.
+            clear_progress_cache()
+            return
+
+        # Keep steps [0, truncate_at); discard the rest.
+        del _cached_steps[truncate_at:]
+
+        # Restore running ID sets from the last kept step.
+        last = _cached_steps[-1]
+        _cache_good_ids.clear()
+        _cache_good_ids.update(last["good_ids"])
+        _cache_bad_ids.clear()
+        _cache_bad_ids.update(last["bad_ids"])
+
+        # Reset the stability prediction chain — it will restart from the
+        # truncation point when _ensure_cache replays the remaining history.
+        _cache_prev_predictions = None
+
+        # Rebuild the diversity tree on next _ensure_cache call so its label
+        # state is re-synced from the truncation point forward.
+        _cache_diversity_tree = None
+
+        # Clear live models — some may have been trained with the old label.
+        _live_models.clear()
+
+
 def inject_live_model(
     good_votes: dict[int, None],
     bad_votes: dict[int, None],

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -80,7 +80,10 @@ def invalidate_progress_cache_from(media_id: int) -> None:
                 break
 
         if truncate_at is None:
-            # Media never appeared in any cached step — nothing to invalidate.
+            # Media never appeared in any cached step.  Still need to clear
+            # live models — they may have been injected by learned-sort
+            # without building the progress cache.
+            _live_models.clear()
             return
 
         if truncate_at == 0:

--- a/vtsearch/utils/state_votes.py
+++ b/vtsearch/utils/state_votes.py
@@ -104,8 +104,9 @@ def toggle_vote(media_id: int, vote: str) -> None:
     opposite vote).
 
     When a vote switches polarity (good→bad or bad→good), the progress
-    cache is invalidated because old cached models were trained with the
-    now-incorrect label and their stability/evaluation metrics are stale.
+    cache is partially invalidated: only cached steps from the point where
+    the media first appeared in the training data are discarded.  Earlier
+    steps (whose models never included this media) are preserved.
 
     This function acquires ``_state_lock`` so that the entire check-then-modify
     sequence is atomic with respect to concurrent requests.
@@ -114,7 +115,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
         media_id: Integer ID of the media to vote on.
         vote: ``"good"`` or ``"bad"``.
     """
-    from vtsearch.models.progress import clear_progress_cache
+    from vtsearch.models.progress import invalidate_progress_cache_from
 
     with _state_lock:
         if vote == "good":
@@ -132,7 +133,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 add_label_to_history(media_id, "good")
                 diversity_tree_label(media_id)
                 if was_opposite:
-                    clear_progress_cache()
+                    invalidate_progress_cache_from(media_id)
         else:
             if media_id in bad_votes:
                 bad_votes.pop(media_id, None)
@@ -148,7 +149,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 add_label_to_history(media_id, "bad")
                 diversity_tree_label(media_id)
                 if was_opposite:
-                    clear_progress_cache()
+                    invalidate_progress_cache_from(media_id)
 
 
 def apply_label(media_id: int, label: str) -> None:

--- a/vtsearch/utils/state_votes.py
+++ b/vtsearch/utils/state_votes.py
@@ -103,6 +103,10 @@ def toggle_vote(media_id: int, vote: str) -> None:
     (unlabelled); otherwise the vote is applied (overriding any existing
     opposite vote).
 
+    When a vote switches polarity (good→bad or bad→good), the progress
+    cache is invalidated because old cached models were trained with the
+    now-incorrect label and their stability/evaluation metrics are stale.
+
     This function acquires ``_state_lock`` so that the entire check-then-modify
     sequence is atomic with respect to concurrent requests.
 
@@ -110,6 +114,8 @@ def toggle_vote(media_id: int, vote: str) -> None:
         media_id: Integer ID of the media to vote on.
         vote: ``"good"`` or ``"bad"``.
     """
+    from vtsearch.models.progress import clear_progress_cache
+
     with _state_lock:
         if vote == "good":
             if media_id in good_votes:
@@ -119,11 +125,14 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 if media_id not in bad_votes:
                     diversity_tree_unlabel(media_id)
             else:
+                was_opposite = media_id in bad_votes
                 bad_votes.pop(media_id, None)
                 good_votes[media_id] = None
                 assign_click_time(media_id)
                 add_label_to_history(media_id, "good")
                 diversity_tree_label(media_id)
+                if was_opposite:
+                    clear_progress_cache()
         else:
             if media_id in bad_votes:
                 bad_votes.pop(media_id, None)
@@ -132,11 +141,14 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 if media_id not in good_votes:
                     diversity_tree_unlabel(media_id)
             else:
+                was_opposite = media_id in good_votes
                 good_votes.pop(media_id, None)
                 bad_votes[media_id] = None
                 assign_click_time(media_id)
                 add_label_to_history(media_id, "bad")
                 diversity_tree_label(media_id)
+                if was_opposite:
+                    clear_progress_cache()
 
 
 def apply_label(media_id: int, label: str) -> None:


### PR DESCRIPTION
## Summary
When a user switches a vote from one polarity to another (good→bad or bad→good), the progress cache is now intelligently truncated rather than fully cleared. Only cached steps from the point where the affected media first appeared in the training data are discarded, while earlier steps are preserved since their models never included this media.

## Key Changes

- **New function `invalidate_progress_cache_from(media_id)`** in `vtsearch/models/progress.py`:
  - Finds the first cached step containing the media and truncates from that point
  - Handles edge cases: full clear if media was in step 0, no-op if media never appeared
  - Restores running ID sets (`_cache_good_ids`, `_cache_bad_ids`) from the last kept step
  - Resets prediction chain and diversity tree to be rebuilt on next cache update
  - Clears live models to ensure consistency

- **Updated `toggle_vote()` in `vtsearch/utils/state_votes.py`**:
  - Detects when a vote switches polarity (not just toggled off or newly added)
  - Calls `invalidate_progress_cache_from()` only on actual polarity switches
  - Preserves cache when toggling votes off (unlabeling) or adding new votes

- **Comprehensive test suite** in `tests/test_votes.py`:
  - Tests both good→bad and bad→good switches
  - Verifies full cache clear when media was in step 0
  - Confirms no-op behavior for toggle-off and new votes
  - Validates live models are cleared on switches
  - Tests cache rebuild and running ID restoration after truncation
  - Ensures labeling progress endpoint works after switches

## Implementation Details

The solution leverages the fact that earlier cached steps are independent of later label changes. By preserving steps before a media's first appearance, we avoid redundant recomputation while ensuring correctness for steps that must be retrained. The running ID sets are restored from the last kept step to maintain consistency for subsequent cache updates.

https://claude.ai/code/session_01SMcSrZ2P9Ls2wJWtUQRMMP