### PR TITLE
Stop media playback on component destruction

### DIFF
--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -54,6 +54,12 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   ngOnDestroy(): void {
+    const audio = this.audioRef?.nativeElement;
+    if (audio) {
+      audio.pause();
+      audio.removeAttribute('src');
+      audio.load();
+    }
     if (this.audioCtx && this.audioCtx.state !== 'closed') {
       this.audioCtx.close();
     }

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -60,8 +60,25 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.stopPlayback();
     this.keyboard.stop();
     this.subs.forEach((s) => s.unsubscribe());
+  }
+
+  /** Stop all media playback (used on navigation away). */
+  stopPlayback(): void {
+    if (this.audioPlayer) {
+      const audio = this.audioPlayer.audioRef?.nativeElement;
+      if (audio) {
+        audio.pause();
+      }
+    }
+    if (this.videoPlayer) {
+      const video = this.videoPlayer.videoRef?.nativeElement;
+      if (video) {
+        video.pause();
+      }
+    }
   }
 
   /** Initialize: load settings, start keyboard listener. */

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MediaItem } from '../../../models/api.models';
 
 @Component({
@@ -7,7 +7,7 @@ import { MediaItem } from '../../../models/api.models';
   templateUrl: './video-player.component.html',
   styleUrl: './video-player.component.scss',
 })
-export class VideoPlayerComponent implements OnChanges {
+export class VideoPlayerComponent implements OnChanges, OnDestroy {
   @Input() media!: MediaItem;
   @Input() volume = 1;
   @Input() audioPlaying = true;
@@ -26,6 +26,15 @@ export class VideoPlayerComponent implements OnChanges {
     }
     if (changes['audioPlaying'] && !changes['media'] && this.videoRef?.nativeElement) {
       this.syncPlaybackState();
+    }
+  }
+
+  ngOnDestroy(): void {
+    const video = this.videoRef?.nativeElement;
+    if (video) {
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
     }
   }
 


### PR DESCRIPTION
## Summary
This PR ensures that audio and video playback is properly stopped and cleaned up when components are destroyed or navigation occurs, preventing media from continuing to play in the background.

## Key Changes
- **CenterPanelComponent**: Added `stopPlayback()` method that pauses both audio and video players when the component is destroyed
- **AudioPlayerComponent**: Implemented `ngOnDestroy()` lifecycle hook to pause audio, remove the src attribute, and close the Web Audio API context
- **VideoPlayerComponent**: Implemented `ngOnDestroy()` lifecycle hook to pause video and clean up the src attribute

## Implementation Details
- The `stopPlayback()` method in CenterPanelComponent safely accesses native audio/video elements through template references and pauses playback
- Both audio and video player components now properly clean up their media elements by:
  - Pausing playback
  - Removing the `src` attribute
  - Calling `load()` to reset the media element state
- The AudioPlayerComponent also ensures the Web Audio API context is closed if it exists
- These changes prevent memory leaks and unwanted background audio/video playback when navigating away from the component

https://claude.ai/code/session_01RcCjuYVJRjeoVSwDw68fsf