### PR TITLE
Adjust grid icon size mappings for better visual hierarchy

### DIFF
--- a/frontend/src/app/utils/grid-icon-size.ts
+++ b/frontend/src/app/utils/grid-icon-size.ts
@@ -1,9 +1,9 @@
 const ICON_SIZE_GOAL_WIDTH: Record<string, number> = {
-  XS: 40,
-  S: 60,
+  XS: 25,
+  S: 50,
   M: 80,
-  L: 120,
-  XL: 180,
+  L: 130,
+  XL: 200,
 };
 
 export function iconSizeToGoalWidth(size: string): number {


### PR DESCRIPTION
## Summary
Updated the icon size goal width constants to provide better visual scaling across different size categories.

## Changes
- **XS**: 40 → 25 (reduced for more compact display)
- **S**: 60 → 50 (reduced for tighter spacing)
- **M**: 80 (unchanged)
- **L**: 120 → 130 (increased for better prominence)
- **XL**: 180 → 200 (increased for larger display areas)

## Details
These adjustments refine the icon sizing scale to create a more balanced visual hierarchy. The smaller sizes (XS, S) are now more compact, while the larger sizes (L, XL) have been increased to provide better visual distinction and prominence in grid layouts.

https://claude.ai/code/session_01JSrGPc6TAQ43tsYzZryzM1