### PR TITLE
Support CDN-decompressed tar.gz files in archive validation

### DIFF
--- a/tests/test_download_and_extract.py
+++ b/tests/test_download_and_extract.py
@@ -393,7 +393,7 @@ class TestCorruptArchiveValidation:
 
         # Simulate a corrupt file already on disk (download is skipped).
         corrupt_file = tmp_path / "test.tar.gz"
-        corrupt_file.write_bytes(b"UCF101 fake html page content")
+        corrupt_file.write_bytes(b"this is not a valid archive at all")
 
         with patch.object(dl_module, "DATA_DIR", tmp_path):
             with pytest.raises(RuntimeError, match="invalid file"):
@@ -434,6 +434,56 @@ class TestCorruptArchiveValidation:
 
         msg = str(exc_info.value)
         assert "try again" in msg.lower()
+
+
+class TestCdnDecompressedTarGz:
+    """CDN-decompressed .tar.gz files (raw tar) are accepted and extracted."""
+
+    def test_raw_tar_with_tar_gz_name_passes_validation(self, tmp_path):
+        """A raw tar served for a .tar.gz URL passes validation."""
+        from vtsearch.datasets import downloader as dl_module
+
+        # Create an uncompressed tar but name it .tar.gz (mimics CDN behaviour).
+        tar_path = _make_tar(tmp_path, arcname="data_dir")
+        misnamed = tmp_path / "test.tar.gz"
+        tar_path.rename(misnamed)
+
+        # Should not raise — the file is a valid tar even without gzip.
+        dl_module._validate_archive(misnamed, "test.tar.gz", "Test")
+
+    def test_raw_tar_with_tar_gz_name_extracts(self, tmp_path):
+        """A raw tar named .tar.gz extracts correctly via _download_and_extract."""
+        from vtsearch.datasets import downloader as dl_module
+
+        tar_path = _make_tar(tmp_path, arcname="data_dir")
+        misnamed = tmp_path / "staging" / "test.tar.gz"
+        misnamed.parent.mkdir(parents=True, exist_ok=True)
+        tar_path.rename(misnamed)
+
+        extract_to = tmp_path / "extracted"
+        check_path = extract_to / "data_dir"
+        data_dir = tmp_path / "data"
+
+        with (
+            patch.object(dl_module, "DATA_DIR", data_dir),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: misnamed.rename(dest),
+            ),
+        ):
+            dl_module._download_and_extract(
+                url="http://example.com/test.tar.gz",
+                archive_name="test.tar.gz",
+                extract_to=extract_to,
+                check_path=check_path,
+                download_size_mb=1,
+                dataset_name="Test",
+                on_progress=lambda *a: None,
+            )
+
+        assert check_path.exists()
+        assert (check_path / "file.txt").read_text() == "hello"
 
 
 class TestCaltech101ExtractionProgress:

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -115,7 +115,7 @@ _ZIP_MAGIC = b"PK"
 # Uncompressed tar: first 257 bytes contain "ustar" at offset 257,
 # but a simpler heuristic is that the file does NOT start with common
 # non-archive signatures (HTML, JSON, plain text error pages).
-_HTML_SIGNATURES = (b"<", b"<!",  b"{", b"UC")
+_HTML_SIGNATURES = (b"<", b"<!",  b"{")
 
 
 def _validate_archive(archive_path: Path, archive_name: str, dataset_name: str) -> None:
@@ -132,7 +132,9 @@ def _validate_archive(archive_path: Path, archive_name: str, dataset_name: str) 
 
     ok = True
     if suffix.endswith((".tar.gz", ".tgz")):
-        ok = header[:2] == _GZIP_MAGIC
+        # Accept genuine gzip OR a raw tar that the CDN decompressed on the
+        # fly (HuggingFace Xet storage does this).
+        ok = header[:2] == _GZIP_MAGIC or tarfile.is_tarfile(archive_path)
     elif suffix.endswith(".zip"):
         ok = header[:2] == _ZIP_MAGIC
     elif suffix.endswith(".tar"):
@@ -195,7 +197,9 @@ def _download_and_extract(
 
     suffix = archive_name.lower()
     if suffix.endswith((".tar.gz", ".tgz")):
-        with tarfile.open(archive_path, "r:gz") as tar_ref:
+        # Use "r:*" to auto-detect compression — some CDNs (e.g. HuggingFace
+        # Xet) transparently decompress .tar.gz files during transfer.
+        with tarfile.open(archive_path, "r:*") as tar_ref:
             members = tar_ref.getmembers()
             total = len(members)
             for i, member in enumerate(members):


### PR DESCRIPTION
## Summary
This PR adds support for handling `.tar.gz` files that have been transparently decompressed by CDNs (such as HuggingFace Xet storage) during transfer. These files arrive as raw tar archives despite having a `.tar.gz` extension, and the code now accepts and extracts them correctly.

## Key Changes
- **Archive validation**: Modified `_validate_archive()` to accept both gzip-compressed files and raw tar files for `.tar.gz` extensions by checking `tarfile.is_tarfile()` as a fallback
- **Archive extraction**: Changed `_download_and_extract()` to use `tarfile.open()` with mode `"r:*"` (auto-detect compression) instead of `"r:gz"` (gzip-only), allowing it to handle both compressed and uncompressed tar files
- **Signature detection**: Removed `b"UC"` from `_HTML_SIGNATURES` tuple as it was overly broad and could match valid tar content
- **Test coverage**: Added comprehensive test suite `TestCdnDecompressedTarGz` with two test cases:
  - Validation of raw tar files with `.tar.gz` extension
  - End-to-end extraction of raw tar files through `_download_and_extract()`
- **Test maintenance**: Updated existing corrupt file test to use a more generic invalid archive signature

## Implementation Details
The solution leverages Python's `tarfile` module's built-in capabilities:
- `tarfile.is_tarfile()` reliably detects raw tar archives regardless of file extension
- `tarfile.open()` with mode `"r:*"` automatically detects and handles both gzip-compressed and uncompressed tar streams, making the extraction logic transparent to the caller

This approach is backward compatible—genuinely gzip-compressed `.tar.gz` files continue to work as before.

https://claude.ai/code/session_016u1GNtvfpAkKRCFVNk53fH