### PR TITLE
Update frontend setup documentation to reflect build requirement

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -144,9 +144,9 @@ bash install-gpu.sh cu124    # for CUDA 12.4
 
 The `--extra-index-url` flag pulls the smaller CPU-only PyTorch wheel (~200 MB) instead of the default CUDA build (~2 GB). The `install-gpu.sh` script handles selecting the right CUDA version.
 
-## Building the frontend (optional)
+## Building the frontend
 
-The Angular frontend is pre-built and committed to `static/`, so you can skip this step if you're only working on the backend. If you need to modify the frontend, you'll need **Node.js 18+** and **npm**.
+The Angular frontend must be built after checking out the code — the compiled files are not committed to Git. You'll need **Node.js 18+** and **npm**.
 
 Check if they're installed:
 


### PR DESCRIPTION
## Summary
Updated the frontend setup documentation to clarify that building the Angular frontend is a required step, not optional.

## Changes
- Changed section heading from "Building the frontend (optional)" to "Building the frontend" to indicate this is a required step
- Updated the description to clarify that compiled frontend files are not committed to Git and must be built after checking out the code
- Removed the language suggesting this step could be skipped for backend-only work

## Details
The documentation previously suggested that the frontend build was optional since pre-built files were committed to the repository. This change reflects a shift in the project's approach to not commit compiled frontend artifacts to Git, making the build step mandatory for all developers.

https://claude.ai/code/session_01ETWa4Qr279sPwWAg1G3BC7