### PR TITLE
Add --prefer-binary flag to pip requirements files

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,5 +1,10 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
+# Prefer pre-built wheels over source distributions.  The PyTorch extra
+# index sometimes serves source tarballs for packages like numpy, which
+# fail to build without a C++ compiler (g++).
+--prefer-binary
+
 # Core packages
 flask
 numpy==1.26.4

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -3,6 +3,11 @@
 #   pip install -r requirements-gpu.txt --extra-index-url https://download.pytorch.org/whl/cu118
 --extra-index-url https://download.pytorch.org/whl/cu118
 
+# Prefer pre-built wheels over source distributions.  The PyTorch extra
+# index sometimes serves source tarballs for packages like numpy, which
+# fail to build without a C++ compiler (g++).
+--prefer-binary
+
 # Core packages
 flask
 numpy==1.26.4


### PR DESCRIPTION
## Summary
Added the `--prefer-binary` flag to both CPU and GPU requirements files to ensure pip installs pre-built wheels instead of source distributions when available.

## Key Changes
- Added `--prefer-binary` flag to `requirements-cpu.txt`
- Added `--prefer-binary` flag to `requirements-gpu.txt`
- Included explanatory comments in both files documenting why this flag is necessary

## Details
The PyTorch extra index sometimes serves source tarballs for packages like numpy, which fail to build without a C++ compiler (g++). By preferring pre-built wheels, we avoid build failures in environments that lack the necessary compilation tools. This improves installation reliability and reduces build times.

https://claude.ai/code/session_013dB67QnM9MRhGgocVKu3U3