### PR TITLE
Fix autopilot phase regression when vote state is cleared

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -491,4 +491,32 @@ describe('LabelViewComponent', () => {
     freshFixture.componentInstance.ngOnDestroy();
     httpMock.match(() => true);
   });
+
+  it('should clear stale vote state so autopilot starts in good phase', () => {
+    const autopilot = TestBed.inject(AutopilotStateService);
+    const voteState = TestBed.inject(VoteStateService);
+
+    // Simulate leftover votes from a previous session (e.g. old detector)
+    voteState.applyOptimisticVote(1, 'good');
+    voteState.applyOptimisticVote(2, 'good');
+    voteState.applyOptimisticVote(3, 'good');
+    voteState.applyOptimisticVote(4, 'bad');
+    voteState.applyOptimisticVote(5, 'bad');
+    voteState.applyOptimisticVote(6, 'bad');
+    voteState.applyOptimisticVote(7, 'bad');
+    expect(voteState.goodVotes.size).toBe(3);
+    expect(voteState.badVotes.size).toBe(4);
+
+    // Creating a new label-view should clear stale votes before autopilot
+    // activates, so it starts in 'good' phase — NOT 'hard' (Refine Boundary)
+    const freshFixture = TestBed.createComponent(LabelViewComponent);
+    freshFixture.detectChanges();
+
+    expect(voteState.goodVotes.size).toBe(0);
+    expect(voteState.badVotes.size).toBe(0);
+    expect(autopilot.state.phase).toBe('good');
+
+    freshFixture.componentInstance.ngOnDestroy();
+    httpMock.match(() => true);
+  });
 });

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -93,6 +93,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit(): void {
     this.autopilotStateService.clear();
+    this.voteState.clear();
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     this.mediaState.loadMedias();

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -55,10 +55,11 @@ describe('AutopilotPanelComponent', () => {
 
   it('should transition from bad to hard phase', () => {
     // Advance to bad phase first
+    component.goodVotes = new Set([1, 2, 3]);
     autopilotState.checkPhaseTransition(3, 0);
     expect(component.state.phase).toBe('bad');
 
-    component.badVotes = new Set([1, 2, 3, 4]);
+    component.badVotes = new Set([4, 5, 6, 7]);
     component.ngOnChanges({
       badVotes: { currentValue: component.badVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
     });
@@ -67,6 +68,8 @@ describe('AutopilotPanelComponent', () => {
 
   it('should transition from hard to new when smart+stable are green', () => {
     // Advance to hard phase
+    component.goodVotes = new Set([1, 2, 3]);
+    component.badVotes = new Set([4, 5, 6, 7]);
     autopilotState.checkPhaseTransition(3, 0);
     autopilotState.checkPhaseTransition(3, 4);
     expect(component.state.phase).toBe('hard');
@@ -84,6 +87,8 @@ describe('AutopilotPanelComponent', () => {
 
   it('should transition from new to done when span is green', () => {
     // Advance to new phase
+    component.goodVotes = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    component.badVotes = new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
     autopilotState.checkPhaseTransition(3, 0);
     autopilotState.checkPhaseTransition(3, 4);
     autopilotState.updateFromLabelingStatus({
@@ -107,6 +112,8 @@ describe('AutopilotPanelComponent', () => {
 
   it('should bounce from new back to hard when smart drops to yellow', () => {
     // Advance to new phase
+    component.goodVotes = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    component.badVotes = new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
     autopilotState.checkPhaseTransition(3, 0);
     autopilotState.checkPhaseTransition(3, 4);
     autopilotState.updateFromLabelingStatus({
@@ -170,6 +177,33 @@ describe('AutopilotPanelComponent', () => {
     spyOn(component.started, 'emit');
     component.activate();
     expect(component.started.emit).not.toHaveBeenCalled();
+  });
+
+  it('should regress from hard to good when vote counts drop to zero', () => {
+    // Advance to hard phase with sufficient votes
+    autopilotState.checkPhaseTransition(3, 4);
+    expect(component.state.phase).toBe('hard');
+
+    // Votes are cleared (e.g. new detector session) — phase should regress
+    component.goodVotes = new Set();
+    component.badVotes = new Set();
+    component.ngOnChanges({
+      goodVotes: { currentValue: component.goodVotes, previousValue: new Set([1, 2, 3]), firstChange: false, isFirstChange: () => false },
+    });
+    expect(component.state.phase).toBe('good');
+  });
+
+  it('should regress from hard to bad when good count drops below threshold', () => {
+    autopilotState.checkPhaseTransition(3, 4);
+    expect(component.state.phase).toBe('hard');
+
+    // Good votes drop below threshold but bad are still sufficient
+    component.goodVotes = new Set([1]);
+    component.badVotes = new Set([4, 5, 6, 7]);
+    component.ngOnChanges({
+      goodVotes: { currentValue: component.goodVotes, previousValue: new Set([1, 2, 3]), firstChange: false, isFirstChange: () => false },
+    });
+    expect(component.state.phase).toBe('good');
   });
 
   it('should show tooltip on each step label via title attribute', () => {

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -70,23 +70,20 @@ export class AutopilotStateService {
 
   checkPhaseTransition(goodCount: number, badCount: number): void {
     const st = this.stateSubject.value;
-    let nextPhase = st.phase;
+    if (st.phase === 'idle') return;
 
-    // Use sequential `if` (not `else if`) so phases can cascade in one call,
-    // e.g. good→bad→hard when both vote thresholds are already met.
-    if (nextPhase === 'good' && goodCount >= st.goodToStart) {
+    // Derive the correct phase from current counts and indicator statuses.
+    // This allows both forward and backward transitions (e.g. if votes are
+    // cleared or un-toggled, the phase regresses to match).
+    let nextPhase: AutopilotPhase;
+    if (goodCount < st.goodToStart) {
+      nextPhase = 'good';
+    } else if (badCount < st.badToStart) {
       nextPhase = 'bad';
-    }
-    if (nextPhase === 'bad' && badCount >= st.badToStart) {
+    } else if (st.smartStatus === 'green' && st.stableStatus === 'green') {
+      nextPhase = st.spanStatus === 'green' ? 'done' : 'new';
+    } else {
       nextPhase = 'hard';
-    }
-    if (nextPhase === 'hard' && st.smartStatus === 'green' && st.stableStatus === 'green') {
-      nextPhase = 'new';
-    }
-    if (nextPhase === 'new' && (st.smartStatus !== 'green' || st.stableStatus !== 'green')) {
-      nextPhase = 'hard';
-    } else if (nextPhase === 'new' && st.spanStatus === 'green') {
-      nextPhase = 'done';
     }
 
     if (nextPhase !== st.phase) {


### PR DESCRIPTION
## Summary
This PR fixes autopilot phase transitions to support backward regression when vote counts decrease or are cleared (e.g., when starting a new detector session). Previously, the phase transition logic only allowed forward progression, causing autopilot to remain stuck in advanced phases even when vote thresholds were no longer met.

## Key Changes

- **Autopilot state service**: Refactored `checkPhaseTransition()` to derive the correct phase from current vote counts and indicator statuses rather than only allowing forward transitions. This enables both forward and backward phase transitions based on actual state.

- **Vote state clearing**: Added `this.voteState.clear()` call in `LabelViewComponent.ngOnInit()` to clear stale votes from previous sessions before autopilot activates, ensuring it starts in the 'good' phase.

- **Phase transition logic**: Changed from sequential `if` statements (which only allowed cascading forward) to a decision tree that:
  - Regresses to 'good' if good votes drop below threshold
  - Regresses to 'bad' if bad votes drop below threshold
  - Progresses to 'new' or 'done' when smart+stable indicators are green
  - Falls back to 'hard' otherwise

- **Test coverage**: Added comprehensive tests for:
  - Regression from hard to good when all votes are cleared
  - Regression from hard to bad when good votes drop below threshold
  - Clearing stale vote state on new label-view creation

## Implementation Details

The key insight is that phase transitions should be **state-derived** rather than **event-driven**. By checking vote counts and indicator statuses against thresholds, the phase automatically adjusts to match reality, supporting both progression and regression scenarios.

https://claude.ai/code/session_017cTVW7VfuEjjdeCwMrGq6D