### PR TITLE
Refactor dataset importer modal styles for consistency

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,17 +1,20 @@
 .importer-picker { flex-direction: column; }
 .importer-card { padding: 12px 16px; }
-.btn--sm { padding: 2px 10px; font-size: 0.85rem; }
+.btn--sm { padding: 2px 10px; font-size: .85rem; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+
+.clipper-params, .demo-picker, .server-folder-browser, .sf-browse-section {
+  display: flex;
+  flex-direction: column;
+}
 
 .clipper-params {
   padding-left: 16px;
   border-left: 2px solid var(--border);
-  display: flex;
-  flex-direction: column;
   gap: 8px;
 }
 
-.demo-picker { display: flex; flex-direction: column; gap: 8px; }
+.demo-picker { gap: 8px; }
 
 .demo-tab-bar {
   display: flex;
@@ -28,11 +31,11 @@
   padding: 8px 16px;
   border: none;
   border-bottom: 2px solid transparent;
-  background: transparent;
+  background: none;
   color: var(--text-secondary, var(--text-muted));
-  font-size: 0.85rem;
+  font-size: .85rem;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all .15s;
   margin-bottom: -2px;
   white-space: nowrap;
 
@@ -54,7 +57,7 @@
   gap: 8px;
   margin-bottom: 8px;
 
-  .form-label { margin: 0; font-size: 0.85rem; white-space: nowrap; }
+  .form-label { margin: 0; font-size: .85rem; white-space: nowrap; }
   .form-select--inline { width: auto; min-width: 140px; }
   .form-select { max-width: 200px; }
 }
@@ -67,14 +70,14 @@
 .demo-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.75rem;
+  font-size: .75rem;
   table-layout: fixed;
 
   thead th {
     text-align: left;
     padding: 5px 8px;
     color: var(--text-secondary, var(--text-muted));
-    font-size: 0.7rem;
+    font-size: .7rem;
     font-weight: 600;
     cursor: pointer;
     user-select: none;
@@ -98,13 +101,13 @@
   white-space: nowrap;
 }
 
-.col-desc { color: var(--text-muted); font-size: 0.7rem; }
+.col-desc { color: var(--text-muted); font-size: .7rem; }
 .col-name { font-weight: 600; color: var(--text-primary); }
 
 .sf-dir-date {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 0.75rem;
+  font-size: .75rem;
   flex-shrink: 0;
   white-space: nowrap;
 }
@@ -113,20 +116,18 @@
 
 .demo-row {
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background .15s;
 
   td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
   &:hover { background: var(--bg-subtle); }
   &.ready .col-name { color: var(--color-good); }
 }
 
-// --- Badges (shared base) ---
-
 .badge-ready, .badge-embedding, .badge-download {
   display: inline-block;
   padding: 1px 7px;
   color: #fff;
-  font-size: 0.7rem;
+  font-size: .7rem;
   border-radius: 3px;
 }
 
@@ -134,11 +135,9 @@
 .badge-embedding { background: var(--badge-embedding, var(--accent)); }
 .badge-download { background: var(--border); color: var(--text-muted); }
 
-// --- Server folder browser ---
-
-.server-folder-browser { display: flex; flex-direction: column; gap: 12px; }
-.sf-browse-section { display: flex; flex-direction: column; gap: 6px; }
-.sf-breadcrumbs { display: flex; align-items: center; gap: 2px; font-size: 0.8rem; flex-wrap: wrap; }
+.server-folder-browser { gap: 12px; }
+.sf-browse-section { gap: 6px; }
+.sf-breadcrumbs { display: flex; align-items: center; gap: 2px; font-size: .8rem; flex-wrap: wrap; }
 
 .sf-breadcrumb {
   background: none;
@@ -147,7 +146,7 @@
   cursor: pointer;
   padding: 2px 4px;
   border-radius: 3px;
-  font-size: 0.8rem;
+  font-size: .8rem;
 
   &:hover { background: var(--bg-subtle); }
 
@@ -159,7 +158,7 @@
   }
 }
 
-.sf-breadcrumb-sep { color: var(--text-muted); font-size: 0.75rem; }
+.sf-breadcrumb-sep { color: var(--text-muted); font-size: .75rem; }
 
 .sf-dir-list {
   border: 1px solid var(--border);
@@ -180,19 +179,18 @@
   cursor: pointer;
   text-align: left;
   color: var(--text-primary);
-  font-size: 0.85rem;
-  transition: background 0.15s;
+  font-size: .85rem;
+  transition: background .15s;
 
   &:last-child { border-bottom: none; }
   &:hover { background: var(--bg-subtle); }
 }
 
-.sf-dir-icon { font-size: 0.9rem; flex-shrink: 0; }
-
+.sf-dir-icon { font-size: .9rem; flex-shrink: 0; }
 
 .sf-empty-dir {
   color: var(--text-muted);
-  font-size: 0.8rem;
+  font-size: .8rem;
   padding: 12px;
   text-align: center;
 }
@@ -200,7 +198,7 @@
 .sf-selected-path { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
 
 .sf-path-display {
-  font-size: 0.8rem;
+  font-size: .8rem;
   color: var(--text-secondary, var(--text-muted));
   background: var(--bg-subtle);
   padding: 3px 8px;


### PR DESCRIPTION
## Summary
This PR refactors the SCSS stylesheet for the dataset importer modal component to improve code organization and consistency. The changes focus on consolidating duplicate style declarations and standardizing CSS value formatting.

## Key Changes
- **Consolidated flex layout rules**: Moved common `display: flex` and `flex-direction: column` declarations to a shared selector group (`.clipper-params, .demo-picker, .server-folder-browser, .sf-browse-section`) to reduce duplication
- **Standardized font-size notation**: Changed all `0.XXrem` values to `.XXrem` format for consistency across the stylesheet
- **Simplified property values**: Changed `background: transparent` to `background: none` for cleaner CSS
- **Removed redundant declarations**: Eliminated duplicate flex properties from individual selectors that now inherit from the consolidated group
- **Cleaned up comments**: Removed section separator comments that are no longer needed after refactoring

## Notable Implementation Details
- The refactoring maintains all existing visual behavior while reducing CSS duplication
- Font-size values were standardized to omit the leading zero (e.g., `.85rem` instead of `0.85rem`), which is valid CSS and improves readability
- The consolidated flex layout group at the top of the stylesheet makes it easier to maintain consistent spacing and layout patterns across related components

https://claude.ai/code/session_014vbC2VXvapdBpzfC6UbK6M