### PR TITLE
Auto-select item at threshold boundary after sort

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -117,14 +117,27 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response: any) => {
+          const sorted = response.results.map((r: any) => ({ id: r.id, score: r.score }));
+          const threshold = response.threshold;
           // Set sort results for stripe display
-          this.sortState.setSortResults(
-            response.results.map((r: any) => ({ id: r.id, score: r.score })),
-            response.threshold,
-          );
+          this.sortState.setSortResults(sorted, threshold);
           this.sortState.setLoadSortLabel(this.findSession.modelName || 'Detector');
           this.sortState.setSortBusy(false);
           this.sortState.setSortStatus('');
+          // Select the item just above the threshold (last item with score >= threshold)
+          if (threshold != null && sorted.length > 0) {
+            let aboveId: number | null = null;
+            for (const item of sorted) {
+              if (item.score >= threshold) {
+                aboveId = item.id;
+              } else {
+                break;
+              }
+            }
+            if (aboveId != null) {
+              this.mediaState.selectMedia(aboveId);
+            }
+          }
           // Reload votes to reflect newly applied labels
           this.voteState.loadVotes();
         },


### PR DESCRIPTION
## Summary
This change enhances the sort results workflow by automatically selecting the media item that sits at the threshold boundary after sorting completes.

## Key Changes
- Refactored sort results assignment to extract `sorted` and `threshold` variables for improved readability
- Added logic to automatically select the last item with a score >= threshold after sort results are loaded
- The selection only occurs when a threshold exists and sorted results are available

## Implementation Details
- The code iterates through sorted results in order and tracks the last item that meets or exceeds the threshold score
- Once an item falls below the threshold, iteration stops (assumes results are ordered by score)
- The identified item is selected via `mediaState.selectMedia()` to update the UI
- This provides a better user experience by automatically focusing on the critical item at the decision boundary

https://claude.ai/code/session_01KEWvPtZ8pDXfLNtMxcG92Y