### PR TITLE
Fix demo dataset file resolution for audio datasets with category prefixes

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -211,6 +211,78 @@ class TestResolveDemoOrigin:
         origin = {"importer": "demo", "params": {"name": "nonexistent_dataset"}}
         assert importer.resolve_file(origin, origin_name="foo.jpg") is None
 
+    def test_resolves_flat_dir_with_category_prefix(self, tmp_path):
+        """ESC-50 style: origin_name has category prefix but dir is flat."""
+        from vtsearch.datasets.importers.demo import DemoDatasetImporter
+
+        # Create a flat audio directory (like ESC-50-master/audio/)
+        audio_dir = tmp_path / "ESC-50-master" / "audio"
+        audio_dir.mkdir(parents=True)
+        target = audio_dir / "1-100032-A-0.wav"
+        target.write_bytes(b"fake_audio")
+
+        importer = DemoDatasetImporter()
+        origin = {"importer": "demo", "params": {"name": "esc50_s"}}
+
+        import vtsearch.datasets.importers.demo as demo_mod
+
+        old = demo_mod._SOURCE_DIRS
+        demo_mod._SOURCE_DIRS = {"esc50": audio_dir}
+        try:
+            # origin_name includes category prefix, but file is flat
+            result = importer.resolve_file(origin, origin_name="dog/1-100032-A-0.wav")
+            assert result == target
+        finally:
+            demo_mod._SOURCE_DIRS = old
+
+    def test_resolves_fold_dir_with_category_prefix(self, tmp_path):
+        """UrbanSound8K style: origin_name has category prefix, files in fold subdirs."""
+        from vtsearch.datasets.importers.demo import DemoDatasetImporter
+
+        # Create fold-based directory structure (like UrbanSound8K/audio/)
+        audio_dir = tmp_path / "UrbanSound8K" / "audio"
+        fold_dir = audio_dir / "fold3"
+        fold_dir.mkdir(parents=True)
+        target = fold_dir / "100032-3-0-0.wav"
+        target.write_bytes(b"fake_audio")
+
+        importer = DemoDatasetImporter()
+        origin = {"importer": "demo", "params": {"name": "urbansound8k_a"}}
+
+        import vtsearch.datasets.importers.demo as demo_mod
+
+        old = demo_mod._SOURCE_DIRS
+        demo_mod._SOURCE_DIRS = {"urbansound8k": audio_dir}
+        try:
+            # origin_name has category prefix, actual file in fold subdir
+            result = importer.resolve_file(origin, origin_name="car_horn/100032-3-0-0.wav")
+            assert result == target
+        finally:
+            demo_mod._SOURCE_DIRS = old
+
+    def test_basename_fallback_skips_ambiguous(self, tmp_path):
+        """When multiple files share the same basename, fallback returns None."""
+        from vtsearch.datasets.importers.demo import DemoDatasetImporter
+
+        audio_dir = tmp_path / "audio"
+        (audio_dir / "fold1").mkdir(parents=True)
+        (audio_dir / "fold2").mkdir(parents=True)
+        (audio_dir / "fold1" / "same.wav").write_bytes(b"a")
+        (audio_dir / "fold2" / "same.wav").write_bytes(b"b")
+
+        importer = DemoDatasetImporter()
+        origin = {"importer": "demo", "params": {"name": "esc50_s"}}
+
+        import vtsearch.datasets.importers.demo as demo_mod
+
+        old = demo_mod._SOURCE_DIRS
+        demo_mod._SOURCE_DIRS = {"esc50": audio_dir}
+        try:
+            result = importer.resolve_file(origin, origin_name="cat/same.wav")
+            assert result is None
+        finally:
+            demo_mod._SOURCE_DIRS = old
+
     def test_dispatches_through_resolver(self, tmp_path):
         """resolve_file_from_origin dispatches to DemoDatasetImporter.resolve_file."""
         img_dir = tmp_path / "caltech-101" / "101_ObjectCategories"
@@ -228,6 +300,28 @@ class TestResolveDemoOrigin:
             assert result == target
         finally:
             demo_mod._SOURCE_DIRS = old
