### PR TITLE
Report determinate progress during archive extraction

### DIFF
--- a/tests/test_download_and_extract.py
+++ b/tests/test_download_and_extract.py
@@ -262,3 +262,142 @@ class TestDownloadAndExtract:
         messages = [msg for _, msg in progress_calls]
         assert any("Starting MyDataset download" in m for m in messages)
         assert any("Extracting MyDataset" in m for m in messages)
+
+    def test_extraction_progress_has_total(self, tmp_path):
+        """Extraction progress reports current/total counts (not indeterminate 0/0)."""
+        from vtsearch.datasets import downloader as dl_module
+
+        staging = tmp_path / "staging_area"
+        staging.mkdir()
+        tar_path = _make_tar_gz(staging, arcname="data_dir")
+        progress_calls = []
+
+        def track_progress(status, msg, cur, tot):
+            progress_calls.append((status, msg, cur, tot))
+
+        data_dir = tmp_path / "data"
+
+        with (
+            patch.object(dl_module, "DATA_DIR", data_dir),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: tar_path.rename(dest),
+            ),
+        ):
+            dl_module._download_and_extract(
+                url="http://example.com/test.tar.gz",
+                archive_name="test.tar.gz",
+                extract_to=data_dir / "extracted",
+                check_path=data_dir / "extracted" / "data_dir",
+                download_size_mb=1,
+                dataset_name="MyDataset",
+                on_progress=track_progress,
+            )
+
+        # Find extraction progress calls (not the initial 0/0 announcement)
+        extract_progress = [
+            (msg, cur, tot)
+            for _, msg, cur, tot in progress_calls
+            if "Extracting" in msg and tot > 0
+        ]
+        assert len(extract_progress) > 0, "Expected determinate extraction progress"
+        last_msg, last_cur, last_tot = extract_progress[-1]
+        assert last_cur == last_tot, "Final progress should show completion"
+
+
+class TestCaltech101ExtractionProgress:
+    """Caltech-101 inner tar extraction reports determinate progress."""
+
+    def test_inner_tar_reports_progress(self, tmp_path):
+        from vtsearch.datasets import downloader as dl_module
+
+        # Build a fake caltech-101.zip containing a nested tar.gz
+        inner_staging = tmp_path / "inner_staging" / "101_ObjectCategories"
+        inner_staging.mkdir(parents=True)
+        for i in range(5):
+            (inner_staging / f"img_{i}.jpg").write_bytes(b"fake")
+
+        inner_tar_path = tmp_path / "101_ObjectCategories.tar.gz"
+        with tarfile.open(inner_tar_path, "w:gz") as tf:
+            tf.add(inner_staging, arcname="101_ObjectCategories")
+
+        outer_zip_path = tmp_path / "caltech-101.zip"
+        with zipfile.ZipFile(outer_zip_path, "w") as zf:
+            zf.write(inner_tar_path, "101_ObjectCategories.tar.gz")
+
+        progress_calls = []
+
+        def track(status, msg, cur, tot):
+            progress_calls.append((status, msg, cur, tot))
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        with (
+            patch.object(dl_module, "DATA_DIR", data_dir),
+            patch.object(dl_module, "IMAGE_DIR", data_dir / "images"),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: __import__("shutil").copy(str(outer_zip_path), str(dest)),
+            ),
+        ):
+            result = dl_module.download_caltech101(on_progress=track)
+
+        assert result.exists()
+
+        # The inner tar extraction should report determinate progress
+        inner_progress = [
+            (msg, cur, tot)
+            for _, msg, cur, tot in progress_calls
+            if "Extracting 101_ObjectCategories" in msg and tot > 0
+        ]
+        assert len(inner_progress) > 0, "Inner tar extraction should report progress with total"
+        last_msg, last_cur, last_tot = inner_progress[-1]
+        assert last_cur == last_tot
+
+
+class TestBbcNewsExtractionProgress:
+    """BBC News zip extraction reports determinate progress."""
+
+    def test_zip_reports_progress(self, tmp_path):
+        from vtsearch.datasets import downloader as dl_module
+
+        # Build a fake BBC News zip
+        zip_path = tmp_path / "bbc-news.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for cat in ("business", "entertainment", "politics", "sport", "tech"):
+                for i in range(3):
+                    zf.writestr(f"bbc/{cat}/{i:03d}.txt", f"Article {cat} {i}")
+
+        progress_calls = []
+
+        def track(status, msg, cur, tot):
+            progress_calls.append((status, msg, cur, tot))
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        with (
+            patch.object(dl_module, "DATA_DIR", data_dir),
+            patch.object(dl_module, "IMAGE_DIR", data_dir / "images"),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: __import__("shutil").copy(str(zip_path), str(dest)),
+            ),
+        ):
+            result = dl_module.download_bbc_news(on_progress=track)
+
+        assert result.exists()
+
+        # The zip extraction should report determinate progress
+        extract_progress = [
+            (msg, cur, tot)
+            for _, msg, cur, tot in progress_calls
+            if "Extracting BBC News dataset" in msg and tot > 0
+        ]
+        assert len(extract_progress) > 0, "BBC News extraction should report progress with total"
+        last_msg, last_cur, last_tot = extract_progress[-1]
+        assert last_cur == last_tot

