### PR TITLE
Add custom_metadata_map support for per-file metadata and MD5 overrides

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -174,6 +174,41 @@ class TestImporterBaseContentMD5s:
         assert imp.content_md5s["test.wav"] == "d41d8cd98f00b204e9800998ecf8427e"
 
 
+class TestImporterBaseCustomMetadataMap:
+    def test_base_class_instance_has_custom_metadata_map(self):
+        from vtsearch.datasets.importers.base import DatasetImporter
+
+        class MinimalImporter(DatasetImporter):
+            name = "minimal"
+            display_name = "Minimal"
+            description = "Minimal importer."
+            fields = []
+
+            def run(self, field_values, medias):
+                pass
+
+        imp = MinimalImporter()
+        assert hasattr(imp, "custom_metadata_map")
+        assert imp.custom_metadata_map == {}
+
+    def test_custom_metadata_map_independent_across_instances(self):
+        from vtsearch.datasets.importers.base import DatasetImporter
+
+        class Imp(DatasetImporter):
+            name = "t"
+            display_name = "T"
+            description = "T"
+            fields = []
+
+            def run(self, field_values, medias):
+                pass
+
+        a = Imp()
+        b = Imp()
+        a.custom_metadata_map["file.wav"] = {"md5": "abc123"}
+        assert b.custom_metadata_map == {}
+
+
 class TestImporterBaseIcon:
     def test_base_class_has_icon_attribute(self):
         from vtsearch.datasets.importers.base import DatasetImporter

--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -73,6 +73,66 @@ class TestMediaMD5:
         assert hashlib.md5(wav_bytes).hexdigest() == media["md5"]
 
 
