### PR TITLE
Add model export functionality to dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -95,6 +95,7 @@
                 (rowClick)="toggleModelSelection(model.id, $event)"
                 (rename)="renameModel(model, $event)"
                 (delete)="deleteModel(model)"
+                (export)="openExportModal(model)"
                 (autorunToggle)="toggleAutorun(model, $event)"
               />
             }
@@ -154,6 +155,14 @@
   <vt-new-model-modal
     (closed)="closeNewModelModal()"
     (created)="onModelCreated()"
+  />
+}
+
+@if (exportModalOpen) {
+  <vt-detector-export-modal
+    [detectorName]="exportModelName"
+    (closed)="closeExportModal()"
+    (exported)="closeExportModal()"
   />
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -18,6 +18,7 @@ import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
 import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
+import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
 
 @Component({
   selector: 'vt-dashboard',
@@ -30,6 +31,7 @@ import { NewModelModalComponent } from './new-model-modal/new-model-modal.compon
     ModelCardComponent,
     DatasetImporterModalComponent,
     NewModelModalComponent,
+    DetectorExportModalComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
@@ -44,6 +46,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   importerModalOpen = false;
   newModelModalOpen = false;
+  exportModalOpen = false;
+  exportModelName = '';
   findResultsOpen = false;
   findResultsData: AutoDetectResultsData = { results: {} };
 
@@ -257,6 +261,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.detectorsApi.setAutodetect(detectorName, autorun).subscribe({
       next: () => this.datasetState.refresh(),
     });
+  }
+
+  // --- Export modal ---
+
+  openExportModal(model: ModelRegistryEntry): void {
+    this.exportModelName = model.detector_name || model.name;
+    this.exportModalOpen = true;
+  }
+
+  closeExportModal(): void {
+    this.exportModalOpen = false;
+    this.exportModelName = '';
   }
 
   // --- Importer modal ---

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -61,6 +61,13 @@
       <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
     </svg>
   </button>
+  <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+      <polyline points="7 10 12 15 17 10"></polyline>
+      <line x1="12" y1="15" x2="12" y2="3"></line>
+    </svg>
+  </button>
   <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="3 6 5 6 21 6"></polyline>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -78,6 +78,24 @@
   font-size: 0.75rem;
 }
 
+.export-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
 .delete-btn {
   background: none;
   border: none;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -20,6 +20,7 @@ export class ModelCardComponent {
   }
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
+  @Output() export = new EventEmitter<void>();
   @Output() autorunToggle = new EventEmitter<boolean>();
 
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
@@ -57,6 +58,11 @@ export class ModelCardComponent {
   onDelete(event: MouseEvent): void {
     event.stopPropagation();
     this.delete.emit();
+  }
+
+  onExport(event: MouseEvent): void {
+    event.stopPropagation();
+    this.export.emit();
   }
 
   onAutorunToggle(event: Event): void {


### PR DESCRIPTION
## Summary
This PR adds the ability to export detector models from the dashboard. Users can now click an export button on model cards to open an export modal dialog.

## Key Changes
- **Model Card UI**: Added an export button with a download icon to the model card component, positioned between the rename and delete buttons
- **Export Button Styling**: Created `.export-btn` class with hover effects matching the existing UI design patterns
- **Modal Integration**: Integrated `DetectorExportModalComponent` into the dashboard component
- **Event Handling**: 
  - Added `export` output event to `ModelCardComponent` that emits when the export button is clicked
  - Implemented `openExportModal()` and `closeExportModal()` methods in `DashboardComponent` to manage export modal state
  - Wired up the export button click to trigger the modal with the selected model's name

## Implementation Details
- The export button uses the same styling approach as the delete button with a transparent background and hover state
- Event propagation is stopped on the export button click to prevent unintended row selection
- The modal receives the detector name (or model name as fallback) and can be closed via the `closed` or `exported` events
- The export modal state is managed with `exportModalOpen` boolean and `exportModelName` string properties

https://claude.ai/code/session_0152RR1Nx2nQST5j4HGJBdbZ