+
+
+class TestAudioDemoDatasetSources:
+    """Verify all audio demo datasets have source fields for proper resolution."""
+
+    def test_esc50_datasets_have_source(self):
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        for ds_id in ("esc50_s", "esc50_m", "esc50_l"):
+            assert ds_id in DEMO_DATASETS, f"{ds_id} not in DEMO_DATASETS"
+            assert "source" in DEMO_DATASETS[ds_id], f"{ds_id} missing 'source' field"
+            assert DEMO_DATASETS[ds_id]["source"] == "esc50"
+
+    def test_all_audio_demos_have_source(self):
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        audio_demos = {k: v for k, v in DEMO_DATASETS.items() if v.get("media_type") == "audio"}
+        for ds_id, info in audio_demos.items():
+            assert "source" in info, (
+                f"Audio demo dataset {ds_id!r} is missing a 'source' field — "
+                f"resolve_file() won't be able to map it to a download directory"
+            )
 
 
 class TestResolveNoneOrigin:

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -159,6 +159,22 @@ class DemoDatasetImporter(DatasetImporter):
                 if candidate.is_file():
                     return candidate
 
+        # Basename fallback — some demo datasets store origin_name with a
+        # category prefix (e.g. "dog/1-100032-A-0.wav") but the on-disk
+        # layout is flat (ESC-50) or uses a different hierarchy (UrbanSound8K
+        # fold dirs, Oxford Flowers flat jpg/).  Try the bare filename.
+        for name in (origin_name, filename):
+            if name:
+                basename = Path(name).name
+                # Direct child first (flat directories like ESC-50)
+                candidate = root / basename
+                if candidate.is_file():
+                    return candidate
+                # Recursive search (fold-based layouts like UrbanSound8K)
+                matches = list(root.rglob(basename))
+                if len(matches) == 1:
+                    return matches[0]
+
         return None
 
 
@@ -187,7 +203,7 @@ def _source_directory(source: str) -> Path | None:
             "esc50": DATA_DIR / "ESC-50-master" / "audio",
             "gtzan": DATA_DIR / "gtzan" / "genres",
             "speech_commands_v2": DATA_DIR / "speech_commands_v2",
-            "urbansound8k": DATA_DIR / "UrbanSound8K",
+            "urbansound8k": DATA_DIR / "UrbanSound8K" / "audio",
             # Video sources
             "ucf101": video_dir / "ucf101",
         }

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -144,19 +144,19 @@ class AudioMediaType(MediaType):
             DemoDataset(
                 id="esc50_s", label="ESC-50 (S)",
                 description="Real-world environmental recordings — animals, nature, cities, homes, and people.",
-                categories=cats, required_folder=folder,
+                categories=cats, source="esc50", required_folder=folder,
                 slice_start=0, slice_end=7, download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="esc50_m", label="ESC-50 (M)",
                 description="Real-world environmental recordings — animals, nature, cities, homes, and people.",
-                categories=cats, required_folder=folder,
+                categories=cats, source="esc50", required_folder=folder,
                 slice_start=7, slice_end=20, download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="esc50_l", label="ESC-50 (L)",
                 description="Real-world environmental recordings — animals, nature, cities, homes, and people.",
-                categories=cats, required_folder=folder,
+                categories=cats, source="esc50", required_folder=folder,
                 slice_start=20, slice_end=40, download_size_mb=ESC50_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(


### PR DESCRIPTION
## Summary
Improve the file resolution logic for demo audio datasets that store file paths with category prefixes (e.g., "dog/1-100032-A-0.wav") but have different on-disk directory structures. This enables proper file lookup for ESC-50, UrbanSound8K, and similar datasets.

## Key Changes
- **Enhanced `resolve_file()` fallback logic**: Added a basename fallback mechanism that:
  - Extracts the filename from the origin_name path
  - First checks for direct children in the root directory (flat layouts like ESC-50)
  - Falls back to recursive search for fold-based structures (like UrbanSound8K)
  - Returns `None` when multiple files share the same basename (ambiguous case)

- **Added `source` field to audio demo datasets**: 
  - ESC-50 variants (esc50_s, esc50_m, esc50_l) now include `source="esc50"`
  - This field maps demo dataset IDs to their download source directories

- **Fixed UrbanSound8K source path**: Updated the source directory from `UrbanSound8K` to `UrbanSound8K/audio` to match the actual file structure

## Implementation Details
The basename fallback handles the common pattern where demo datasets include category information in the origin_name (for semantic purposes) but store files in a flat or differently-organized directory structure. The implementation safely avoids ambiguous matches by returning `None` when multiple files with the same basename exist.

New tests verify:
- Flat directory resolution with category prefixes (ESC-50 style)
- Fold-based directory resolution with category prefixes (UrbanSound8K style)
- Ambiguous basename handling (returns None for multiple matches)
- All audio demo datasets have required `source` field

https://claude.ai/code/session_01VN1SXqG2WMzcwYGJLtcB2D