### PR TITLE
Add progress tracking to label embedding resolution

### DIFF
--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -217,6 +217,7 @@ def embed_file(file_path: Path, media_type: str) -> np.ndarray | None:
 def resolve_label_embeddings(
     labels: list[dict[str, Any]],
     media_type: str,
+    progress_callback: Any | None = None,
 ) -> ResolvedLabels:
     """Resolve label entries to embeddings by following their origin trails.
 
@@ -245,9 +246,13 @@ def resolve_label_embeddings(
         len(labels), media_type,
     )
 
+    _total_entries = len(labels)
+
     for i, entry in enumerate(labels):
         label_val = entry.get("label", "")
         if label_val not in ("good", "bad"):
+            if progress_callback is not None:
+                progress_callback(current=i + 1, total=_total_entries)
             continue
 
         result.total_count += 1
@@ -275,6 +280,8 @@ def resolve_label_embeddings(
                     i, origin.get("importer", "?"), origin_name, filename,
                     origin.get("params", {}),
                 )
+            if progress_callback is not None:
+                progress_callback(current=i + 1, total=_total_entries)
             continue
 
         embedding = embed_file(file_path, media_type)
@@ -286,6 +293,8 @@ def resolve_label_embeddings(
                 "embedding returned None for media_type=%r",
                 i, file_path, media_type,
             )
+            if progress_callback is not None:
+                progress_callback(current=i + 1, total=_total_entries)
             continue
 
         result.embeddings.append(embedding)
@@ -295,6 +304,8 @@ def resolve_label_embeddings(
             "  label[%d] OK: %s → %s (label=%s)",
             i, origin_name or filename, file_path.name, label_val,
         )
+        if progress_callback is not None:
+            progress_callback(current=i + 1, total=_total_entries)
 
     # --- Summary ---
     n_good = sum(1 for v in result.labels if v == 1.0)

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -211,12 +211,23 @@ def find_label():
             if unresolved:
                 from vtsearch.models.resolver import resolve_label_embeddings
 
+                _n_unresolved = len(unresolved)
                 update_find_progress(
-                    "running", f"Resolving {len(unresolved)} label origins…",
-                    current=0, total=0,
+                    "running", f"Resolving {_n_unresolved} label origins…",
+                    current=0, total=_n_unresolved,
                     step=2, total_steps=_FIND_LABEL_STEPS,
                 )
-                resolved = resolve_label_embeddings(unresolved, media_type)
+
+                def _origin_progress(current: int, total: int) -> None:
+                    update_find_progress(
+                        "running", f"Resolving {_n_unresolved} label origins…",
+                        current=current, total=total,
+                        step=2, total_steps=_FIND_LABEL_STEPS,
+                    )
+
+                resolved = resolve_label_embeddings(
+                    unresolved, media_type, progress_callback=_origin_progress,
+                )
                 X_list.extend(resolved.embeddings)
                 y_list.extend(resolved.labels)
 


### PR DESCRIPTION
## Summary
This PR adds progress callback support to the label embedding resolution process, enabling real-time progress updates during the resolution of label origins.

## Key Changes
- **detectors_scoring.py**: 
  - Store the count of unresolved labels in a variable for reuse
  - Set the `total` parameter in progress updates to the actual number of unresolved items
  - Define a `_origin_progress` callback function to track resolution progress
  - Pass the callback to `resolve_label_embeddings()` via new `progress_callback` parameter

- **resolver.py**:
  - Add optional `progress_callback` parameter to `resolve_label_embeddings()` function
  - Invoke the callback at each iteration of the label processing loop, reporting current progress and total count
  - Callback is triggered for all code paths: invalid labels, missing files, failed embeddings, and successful resolutions

## Implementation Details
- The progress callback receives `current` (1-indexed iteration count) and `total` (total number of labels) parameters
- Progress updates are sent for every processed label, regardless of success or failure
- The callback is optional and safely ignored if not provided (None check before invocation)
- This enables the UI to display accurate progress information during potentially long-running label resolution operations

https://claude.ai/code/session_014GUA3eLDhJ8v92f4X275Vj