### PR TITLE
Change type-cell display from flex to inline-flex

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -56,7 +56,7 @@ td {
 }
 
 .type-cell {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 5px;
 }

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -56,7 +56,7 @@ td {
 }
 
 .type-cell {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 5px;
 }


### PR DESCRIPTION
## Summary
Updated the CSS display property for `.type-cell` elements from `flex` to `inline-flex` in both dataset and model card components to improve layout behavior.

## Key Changes
- Modified `dataset-card.component.scss`: Changed `.type-cell` display from `flex` to `inline-flex`
- Modified `model-card.component.scss`: Changed `.type-cell` display from `flex` to `inline-flex`

## Implementation Details
The `inline-flex` display property allows the type cells to respect the inline flow of their parent container while maintaining flexbox layout capabilities for their children. This change prevents unnecessary line breaks and allows the cells to sit inline with surrounding content, resulting in more compact and efficient use of horizontal space in the card layouts.

https://claude.ai/code/session_01TdEFRFTVBJiKqPx9Q41MwR