### PR TITLE
Fix duplicate columns in enriched export by filtering case-insensitive

### DIFF
--- a/tests/test_export_options.py
+++ b/tests/test_export_options.py
@@ -414,3 +414,17 @@ class TestExportWithFilteredResults:
             assert fpath.exists()
             written = json.loads(fpath.read_text())
             assert "fill_from_sort" in written["results"]
+
+
+class TestAvailableColumnsNoDuplicates:
+    """Enriched export should not return duplicate columns differing only by case."""
+
+    def test_no_duplicate_category_column(self, client):
+        """Category appears once in available_columns, not twice (lowercase + capitalized)."""
+        app_module.good_votes[1] = None
+        resp = client.get("/api/labels/export?enrich=true")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        cols = data["available_columns"]
+        category_cols = [c for c in cols if c.lower() == "category"]
+        assert len(category_cols) == 1, f"Expected 1 category column, got: {category_cols}"

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -348,7 +348,9 @@ def export_labels():
                 all_meta_keys.update(meta.keys())
 
         base_columns = ["label", "md5", "origin_name", "filename", "category"]
-        result["available_columns"] = base_columns + sorted(all_meta_keys)
+        base_lower = {c.lower() for c in base_columns}
+        extra_keys = sorted(k for k in all_meta_keys if k.lower() not in base_lower)
+        result["available_columns"] = base_columns + extra_keys
 
     return jsonify(result)
 


### PR DESCRIPTION
## Summary
Fixed an issue where the enriched export endpoint could return duplicate column names that differ only by case (e.g., "category" and "Category"). The fix ensures that metadata keys are deduplicated against base columns using case-insensitive comparison.

## Changes
- **vtsearch/routes/sorting.py**: Modified the `export_labels()` function to filter out metadata keys that would create case-insensitive duplicates with base columns. Now performs a case-insensitive comparison before adding extra keys to `available_columns`.
- **tests/test_export_options.py**: Added `TestAvailableColumnsNoDuplicates` test class with `test_no_duplicate_category_column()` to verify that the "category" column appears exactly once in the available columns list, regardless of case variations.

## Implementation Details
The fix uses a set of lowercase base column names (`base_lower`) to check if each metadata key would create a duplicate when compared case-insensitively. Only metadata keys that don't match any base column (case-insensitive) are included in the final `available_columns` list.

https://claude.ai/code/session_016gye8RqoED9nB7NoNuQorK