### PR TITLE
Refactor settings save to use partial updates instead of full object

### DIFF
--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.ts
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.ts
@@ -56,8 +56,9 @@ export class LeftViewSettingsModalComponent implements OnInit {
   onViewModeChange(typeId: string, value: string): void {
     const dict = (this.settings.view_mode_left as Record<string, string>) || {};
     dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['view_mode_left'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['view_mode_left'] = updated;
+    this.saveField({ view_mode_left: updated });
   }
 
   getViewMode(typeId: string): string {
@@ -69,8 +70,9 @@ export class LeftViewSettingsModalComponent implements OnInit {
   onGridIconSizeChange(typeId: string, value: string): void {
     const dict = (this.settings.grid_icon_size_left as Record<string, string>) || {};
     dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['grid_icon_size_left'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['grid_icon_size_left'] = updated;
+    this.saveField({ grid_icon_size_left: updated });
   }
 
   getGridIconSize(typeId: string): string {
@@ -82,8 +84,9 @@ export class LeftViewSettingsModalComponent implements OnInit {
   onFocusModeChange(typeId: string, value: string): void {
     const dict = (this.settings.focus_mode_left as Record<string, string>) || {};
     dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['focus_mode_left'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['focus_mode_left'] = updated;
+    this.saveField({ focus_mode_left: updated });
   }
 
   getFocusMode(typeId: string): string {
@@ -96,8 +99,9 @@ export class LeftViewSettingsModalComponent implements OnInit {
     const clamped = Math.max(10, Math.min(90, Math.round(value)));
     const dict = (this.settings.panel_pct_left as Record<string, number>) || {};
     dict[typeId] = clamped;
-    (this.settings as Record<string, unknown>)['panel_pct_left'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['panel_pct_left'] = updated;
+    this.saveField({ panel_pct_left: updated });
   }
 
   getPanelPct(typeId: string): number {
@@ -106,8 +110,11 @@ export class LeftViewSettingsModalComponent implements OnInit {
     return dict[typeId] ?? 50;
   }
 
-  private save(): void {
-    this.settingsState.update(this.settings).subscribe({
+  private saveField(changes: Partial<AppSettings>): void {
+    this.settingsState.update(changes).subscribe({
+      next: (updated) => {
+        this.settings = updated;
+      },
       error: () => {
         this.error = 'Failed to save settings';
       },

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.ts
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.ts
@@ -56,8 +56,9 @@ export class ViewSettingsModalComponent implements OnInit {
   onViewModeChange(typeId: string, value: string): void {
     const dict = (this.settings.view_mode_right as Record<string, string>) || {};
     dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['view_mode_right'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['view_mode_right'] = updated;
+    this.saveField({ view_mode_right: updated });
   }
 
   getViewMode(typeId: string): string {
@@ -69,8 +70,9 @@ export class ViewSettingsModalComponent implements OnInit {
   onGridIconSizeChange(typeId: string, value: string): void {
     const dict = (this.settings.grid_icon_size_right as Record<string, string>) || {};
     dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['grid_icon_size_right'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['grid_icon_size_right'] = updated;
+    this.saveField({ grid_icon_size_right: updated });
   }
 
   getGridIconSize(typeId: string): string {
@@ -82,8 +84,9 @@ export class ViewSettingsModalComponent implements OnInit {
   onFocusModeChange(typeId: string, value: string): void {
     const dict = (this.settings.focus_mode_right as Record<string, string>) || {};
     dict[typeId] = value;
-    (this.settings as Record<string, unknown>)['focus_mode_right'] = { ...dict };
-    this.save();
+    const updated = { ...dict };
+    (this.settings as Record<string, unknown>)['focus_mode_right'] = updated;
+    this.saveField({ focus_mode_right: updated });
   }
 
   getFocusMode(typeId: string): string {
@@ -92,8 +95,11 @@ export class ViewSettingsModalComponent implements OnInit {
     return dict[typeId] ?? 'click';
   }
 
-  private save(): void {
-    this.settingsState.update(this.settings).subscribe({
+  private saveField(changes: Partial<AppSettings>): void {
+    this.settingsState.update(changes).subscribe({
+      next: (updated) => {
+        this.settings = updated;
+      },
       error: () => {
         this.error = 'Failed to save settings';
       },


### PR DESCRIPTION
## Summary
Refactored the settings modal components to send only the changed fields to the backend instead of the entire settings object. This improves efficiency and reduces unnecessary data transmission.

## Key Changes
- **Renamed `save()` to `saveField()`**: Changed the private method signature to accept `Partial<AppSettings>` instead of operating on the full settings object
- **Partial updates**: Modified all four setting change handlers (`onViewModeChange`, `onGridIconSizeChange`, `onFocusModeChange`, and `onPanelPctChange` in left-view-settings-modal) to pass only the specific field being updated to the backend
- **State synchronization**: Added a `next` callback to the subscription to update the local `settings` object with the response from the backend, ensuring the component state stays in sync
- **Applied to both components**: Changes made consistently to both `LeftViewSettingsModalComponent` and `ViewSettingsModalComponent`

## Implementation Details
- Each handler now creates an `updated` variable to hold the modified dictionary before passing it to `saveField()`
- The `saveField()` method now calls `this.settingsState.update(changes)` with only the changed field(s) instead of the entire settings object
- The subscription now includes a `next` handler to update the local settings state with the server response, improving data consistency

https://claude.ai/code/session_01E4Dtaq28kWaUbSz7qtrnG2