### PR TITLE
Move all media-type deps into base install, eliminating selective extras

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,6 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer folder --path /data/sounds --media-type sounds --settings <settings.json>`
 - **Install deps (CPU)**: `pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[cpu,dev]"`
 - **Install deps (GPU)**: `bash install-gpu.sh` (or `bash install-gpu.sh cu121` for CUDA 12.1)
-- **Install minimal (no media types)**: `pip install -e "."` (Flask UI only, media types error on first use)
-- **Install selective media types**: `pip install -e ".[audio,text,dev]"` (only audio + text support)
 - **Build frontend**: `cd frontend && npm install && npm run build:prod` (builds Angular app to `static/`)
 - **Frontend dev server**: `cd frontend && npm start` (proxies `/api/*` to Flask at localhost:5000)
 - **Frontend tests**: `cd frontend && ng test --watch=false` (requires Chrome/Chromium; see Environment Notes below)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -337,23 +337,15 @@ Add `--no-cache` after dependency changes to force a full rebuild.
 
 ## Dependency structure
 
-Dependencies are declared in `pyproject.toml` using optional extras:
+Dependencies are declared in `pyproject.toml`. All media types (audio, image, text, video, document), importers/exporters, and eval deps are included in the base install. The only optional extras are:
 
 ```
 pyproject.toml
-  [project.dependencies]          ← Core deps (Flask, PyTorch, NumPy, transformers)
+  [project.dependencies]          ← All app deps (Flask, NumPy, transformers, media types, etc.)
   [project.optional-dependencies]
     cpu                           ← CPU-only PyTorch wheel
     gpu                           ← GPU PyTorch wheel
     dev                           ← Dev tools (pytest, ruff)
-    audio                         ← Audio media type deps (librosa, laion_clap, etc.)
-    video                         ← Video media type deps (opencv, etc.)
-    image                         ← Image media type deps (ultralytics, etc.)
-    text                          ← Text media type deps (sentence-transformers, etc.)
-    document                      ← Document media type deps (PyMuPDF, etc.)
-    all-media                     ← All media type extras combined
-    email                         ← Email exporter deps
-    eval                          ← Evaluation framework deps
 ```
 
 Install commands:
