### PR TITLE
Add support for exporting labels with selected columns

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -275,7 +275,10 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     this.error = '';
     this.submitting = true;
 
-    const labelsData = { labels: this.filteredLabels };
+    const labelsData = {
+      labels: this.filteredLabels,
+      selected_columns: this.enabledColumns.map((c) => c.key),
+    };
     this.exportersApi
       .runExport({
         exporter_name: exporter.name,

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -297,6 +297,254 @@ class TestCsvExporterExport:
         assert "2 detector(s)" in result["message"]
 
 
+# ---------------------------------------------------------------------------
+# CSV Exporter — labels format with selected columns
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_LABELS = [
+    {"label": "good", "md5": "abc123", "origin_name": "dataset_a", "filename": "clip1.wav", "category": "birds", "custom_metadata": {"source": "field", "quality": "high"}},
+    {"label": "bad", "md5": "def456", "origin_name": "dataset_a", "filename": "clip2.wav", "category": "rain", "custom_metadata": {"source": "studio", "quality": "low"}},
+    {"label": "good", "md5": "ghi789", "origin_name": "dataset_b", "filename": "clip3.wav", "category": "birds", "custom_metadata": {"source": "field"}},
+]
+
+
+class TestCsvExporterLabelsFormat:
+    """Tests for CSV export of labels with selected columns."""
+
+    def test_labels_format_uses_selected_columns(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["label", "filename", "category"],
+        }
+        filepath = tmp_path / "labels.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+        assert header == ["label", "filename", "category"]
+
+    def test_labels_format_correct_row_count(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["label", "filename"],
+        }
+        filepath = tmp_path / "labels.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 4  # 1 header + 3 labels
+
+    def test_labels_format_row_values(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["label", "filename", "category"],
+        }
+        filepath = tmp_path / "labels.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            next(reader)  # skip header
+            first_row = next(reader)
+        assert first_row == ["good", "clip1.wav", "birds"]
+
+    def test_labels_format_includes_metadata_columns(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["filename", "source", "quality"],
+        }
+        filepath = tmp_path / "labels.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            first_row = next(reader)
+        assert header == ["filename", "source", "quality"]
+        assert first_row == ["clip1.wav", "field", "high"]
+
+    def test_labels_format_missing_metadata_gives_empty(self, tmp_path):
+        """When a metadata column is missing from an entry, output empty string."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["filename", "quality"],
+        }
+        filepath = tmp_path / "labels.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        # Third entry (clip3.wav) has no "quality" in metadata
+        assert rows[3] == ["clip3.wav", ""]
+
+    def test_labels_format_changed_columns_reflected(self, tmp_path):
+        """Changing selected_columns between exports produces different output."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+
+        # First export with all base columns
+        results1 = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["label", "md5", "origin_name", "filename", "category"],
+        }
+        filepath1 = tmp_path / "export1.csv"
+        exp.export(results1, {"filepath": str(filepath1)})
+
+        # Second export with only a metadata column
+        results2 = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["source"],
+        }
+        filepath2 = tmp_path / "export2.csv"
+        exp.export(results2, {"filepath": str(filepath2)})
+
+        with open(filepath1, newline="", encoding="utf-8") as f:
+            header1 = next(csv.reader(f))
+        with open(filepath2, newline="", encoding="utf-8") as f:
+            header2 = next(csv.reader(f))
+
+        assert header1 == ["label", "md5", "origin_name", "filename", "category"]
+        assert header2 == ["source"]
+
+    def test_labels_format_no_selected_columns_uses_defaults(self, tmp_path):
+        """When selected_columns is absent, fall back to base columns."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {"labels": SAMPLE_LABELS}
+        filepath = tmp_path / "labels.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+        with open(filepath, newline="", encoding="utf-8") as f:
+            header = next(csv.reader(f))
+        assert header == ["label", "md5", "origin_name", "filename", "category"]
+
+    def test_labels_format_message(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["label", "filename"],
+        }
+        filepath = tmp_path / "labels.csv"
+
+        result = exp.export(results, {"filepath": str(filepath)})
+        assert "3 label(s)" in result["message"]
+
+    def test_labels_format_empty_labels(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = {"labels": [], "selected_columns": ["label", "filename"]}
+        filepath = tmp_path / "empty.csv"
+
+        result = exp.export(results, {"filepath": str(filepath)})
+        assert "0 label(s)" in result["message"]
+        with open(filepath, newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 1  # header only
+
+
+# ---------------------------------------------------------------------------
+# JSON Exporter — labels format with selected columns
+# ---------------------------------------------------------------------------
+
+
+class TestJsonExporterLabelsFormat:
+    """Tests for JSON export of labels with selected columns."""
+
+    def test_labels_format_filters_to_selected_columns(self, tmp_path):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["label", "filename"],
+        }
+        filepath = tmp_path / "labels.json"
+
+        exp.export(results, {"filepath": str(filepath)})
+        written = json.loads(filepath.read_text())
+        assert written["selected_columns"] == ["label", "filename"]
+        for entry in written["labels"]:
+            assert set(entry.keys()) == {"label", "filename"}
+
+    def test_labels_format_includes_metadata(self, tmp_path):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        results = {
+            "labels": SAMPLE_LABELS,
+            "selected_columns": ["filename", "source"],
+        }
+        filepath = tmp_path / "labels.json"
+
+        exp.export(results, {"filepath": str(filepath)})
+        written = json.loads(filepath.read_text())
+        assert written["labels"][0] == {"filename": "clip1.wav", "source": "field"}
+
+    def test_labels_format_no_selected_columns_keeps_all(self, tmp_path):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        results = {"labels": SAMPLE_LABELS}
+        filepath = tmp_path / "labels.json"
+
+        exp.export(results, {"filepath": str(filepath)})
+        written = json.loads(filepath.read_text())
+        assert written["labels"] == SAMPLE_LABELS
+
+    def test_labels_format_changed_columns(self, tmp_path):
+        """Changing selected_columns between exports produces different JSON."""
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+
+        results1 = {"labels": SAMPLE_LABELS, "selected_columns": ["label", "md5"]}
+        filepath1 = tmp_path / "export1.json"
+        exp.export(results1, {"filepath": str(filepath1)})
+
+        results2 = {"labels": SAMPLE_LABELS, "selected_columns": ["source"]}
+        filepath2 = tmp_path / "export2.json"
+        exp.export(results2, {"filepath": str(filepath2)})
+
+        written1 = json.loads(filepath1.read_text())
+        written2 = json.loads(filepath2.read_text())
+
+        assert set(written1["labels"][0].keys()) == {"label", "md5"}
+        assert set(written2["labels"][0].keys()) == {"source"}
+
+    def test_labels_format_message(self, tmp_path):
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        results = {"labels": SAMPLE_LABELS, "selected_columns": ["label"]}
+        filepath = tmp_path / "labels.json"
+
+        result = exp.export(results, {"filepath": str(filepath)})
+        assert "3 label(s)" in result["message"]
+
+
 class TestCsvExporterIntegration:
     """Integration: CSV exporter via _run_exporter and with real detector results."""
 

--- a/tests/test_export_options.py
+++ b/tests/test_export_options.py
@@ -416,6 +416,93 @@ class TestExportWithFilteredResults:
             assert "fill_from_sort" in written["results"]
 
 
+class TestExportWithSelectedColumns:
+    """Exporting labels via the API respects selected_columns."""
+
+    def test_csv_export_with_selected_columns(self, client):
+        """POST /api/exporters/export with labels + selected_columns uses those columns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "cols.csv"
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_csv_file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": {
+                        "labels": [
+                            {"label": "good", "md5": "aaa", "filename": "a.wav", "category": "x"},
+                            {"label": "bad", "md5": "bbb", "filename": "b.wav", "category": "y"},
+                        ],
+                        "selected_columns": ["label", "filename"],
+                    },
+                },
+            )
+            assert resp.status_code == 200
+            import csv
+
+            with open(fpath, newline="", encoding="utf-8") as f:
+                rows = list(csv.reader(f))
+            assert rows[0] == ["label", "filename"]
+            assert rows[1] == ["good", "a.wav"]
+            assert rows[2] == ["bad", "b.wav"]
+
+    def test_json_export_with_selected_columns(self, client):
+        """POST /api/exporters/export with labels + selected_columns filters JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = Path(tmpdir) / "cols.json"
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": str(fpath)},
+                    "results": {
+                        "labels": [
+                            {"label": "good", "md5": "aaa", "filename": "a.wav", "category": "x"},
+                        ],
+                        "selected_columns": ["filename", "category"],
+                    },
+                },
+            )
+            assert resp.status_code == 200
+            written = json.loads(Path(fpath).read_text())
+            assert written["labels"] == [{"filename": "a.wav", "category": "x"}]
+
+    def test_changed_columns_between_exports(self, client):
+        """Exporting twice with different selected_columns produces different output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            labels = [{"label": "good", "md5": "aaa", "filename": "a.wav", "category": "x"}]
+
+            fpath1 = Path(tmpdir) / "v1.csv"
+            client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_csv_file",
+                    "field_values": {"filepath": str(fpath1)},
+                    "results": {"labels": labels, "selected_columns": ["label", "md5", "filename"]},
+                },
+            )
+
+            fpath2 = Path(tmpdir) / "v2.csv"
+            client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_csv_file",
+                    "field_values": {"filepath": str(fpath2)},
+                    "results": {"labels": labels, "selected_columns": ["category"]},
+                },
+            )
+
+            import csv
+
+            with open(fpath1, newline="", encoding="utf-8") as f:
+                header1 = next(csv.reader(f))
+            with open(fpath2, newline="", encoding="utf-8") as f:
+                header2 = next(csv.reader(f))
+
+            assert header1 == ["label", "md5", "filename"]
+            assert header2 == ["category"]
+
+
 class TestAvailableColumnsNoDuplicates:
     """Enriched export should not return duplicate columns differing only by case."""
 

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -44,6 +44,9 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         ),
     ]
 