--- a/tests/test_download_and_extract.py
+++ b/tests/test_download_and_extract.py
@@ -324,7 +324,8 @@ class TestCaltech101ExtractionProgress:
 
         outer_zip_path = tmp_path / "caltech-101.zip"
         with zipfile.ZipFile(outer_zip_path, "w") as zf:
-            zf.write(inner_tar_path, "101_ObjectCategories.tar.gz")
+            # Real zip extracts to DATA_DIR; inner tar must land under caltech-101/
+            zf.write(inner_tar_path, "caltech-101/101_ObjectCategories.tar.gz")
 
         progress_calls = []
 
@@ -390,7 +391,9 @@ class TestBbcNewsExtractionProgress:
         ):
             result = dl_module.download_bbc_news(on_progress=track)
 
-        assert result.exists()
+        # download_bbc_news returns a dict of category -> articles
+        assert isinstance(result, dict)
+        assert len(result) > 0
 
         # The zip extraction should report determinate progress
         extract_progress = [

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -421,7 +421,17 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
         if inner_tar.exists() and not categories_dir.exists():
             on_progress("downloading", "Extracting 101_ObjectCategories...", 0, 0)
             with tarfile.open(inner_tar, "r:gz") as tar_ref:
-                tar_ref.extractall(extract_dir, filter="data")
+                members = tar_ref.getmembers()
+                total = len(members)
+                for i, member in enumerate(members):
+                    if i % 100 == 0 or i == total - 1:
+                        on_progress(
+                            "downloading",
+                            f"Extracting 101_ObjectCategories ({i + 1}/{total})...",
+                            i + 1,
+                            total,
+                        )
+                    tar_ref.extract(member, extract_dir, filter="data")
             inner_tar.unlink(missing_ok=True)
 
     return categories_dir
@@ -820,7 +830,17 @@ def download_bbc_news(
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             # The zip may contain a top-level folder (e.g. "bbc/"); extract
             # all members and then locate category directories below.
-            zip_ref.extractall(DATA_DIR / "bbc-fulltext-raw")
+            members = zip_ref.namelist()
+            total = len(members)
+            for i, member in enumerate(members):
+                if i % 100 == 0 or i == total - 1:
+                    on_progress(
+                        "downloading",
+                        f"Extracting BBC News dataset ({i + 1}/{total})...",
+                        i + 1,
+                        total,
+                    )
+                zip_ref.extract(member, DATA_DIR / "bbc-fulltext-raw")
 
         # Find the directory that contains the category subfolders.
         raw_root = DATA_DIR / "bbc-fulltext-raw"


### PR DESCRIPTION
## Summary
This PR improves the user experience during dataset extraction by reporting determinate progress (current/total counts) instead of indeterminate progress (0/0). Previously, extraction operations would report progress without a known total, making it impossible for users to gauge completion. Now, the code counts archive members upfront and reports progress as each member is extracted.

## Key Changes
- **Generic tar.gz extraction**: Modified `_download_and_extract()` to iterate through tar members and report progress with current/total counts, updating every 100 members or at completion
- **Caltech-101 inner tar extraction**: Updated `download_caltech101()` to report determinate progress when extracting the nested `101_ObjectCategories.tar.gz` file
- **BBC News zip extraction**: Updated `download_bbc_news()` to report determinate progress when extracting the BBC News dataset zip file
- **Test coverage**: Added three new test classes with comprehensive test cases:
  - `test_extraction_progress_has_total`: Verifies generic tar.gz extraction reports determinate progress
  - `TestCaltech101ExtractionProgress`: Verifies inner tar extraction reports progress with total
  - `TestBbcNewsExtractionProgress`: Verifies zip extraction reports progress with total

## Implementation Details
- Progress callbacks are invoked at regular intervals (every 100 members) and always at completion to avoid excessive callback overhead
- The final progress report always shows `current == total` to clearly indicate completion
- All extraction operations maintain the same security filter (`filter="data"`) to prevent path traversal attacks
- Tests use mocking to avoid actual network downloads while validating progress reporting behavior

https://claude.ai/code/session_01HmQbn3YBaAwfcXngRNt2WW