### PR TITLE
Pin numpy to version 1.26.4

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -2,7 +2,7 @@
 
 # Core packages
 flask
-numpy
+numpy==1.26.4
 torch>=2.0.0
 requests
 tqdm

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -5,7 +5,7 @@
 
 # Core packages
 flask
-numpy
+numpy==1.26.4
 torch>=2.0.0
 requests
 tqdm


### PR DESCRIPTION
## Summary
This PR pins the numpy dependency to a specific version (1.26.4) across both CPU and GPU requirement files to ensure consistent and reproducible builds.

## Changes
- Updated `requirements-cpu.txt` to pin numpy to version 1.26.4
- Updated `requirements-gpu.txt` to pin numpy to version 1.26.4

## Details
Previously, numpy was specified without a version constraint, which could lead to different versions being installed in different environments. By pinning to version 1.26.4, we ensure all installations use the same numpy version, improving reproducibility and reducing potential compatibility issues with other dependencies like torch.

https://claude.ai/code/session_01YGviX5BFUw5JBJRYRS8rHf