### PR TITLE
Fix X-CLIP model loading and video embedding processor API

### DIFF
--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -626,7 +626,7 @@ class TestXCLIPEmbeddingGPU:
 
         # Create 8 dummy frames
         frames = [Image.new("RGB", (224, 224), color=(i * 30, 100, 200)) for i in range(8)]
-        inputs = processor(videos=list(frames), return_tensors="pt")
+        inputs = processor(images=[list(frames)], return_tensors="pt")
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():
             from vtsearch.media.video.media_type import _extract_tensor

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -75,6 +75,7 @@ class VideoXClipEmbedder(MediaEmbedder):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading X-CLIP model weights…", 0, 0)
+        XCLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading X-CLIP model weights…"
         ):
@@ -139,7 +140,7 @@ class VideoXClipEmbedder(MediaEmbedder):
                 print(f"Error: could not extract frames from {file_path}")
                 return None
 
-            inputs = self._processor(videos=list(frames), return_tensors="pt")
+            inputs = self._processor(images=[list(frames)], return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():


### PR DESCRIPTION
## Summary
This PR fixes compatibility issues with the X-CLIP model by updating the processor API call and configuring the model to ignore unexpected position_ids weights during loading.

## Key Changes
- Added `XCLIPModel._keys_to_ignore_on_load_unexpected` configuration to ignore position_ids weights during model loading, preventing warnings/errors from unexpected weight keys
- Updated processor API calls from `videos=list(frames)` to `images=[list(frames)]` to match the current X-CLIP processor interface
  - Changed in `vtsearch/media/video/embedder.py` (production code)
  - Changed in `tests/test_gpu.py` (test code)

## Implementation Details
The X-CLIP processor expects frames to be passed as a list of frame lists under the `images` parameter rather than directly under `videos`. This change aligns with the current HuggingFace transformers API for X-CLIP models. The position_ids configuration prevents model loading issues when the checkpoint contains unexpected weight keys that should be safely ignored.

https://claude.ai/code/session_01SjQC2rrDDGN3WF7XwX83Co