### PR TITLE
Replace emoji icons with SVG icon type names

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -63,8 +63,8 @@ describe('DatasetImporterModalComponent', () => {
   ];
 
   const mockMediaTypes = [
-    { type_id: 'audio', name: 'Audio', icon: '\uD83C\uDFB5', tab_title: 'Audio' },
-    { type_id: 'images', name: 'Images', icon: '\uD83D\uDDBC\uFE0F', tab_title: 'Images' },
+    { type_id: 'audio', name: 'Audio', icon: 'audio', tab_title: 'Audio' },
+    { type_id: 'images', name: 'Images', icon: 'image', tab_title: 'Images' },
   ];
 
   beforeEach(async () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -356,7 +356,7 @@ export class DatasetImporterModalComponent implements OnInit {
   getMediaTypeOptionLabel(opt: string): string {
     const mt = this.mediaTypes.find((m) => m.folder_import_name === opt);
     if (mt) {
-      return `${mt.icon || ''} ${mt.tab_title || mt.name}`.trim();
+      return (mt.tab_title || mt.name).trim();
     }
     return opt;
   }
@@ -364,7 +364,7 @@ export class DatasetImporterModalComponent implements OnInit {
   getTabLabel(mediaType: string): string {
     const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
     if (mt) {
-      return `${mt.icon || ''} ${mt.tab_title || mt.name}`.trim();
+      return (mt.tab_title || mt.name).trim();
     }
     return mediaType;
   }

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -332,7 +332,7 @@ export class NewModelModalComponent implements OnInit {
   getMediaTypeLabel(typeId: string): string {
     const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
     if (mt) {
-      return `${mt.icon || ''} ${mt.tab_title || mt.name}`.trim();
+      return (mt.tab_title || mt.name).trim();
     }
     return typeId;
   }

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -5,17 +5,21 @@ import { CommonModule } from '@angular/common';
  * Maps emoji strings (from backend or hardcoded) to an SVG icon type.
  * Falls back to a generic "file" icon for unrecognised values.
  */
+const KNOWN_TYPES = new Set([
+  'audio', 'image', 'file-text', 'video', 'document',
+  'server', 'globe', 'email', 'satellite',
+  'folder', 'folder-open', 'upload',
+  'graduation', 'arrow-up', 'shuffle', 'elephant', 'cloud',
+  'check', 'warning', 'x-circle', 'info', 'file',
+]);
+
 function emojiToType(icon: string): string {
   if (!icon) return '';
+  // Pass through known SVG type names directly
+  if (KNOWN_TYPES.has(icon)) return icon;
   // Normalise: strip variation selectors (U+FE0E, U+FE0F)
   const norm = icon.replace(/[\uFE0E\uFE0F]/g, '');
   const map: Record<string, string> = {
-    // Media types
-    '\uD83D\uDD0A': 'audio',       // 🔊
-    '\uD83D\uDDBC': 'image',       // 🖼
-    '\uD83D\uDCC4': 'file-text',   // 📄
-    '\uD83C\uDFAC': 'video',       // 🎬
-    '\uD83D\uDCD1': 'document',    // 📑
     // Infrastructure
     '\uD83D\uDDA5': 'server',      // 🖥
     '\uD83C\uDF10': 'globe',       // 🌐

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -27,8 +27,8 @@ describe('SettingsModalComponent', () => {
 
   const mockMediaTypes = {
     media_types: [
-      { type_id: 'audio', name: 'Sound', icon: '\uD83D\uDD0A' },
-      { type_id: 'image', name: 'Image', icon: '\uD83D\uDDBC\uFE0F' },
+      { type_id: 'audio', name: 'Sound', icon: 'audio' },
+      { type_id: 'image', name: 'Image', icon: 'image' },
     ],
   };
 
@@ -182,8 +182,8 @@ describe('SettingsModalComponent', () => {
 
   it('should return media type icon for embedder', () => {
     flushInit();
-    expect(component.getMediaTypeIcon('audio')).toBe('\uD83D\uDD0A');
-    expect(component.getMediaTypeIcon('image')).toBe('\uD83D\uDDBC\uFE0F');
+    expect(component.getMediaTypeIcon('audio')).toBe('audio');
+    expect(component.getMediaTypeIcon('image')).toBe('image');
     expect(component.getMediaTypeIcon('unknown')).toBe('');
   });
 

--- a/tests/test_document_and_converters.py
+++ b/tests/test_document_and_converters.py
@@ -103,7 +103,7 @@ class TestDocumentMediaType:
 
     def test_icon(self):
         mt = DocumentMediaType()
-        assert mt.icon == "📑"
+        assert mt.icon == "document"
 
     def test_file_extensions(self):
         mt = DocumentMediaType()

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -41,7 +41,7 @@ class AudioMediaType(MediaType):
 
     @property
     def icon(self) -> str:
-        return "🔊"
+        return "audio"
 
     # ------------------------------------------------------------------
     # File import

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -461,7 +461,7 @@ class MediaType(ABC):
     @property
     @abstractmethod
     def icon(self) -> str:
-        """Icon for the UI (emoji or icon name), e.g. ``"🔊"``."""
+        """SVG icon type name for the UI, e.g. ``"audio"``."""
 
     # ------------------------------------------------------------------
     # File import

--- a/vtsearch/media/document/media_type.py
+++ b/vtsearch/media/document/media_type.py
@@ -51,7 +51,7 @@ class DocumentMediaType(MediaType):
 
     @property
     def icon(self) -> str:
-        return "📑"
+        return "document"
 
     # ------------------------------------------------------------------
     # File import

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -48,7 +48,7 @@ class ImageMediaType(MediaType):
 
     @property
     def icon(self) -> str:
-        return "🖼️"
+        return "image"
 
     # ------------------------------------------------------------------
     # File import

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -40,7 +40,7 @@ class TextMediaType(MediaType):
 
     @property
     def icon(self) -> str:
-        return "📄"
+        return "file-text"
 
     # ------------------------------------------------------------------
     # File import

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -45,7 +45,7 @@ class VideoMediaType(MediaType):
 
     @property
     def icon(self) -> str:
-        return "🎬"
+        return "video"
 
     # ------------------------------------------------------------------
     # File import


### PR DESCRIPTION
## Summary
This PR replaces emoji icons with SVG icon type names throughout the codebase. The backend now returns icon identifiers (e.g., `"audio"`, `"image"`) instead of emoji characters, and the frontend's icon component has been updated to handle both emoji-to-icon mapping and direct SVG type name pass-through.

## Key Changes

- **Backend media types**: Updated all media type classes to return SVG icon type names instead of emoji:
  - Audio: `"🔊"` → `"audio"`
  - Image: `"🖼️"` → `"image"`
  - Text: `"📄"` → `"file-text"`
  - Video: `"🎬"` → `"video"`
  - Document: `"📑"` → `"document"`

- **Frontend icon component**: Enhanced `emojiToType()` function to:
  - Recognize and pass through known SVG type names directly
  - Maintain backward compatibility with emoji-to-icon mapping for legacy data
  - Added `KNOWN_TYPES` set containing all supported SVG icon identifiers

- **Frontend UI components**: Removed emoji concatenation from media type labels in:
  - `DatasetImporterModalComponent`
  - `NewModelModalComponent`
  - Labels now display only the media type name without icon prefix

- **Tests**: Updated test expectations to use SVG icon type names instead of emoji characters

## Implementation Details

The icon component now prioritizes known SVG type names, allowing the backend to send semantic icon identifiers while maintaining support for emoji input through the existing mapping logic. This provides a cleaner separation between data representation and UI presentation.

https://claude.ai/code/session_01WNqN7nAxr7stvKqkYb4drP