### PR TITLE
Refactor export modal to use tabbed interface

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -90,110 +90,121 @@
     }
   </div>
 
-  <!-- Export Actions -->
+  <!-- Export Tabs -->
   <div class="export-section">
     <h3>Export Labels</h3>
-    <div class="export-buttons">
+    <div class="export-tabs">
+      <!-- Clipboard tab -->
       <button
-        class="btn btn--primary"
-        (click)="copyToClipboard()"
-        [disabled]="!hasLabels || enabledColumns.length === 0"
+        class="export-tab"
+        [class.active]="activeTab === 'clipboard'"
+        (click)="activeTab = 'clipboard'"
       >
-        @if (copySuccess) {
-          <span class="clipboard-icon">&#x2705;</span> Copied!
-        } @else {
-          <span class="clipboard-icon">&#x1F4CB;</span> Copy to Clipboard
-        }
+        <span class="tab-icon">&#x1F4CB;</span> Clipboard
       </button>
 
+      <!-- Exporter tabs -->
       @for (exp of exporters; track exp.name) {
         <button
-          class="btn btn--secondary"
-          (click)="startExporter(exp)"
-          [disabled]="!hasLabels"
+          class="export-tab"
+          [class.active]="activeTab === exp.name"
+          (click)="selectExporterTab(exp)"
         >
-          @if (exp.icon) {<span class="exporter-icon">{{ exp.icon }}</span>}{{ exp.display_name || exp.name }}
+          @if (exp.icon) {<span class="tab-icon">{{ exp.icon }}</span>}{{ exp.display_name || exp.name }}
         </button>
+      }
+    </div>
+
+    <!-- Tab content -->
+    <div class="tab-content">
+      @if (activeTab === 'clipboard') {
+        <div class="tab-pane">
+          <button
+            class="btn btn--primary"
+            (click)="copyToClipboard()"
+            [disabled]="!hasLabels || enabledColumns.length === 0"
+          >
+            @if (copySuccess) {
+              &#x2705; Copied!
+            } @else {
+              Copy
+            }
+          </button>
+        </div>
+      } @else if (activeTabExporter) {
+        <div class="tab-pane">
+          @if (activeTabExporter.fields && activeTabExporter.fields.length > 0) {
+            @for (field of activeTabExporter.fields; track field.key) {
+              <div class="tab-field">
+                <label class="form-label" [for]="'field-' + field.key">
+                  {{ field.label || field.key }}
+                  @if (field.required) {
+                    <span class="required">*</span>
+                  }
+                </label>
+
+                @if (field.field_type === 'password') {
+                  <input
+                    [id]="'field-' + field.key"
+                    type="password"
+                    class="form-input"
+                    [(ngModel)]="formValues[field.key]"
+                    [placeholder]="field.placeholder || field.description || field.label || field.key"
+                  />
+                } @else if (field.field_type === 'email') {
+                  <input
+                    [id]="'field-' + field.key"
+                    type="email"
+                    class="form-input"
+                    [(ngModel)]="formValues[field.key]"
+                    [placeholder]="field.placeholder || field.description || field.label || field.key"
+                  />
+                } @else if (field.field_type === 'url') {
+                  <input
+                    [id]="'field-' + field.key"
+                    type="url"
+                    class="form-input"
+                    [(ngModel)]="formValues[field.key]"
+                    [placeholder]="field.placeholder || field.description || field.label || field.key"
+                  />
+                } @else if (field.field_type === 'select') {
+                  <select
+                    [id]="'field-' + field.key"
+                    class="form-select"
+                    [(ngModel)]="formValues[field.key]"
+                  >
+                    @for (opt of field.options || []; track opt) {
+                      <option [value]="opt">{{ opt }}</option>
+                    }
+                  </select>
+                } @else {
+                  <input
+                    [id]="'field-' + field.key"
+                    type="text"
+                    class="form-input"
+                    [(ngModel)]="formValues[field.key]"
+                    [placeholder]="field.placeholder || field.description || field.label || field.key"
+                  />
+                }
+              </div>
+            }
+          }
+
+          <button
+            class="btn btn--primary"
+            (click)="submitExporterTab()"
+            [disabled]="!hasLabels || submitting"
+          >
+            @if (submitting) {
+              Exporting...
+            } @else {
+              {{ activeTabAction }}
+            }
+          </button>
+        </div>
       }
     </div>
   </div>
