### PR TITLE
Add npm dependency overrides for security and compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,5 +34,12 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.7.2"
+  },
+  "overrides": {
+    "glob": "^13.0.6",
+    "rimraf": "^6.1.3",
+    "pacote": {
+      "tar": "^7.5.12"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Added npm package overrides to the frontend project to enforce specific versions of critical dependencies and address potential security or compatibility issues.

## Key Changes
- Added `overrides` configuration to `package.json` to pin specific versions of transitive dependencies:
  - `glob` pinned to `^13.0.6`
  - `rimraf` pinned to `^6.1.3`
  - `tar` (as a dependency of `pacote`) pinned to `^7.5.12`

## Details
These overrides ensure that all packages in the dependency tree use the specified versions of these utilities, preventing version conflicts and potential security vulnerabilities that may arise from different versions being installed by various dependencies.

https://claude.ai/code/session_01TYQnKq7383YkhnddXb7rCA