### PR TITLE
Redesign dashboard and settings icons in navigation menu

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -28,9 +28,11 @@
         tabindex="-1"
         (click)="onDashboard()"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect x="1" y="1" width="14" height="14" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
-          <rect x="3" y="3" width="10" height="4" rx="0.5" fill="currentColor"/>
-          <rect x="3" y="9" width="10" height="4" rx="0.5" fill="currentColor"/>
+          <rect x="1" y="1" width="14" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
+          <rect x="3.5" y="3" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
+          <rect x="3.5" y="7.5" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
+          <line x1="8" y1="12" x2="8" y2="14" stroke="currentColor" stroke-width="1.2"/>
+          <line x1="5.5" y1="14" x2="10.5" y2="14" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
         </svg> Dashboard</div>
       <div
         class="burger-item"
@@ -38,8 +40,8 @@
         tabindex="-1"
         (click)="onSettings()"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M8 10a2 2 0 100-4 2 2 0 000 4z" stroke="currentColor" stroke-width="1.2"/>
-          <path d="M13.4 6.5l-.7-.4a5.5 5.5 0 00-.5-.9l.2-.8a.5.5 0 00-.2-.5l-1-.6a.5.5 0 00-.5 0l-.7.5a5 5 0 00-1 0l-.7-.5a.5.5 0 00-.5 0l-1 .6a.5.5 0 00-.2.5l.2.8a5.5 5.5 0 00-.5.9l-.7.4a.5.5 0 00-.3.4v1.2a.5.5 0 00.3.4l.7.4c.1.3.3.6.5.9l-.2.8a.5.5 0 00.2.5l1 .6a.5.5 0 00.5 0l.7-.5a5 5 0 001 0l.7.5a.5.5 0 00.5 0l1-.6a.5.5 0 00.2-.5l-.2-.8c.2-.3.4-.6.5-.9l.7-.4a.5.5 0 00.3-.4V6.9a.5.5 0 00-.3-.4z" stroke="currentColor" stroke-width="1.0"/>
+          <path d="M6.7 1.5h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 5.5l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
+          <circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.2"/>
         </svg> Settings</div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
Updated the SVG icons in the navigation menu to improve visual clarity and consistency. The dashboard icon now features a monitor-like design, and the settings icon has been redesigned with a more modern gear appearance.

## Key Changes
- **Dashboard Icon**: Redesigned to resemble a desktop monitor with a stand
  - Changed outer rectangle height from 14 to 11 units
  - Replaced two filled rectangles with stroked rectangles for a cleaner look
  - Added vertical and horizontal lines at the bottom to represent a monitor stand
  
- **Settings Icon**: Completely redesigned with a modern gear aesthetic
  - Replaced the previous gear path with a new design featuring a more defined gear shape
  - Added a centered circle to represent the gear hub
  - Updated stroke properties for better visual consistency

## Implementation Details
- All icon changes maintain the existing `viewBox="0 0 16 16"` dimensions
- Stroke widths adjusted for visual balance (1.0-1.2px)
- Icons continue to use `currentColor` for consistent theming
- No functional changes to the component logic or click handlers

https://claude.ai/code/session_01M3X493cKiZQMMgaEhaxjCH