### PR TITLE
Add progress reporting for detector scoring operations

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -12,6 +12,8 @@
       [inclusion]="sortState.inclusion"
       [sortBusy]="sortState.sortBusy"
       [sortStatus]="sortState.sortStatus"
+      [sortProgress]="sortState.sortProgress"
+      [sortProgressTotal]="sortState.sortProgressTotal"
       [labelingStatus]="null"
       [viewMode]="viewModeLeft"
       [gridGoalWidth]="gridGoalWidthLeft"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Subject, Subscription, timer } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -95,6 +95,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.stopProgressPolling();
     this.destroy$.next();
     this.destroy$.complete();
     this.voteState.stopPolling();
@@ -106,17 +107,49 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Find-label scoring ---
 
+  private progressPollSub: Subscription | null = null;
+
+  private startProgressPolling(): void {
+    this.stopProgressPolling();
+    this.progressPollSub = timer(200, 500)
+      .pipe(
+        switchMap(() => this.detectorsApi.getFindProgress()),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((prog: any) => {
+        if (prog.status === 'running') {
+          const msg = prog.message || 'Scoring with detector…';
+          const current = prog.current || 0;
+          const total = prog.total || 0;
+          this.sortState.setSortStatus(msg);
+          this.sortState.setSortProgress(current, total);
+        }
+      });
+  }
+
+  private stopProgressPolling(): void {
+    if (this.progressPollSub) {
+      this.progressPollSub.unsubscribe();
+      this.progressPollSub = null;
+    }
+  }
+
   private runFindLabel(): void {
     const modelId = this.findSession.modelId;
     if (!modelId) return;
 
     this.sortState.setSortBusy(true);
-    this.sortState.setSortStatus('Scoring with detector...');
+    this.sortState.setSortStatus('Scoring with detector…');
+    this.sortState.setSortProgress(0, 0);
+
+    // Start polling for progress concurrently
+    this.startProgressPolling();
 
     this.detectorsApi.findLabel({ model_id: modelId })
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response: any) => {
+          this.stopProgressPolling();
           const sorted = response.results.map((r: any) => ({ id: r.id, score: r.score }));
           const threshold = response.threshold;
           // Set sort results for stripe display
@@ -124,6 +157,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.sortState.setLoadSortLabel(this.findSession.modelName || 'Detector');
           this.sortState.setSortBusy(false);
           this.sortState.setSortStatus('');
+          this.sortState.setSortProgress(0, 0);
           // Select the item just above the threshold (last item with score >= threshold)
           if (threshold != null && sorted.length > 0) {
             let aboveId: number | null = null;
@@ -142,8 +176,10 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.voteState.loadVotes();
         },
         error: () => {
+          this.stopProgressPolling();
           this.sortState.setSortBusy(false);
           this.sortState.setSortStatus('Scoring failed');
+          this.sortState.setSortProgress(0, 0);
         },
       });
   }

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -12,6 +12,8 @@
       [inclusion]="sortState.inclusion"
       [sortBusy]="sortState.sortBusy"
       [sortStatus]="sortState.sortStatus"
+      [sortProgress]="sortState.sortProgress"
+      [sortProgressTotal]="sortState.sortProgressTotal"
       [labelingStatus]="labelingStatus"
       [viewMode]="viewModeLeft"
       [gridGoalWidth]="gridGoalWidthLeft"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -68,6 +68,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly DIVIDER_TOTAL = 8; // 2 × 4px dividers
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
+  private scoringProgressPoll$: Subscription | null = null;
   private learnedSortPending = false;
   private autopilotTextSortPending = false;
   private autopilotMediaSortPending = false;
@@ -145,6 +146,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.stopScoringProgressPoll();
     this.destroy$.next();
     this.destroy$.complete();
     this.voteState.stopPolling();
@@ -358,14 +360,44 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Re-sort using existing load sort results when switching back to load mode
   }
 
