### PR TITLE
Fix flaky test: seed random weights in test_build_model_output_is_logits

### DIFF
--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -121,7 +121,11 @@ class TestBuildModel:
         """build_model should NOT include sigmoid — output can be outside [0,1]."""
         from vtsearch.models.training import build_model
 
-        model = build_model(32)
+        # Use a seeded generator so the random weights are deterministic —
+        # without this, the test is flaky because random initialisation can
+        # occasionally produce weights that map extreme input into [0, 1].
+        gen = torch.Generator().manual_seed(42)
+        model = build_model(32, generator=gen)
         model.eval()
         # Use extreme input to push output well outside [0, 1]
         X = torch.ones(1, 32) * 100.0


### PR DESCRIPTION
The test asserts that build_model output is unbounded (outside [0,1]) with extreme input. Without a seeded generator, random weight initialization could occasionally produce weights that map the input into [0,1], causing intermittent failures.

https://claude.ai/code/session_017N6VpbQ38fEayW1Jvb3LaU