### PR TITLE
Add GPU installation script to avoid C++ compiler errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter server_json_file --filepath results.json`
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings <settings.json>`
-- **Install deps**: `pip install -r requirements-cpu.txt` (or `requirements-gpu.txt`)
+- **Install deps (CPU)**: `pip install -r requirements-cpu.txt`
+- **Install deps (GPU)**: `bash install-gpu.sh` (or `bash install-gpu.sh cu121` for CUDA 12.1)
 - **Build frontend**: `cd frontend && npm install && npm run build:prod` (builds Angular app to `static/`)
 - **Frontend dev server**: `cd frontend && npm start` (proxies `/api/*` to Flask at localhost:5000)
 - **Frontend tests**: `cd frontend && ng test --watch=false` (requires Chrome/Chromium; see Environment Notes below)

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -38,7 +38,10 @@ COPY vtsearch/exporters/email_smtp/requirements.txt vtsearch/exporters/email_smt
 COPY vtsearch/exporters/webhook/requirements.txt vtsearch/exporters/webhook/requirements.txt
 COPY vtsearch/datasets/importers/combine_datasets/requirements.txt vtsearch/datasets/importers/combine_datasets/requirements.txt
 
+# Pre-install numpy/scipy as binary-only wheels so the PyTorch extra-index
+# cannot pull in source tarballs that require g++.
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir --only-binary numpy,scipy "numpy==1.26.4" scipy && \
     pip install --no-cache-dir -r requirements-gpu.txt
 
 # ---------- application layer ----------

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -137,6 +137,17 @@ pip install -r requirements-cpu.txt
 **For GPU** (NVIDIA CUDA-compatible systems):
 
 ```bash
+bash install-gpu.sh          # defaults to CUDA 11.8
+bash install-gpu.sh cu121    # for CUDA 12.1
+bash install-gpu.sh cu124    # for CUDA 12.4
+```
+
+The install script pre-installs numpy/scipy as binary wheels before processing
+`requirements-gpu.txt`, avoiding C++ compiler errors from PyTorch's extra index.
+
+If you prefer raw pip, ensure g++ is installed first:
+
+```bash
 pip install -r requirements-gpu.txt
 ```
 

--- a/install-gpu.sh
+++ b/install-gpu.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# GPU dependency installer for VTSearch.
+#
+# The PyTorch extra-index (download.pytorch.org/whl/cu*) sometimes serves
+# source tarballs for packages like numpy and scipy.  Building those from
+# source requires a C++ compiler (g++) that isn't always present on GPU
+# machines.  This script works around the issue by pre-installing
+# compilation-heavy packages as binary-only wheels from PyPI before
+# processing the full requirements file.
+#
+# Usage:
+#   bash install-gpu.sh              # defaults to cu118
+#   bash install-gpu.sh cu121        # for CUDA 12.1
+#   bash install-gpu.sh cu124        # for CUDA 12.4
+
+CUDA_TAG="${1:-cu118}"
+EXTRA_INDEX="https://download.pytorch.org/whl/${CUDA_TAG}"
+
+echo "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})..."
+
+# Step 1: Pre-install packages that the PyTorch index may serve as source
+# tarballs.  Using --only-binary ensures we get pre-built wheels from PyPI,
+# avoiding the need for a C++ compiler.
+echo "Pre-installing binary-only wheels (numpy, scipy)..."
+pip install --only-binary numpy,scipy \
+  "numpy==1.26.4" \
+  "scipy" \
+  -q
+
+# Step 2: Install the full GPU requirements.  numpy/scipy are already
+# satisfied from step 1, so pip will skip them even if the extra index
+# offers a source dist.
+echo "Installing remaining GPU dependencies..."
+pip install --extra-index-url "$EXTRA_INDEX" \
+  --prefer-binary \
+  -r requirements-gpu.txt \
+  -q
+
+echo "GPU dependencies installed successfully."

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,11 +1,18 @@
 # GPU PyTorch index — install the CUDA build matching your system.
 # Adjust the cu* suffix for your CUDA version (cu118, cu121, cu124, etc.):
 #   pip install -r requirements-gpu.txt --extra-index-url https://download.pytorch.org/whl/cu118
+#
+# RECOMMENDED: use the install script instead of pip directly, to avoid
+# C++ compiler errors when building numpy/scipy from source:
+#   bash install-gpu.sh          # defaults to cu118
+#   bash install-gpu.sh cu121    # for CUDA 12.1
+# See install-gpu.sh for details.
 --extra-index-url https://download.pytorch.org/whl/cu118
 
 # Prefer pre-built wheels over source distributions.  The PyTorch extra
 # index sometimes serves source tarballs for packages like numpy, which
-# fail to build without a C++ compiler (g++).
+# fail to build without a C++ compiler (g++).  If you still hit build
+# errors, use install-gpu.sh which pre-installs these as binary-only.
 --prefer-binary
 
 # Core packages


### PR DESCRIPTION
## Summary
This PR adds a dedicated GPU installation script and updates documentation to work around C++ compiler errors when installing GPU dependencies. The PyTorch extra index sometimes serves source tarballs for packages like numpy and scipy, which fail to build without a C++ compiler. The new script pre-installs these packages as binary-only wheels before processing the full requirements file.

## Key Changes
- **New `install-gpu.sh` script**: Bash script that pre-installs numpy/scipy as binary wheels from PyPI before installing remaining GPU dependencies from the PyTorch extra index. Supports configurable CUDA versions (cu118, cu121, cu124, etc.) with cu118 as default.
- **Updated `docs/SETUP.md`**: Added GPU installation instructions recommending the new script, with fallback instructions for manual pip installation.
- **Updated `requirements-gpu.txt`**: Added comments explaining the C++ compiler issue and recommending use of the install script.
- **Updated `CLAUDE.md`**: Clarified CPU vs GPU installation commands with specific examples for different CUDA versions.
- **Updated `Dockerfile.gpu`**: Added pre-installation of numpy/scipy as binary-only wheels before processing requirements-gpu.txt, mirroring the script's approach.

## Implementation Details
The script uses `pip install --only-binary numpy,scipy` to force binary wheel installation from PyPI, preventing the PyTorch extra index from serving source distributions. Once these compilation-heavy packages are satisfied, the full requirements file is processed with `--prefer-binary` to minimize source builds. This approach eliminates the need for a C++ compiler on GPU machines while maintaining compatibility with all CUDA versions.

https://claude.ai/code/session_01BvmSbDcE2n51CehbjR2gJf