### PR TITLE
Disable UI interactions during Find mode detector scoring

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -79,7 +79,7 @@
     <vt-voting-overlay
       [isGood]="isGood"
       [isBad]="isBad"
-      [disabled]="isVoting"
+      [disabled]="isVoting || disabled"
       (voted)="castVote($event)"
     ></vt-voting-overlay>
   }

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -30,6 +30,7 @@ import { VotingOverlayComponent } from './voting-overlay/voting-overlay.componen
 })
 export class CenterPanelComponent implements OnChanges, OnDestroy {
   @Input() media: MediaItem | null = null;
+  @Input() disabled = false;
   @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
   @ViewChild(AudioPlayerComponent) audioPlayer?: AudioPlayerComponent;
@@ -71,7 +72,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
       this.keyboard.action$.subscribe((action) => {
         switch (action.type) {
           case 'vote':
-            if (this.media && action.direction) {
+            if (this.media && action.direction && !this.disabled) {
               this.castVote(action.direction);
             }
             break;

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -32,8 +32,14 @@
     (mousedown)="onDividerMouseDown($event)"
   ></div>
   <div class="panel-center">
+    @if (sortState.sortBusy) {
+      <div class="find-wait-overlay">
+        <p class="find-wait-message">Please wait — scoring dataset with detector…</p>
+      </div>
+    }
     <vt-center-panel
       [media]="mediaState.selectedMedia"
+      [disabled]="sortState.sortBusy"
       (mediaVoted)="onMediaVoted($event)"
     />
   </div>
@@ -45,6 +51,7 @@
     <vt-right-panel
       [medias]="mediaState.medias"
       [focusMode]="focusModeRight"
+      [disabled]="sortState.sortBusy"
       mode="find"
       (mediaSelected)="onMediaSelect($event)"
       (mediaVoted)="onHoverVote($event)"

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -33,6 +33,7 @@
   background: var(--bg-panel);
   display: flex;
   min-width: 100px;
+  position: relative;
 }
 
 .divider-right {
@@ -52,4 +53,24 @@
   background: var(--bg-panel);
   min-width: 150px;
   padding: 0;
+}
+
+// "Please wait" overlay shown in Find mode while detector scoring is running
+.find-wait-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  background: var(--bg-panel);
+  opacity: 0.85;
+  pointer-events: all;
+}
+
+.find-wait-message {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 0 24px;
 }

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -304,6 +304,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
+    if (this.sortState.sortBusy) return;
     this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.onMediaVoted(event);

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -6,7 +6,7 @@
   />
 
   <div class="import-row">
-    <button class="panel-btn import-btn" (click)="onImportLabels()">Import Labels</button>
+    <button class="panel-btn import-btn" [disabled]="disabled" (click)="onImportLabels()">Import Labels</button>
   </div>
 
   <div class="sort-row">
@@ -53,7 +53,7 @@
   />
 
   <div class="export-row">
-    <button class="panel-btn export-btn" (click)="onExport()">Export</button>
+    <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()">Export</button>
   </div>
 </aside>
 

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -81,10 +81,15 @@
   white-space: nowrap;
   transition: all 0.15s;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-primary);
     border-color: var(--accent);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }
 

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -40,6 +40,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   @Input() focusMode: 'click' | 'hover' = 'click';
   /** 'label' = Labeling mode (detector export allowed), 'find' = Finding mode (no detector export). */
   @Input() mode: 'label' | 'find' = 'label';
+  /** Disable interactive buttons (used during Find scoring). */
+  @Input() disabled = false;
   @Output() mediaSelected = new EventEmitter<number>();
   @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 


### PR DESCRIPTION
## Summary
Add a "Please wait" overlay and disable interactive UI elements in Find mode while detector scoring is running. This prevents users from interacting with the interface during the scoring process.

## Key Changes
- **Find View**: Added conditional overlay with "Please wait" message that displays when `sortState.sortBusy` is true
- **Styling**: 
  - Added `position: relative` to `.panel-left` to enable absolute positioning of overlay
  - Created `.find-wait-overlay` and `.find-wait-message` styles for the blocking overlay
  - Updated button hover states to exclude disabled buttons (`:hover:not(:disabled)`)
  - Added disabled button styling with reduced opacity and `not-allowed` cursor
- **Center Panel**: 
  - Added `disabled` input property
  - Prevented vote keyboard shortcuts when disabled
  - Passed disabled state to voting overlay
- **Right Panel**: 
  - Added `disabled` input property
  - Disabled Import Labels and Export buttons during scoring
  - Added visual feedback for disabled state
- **Find View Component**: Added guard to prevent hover votes when `sortBusy` is true

## Implementation Details
The overlay uses `position: absolute` with `inset: 0` to cover the entire panel-center area, with `pointer-events: all` to capture all interactions. The disabled state is propagated through component inputs to prevent any user actions during the scoring operation.

https://claude.ai/code/session_01Kaz6NQvssFLAwSDfg5eEir