### PR TITLE
Remove default outline from center panel button

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -139,6 +139,7 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   transition: color 0.15s;
+  outline: none;
 
   &:hover {
     color: var(--text-primary);


### PR DESCRIPTION
## Summary
This change removes the default browser outline from a button element in the center panel component by adding `outline: none;` to its styling.

## Key Changes
- Added `outline: none;` CSS property to the button styling in center-panel.component.scss
- This prevents the default focus outline from appearing while maintaining the existing hover state styling

## Implementation Details
The outline removal is applied to the same button element that has the uppercase text transformation and color transition effects. The existing hover state (which changes the text color to the primary text color) remains unaffected by this change.

https://claude.ai/code/session_012Zntf92AhUt6Q4ujbHMEEN