### PR TITLE
Set fixed width for export modal content

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -1,3 +1,7 @@
+:host ::ng-deep .modal-content {
+  width: 720px;
+}
+
 .export-section {
   margin-bottom: 1.25rem;
 


### PR DESCRIPTION
## Summary
This change sets a fixed width for the export modal dialog to improve its visual presentation and layout consistency.

## Key Changes
- Added CSS rule to set the modal content width to 720px using `::ng-deep` to pierce Angular's view encapsulation

## Implementation Details
The width constraint is applied at the `:host` level using the `::ng-deep` combinator, which allows styling of the modal-content element that exists outside the component's shadow DOM. This ensures the export modal maintains a consistent, readable width regardless of viewport size.

https://claude.ai/code/session_01Vccbqwwx2uoB1SajdVKGeV