+  private startScoringProgressPoll(): void {
+    this.stopScoringProgressPoll();
+    this.scoringProgressPoll$ = timer(200, 500)
+      .pipe(
+        switchMap(() => this.detectorsApi.getFindProgress()),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((prog: any) => {
+        if (prog.status === 'running') {
+          const msg = prog.message || 'Scoring with detector…';
+          const current = prog.current || 0;
+          const total = prog.total || 0;
+          this.sortState.setSortStatus(msg);
+          this.sortState.setSortProgress(current, total);
+        }
+      });
+  }
+
+  private stopScoringProgressPoll(): void {
+    if (this.scoringProgressPoll$) {
+      this.scoringProgressPoll$.unsubscribe();
+      this.scoringProgressPoll$ = null;
+    }
+  }
+
   onDetectorLoaded(data: unknown): void {
     const detector = data as Record<string, unknown>;
     const name = (detector['name'] as string) || 'Detector';
     this.sortState.setSortMode('load');
     this.sortState.setSortBusy(true);
-    this.sortState.setSortStatus('Scoring with detector...');
+    this.sortState.setSortStatus('Scoring with detector…');
+    this.sortState.setSortProgress(0, 0);
+
+    this.startScoringProgressPoll();
+
     this.detectorsApi.detectorSort({ detector }).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
+        this.stopScoringProgressPoll();
         this.sortState.setSortResults(
           response.results.map((r) => ({ id: r.id, score: r.score })),
           response.threshold,
@@ -373,11 +405,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         this.sortState.setLoadSortLabel(name);
         this.sortState.setSortBusy(false);
         this.sortState.setSortStatus('');
+        this.sortState.setSortProgress(0, 0);
         this.autoSelectNext();
       },
       error: () => {
+        this.stopScoringProgressPoll();
         this.sortState.setSortBusy(false);
         this.sortState.setSortStatus('Detector sort failed');
+        this.sortState.setSortProgress(0, 0);
       },
     });
   }

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -14,6 +14,8 @@
           [labelingStatus]="null"
           [sortBusy]="sortBusy"
           [sortStatus]="sortStatus"
+          [sortProgress]="sortProgress"
+          [sortProgressTotal]="sortProgressTotal"
         />
       }
 
@@ -90,6 +92,8 @@
           [labelingStatus]="labelingStatus"
           [sortBusy]="sortBusy"
           [sortStatus]="sortStatus"
+          [sortProgress]="sortProgress"
+          [sortProgressTotal]="sortProgressTotal"
           (indicatorClick)="indicatorClick.emit($event)"
         />
 

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -43,6 +43,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() inclusion: number = 0;
   @Input() sortBusy = false;
   @Input() sortStatus = '';
+  @Input() sortProgress = 0;
+  @Input() sortProgressTotal = 0;
   @Input() labelingStatus: LabelingStatusResponse | null = null;
   @Input() viewMode: 'grid' | 'list' = 'list';
   @Input() gridGoalWidth: number = 80;

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -4,7 +4,11 @@
       @if (sortStatus) {
         <span class="sort-overlay-status">{{ sortStatus }}</span>
       }
