### PR TITLE
Prevent find-label from overwriting model training labels

### DIFF
--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -490,6 +490,90 @@ class TestFindLabel:
         finally:
             set_trainable_models_dir(original_dir)
 
+    def test_find_label_does_not_overwrite_training_labels(self, client, tmp_path):
+        """Running Find must NOT overwrite the model's saved training labels.
+
+        Reproduces the bug: train on Dataset A (6 labels), load Dataset B,
+        run Find → the model's labelset on disk should still have exactly 6
+        training labels, not the N scoring labels from Dataset B.
+        """
+        from vtsearch.datasets.labelset import LabelSet
+        from vtsearch.models.registry import register_model, reset_for_tests, set_loaded_id
+        from vtsearch.routes.trainable_models import _read_model, _write_model, sync_labels_to_loaded_model
+        from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
+        from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+
+        reset_for_tests()
+
+        # --- Phase 1: simulate training on "Dataset A" (6 labels) ---
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
+
+        snap = snapshot_medias()
+        labelset = LabelSet.from_clips_and_votes(snap, good_votes, bad_votes, expand_dupes=False)
+        original_label_count = len(labelset)
+        assert original_label_count == 6
+
+        original_dir = get_trainable_models_dir()
+        set_trainable_models_dir(tmp_path)
+        try:
+            tm_name = "persist-test"
+            tm_path = tmp_path / f"{tm_name}.json"
+            _write_model(
+                tm_path,
+                {
+                    "name": tm_name,
+                    "text_query": "",
+                    "examples": [],
+                    "labelset": labelset.to_dict(),
+                },
+            )
+
+            entry = register_model(
+                name="Persist Test",
+                media_type="audio",
+                trainable=True,
+                trainable_model_name=tm_name,
+            )
+            model_id = entry["id"]
+            set_loaded_id(model_id)
+
+            # --- Phase 2: simulate loading Dataset B (clear votes) ---
+            good_votes.clear()
+            bad_votes.clear()
+
+            # --- Phase 3: run Find → scores all N medias, applies labels ---
+            resp = client.post("/api/find-label", json={"model_id": model_id})
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["ok"] is True
+            total_scored = data["good_count"] + data["bad_count"]
+            assert total_scored == app_module.NUM_MEDIAS
+
+            # --- Phase 4: trigger sync (as a subsequent vote would) ---
+            sync_labels_to_loaded_model()
+
+            # --- Assert: the saved labelset must still have 6 labels ---
+            saved = _read_model(tm_path)
+            saved_labels = saved["labelset"]["labels"]
+            assert len(saved_labels) == original_label_count, (
+                f"Expected {original_label_count} training labels but got "
+                f"{len(saved_labels)} — find-label scoring overwrote training data"
+            )
+        finally:
+            set_trainable_models_dir(original_dir)
+
+    def test_find_mode_cleared_on_model_load(self, client):
+        """Loading a new model should clear find mode so training syncs resume."""
+        from vtsearch.models.registry import is_find_mode, reset_for_tests, set_find_mode, set_loaded_id
+
+        reset_for_tests()
+        set_find_mode(True)
+        assert is_find_mode()
+
+        set_loaded_id(None)
+        assert not is_find_mode()
+
     def test_find_label_missing_model_id(self, client):
         resp = client.post("/api/find-label", json={})
         assert resp.status_code == 400

--- a/vtsearch/models/registry.py
+++ b/vtsearch/models/registry.py
@@ -36,6 +36,11 @@ _entries: list[dict[str, Any]] | None = None
 # The ``id`` of the currently loaded model, or ``None``.
 _loaded_id: str | None = None
 
+# When ``True`` the loaded model is in "find mode" — it was used for scoring
+# via ``/api/find-label`` and the resulting labels should NOT be synced back
+# to the trainable model's saved labelset.
+_find_mode: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Persistence
@@ -204,14 +209,29 @@ def get_loaded_id() -> str | None:
 
 def set_loaded_id(model_id: str | None) -> None:
     """Mark *model_id* as the currently loaded model (or ``None``)."""
-    global _loaded_id
+    global _loaded_id, _find_mode
     with _lock:
         _loaded_id = model_id
+        _find_mode = False
+
+
+def is_find_mode() -> bool:
+    """Return ``True`` if the loaded model is in find/scoring mode."""
+    with _lock:
+        return _find_mode
+
+
+def set_find_mode(enabled: bool = True) -> None:
+    """Set or clear find mode for the loaded model."""
+    global _find_mode
+    with _lock:
+        _find_mode = enabled
 
 
 def reset_for_tests() -> None:
     """Reset the in-memory cache (for test isolation)."""
-    global _entries, _loaded_id
+    global _entries, _loaded_id, _find_mode
     with _lock:
         _entries = None
         _loaded_id = None
+        _find_mode = False

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -205,6 +205,13 @@ def find_label():
             bad_count += 1
     apply_labels_bulk_with_click_time(label_pairs)
 
+    # Mark the loaded model as being in "find mode" so that
+    # sync_labels_to_loaded_model() won't overwrite the model's saved
+    # training labels with these scoring results.
+    from vtsearch.models.registry import set_find_mode
+
+    set_find_mode(True)
+
     return jsonify({
         "ok": True,
         "results": results,

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -77,8 +77,15 @@ def sync_labels_to_loaded_model() -> None:
 
     Called automatically after each vote so the dashboard's "# Training"
     and "Last Trained" columns stay up to date without an explicit save.
+
+    Skipped when the model is in "find mode" (after ``/api/find-label``),
+    because the global votes reflect scoring results on a different dataset,
+    not the model's original training labels.
     """
-    from vtsearch.models.registry import get_loaded_id, get_model, update_model
+    from vtsearch.models.registry import get_loaded_id, get_model, is_find_mode, update_model
+
+    if is_find_mode():
+        return
 
     loaded_id = get_loaded_id()
     if not loaded_id:


### PR DESCRIPTION
## Summary
Fixes a bug where running the `/api/find-label` endpoint would overwrite a trainable model's saved training labels with scoring results from a different dataset. The fix introduces a "find mode" flag that prevents label synchronization when a model is used for scoring.

## Key Changes
- **Added find mode tracking** (`_find_mode` flag in `registry.py`):
  - New `is_find_mode()` and `set_find_mode()` functions to manage find mode state
  - Find mode is automatically cleared when a new model is loaded via `set_loaded_id()`
  - Find mode is reset during test cleanup

- **Updated label synchronization logic** (`trainable_models.py`):
  - `sync_labels_to_loaded_model()` now skips synchronization when the model is in find mode
  - Prevents scoring results from overwriting the model's original training labels

- **Set find mode after scoring** (`detectors_scoring.py`):
  - `/api/find-label` endpoint now sets find mode to `True` after scoring completes
  - Ensures subsequent votes won't sync the scoring labels back to the model

- **Added comprehensive test** (`test_detectors.py`):
  - `test_find_label_does_not_overwrite_training_labels()` reproduces the original bug scenario
  - Verifies that training labels persist after find-label scoring on a different dataset
  - `test_find_mode_cleared_on_model_load()` ensures find mode is cleared when loading a new model

## Implementation Details
The solution uses a simple state flag rather than complex label tracking, making it easy to understand and maintain. Find mode is automatically managed—it's set when scoring occurs and cleared when a new model is loaded, so users don't need to manually manage this state.

https://claude.ai/code/session_015x6pMdae2Lb5GpwUs6P4jP