### PR TITLE
Reduce header padding for more compact layout

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -8,7 +8,7 @@ header {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 16px;
+  padding: 3px 8px;
   background: #1a3b8a;
   border-bottom: 1px solid #152e6b;
 


### PR DESCRIPTION
## Summary
Adjusted the header component's padding to create a more compact vertical layout while maintaining horizontal spacing.

## Changes
- Reduced header vertical padding from `8px` to `3px`
- Reduced header horizontal padding from `16px` to `8px`

## Details
This change tightens the spacing around the header content, reducing the overall height of the header while keeping the gap between flex items consistent at `12px`. The adjustment creates a more compact header appearance while maintaining visual balance.

https://claude.ai/code/session_01RMH4Bhf5RKyPDy7JMH3ThB