### PR TITLE
Update NumPy dependency and add GPU PyTorch installation guide

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -2,7 +2,7 @@
 
 # Core packages
 flask
-numpy<2
+numpy
 torch>=2.0.0
 requests
 tqdm

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,6 +1,11 @@
+# GPU PyTorch index — install the CUDA build matching your system.
+# Adjust the cu* suffix for your CUDA version (cu118, cu121, cu124, etc.):
+#   pip install -r requirements-gpu.txt --extra-index-url https://download.pytorch.org/whl/cu118
+--extra-index-url https://download.pytorch.org/whl/cu118
+
 # Core packages
 flask
-numpy<2
+numpy
 torch>=2.0.0
 requests
 tqdm


### PR DESCRIPTION
## Summary
This PR updates the NumPy dependency constraint and improves GPU PyTorch installation documentation.

## Key Changes
- **Removed NumPy version constraint**: Changed `numpy<2` to `numpy` in both `requirements-gpu.txt` and `requirements-cpu.txt` to allow NumPy 2.x compatibility
- **Added GPU PyTorch installation guide**: Added comprehensive comments to `requirements-gpu.txt` explaining how to install the correct CUDA-specific PyTorch build, including:
  - Instructions for using the PyTorch wheel index
  - Guidance on adjusting the `cu*` suffix based on system CUDA version (cu118, cu121, cu124, etc.)
  - Example pip install command with the appropriate index URL

## Implementation Details
The GPU requirements file now includes an `--extra-index-url` pointing to PyTorch's CUDA wheel repository (cu118 as default), allowing users to easily install GPU-accelerated PyTorch builds matching their CUDA installation.

https://claude.ai/code/session_01PEuoE8NySrcJFvrCEhcG4v