### PR TITLE
Fix find-label to overwrite existing votes instead of skipping items

### DIFF
--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -358,6 +358,84 @@ class TestAutorunDetectors:
         assert "inclusion" in stored
 
 
+class TestFindLabel:
+    """Tests for POST /api/find-label — score all medias and apply Good/Bad labels."""
+
+    def _create_model_with_detector(self, client):
+        """Helper: train a detector, register it as autorun, register in model registry."""
+        from vtsearch.models.registry import register_model, reset_for_tests
+        from vtsearch.utils import add_autorun_detector
+
+        reset_for_tests()
+
+        # Train a detector from votes
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        export_resp = client.post("/api/detector/export")
+        assert export_resp.status_code == 200
+        detector = export_resp.get_json()
+
+        # Register as autorun detector
+        det_name = "find-label-det"
+        add_autorun_detector(
+            det_name,
+            "audio",
+            weights=detector["weights"],
+            threshold=detector["threshold"],
+        )
+
+        # Register in model registry
+        entry = register_model(
+            name="Find Label Test Model",
+            media_type="audio",
+            trainable=False,
+            detector_name=det_name,
+        )
+
+        # Clear the training votes
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+        return entry["id"]
+
+    def test_find_label_marks_all_items(self, client):
+        """find-label should mark every loaded media as good or bad."""
+        model_id = self._create_model_with_detector(client)
+        resp = client.post("/api/find-label", json={"model_id": model_id})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        total = data["good_count"] + data["bad_count"]
+        assert total == app_module.NUM_MEDIAS
+
+    def test_find_label_overwrites_existing_votes(self, client):
+        """find-label must mark ALL items even when votes already exist.
+
+        Reproduces the bug: train on Dataset A, load Dataset B (which reuses
+        integer IDs), run Find — previously, items whose IDs matched stale
+        votes were skipped and never marked.
+        """
+        model_id = self._create_model_with_detector(client)
+
+        # Simulate stale votes from a previous dataset (all IDs overlap)
+        app_module.good_votes.update({k: None for k in range(1, 11)})
+        app_module.bad_votes.update({k: None for k in range(11, 21)})
+
+        resp = client.post("/api/find-label", json={"model_id": model_id})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        total = data["good_count"] + data["bad_count"]
+        assert total == app_module.NUM_MEDIAS
+
+    def test_find_label_missing_model_id(self, client):
+        resp = client.post("/api/find-label", json={})
+        assert resp.status_code == 400
+
+    def test_find_label_unknown_model_id(self, client):
+        resp = client.post("/api/find-label", json={"model_id": "nonexistent"})
+        assert resp.status_code == 404
+
+
 class TestAutoDetect:
     """Tests for POST /api/auto-detect."""
 

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -92,8 +92,6 @@ def find_label():
     from vtsearch.utils import (
         apply_label_with_click_time,
         get_autorun_detectors,
-        good_votes,
-        bad_votes,
     )
 
     body = request.get_json(force=True, silent=True) or {}
@@ -150,9 +148,6 @@ def find_label():
     bad_count = 0
     for entry in results:
         cid = entry["id"]
-        # Skip already-labeled items
-        if cid in good_votes or cid in bad_votes:
-            continue
         if entry["score"] >= threshold:
             apply_label_with_click_time(cid, "good")
             good_count += 1


### PR DESCRIPTION
## Summary
Fixed a bug in the `find-label` endpoint where items with existing votes were skipped during labeling. This caused incomplete labeling when reusing media IDs across different datasets.

## Key Changes
- **Removed vote-skipping logic** in `vtsearch/routes/detectors_scoring.py`: Deleted the check that skipped items already present in `good_votes` or `bad_votes`, ensuring all loaded media are labeled regardless of prior vote state
- **Added comprehensive test coverage** in `tests/test_detectors.py`:
  - `test_find_label_marks_all_items`: Verifies all media items are labeled
  - `test_find_label_overwrites_existing_votes`: Reproduces and validates the fix for the stale votes bug
  - `test_find_label_missing_model_id`: Validates error handling for missing parameters
  - `test_find_label_unknown_model_id`: Validates error handling for invalid model IDs

## Implementation Details
The bug occurred when datasets were reloaded with reused integer IDs. The old code would skip labeling any item whose ID matched a vote from a previous dataset, leaving those items unlabeled. By removing the skip condition, `find-label` now correctly overwrites all votes and ensures complete labeling of the current dataset.

https://claude.ai/code/session_01St4Nk46SZnDJfPiJC2KDqZ