-
-  <!-- Exporter Field Form (shown inline, doesn't replace the above) -->
-  @if (hasExporterForm && selectedExporter) {
-    <div class="export-section exporter-form-section">
-      <h3>{{ selectedExporter.display_name || selectedExporter.name }}</h3>
-
-      @if (selectedExporter.fields && selectedExporter.fields.length > 0) {
-        @for (field of selectedExporter.fields; track field.key) {
-          <div class="form-group">
-            <label class="form-label" [for]="'field-' + field.key">
-              {{ field.label || field.key }}
-              @if (field.required) {
-                <span class="required">*</span>
-              }
-            </label>
-
-            @if (field.field_type === 'password') {
-              <input
-                [id]="'field-' + field.key"
-                type="password"
-                class="form-input"
-                [(ngModel)]="formValues[field.key]"
-                [placeholder]="field.placeholder || field.description || field.label || field.key"
-              />
-            } @else if (field.field_type === 'email') {
-              <input
-                [id]="'field-' + field.key"
-                type="email"
-                class="form-input"
-                [(ngModel)]="formValues[field.key]"
-                [placeholder]="field.placeholder || field.description || field.label || field.key"
-              />
-            } @else if (field.field_type === 'url') {
-              <input
-                [id]="'field-' + field.key"
-                type="url"
-                class="form-input"
-                [(ngModel)]="formValues[field.key]"
-                [placeholder]="field.placeholder || field.description || field.label || field.key"
-              />
-            } @else if (field.field_type === 'select') {
-              <select
-                [id]="'field-' + field.key"
-                class="form-select"
-                [(ngModel)]="formValues[field.key]"
-              >
-                @for (opt of field.options || []; track opt) {
-                  <option [value]="opt">{{ opt }}</option>
-                }
-              </select>
-            } @else {
-              <input
-                [id]="'field-' + field.key"
-                type="text"
-                class="form-input"
-                [(ngModel)]="formValues[field.key]"
-                [placeholder]="field.placeholder || field.description || field.label || field.key"
-              />
-            }
-          </div>
-        }
-      } @else {
-        <p class="info-text">This exporter requires no additional configuration.</p>
-      }
-
-      <div class="form-actions">
-        <button class="btn btn--secondary" (click)="cancelExporterForm()">Cancel</button>
-        <button class="btn btn--primary" (click)="submitForm()" [disabled]="submitting">
-          @if (submitting) {
-            Exporting...
-          } @else {
-            Export
-          }
-        </button>
-      </div>
-    </div>
-  }
 
   <!-- Detector Export (Labeling mode only) -->
   @if (showDetectorSection) {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -116,7 +116,7 @@
   border-bottom: none;
 }
 
-// --- Export action buttons ---
+// --- Export action buttons (detector section) ---
 
 .export-buttons {
   display: flex;
@@ -124,22 +124,69 @@
   gap: 8px;
 }
 
-.exporter-icon {
-  margin-right: 4px;
+// --- Export tabs ---
+
+.export-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--border);
+  margin-bottom: 0;
 }
 
