### PR TITLE
Update settings icon design in navigation menu

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -41,7 +41,7 @@
         (click)="onSettings()"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M6.7 1.5h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 5.5l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
-          <circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.2"/>
+          <circle cx="8" cy="8" r="1.3" fill="currentColor"/>
         </svg> Settings</div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
Updated the settings icon SVG in the navigation menu to improve its visual appearance and consistency.

## Key Changes
- Modified the center circle of the settings gear icon:
  - Changed radius from `2.2` to `1.3` for a smaller center point
  - Switched from `stroke` rendering to `fill` rendering
  - Removed `stroke-width="1.2"` attribute as it's no longer needed for a filled circle

## Implementation Details
This change makes the settings icon's center circle smaller and solid-filled rather than outlined, which likely improves the visual hierarchy and overall aesthetic of the icon while maintaining consistency with the design system.

https://claude.ai/code/session_01VU9YwdC9BNQBVKDxp9dRK2