### PR TITLE
Add horizontal divider between Inclusion and Media header in left Manual panel

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -52,6 +52,8 @@
         (valueChange)="inclusionChange.emit($event)"
       />
 
+      <div class="label-divider"></div>
+
       <div class="images-header">
         <h3 class="images-header-title">
           {{ mediaTypeName }}

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -71,6 +71,11 @@
   }
 }
 
+.label-divider {
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
 .images-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Matches the existing label-divider style used in the right panel between
Good/Bad sections.

https://claude.ai/code/session_0113y33vus6wkFryB45yTYgt