### PR TITLE
Fix progress tracking in DiversityTree to count k-means fits

### DIFF
--- a/tests/test_diversity_tree.py
+++ b/tests/test_diversity_tree.py
@@ -603,13 +603,17 @@ class TestKmeansProgress:
         assert calls[1][0] > 0, "Progress should advance after root k-means"
 
     def test_progress_total_reflects_estimated_work(self):
-        """Total should be based on N * num_levels, not just N."""
+        """Total should be based on estimated clustering fits (nodes × N_INIT)."""
         vecs = _make_vectors(200)
         calls = []
         DiversityTree(vecs, k=2, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
         total = calls[0][1]
-        n = len(vecs)
-        assert total > n, f"Estimated total work ({total}) should exceed vector count ({n})"
+        from vtsearch.models.diversity_tree import _N_INIT
+
+        # With k=2, 200 vectors, min_node_size=10 → 5 levels.
+        # Estimated internal nodes = (2^5 - 1) / (2 - 1) = 31.
+        # Estimated total = 31 * _N_INIT = 310.
+        assert total == 31 * _N_INIT, f"Expected 31 * {_N_INIT} = {31 * _N_INIT}, got {total}"
 
     def test_no_progress_for_small_input(self):
         """Vectors below min_node_size should not trigger k-means progress."""

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -74,16 +74,22 @@ class DiversityTree:
             total = len(ids)
             vecs = np.array([vectors[i] for i in ids], dtype=np.float32)
             self._on_progress = on_progress
-            # Estimate total k-means work: each tree level clusters ~N vectors
-            # total.  Number of levels ≈ log_k(N / min_node_size), capped at
-            # max_depth.  Progress is reported after each k-means call, weighted
-            # by the number of vectors in that call.
+            # Estimate total k-means work: count the expected number of
+            # clustering operations (k-means fits).  Each internal node runs
+            # _N_INIT fits.  The number of internal (splitting) nodes in a
+            # balanced k-ary tree of *num_levels* levels is
+            # (k^num_levels - 1) / (k - 1).  Progress increments by 1 per
+            # fit so that every clustering contributes equally — this keeps
+            # the bar moving during the expensive root clustering instead of
+            # weighting by vector count (which bunches progress into the
+            # many tiny leaf-adjacent nodes).
             if total >= min_node_size and total >= 2 * k:
                 num_levels = max(1, math.ceil(math.log(total / min_node_size, k)))
                 num_levels = min(num_levels, max_depth)
             else:
                 num_levels = 0
-            self._estimated_total_work = max(total * num_levels * _N_INIT, 1)
+            estimated_nodes = (k**num_levels - 1) // (k - 1) if num_levels > 0 else 0
+            self._estimated_total_work = max(estimated_nodes * _N_INIT, 1)
             self._work_done = 0
             if on_progress:
                 on_progress(0, self._estimated_total_work)
@@ -141,8 +147,8 @@ class DiversityTree:
                 best_inertia = km.inertia_
                 best_labels = candidate_labels
 
-            # Report progress after each init
-            self._work_done += len(ids)
+            # Report progress after each init (one fit = one unit of work)
+            self._work_done += 1
             if self._on_progress:
                 self._on_progress(
                     min(self._work_done, self._estimated_total_work),

--- a/vtsearch/utils/state_diversity.py
+++ b/vtsearch/utils/state_diversity.py
@@ -20,7 +20,7 @@ def build_diversity_tree(
     replayed into the new tree so the seen state stays accurate.
 
     *on_progress*, when provided, is called as ``on_progress(current, total)``
-    to report how many vectors have been placed into leaf nodes so far.
+    to report how many k-means clustering fits have been completed so far.
     """
     import numpy as np
 


### PR DESCRIPTION
## Summary
Changed progress tracking in `DiversityTree` to count individual k-means clustering operations (fits) rather than vectors processed. This provides more accurate progress estimation and ensures the progress bar advances evenly throughout the build process.

## Key Changes
- **Progress unit redefined**: Changed from counting vectors to counting k-means fits. Each internal node performs `_N_INIT` fits, so progress now increments by 1 per fit rather than by the number of vectors in that node.
- **Work estimation formula updated**: Replaced `total * num_levels * _N_INIT` with `(k^num_levels - 1) / (k - 1) * _N_INIT`, which correctly calculates the number of internal (splitting) nodes in a balanced k-ary tree.
- **Progress reporting**: Updated `_build_node()` to increment `_work_done` by 1 per k-means fit instead of by the node size.
- **Documentation**: Clarified comments and docstrings to explain that progress is based on clustering operations, not vector counts. Updated `on_progress` callback documentation in `state_diversity.py`.
- **Test updates**: Modified `test_progress_total_reflects_estimated_work()` to verify the new formula with a concrete example (31 internal nodes for k=2, 200 vectors, min_node_size=10).

## Implementation Details
The new approach ensures that expensive root-level clustering (which processes many vectors) doesn't cause the progress bar to jump significantly, while many small leaf-adjacent nodes don't cause it to stall. By weighting each clustering operation equally, the progress bar moves more smoothly and predictably throughout the tree construction.

https://claude.ai/code/session_01SXcnTenHmGwGsEtSiEwqDj