### PR TITLE
Replace native select with custom dropdown for media type

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -20,7 +20,7 @@
           <button type="button" class="custom-select-trigger form-input" (click)="mediaTypeDropdownOpen = !mediaTypeDropdownOpen">
             <span class="select-option-content">
               @if (getMediaTypeIcon(mediaType)) {
-                <vt-icon [type]="getMediaTypeIcon(mediaType)" size="14"></vt-icon>
+                <vt-icon [type]="getMediaTypeIcon(mediaType)" [size]="14"></vt-icon>
               }
               <span>{{ getMediaTypeLabel(mediaType) }}</span>
             </span>
@@ -31,7 +31,7 @@
               @for (mt of mediaTypes; track mt) {
                 <button type="button" class="custom-select-option" [class.selected]="mt === mediaType" (click)="mediaType = mt; mediaTypeDropdownOpen = false">
                   @if (getMediaTypeIcon(mt)) {
-                    <vt-icon [type]="getMediaTypeIcon(mt)" size="14"></vt-icon>
+                    <vt-icon [type]="getMediaTypeIcon(mt)" [size]="14"></vt-icon>
                   }
                   <span>{{ getMediaTypeLabel(mt) }}</span>
                 </button>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -15,12 +15,30 @@
       </div>
 
       <div class="form-group">
-        <label for="model-media-type" title="The type of media this model will process">Media Type</label>
-        <select id="model-media-type" class="form-input" [(ngModel)]="mediaType" name="mediaType" title="The type of media this model will process">
-          @for (mt of mediaTypes; track mt) {
-            <option [value]="mt">{{ getMediaTypeLabel(mt) }}</option>
+        <label title="The type of media this model will process">Media Type</label>
+        <div class="custom-select" [class.open]="mediaTypeDropdownOpen" title="The type of media this model will process">
+          <button type="button" class="custom-select-trigger form-input" (click)="mediaTypeDropdownOpen = !mediaTypeDropdownOpen">
+            <span class="select-option-content">
+              @if (getMediaTypeIcon(mediaType)) {
+                <vt-icon [type]="getMediaTypeIcon(mediaType)" size="14"></vt-icon>
+              }
+              <span>{{ getMediaTypeLabel(mediaType) }}</span>
+            </span>
+            <svg class="select-arrow" width="10" height="6" viewBox="0 0 10 6" fill="currentColor"><path d="M0 0l5 6 5-6z"/></svg>
+          </button>
+          @if (mediaTypeDropdownOpen) {
+            <div class="custom-select-options">
+              @for (mt of mediaTypes; track mt) {
+                <button type="button" class="custom-select-option" [class.selected]="mt === mediaType" (click)="mediaType = mt; mediaTypeDropdownOpen = false">
+                  @if (getMediaTypeIcon(mt)) {
+                    <vt-icon [type]="getMediaTypeIcon(mt)" size="14"></vt-icon>
+                  }
+                  <span>{{ getMediaTypeLabel(mt) }}</span>
+                </button>
+              }
+            </div>
           }
-        </select>
+        </div>
       </div>
 
       @if (hasMediaExample) {

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -242,3 +242,72 @@
   font-size: 0.85rem;
   flex-shrink: 0;
 }
+
+// Custom select dropdown (supports icons inside options)
+.custom-select {
+  position: relative;
+}
+
+.custom-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+  background: var(--bg-input, var(--bg-subtle));
+}
+
+.select-option-content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.select-arrow {
+  flex-shrink: 0;
+  opacity: 0.6;
+  transition: transform 0.15s;
+
+  .custom-select.open & {
+    transform: rotate(180deg);
+  }
+}
+
+.custom-select-options {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin-top: 2px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-primary, var(--bg-subtle));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.custom-select-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  font-size: inherit;
+  transition: background 0.1s;
+
+  &:hover {
+    background: var(--bg-hover);
+  }
+
+  &.selected {
+    background: var(--bg-active, var(--bg-hover));
+    font-weight: 600;
+  }
+}

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
@@ -22,8 +22,8 @@ describe('NewModelModalComponent', () => {
     // Flush the media types request from ngOnInit
     httpMock.expectOne('/api/media-types').flush({
       media_types: [
-        { type_id: 'audio', name: 'Audio' },
-        { type_id: 'image', name: 'Image' },
+        { type_id: 'audio', name: 'Audio', icon: 'audio', tab_title: 'Sounds' },
+        { type_id: 'image', name: 'Image', icon: 'image', tab_title: 'Images' },
       ],
     });
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
@@ -116,6 +116,12 @@ describe('NewModelModalComponent', () => {
     );
 
     expect(component.error).toBe('Model already exists');
+  });
+
+  it('should return media type icon', () => {
+    expect(component.getMediaTypeIcon('audio')).toBe('audio');
+    expect(component.getMediaTypeIcon('image')).toBe('image');
+    expect(component.getMediaTypeIcon('unknown')).toBe('');
   });
 
   it('should emit closed on close', () => {

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -41,6 +41,7 @@ export class NewModelModalComponent implements OnInit {
   mediaTypeInfos: MediaTypeInfo[] = [];
   submitting = false;
   error = '';
+  mediaTypeDropdownOpen = false;
 
   // Single example (text or media, not both)
   exampleType: 'text' | 'media' | null = null;
@@ -65,6 +66,14 @@ export class NewModelModalComponent implements OnInit {
     private datasetsApi: DatasetsApiService,
     private sortingApi: SortingApiService,
   ) {}
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+    if (this.mediaTypeDropdownOpen && !target.closest('.custom-select')) {
+      this.mediaTypeDropdownOpen = false;
+    }
+  }
 
   ngOnInit(): void {
     this.datasetsApi.getMediaTypes().subscribe({
@@ -335,6 +344,11 @@ export class NewModelModalComponent implements OnInit {
       return (mt.tab_title || mt.name).trim();
     }
     return typeId;
+  }
+
+  getMediaTypeIcon(typeId: string): string {
+    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
+    return mt?.icon || '';
   }
 
   close(): void {


### PR DESCRIPTION
## Summary
Replaced the native HTML `<select>` element with a custom dropdown component that supports displaying icons alongside media type options, improving the visual presentation of the media type selector in the new model modal.

## Key Changes
- **Custom dropdown UI**: Implemented a custom select dropdown with styled trigger button, dropdown menu, and individual options
- **Icon support**: Added `getMediaTypeIcon()` method to retrieve and display media type icons within dropdown options
- **Dropdown state management**: Added `mediaTypeDropdownOpen` property to track dropdown visibility
- **Click-outside handling**: Implemented `@HostListener` to close dropdown when clicking outside the component
- **Styling**: Added comprehensive SCSS for custom select styling including hover states, animations, and icon spacing
- **Test updates**: Updated test fixtures to include `icon` and `tab_title` properties in media type responses and added test for `getMediaTypeIcon()` method

## Implementation Details
- The custom dropdown uses a button-based trigger with an SVG arrow that rotates when open
- Options are rendered conditionally using `@if` directive and display icons via `vt-icon` component
- Dropdown positioning is absolute, appearing below the trigger with proper z-index and shadow
- Selected option is highlighted with different styling and font weight
- All interactions (open/close, selection) are handled through component properties and event handlers

https://claude.ai/code/session_019UwMJC9v4AsCi5EGRnN6EC