### PR TITLE
Add label filtering and dynamic metadata columns to export modal

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -1,128 +1,127 @@
-<vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
-  @if (!showExporterForm) {
-    <!-- Column Selection -->
-    <div class="export-section">
-      <h3>Columns</h3>
-      <div class="column-checkboxes">
-        @for (col of columns; track col.key) {
-          <label class="column-toggle">
-            <input type="checkbox" [(ngModel)]="col.enabled" />
-            {{ col.label }}
-          </label>
-        }
-      </div>
-    </div>
-
-    <!-- Delimiter -->
-    <div class="export-section">
-      <h3>Delimiter</h3>
-      <div class="delimiter-row">
-        @for (opt of delimiterOptions; track opt.value) {
-          <label class="delimiter-option">
-            <input type="radio" name="delimiter" [value]="opt.value" [(ngModel)]="delimiter" />
-            {{ opt.label }}
-          </label>
-        }
-      </div>
-    </div>
-
-    <!-- Data Preview -->
-    <div class="export-section">
-      <h3>
-        Preview
-        @if (labelsLoaded) {
-          <span class="preview-count">({{ labels.length }} rows)</span>
-        }
-      </h3>
-      @if (!labelsLoaded) {
-        <p class="empty-state">Loading labels...</p>
-      } @else if (labels.length === 0) {
-        <p class="empty-state">No labeled items to export.</p>
-      } @else {
-        <div class="table-scroll">
-          <table class="export-table">
-            <thead>
-              <tr>
-                @for (col of enabledColumns; track col.key) {
-                  <th>{{ col.label }}</th>
-                }
-              </tr>
-            </thead>
-            <tbody>
-              @for (entry of previewLabels; track entry.md5) {
-                <tr>
-                  @for (col of enabledColumns; track col.key) {
-                    <td [class.label-good]="col.key === 'label' && entry.label === 'good'"
-                        [class.label-bad]="col.key === 'label' && entry.label === 'bad'">
-                      {{ getCellValue(entry, col.key) }}
-                    </td>
-                  }
-                </tr>
-              }
-              @if (labels.length > 50) {
-                <tr class="truncated-row">
-                  <td [attr.colspan]="enabledColumns.length">
-                    ... {{ labels.length - 50 }} more rows
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
-        </div>
+<vt-modal title="Export" [open]="true" (closed)="close()">
+  <!-- Column Selection -->
+  <div class="export-section">
+    <h3>Columns</h3>
+    <div class="column-checkboxes">
+      @for (col of columns; track col.key) {
+        <label class="column-toggle">
+          <input type="checkbox" [(ngModel)]="col.enabled" />
+          {{ col.label }}
+        </label>
       }
     </div>
+  </div>
 
-    <!-- Export Actions -->
-    <div class="export-section">
-      <h3>Export Labels</h3>
-      <div class="export-buttons">
-        <button
-          class="btn btn--primary"
-          (click)="copyToClipboard()"
-          [disabled]="!hasLabels || enabledColumns.length === 0"
-        >
-          @if (copySuccess) {
-            Copied!
-          } @else {
-            Copy to Clipboard
-          }
-        </button>
-
-        @for (exp of exporters; track exp.name) {
-          <button
-            class="btn btn--secondary"
-            (click)="startExporter(exp)"
-            [disabled]="!hasLabels"
-          >
-            @if (exp.icon) {<span class="exporter-icon">{{ exp.icon }}</span>}{{ exp.display_name || exp.name }}
-          </button>
-        }
-      </div>
+  <!-- Delimiter -->
+  <div class="export-section">
+    <h3>Delimiter</h3>
+    <div class="delimiter-row">
+      @for (opt of delimiterOptions; track opt.value) {
+        <label class="delimiter-option">
+          <input type="radio" name="delimiter" [value]="opt.value" [(ngModel)]="delimiter" />
+          {{ opt.label }}
+        </label>
+      }
     </div>
+  </div>
 
-    <!-- Detector Export (Labeling mode only) -->
-    @if (showDetectorSection) {
-      <div class="export-section">
-        <h3>Export Detector Weights</h3>
-        <div class="export-buttons">
-          <button class="btn btn--primary" (click)="exportDetectorBrowser()">Browser Download</button>
-          <button class="btn btn--secondary" (click)="exportDetectorServer()">Save to Server</button>
-        </div>
+  <!-- Label Filter -->
+  <div class="export-section">
+    <h3>Show Labels</h3>
+    <div class="delimiter-row">
+      <label class="delimiter-option">
+        <input type="radio" name="labelFilter" value="both" [(ngModel)]="labelFilter" />
+        Both
+      </label>
+      <label class="delimiter-option">
+        <input type="radio" name="labelFilter" value="good" [(ngModel)]="labelFilter" />
+        Good only
+      </label>
+      <label class="delimiter-option">
+        <input type="radio" name="labelFilter" value="bad" [(ngModel)]="labelFilter" />
+        Bad only
+      </label>
+    </div>
+  </div>
+
+  <!-- Data Preview -->
+  <div class="export-section">
+    <h3>
+      Preview
+      @if (labelsLoaded) {
+        <span class="preview-count">({{ filteredLabels.length }} rows)</span>
+      }
+    </h3>
+    @if (!labelsLoaded) {
+      <p class="empty-state">Loading labels...</p>
+    } @else if (filteredLabels.length === 0) {
+      <p class="empty-state">No labeled items to export.</p>
+    } @else {
+      <div class="table-scroll">
+        <table class="export-table">
+          <thead>
+            <tr>
+              @for (col of enabledColumns; track col.key) {
+                <th>{{ col.label }}</th>
+              }
+            </tr>
+          </thead>
+          <tbody>
+            @for (entry of previewLabels; track entry.md5) {
+              <tr>
+                @for (col of enabledColumns; track col.key) {
+                  <td [class.label-good]="col.key === 'label' && entry.label === 'good'"
+                      [class.label-bad]="col.key === 'label' && entry.label === 'bad'">
+                    {{ getCellValue(entry, col) }}
+                  </td>
+                }
+              </tr>
+            }
+            @if (filteredLabels.length > 50) {
+              <tr class="truncated-row">
+                <td [attr.colspan]="enabledColumns.length">
+                  ... {{ filteredLabels.length - 50 }} more rows
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
       </div>
     }
+  </div>
 
-    @if (status) {
-      <p class="status-text">{{ status }}</p>
-    }
-    @if (error) {
-      <p class="error-text">{{ error }}</p>
-    }
-  }
+  <!-- Export Actions -->
+  <div class="export-section">
+    <h3>Export Labels</h3>
+    <div class="export-buttons">
+      <button
+        class="btn btn--primary"
+        (click)="copyToClipboard()"
+        [disabled]="!hasLabels || enabledColumns.length === 0"
+      >
+        @if (copySuccess) {
+          <span class="clipboard-icon">&#x2705;</span> Copied!
+        } @else {
+          <span class="clipboard-icon">&#x1F4CB;</span> Copy to Clipboard
+        }
+      </button>
 
-  <!-- Exporter Field Form -->
-  @if (showExporterForm && selectedExporter) {
-    <div class="exporter-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="backFromForm()">&larr; Back</button>
+      @for (exp of exporters; track exp.name) {
+        <button
+          class="btn btn--secondary"
+          (click)="startExporter(exp)"
+          [disabled]="!hasLabels"
+        >
+          @if (exp.icon) {<span class="exporter-icon">{{ exp.icon }}</span>}{{ exp.display_name || exp.name }}
+        </button>
+      }
+    </div>
+  </div>
+
+  <!-- Exporter Field Form (shown inline, doesn't replace the above) -->
+  @if (hasExporterForm && selectedExporter) {
+    <div class="export-section exporter-form-section">
+      <h3>{{ selectedExporter.display_name || selectedExporter.name }}</h3>
 
       @if (selectedExporter.fields && selectedExporter.fields.length > 0) {
         @for (field of selectedExporter.fields; track field.key) {
@@ -183,12 +182,8 @@
         <p class="info-text">This exporter requires no additional configuration.</p>
       }
 
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
-      }
-
-      <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="backFromForm()">Cancel</button>
+      <div class="form-actions">
+        <button class="btn btn--secondary" (click)="cancelExporterForm()">Cancel</button>
         <button class="btn btn--primary" (click)="submitForm()" [disabled]="submitting">
           @if (submitting) {
             Exporting...
@@ -198,5 +193,23 @@
         </button>
       </div>
     </div>
+  }
+
+  <!-- Detector Export (Labeling mode only) -->
+  @if (showDetectorSection) {
+    <div class="export-section">
+      <h3>Export Detector Weights</h3>
+      <div class="export-buttons">
+        <button class="btn btn--primary" (click)="exportDetectorBrowser()">Browser Download</button>
+        <button class="btn btn--secondary" (click)="exportDetectorServer()">Save to Server</button>
+      </div>
+    </div>
+  }
+
+  @if (status) {
+    <p class="status-text">{{ status }}</p>
+  }
+  @if (error) {
+    <p class="error-text">{{ error }}</p>
   }
 </vt-modal>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -124,22 +124,17 @@
   margin-right: 4px;
 }
 
-// --- Exporter form ---
-
-.exporter-form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.clipboard-icon {
+  margin-right: 2px;
 }
 
-.back-btn {
-  align-self: flex-start;
-  margin-bottom: 4px;
-}
+// --- Exporter form (inline section) ---
 
-.btn--sm {
-  padding: 2px 10px;
-  font-size: 0.85rem;
+.exporter-form-section {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  background: var(--bg-subtle);
 }
 
 .form-group {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -2,19 +2,18 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angu
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { ExporterInfo, LabelEntry } from '../../../models/api.models';
 
-export type ExportColumn = 'label' | 'md5' | 'origin_name' | 'filename' | 'category';
-
 export interface ColumnDef {
-  key: ExportColumn;
+  key: string;
   label: string;
   enabled: boolean;
+  isMetadata?: boolean;
 }
 
 @Component({
@@ -40,26 +39,22 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   labels: LabelEntry[] = [];
   labelsLoaded = false;
 
-  /** Column definitions with selection state. */
-  columns: ColumnDef[] = [
-    { key: 'label', label: 'Label', enabled: true },
-    { key: 'md5', label: 'MD5', enabled: true },
-    { key: 'origin_name', label: 'Origin Name', enabled: true },
-    { key: 'filename', label: 'Filename', enabled: true },
-    { key: 'category', label: 'Category', enabled: true },
-  ];
+  /** Column definitions with selection state — built dynamically from API response. */
+  columns: ColumnDef[] = [];
+
+  /** Filter which labels to show/export. */
+  labelFilter: 'good' | 'bad' | 'both' = 'both';
 
   /** Delimiter for text export. */
   delimiter = ',';
   delimiterOptions = [
     { value: ',', label: 'Comma (,)' },
-    { value: '\t', label: 'Tab' },
+    { value: '\t', label: 'Tab (\u21E5)' },
     { value: '|', label: 'Pipe (|)' },
     { value: ';', label: 'Semicolon (;)' },
   ];
 
   /** Exporter form state. */
-  showExporterForm = false;
   selectedExporter: ExporterInfo | null = null;
   formValues: Record<string, string> = {};
   submitting = false;
@@ -68,6 +63,15 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   copySuccess = false;
 
   private destroy$ = new Subject<void>();
+
+  /** Base columns that are always present. */
+  private static readonly BASE_COLUMNS: { key: string; label: string }[] = [
+    { key: 'label', label: 'Label' },
+    { key: 'md5', label: 'MD5' },
+    { key: 'origin_name', label: 'Origin Name' },
+    { key: 'filename', label: 'Filename' },
+    { key: 'category', label: 'Category' },
+  ];
 
   constructor(
     private detectorsApi: DetectorsApiService,
@@ -87,43 +91,83 @@ export class ExportModalComponent implements OnInit, OnDestroy {
       },
     });
 
-    this.sortingApi.exportLabels().subscribe({
+    this.sortingApi.exportLabels(false, { enrich: true }).subscribe({
       next: (data) => {
         this.labels = data.labels || [];
         this.labelsLoaded = true;
+        this.buildColumns(data.available_columns);
       },
       error: () => {
         this.labelsLoaded = true;
         this.error = 'Failed to load labels';
+        this.buildColumns();
       },
     });
+  }
+
+  /** Build column definitions from available_columns or fall back to defaults. */
+  private buildColumns(availableColumns?: string[]): void {
+    const baseKeys = new Set(ExportModalComponent.BASE_COLUMNS.map((c) => c.key));
+    // Start with base columns
+    this.columns = ExportModalComponent.BASE_COLUMNS.map((c) => ({
+      key: c.key,
+      label: c.label,
+      enabled: true,
+    }));
+    // Add metadata columns discovered from the data
+    if (availableColumns) {
+      for (const key of availableColumns) {
+        if (!baseKeys.has(key)) {
+          this.columns.push({
+            key,
+            label: key,
+            enabled: true,
+            isMetadata: true,
+          });
+        }
+      }
+    }
   }
 
   get enabledColumns(): ColumnDef[] {
     return this.columns.filter((c) => c.enabled);
   }
 
+  get filteredLabels(): LabelEntry[] {
+    if (this.labelFilter === 'good') {
+      return this.labels.filter((e) => e.label === 'good');
+    }
+    if (this.labelFilter === 'bad') {
+      return this.labels.filter((e) => e.label === 'bad');
+    }
+    return this.labels;
+  }
+
   get previewLabels(): LabelEntry[] {
-    return this.labels.slice(0, 50);
+    return this.filteredLabels.slice(0, 50);
   }
 
   get hasLabels(): boolean {
-    return this.labels.length > 0;
+    return this.filteredLabels.length > 0;
   }
 
   get showDetectorSection(): boolean {
     return this.mode === 'label';
   }
 
-  get modalTitle(): string {
-    if (this.showExporterForm && this.selectedExporter) {
-      return this.selectedExporter.display_name || this.selectedExporter.name;
-    }
-    return 'Export';
+  get hasExporterForm(): boolean {
+    return this.selectedExporter !== null;
   }
 
-  getCellValue(entry: LabelEntry, col: ExportColumn): string {
-    return String((entry as unknown as Record<string, unknown>)[col] ?? '');
+  getCellValue(entry: LabelEntry, col: ColumnDef): string {
+    if (col.isMetadata) {
+      const meta = entry.custom_metadata;
+      if (meta && col.key in meta) {
+        return String(meta[col.key] ?? '');
+      }
+      return '';
+    }
+    return String((entry as unknown as Record<string, unknown>)[col.key] ?? '');
   }
 
   /** Build delimited text from labels using selected columns. */
@@ -131,8 +175,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     const cols = this.enabledColumns;
     if (cols.length === 0) return '';
     const header = cols.map((c) => c.label).join(this.delimiter);
-    const rows = this.labels.map((entry) =>
-      cols.map((c) => this.getCellValue(entry, c.key)).join(this.delimiter),
+    const rows = this.filteredLabels.map((entry) =>
+      cols.map((c) => this.getCellValue(entry, c)).join(this.delimiter),
     );
     return [header, ...rows].join('\n');
   }
@@ -143,7 +187,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     navigator.clipboard.writeText(text).then(
       () => {
         this.copySuccess = true;
-        this.status = `Copied ${this.labels.length} rows to clipboard.`;
+        this.status = `Copied ${this.filteredLabels.length} rows to clipboard.`;
         setTimeout(() => (this.copySuccess = false), 2000);
       },
       () => {
@@ -164,13 +208,11 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     for (const f of fields) {
       this.formValues[f.key] = f.default || '';
     }
-    this.showExporterForm = true;
     this.error = '';
     this.status = '';
   }
 
-  backFromForm(): void {
-    this.showExporterForm = false;
+  cancelExporterForm(): void {
     this.selectedExporter = null;
     this.error = '';
     this.status = '';
@@ -186,8 +228,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     this.error = '';
     this.submitting = true;
 
-    // Build a results dict that includes selected columns info
-    const labelsData = { labels: this.labels };
+    const labelsData = { labels: this.filteredLabels };
     this.exportersApi
       .runExport({
         exporter_name: exporter.name,
@@ -199,7 +240,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
         next: () => {
           this.status = 'Labels exported.';
           this.submitting = false;
-          this.showExporterForm = false;
+          this.selectedExporter = null;
           this.exported.emit();
         },
         error: () => {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -94,10 +94,14 @@ export interface LabelEntry {
   label: 'good' | 'bad';
   origin_name?: string;
   filename?: string;
+  category?: string;
+  custom_metadata?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 export interface LabelsExportResponse {
   labels: LabelEntry[];
+  available_columns?: string[];
 }
 
 export interface LabelsImportResponse {

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -63,10 +63,13 @@ export class SortingApiService {
     return this.http.post<SafeThresholdsResponse>('/api/safe-thresholds', { safe_thresholds: value });
   }
 
-  exportLabels(goodsOnly?: boolean): Observable<LabelsExportResponse> {
+  exportLabels(goodsOnly?: boolean, options?: { enrich?: boolean }): Observable<LabelsExportResponse> {
     const params: Record<string, string> = {};
     if (goodsOnly) {
       params['goods_only'] = 'true';
+    }
+    if (options?.enrich) {
+      params['enrich'] = 'true';
     }
     return this.http.get<LabelsExportResponse>('/api/labels/export', { params });
   }

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -295,13 +295,61 @@ def export_labels():
 
     Query params:
         goods_only: If ``"1"`` or ``"true"``, only export good labels.
+        label_filter: ``"good"``, ``"bad"``, or ``"both"`` (default).
+            Overrides ``goods_only`` when present.
+        enrich: If ``"1"`` or ``"true"``, include per-item
+            ``custom_metadata`` and a top-level ``available_columns`` list.
     """
     from vtsearch.datasets.labelset import LabelSet
 
-    goods_only = request.args.get("goods_only", "").lower() in ("1", "true")
-    bads = {} if goods_only else bad_votes
-    labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bads)
+    label_filter = request.args.get("label_filter", "").lower()
+    if label_filter == "good":
+        goods, bads = good_votes, {}
+    elif label_filter == "bad":
+        goods, bads = {}, bad_votes
+    elif label_filter:
+        goods, bads = good_votes, bad_votes
+    else:
+        # Backward compat: fall back to goods_only flag
+        goods_only = request.args.get("goods_only", "").lower() in ("1", "true")
+        goods = good_votes
+        bads = {} if goods_only else bad_votes
+
+    all_medias = snapshot_medias()
+    labelset = LabelSet.from_clips_and_votes(all_medias, goods, bads)
     result: dict = labelset.to_dict()
+
+    enrich = request.args.get("enrich", "").lower() in ("1", "true")
+    if enrich:
+        from vtsearch.media import get as get_media_type  # noqa: PLC0415
+
+        md5_to_media: dict = {}
+        for m in all_medias.values():
+            md5_val = m.get("md5")
+            if md5_val:
+                md5_to_media[md5_val] = m
+
+        all_meta_keys: set[str] = set()
+        for entry in result["labels"]:
+            media = md5_to_media.get(entry.get("md5"))
+            if not media:
+                continue
+            media_type_id = media.get("type", "audio")
+            try:
+                mt = get_media_type(media_type_id)
+                meta = mt.display_metadata(media)
+            except KeyError:
+                meta = {}
+            importer_custom = media.get("custom_metadata")
+            if importer_custom:
+                meta.update(importer_custom)
+            if meta:
+                entry["custom_metadata"] = meta
+                all_meta_keys.update(meta.keys())
+
+        base_columns = ["label", "md5", "origin_name", "filename", "category"]
+        result["available_columns"] = base_columns + sorted(all_meta_keys)
+
     return jsonify(result)
 
 


### PR DESCRIPTION
## Summary
Enhanced the export modal to support filtering labels by status (good/bad/both) and dynamically display custom metadata columns discovered from the API response.

## Key Changes

**Frontend (export-modal component):**
- Added label filter UI with radio buttons to show "Good only", "Bad only", or "Both" labels
- Introduced `labelFilter` property and `filteredLabels` getter to filter displayed/exported data based on selection
- Refactored column definitions to be built dynamically from API response via new `buildColumns()` method
- Added support for metadata columns with `isMetadata` flag to distinguish them from base columns
- Updated `getCellValue()` to handle metadata columns from `custom_metadata` field
- Simplified modal title (removed dynamic title switching) and reorganized exporter form to display inline as a section
- Renamed `showExporterForm` to `hasExporterForm` and `backFromForm()` to `cancelExporterForm()` for clarity
- Updated all label count references to use `filteredLabels` instead of `labels`
- Added clipboard icon emoji to copy button

**Backend (sorting.py):**
- Added `label_filter` query parameter supporting "good", "bad", or "both" values (overrides legacy `goods_only` flag)
- Implemented `enrich` query parameter to optionally include per-item `custom_metadata` and top-level `available_columns` list
- Added logic to collect metadata from media objects and merge with importer custom metadata
- Returns sorted list of all discovered metadata keys in `available_columns`

**API Models:**
- Extended `LabelEntry` interface with `category`, `custom_metadata`, and generic `[key: string]` properties
- Added `available_columns` optional field to `LabelsExportResponse`

**Service:**
- Updated `exportLabels()` method signature to accept optional `options` parameter with `enrich` flag

**Styling:**
- Styled exporter form section with border, background, and padding for visual distinction
- Added clipboard icon styling with margin

## Implementation Details
- Base columns (label, md5, origin_name, filename, category) are always present and enabled by default
- Metadata columns are discovered from API response and appended to the column list
- Label filtering is applied consistently across preview, export text generation, and row counts
- Backward compatibility maintained for legacy `goods_only` parameter when `label_filter` is not provided

https://claude.ai/code/session_01PASXB3eFuC5j11csRykFJ2