### PR TITLE
Preserve scroll position when switching view modes in label list

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -38,10 +38,16 @@ export class MediaListComponent implements AfterViewChecked, OnChanges {
   @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
 
   private pendingScrollToSelected = false;
+  private pendingScrollPct: number | null = null;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['selectedId'] && !changes['selectedId'].firstChange) {
       this.pendingScrollToSelected = true;
+    }
+    if (changes['viewMode'] && !changes['viewMode'].firstChange && this.listContainer) {
+      const el = this.listContainer.nativeElement;
+      const maxScroll = el.scrollHeight - el.clientHeight;
+      this.pendingScrollPct = maxScroll > 0 ? el.scrollTop / maxScroll : 0;
     }
   }
 
@@ -87,7 +93,14 @@ export class MediaListComponent implements AfterViewChecked, OnChanges {
   }
 
   ngAfterViewChecked(): void {
-    if (this.pendingScrollToSelected && this.listContainer) {
+    if (this.pendingScrollPct !== null && this.listContainer) {
+      const pct = this.pendingScrollPct;
+      this.pendingScrollPct = null;
+      this.pendingScrollToSelected = false;
+      const el = this.listContainer.nativeElement;
+      const maxScroll = el.scrollHeight - el.clientHeight;
+      el.scrollTop = pct * maxScroll;
+    } else if (this.pendingScrollToSelected && this.listContainer) {
       this.pendingScrollToSelected = false;
       const activeEl = this.listContainer.nativeElement.querySelector('.media-item.active');
       if (activeEl) {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -2,7 +2,7 @@
   <h3 [class]="label">
     {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length }})
   </h3>
-  <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'">
+  <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>
     @for (entry of sortedEntries; track trackById($index, entry)) {
       <div
         class="vote-entry"

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -33,13 +33,14 @@ h3 {
 }
 
 .vote-list {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+
   &.grid-layout {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(var(--grid-goal-width, 80px), 1fr));
     gap: 4px;
-    overflow-y: auto;
-    flex: 1;
-    min-height: 0;
     align-content: start;
   }
 }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MediaItem } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
@@ -18,7 +18,7 @@ export interface LabelEntry {
   templateUrl: './label-list.component.html',
   styleUrl: './label-list.component.scss',
 })
-export class LabelListComponent implements OnInit, OnChanges {
+export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
   @Input() medias: MediaItem[] = [];
@@ -31,14 +31,32 @@ export class LabelListComponent implements OnInit, OnChanges {
   @Output() mediaSelected = new EventEmitter<number>();
   @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
+  @ViewChild('voteListContainer') voteListContainer?: ElementRef<HTMLDivElement>;
+
   sortedEntries: LabelEntry[] = [];
+  private pendingScrollPct: number | null = null;
 
   ngOnInit(): void {
     this.sortedEntries = this.buildSortedEntries();
   }
 
-  ngOnChanges(_changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['viewMode'] && !changes['viewMode'].firstChange && this.voteListContainer) {
+      const el = this.voteListContainer.nativeElement;
+      const maxScroll = el.scrollHeight - el.clientHeight;
+      this.pendingScrollPct = maxScroll > 0 ? el.scrollTop / maxScroll : 0;
+    }
     this.sortedEntries = this.buildSortedEntries();
+  }
+
+  ngAfterViewChecked(): void {
+    if (this.pendingScrollPct !== null && this.voteListContainer) {
+      const pct = this.pendingScrollPct;
+      this.pendingScrollPct = null;
+      const el = this.voteListContainer.nativeElement;
+      const maxScroll = el.scrollHeight - el.clientHeight;
+      el.scrollTop = pct * maxScroll;
+    }
   }
 
   private buildSortedEntries(): LabelEntry[] {


### PR DESCRIPTION
## Summary
This PR adds scroll position preservation functionality to the label list component when the view mode changes between grid and list layouts. The implementation mirrors the existing scroll preservation logic in the media list component.

## Key Changes
- **label-list.component.ts**: 
  - Added `ViewChild`, `ElementRef`, and `AfterViewChecked` lifecycle hook imports
  - Implemented `AfterViewChecked` interface to handle deferred scroll restoration
  - Added `@ViewChild('voteListContainer')` reference to the vote list container
  - Added `pendingScrollPct` property to store scroll position as a percentage
  - Enhanced `ngOnChanges()` to capture scroll position before view mode changes
  - Implemented `ngAfterViewChecked()` to restore scroll position after DOM updates

- **label-list.component.html**:
  - Added template reference variable `#voteListContainer` to the vote list div

- **label-list.component.scss**:
  - Moved `overflow-y: auto`, `flex: 1`, and `min-height: 0` styles from grid-layout-specific rules to the base `.vote-list` class to ensure scrolling works in both layout modes

- **media-list.component.ts**:
  - Enhanced `ngOnChanges()` to also capture scroll position on view mode changes (in addition to existing selectedId handling)
  - Updated `ngAfterViewChecked()` to prioritize scroll position restoration over scroll-to-selected behavior

## Implementation Details
The scroll position is preserved as a percentage of the maximum scrollable distance rather than an absolute pixel value. This approach ensures the scroll position remains proportional when the container size changes due to layout switching. The restoration is deferred to `ngAfterViewChecked()` to ensure the DOM has been fully updated before applying the scroll position.

https://claude.ai/code/session_013bTWEGyzZzWxzbaBC84uR5