### PR TITLE
Restore saved labels when loading trainable models

### DIFF
--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -435,6 +435,76 @@ class TestLoadModelEndpoint:
         res = client.post("/api/models/registry/load", json={"model_id": "nope"})
         assert res.status_code == 404
 
+    def test_load_clears_previous_labels(self, client):
+        """Loading model B must not carry over labels from model A."""
+        from vtsearch.utils import bad_votes, good_votes, medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        ids = list(medias.keys())
+
+        # Create two trainable models + registry entries.
+        for name in ("ModelA", "ModelB"):
+            client.post(
+                "/api/trainable-models",
+                json={"name": name, "media_type": "audio", "text_query": "test"},
+            )
+        res_a = client.post(
+            "/api/models/registry",
+            json={"name": "ModelA", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        mid_a = res_a.get_json()["model"]["id"]
+        res_b = client.post(
+            "/api/models/registry",
+            json={"name": "ModelB", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        mid_b = res_b.get_json()["model"]["id"]
+
+        # Load model A and cast some votes.
+        client.post("/api/models/registry/load", json={"model_id": mid_a})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{ids[1]}/vote", json={"vote": "bad"})
+        assert ids[0] in good_votes
+        assert ids[1] in bad_votes
+
+        # Now load model B — votes from A must be gone.
+        client.post("/api/models/registry/load", json={"model_id": mid_b})
+        assert ids[0] not in good_votes, "good vote from model A leaked into model B"
+        assert ids[1] not in bad_votes, "bad vote from model A leaked into model B"
+
+    def test_load_restores_saved_labels(self, client):
+        """Loading a model that has a saved labelset should restore its labels."""
+        from vtsearch.utils import good_votes, medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        ids = list(medias.keys())
+
+        # Create model, load it, vote, then save labels.
+        client.post(
+            "/api/trainable-models",
+            json={"name": "Persist", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/models/registry",
+            json={"name": "Persist", "media_type": "audio", "trainable": True, "text_query": "test"},
+        )
+        mid = res.get_json()["model"]["id"]
+        client.post("/api/models/registry/load", json={"model_id": mid})
+        client.post(f"/api/medias/{ids[0]}/vote", json={"vote": "good"})
+        # Labels auto-sync on vote, so the trainable model file now has 1 label.
+
+        # Unload to clear votes, then reload — label should be restored.
+        client.post("/api/models/registry/load", json={"model_id": None})
+        assert ids[0] not in good_votes
+
+        res = client.post("/api/models/registry/load", json={"model_id": mid})
+        assert res.status_code == 200
+        assert res.get_json().get("labels_restored", 0) >= 1
+        assert ids[0] in good_votes, "saved label was not restored on model load"
+
 
 class TestVoteSyncsToLoadedModel:
     """Voting while a trainable model is loaded should auto-update the model's labelset."""

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -230,6 +230,48 @@ def _seed_good_votes_from_examples(examples: list[dict]) -> int:
     return seeded
 
 
+def _restore_labels_from_trainable_model(tm_data: dict) -> int:
+    """Restore saved labels from a trainable model's labelset into votes.
+
+    Matches labelset entries to loaded medias by origin+origin_name and MD5,
+    then applies each label.  Returns the number of labels successfully
+    restored.
+    """
+    from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.utils import (
+        apply_label,
+        build_media_lookup,
+        resolve_media_ids,
+        snapshot_medias,
+    )
+
+    labelset_dict = tm_data.get("labelset")
+    if not labelset_dict:
+        return 0
+
+    labelset = LabelSet.from_dict(labelset_dict)
+    if not labelset.elements:
+        return 0
+
+    snap = snapshot_medias()
+    if not snap:
+        return 0
+
+    origin_lookup, md5_lookup = build_media_lookup(snap)
+
+    restored = 0
+    for elem in labelset.elements:
+        if elem.label not in ("good", "bad"):
+            continue
+        cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup)
+        for cid in cids:
+            apply_label(cid, elem.label)
+        if cids:
+            restored += 1
+
+    return restored
+
+
 def _list_all() -> list[dict]:
     """Return summary info for every trainable model on disk."""
     tm_dir = get_trainable_models_dir()
@@ -574,12 +616,15 @@ def load_model_route():
 
     Pass ``model_id: null`` to unload.
 
-    When loading a model that has media examples, any example files whose
-    MD5 matches a loaded media item are automatically added to
-    ``good_votes`` so that the labeling session starts with those examples
-    pre-labeled as Good.
+    When loading a trainable model:
+
+    1. The current model's labels are saved (auto-sync).
+    2. All votes are cleared so labels from the previous session don't leak.
+    3. The new model's saved labelset is restored into votes.
+    4. Media examples are seeded as good votes.
     """
-    from vtsearch.models.registry import get_model, set_loaded_id
+    from vtsearch.models.registry import get_loaded_id, get_model, set_loaded_id
+    from vtsearch.utils import clear_votes
 
     data = request.get_json(force=True, silent=True) or {}
     model_id = data.get("model_id")
@@ -589,20 +634,32 @@ def load_model_route():
         if entry is None:
             return jsonify({"error": "Model not found"}), 404
 
+    # Save current model's labels before switching.
+    sync_labels_to_loaded_model()
+
+    # Clear votes so labels from the previous session don't carry over.
+    clear_votes()
+
     set_loaded_id(model_id)
 
-    # Seed good votes from media examples on the loaded model.
+    # Restore saved labels and seed examples from the newly loaded model.
+    labels_restored = 0
     examples_seeded = 0
     if model_id is not None and entry is not None:
         tm_name = entry.get("trainable_model_name", "")
         if tm_name:
             tm_data = _read_model(_model_path(tm_name))
             if tm_data:
+                labels_restored = _restore_labels_from_trainable_model(tm_data)
                 examples_seeded = _seed_good_votes_from_examples(
                     tm_data.get("examples", [])
                 )
 
-    return jsonify({"ok": True, "examples_seeded": examples_seeded})
+    return jsonify({
+        "ok": True,
+        "labels_restored": labels_restored,
+        "examples_seeded": examples_seeded,
+    })
 
 
 @trainable_models_bp.route("/api/models/registry/<model_id>", methods=["DELETE"])


### PR DESCRIPTION
## Summary
This PR adds label persistence to trainable model loading. When switching between trainable models, the system now:
1. Saves the current model's labels before switching
2. Clears all votes to prevent label leakage between sessions
3. Restores the newly loaded model's previously saved labels
4. Seeds media examples as good votes (existing behavior)

## Key Changes
- **New function `_restore_labels_from_trainable_model()`**: Restores saved labels from a trainable model's labelset into votes by matching labelset entries to loaded medias by origin+origin_name and MD5
- **Updated `load_model_route()`**: 
  - Now calls `sync_labels_to_loaded_model()` to save the current model's labels before switching
  - Calls `clear_votes()` to prevent label leakage between sessions
  - Calls `_restore_labels_from_trainable_model()` to restore the new model's saved labels
  - Returns `labels_restored` count in the response alongside `examples_seeded`
  - Updated docstring to document the new behavior
- **New tests**:
  - `test_load_clears_previous_labels()`: Verifies that loading a different model clears votes from the previous session
  - `test_load_restores_saved_labels()`: Verifies that loading a model restores its previously saved labels

## Implementation Details
- Label restoration uses the same media lookup mechanism (`build_media_lookup`, `resolve_media_ids`) as the existing example seeding functionality
- Only "good" and "bad" labels are restored (other label types are skipped)
- The restoration count is returned to the client for visibility into the operation

https://claude.ai/code/session_01EcFCuYw8MHJcE9TWvtEexv