### PR TITLE
Add required_folder paths to image dataset configurations

### DIFF
--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -393,14 +393,16 @@ class DemoDataset:
     Leave empty for sources that don't require an explicit identifier."""
 
     required_folder: Optional[Path] = None
-    """Local directory that must exist for a cached ``.pkl`` to be usable.
+    """Local directory containing the extracted source files for this dataset.
 
-    Audio and video datasets store references to external media files rather
-    than inlining the bytes, so a stale ``.pkl`` left behind after the source
-    directory was removed would incorrectly appear ready.  Set this to the
-    directory that the importer places the source files into (e.g.
-    ``DATA_DIR / "ESC-50-master" / "audio"``).  Leave ``None`` for datasets
-    whose ``.pkl`` is entirely self-contained (images, text)."""
+    Used both as a staleness check (a cached ``.pkl`` is only considered valid
+    when this directory still exists on disk) and as the browsable root for
+    the *Select Media Example* file picker.  Set this to the directory that the
+    downloader extracts source files into (e.g.
+    ``DATA_DIR / "ESC-50-master" / "audio"`` or
+    ``DATA_DIR / "caltech-101" / "101_ObjectCategories"``).
+    Leave ``None`` only for datasets that have no on-disk source directory
+    (e.g. text datasets generated from in-memory data)."""
 
     slice_start: int = 0
     """Per-category start index for element slicing (inclusive).

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import numpy as np
 
+from vtsearch.config import DATA_DIR
 from vtsearch.media.base import (
     DemoDataset,
     MediaResponse,
@@ -228,48 +229,56 @@ class ImageMediaType(MediaType):
                 id="caltech101_s", label="Caltech-101 (S)",
                 description="Centered, well-lit object photos — a classic vision benchmark.",
                 categories=cats101, source="caltech101",
+                required_folder=DATA_DIR / "caltech-101" / "101_ObjectCategories",
                 slice_start=0, slice_end=20, download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="caltech101_m", label="Caltech-101 (M)",
                 description="Centered, well-lit object photos — a classic vision benchmark.",
                 categories=cats101, source="caltech101",
+                required_folder=DATA_DIR / "caltech-101" / "101_ObjectCategories",
                 slice_start=20, slice_end=60, download_size_mb=CALTECH101_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="caltech256_l", label="Caltech-256 (L)",
                 description="Harder object photos with more varied, cluttered backgrounds than Caltech-101.",
                 categories=cats256, source="caltech256",
+                required_folder=DATA_DIR / "caltech-256" / "256_ObjectCategories",
                 slice_start=0, slice_end=80, download_size_mb=CALTECH256_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="oxford_flowers_102_a", label="Oxford Flowers 102 (A)",
                 description="Close-up flower photography with fine-grained species variation.",
                 categories=self._OXFORD_FLOWERS_CATEGORIES, source="oxford_flowers_102",
+                required_folder=DATA_DIR / "oxford_flowers",
                 slice_start=0, slice_end=80, download_size_mb=OXFORD_FLOWERS_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="food101_a", label="Food-101 (A)",
                 description="Crowd-sourced food photos, some mislabeled — a deliberately noisy benchmark.",
                 categories=self._FOOD101_CATEGORIES, source="food101",
+                required_folder=DATA_DIR / "food-101" / "images",
                 slice_start=0, slice_end=1000, download_size_mb=FOOD101_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="eurosat_a", label="EuroSAT (A)",
                 description="Sentinel-2 satellite imagery classified by land use type.",
                 categories=self._EUROSAT_CATEGORIES, source="eurosat",
+                required_folder=DATA_DIR / "EuroSAT_RGB",
                 slice_start=0, slice_end=2700, download_size_mb=EUROSAT_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="stanford_dogs_a", label="Stanford Dogs (A)",
                 description="Fine-grained dog breed photos — many visually similar breeds.",
                 categories=self._STANFORD_DOGS_CATEGORIES, source="stanford_dogs",
+                required_folder=DATA_DIR / "stanford_dogs" / "Images",
                 slice_start=0, slice_end=171, download_size_mb=STANFORD_DOGS_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
                 id="ucsf_documents_a", label="UCSF Documents (A)",
                 description="Scanned industry document pages from the UCSF Industry Documents Library.",
                 categories=self._UCSF_DOCUMENTS_CATEGORIES, source="ucsf_documents",
+                required_folder=DATA_DIR / "ucsf_documents",
                 slice_start=0, slice_end=25, download_size_mb=UCSF_IDL_DOWNLOAD_SIZE_MB,
             ),
         ]


### PR DESCRIPTION
## Summary
This PR updates the image dataset configurations to include `required_folder` paths, enabling proper staleness checking for cached datasets and providing a browsable root directory for the file picker.

## Key Changes
- Updated the `required_folder` docstring in `DemoDataset` to clarify its dual purpose: staleness validation and file picker root directory
- Added `required_folder` parameter to all 9 image dataset configurations:
  - Caltech-101 (S and M variants): `DATA_DIR / "caltech-101" / "101_ObjectCategories"`
  - Caltech-256: `DATA_DIR / "caltech-256" / "256_ObjectCategories"`
  - Oxford Flowers 102: `DATA_DIR / "oxford_flowers"`
  - Food-101: `DATA_DIR / "food-101" / "images"`
  - EuroSAT: `DATA_DIR / "EuroSAT_RGB"`
  - Stanford Dogs: `DATA_DIR / "stanford_dogs" / "Images"`
  - UCSF Documents: `DATA_DIR / "ucsf_documents"`
- Added import of `DATA_DIR` from `vtsearch.config` to support the path configurations

## Implementation Details
The `required_folder` paths point to the actual extracted source directories where the downloader places dataset files, ensuring that:
1. Stale cached `.pkl` files are invalidated when their source directory is removed
2. The file picker has a valid root directory to browse media examples from

https://claude.ai/code/session_019PsfVCS1LAUmgfiXnGP6oV