### PR TITLE
Fix demo tab styling and icon spacing in dataset importer

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -38,7 +38,7 @@
               class="demo-tab"
               [class.active]="activeTab === tab"
               (click)="selectDemoTabWithEmbedder(tab)"
-            >@if (getTabIcon(tab)) {<vt-icon [icon]="getTabIcon(tab)" [size]="14"></vt-icon> }{{ getTabText(tab) }}</button>
+            >@if (getTabIcon(tab)) {<vt-icon [icon]="getTabIcon(tab)" [size]="14"></vt-icon>}{{ getTabText(tab) }}</button>
           }
         </div>
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -22,6 +22,9 @@
 }
 
 .demo-tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   padding: 8px 16px;
   border: none;
   border-bottom: 2px solid transparent;


### PR DESCRIPTION
## Summary
This PR improves the visual presentation of demo tabs in the dataset importer modal by adding proper flexbox styling and fixing whitespace in the template.

## Key Changes
- **SCSS**: Added flexbox layout to `.demo-tab` class with centered alignment and 5px gap between icon and text
  - `display: flex`
  - `align-items: center`
  - `gap: 5px`
- **HTML**: Removed unnecessary space before closing brace in the icon conditional block for cleaner markup

## Implementation Details
The flexbox styling ensures that the icon and text within demo tabs are properly aligned vertically and have consistent spacing between them. The gap property provides a cleaner alternative to manual margin adjustments and makes the spacing more maintainable.

https://claude.ai/code/session_01P7S2Dsd4dxL93LrPoB25Lt