### PR TITLE
Add frontend TypeScript build check to run-tests.sh

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -32,10 +32,15 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu \
   -e ".[cpu,dev]" \
   -q
 
-# Install frontend (Angular) dependencies if not already present
-if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
-  echo "Installing frontend dependencies..."
-  (cd frontend && npm install --no-audit --no-fund -q)
+# Install frontend (Angular) dependencies.
+# Re-run npm install whenever package-lock.json is newer than node_modules,
+# so added/removed packages are always in sync.
+if [ -f "frontend/package.json" ]; then
+  if [ ! -d "frontend/node_modules" ] || \
+     [ "frontend/package-lock.json" -nt "frontend/node_modules" ]; then
+    echo "Installing frontend dependencies..."
+    (cd frontend && npm install --no-audit --no-fund -q)
+  fi
 fi
 
 touch "$MARKER"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 Media explorer web app for browsing/voting on audio, images, text, video, or documents. Semantic sorting (LAION-CLAP, CLIP, X-CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + Angular + PyTorch.
 
 ## Commands
-- **Run tests (CPU, fast)**: `./run-tests.sh`
-- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below)
+- **Run tests (CPU, fast)**: `./run-tests.sh` (also checks frontend TypeScript build)
+- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; `core` includes frontend build check)
 - **Run multiple groups**: `./run-tests.sh core sorting api`
 - **Run tests with extra args**: `./run-tests.sh core -- -x --tb=long` (args after `--` go to pytest)
 - **Run tests (CPU, full)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -q --tb=short -m 'not gpu'`

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,10 +2,10 @@
 # Run tests with minimal output and a clear PASS/FAIL summary.
 #
 # Usage:
-#   ./run-tests.sh              # run all fast tests (default)
-#   ./run-tests.sh core         # run only core group
+#   ./run-tests.sh              # run all fast tests (default) + frontend build check
+#   ./run-tests.sh core         # run only core group + frontend build check
 #   ./run-tests.sh sorting      # run only sorting group
-#   ./run-tests.sh core sorting # run core + sorting groups
+#   ./run-tests.sh core sorting # run core + sorting groups + frontend build check
 #
 # Available groups: core, api, sorting, datasets, io, models,
 #                   downloads, integration, cli, converters
@@ -35,6 +35,39 @@ for arg in "$@"; do
         TEST_GROUPS+=("$arg")
     fi
 done
+
+# Run frontend TypeScript build check for full suite or when core/frontend groups are requested.
+# Catches compilation errors without needing a browser (ng test requires Chrome, build:prod does not).
+_run_frontend_check=false
+if [[ ${#TEST_GROUPS[@]} -eq 0 ]]; then
+    _run_frontend_check=true
+else
+    for _g in "${TEST_GROUPS[@]}"; do
+        if [[ "$_g" == "core" || "$_g" == "frontend" ]]; then
+            _run_frontend_check=true
+            break
+        fi
+    done
+fi
+
+if $_run_frontend_check && [ -d "frontend/node_modules" ]; then
+    echo "Checking frontend TypeScript build..."
+    _fe_log=$(mktemp)
+    if (cd frontend && npm run build:prod 2>&1) > "$_fe_log"; then
+        echo "Frontend build OK"
+    else
+        echo ""
+        echo "======================================================================"
+        echo "FRONTEND BUILD FAILED"
+        echo "======================================================================"
+        cat "$_fe_log"
+        rm -f "$_fe_log"
+        exit 1
+    fi
+    rm -f "$_fe_log"
+elif $_run_frontend_check && [ ! -d "frontend/node_modules" ]; then
+    echo "Skipping frontend build check (node_modules not installed; run: cd frontend && npm install)"
+fi
 
 # Build the pytest marker expression
 if [[ ${#TEST_GROUPS[@]} -eq 0 ]]; then


### PR DESCRIPTION
./run-tests.sh and ./run-tests.sh core now run npm run build:prod before pytest, so TypeScript/Angular compiler errors are caught automatically without needing Chrome. Focused group runs (sorting, api, etc.) are unaffected.

Also update ensure-test-deps.sh to re-run npm install whenever package-lock.json is newer than node_modules, keeping deps in sync after package changes.

https://claude.ai/code/session_016bKHxR5McgbSJbS4Jj8tTG