### PR TITLE
Add autopilot refocus functionality when re-clicking active tab

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -35,6 +35,7 @@
       [autopilotEnabled]="autopilotEnabled"
       (autopilotStart)="onAutopilotStart()"
       (autopilotStop)="onAutopilotStop()"
+      (autopilotRefocus)="onAutopilotRefocus()"
       (autopilotToggleCollapse)="onAutopilotToggleCollapse()"
       (autopilotEnabledChange)="onAutopilotEnabledChange($event)"
     />

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -473,6 +473,25 @@ describe('LabelViewComponent', () => {
     expect(component.showResortPrompt).toBeFalse();
   });
 
+  it('should re-select autopilot suggestion on refocus', () => {
+    flushInitialRequests();
+
+    // Set up sort order and select mode
+    component.sortState.setSortResults(
+      [{ id: 2, score: 0.9 }, { id: 1, score: 0.3 }],
+      0.5,
+    );
+    component.sortState.setSelectMode('top');
+
+    // Manually select a different media (simulating user clicking right panel)
+    component.onMediaSelect(1);
+    expect(component.mediaState.selectedId).toBe(1);
+
+    // Refocus should re-select the autopilot suggestion (top unlabeled = id 2)
+    component.onAutopilotRefocus();
+    expect(component.mediaState.selectedId).toBe(2);
+  });
+
   it('should clear stale autopilot state from previous session on init', () => {
     const autopilot = TestBed.inject(AutopilotStateService);
     // Simulate leftover state from a previous detector session

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -648,6 +648,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.onResortKeep();
   }
 
+  onAutopilotRefocus(): void {
+    this.autoSelectNext();
+  }
+
   onAutopilotToggleCollapse(): void {
     const newVal = !this.autopilotCollapsed;
     this.setAutopilotCollapsed(newVal);

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -80,10 +80,23 @@ describe('LeftPanelComponent', () => {
     expect(component.autopilotStop.emit).toHaveBeenCalled();
   });
 
-  it('should not emit when setting the same tab', () => {
+  it('should not emit start when setting the same tab', () => {
     spyOn(component.autopilotStart, 'emit');
     component.setTab('autopilot');
     expect(component.autopilotStart.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit autopilotRefocus when clicking already-active autopilot tab', () => {
+    spyOn(component.autopilotRefocus, 'emit');
+    component.setTab('autopilot');
+    expect(component.autopilotRefocus.emit).toHaveBeenCalled();
+  });
+
+  it('should not emit autopilotRefocus when clicking already-active manual tab', () => {
+    component.setTab('manual');
+    spyOn(component.autopilotRefocus, 'emit');
+    component.setTab('manual');
+    expect(component.autopilotRefocus.emit).not.toHaveBeenCalled();
   });
 
   it('should emit sortModeChange', () => {

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -69,6 +69,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Output() indicatorClick = new EventEmitter<string>();
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();
+  @Output() autopilotRefocus = new EventEmitter<void>();
   @Output() autopilotToggleCollapse = new EventEmitter<void>();
   @Output() autopilotEnabledChange = new EventEmitter<boolean>();
 
@@ -122,7 +123,12 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   }
 
   setTab(tab: 'manual' | 'autopilot'): void {
-    if (tab === this.activeTab) return;
+    if (tab === this.activeTab) {
+      if (tab === 'autopilot') {
+        this.autopilotRefocus.emit();
+      }
+      return;
+    }
     const previous = this.activeTab;
     this.activeTab = tab;
     if (previous === 'autopilot') {


### PR DESCRIPTION
## Summary
This PR adds a refocus mechanism for the autopilot feature that allows users to re-select the autopilot suggestion when they click on the already-active autopilot tab in the left panel.

## Key Changes
- **LeftPanelComponent**: Added new `autopilotRefocus` output event that emits when the autopilot tab is clicked while already active
- **LabelViewComponent**: Added `onAutopilotRefocus()` method that re-selects the top autopilot suggestion by calling `autoSelectNext()`
- **Template binding**: Connected the `autopilotRefocus` event from left panel to the label view component
- **Tests**: Added comprehensive test coverage for the new refocus behavior in both components

## Implementation Details
- The refocus only triggers when clicking the autopilot tab while it's already the active tab (clicking the manual tab while active does not trigger refocus)
- The refocus mechanism reuses the existing `autoSelectNext()` logic to select the top unlabeled media item according to the current sort state
- This allows users to quickly return to the autopilot suggestion without having to manually navigate or switch tabs

https://claude.ai/code/session_01HuwBg8LUQ6fujMLFWEPkXk