### PR TITLE
Auto-select media type in importer modal based on existing datasets

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -145,6 +145,7 @@
 
 @if (importerModalOpen) {
   <vt-dataset-importer-modal
+    [guessedMediaType]="guessedMediaType"
     (closed)="closeImporterModal()"
     (importStarted)="onImportComplete()"
     (demoSelected)="onDemoSelected($event)"

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -277,6 +277,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Importer modal ---
 
+  /** Guess the media type the user likely wants based on existing datasets/models. */
+  get guessedMediaType(): string {
+    const types = new Set<string>();
+    for (const d of this.datasets) {
+      if (d.media_type) types.add(d.media_type);
+    }
+    for (const m of this.models) {
+      if (m.media_type) types.add(m.media_type);
+    }
+    return types.size === 1 ? [...types][0] : '';
+  }
+
   openImporterModal(): void {
     this.importerModalOpen = true;
   }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -17,6 +17,9 @@ type ModalView = 'picker' | 'form' | 'demo' | 'server_folder';
   styleUrl: './dataset-importer-modal.component.scss',
 })
 export class DatasetImporterModalComponent implements OnInit {
+  /** Media type_id guessed from existing datasets/models (e.g. "image"). */
+  @Input() guessedMediaType = '';
+
   @Output() closed = new EventEmitter<void>();
   @Output() importStarted = new EventEmitter<void>();
   @Output() demoSelected = new EventEmitter<DemoDataset>();
@@ -110,8 +113,16 @@ export class DatasetImporterModalComponent implements OnInit {
       }
     }
 
-    // Load clippers and embedders for the default media type
+    // Override media_type default with guessed type when available
     const mediaTypeField = importer.fields?.find((f) => f.key === 'media_type');
+    if (mediaTypeField && this.guessedMediaType) {
+      const folderName = this.toFolderName(this.guessedMediaType);
+      if (folderName && mediaTypeField.options?.includes(folderName)) {
+        this.formValues['media_type'] = folderName;
+      }
+    }
+
+    // Load clippers and embedders for the default media type
     if (mediaTypeField) {
       const defaultType = this.formValues['media_type'] || mediaTypeField.default || '';
       this.loadClippers(defaultType);
@@ -218,7 +229,12 @@ export class DatasetImporterModalComponent implements OnInit {
       }
     }
     if (this.demoTabs.length > 0 && !this.activeTab) {
-      this.activeTab = this.demoTabs[0];
+      // Prefer guessed media type if it has demos
+      if (this.guessedMediaType && this.demoTabs.includes(this.guessedMediaType)) {
+        this.activeTab = this.guessedMediaType;
+      } else {
+        this.activeTab = this.demoTabs[0];
+      }
       this.loadDemoEmbedders(this.activeTab);
     }
   }
@@ -353,6 +369,13 @@ export class DatasetImporterModalComponent implements OnInit {
     return this.demoSortAsc ? ' \u25B2' : ' \u25BC';
   }
 
+  /** Convert a type_id (e.g. "image") to the corresponding folder_import_name (e.g. "images"). */
+  private toFolderName(typeId: string): string {
+    if (!typeId) return '';
+    const mt = this.mediaTypes.find((m) => m.type_id === typeId);
+    return mt?.folder_import_name || typeId;
+  }
+
   getMediaTypeOptionLabel(opt: string): string {
     const mt = this.mediaTypes.find((m) => m.folder_import_name === opt);
     if (mt) {
@@ -419,7 +442,14 @@ export class DatasetImporterModalComponent implements OnInit {
     const folderImporter = this.importers.find((imp) => imp.name === 'folder');
     const mtField = folderImporter?.fields?.find((f) => f.key === 'media_type');
     this.sfMediaTypeOptions = mtField?.options || [];
-    this.sfMediaType = mtField?.default || this.sfMediaTypeOptions[0] || 'sounds';
+
+    // Prefer guessed media type when available
+    const guessedFolder = this.toFolderName(this.guessedMediaType);
+    if (guessedFolder && this.sfMediaTypeOptions.includes(guessedFolder)) {
+      this.sfMediaType = guessedFolder;
+    } else {
+      this.sfMediaType = mtField?.default || this.sfMediaTypeOptions[0] || 'sounds';
+    }
 
     this.sfLoadEmbedders(this.sfMediaType);
     this.sfLoadClippers(this.sfMediaType);


### PR DESCRIPTION
## Summary
This PR enhances the dataset importer modal to intelligently pre-select the media type based on existing datasets and models in the workspace. When all existing datasets/models share the same media type, that type is automatically selected in the importer form, demo tabs, and server folder view.

## Key Changes
- Added `@Input() guessedMediaType` to `DatasetImporterModalComponent` to receive the guessed media type from the parent
- Implemented `guessedMediaType` getter in `DashboardComponent` that analyzes all datasets and models to determine if they share a common media type
- Updated the importer modal to use the guessed media type as the default selection in three places:
  - Form initialization: Sets the `media_type` field default when available
  - Demo tabs: Prefers the guessed media type tab if it has demos
  - Server folder view: Uses the guessed media type as the initial selection
- Added `toFolderName()` helper method to convert media type IDs (e.g., "image") to folder import names (e.g., "images")
- Passed `guessedMediaType` from `DashboardComponent` to the importer modal in the template

## Implementation Details
- The guessed media type is only used when it's a single, consistent type across all datasets and models (returns empty string if multiple types exist)
- The implementation validates that the guessed type is available in the media type options before applying it
- The helper method `toFolderName()` safely handles the conversion using the existing `mediaTypes` array, with fallback to the original type ID

https://claude.ai/code/session_01BvueqAeiwuXZs6dVsE2QCL