### PR TITLE
Improve DatasetImporter resolve_file contract and error visibility

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1054,3 +1054,47 @@ def _write_zip_to(archive_path, tmp_path):
     """Helper: write a minimal .zip so _extract_archive succeeds."""
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("dummy.wav", _make_wav_bytes())
+
+
+# ---------------------------------------------------------------------------
+# Registry-level contract: importers that store files must override resolve_file
+# ---------------------------------------------------------------------------
+
+
+class TestImporterResolveFileContract:
+    """Verify that importers which produce disk-backed media override resolve_file.
+
+    This prevents a repeat of the demo-importer bug where a missing
+    resolve_file() caused cross-dataset detector labels to silently fail
+    to resolve, producing "N/A" verdicts with no error.
+
+    Importers that legitimately cannot resolve files (e.g. ``pickle`` for
+    browser uploads, ``combine_datasets`` which delegates to sub-origins)
+    are excluded.
+    """
+
+    # Importers whose media origins always delegate resolution elsewhere:
+    # - pickle: browser-uploaded files with no guaranteed server path
+    # - combine_datasets: each element retains its source dataset's origin
+    _DELEGATE_IMPORTERS = {"pickle", "combine_datasets"}
+
+    def test_all_disk_importers_override_resolve_file(self):
+        """Every registered importer that stores files must override resolve_file."""
+        from vtsearch.datasets.importers import list_importers
+        from vtsearch.datasets.importers.base import DatasetImporter
+
+        default_method = DatasetImporter.resolve_file
+
+        missing = []
+        for imp in list_importers():
+            if imp.name in self._DELEGATE_IMPORTERS:
+                continue
+            # Check if the importer's resolve_file is the unoverridden default
+            if type(imp).resolve_file is default_method:
+                missing.append(imp.name)
+
+        assert missing == [], (
+            f"Importers {missing} do not override resolve_file(). "
+            "Cross-dataset label resolution will silently fail for media "
+            "loaded by these importers. See DatasetImporter.resolve_file docstring."
+        )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -870,3 +870,54 @@ class TestFindCheckLabels:
         assert w["total_labels"] == 2
         assert w["resolved_labels"] == 1
         assert w["failed_labels"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Logging on resolution failure
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionWarningLogs:
+    """Verify that resolve_label_embeddings logs warnings on resolution failure."""
+
+    def test_logs_warning_on_total_failure(self, caplog):
+        """Zero resolved labels out of N should emit a clear warning."""
+        import logging
+
+        labels = [
+            {"label": "good", "origin": {"importer": "nonexistent", "params": {}}, "origin_name": "a.wav",
+             "filename": "a.wav"},
+            {"label": "bad", "origin": {"importer": "nonexistent", "params": {}}, "origin_name": "b.wav",
+             "filename": "b.wav"},
+        ]
+        with caplog.at_level(logging.WARNING, logger="vtsearch.models.resolver"):
+            result = resolve_label_embeddings(labels, "audio")
+
+        assert result.resolved_count == 0
+        assert result.total_count == 2
+        assert any("0 of 2 labels resolved" in m for m in caplog.messages)
+        assert any("resolve_file()" in m or "origin_name=" in m for m in caplog.messages)
+
+    def test_logs_warning_on_partial_failure(self, tmp_path, caplog):
+        """Some resolved, some missing should log partial resolution warning."""
+        import logging
+
+        wav = tmp_path / "found.wav"
+        wav.write_bytes(b"\x00" * 100)
+
+        labels = [
+            {"label": "good", "origin": None, "origin_name": "", "filename": ""},
+            {"label": "bad", "origin": {"importer": "folder", "params": {"path": str(tmp_path)}},
+             "origin_name": "found.wav", "filename": "found.wav"},
+        ]
+
+        dummy_emb = np.zeros(10)
+        with (
+            caplog.at_level(logging.WARNING, logger="vtsearch.models.resolver"),
+            patch("vtsearch.models.resolver.embed_file", return_value=dummy_emb),
+        ):
+            result = resolve_label_embeddings(labels, "audio")
+
+        assert result.resolved_count == 1
+        assert result.total_count == 2
+        assert any("1 of 2 labels resolved" in m for m in caplog.messages)

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -340,8 +340,19 @@ class DatasetImporter(PluginBase):
         :class:`~pathlib.Path` to the actual file on disk — or ``None``
         if the file cannot be found.
 
-        The default implementation returns ``None``.  Importers that store
-        files on disk (e.g. ``folder``) should override this to resolve
-        the path.
+        .. important::
+
+           Every importer whose media can be located on disk **must**
+           override this method.  Cross-dataset features (e.g. applying a
+           saved Detector to a different dataset via "Find") rely on
+           resolving label entries back to files for re-embedding.  If this
+           method is not overridden, those features silently produce empty
+           results ("N/A" verdicts) with no error — making the root cause
+           very hard to diagnose.
+
+        The default implementation returns ``None``, which is only
+        appropriate for importers whose media truly cannot be resolved
+        from disk (e.g. ``pickle`` with browser-uploaded files and no
+        server path).
         """
         return None

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -197,4 +197,27 @@ def resolve_label_embeddings(
         result.labels.append(1.0 if label_val == "good" else 0.0)
         result.resolved_count += 1
 
+    if result.total_count > 0 and result.resolved_count == 0:
+        log.warning(
+            "Label resolution failed: 0 of %d labels resolved. "
+            "This usually means the importer's resolve_file() method is missing or "
+            "the source files are no longer on disk.",
+            result.total_count,
+        )
+        if result.missing_entries:
+            first = result.missing_entries[0]
+            log.warning(
+                "First unresolved label: origin=%r, origin_name=%r, filename=%r",
+                first.get("origin"),
+                first.get("origin_name", ""),
+                first.get("filename", ""),
+            )
+    elif result.missing_entries:
+        log.warning(
+            "Partial label resolution: %d of %d labels resolved (%d missing).",
+            result.resolved_count,
+            result.total_count,
+            len(result.missing_entries),
+        )
+
     return result


### PR DESCRIPTION
After the demo importer bug where missing resolve_file() caused silent cross-dataset label resolution failure, this adds three safeguards:

1. Strengthen the base class docstring to make clear that resolve_file() is required (not optional) for any importer whose media lives on disk.

2. Add log.warning() in resolve_label_embeddings() when resolution fails completely (0/N) or partially, including the first unresolved label's origin info to aid debugging.

3. Add a registry-level test that checks all registered importers either override resolve_file() or are explicitly listed as delegate importers (pickle, combine_datasets) that don't need it.

https://claude.ai/code/session_01AdtkZUy4E2ntt7xnwgvTto