### PR TITLE
Include /find route in label view detection logic

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -31,7 +31,8 @@ export class AppComponent {
     this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
       .subscribe((e) => {
-        this.isOnLabelView = e.urlAfterRedirects.startsWith('/label');
+        this.isOnLabelView =
+          e.urlAfterRedirects.startsWith('/label') || e.urlAfterRedirects.startsWith('/find');
       });
   }
 


### PR DESCRIPTION
## Summary
Updated the label view detection logic to recognize the `/find` route in addition to the existing `/label` route.

## Changes
- Modified the `isOnLabelView` condition in `AppComponent` to include routes starting with `/find`
- The component now treats both `/label` and `/find` routes as label view contexts

## Implementation Details
The `isOnLabelView` property is now set to `true` when the current URL starts with either `/label` or `/find`, allowing the component to apply label view-specific styling or behavior to both routes.

https://claude.ai/code/session_01HthRHy5CGfAyDxjMtyNfJ4