### PR TITLE
Make k-fold calibration threshold calculation deterministic

### DIFF
--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -523,12 +523,16 @@ def train_and_score(
     # scores (same capacity, same score distribution shape).
     hidden_dim = _auto_hidden_dim(len(X_list))
 
-    # Calculate threshold using k-fold calibration
+    # Calculate threshold using k-fold calibration.
+    # Use a seeded RNG so that train/calibrate splits are deterministic —
+    # without this, the global np.random state makes results non-reproducible.
+    cal_rng = np.random.RandomState(42)
     threshold = calculate_cross_calibration_threshold(
         X_list,
         y_list,
         input_dim,
         inclusion_value,
+        rng=cal_rng,
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         hidden_dim=hidden_dim,


### PR DESCRIPTION
## Summary
This change improves the reproducibility of the `train_and_score` function by ensuring that the k-fold calibration threshold calculation produces consistent results across runs.

## Key Changes
- Added a seeded `RandomState` (seed=42) for the calibration process to ensure deterministic train/calibrate splits
- Passed the seeded RNG to `calculate_cross_calibration_threshold` via a new `rng` parameter
- Updated comment to clarify the purpose of using a seeded RNG

## Implementation Details
Previously, the calibration threshold calculation relied on the global `np.random` state, which could vary between runs and make results non-reproducible. By explicitly creating a `RandomState` with a fixed seed and passing it to the calibration function, the train/calibrate splits are now deterministic, ensuring consistent threshold values and reproducible model training results.

https://claude.ai/code/session_015oon1RK1R4bQmzjJYGLyoJ