+    #: Base columns for label exports (used when no selected_columns provided).
+    _LABEL_BASE_COLUMNS = ["label", "md5", "origin_name", "filename", "category"]
+
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
         filepath_str = field_values.get("filepath", "").strip()
         if not filepath_str:
@@ -52,6 +55,43 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         filepath = Path(filepath_str)
         filepath.parent.mkdir(parents=True, exist_ok=True)
 
+        # Labels format (from the export modal UI)
+        if "labels" in results:
+            return self._export_labels(results, filepath)
+
+        # Autodetect results format (from CLI / fill-from-sort)
+        return self._export_autodetect(results, filepath)
+
+    def _export_labels(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
+        """Export labels with user-selected columns."""
+        labels = results.get("labels", [])
+        columns: list[str] = results.get("selected_columns") or self._LABEL_BASE_COLUMNS
+
+        total_rows = 0
+        with open(filepath, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(columns)
+
+            for entry in labels:
+                meta = entry.get("custom_metadata") or {}
+                row = []
+                for col in columns:
+                    if col in entry:
+                        row.append(str(entry[col] if entry[col] is not None else ""))
+                    elif col in meta:
+                        row.append(str(meta[col] if meta[col] is not None else ""))
+                    else:
+                        row.append("")
+                writer.writerow(row)
+                total_rows += 1
+
+        return {
+            "message": f"Saved {total_rows} label(s) to {filepath.resolve()}.",
+            "filepath": str(filepath.resolve()),
+        }
+
+    def _export_autodetect(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
+        """Export autodetect results (detector hits)."""
         total_hits = 0
         with open(filepath, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)

--- a/vtsearch/exporters/server_json_file/__init__.py
+++ b/vtsearch/exporters/server_json_file/__init__.py
@@ -51,6 +51,12 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
 
         filepath = Path(filepath_str)
         filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        # Labels format (from the export modal UI) — filter to selected columns
+        if "labels" in results:
+            return self._export_labels(results, filepath)
+
+        # Autodetect results format (from CLI / fill-from-sort)
         filepath.write_text(json.dumps(results, indent=2), encoding="utf-8")
 
         total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
@@ -60,6 +66,32 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
                 f"{results.get('detectors_run', 0)} detector(s) "
                 f"to {filepath.resolve()}."
             ),
+            "filepath": str(filepath.resolve()),
+        }
+
+    def _export_labels(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
+        """Export labels, filtering to selected columns when provided."""
+        labels = results.get("labels", [])
+        selected_columns: list[str] | None = results.get("selected_columns")
+
+        if selected_columns is not None:
+            filtered_labels = []
+            for entry in labels:
+                row: dict[str, Any] = {}
+                meta = entry.get("custom_metadata") or {}
+                for col in selected_columns:
+                    if col in entry:
+                        row[col] = entry[col]
+                    elif col in meta:
+                        row[col] = meta[col]
+                filtered_labels.append(row)
+            output = {"labels": filtered_labels, "selected_columns": selected_columns}
+        else:
+            output = {"labels": labels}
+
+        filepath.write_text(json.dumps(output, indent=2), encoding="utf-8")
+        return {
+            "message": f"Saved {len(labels)} label(s) to {filepath.resolve()}.",
             "filepath": str(filepath.resolve()),
         }
 


### PR DESCRIPTION
## Summary
This PR adds support for exporting labels with user-selected columns in both CSV and JSON formats. When exporting labels via the export modal UI, users can now choose which columns to include in the output, and the exporters will respect those selections.

## Key Changes

- **CSV Exporter**: Added `_export_labels()` method to handle label exports with column filtering. Falls back to default base columns (`label`, `md5`, `origin_name`, `filename`, `category`) when no selection is provided. Supports extracting values from both top-level fields and `custom_metadata`.

- **JSON Exporter**: Added `_export_labels()` method to filter label objects to only include selected columns. When `selected_columns` is provided, the output includes both the filtered labels and the column list for reference.

- **Export Modal UI**: Updated the export submission to include `selected_columns` in the request payload, passing the list of enabled column keys to the backend.

- **API Integration Tests**: Added comprehensive test coverage for the new functionality in both CSV and JSON exporters, including:
  - Column selection and filtering
  - Metadata field extraction
  - Handling missing metadata (outputs empty strings)
  - Fallback to defaults when no columns selected
  - Multiple exports with different column selections

## Implementation Details

- The CSV exporter checks both the label entry itself and its `custom_metadata` object when building rows, allowing users to export custom metadata fields alongside standard fields.
- Missing metadata values are represented as empty strings in CSV output.
- The JSON exporter preserves the `selected_columns` list in the output for reference.
- Both exporters maintain backward compatibility with existing autodetect result exports (detector hits).

https://claude.ai/code/session_0168T1keh5kmGNBy1SZWX1Jz