### PR TITLE
Add missing media resolution flow to label importer modal

### DIFF
--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -156,4 +156,30 @@
       </div>
     </div>
   }
+  @if (view === 'missing') {
+    <div class="missing-view">
+      @if (successMessage) {
+        <p class="success-text">{{ successMessage }}</p>
+      }
+      <p class="missing-info">
+        {{ missingEntries.length }} labeled element(s) were not found in the current dataset.
+        Would you like to resolve and add them from their original sources?
+      </p>
+
+      @if (error) {
+        <p class="error-text">{{ error }}</p>
+      }
+
+      <div class="form-actions" modal-footer>
+        <button class="btn btn--secondary" (click)="skipMissing()" [disabled]="ingesting">Skip</button>
+        <button class="btn btn--primary" (click)="ingestMissing()" [disabled]="ingesting">
+          @if (ingesting) {
+            Ingesting...
+          } @else {
+            Resolve &amp; Add
+          }
+        </button>
+      </div>
+    </div>
+  }
 </vt-modal>

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -131,6 +131,18 @@
   }
 }
 
+.missing-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.missing-info {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
 .btn-add-bad {
   flex: 1;
   padding: 8px 12px;

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -19,7 +19,7 @@ interface LabelImporterInfo {
   hidden_from_picker?: boolean;
 }
 
-type ModalView = 'picker' | 'form';
+type ModalView = 'picker' | 'form' | 'missing';
 
 @Component({
   selector: 'vt-label-importer-modal',
@@ -47,6 +47,8 @@ export class LabelImporterModalComponent implements OnInit {
   successMessage = '';
   addingGood = false;
   addingBad = false;
+  missingEntries: unknown[] = [];
+  ingesting = false;
 
   constructor(
     private labelImportersApi: LabelImportersApiService,
@@ -55,6 +57,9 @@ export class LabelImporterModalComponent implements OnInit {
   ) {}
 
   get modalTitle(): string {
+    if (this.view === 'missing') {
+      return 'Missing Media';
+    }
     if (this.view === 'form' && this.selectedImporter) {
       return this.selectedImporter.display_name || this.selectedImporter.name;
     }
@@ -121,13 +126,44 @@ export class LabelImporterModalComponent implements OnInit {
         this.submitting = false;
         this.successMessage = res.message || `Applied ${res.applied ?? 0} labels`;
         this.imported.emit();
-        setTimeout(() => this.close(), 1500);
+
+        if (res.missing_count > 0 && res.missing?.length) {
+          this.missingEntries = res.missing;
+          this.view = 'missing';
+        } else {
+          setTimeout(() => this.close(), 1500);
+        }
       },
       error: (err) => {
         this.submitting = false;
         this.error = err.error?.error || 'Import failed';
       },
     });
+  }
+
+  ingestMissing(): void {
+    if (!this.missingEntries.length) return;
+    this.ingesting = true;
+    this.error = '';
+
+    this.labelImportersApi.ingestMissing(this.missingEntries).subscribe({
+      next: (res: any) => {
+        this.ingesting = false;
+        this.successMessage = res.message || `Ingested ${res.ingested ?? 0} media(s), applied ${res.applied ?? 0} label(s).`;
+        this.missingEntries = [];
+        this.imported.emit();
+        setTimeout(() => this.close(), 1500);
+      },
+      error: (err) => {
+        this.ingesting = false;
+        this.error = err.error?.error || 'Failed to ingest missing media';
+      },
+    });
+  }
+
+  skipMissing(): void {
+    this.missingEntries = [];
+    this.close();
   }
 
   triggerAddGood(): void {

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -60,7 +60,7 @@
 </aside>
 
 @if (showLabelImport) {
-  <vt-label-importer-modal (closed)="showLabelImport = false" (imported)="showLabelImport = false" />
+  <vt-label-importer-modal (closed)="showLabelImport = false" (imported)="voteState.loadVotes()" />
 }
 
 @if (showExport) {

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -25,7 +25,7 @@ export class LabelImportersApiService {
     return this.http.post(`/api/label-importers/import/${importerName}`, params);
   }
 
-  ingestMissing(): Observable<unknown> {
-    return this.http.post('/api/label-importers/ingest-missing', {});
+  ingestMissing(entries: unknown[]): Observable<unknown> {
+    return this.http.post('/api/label-importers/ingest-missing', { entries });
   }
 }


### PR DESCRIPTION
## Summary
This PR adds a new workflow to handle missing media entries during label import operations. When labels are imported and some media entries are not found in the current dataset, users are now presented with an option to resolve and ingest these missing entries from their original sources.

## Key Changes
- **New modal view**: Added 'missing' view type to display missing media entries after import
- **Missing entries handling**: When import completes with missing entries, the modal transitions to a new view showing the count of missing items
- **Ingest missing functionality**: Implemented `ingestMissing()` method to process and add missing media entries
- **Skip option**: Added `skipMissing()` method to allow users to dismiss the missing entries dialog
- **API service update**: Modified `ingestMissing()` to accept and send missing entries array to the backend
- **UI improvements**: 
  - Added missing view template with informative messaging
  - Added styling for the missing entries view
  - Added loading state ("Ingesting...") during the ingest operation
  - Added Skip and "Resolve & Add" action buttons
- **Vote state refresh**: Updated right panel to refresh votes after import completes, ensuring UI reflects newly imported labels

## Implementation Details
- The missing view is displayed conditionally when `res.missing_count > 0` and missing entries exist
- The modal title dynamically updates to "Missing Media" when in the missing view
- Both `ingesting` and `missingEntries` state variables are managed to track the ingest operation
- Error handling is included for failed ingest operations with user-friendly error messages
- The modal auto-closes after successful ingest with a 1.5 second delay

https://claude.ai/code/session_01PgtfrgczykFSvbk2RoW5CW