### PR TITLE
Update UI labels to reference "Train Mode" instead of "Labeling"

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -80,7 +80,7 @@
               <th (click)="sortModels('name')" class="sortable" title="Model display name (click to sort)">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
               <th (click)="sortModels('media_type')" class="sortable text-center" title="Media type this model operates on (click to sort)">Type<span class="sort-indicator" [class.active]="isModelSortActive('media_type')">{{ modelSortIndicator('media_type') }}</span></th>
               <th (click)="sortModels('num_training')" class="sortable text-center" title="Number of labeled training examples (click to sort)"># Training<span class="sort-indicator" [class.active]="isModelSortActive('num_training')">{{ modelSortIndicator('num_training') }}</span></th>
-              <th class="text-center" title="Is this Model one we can load into the Labeling interface and improve?">Trainable</th>
+              <th class="text-center" title="Is this Model one we can load into Train Mode and improve?">Trainable</th>
               <th (click)="sortModels('autodetect')" class="sortable text-center" title="Include this model in CLI autorun (click to sort)">Autorun<span class="sort-indicator" [class.active]="isModelSortActive('autodetect')">{{ modelSortIndicator('autodetect') }}</span></th>
               <th (click)="sortModels('last_trained_at')" class="sortable text-center" title="When the model was last trained (click to sort)">Last Trained<span class="sort-indicator" [class.active]="isModelSortActive('last_trained_at')">{{ modelSortIndicator('last_trained_at') }}</span></th>
               <th (click)="sortModels('created_at')" class="sortable text-center" title="When the model was created (click to sort)">Created<span class="sort-indicator" [class.active]="isModelSortActive('created_at')">{{ modelSortIndicator('created_at') }}</span></th>
@@ -125,7 +125,7 @@
         [title]="labelHint"
         (click)="onLabel()"
       >
-        Label
+        Train
       </button>
       <span class="btn-disabled-reason" [style.visibility]="(!labelEnabled && labelHint) ? 'visible' : 'hidden'">{{ labelHint || '&nbsp;' }}</span>
     </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -518,7 +518,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (model && dataset && model.media_type !== dataset.media_type) {
       return 'Media type mismatch';
     }
-    return 'Label the selected dataset to train the selected model';
+    return 'Open Train Mode with the selected dataset and model';
   }
 
   private storeSelectedModelTextQuery(): void {


### PR DESCRIPTION
## Summary
Updated user-facing labels and tooltips in the dashboard component to use "Train Mode" terminology instead of "Labeling interface" for consistency with the application's current naming conventions.

## Key Changes
- Updated the "Trainable" column tooltip from "Is this Model one we can load into the Labeling interface and improve?" to "Is this Model one we can load into Train Mode and improve?"
- Changed the action button label from "Label" to "Train"
- Updated the button's tooltip/hint text from "Label the selected dataset to train the selected model" to "Open Train Mode with the selected dataset and model"

## Details
These changes improve clarity by aligning the UI terminology with the actual feature name ("Train Mode") rather than the previous implementation detail reference ("Labeling interface"). This makes the interface more intuitive for users and provides clearer guidance on what action will be performed when interacting with these controls.

https://claude.ai/code/session_01Y77HavJ3RhUv8VXZw6DX5s