### PR TITLE
Add traceback logging to dataset loading error handlers

### DIFF
--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import traceback
 import threading
 from pathlib import Path
 from uuid import uuid4
@@ -434,6 +435,7 @@ def _run_origin_load_in_background(
                 total_steps=None,
             )
         except Exception as e:
+            traceback.print_exc()
             update_progress("idle", "", 0, 0, str(e), step=None, total_steps=None)
 
     # Signal "loading" before the thread starts so frontend polling never
@@ -540,6 +542,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 "Out of memory — this dataset is too large. Try a smaller dataset or free up system RAM.",
             )
         except Exception as e:
+            traceback.print_exc()
             update_progress("idle", "", 0, 0, str(e))
 
     thread = threading.Thread(target=stage_task, daemon=True)


### PR DESCRIPTION
## Summary
Added traceback printing to exception handlers in the dataset loading module to improve debugging visibility when errors occur during dataset operations.

## Key Changes
- Imported `traceback` module in `datasets_loading.py`
- Added `traceback.print_exc()` calls in two exception handlers:
  - In the diversity progress callback exception handler (line 438)
  - In the stage_task exception handler (line 545)

## Details
These changes ensure that full stack traces are printed to the console when exceptions occur during dataset loading and staging operations. Previously, only the error message string was being captured and sent to the progress update. With traceback printing, developers and users will have better visibility into the root cause of failures, making it easier to diagnose issues with dataset loading.

https://claude.ai/code/session_01Mm7GLVj8KxGG635tQ8TFg6