### PR TITLE
Auto-resolve missing media during label import on server-side

### DIFF
--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -156,30 +156,4 @@
       </div>
     </div>
   }
-  @if (view === 'missing') {
-    <div class="missing-view">
-      @if (successMessage) {
-        <p class="success-text">{{ successMessage }}</p>
-      }
-      <p class="missing-info">
-        {{ missingEntries.length }} labeled element(s) were not found in the current dataset.
-        Would you like to resolve and add them from their original sources?
-      </p>
-
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
-      }
-
-      <div class="form-actions" modal-footer>
-        <button class="btn btn--secondary" (click)="skipMissing()" [disabled]="ingesting">Skip</button>
-        <button class="btn btn--primary" (click)="ingestMissing()" [disabled]="ingesting">
-          @if (ingesting) {
-            Ingesting...
-          } @else {
-            Resolve &amp; Add
-          }
-        </button>
-      </div>
-    </div>
-  }
 </vt-modal>

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -19,7 +19,7 @@ interface LabelImporterInfo {
   hidden_from_picker?: boolean;
 }
 
-type ModalView = 'picker' | 'form' | 'missing';
+type ModalView = 'picker' | 'form';
 
 @Component({
   selector: 'vt-label-importer-modal',
@@ -47,7 +47,9 @@ export class LabelImporterModalComponent implements OnInit {
   successMessage = '';
   addingGood = false;
   addingBad = false;
+  /** @deprecated No longer used — auto-resolve happens server-side. */
   missingEntries: unknown[] = [];
+  /** @deprecated No longer used — auto-resolve happens server-side. */
   ingesting = false;
 
   constructor(
@@ -57,9 +59,6 @@ export class LabelImporterModalComponent implements OnInit {
   ) {}
 
   get modalTitle(): string {
-    if (this.view === 'missing') {
-      return 'Missing Media';
-    }
     if (this.view === 'form' && this.selectedImporter) {
       return this.selectedImporter.display_name || this.selectedImporter.name;
     }
@@ -128,11 +127,11 @@ export class LabelImporterModalComponent implements OnInit {
         this.imported.emit();
 
         if (res.missing_count > 0 && res.missing?.length) {
-          this.missingEntries = res.missing;
-          this.view = 'missing';
-        } else {
-          setTimeout(() => this.close(), 1500);
+          // Show unresolved elements as a warning but don't prompt — the
+          // backend already tried to auto-resolve them.
+          this.error = `${res.missing_count} element(s) could not be resolved from their original sources.`;
         }
+        setTimeout(() => this.close(), res.missing_count > 0 ? 3000 : 1500);
       },
       error: (err) => {
         this.submitting = false;
@@ -141,30 +140,6 @@ export class LabelImporterModalComponent implements OnInit {
     });
   }
 
-  ingestMissing(): void {
-    if (!this.missingEntries.length) return;
-    this.ingesting = true;
-    this.error = '';
-
-    this.labelImportersApi.ingestMissing(this.missingEntries).subscribe({
-      next: (res: any) => {
-        this.ingesting = false;
-        this.successMessage = res.message || `Ingested ${res.ingested ?? 0} media(s), applied ${res.applied ?? 0} label(s).`;
-        this.missingEntries = [];
-        this.imported.emit();
-        setTimeout(() => this.close(), 1500);
-      },
-      error: (err) => {
-        this.ingesting = false;
-        this.error = err.error?.error || 'Failed to ingest missing media';
-      },
-    });
-  }
-
-  skipMissing(): void {
-    this.missingEntries = [];
-    this.close();
-  }
 
   triggerAddGood(): void {
     this.addGoodInput.nativeElement.click();

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -633,6 +633,87 @@ class TestLabelImportMissingElements:
         assert result["missing_count"] == 0
         assert result["missing"] == []
 
+    def test_auto_resolve_ingests_and_applies(self, client, tmp_path):
+        """Missing elements are auto-resolved from their origin during import."""
+        import hashlib
+
+        # Save/restore medias since auto-resolve adds new entries
+        saved = dict(app_module.medias)
+        try:
+            # Create a text file that can be ingested
+            text_dir = tmp_path / "texts"
+            text_dir.mkdir()
+            content = "Hello world, this is a test paragraph for auto-resolve embedding."
+            (text_dir / "hello.txt").write_text(content)
+            md5 = hashlib.md5(content.encode()).hexdigest()
+
+            origin = {"importer": "folder", "params": {"path": str(text_dir), "media_type": "paragraphs"}}
+
+            known_md5 = app_module.medias[1]["md5"]
+            payload = json.dumps(
+                {
+                    "labels": [
+                        {"md5": known_md5, "label": "good"},
+                        {
+                            "md5": md5,
+                            "label": "bad",
+                            "origin": origin,
+                            "origin_name": "hello.txt",
+                            "filename": "hello.txt",
+                        },
+                    ]
+                }
+            )
+            p = tmp_path / "labels.json"
+            p.write_text(payload)
+            res = client.post(
+                "/api/label-importers/import/server_json_file",
+                json={"filepath": str(p)},
+            )
+            assert res.status_code == 200
+            result = res.get_json()
+            # Both labels should be applied (1 existing + 1 auto-resolved)
+            assert result["applied"] == 2
+            assert result["ingested"] == 1
+            assert result["missing_count"] == 0
+            assert result["missing"] == []
+            # The new media should be in the dataset and labeled
+            new_ids = [cid for cid, m in app_module.medias.items() if m.get("md5") == md5]
+            assert len(new_ids) == 1
+            assert new_ids[0] in app_module.bad_votes
+        finally:
+            app_module.medias.clear()
+            app_module.medias.update(saved)
+
+    def test_auto_resolve_reports_unresolvable(self, client, tmp_path):
+        """Elements that can't be resolved are reported in the response."""
+        known_md5 = app_module.medias[1]["md5"]
+        payload = json.dumps(
+            {
+                "labels": [
+                    {"md5": known_md5, "label": "good"},
+                    {
+                        "md5": "totally_unknown_md5",
+                        "label": "bad",
+                        "origin": {"importer": "folder", "params": {"path": "/nonexistent/path"}},
+                        "origin_name": "ghost.wav",
+                    },
+                ]
+            }
+        )
+        p = tmp_path / "labels.json"
+        p.write_text(payload)
+        res = client.post(
+            "/api/label-importers/import/server_json_file",
+            json={"filepath": str(p)},
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 1
+        assert result["missing_count"] == 1
+        assert result["missing"][0]["md5"] == "totally_unknown_md5"
+        assert "could not be resolved" in result["message"]
+
 
 # ---------------------------------------------------------------------------
 # API – POST /api/label-importers/ingest-missing

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -142,16 +142,39 @@ def run_label_import(importer_name: str):
     # by _apply_labels, but we report them separately now.
     skipped -= len(missing)
 
-    msg = f"Applied {applied} label(s), skipped {skipped}."
+    # Auto-resolve: try to ingest missing medias from their origins
+    ingested = 0
+    resolved_applied = 0
+    unresolved: list[dict] = []
     if missing:
-        msg += f" {len(missing)} element(s) not found in dataset."
+        from vtsearch.datasets.ingest import ingest_missing_medias
+
+        ingested = ingest_missing_medias(missing, medias)
+
+        if ingested > 0:
+            # Re-apply labels now that new medias are available
+            origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
+            resolved_applied, _ = _apply_labels(missing, origin_lookup, md5_lookup)
+            applied += resolved_applied
+
+        # Check which entries still couldn't be resolved
+        if ingested < len(missing):
+            origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
+            unresolved = find_missing_entries(missing, origin_lookup, md5_lookup)
+
+    msg = f"Applied {applied} label(s), skipped {skipped}."
+    if ingested > 0:
+        msg += f" Auto-resolved {ingested} missing element(s) from their sources."
+    if unresolved:
+        msg += f" {len(unresolved)} element(s) could not be resolved."
 
     return jsonify(
         {
             "applied": applied,
             "skipped": skipped,
-            "missing_count": len(missing),
-            "missing": missing,
+            "missing_count": len(unresolved),
+            "missing": unresolved,
+            "ingested": ingested,
             "message": msg,
         }
     )


### PR DESCRIPTION
## Summary
Moves the missing media resolution logic from the frontend to the backend during label import. The server now automatically attempts to ingest missing media from their origin sources, eliminating the need for a separate "missing media" modal view.

## Key Changes

- **Backend (`vtsearch/routes/label_importers.py`)**:
  - Added automatic ingestion of missing media via `ingest_missing_medias()` after initial label application
  - Re-applies labels to newly ingested media
  - Reports both successfully resolved and unresolvable entries in the response
  - Returns new `ingested` count in the response payload

- **Frontend (`label-importer-modal.component.ts`)**:
  - Removed `'missing'` view type from `ModalView` union type
  - Removed the entire "missing media" modal view and related UI logic
  - Removed `ingestMissing()` and `skipMissing()` methods
  - Deprecated `missingEntries` and `ingesting` properties (marked with `@deprecated` comments)
  - Changed behavior to show unresolved elements as a warning message instead of prompting user action
  - Extended modal close timeout to 3 seconds when unresolved elements exist

- **Frontend Template (`label-importer-modal.component.html`)**:
  - Removed entire `missing-view` section and its associated UI elements

- **Tests (`tests/test_label_importers.py`)**:
  - Added `test_auto_resolve_ingests_and_applies()` to verify successful auto-resolution and label application
  - Added `test_auto_resolve_reports_unresolvable()` to verify proper handling of unresolvable entries

## Implementation Details

The auto-resolution happens transparently during the import process. If media cannot be found in the dataset, the backend checks if they have origin metadata and attempts to ingest them from their original sources. This eliminates the need for user interaction and provides a seamless import experience. Entries that still cannot be resolved are reported in the response message but don't block the import completion.

https://claude.ai/code/session_01HYEKQQHGietJnxQ1BJBHmE