### PR TITLE
Add optional label field to ExporterInfo interface

### DIFF
--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -292,6 +292,7 @@ export interface AutorunProcessor {
 
 export interface ExporterInfo {
   name: string;
+  label?: string;
   display_name?: string;
   description?: string;
   icon?: string;


### PR DESCRIPTION
## Summary
Added an optional `label` field to the `ExporterInfo` interface to support additional labeling capabilities for exporters.

## Changes
- Added `label?: string;` property to the `ExporterInfo` interface in `frontend/src/app/models/api.models.ts`
- The field is positioned before the existing `display_name` property for logical grouping of naming-related fields

## Implementation Details
- The `label` field is optional (marked with `?`) to maintain backward compatibility with existing exporter configurations
- This allows exporters to provide an additional label distinct from their `name` and `display_name` properties

https://claude.ai/code/session_01CFakvz5tWbUmJiHqd3JAtZ