### PR TITLE
Pass inclusion_value parameter to diversity calculation functions

### DIFF
--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -693,16 +693,16 @@ def compute_labeling_status(
 def calculate_diversity_level_over_time(
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
+    inclusion_value: int = 0,
 ) -> list[dict[str, Any]]:
     """Return cached per-step diversity levels.
 
     Diversity levels are computed and stored by :func:`_ensure_cache` as it
-    processes each label-history step, so this function is just a read of the
-    already-populated cache.  :func:`analyze_labeling_progress` calls
-    ``_ensure_cache`` before calling this function, so the cache is always
-    current by the time we arrive here.
+    processes each label-history step, so this function ensures the cache is
+    current before reading it.
     """
     with _progress_lock:
+        _ensure_cache(clips_dict, label_history, inclusion_value)
         return [step["diversity"] for step in _cached_steps if step.get("diversity") is not None]
 
 
@@ -725,7 +725,7 @@ def analyze_labeling_progress(
 
         stability = [step["stability"] for step in _cached_steps if step["stability"] is not None]
 
-        diversity = calculate_diversity_level_over_time(clips_dict, label_history)
+        diversity = calculate_diversity_level_over_time(clips_dict, label_history, inclusion_value)
 
     return {
         "error_cost_over_time": error_cost,

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -898,7 +898,7 @@ def indicator_score_history():
             data = calculate_prediction_stability_over_time(clips, label_history, inclusion)
             return jsonify({"metric": "stable", "history": data})
         else:
-            data = calculate_diversity_level_over_time(clips, label_history)
+            data = calculate_diversity_level_over_time(clips, label_history, inclusion)
             return jsonify({"metric": "diverse", "history": data})
     except Exception:
         import logging
@@ -990,7 +990,7 @@ def eval_train_and_score():
             update_eval_progress("idle", "Done", n_total, n_total)
             return jsonify({"stability": result_data})
         else:
-            result_data = calculate_diversity_level_over_time(clips, history)
+            result_data = calculate_diversity_level_over_time(clips, history, inclusion)
             update_eval_progress("idle", "Done", n_total, n_total)
             return jsonify({"diversity": result_data})
     except Exception:


### PR DESCRIPTION
## Summary
Updated the `calculate_diversity_level_over_time` function to accept and use the `inclusion_value` parameter, ensuring that diversity calculations respect the inclusion filter setting. Additionally, refactored the function to ensure cache consistency by calling `_ensure_cache` internally rather than relying on external callers.

## Key Changes
- Added `inclusion_value: int = 0` parameter to `calculate_diversity_level_over_time` function signature
- Modified function to call `_ensure_cache` internally to guarantee cache is current before reading diversity data
- Updated docstring to reflect that the function now ensures cache currency rather than assuming it's pre-populated
- Updated all call sites to pass the `inclusion_value` parameter:
  - `analyze_labeling_progress` in `vtsearch/models/progress.py`
  - `indicator_score_history` endpoint in `vtsearch/routes/sorting.py`
  - `eval_train_and_score` endpoint in `vtsearch/routes/sorting.py`

## Implementation Details
The change makes the diversity calculation function more self-contained and consistent with how `calculate_prediction_stability_over_time` handles the inclusion parameter. By moving the `_ensure_cache` call inside the function, we eliminate the implicit dependency on external callers to maintain cache state, reducing the risk of stale data being used in diversity calculations.

https://claude.ai/code/session_01UxQCPcVzJDw2BYcdrDa9nG