### PR TITLE
Increase header logo height from 28px to 36px

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -13,7 +13,7 @@ header {
   border-bottom: 1px solid #152e6b;
 
   .header-logo {
-    height: 28px;
+    height: 36px;
     width: auto;
   }
 


### PR DESCRIPTION
## Summary
Updated the header logo styling to improve visibility and visual hierarchy by increasing its height.

## Changes
- Increased `.header-logo` height from 28px to 36px in `frontend/src/app/app.component.scss`
- Width remains set to `auto` to maintain aspect ratio

## Details
This change makes the header logo more prominent while preserving its original proportions through the `auto` width setting.

https://claude.ai/code/session_018gn1kvKgDYoQhk5QDeprdw