### PR TITLE
Hide import labels button in find mode

### DIFF
--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -5,9 +5,11 @@
     (renamed)="onDetectorRenamed($event)"
   />
 
-  <div class="import-row">
-    <button class="panel-btn import-btn" [disabled]="disabled" (click)="onImportLabels()">Import Labels</button>
-  </div>
+  @if (mode !== 'find') {
+    <div class="import-row">
+      <button class="panel-btn import-btn" [disabled]="disabled" (click)="onImportLabels()">Import Labels</button>
+    </div>
+  }
 
   <div class="sort-row">
     <vt-label-sort


### PR DESCRIPTION
## Summary
Conditionally hide the "Import Labels" button when the component is in 'find' mode by wrapping it with an Angular `@if` control flow directive.

## Key Changes
- Wrapped the import labels button and its container div with `@if (mode !== 'find')` conditional block
- This prevents the import functionality from being accessible when the right panel is in find mode

## Implementation Details
- Uses Angular's new control flow syntax (`@if`) instead of `*ngIf`
- The button remains fully functional in all other modes
- The conditional check is performed at the template level, ensuring the DOM element is not rendered rather than just hidden

https://claude.ai/code/session_01HuwRdvdRMCkerk9sVd2K6Q