### PR TITLE
Add brain icon and enhance dashboard section headers with icons

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
   <!-- Dataset Section -->
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Imported datasets available for labeling and searching">Datasets</span>
+      <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="database" [size]="18"></vt-icon> Datasets</span>
       @if (loading) {
         <div class="dashboard-progress">
           <span class="progress-msg">{{ progressMessage }}</span>
@@ -70,7 +70,7 @@
   <!-- Model Section -->
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Trained models for scoring and finding media">Models</span>
+      <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="brain" [size]="18"></vt-icon> Models</span>
       <div class="dashboard-section-actions">
         <button class="btn btn--primary btn--sm" (click)="openNewModelModal()" title="Create a new model">+</button>
       </div>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -19,6 +19,7 @@ import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
 import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
 import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
+import { IconComponent } from '../icon/icon.component';
 
 @Component({
   selector: 'vt-dashboard',
@@ -32,6 +33,7 @@ import { DetectorExportModalComponent } from '../modals/detector-export-modal/de
     DatasetImporterModalComponent,
     NewModelModalComponent,
     DetectorExportModalComponent,
+    IconComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -10,7 +10,7 @@ const KNOWN_TYPES = new Set([
   'server', 'globe', 'email', 'satellite',
   'folder', 'folder-open', 'upload',
   'graduation', 'arrow-up', 'shuffle', 'elephant', 'cloud',
-  'check', 'warning', 'x-circle', 'info', 'file',
+  'check', 'warning', 'x-circle', 'info', 'file', 'brain',
 ]);
 
 function emojiToType(icon: string): string {
@@ -121,6 +121,9 @@ function emojiToType(icon: string): string {
       }
       @case ('info') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+      }
+      @case ('brain') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 2a3.5 3.5 0 0 0-3.4 2.7A3 3 0 0 0 4 7.5a3 3 0 0 0 .7 1.9A3.5 3.5 0 0 0 3 12.5a3.5 3.5 0 0 0 1.7 3A3 3 0 0 0 7 19a3 3 0 0 0 2.5-1.3"/><path d="M14.5 2a3.5 3.5 0 0 1 3.4 2.7A3 3 0 0 1 20 7.5a3 3 0 0 1-.7 1.9 3.5 3.5 0 0 1 1.7 3.1 3.5 3.5 0 0 1-1.7 3A3 3 0 0 1 17 19a3 3 0 0 1-2.5-1.3"/><path d="M12 2v20"/><path d="M12 8h-2"/><path d="M12 14h2"/><path d="M12 11h-3"/><path d="M12 17h3"/><path d="M12 5h2"/></svg>
       }
       @case ('file') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>


### PR DESCRIPTION
## Summary
This PR adds a new brain icon to the icon component library and enhances the dashboard section headers by displaying icons alongside section titles for better visual hierarchy and user experience.

## Key Changes
- **Icon Component**: Added 'brain' icon type to the `KNOWN_TYPES` set and implemented the corresponding SVG rendering in the icon component template
- **Dashboard Headers**: Enhanced the "Datasets" and "Models" section headers with visual icons:
  - Datasets section now displays a database icon
  - Models section now displays the new brain icon
- **Component Dependencies**: Added `IconComponent` to the dashboard component's imports and declarations to support the new icon usage

## Implementation Details
- The brain icon SVG follows the same styling pattern as existing icons (stroke-based, scalable, using currentColor)
- Icons are sized at 18px to maintain visual balance with the section titles
- The icon component is properly imported and declared in the dashboard module to ensure availability in the template

https://claude.ai/code/session_0176v5roLyfGbpfWTmZ6rUi6