### PR TITLE
Remove uppercase styling and simplify header count display

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -4,8 +4,7 @@
     <div class="tab-panel-manual" role="region" aria-label="Find results">
       <div class="images-header">
         <h3 class="images-header-title">
-          {{ mediaTypeName }}
-          <span class="images-header-count">({{ medias.length }})</span>
+          {{ mediaTypeName }}s ({{ medias.length }})
         </h3>
         <button class="view-btn" (click)="showLeftViewSettings = true">View</button>
       </div>
@@ -95,8 +94,7 @@
 
         <div class="images-header">
           <h3 class="images-header-title">
-            {{ mediaTypeName }}
-            <span class="images-header-count">({{ medias.length }})</span>
+            {{ mediaTypeName }}s ({{ medias.length }})
           </h3>
           <button class="view-btn" (click)="showLeftViewSettings = true">View</button>
         </div>

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -85,16 +85,9 @@
 
 .images-header-title {
   font-size: 0.8rem;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0;
   color: var(--text-secondary);
-  font-weight: 600;
-}
-
-.images-header-count {
-  font-size: 0.75rem;
-  color: var(--text-muted);
   font-weight: normal;
 }
 

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -1,7 +1,6 @@
 <div class="vote-section">
   <h3 [class]="label">
-    {{ label === 'good' ? 'Good' : 'Bad' }}
-    <span class="label-count">({{ ids.length }})</span>
+    {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length }})
   </h3>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-columns]="gridColumns">
     @for (entry of sortedEntries; track trackById($index, entry)) {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -16,12 +16,12 @@
 
 h3 {
   font-size: 0.8rem;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 8px 0;
   flex-shrink: 0;
   display: flex;
   align-items: center;
+  font-weight: normal;
 
   &.good {
     color: var(--color-good);
@@ -30,12 +30,6 @@ h3 {
   &.bad {
     color: var(--color-bad);
   }
-}
-
-.label-count {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  font-weight: normal;
 }
 
 .vote-list {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -34,7 +34,7 @@ describe('LabelListComponent', () => {
 
     const el = fixture.nativeElement as HTMLElement;
     const heading = el.querySelector('h3');
-    expect(heading?.textContent).toContain('Good');
+    expect(heading?.textContent).toContain('Goods');
     expect(heading?.textContent).toContain('(2)');
     expect(heading?.classList.contains('good')).toBeTrue();
   });
@@ -47,7 +47,7 @@ describe('LabelListComponent', () => {
 
     const el = fixture.nativeElement as HTMLElement;
     const heading = el.querySelector('h3');
-    expect(heading?.textContent).toContain('Bad');
+    expect(heading?.textContent).toContain('Bads');
     expect(heading?.classList.contains('bad')).toBeTrue();
   });
 


### PR DESCRIPTION
## Summary
This PR removes uppercase text transformation from section headers and simplifies the display of item counts by integrating them directly into the header text rather than using separate styled spans.

## Key Changes
- **Removed `text-transform: uppercase`** from h3 headers in both label-list and left-panel components
- **Removed `.label-count` and `.images-header-count` CSS classes** that were previously used for styling count badges
- **Simplified header markup** by combining label text and count into a single text node instead of using separate spans
- **Updated label text** to use plural forms ("Goods"/"Bads" instead of "Good"/"Bad", "mediaTypeNames" with 's' suffix)
- **Adjusted font-weight** to `normal` for headers (removed `font-weight: 600` from images-header-title)
- **Updated unit tests** to reflect the new plural label text

## Implementation Details
- The count display format changed from `Label (count)` with separate styling to `Labels (count)` as plain text
- This reduces CSS complexity by eliminating dedicated count styling classes
- Headers now have consistent font-weight of `normal` across components
- The changes maintain the same visual information while simplifying the DOM structure

https://claude.ai/code/session_01S3C42qHq66CzGur5uU3jNL