### PR TITLE
Add dynamic default filenames to export modal

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -498,6 +498,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.labelSession.textQuery = model?.text_query || '';
     this.labelSession.mediaExample = model?.media_example || '';
     this.labelSession.examples = (model?.['examples'] as { type: string; value: string }[]) || [];
+    this.labelSession.modelName = model?.name || '';
   }
 
   onLabel(): void {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -30,20 +30,20 @@
     <h3>Categories</h3>
     <div class="delimiter-row">
       <label class="delimiter-option">
-        <input type="radio" name="labelFilter" value="both" [(ngModel)]="labelFilter" />
+        <input type="radio" name="labelFilter" value="both" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         All
       </label>
       <label class="delimiter-option">
-        <input type="radio" name="labelFilter" value="good" [(ngModel)]="labelFilter" />
+        <input type="radio" name="labelFilter" value="good" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         Good
       </label>
       <label class="delimiter-option">
-        <input type="radio" name="labelFilter" value="bad" [(ngModel)]="labelFilter" />
+        <input type="radio" name="labelFilter" value="bad" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         Bad
       </label>
       @if (hasCorrections) {
         <label class="delimiter-option">
-          <input type="radio" name="labelFilter" value="corrections" [(ngModel)]="labelFilter" />
+          <input type="radio" name="labelFilter" value="corrections" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
           Corrections
         </label>
       }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
+import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -65,6 +66,9 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   /** Copy feedback. */
   copySuccess = false;
 
+  /** Dataset display name for default filenames. */
+  private datasetName = '';
+
   private destroy$ = new Subject<void>();
 
   /** Base columns that are always present. */
@@ -77,12 +81,19 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   ];
 
   constructor(
+    private datasetsApi: DatasetsApiService,
     private detectorsApi: DetectorsApiService,
     private exportersApi: ExportersApiService,
     private sortingApi: SortingApiService,
   ) {}
 
   ngOnInit(): void {
+    this.datasetsApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (status) => {
+        this.datasetName = status.display_name || '';
+      },
+    });
+
     this.exportersApi.getExporters().subscribe({
       next: (list) => {
         this.exporters = list.filter((e) => !e.hidden_from_picker);
@@ -207,6 +218,33 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     );
   }
 
+  /** Build a descriptive default filename for export.
+   *  e.g. "Good-MyDetector-MyDataset.json" */
+  private buildDefaultFilename(ext: string): string {
+    const parts: string[] = [];
+    if (this.labelFilter === 'good') parts.push('Good');
+    else if (this.labelFilter === 'bad') parts.push('Bad');
+    else if (this.labelFilter === 'corrections') parts.push('Corrections');
+    if (this.detectorName) parts.push(this.detectorName);
+    if (this.datasetName) parts.push(this.datasetName);
+    if (parts.length === 0) parts.push('labels');
+    // Sanitise: replace characters unsafe for filenames with hyphens
+    const stem = parts.join('-').replace(/[\\/:*?"<>|]+/g, '-');
+    return `${stem}.${ext}`;
+  }
+
+  /** Apply the dynamic default filename to the filepath form field if present. */
+  private applyDefaultFilename(exporter: ExporterInfo): void {
+    const filepathField = (exporter.fields || []).find((f) => f.key === 'filepath');
+    if (filepathField) {
+      const staticDefault = filepathField.default || '';
+      // Derive extension from the static default (e.g. ".json", ".csv") or fall back
+      const extMatch = staticDefault.match(/\.(\w+)$/);
+      const ext = extMatch ? extMatch[1] : 'json';
+      this.formValues['filepath'] = this.buildDefaultFilename(ext);
+    }
+  }
+
   /** Start exporter flow — if no fields, export immediately. */
   startExporter(exporter: ExporterInfo): void {
     const fields = exporter.fields || [];
@@ -219,6 +257,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     for (const f of fields) {
       this.formValues[f.key] = f.default || '';
     }
+    this.applyDefaultFilename(exporter);
     this.error = '';
     this.status = '';
   }
@@ -231,8 +270,17 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     for (const f of exporter.fields || []) {
       this.formValues[f.key] = f.default || '';
     }
+    this.applyDefaultFilename(exporter);
     this.error = '';
     this.status = '';
+  }
+
+  /** Re-generate the default filename when the label filter changes. */
+  onLabelFilterChange(): void {
+    const exp = this.activeTabExporter;
+    if (exp) {
+      this.applyDefaultFilename(exp);
+    }
   }
 
   /** The exporter object for the currently active tab (null if clipboard). */
@@ -310,7 +358,12 @@ export class ExportModalComponent implements OnInit, OnDestroy {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `${this.detectorName || 'detector'}.json`;
+        const parts: string[] = [];
+        if (this.detectorName) parts.push(this.detectorName);
+        if (this.datasetName) parts.push(this.datasetName);
+        if (parts.length === 0) parts.push('detector');
+        const stem = parts.join('-').replace(/[\\/:*?"<>|]+/g, '-');
+        a.download = `${stem}.json`;
         a.click();
         URL.revokeObjectURL(url);
         this.status = 'Downloaded.';

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -7,6 +7,8 @@ import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
+import { FindSessionService } from '../../../services/find-session.service';
+import { LabelSessionService } from '../../../services/label-session.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { ExporterInfo, LabelEntry } from '../../../models/api.models';
 
@@ -84,8 +86,15 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     private datasetsApi: DatasetsApiService,
     private detectorsApi: DetectorsApiService,
     private exportersApi: ExportersApiService,
+    private findSession: FindSessionService,
+    private labelSession: LabelSessionService,
     private sortingApi: SortingApiService,
   ) {}
+
+  /** Detector/model name from any available source. */
+  private get effectiveDetectorName(): string {
+    return this.detectorName || this.labelSession.modelName || this.findSession.modelName || '';
+  }
 
   ngOnInit(): void {
     this.datasetsApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
@@ -225,7 +234,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     if (this.labelFilter === 'good') parts.push('Good');
     else if (this.labelFilter === 'bad') parts.push('Bad');
     else if (this.labelFilter === 'corrections') parts.push('Corrections');
-    if (this.detectorName) parts.push(this.detectorName);
+    const detName = this.effectiveDetectorName;
+    if (detName) parts.push(detName);
     if (this.datasetName) parts.push(this.datasetName);
     if (parts.length === 0) parts.push('labels');
     // Sanitise: replace characters unsafe for filenames with hyphens
@@ -359,7 +369,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
         const a = document.createElement('a');
         a.href = url;
         const parts: string[] = [];
-        if (this.detectorName) parts.push(this.detectorName);
+        const detName = this.effectiveDetectorName;
+        if (detName) parts.push(detName);
         if (this.datasetName) parts.push(this.datasetName);
         if (parts.length === 0) parts.push('detector');
         const stem = parts.join('-').replace(/[\\/:*?"<>|]+/g, '-');

--- a/frontend/src/app/services/label-session.service.ts
+++ b/frontend/src/app/services/label-session.service.ts
@@ -16,6 +16,7 @@ export class LabelSessionService {
   textQuery = '';
   mediaExample = '';
   examples: ModelExample[] = [];
+  modelName = '';
 
   /** Total votes cast since the last re-sort prompt. */
   resortVoteCount = 0;


### PR DESCRIPTION
## Summary
Enhanced the export modal to generate descriptive default filenames based on the current label filter, detector/model name, and dataset name. This improves the user experience by providing meaningful default filenames when exporting data.

## Key Changes
- **Dynamic filename generation**: Added `buildDefaultFilename()` method that constructs filenames from label filter status, detector name, and dataset name (e.g., "Good-MyDetector-MyDataset.json")
- **Dataset information**: Integrated `DatasetsApiService` to fetch and display the dataset name in default filenames
- **Model name tracking**: Added `modelName` property to `LabelSessionService` and `FindSessionService` to track the active model/detector across sessions
- **Effective detector name**: Introduced `effectiveDetectorName` getter that resolves the detector name from multiple sources (direct property, label session, or find session)
- **Reactive filename updates**: Added `onLabelFilterChange()` handler that regenerates the default filename whenever the label filter changes
- **Filename sanitization**: Implemented character replacement for unsafe filename characters (backslash, forward slash, colon, asterisk, question mark, quotes, angle brackets, pipe)
- **Detector download enhancement**: Updated the detector model download filename to use the same naming convention as export filenames

## Implementation Details
- The `applyDefaultFilename()` method intelligently extracts the file extension from the exporter's static default and applies it to the dynamically generated filename
- Label filter change detection is wired through `(ngModelChange)` events on all radio button inputs
- The dataset name is fetched once during component initialization via `DatasetsApiService.getStatus()`
- Filename generation gracefully falls back to generic names ("labels" for exports, "detector" for downloads) when no specific information is available

https://claude.ai/code/session_0145hcmqjoY12PqZErFGcnxc