-      <vt-progress-bar [indeterminate]="true" />
+      <vt-progress-bar
+        [indeterminate]="isIndeterminate"
+        [value]="sortProgress"
+        [max]="sortProgressTotal"
+      />
     </div>
   } @else {
     <button

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -14,8 +14,14 @@ export class ProgressIndicatorsComponent {
   @Input() labelingStatus: LabelingStatusResponse | null = null;
   @Input() sortBusy = false;
   @Input() sortStatus = '';
+  @Input() sortProgress = 0;
+  @Input() sortProgressTotal = 0;
 
   @Output() indicatorClick = new EventEmitter<string>();
+
+  get isIndeterminate(): boolean {
+    return this.sortProgressTotal <= 0;
+  }
 
   get smartStatus(): string {
     return (this.labelingStatus?.smart?.status as string) || '';

--- a/frontend/src/app/services/sort-state.service.ts
+++ b/frontend/src/app/services/sort-state.service.ts
@@ -17,6 +17,8 @@ export class SortStateService {
   private readonly thresholdSubject = new BehaviorSubject<number | null>(null);
   private readonly sortBusySubject = new BehaviorSubject<boolean>(false);
   private readonly sortStatusSubject = new BehaviorSubject<string>('');
+  private readonly sortProgressSubject = new BehaviorSubject<number>(0);
+  private readonly sortProgressTotalSubject = new BehaviorSubject<number>(0);
   private readonly inclusionSubject = new BehaviorSubject<number>(0);
   private readonly loadSortLabelSubject = new BehaviorSubject<string>('');
   private readonly textQuerySubject = new BehaviorSubject<string>('');
@@ -27,6 +29,8 @@ export class SortStateService {
   readonly threshold$ = this.thresholdSubject.asObservable();
   readonly sortBusy$ = this.sortBusySubject.asObservable();
   readonly sortStatus$ = this.sortStatusSubject.asObservable();
+  readonly sortProgress$ = this.sortProgressSubject.asObservable();
+  readonly sortProgressTotal$ = this.sortProgressTotalSubject.asObservable();
   readonly inclusion$ = this.inclusionSubject.asObservable();
   readonly loadSortLabel$ = this.loadSortLabelSubject.asObservable();
   readonly textQuery$ = this.textQuerySubject.asObservable();
@@ -53,6 +57,14 @@ export class SortStateService {
 
   get sortStatus(): string {
     return this.sortStatusSubject.value;
+  }
+
+  get sortProgress(): number {
+    return this.sortProgressSubject.value;
+  }
+
+  get sortProgressTotal(): number {
+    return this.sortProgressTotalSubject.value;
   }
 
   get inclusion(): number {
@@ -88,6 +100,11 @@ export class SortStateService {
     this.sortStatusSubject.next(status);
   }
 
+  setSortProgress(current: number, total: number): void {
+    this.sortProgressSubject.next(current);
+    this.sortProgressTotalSubject.next(total);
+  }
+
   setInclusion(value: number): void {
     this.inclusionSubject.next(value);
   }
@@ -107,6 +124,8 @@ export class SortStateService {
     this.thresholdSubject.next(null);
     this.sortBusySubject.next(false);
     this.sortStatusSubject.next('');
+    this.sortProgressSubject.next(0);
+    this.sortProgressTotalSubject.next(0);
     this.inclusionSubject.next(0);
     this.loadSortLabelSubject.next('');
     this.textQuerySubject.next('');

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -582,6 +582,127 @@ class TestFindLabel:
         resp = client.post("/api/find-label", json={"model_id": "nonexistent"})
         assert resp.status_code == 404
 
+    def test_find_label_reports_progress(self, client):
+        """find-label should update find_progress with discrete steps."""
+        from vtsearch.utils.progress import find_progress
+
+        model_id = self._create_model_with_detector(client)
+
+        # Capture progress snapshots by monkey-patching update
+        snapshots = []
+        original_update = find_progress.update
+
+        def capturing_update(*args, **kwargs):
+            original_update(*args, **kwargs)
+            snapshots.append(find_progress.get())
+
+        find_progress.update = capturing_update
+        try:
+            resp = client.post("/api/find-label", json={"model_id": model_id})
+        finally:
+            find_progress.update = original_update
+
+        assert resp.status_code == 200
+
+        # Should have progress snapshots from each phase
+        assert len(snapshots) >= 3
+
+        # Step 1: resolving model
+        step1 = [s for s in snapshots if s.get("step") == 1]
+        assert len(step1) >= 1
+        assert step1[0]["status"] == "running"
+        assert step1[0]["total_steps"] == 4
+
+        # Step 3: scoring (step 2 skipped when weights exist)
+        step3 = [s for s in snapshots if s.get("step") == 3]
+        assert len(step3) >= 1
+        assert "Scoring" in step3[0]["message"]
+        assert step3[0]["total"] == app_module.NUM_MEDIAS
+
+        # Step 4: applying labels
+        step4 = [s for s in snapshots if s.get("step") == 4]
+        assert len(step4) >= 1
+        assert "Applying labels" in step4[0]["message"]
+
+        # Final state should be idle
+        final = find_progress.get()
+        assert final["status"] == "idle"
+
+    def test_find_label_progress_resets_on_error(self, client):
+        """find_progress should reset to idle when find-label returns an error."""
+        from vtsearch.models.registry import reset_for_tests
+        from vtsearch.utils.progress import find_progress
+
+        reset_for_tests()
+        resp = client.post("/api/find-label", json={})
+        assert resp.status_code == 400
+        data = find_progress.get()
+        assert data["status"] == "idle"
+
+    def test_find_label_progress_resets_on_not_found(self, client):
+        """find_progress should reset to idle when model is not found."""
+        from vtsearch.utils.progress import find_progress
+
+        resp = client.post("/api/find-label", json={"model_id": "nonexistent"})
+        assert resp.status_code == 404
+        data = find_progress.get()
+        assert data["status"] == "idle"
+
+    def test_find_label_progress_visible_via_endpoint(self, client):
+        """GET /api/find/progress should reflect find-label progress."""
+        resp = client.get("/api/find/progress")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Should be idle when nothing is running
+        assert data["status"] == "idle"
+
+
+class TestDetectorSortProgress:
+    """Tests for progress reporting during POST /api/detector-sort."""
+
+    def test_detector_sort_reports_progress(self, client):
+        """detector-sort should update find_progress while scoring."""
+        from vtsearch.utils.progress import find_progress
+
+        # Train a detector
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        export_resp = client.post("/api/detector/export")
+        assert export_resp.status_code == 200
+        detector = export_resp.get_json()
+        app_module.good_votes.clear()
+        app_module.bad_votes.clear()
+
+        # Capture progress snapshots
+        snapshots = []
+        original_update = find_progress.update
+
+        def capturing_update(*args, **kwargs):
+            original_update(*args, **kwargs)
+            snapshots.append(find_progress.get())
+
+        find_progress.update = capturing_update
+        try:
+            resp = client.post("/api/detector-sort", json={"detector": detector})
+        finally:
+            find_progress.update = original_update
+
+        assert resp.status_code == 200
+
+        # Should have scoring progress snapshots
+        scoring = [s for s in snapshots if s.get("step") == 1 and s["status"] == "running"]
+        assert len(scoring) >= 1
+        assert "Scoring" in scoring[0]["message"]
+        assert scoring[0]["total"] == app_module.NUM_MEDIAS
+
+        # Should end with complete progress
+        final_running = [s for s in snapshots if s["current"] == app_module.NUM_MEDIAS and s["status"] == "running"]
+        assert len(final_running) >= 1
+
+        # Final state should be idle
+        final = find_progress.get()
+        assert final["status"] == "idle"
+
 
 class TestAutoDetect:
     """Tests for POST /api/auto-detect."""

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -15,6 +15,7 @@ from vtsearch.utils import (
     get_autorun_localizers_by_media,
     snapshot_medias,
 )
+from vtsearch.utils.progress import update_find_progress
 from vtsearch.routes.detectors_crud import _build_extractor, _build_localizer
 
 detectors_scoring_bp = Blueprint("detectors_scoring", __name__)
@@ -59,17 +60,36 @@ def detector_sort():
     if not snap:
         return jsonify({"error": "no medias loaded"}), 400
 
+    n_total = len(snap)
+    update_find_progress(
+        "running", f"Scoring {n_total} items…",
+        current=0, total=n_total,
+        step=1, total_steps=1,
+    )
+
     # Score every media
     all_ids = sorted(snap.keys())
     all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
     X_all = torch.tensor(all_embs, dtype=torch.float32)
 
+    # Score in batches so the progress endpoint can report percentage
+    batch_size = max(1, min(500, n_total // 10))
+    scores: list[float] = []
     with torch.no_grad():
-        raw_logits = model(X_all)
-        scores = torch.sigmoid(raw_logits).squeeze(1).tolist()
+        for start in range(0, n_total, batch_size):
+            end = min(start + batch_size, n_total)
+            batch_logits = model(X_all[start:end])
+            scores.extend(torch.sigmoid(batch_logits).squeeze(1).tolist())
+            update_find_progress(
+                "running", f"Scoring {n_total} items…",
+                current=end, total=n_total,
+                step=1, total_steps=1,
+            )
 
     results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
     results.sort(key=lambda x: x["score"], reverse=True)
+
+    update_find_progress("idle", "Done", current=n_total, total=n_total, step=1, total_steps=1)
     return jsonify({"results": results, "threshold": round(threshold, 4)})
 
 
@@ -94,13 +114,24 @@ def find_label():
         get_autorun_detectors,
     )
 
+    # Total high-level steps: resolve(1) + optional train(2) + score(3) + apply(4)
+    _FIND_LABEL_STEPS = 4
+
     body = request.get_json(force=True, silent=True) or {}
     model_id = body.get("model_id")
     if not model_id:
+        update_find_progress("idle", "")
         return jsonify({"error": "model_id is required"}), 400
+
+    update_find_progress(
+        "running", "Resolving model…",
+        current=0, total=0,
+        step=1, total_steps=_FIND_LABEL_STEPS,
+    )
 
     m = reg_get_model(model_id)
     if m is None:
+        update_find_progress("idle", "")
         return jsonify({"error": f"Model '{model_id}' not found"}), 404
 
     # Resolve model weights
@@ -133,6 +164,12 @@ def find_label():
         if label_entries:
             from vtsearch.routes.detectors_helpers import serialize_weights as _serialize_weights, train_and_threshold
 
+            update_find_progress(
+                "running", "Training model from labels…",
+                current=0, total=0,
+                step=2, total_steps=_FIND_LABEL_STEPS,
+            )
+
             media_type = m.get("media_type", "image")
             X_list: list = []
             y_list: list[float] = []
@@ -160,6 +197,11 @@ def find_label():
             if unresolved:
                 from vtsearch.models.resolver import resolve_label_embeddings
 
+                update_find_progress(
+                    "running", f"Resolving {len(unresolved)} label origins…",
+                    current=0, total=0,
+                    step=2, total_steps=_FIND_LABEL_STEPS,
+                )
                 resolved = resolve_label_embeddings(unresolved, media_type)
                 X_list.extend(resolved.embeddings)
                 y_list.extend(resolved.labels)
@@ -167,17 +209,31 @@ def find_label():
             has_good = any(v == 1.0 for v in y_list)
             has_bad = any(v == 0.0 for v in y_list)
             if has_good and has_bad:
+                update_find_progress(
+                    "running", "Cross-calibrating threshold…",
+                    current=0, total=0,
+                    step=2, total_steps=_FIND_LABEL_STEPS,
+                )
                 trained_model, threshold = train_and_threshold(
                     X_list, y_list, snap=snap_for_train,
                 )
                 weights = _serialize_weights(trained_model)
 
     if weights is None:
+        update_find_progress("idle", "")
         return jsonify({"error": f"Model '{m['name']}' has no weights for scoring"}), 400
 
     snap = snapshot_medias()
     if not snap:
+        update_find_progress("idle", "")
         return jsonify({"error": "No medias loaded"}), 400
+
+    n_total = len(snap)
+    update_find_progress(
+        "running", f"Scoring {n_total} items…",
+        current=0, total=n_total,
+        step=3, total_steps=_FIND_LABEL_STEPS,
+    )
 
     # Score all medias
     model = build_model_from_weights(weights)
@@ -185,14 +241,29 @@ def find_label():
     all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
     X_all = torch.tensor(all_embs, dtype=torch.float32)
 
+    # Score in batches so the progress endpoint can report percentage
+    batch_size = max(1, min(500, n_total // 10))
+    scores: list[float] = []
     with torch.no_grad():
-        raw_logits = model(X_all)
-        scores = torch.sigmoid(raw_logits).squeeze(1).tolist()
+        for start in range(0, n_total, batch_size):
+            end = min(start + batch_size, n_total)
+            batch_logits = model(X_all[start:end])
+            scores.extend(torch.sigmoid(batch_logits).squeeze(1).tolist())
+            update_find_progress(
+                "running", f"Scoring {n_total} items…",
+                current=end, total=n_total,
+                step=3, total_steps=_FIND_LABEL_STEPS,
+            )
 
     results = [{"id": cid, "score": round(s, 4)} for cid, s in zip(all_ids, scores)]
     results.sort(key=lambda x: x["score"], reverse=True)
 
     # Apply labels to ALL elements based on threshold (bulk for performance)
+    update_find_progress(
+        "running", f"Applying labels to {n_total} items…",
+        current=0, total=n_total,
+        step=4, total_steps=_FIND_LABEL_STEPS,
+    )
     label_pairs = []
     good_count = 0
     bad_count = 0
@@ -211,6 +282,12 @@ def find_label():
     from vtsearch.models.registry import set_find_mode
 
     set_find_mode(True)
+
+    update_find_progress(
+        "idle", "Done",
+        current=n_total, total=n_total,
+        step=_FIND_LABEL_STEPS, total_steps=_FIND_LABEL_STEPS,
+    )
 
     return jsonify({
         "ok": True,


### PR DESCRIPTION
## Summary
This PR adds real-time progress reporting for long-running detector scoring operations (`find-label` and `detector-sort`). The backend now tracks progress through discrete steps and reports current/total counts, while the frontend polls for updates and displays them in the progress bar.

## Key Changes

**Backend (Python)**
- Added progress tracking to `find_label()` endpoint with 4 steps: resolve model → train (optional) → score → apply labels
- Added progress tracking to `detector_sort()` endpoint with scoring progress
- Implemented batch-based scoring in both endpoints to enable granular progress updates
- Progress is reset to "idle" on errors or when endpoints return early
- New tests verify progress snapshots at each phase and proper cleanup on errors

**Frontend (Angular)**
- Added `sortProgress` and `sortProgressTotal` observables to `SortStateService`
- Implemented progress polling in `FindViewComponent` and `LabelViewComponent` that:
  - Starts polling when scoring begins
  - Stops polling when operation completes or errors
  - Updates sort state with current/total counts
- Updated `ProgressIndicatorsComponent` to display determinate progress bar when total > 0
- Updated templates to pass progress values through component hierarchy

## Implementation Details
- Progress polling uses RxJS `timer` with 200ms initial delay and 500ms interval
- Scoring is batched (batch size = max(1, min(500, n_total // 10))) to allow progress updates without excessive overhead
- Progress state is properly cleaned up in `ngOnDestroy` hooks to prevent memory leaks
- All error paths reset progress to "idle" state
- Frontend gracefully handles indeterminate progress (shows spinner) when total is unknown

https://claude.ai/code/session_01K1iuRjAEcWNQedgYsqQ4hH