### PR TITLE
Fix pip compatibility for numpy/scipy installation in GPU setup

### DIFF
--- a/install-gpu.sh
+++ b/install-gpu.sh
@@ -23,8 +23,16 @@ echo "Installing VTSearch GPU dependencies (CUDA tag: ${CUDA_TAG})..."
 # Step 1: Pre-install packages that the PyTorch index may serve as source
 # tarballs.  Using --only-binary ensures we get pre-built wheels from PyPI,
 # avoiding the need for a C++ compiler.
+#
+# Notes:
+# - We use --only-binary :all: (not comma-separated package names) for
+#   compatibility with pip >= 25, which deprecated the comma syntax.
+# - We explicitly set --index-url to PyPI so that any extra-index-url
+#   configured elsewhere (pip.conf, env vars, etc.) doesn't interfere
+#   with finding the correct binary wheels.
 echo "Pre-installing binary-only wheels (numpy, scipy)..."
-pip install --only-binary numpy,scipy \
+pip install --only-binary :all: \
+  --index-url https://pypi.org/simple \
   "numpy==1.26.4" \
   "scipy" \
   -q


### PR DESCRIPTION
## Summary
Updated the GPU installation script to ensure compatibility with pip >= 25 by modernizing the binary wheel installation syntax and explicitly specifying the PyPI index.

## Key Changes
- Changed `--only-binary numpy,scipy` to `--only-binary :all:` for pip >= 25 compatibility (comma-separated package syntax was deprecated)
- Added explicit `--index-url https://pypi.org/simple` to prevent interference from custom index configurations in pip.conf or environment variables
- Added clarifying comments explaining the rationale for both changes

## Implementation Details
The comma-separated syntax for `--only-binary` was deprecated in pip 25, requiring the use of `:all:` to apply the constraint to all packages being installed. The explicit index URL ensures that the correct binary wheels are found regardless of any extra index configurations that may be present in the user's environment, improving reliability of the installation process.

https://claude.ai/code/session_01F4Wuz9NCBr6V7JkqtvvF7W