-.clipboard-icon {
-  margin-right: 2px;
+.export-tab {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+  }
+
+  &.active {
+    color: var(--text-primary);
+    border-bottom-color: var(--color-accent, #4a90d9);
+    font-weight: 600;
+  }
 }
 
-// --- Exporter form (inline section) ---
+.tab-icon {
+  font-size: 1rem;
+}
 
-.exporter-form-section {
+.tab-content {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-top: none;
+  border-radius: 0 0 6px 6px;
   padding: 12px;
   background: var(--bg-subtle);
 }
+
+.tab-pane {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.tab-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+// --- Form elements ---
 
 .form-group {
   display: flex;

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -54,6 +54,9 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     { value: ';', label: 'Semicolon (;)' },
   ];
 
+  /** Active export tab — 'clipboard' or an exporter name. */
+  activeTab = 'clipboard';
+
   /** Exporter form state. */
   selectedExporter: ExporterInfo | null = null;
   formValues: Record<string, string> = {};
@@ -210,6 +213,42 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     }
     this.error = '';
     this.status = '';
+  }
+
+  /** Select an exporter tab and initialise its form values. */
+  selectExporterTab(exporter: ExporterInfo): void {
+    this.activeTab = exporter.name;
+    this.selectedExporter = exporter;
+    this.formValues = {};
+    for (const f of exporter.fields || []) {
+      this.formValues[f.key] = f.default || '';
+    }
+    this.error = '';
+    this.status = '';
+  }
+
+  /** The exporter object for the currently active tab (null if clipboard). */
+  get activeTabExporter(): ExporterInfo | null {
+    if (this.activeTab === 'clipboard') return null;
+    return this.exporters.find((e) => e.name === this.activeTab) || null;
+  }
+
+  /** Label for the action button on the active exporter tab. */
+  get activeTabAction(): string {
+    const exp = this.activeTabExporter;
+    if (!exp) return 'Export';
+    const name = (exp.display_name || exp.name).toLowerCase();
+    if (name.includes('email') || name.includes('smtp')) return 'Send';
+    if (name.includes('csv') || name.includes('file') || name.includes('json')) return 'Save';
+    if (name.includes('webhook')) return 'Send';
+    return 'Export';
+  }
+
+  /** Submit the currently active exporter tab. */
+  submitExporterTab(): void {
+    const exp = this.activeTabExporter;
+    if (!exp) return;
+    this.exportLabelsWith(exp, { ...this.formValues });
   }
 
   cancelExporterForm(): void {


### PR DESCRIPTION
## Summary
Refactored the export modal to use a tabbed interface instead of separate action buttons and an inline form. This provides a cleaner, more organized UX for managing clipboard and exporter options.

## Key Changes

- **Replaced button-based layout with tabs**: Converted the export actions section from individual buttons (`btn--primary`, `btn--secondary`) to a tab-based navigation system with "Clipboard" and exporter tabs
- **Consolidated form display**: Moved the exporter form from a separate inline section into tab content that appears below the tab navigation
- **Added tab state management**: 
  - New `activeTab` property tracks the currently selected tab ('clipboard' or exporter name)
  - New `selectExporterTab()` method handles tab selection and form initialization
  - New `activeTabExporter` getter returns the exporter object for the active tab
  - New `activeTabAction` getter provides context-aware button labels (e.g., "Send" for email exporters, "Save" for file exporters)
  - New `submitExporterTab()` method submits the active exporter tab
- **Updated styling**:
  - Added `.export-tabs` for tab navigation with bottom border
  - Added `.export-tab` for individual tab buttons with active state styling
  - Added `.tab-content` and `.tab-pane` for tab content areas
  - Added `.tab-field` for form fields within tabs
  - Improved responsive layout with flexbox for tab content
- **Simplified UI**: Removed redundant "Cancel" button and streamlined the form presentation

## Implementation Details

- Tab content is conditionally rendered based on `activeTab` value
- Form fields are displayed inline within the tab pane for better space utilization
- The clipboard tab shows a simple copy button, while exporter tabs display their configuration fields
- Action button labels are dynamically determined based on the exporter type (e.g., "Send" for webhooks/email, "Save" for file-based exporters)

https://claude.ai/code/session_01W778giFyxbN11wMjqZFXyW