### PR TITLE
Display human-readable clipper names in dataset registry

### DIFF
--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -914,7 +914,7 @@ class TestDatasetRegistryClipperColumn:
         resp = client.get("/api/datasets/registry")
         data = resp.get_json()
         ds = data["datasets"][0]
-        assert ds["clipper"] == "sound_tiling"
+        assert ds["clipper"] == "Sound Tiling"
 
     def test_registry_clipper_defaults_to_empty(self, client):
         from vtsearch.datasets.registry import register_dataset
@@ -929,6 +929,21 @@ class TestDatasetRegistryClipperColumn:
         data = resp.get_json()
         ds = data["datasets"][0]
         assert ds["clipper"] == ""
+
+    def test_registry_default_clipper_shows_dash(self, client):
+        from vtsearch.datasets.registry import register_dataset
+
+        register_dataset(
+            name="default-clip",
+            media_type="image",
+            num_items=3,
+            pkl_path="/tmp/defclip.pkl",
+            clipper="image_default",
+        )
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        ds = data["datasets"][0]
+        assert ds["clipper"] == "-"
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -585,6 +585,8 @@ def list_registered_datasets():
 
     entries = _reg_list_for_user(get_current_user())
     loaded_id = _reg_loaded_id()
+    from vtsearch.media import get_clipper
+
     for entry in entries:
         entry["loaded"] = entry["id"] == loaded_id
         if entry["loaded"]:
@@ -593,6 +595,16 @@ def list_registered_datasets():
             entry.setdefault("num_dupes", 0)
         entry.setdefault("embedder", "")
         entry.setdefault("readers", [])
+        # Resolve clipper name to display name; default clippers show as "-"
+        raw_clipper = entry.get("clipper", "")
+        if raw_clipper:
+            if raw_clipper.endswith("_default"):
+                entry["clipper"] = "-"
+            else:
+                try:
+                    entry["clipper"] = get_clipper(raw_clipper).display_name
+                except KeyError:
+                    pass  # keep raw name if clipper not found
     return jsonify({"datasets": entries})
 
 


### PR DESCRIPTION
## Summary
Updated the dataset registry API to display human-readable clipper names instead of internal identifiers, with special handling for default clippers.

## Key Changes
- Modified `/api/datasets/registry` endpoint to resolve clipper identifiers to their display names
- Default clippers (those ending with `_default`) now display as "-" to indicate they are system defaults
- Non-default clippers display their `display_name` property from the clipper object
- Added error handling to gracefully fall back to raw clipper name if clipper lookup fails
- Updated test expectations to match new display format (e.g., "sound_tiling" → "Sound Tiling")
- Added new test case to verify default clippers display as "-"

## Implementation Details
- Leverages existing `get_clipper()` function from `vtsearch.media` module to look up clipper display names
- Clipper resolution happens in the `list_registered_datasets()` route handler
- Maintains backward compatibility by keeping raw clipper name if the clipper cannot be found in the registry

https://claude.ai/code/session_01FnGCoWvpNATTrthsiEhTTb