### PR TITLE
Disable left panel interactions during Find scoring

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -21,6 +21,7 @@
       [loadSortLabel]="sortState.loadSortLabel"
       [textQuery]="sortState.textQuery"
       [panelMode]="'find'"
+      [disabled]="sortState.sortBusy"
       [autopilotCollapsed]="false"
       [autopilotEnabled]="false"
       (mediaSelect)="onMediaSelect($event)"

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -1,4 +1,4 @@
-<div class="left-panel" [class.collapsed-autopilot]="panelMode === 'label' && activeTab === 'autopilot' && autopilotCollapsed">
+<div class="left-panel" [class.collapsed-autopilot]="panelMode === 'label' && activeTab === 'autopilot' && autopilotCollapsed" [class.disabled]="disabled">
   @if (panelMode === 'find') {
     <!-- Find mode: simplified view — just the media list header + media + stripe -->
     <div class="tab-panel-manual" role="region" aria-label="Find results">

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -5,6 +5,11 @@
   overflow: hidden;
   container-type: inline-size;
   container-name: left-panel;
+
+  &.disabled {
+    pointer-events: none;
+    opacity: 0.45;
+  }
 }
 
 .left-tabs {

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -55,6 +55,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() autopilotEnabled = true;
   /** 'label' = full labeling UI (default), 'find' = simplified media-only view */
   @Input() panelMode: 'label' | 'find' = 'label';
+  /** Disable all interaction (used during Find scoring). */
+  @Input() disabled = false;
 
   @Output() sortModeChange = new EventEmitter<SortMode>();
   @Output() selectModeChange = new EventEmitter<SelectMode>();


### PR DESCRIPTION
## Summary
Add a `disabled` input property to the LeftPanelComponent that prevents user interactions during Find scoring operations. When disabled, the panel becomes non-interactive with reduced opacity to provide visual feedback.

## Key Changes
- Added `disabled` input property to LeftPanelComponent to control interaction state
- Added `.disabled` CSS class styling that applies `pointer-events: none` and `opacity: 0.45` to visually indicate disabled state
- Bound the `disabled` class in the template based on the input property
- Connected FindViewComponent to pass `sortState.sortBusy` to the left panel's `disabled` input, preventing interactions while Find scoring is in progress

## Implementation Details
- The disabled state is purely visual and behavioral—it prevents pointer events and reduces opacity to 45% to clearly indicate the panel is unavailable
- The integration with FindViewComponent ensures the left panel is automatically disabled whenever a sort/scoring operation is active (`sortBusy` flag)
- This prevents users from modifying selections or other panel state while Find scoring is being performed

https://claude.ai/code/session_011kijznDCRwD3xqZ58GvzqC