### PR TITLE
Remove hardcoded 500px max-width on Left/Right panels

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -32,6 +32,7 @@
   overflow: hidden;
   background: var(--bg-panel);
   display: flex;
+  min-width: 100px;
 }
 
 .divider-right {

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -333,6 +333,61 @@ describe('LabelViewComponent', () => {
     expect(sortState.threshold).toBe(0.5);
   }));
 
+  it('should switch to hard select mode when bouncing from new back to hard', fakeAsync(() => {
+    flushInitialRequests();
+
+    const autopilot = TestBed.inject(AutopilotStateService);
+    const sortState = TestBed.inject(SortStateService);
+
+    // Set up votes so learned sort will fire
+    component.voteState.loadVotes();
+    httpMock.expectOne('/api/votes').flush({ good: [1], bad: [2], click_times: {}, learned_scores: {} });
+
+    // Activate and advance to new phase
+    autopilot.activate();
+    fixture.detectChanges();
+    autopilot.checkPhaseTransition(3, 0); // good → bad
+    fixture.detectChanges();
+    autopilot.checkPhaseTransition(3, 4); // bad → hard
+    fixture.detectChanges();
+    // Flush learned sort from hard transition
+    httpMock.expectOne('/api/learned-sort').flush({
+      results: [{ id: 1, score: 0.8 }, { id: 2, score: 0.2 }],
+      threshold: 0.5,
+    });
+
+    autopilot.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    autopilot.checkPhaseTransition(10, 10); // hard → new
+    fixture.detectChanges();
+    expect(autopilot.state.phase).toBe('new');
+    expect(sortState.selectMode).toBe('new');
+
+    // Surprise vote causes smart to drop → bounce back to hard
+    autopilot.updateFromLabelingStatus({
+      smart: { status: 'yellow' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    autopilot.checkPhaseTransition(12, 12); // new → hard
+    fixture.detectChanges();
+    expect(autopilot.state.phase).toBe('hard');
+    expect(sortState.selectMode).toBe('hard');
+    expect(sortState.sortMode).toBe('learned');
+    expect(sortState.sortBusy).toBeTrue();
+
+    // Flush the learned sort request from bounce-back
+    const req = httpMock.expectOne('/api/learned-sort');
+    req.flush({
+      results: [{ id: 1, score: 0.7 }, { id: 2, score: 0.3 }],
+      threshold: 0.5,
+    });
+    expect(sortState.sortBusy).toBeFalse();
+  }));
+
   it('should advance past just-voted item even when vote state is stale', () => {
     flushInitialRequests();
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -58,9 +58,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly COLLAPSED_WIDTH = 48;
   private savedLeftWidth = 260;
   private readonly LEFT_MIN = 180;
-  private readonly LEFT_MAX = 500;
   private readonly RIGHT_MIN = 150;
-  private readonly RIGHT_MAX = 500;
+  private readonly CENTER_MIN = 100;
+  private readonly DIVIDER_TOTAL = 8; // 2 × 4px dividers
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private learnedSortPending = false;
@@ -164,7 +164,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
     let newWidth = event.clientX - layoutRect.left;
     const minWidth = this.autopilotCollapsed ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
-    newWidth = Math.max(minWidth, Math.min(this.LEFT_MAX, newWidth));
+    const leftMax = layoutRect.width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
+    newWidth = Math.max(minWidth, Math.min(leftMax, newWidth));
     this.ngZone.run(() => {
       if (this.autopilotCollapsed && newWidth >= this.LEFT_MIN) {
         this.autopilotCollapsed = false;
@@ -197,7 +198,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!this.draggingRight) return;
     const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
     let newWidth = layoutRect.right - event.clientX;
-    newWidth = Math.max(this.RIGHT_MIN, Math.min(this.RIGHT_MAX, newWidth));
+    const rightMax = layoutRect.width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
+    newWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, newWidth));
     this.ngZone.run(() => {
       this.rightWidth = newWidth;
       this.layoutRef.nativeElement.style.setProperty('--right-width', `${newWidth}px`);
@@ -646,14 +648,17 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private applyPanelPx(mediaType: string): void {
+    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width || 1200;
     const leftPx = this.panelPxLeftDict[mediaType];
     if (leftPx != null && !this.autopilotCollapsed) {
-      this.leftWidth = Math.max(this.LEFT_MIN, Math.min(this.LEFT_MAX, leftPx));
+      const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
+      this.leftWidth = Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx));
       this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     }
     const rightPx = this.panelPxRightDict[mediaType];
     if (rightPx != null) {
-      this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(this.RIGHT_MAX, rightPx));
+      const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
+      this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx));
       this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     }
   }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -105,6 +105,50 @@ describe('AutopilotPanelComponent', () => {
     expect(component.state.phase).toBe('done');
   });
 
+  it('should bounce from new back to hard when smart drops to yellow', () => {
+    // Advance to new phase
+    autopilotState.checkPhaseTransition(3, 0);
+    autopilotState.checkPhaseTransition(3, 4);
+    autopilotState.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: '' },
+    });
+    autopilotState.checkPhaseTransition(10, 10);
+    expect(component.state.phase).toBe('new');
+
+    // A surprise vote causes smart to drop
+    component.labelingStatus = {
+      smart: { status: 'yellow' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    };
+    component.ngOnChanges({
+      labelingStatus: { currentValue: component.labelingStatus, previousValue: null, firstChange: false, isFirstChange: () => false },
+    });
+    expect(component.state.phase).toBe('hard');
+  });
+
+  it('should show smart/stable status icons during new phase', () => {
+    // Advance to new phase
+    autopilotState.checkPhaseTransition(3, 0);
+    autopilotState.checkPhaseTransition(3, 4);
+    autopilotState.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    autopilotState.checkPhaseTransition(10, 10);
+    expect(component.state.phase).toBe('new');
+
+    fixture.detectChanges();
+    const steps = component.steps;
+    const newStep = steps.find((s: any) => s.phase === 'new');
+    expect(newStep!.statusIcons.length).toBe(2);
+    expect(newStep!.statusIcons[0].color).toBe('green');
+    expect(newStep!.statusIcons[1].color).toBe('green');
+  });
+
   it('should deactivate autopilot', () => {
     spyOn(component.stopped, 'emit');
     component.deactivate();

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -125,7 +125,7 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   }
 
   private phaseStatusIcons(phase: AutopilotPhase): StatusIcon[] {
-    if (phase !== 'hard') return [];
+    if (phase !== 'hard' && phase !== 'new') return [];
     const st = this.state;
     return [
       { color: st.smartStatus === 'green' ? 'green' : 'yellow', ariaLabel: `Smart: ${st.smartStatus === 'green' ? 'green' : 'pending'}` },

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -52,6 +52,8 @@
         (valueChange)="inclusionChange.emit($event)"
       />
 
+      <div class="label-divider"></div>
+
       <div class="images-header">
         <h3 class="images-header-title">
           {{ mediaTypeName }}

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -71,6 +71,11 @@
   }
 }
 
+.label-divider {
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
 .images-header {
   display: flex;
   align-items: center;

--- a/frontend/src/app/services/autopilot-state.service.spec.ts
+++ b/frontend/src/app/services/autopilot-state.service.spec.ts
@@ -87,6 +87,107 @@ describe('AutopilotStateService', () => {
     expect(service.state.phase).toBe('done');
   });
 
+  it('should bounce from new back to hard when smart goes non-green', () => {
+    service.activate();
+    service.checkPhaseTransition(3, 0);
+    service.checkPhaseTransition(3, 4);
+
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(10, 10);
+    expect(service.state.phase).toBe('new');
+
+    // Smart drops to yellow (surprise destabilized the model)
+    service.updateFromLabelingStatus({
+      smart: { status: 'yellow' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(12, 12);
+    expect(service.state.phase).toBe('hard');
+  });
+
+  it('should bounce from new back to hard when stable goes non-green', () => {
+    service.activate();
+    service.checkPhaseTransition(3, 0);
+    service.checkPhaseTransition(3, 4);
+
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(10, 10);
+    expect(service.state.phase).toBe('new');
+
+    // Stable drops to yellow (surprise caused prediction flips)
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'yellow' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(12, 12);
+    expect(service.state.phase).toBe('hard');
+  });
+
+  it('should return to new after bouncing back to hard once indicators recover', () => {
+    service.activate();
+    service.checkPhaseTransition(3, 0);
+    service.checkPhaseTransition(3, 4);
+
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(10, 10);
+    expect(service.state.phase).toBe('new');
+
+    // Bounce back to hard
+    service.updateFromLabelingStatus({
+      smart: { status: 'yellow' },
+      stable: { status: 'yellow' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(12, 12);
+    expect(service.state.phase).toBe('hard');
+
+    // Indicators recover — should go back to new
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(15, 15);
+    expect(service.state.phase).toBe('new');
+  });
+
+  it('should not bounce from new if both smart and stable remain green', () => {
+    service.activate();
+    service.checkPhaseTransition(3, 0);
+    service.checkPhaseTransition(3, 4);
+
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(10, 10);
+    expect(service.state.phase).toBe('new');
+
+    // Both still green — should stay in new
+    service.updateFromLabelingStatus({
+      smart: { status: 'green' },
+      stable: { status: 'green' },
+      span: { status: 'yellow' },
+    });
+    service.checkPhaseTransition(12, 12);
+    expect(service.state.phase).toBe('new');
+  });
+
   it('updateFromLabelingStatus should update status fields', () => {
     service.activate();
     const status: LabelingStatusResponse = {

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -78,6 +78,8 @@ export class AutopilotStateService {
       nextPhase = 'hard';
     } else if (st.phase === 'hard' && st.smartStatus === 'green' && st.stableStatus === 'green') {
       nextPhase = 'new';
+    } else if (st.phase === 'new' && (st.smartStatus !== 'green' || st.stableStatus !== 'green')) {
+      nextPhase = 'hard';
     } else if (st.phase === 'new' && st.spanStatus === 'green') {
       nextPhase = 'done';
     }


### PR DESCRIPTION
Replace static LEFT_MAX/RIGHT_MAX (500px) with dynamic limits computed
from the layout width, the opposite panel, and a 100px center-panel
minimum. This lets users drag panels much wider (e.g. for grid view
with many columns) while still preventing panels from overlapping.

https://claude.ai/code/session_01JbRjUph3fYenuH5bvVr761