### PR TITLE
Add padding to table data cells in dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -134,6 +134,10 @@
     white-space: nowrap;
   }
 
+  td {
+    padding: 6px 12px;
+  }
+
   th {
     position: sticky;
     top: 0;


### PR DESCRIPTION
## Summary
Added consistent padding to table data cells (`<td>` elements) in the dashboard component to improve spacing and readability.

## Changes
- Added `padding: 6px 12px;` CSS rule to `td` elements in the dashboard table
  - Provides 6px vertical padding and 12px horizontal padding for better visual spacing
  - Aligns with existing table styling patterns in the component

## Details
This styling enhancement improves the visual presentation of table data by ensuring consistent spacing around cell content, making the dashboard table more readable and visually balanced.

https://claude.ai/code/session_016xJ3mfCqC6C8us5e7FuoTz