### PR TITLE
Add consistent table cell styling to dataset and model cards

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -12,6 +12,12 @@
   }
 }
 
+td {
+  padding: 6px 10px;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
 .name-cell {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -12,6 +12,12 @@
   }
 }
 
+td {
+  padding: 6px 10px;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
 .name-cell {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Added consistent styling for table cells (`<td>` elements) in the dataset and model card components to improve visual consistency and readability across the dashboard.

## Key Changes
- Added `td` styling rule to both `dataset-card.component.scss` and `model-card.component.scss`
- Applied consistent padding (6px 10px) to all table cells
- Set `white-space: nowrap` to prevent text wrapping within cells
- Added subtle bottom border using the design system's `--border-subtle` CSS variable

## Implementation Details
The styling ensures that table cells in both components have:
- Uniform spacing and alignment
- Consistent visual separation between rows via bottom borders
- Proper text handling to maintain compact table layouts

https://claude.ai/code/session_01XAyVMdSgfzuuZuAxtWXmVa