### PR TITLE
Replace intercept_tqdm_progress context manager with direct callback assignment

### DIFF
--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -518,11 +518,13 @@ def load_dataset_from_folder(
     # Eagerly load models before starting the embedding timer so that
     # download / weight-loading time does not pollute the progress bar.
     if emb is not None and getattr(emb, "_model", None) is None:
-        from vtsearch.media.base import intercept_tqdm_progress
-
         on_progress("loading", "Loading embedding model…", 0, 0)
-        with intercept_tqdm_progress(on_progress):
+        original_cb = emb._on_progress
+        emb._on_progress = on_progress
+        try:
             emb.load_models()
+        finally:
+            emb._on_progress = original_cb
 
     # Find all files of the specified media type (recursive so that
     # subdirectory structures are preserved).
@@ -753,11 +755,13 @@ def load_dataset_from_folder_chunked(
     # Eagerly load models before starting the embedding timer so that
     # download / weight-loading time does not pollute the progress bar.
     if emb is not None and getattr(emb, "_model", None) is None:
-        from vtsearch.media.base import intercept_tqdm_progress
-
         on_progress("loading", "Loading embedding model…", 0, 0)
-        with intercept_tqdm_progress(on_progress):
+        original_cb = emb._on_progress
+        emb._on_progress = on_progress
+        try:
             emb.load_models()
+        finally:
+            emb._on_progress = original_cb
 
     # Find all files of the specified media type (recursive so that
     # subdirectory structures are preserved).

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -14,7 +14,6 @@ from vtsearch.media.base import (
     MediaType,
     ProgressCallback,
     _noop_progress,
-    intercept_tqdm_progress,
 )
 
 
@@ -278,8 +277,12 @@ class AudioMediaType(MediaType):
         # Load models
         if getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading audio embedding model…", 0, 0)
-            with intercept_tqdm_progress(on_progress):
+            original_cb = embedder._on_progress
+            embedder._on_progress = on_progress
+            try:
                 embedder.load_models()
+            finally:
+                embedder._on_progress = original_cb
 
         clip_id = 1
         total = len(audio_files)

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -13,7 +13,6 @@ from vtsearch.media.base import (
     MediaType,
     ProgressCallback,
     _noop_progress,
-    intercept_tqdm_progress,
 )
 
 
@@ -305,8 +304,12 @@ class ImageMediaType(MediaType):
             """Embed a list of (img_path, category) tuples."""
             if getattr(embedder, "_model", None) is None:
                 on_progress("loading", "Loading image embedding model…", 0, 0)
-                with intercept_tqdm_progress(on_progress):
+                original_cb = embedder._on_progress
+                embedder._on_progress = on_progress
+                try:
                     embedder.load_models()
+                finally:
+                    embedder._on_progress = original_cb
 
             clip_id = 1
             total = len(selected)
@@ -463,8 +466,12 @@ class ImageMediaType(MediaType):
 
             if getattr(embedder, "_model", None) is None:
                 on_progress("loading", "Loading image embedding model…", 0, 0)
-                with intercept_tqdm_progress(on_progress):
+                original_cb = embedder._on_progress
+                embedder._on_progress = on_progress
+                try:
                     embedder.load_models()
+                finally:
+                    embedder._on_progress = original_cb
 
             clip_id = 1
             total = len(selected_pages)
@@ -520,7 +527,12 @@ class ImageMediaType(MediaType):
 
             if getattr(embedder, "_model", None) is None:
                 on_progress("loading", "Loading image embedding model…", 0, 0)
-                embedder.load_models()
+                original_cb = embedder._on_progress
+                embedder._on_progress = on_progress
+                try:
+                    embedder.load_models()
+                finally:
+                    embedder._on_progress = original_cb
 
             clip_id = 1
             total = len(selected_images)

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -13,7 +13,6 @@ from vtsearch.media.base import (
     MediaType,
     ProgressCallback,
     _noop_progress,
-    intercept_tqdm_progress,
 )
 
 
@@ -230,8 +229,12 @@ class TextMediaType(MediaType):
 
         if getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading text embedding model…", 0, 0)
-            with intercept_tqdm_progress(on_progress):
+            original_cb = embedder._on_progress
+            embedder._on_progress = on_progress
+            try:
                 embedder.load_models()
+            finally:
+                embedder._on_progress = original_cb
 
         clip_id = 1
         total = len(selected_texts)

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -10,7 +10,6 @@ from vtsearch.media.base import (
     MediaType,
     ProgressCallback,
     _noop_progress,
-    intercept_tqdm_progress,
 )
 
 
@@ -172,8 +171,12 @@ class VideoMediaType(MediaType):
 
         if getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading video embedding model…", 0, 0)
-            with intercept_tqdm_progress(on_progress):
+            original_cb = embedder._on_progress
+            embedder._on_progress = on_progress
+            try:
                 embedder.load_models()
+            finally:
+                embedder._on_progress = original_cb
 
         clip_id = 1
         total = len(video_files)

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -123,8 +123,6 @@ def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = 
     if total_steps is None:
         total_steps = _TOTAL_LOAD_STEPS
 
-    from vtsearch.media.base import intercept_tqdm_progress, intercept_weight_loading_progress
-
     emb = _get_embedder_for_clips()
     if emb is None:
         update_progress("idle", "Ready", step=None, total_steps=None)
@@ -141,11 +139,12 @@ def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = 
         step=step,
         total_steps=total_steps,
     )
-    with (
-        intercept_tqdm_progress(_model_load_progress),
-        intercept_weight_loading_progress(_model_load_progress, "Loading model weights…"),
-    ):
+    original_cb = emb._on_progress
+    emb._on_progress = _model_load_progress
+    try:
         emb.load_models()
+    finally:
+        emb._on_progress = original_cb
 
     # Warm up the text encoder so the first text sort is instant.
     update_progress(


### PR DESCRIPTION
## Summary
This PR refactors progress callback handling by replacing the `intercept_tqdm_progress` context manager with a simpler pattern of directly assigning and restoring the embedder's `_on_progress` callback.

## Key Changes
- Removed imports of `intercept_tqdm_progress` and `intercept_weight_loading_progress` from multiple modules
- Replaced all `with intercept_tqdm_progress(on_progress):` context manager calls with a try/finally pattern that:
  - Saves the original `_on_progress` callback
  - Assigns the new progress callback
  - Restores the original callback in the finally block
- Applied this pattern consistently across:
  - `vtsearch/media/image/media_type.py` (3 occurrences)
  - `vtsearch/media/audio/media_type.py` (1 occurrence)
  - `vtsearch/media/text/media_type.py` (1 occurrence)
  - `vtsearch/media/video/media_type.py` (1 occurrence)
  - `vtsearch/datasets/loader.py` (2 occurrences)
  - `vtsearch/routes/datasets_loading.py` (1 occurrence)

## Implementation Details
The new pattern is more explicit and direct:
```python
original_cb = embedder._on_progress
embedder._on_progress = on_progress
try:
    embedder.load_models()
finally:
    embedder._on_progress = original_cb
```

This approach eliminates the need for the `intercept_tqdm_progress` helper function while maintaining the same callback restoration guarantee through try/finally semantics.

https://claude.ai/code/session_01LSWg3GcUXHi3r9YGfyj48q