### PR TITLE
Replace emoji icon with SVG in export modal clipboard tab

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -106,7 +106,7 @@
         [class.active]="activeTab === 'clipboard'"
         (click)="activeTab = 'clipboard'"
       >
-        <span class="tab-icon">&#x1F4CB;</span> Clipboard
+        <svg class="tab-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg> Clipboard
       </button>
 
       <!-- Exporter tabs -->

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -163,6 +163,12 @@
   font-size: 1rem;
 }
 
+.tab-icon-svg {
+  width: 1rem;
+  height: 1rem;
+  vertical-align: middle;
+}
+
 .tab-content {
   border: 1px solid var(--border);
   border-top: none;


### PR DESCRIPTION
## Summary
Replaced the Unicode clipboard emoji icon with a scalable SVG icon in the export modal's clipboard tab for better visual consistency and control.

## Key Changes
- Replaced `&#x1F4CB;` emoji character with an inline SVG clipboard icon in the clipboard tab button
- Added new `.tab-icon-svg` CSS class to style the SVG icon with consistent sizing (1rem × 1rem) and vertical alignment
- The SVG uses a stroke-based design matching common icon library patterns (viewBox="0 0 24 24", stroke-width="2")

## Implementation Details
- The SVG icon is a clipboard with a document representation, using `currentColor` for stroke to inherit text color
- The new CSS class ensures the icon is properly sized and aligned with the adjacent "Clipboard" text label
- This change improves icon rendering quality and provides better design flexibility compared to emoji characters

https://claude.ai/code/session_0125RxZCRVohTu2tAaoL6gR9