@@ -364,12 +356,6 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[cpu,dev
 
 # GPU
 bash install-gpu.sh
-
-# Selective media types
-pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[audio,text,dev]"
-
-# Minimal (core only)
-pip install -e "."
 ```
 
 ### Key dependencies
@@ -435,9 +421,7 @@ via the folder or pickle importer instead.
 
 **Symptom**: `ModuleNotFoundError` for a media type or importer package.
 
-**Fix**: Install with all extras:
+**Fix**: Reinstall to ensure all dependencies are present:
 ```bash
-pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[cpu,all-media,email,dev]"
+pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[cpu,dev]"
 ```
-
-For specific media types only, install selective extras (e.g. `.[audio,text]`).

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1335,51 +1335,26 @@ class ObjectExtractor(Extractor):
 
 ## Dependency Management
 
-VTSearch declares all dependencies in `pyproject.toml` using optional extras:
+VTSearch declares all dependencies in `pyproject.toml`:
 
 ```
 pyproject.toml
-  [project.dependencies]          # Core deps (Flask, PyTorch, NumPy, transformers)
+  [project.dependencies]          # All app deps (Flask, NumPy, transformers, media types, etc.)
   [project.optional-dependencies]
     cpu                           # CPU-only PyTorch wheel
     gpu                           # GPU PyTorch wheel
     dev                           # Dev tools (pytest, ruff)
-    audio                         # Audio media type deps
-    video                         # Video media type deps
-    image                         # Image media type deps
-    text                          # Text media type deps
-    document                      # Document media type deps
-    all-media                     # All media type extras combined
-    email                         # Email exporter deps
-    eval                          # Evaluation framework deps
 ```
 
-### For a new media type
+All media types, importers/exporters, and eval deps are in the base
+`[project.dependencies]`. The only optional extras are `cpu`/`gpu` (for
+choosing the right PyTorch build) and `dev` (for test/lint tools).
 
-Add your packages to an existing extra or create a new one in
-`[project.optional-dependencies]` in `pyproject.toml`. You can also keep a
-`requirements.txt` in the plugin directory for documentation purposes.
+### For a new media type, importer, or exporter
 
-### For a new data importer
-
-Add any extra packages to `[project.optional-dependencies]` in
-`pyproject.toml`. If the importer's dependencies are niche, consider
-creating a new named extra for it.
-
-### For a new exporter
-
-Add any extra packages to `[project.optional-dependencies]` in
-`pyproject.toml` (e.g. to the `email` extra for email-related deps, or
-create a new extra).
-
-### Why extras?
-
-- Each extra groups the packages for a specific feature (media type,
-  exporter, etc.) so users can install only what they need.
-- `pip install -e ".[audio,text,dev]"` installs only audio and text
-  support plus dev tools.
-- Failed imports of a plugin's sub-package emit a warning rather than
-  crashing, so missing optional dependencies degrade gracefully.
+Add your packages to `[project.dependencies]` in `pyproject.toml`.
+Failed imports of a plugin's sub-package emit a warning rather than
+crashing, so missing system-level dependencies degrade gracefully.
 
 ---
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -244,7 +244,7 @@ Use this checklist when setting up VTSearch for a new environment.
 
 - [ ] NVIDIA GPU with CUDA support available
 - [ ] NVIDIA Container Toolkit installed (for Docker)
-- [ ] Use `Dockerfile.gpu` or `pip install -e ".[gpu,dev]"`
+- [ ] Use `Dockerfile.gpu` or `bash install-gpu.sh`
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for full details.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -126,7 +126,7 @@ When activated, you'll see `(venv)` at the start of your terminal prompt.
 
 ## Installing dependencies
 
-Dependencies are declared in `pyproject.toml` with optional extras.
+Dependencies are declared in `pyproject.toml`. All media types (audio, image, text, video, document) are included in the base install — you just pick CPU or GPU for PyTorch.
 
 **For CPU only** (recommended if you don't have a compatible GPU):
 
@@ -142,25 +142,7 @@ bash install-gpu.sh cu121    # for CUDA 12.1
 bash install-gpu.sh cu124    # for CUDA 12.4
 ```
 
-**Selective install** (only the media types you need):
-
-```bash
-pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[audio,text,dev]"
-```
-
-**Minimal install** (core only, no media type extras):
-
-```bash
-pip install -e "."
-```
-
-This installs Flask, NumPy, PyTorch, and other ML / media processing dependencies (including importers and exporters).
-
-**For development tools only** (adds pytest and other dev tools):
-
-```bash
-pip install -e ".[dev]"
-```
+The `--extra-index-url` flag pulls the smaller CPU-only PyTorch wheel (~200 MB) instead of the default CUDA build (~2 GB). The `install-gpu.sh` script handles selecting the right CUDA version.
 
 ## Building the frontend (optional)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.10"
 description = "Media explorer for browsing and voting on audio, images, text, video, or documents"
 
-# Core dependencies — enough to start the Flask app and serve the UI.
-# Media-type packages (audio, video, image, text, document) are optional;
-# models load lazily so missing packages only error when that media type
-# is actually used.
+# Core dependencies — everything needed to run VTSearch with all media types.
 dependencies = [
     "flask",
     "numpy<2",
@@ -16,32 +13,25 @@ dependencies = [
     "scikit-learn",
     "transformers",
     "pandas",
+    # Media types
+    "librosa",
+    "soundfile",
+    "opencv-python-headless<4.10",
+    "Pillow",
+    "ultralytics",
+    "sentence-transformers",
+    "PyMuPDF",
+    # Importers / exporters
+    "dnspython>=2.0.0",
+    # Eval / visualization
+    "matplotlib",
+    "scipy",
 ]
 
 [project.optional-dependencies]
-# ── Media types (install only what you need) ──────────────────────────
-audio = ["librosa", "soundfile"]
-video = ["opencv-python-headless<4.10"]
-image = ["Pillow", "ultralytics"]
-text  = ["sentence-transformers"]
-document = ["PyMuPDF"]
-all-media = [
-    "vtsearch[audio]",
-    "vtsearch[video]",
-    "vtsearch[image]",
-    "vtsearch[text]",
-    "vtsearch[document]",
-]
-
-# ── Importers / exporters with extra deps ─────────────────────────────
-email = ["dnspython>=2.0.0"]
-
-# ── Eval / visualization ──────────────────────────────────────────────
-eval = ["matplotlib", "scipy"]
-
 # ── PyTorch: pick ONE of cpu / gpu ────────────────────────────────────
-cpu = ["torch>=2.0.0", "vtsearch[all-media]", "vtsearch[email]", "vtsearch[eval]"]
-gpu = ["torch>=2.0.0", "vtsearch[all-media]", "vtsearch[email]", "vtsearch[eval]"]
+cpu = ["torch>=2.0.0"]
+gpu = ["torch>=2.0.0"]
 
 # ── Development ───────────────────────────────────────────────────────
 dev = ["pytest", "ruff"]


### PR DESCRIPTION
All media types (audio, image, text, video, document), importers/exporters, and eval deps are now in [project.dependencies] instead of optional extras. The only remaining extras are cpu/gpu (PyTorch build selection) and dev (pytest/ruff). This simplifies installation from 3 dimensions of choice (cpu/gpu × dev/not × which media types) down to 2 (cpu/gpu × dev/not).

https://claude.ai/code/session_01F4Wuz9NCBr6V7JkqtvvF7W