+class TestApplyCustomMetadataMD5:
+    """Tests for apply_custom_metadata_md5: use MD5 from custom_metadata when provided."""
+
+    def test_replaces_md5_from_custom_metadata(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash", "custom_metadata": {"md5": "provided_hash", "title": "foo"}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 1
+        assert media_dict[1]["md5"] == "provided_hash"
+
+    def test_skips_when_no_custom_metadata(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash"},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 0
+        assert media_dict[1]["md5"] == "calculated_hash"
+
+    def test_skips_when_custom_metadata_has_no_md5(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash", "custom_metadata": {"title": "foo"}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 0
+        assert media_dict[1]["md5"] == "calculated_hash"
+
+    def test_skips_when_custom_metadata_md5_is_empty(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash", "custom_metadata": {"md5": ""}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 0
+        assert media_dict[1]["md5"] == "calculated_hash"
+
+    def test_handles_mixed_medias(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calc1", "custom_metadata": {"md5": "provided1"}},
+            2: {"md5": "calc2", "custom_metadata": {"title": "no md5 here"}},
+            3: {"md5": "calc3"},
+            4: {"md5": "calc4", "custom_metadata": {"md5": "provided4"}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 2
+        assert media_dict[1]["md5"] == "provided1"
+        assert media_dict[2]["md5"] == "calc2"
+        assert media_dict[3]["md5"] == "calc3"
+        assert media_dict[4]["md5"] == "provided4"
+
+
 class TestListMedias:
     def test_returns_all_medias(self, client):
         resp = client.get("/api/medias")

--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -132,6 +132,105 @@ class TestApplyCustomMetadataMD5:
         assert media_dict[3]["md5"] == "calc3"
         assert media_dict[4]["md5"] == "provided4"
 
+    def test_skips_when_custom_metadata_md5_is_none(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash", "custom_metadata": {"md5": None}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 0
+        assert media_dict[1]["md5"] == "calculated_hash"
+
+
+class TestCustomMetadataMapInLoader:
+    """Tests that custom_metadata_map in load_dataset_from_folder skips MD5 calculation."""
+
+    def test_md5_from_custom_metadata_map_used(self, tmp_path):
+        """When custom_metadata_map provides md5, the loader uses it."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+        from vtsearch.audio.generator import generate_wav
+
+        # Create a WAV file in tmp_path
+        wav_path = tmp_path / "test.wav"
+        wav_path.write_bytes(generate_wav(440, 0.5))
+
+        medias_dict: dict = {}
+        custom_md5 = "custom_provided_md5_value_here"
+        cm_map = {"test.wav": {"md5": custom_md5, "source": "external_db"}}
+
+        load_dataset_from_folder(
+            tmp_path, "sounds", medias_dict, custom_metadata_map=cm_map,
+        )
+
+        assert len(medias_dict) == 1
+        media = next(iter(medias_dict.values()))
+        # MD5 should be from custom_metadata_map, not computed from file bytes
+        assert media["md5"] == custom_md5
+        # custom_metadata should be attached to the media
+        assert media["custom_metadata"]["md5"] == custom_md5
+        assert media["custom_metadata"]["source"] == "external_db"
+
+    def test_empty_md5_in_custom_metadata_map_falls_through(self, tmp_path):
+        """When custom_metadata_map has empty md5, the loader computes it."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+        from vtsearch.audio.generator import generate_wav
+
+        wav_path = tmp_path / "test.wav"
+        wav_bytes = generate_wav(440, 0.5)
+        wav_path.write_bytes(wav_bytes)
+
+        medias_dict: dict = {}
+        cm_map = {"test.wav": {"md5": "", "source": "external_db"}}
+
+        load_dataset_from_folder(
+            tmp_path, "sounds", medias_dict, custom_metadata_map=cm_map,
+        )
+
+        media = next(iter(medias_dict.values()))
+        expected_md5 = hashlib.md5(wav_bytes).hexdigest()
+        assert media["md5"] == expected_md5
+        # custom_metadata should still be attached
+        assert media["custom_metadata"]["source"] == "external_db"
+
+    def test_no_custom_metadata_map_computes_md5(self, tmp_path):
+        """Without custom_metadata_map, md5 is computed normally."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+        from vtsearch.audio.generator import generate_wav
+
+        wav_path = tmp_path / "test.wav"
+        wav_bytes = generate_wav(440, 0.5)
+        wav_path.write_bytes(wav_bytes)
+
+        medias_dict: dict = {}
+        load_dataset_from_folder(tmp_path, "sounds", medias_dict)
+
+        media = next(iter(medias_dict.values()))
+        expected_md5 = hashlib.md5(wav_bytes).hexdigest()
+        assert media["md5"] == expected_md5
+        assert "custom_metadata" not in media
+
+    def test_custom_metadata_map_with_relative_path_key(self, tmp_path):
+        """custom_metadata_map keys can be relative paths (subdir/file.wav)."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+        from vtsearch.audio.generator import generate_wav
+
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        wav_path = subdir / "test.wav"
+        wav_path.write_bytes(generate_wav(440, 0.5))
+
+        medias_dict: dict = {}
+        custom_md5 = "relpath_provided_md5"
+        cm_map = {"sub/test.wav": {"md5": custom_md5}}
+
+        load_dataset_from_folder(
+            tmp_path, "sounds", medias_dict, custom_metadata_map=cm_map,
+        )
+
+        media = next(iter(medias_dict.values()))
+        assert media["md5"] == custom_md5
+
 
 class TestListMedias:
     def test_returns_all_medias(self, client):

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import numpy as np
 
-from vtsearch.datasets.loader import load_dataset_from_pickle
+from vtsearch.datasets.loader import apply_custom_metadata_md5, load_dataset_from_pickle
 from vtsearch.utils.hits import build_media_hit
 
 
@@ -171,6 +171,7 @@ def run_autodetect_with_importer(
     # Use thin mode — CLI only needs embeddings for scoring, not media bytes
     medias: dict[int, dict[str, Any]] = {}
     importer.run_cli(field_values, medias, thin=True)
+    apply_custom_metadata_md5(medias)
 
     if not medias:
         raise ValueError(f"No medias loaded by importer '{importer_name}'")
@@ -395,6 +396,7 @@ def _load_importer_whole(importer_name: str, field_values: dict[str, Any]) -> It
 
     medias: dict[int, dict[str, Any]] = {}
     importer.run_cli(field_values, medias, thin=True)
+    apply_custom_metadata_md5(medias)
     if not medias:
         raise ValueError(f"No medias loaded by importer '{importer_name}'")
     yield medias
@@ -449,6 +451,7 @@ def _run_pipeline(
         if not chunk_medias:
             continue
 
+        apply_custom_metadata_md5(chunk_medias)
         total_medias += len(chunk_medias)
 
         if media_type is None:

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -93,6 +93,15 @@ class DatasetImporter(PluginBase):
     will skip its own MD5 calculation for any file whose name appears in
     this mapping.
 
+    Custom metadata map
+    -------------------
+    Importers can populate :attr:`custom_metadata_map` with a mapping of
+    ``filename`` to a metadata dict.  When a metadata dict contains a
+    non-empty ``"md5"`` key, that value is used as the media's content hash
+    (taking priority over both :attr:`content_md5s` and on-the-fly
+    calculation).  The metadata dict is also attached to the media as
+    ``custom_metadata``.
+
     CLI support
     -----------
     Every importer is automatically usable from the command line via
@@ -123,6 +132,14 @@ class DatasetImporter(PluginBase):
         #: :func:`~vtsearch.datasets.loader.load_dataset_from_folder` will
         #: skip its own MD5 calculation for any file whose name appears here.
         self.content_md5s: dict[str, str] = {}
+
+        #: Mapping of filename to a per-file custom metadata dict.  When a
+        #: metadata dict contains a non-empty ``"md5"`` key, that value is
+        #: used as the media's MD5 hash (skipping the normal calculation).
+        #: The metadata dict is also attached to the media as
+        #: ``custom_metadata``.  Keys follow the same lookup order as
+        #: :attr:`content_vectors` (relative path first, then basename).
+        self.custom_metadata_map: dict[str, dict[str, Any]] = {}
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Perform the import, populating *medias* in-place.

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -208,7 +208,10 @@ class FolderDatasetImporter(DatasetImporter):
         emb_name = field_values.get("embedder", "")
         has_regular = True
         try:
-            load_dataset_from_folder(folder, media_type, medias, thin=thin, embedder_name=emb_name)
+            load_dataset_from_folder(
+                folder, media_type, medias, thin=thin, embedder_name=emb_name,
+                custom_metadata_map=self.custom_metadata_map or None,
+            )
         except ValueError:
             # No regular image files found — PDFs or converters may still produce output.
             if media_type != "images" and not field_values.get("converters"):
@@ -244,6 +247,7 @@ class FolderDatasetImporter(DatasetImporter):
         try:
             yield from load_dataset_from_folder_chunked(
                 folder, media_type, chunk_size, thin=thin, embedder_name=emb_name,
+                custom_metadata_map=self.custom_metadata_map or None,
             )
         except ValueError:
             if media_type != "images" and not field_values.get("converters"):

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -225,6 +225,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         try:
             load_dataset_from_folder(
                 extract_dir, media_type, medias, on_progress=progress, thin=thin, embedder_name=emb_name,
+                custom_metadata_map=self.custom_metadata_map or None,
             )
             # Run any user-selected converters on the extracted folder.
             _run_selected_converters(extract_dir, media_type, field_values, medias, thin=thin)
@@ -281,6 +282,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         try:
             yield from load_dataset_from_folder_chunked(
                 extract_dir, media_type, chunk_size, thin=thin, embedder_name=emb_name,
+                custom_metadata_map=self.custom_metadata_map or None,
             )
             # Run converters on the extracted folder and yield as a chunk.
             converters_str = field_values.get("converters", "")

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -433,6 +433,7 @@ def load_dataset_from_folder(
     origin: dict[str, Any] | None = None,
     thin: bool = False,
     embedder_name: str = "",
+    custom_metadata_map: dict[str, dict[str, Any]] | None = None,
 ) -> None:
     """Generate a dataset in-place from a flat folder of media files.
 
@@ -479,6 +480,12 @@ def load_dataset_from_folder(
         embedder_name: Optional name of a registered embedder to use.
             When empty, the first registered embedder for the media type
             is used.
+        custom_metadata_map: Optional mapping of filename to a metadata dict.
+            Keys follow the same lookup logic as ``content_vectors`` (relative
+            path first, then basename).  When a metadata dict contains a
+            non-empty ``"md5"`` key, that value is used as the media's MD5
+            instead of computing it from the file contents.  The metadata dict
+            is also attached to the media as ``custom_metadata``.
 
     Raises:
         ValueError: If ``media_type`` is not recognised, or if no matching
@@ -558,10 +565,24 @@ def load_dataset_from_folder(
 
             embedder_id = emb.name if emb else ""
 
+            # Look up per-file custom metadata (relative path first, then
+            # basename fallback — same lookup order as content_vectors).
+            file_cm: dict[str, Any] | None = None
+            if custom_metadata_map:
+                if rel_path in custom_metadata_map:
+                    file_cm = custom_metadata_map[rel_path]
+                elif file_path.name in custom_metadata_map:
+                    file_cm = custom_metadata_map[file_path.name]
+
+            # Resolve MD5: custom_metadata > content_md5s > computed
+            cm_md5 = (file_cm.get("md5") or "") if file_cm else ""
+
             if thin:
                 # Thin mode: store file path reference, skip loading bytes.
                 # Use stat for file_size and streaming hash for MD5.
-                if content_md5s and rel_path in content_md5s:
+                if cm_md5:
+                    md5 = cm_md5
+                elif content_md5s and rel_path in content_md5s:
                     md5 = content_md5s[rel_path]
                 elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
@@ -587,7 +608,9 @@ def load_dataset_from_folder(
                 with open(file_path, "rb") as f:
                     file_bytes = f.read()
 
-                if content_md5s and rel_path in content_md5s:
+                if cm_md5:
+                    md5 = cm_md5
+                elif content_md5s and rel_path in content_md5s:
                     md5 = content_md5s[rel_path]
                 elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
@@ -616,6 +639,9 @@ def load_dataset_from_folder(
 
                 # Merge in media-specific fields from the media type
                 media_data.update(mt.load_media_data(file_path))
+
+            if file_cm:
+                media_data["custom_metadata"] = file_cm
 
             medias[media_id] = media_data
             media_id += 1
@@ -666,6 +692,7 @@ def load_dataset_from_folder_chunked(
     origin: dict[str, Any] | None = None,
     thin: bool = False,
     embedder_name: str = "",
+    custom_metadata_map: dict[str, dict[str, Any]] | None = None,
 ) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield chunks of medias from a folder of media files.
 
@@ -688,6 +715,8 @@ def load_dataset_from_folder_chunked(
         embedder_name: Optional name of a registered embedder to use.
             When empty, the first registered embedder for the media type
             is used.
+        custom_metadata_map: Optional mapping of filename to a metadata dict.
+            Same semantics as in :func:`load_dataset_from_folder`.
 
     Yields:
         A dict mapping int media IDs (starting at 1) to media data dicts.
@@ -770,8 +799,20 @@ def load_dataset_from_folder_chunked(
                 if embedding is None:
                     continue
 
+            # Look up per-file custom metadata (same logic as non-chunked).
+            file_cm: dict[str, Any] | None = None
+            if custom_metadata_map:
+                if rel_path in custom_metadata_map:
+                    file_cm = custom_metadata_map[rel_path]
+                elif file_path.name in custom_metadata_map:
+                    file_cm = custom_metadata_map[file_path.name]
+
+            cm_md5 = (file_cm.get("md5") or "") if file_cm else ""
+
             if thin:
-                if content_md5s and rel_path in content_md5s:
+                if cm_md5:
+                    md5 = cm_md5
+                elif content_md5s and rel_path in content_md5s:
                     md5 = content_md5s[rel_path]
                 elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
@@ -797,7 +838,9 @@ def load_dataset_from_folder_chunked(
                 with open(file_path, "rb") as f:
                     file_bytes = f.read()
 
-                if content_md5s and rel_path in content_md5s:
+                if cm_md5:
+                    md5 = cm_md5
+                elif content_md5s and rel_path in content_md5s:
                     md5 = content_md5s[rel_path]
                 elif content_md5s and file_path.name in content_md5s:
                     md5 = content_md5s[file_path.name]
@@ -821,6 +864,9 @@ def load_dataset_from_folder_chunked(
                     "duration": 0,
                 }
                 media_data.update(mt.load_media_data(file_path))
+
+            if file_cm:
+                media_data["custom_metadata"] = file_cm
 
             chunk_medias[media_id] = media_data
             media_id += 1

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -630,6 +630,32 @@ def load_dataset_from_folder(
     on_progress("idle", f"Loaded {len(medias)} {media_type} medias from folder")
 
 
+def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
+    """Use MD5 hashes from custom_metadata when available.
+
+    If a media item's ``custom_metadata`` contains a non-empty ``"md5"`` key,
+    that value is used as the item's ``"md5"`` instead of whatever was
+    calculated during loading.  This lets importers supply authoritative hashes
+    from their data source without recalculation.
+
+    Args:
+        media_dict: The mutable medias dict.  Modified in place.
+
+    Returns:
+        The number of media items whose MD5 was replaced.
+    """
+    count = 0
+    for media in media_dict.values():
+        cm = media.get("custom_metadata")
+        if not cm:
+            continue
+        cm_md5 = cm.get("md5")
+        if cm_md5:
+            media["md5"] = cm_md5
+            count += 1
+    return count
+
+
 def load_dataset_from_folder_chunked(
     folder_path: Path,
     media_type: str,

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from vtsearch.auth import get_current_user
 from vtsearch.config import DATA_DIR
 from vtsearch.datasets import export_dataset_to_file
+from vtsearch.datasets.loader import apply_custom_metadata_md5
 from vtsearch.datasets.registry import (
     get_saved_datasets_dir,
     register_dataset as _reg_register,
@@ -365,6 +366,9 @@ def _run_origin_load_in_background(
             gc.collect()
             load_fn()
             dataset_progress.check_cancelled()
+            # Use MD5 hashes from custom_metadata when the importer
+            # provides them, before duplicate collapsing relies on them.
+            apply_custom_metadata_md5(medias)
             # _stepped_progress (the progress callback injected by
             # _run_importer_in_background) filters out "idle" so that
             # inner functions like load_demo_dataset cannot prematurely
@@ -505,6 +509,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
         try:
             temp_medias: dict = {}
             importer.run(field_values, temp_medias)
+            apply_custom_metadata_md5(temp_medias)
 
             if not temp_medias:
                 update_progress("idle", "", 0, 0, "Import produced no medias.")


### PR DESCRIPTION
## Summary
This PR adds support for importers to provide custom metadata and MD5 hash overrides on a per-file basis through a new `custom_metadata_map` parameter. This allows importers to supply authoritative hashes from external data sources without requiring recalculation, and to attach arbitrary metadata to media items during import.

## Key Changes

- **New `custom_metadata_map` parameter**: Added to `load_dataset_from_folder()`, `load_dataset_from_folder_chunked()`, and the `DatasetImporter` base class. Maps filenames to metadata dicts.

- **MD5 priority chain**: Implemented a three-tier MD5 resolution:
  1. Custom metadata map (highest priority)
  2. Pre-computed `content_md5s` 
  3. On-the-fly calculation (fallback)

- **New `apply_custom_metadata_md5()` function**: Post-processing utility that applies MD5 hashes from `custom_metadata` to media items. Called in CLI and web routes after import to ensure custom hashes take effect.

- **Flexible filename lookup**: Custom metadata keys support both relative paths (e.g., `"sub/file.wav"`) and basename fallback (e.g., `"file.wav"`), matching the existing `content_vectors` lookup behavior.

- **Metadata attachment**: When custom metadata is provided, it's attached to the media item as `custom_metadata` for later reference.

- **Importer integration**: Updated `FolderImporter` and `HttpZipImporter` to pass `custom_metadata_map` to loader functions.

## Implementation Details

- Empty or `None` MD5 values in custom metadata are treated as "not provided" and fall through to the next resolution tier
- The `custom_metadata_map` is instance-specific on importers (not shared across instances)
- Both thin and full loading modes respect the custom metadata MD5 priority
- Chunked loading maintains the same semantics as non-chunked loading

https://claude.ai/code/session_01SWJjvnzcJoTUBFoY4Vh7tC