### PR TITLE
Fix autopilot phase transitions and initialization logic

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -483,23 +483,40 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   // --- Autopilot ---
 
   onAutopilotStart(): void {
-    this.sortState.setSelectMode('top');
     // Initialize re-sort tracking
     this.resortVoteCount = 0;
     this.resortNextThreshold = this.resortInterval;
-    const textQuery = this.labelSession.textQuery;
-    const mediaExample = this.labelSession.mediaExample;
-    if (textQuery) {
-      if (this.mediaState.medias.length > 0) {
-        this.triggerAutopilotTextSort();
+
+    const phase = this.autopilotStateService.state.phase;
+
+    // For phases beyond 'good', the phase-transition subscription already set
+    // the correct selectMode and (for 'hard') triggered a learned sort.
+    // Only override selectMode for the initial 'good' phase.
+    if (phase === 'good') {
+      this.sortState.setSelectMode('top');
+    }
+
+    // For 'hard' and later phases the subscription already triggered learned
+    // sort; no text/media sort needed.  For 'good' and 'bad' phases, kick off
+    // the text/media sort so the user has results to vote on.
+    if (phase === 'good' || phase === 'bad') {
+      const textQuery = this.labelSession.textQuery;
+      const mediaExample = this.labelSession.mediaExample;
+      if (textQuery) {
+        if (this.mediaState.medias.length > 0) {
+          this.triggerAutopilotTextSort();
+        } else {
+          this.autopilotTextSortPending = true;
+        }
+      } else if (mediaExample) {
+        if (this.mediaState.medias.length > 0) {
+          this.triggerAutopilotMediaSort();
+        } else {
+          this.autopilotMediaSortPending = true;
+        }
       } else {
-        this.autopilotTextSortPending = true;
-      }
-    } else if (mediaExample) {
-      if (this.mediaState.medias.length > 0) {
-        this.triggerAutopilotMediaSort();
-      } else {
-        this.autopilotMediaSortPending = true;
+        // No sort query configured; try to select from existing sort results.
+        this.autoSelectNext();
       }
     }
   }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -94,6 +94,11 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   activate(): void {
     if (this.running) return;
     this.autopilotState.activate();
+    // Immediately check whether existing votes already satisfy early phases
+    // (e.g. user labeled 23 goods in Manual mode before switching to Autopilot).
+    // ngOnChanges ran before ngOnInit so `running` was false and the check was
+    // skipped; do it now so the phase cascades (good→bad→hard) before we emit.
+    this.autopilotState.checkPhaseTransition(this.goodVotes.size, this.badVotes.size);
     this.started.emit();
   }
 

--- a/frontend/src/app/services/autopilot-state.service.spec.ts
+++ b/frontend/src/app/services/autopilot-state.service.spec.ts
@@ -188,6 +188,19 @@ describe('AutopilotStateService', () => {
     expect(service.state.phase).toBe('new');
   });
 
+  it('should cascade good→bad→hard in a single checkPhaseTransition call', () => {
+    service.activate();
+    // Both thresholds met at once (user labeled in Manual before switching to Autopilot)
+    service.checkPhaseTransition(10, 10);
+    expect(service.state.phase).toBe('hard');
+  });
+
+  it('should cascade good→bad in one call when only good threshold met', () => {
+    service.activate();
+    service.checkPhaseTransition(5, 2); // enough goods, not enough bads
+    expect(service.state.phase).toBe('bad');
+  });
+
   it('updateFromLabelingStatus should update status fields', () => {
     service.activate();
     const status: LabelingStatusResponse = {

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -72,15 +72,20 @@ export class AutopilotStateService {
     const st = this.stateSubject.value;
     let nextPhase = st.phase;
 
-    if (st.phase === 'good' && goodCount >= st.goodToStart) {
+    // Use sequential `if` (not `else if`) so phases can cascade in one call,
+    // e.g. good→bad→hard when both vote thresholds are already met.
+    if (nextPhase === 'good' && goodCount >= st.goodToStart) {
       nextPhase = 'bad';
-    } else if (st.phase === 'bad' && badCount >= st.badToStart) {
+    }
+    if (nextPhase === 'bad' && badCount >= st.badToStart) {
       nextPhase = 'hard';
-    } else if (st.phase === 'hard' && st.smartStatus === 'green' && st.stableStatus === 'green') {
+    }
+    if (nextPhase === 'hard' && st.smartStatus === 'green' && st.stableStatus === 'green') {
       nextPhase = 'new';
-    } else if (st.phase === 'new' && (st.smartStatus !== 'green' || st.stableStatus !== 'green')) {
+    }
+    if (nextPhase === 'new' && (st.smartStatus !== 'green' || st.stableStatus !== 'green')) {
       nextPhase = 'hard';
-    } else if (st.phase === 'new' && st.spanStatus === 'green') {
+    } else if (nextPhase === 'new' && st.spanStatus === 'green') {
       nextPhase = 'done';
     }
 


### PR DESCRIPTION
## Summary
This PR fixes autopilot phase transition logic to properly handle cascading phase changes and ensures the correct initialization sequence when activating autopilot mode.

## Key Changes

- **Phase Transition Cascading**: Modified `AutopilotStateService.checkPhaseTransition()` to use sequential `if` statements instead of `else if`, allowing multiple phase transitions to occur in a single call. This enables cascading transitions like good→bad→hard when vote thresholds are already met (e.g., when a user labeled items in Manual mode before switching to Autopilot).

- **Autopilot Initialization**: Updated `LabelViewComponent.onAutopilotStart()` to check the current autopilot phase and conditionally apply initialization logic:
  - Only set selectMode to 'top' for the initial 'good' phase
  - Only trigger text/media sorts for 'good' and 'bad' phases
  - For 'hard' and later phases, skip sort initialization since the phase-transition subscription already handled it
  - Added fallback to `autoSelectNext()` when no sort query is configured

- **Early Phase Check**: Added `checkPhaseTransition()` call in `AutopilotPanelComponent.activate()` to immediately evaluate whether existing votes satisfy early phase thresholds before emitting the started event, ensuring phase cascading happens before dependent logic runs.

## Notable Implementation Details

- The phase transition logic now properly handles the case where a user accumulates votes in Manual mode and then switches to Autopilot, allowing the system to skip directly to appropriate phases rather than starting from 'good'.
- Added comprehensive test cases to verify cascading phase transitions work correctly.
- Comments clarify the initialization flow and explain why certain operations are skipped for advanced phases.

https://claude.ai/code/session_01RznAiZdYgBBaX7Hrb28qMx