### PR TITLE
Add progress tracking for Find operation across datasets and models

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -53,6 +53,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   private polling$ = new Subject<void>();
+  private findPolling$ = new Subject<void>();
   private knownDatasetIds = new Set<string>();
   private knownModelIds = new Set<string>();
 
@@ -561,11 +562,52 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+  private startFindProgressPolling(): void {
+    this.findPolling$.next(); // cancel previous
+    timer(0, 500)
+      .pipe(
+        takeUntil(this.findPolling$),
+        takeUntil(this.destroy$),
+        switchMap(() => this.detectorsApi.getFindProgress().pipe(
+          catchError(() => EMPTY),
+        )),
+      )
+      .subscribe({
+        next: (progress: any) => {
+          if (!progress || progress.status === 'idle') return;
+
+          if (progress.current != null && progress.total != null && progress.total > 0) {
+            this.progressIndeterminate = false;
+            this.progressValue = progress.current;
+            this.progressTotal = progress.total;
+          } else {
+            this.progressIndeterminate = true;
+          }
+
+          let msg = progress.message || 'Running Find...';
+          if (progress.step != null && progress.total_steps != null && progress.total_steps > 1) {
+            msg = `[Step ${progress.step}/${progress.total_steps}] ${msg}`;
+          }
+          if (progress.current != null && progress.total != null && progress.total > 0) {
+            const pct = Math.min(100, Math.round((progress.current / progress.total) * 100));
+            msg += ` (${pct}%)`;
+          }
+          this.datasetState.setProgressMessage(msg);
+        },
+      });
+  }
+
+  private stopFindProgressPolling(): void {
+    this.findPolling$.next();
+  }
+
   private runFind(findParams: Record<string, unknown>): void {
     this.datasetState.setProgressMessage('Running Find...');
+    this.startFindProgressPolling();
 
     this.detectorsApi.find(findParams).subscribe({
       next: (response: any) => {
+        this.stopFindProgressPolling();
         this.datasetState.setLoading(false);
         this.progressIndeterminate = false;
 
@@ -625,6 +667,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.findResultsOpen = true;
       },
       error: (err) => {
+        this.stopFindProgressPolling();
         this.datasetState.setLoading(false);
         this.progressIndeterminate = false;
         this.dialog.alert(err.error?.error || 'Find failed.', 'error');

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -165,6 +165,10 @@ export class DetectorsApiService {
     return this.http.post('/api/find', params);
   }
 
+  getFindProgress(): Observable<unknown> {
+    return this.http.get('/api/find/progress');
+  }
+
   // --- Pregen processors ---
 
   getPregenProcessors(): Observable<{ processors: unknown[] }> {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,10 +282,11 @@ def reset_state():
     _core.autorun_localizers.clear()
     clear_progress_cache()
 
-    # Reset the dataset progress cancellation flag
-    from vtsearch.utils.progress import dataset_progress
+    # Reset progress trackers
+    from vtsearch.utils.progress import dataset_progress, find_progress
 
     dataset_progress.reset_cancel()
+    find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
 
     # Reset the login provider to DefaultLoginProvider
     from vtsearch.auth import DefaultLoginProvider, set_login_provider

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -637,7 +637,7 @@ class TestFindProgress:
         # Create a detector with weights
         weights = [0.1] * 512 + [0.0]  # 512 weights + 1 bias
         add_autorun_detector("prog-det", {"weights": weights, "threshold": 0.5, "media_type": "audio"})
-        m = register_model(name="prog-det", media_type="audio", detector_name="prog-det")
+        m = register_model(name="prog-det", media_type="audio", trainable=False, detector_name="prog-det")
 
         # Capture progress snapshots during find by monkey-patching update
         snapshots = []

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -593,3 +593,96 @@ class TestFindButtonValidation:
             combined += resp.data.decode("utf-8")
         assert "resolvedSelectedModels" in combined
         assert "resolvedSelectedDatasets" in combined
+
+
+class TestFindProgress:
+    """Tests for the /api/find/progress endpoint and progress reporting."""
+
+    def test_find_progress_returns_idle_by_default(self, client):
+        """GET /api/find/progress returns idle state when no Find is running."""
+        resp = client.get("/api/find/progress")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "idle"
+        assert data["message"] == ""
+        assert data["step"] is None
+        assert data["total_steps"] is None
+
+    def test_find_progress_updates_during_find(self, client, tmp_path):
+        """The find_progress tracker is updated during /api/find execution."""
+        import pickle
+
+        import numpy as np
+
+        from vtsearch.utils.progress import find_progress
+
+        # Create a dataset pkl
+        ds_medias = {}
+        for i in range(3):
+            emb = np.random.RandomState(i + 50).randn(512).astype(np.float32)
+            ds_medias[i] = {
+                "id": i,
+                "type": "audio",
+                "embedding": emb,
+                "md5": f"prog_md5_{i}",
+                "filename": f"prog_{i}.wav",
+                "origin_name": f"prog_{i}.wav",
+            }
+        pkl_path = tmp_path / "prog_ds.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"medias": ds_medias}, f)
+
+        ds = register_dataset(name="prog-ds", media_type="audio", num_items=3, pkl_path=str(pkl_path))
+
+        # Create a detector with weights
+        weights = [0.1] * 512 + [0.0]  # 512 weights + 1 bias
+        add_autorun_detector("prog-det", {"weights": weights, "threshold": 0.5, "media_type": "audio"})
+        m = register_model(name="prog-det", media_type="audio", detector_name="prog-det")
+
+        # Capture progress snapshots during find by monkey-patching update
+        snapshots = []
+        original_update = find_progress.update
+
+        def capturing_update(*args, **kwargs):
+            original_update(*args, **kwargs)
+            snapshots.append(find_progress.get())
+
+        find_progress.update = capturing_update
+        try:
+            resp = client.post("/api/find", json={"dataset_ids": [ds["id"]], "model_ids": [m["id"]]})
+        finally:
+            find_progress.update = original_update
+
+        assert resp.status_code == 200
+
+        # Should have progress snapshots from each phase
+        assert len(snapshots) >= 3  # at least: prepare models, load dataset, score
+
+        # Check step 1 (preparing models)
+        step1 = [s for s in snapshots if s.get("step") == 1]
+        assert len(step1) >= 1
+        assert step1[0]["total_steps"] == 3
+        assert step1[0]["status"] == "running"
+
+        # Check step 2 (loading dataset)
+        step2 = [s for s in snapshots if s.get("step") == 2]
+        assert len(step2) >= 1
+        assert "Loading dataset" in step2[0]["message"]
+
+        # Check step 3 (scoring)
+        step3 = [s for s in snapshots if s.get("step") == 3]
+        assert len(step3) >= 1
+        assert "Scoring" in step3[0]["message"]
+
+        # Final state should be idle
+        final = find_progress.get()
+        assert final["status"] == "idle"
+
+    def test_find_progress_resets_on_error(self, client):
+        """Progress resets to idle when Find returns an error."""
+        from vtsearch.utils.progress import find_progress
+
+        resp = client.post("/api/find", json={"dataset_ids": [], "model_ids": []})
+        assert resp.status_code == 400
+        data = find_progress.get()
+        assert data["status"] == "idle"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -636,7 +636,7 @@ class TestFindProgress:
 
         # Create a detector with weights
         weights = [0.1] * 512 + [0.0]  # 512 weights + 1 bias
-        add_autorun_detector("prog-det", {"weights": weights, "threshold": 0.5, "media_type": "audio"})
+        add_autorun_detector("prog-det", "audio", weights=weights, threshold=0.5)
         m = register_model(name="prog-det", media_type="audio", trainable=False, detector_name="prog-det")
 
         # Capture progress snapshots during find by monkey-patching update

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -25,6 +25,8 @@ import vtsearch.utils.paths as _paths
 
 from vtsearch.routes.detectors_crud import get_detectors_dir
 
+from vtsearch.utils.progress import get_find_progress, update_find_progress
+
 detectors_training_bp = Blueprint("detectors_training", __name__)
 
 
@@ -549,6 +551,16 @@ def find_check_labels():
     return jsonify({"warnings": warnings})
 
 
+@detectors_training_bp.route("/api/find/progress")
+def find_progress_endpoint():
+    """Return the current progress of the Find operation."""
+    return jsonify(get_find_progress())
+
+
+# Number of high-level Find steps: prepare models, load data, score.
+_FIND_STEPS = 3
+
+
 @detectors_training_bp.route("/api/find", methods=["POST"])
 def multi_find():
     """Run selected models on selected datasets and return merged results.
@@ -577,18 +589,29 @@ def multi_find():
     model_ids = body.get("model_ids", [])
 
     if not dataset_ids:
+        update_find_progress("idle", "", step=None, total_steps=None)
         return jsonify({"error": "No datasets selected"}), 400
     if not model_ids:
+        update_find_progress("idle", "", step=None, total_steps=None)
         return jsonify({"error": "No models selected"}), 400
+
+    # -- Step 1/3: Preparing models --
+    update_find_progress(
+        "running", "Preparing models…",
+        current=0, total=len(model_ids),
+        step=1, total_steps=_FIND_STEPS,
+    )
 
     # Resolve datasets and models from registries
     datasets = []
     for ds_id in dataset_ids:
         ds = reg_get_ds(ds_id)
         if ds is None:
+            update_find_progress("idle", "", step=None, total_steps=None)
             return jsonify({"error": f"Dataset '{ds_id}' not found"}), 404
         pkl_path = ds.get("pkl_path", "")
         if not pkl_path or not Path(pkl_path).is_file():
+            update_find_progress("idle", "", step=None, total_steps=None)
             return jsonify({"error": f"Dataset file missing for '{ds.get('name', ds_id)}'"}), 404
         datasets.append(ds)
 
@@ -596,14 +619,21 @@ def multi_find():
     for m_id in model_ids:
         m = reg_get_model(m_id)
         if m is None:
+            update_find_progress("idle", "", step=None, total_steps=None)
             return jsonify({"error": f"Model '{m_id}' not found"}), 404
         models.append(m)
 
     # Build the list of detector configs (weights+threshold) for each model
     model_configs = []
-    for m in models:
+    for mi, m in enumerate(models):
         det_name = m.get("detector_name", "")
         tm_name = m.get("trainable_model_name", "")
+
+        update_find_progress(
+            "running", f"Preparing model \"{m['name']}\"…",
+            current=mi + 1, total=len(models),
+            step=1, total_steps=_FIND_STEPS,
+        )
 
         # Try autorun detector first (has weights)
         if det_name:
@@ -634,6 +664,7 @@ def multi_find():
                 )
                 continue
 
+        update_find_progress("idle", "", step=None, total_steps=None)
         return jsonify({"error": f"Model '{m['name']}' has no weights or labels for detection"}), 400
 
     # Run Find across all datasets × models
@@ -644,7 +675,23 @@ def multi_find():
     multiple_models = len(model_configs) > 1
     model_names = [mc["name"] for mc in model_configs]
 
-    for ds in datasets:
+    # Compute total scoring units for step 3 progress:
+    # We'll count items scored across all dataset×model combos.
+    total_scoring_units = 0
+    scored_units = 0
+
+    for di, ds in enumerate(datasets):
+        # -- Step 2/3: Loading dataset --
+        ds_label = f"Loading dataset \"{ds['name']}\""
+        if len(datasets) > 1:
+            ds_label += f" ({di + 1}/{len(datasets)})"
+        ds_label += "…"
+        update_find_progress(
+            "running", ds_label,
+            current=di, total=len(datasets),
+            step=2, total_steps=_FIND_STEPS,
+        )
+
         # Load dataset from pkl
         temp_medias: dict = {}
         try:
@@ -663,6 +710,7 @@ def multi_find():
                     emb = np.array(emb, dtype=np.float32)
                 temp_medias[mid] = {**mdata, "id": mid, "embedding": emb}
         except Exception as e:
+            update_find_progress("idle", "", step=None, total_steps=None)
             return jsonify({"error": f"Failed to load dataset '{ds['name']}': {e}"}), 500
 
         if not temp_medias:
@@ -678,6 +726,9 @@ def multi_find():
         all_embs = np.array([temp_medias[cid]["embedding"] for cid in all_ids])
         X_all = torch.tensor(all_embs, dtype=torch.float32)
 
+        # Update total scoring units now that we know the dataset size
+        total_scoring_units += len(all_ids) * len(model_configs)
+
         # Per-media result: {media_id -> {info, per_model_scores}}
         media_results: dict[int, dict] = {}
         for cid in all_ids:
@@ -692,8 +743,18 @@ def multi_find():
                 "model_verdicts": {},
             }
 
-        # Run each model on this dataset
+        # -- Step 3/3: Scoring --
         for mc in model_configs:
+            score_label = f"Scoring with \"{mc['name']}\" on \"{ds['name']}\""
+            if len(datasets) > 1 or len(model_configs) > 1:
+                score_label += f" ({scored_units}/{total_scoring_units} items)"
+            score_label += "…"
+            update_find_progress(
+                "running", score_label,
+                current=scored_units, total=total_scoring_units,
+                step=3, total_steps=_FIND_STEPS,
+            )
+
             if "weights" in mc:
                 # Pre-trained detector with weights
                 try:
@@ -780,6 +841,13 @@ def multi_find():
                             "score": 0,
                         }
 
+            scored_units += len(all_ids)
+            update_find_progress(
+                "running", f"Scored \"{mc['name']}\" on \"{ds['name']}\"",
+                current=scored_units, total=total_scoring_units,
+                step=3, total_steps=_FIND_STEPS,
+            )
+
         # Collect positive and negative hits
         for cid, mr in media_results.items():
             verdicts = mr["model_verdicts"]
@@ -791,6 +859,9 @@ def multi_find():
         # Free memory
         del temp_medias, X_all
         gc.collect()
+
+    # Reset progress to idle
+    update_find_progress("idle", "", step=None, total_steps=None)
 
     return jsonify(
         {

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -122,6 +122,11 @@ sort_progress = ProgressTracker()
 #: Eval progress (used by train-and-score / voting-iterations analysis).
 eval_progress = ProgressTracker()
 
+#: Find progress (used by the /api/find multi-dataset×model scoring operation).
+find_progress = ProgressTracker(
+    extra_fields={"step": None, "total_steps": None, "error": None}
+)
+
 
 # ---------------------------------------------------------------------------
 # Backward-compatible free-function API
@@ -202,3 +207,28 @@ def update_eval_progress(
 def get_eval_progress() -> dict[str, Any]:
     """Return a snapshot of the current eval progress data."""
     return eval_progress.get()
+
+
+def update_find_progress(
+    status: str,
+    message: str = "",
+    current: int = 0,
+    total: int = 0,
+    step: Any = _UNSET,
+    total_steps: Any = _UNSET,
+    error: Any = _UNSET,
+) -> None:
+    """Update the find progress tracker in a thread-safe manner."""
+    kwargs: dict[str, Any] = {}
+    if step is not _UNSET:
+        kwargs["step"] = step
+    if total_steps is not _UNSET:
+        kwargs["total_steps"] = total_steps
+    if error is not _UNSET:
+        kwargs["error"] = error
+    find_progress.update(status, message, current, total, **kwargs)
+
+
+def get_find_progress() -> dict[str, Any]:
+    """Return a snapshot of the current find progress data."""
+    return find_progress.get()


### PR DESCRIPTION
## Summary
This PR adds real-time progress tracking for the `/api/find` endpoint, which performs multi-dataset and multi-model scoring operations. The frontend now polls for progress updates and displays detailed status information including current step, completion percentage, and descriptive messages.

## Key Changes

**Backend (Progress Tracking)**
- Added `find_progress` tracker in `vtsearch/utils/progress.py` with support for step/total_steps fields
- Implemented `update_find_progress()` and `get_find_progress()` helper functions for thread-safe progress updates
- Added `/api/find/progress` endpoint to retrieve current progress state

**Backend (Find Operation)**
- Instrumented `/api/find` endpoint with progress updates across three main phases:
  1. **Step 1**: Preparing models (validating and loading model configurations)
  2. **Step 2**: Loading datasets (reading pickle files and embeddings)
  3. **Step 3**: Scoring (running models on dataset items with per-item progress)
- Progress resets to idle on completion or error
- Provides granular progress metrics (current/total items) during scoring phase

**Frontend**
- Added `getFindProgress()` method to `DetectorsApiService` to fetch progress from the new endpoint
- Implemented `startFindProgressPolling()` and `stopFindProgressPolling()` in `DashboardComponent`
- Polls progress every 500ms during Find execution
- Displays formatted progress messages with step indicators and completion percentages
- Automatically stops polling on completion or error

**Tests**
- Added `TestFindProgress` class with three test cases:
  - Verifies idle state when no Find is running
  - Captures and validates progress snapshots during actual Find execution
  - Confirms progress resets to idle on error
- Updated `conftest.py` to reset find_progress tracker in test fixtures

## Implementation Details
- Progress tracking uses the existing `ProgressTracker` class with additional `step` and `total_steps` fields
- Scoring progress is calculated as cumulative items processed across all dataset×model combinations
- Progress messages include dataset/model names and step indicators for multi-dataset/multi-model operations
- Frontend gracefully handles missing progress data and continues operation if polling fails

https://claude.ai/code/session_01UtLbjFXz11eqC5rWudQvYx