### PR TITLE
Add resolver-based fallback for item-by-item media ingestion

### DIFF
--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -792,6 +792,101 @@ class TestIngestMissingClips:
         groups = _group_by_origin(entries)
         assert len(groups) == 0
 
+    def test_media_type_from_origin_folder(self):
+        """Folder origins resolve media type from params."""
+        from vtsearch.datasets.ingest import _media_type_from_origin
+
+        origin = {"importer": "folder", "params": {"path": "/tmp/x", "media_type": "paragraphs"}}
+        assert _media_type_from_origin(origin) == "text"
+
+    def test_media_type_from_origin_demo(self):
+        """Demo origins resolve media type from DEMO_DATASETS config."""
+        from vtsearch.datasets.config import DEMO_DATASETS
+        from vtsearch.datasets.ingest import _media_type_from_origin
+
+        # Find a real demo dataset name from the config
+        for name, info in DEMO_DATASETS.items():
+            expected = info.get("media_type", "")
+            if expected:
+                origin = {"importer": "demo", "params": {"name": name}}
+                assert _media_type_from_origin(origin) == expected
+                break
+
+    def test_media_type_from_origin_unknown(self):
+        """Unknown origins return empty string."""
+        from vtsearch.datasets.ingest import _media_type_from_origin
+
+        origin = {"importer": "unknown_xyz", "params": {}}
+        assert _media_type_from_origin(origin) == ""
+
+    def test_ingest_via_resolver_with_demo_origin(self, tmp_path):
+        """_ingest_via_resolver resolves demo origin files item-by-item."""
+        import numpy as np
+
+        from vtsearch.datasets.ingest import _ingest_via_resolver
+
+        rng = np.random.default_rng(42)
+
+        # Create a fake image file
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        cat_dir = img_dir / "cat"
+        cat_dir.mkdir()
+        # Create a minimal valid JPEG (just enough bytes for PIL to open)
+        from PIL import Image
+
+        img = Image.new("RGB", (32, 32), color=(255, 0, 0))
+        img_path = cat_dir / "test_001.jpg"
+        img.save(img_path, format="JPEG")
+
+        origin = {"importer": "demo", "params": {"name": "test_demo_dataset"}}
+        entries = [
+            {
+                "origin": origin,
+                "origin_name": "cat/test_001.jpg",
+                "md5": "some_md5",
+                "label": "good",
+            }
+        ]
+
+        existing: dict = {}
+
+        def noop_progress(status, message, current, total):
+            pass
+
+        fake_embedding = rng.standard_normal(512).astype(np.float32)
+
+        # Patch resolve_file_from_origin to return our test file,
+        # embed_file to return a fake embedding, and _media_type_from_origin
+        # to return "image"
+        from unittest.mock import patch
+
+        with (
+            patch("vtsearch.datasets.ingest._media_type_from_origin", return_value="image"),
+            patch("vtsearch.datasets.ingest.resolve_file_from_origin", return_value=img_path),
+            patch("vtsearch.datasets.ingest.embed_file", return_value=fake_embedding),
+        ):
+            result = _ingest_via_resolver(origin, entries, existing, noop_progress)
+
+        assert result == 1
+        assert 1 in existing
+        assert existing[1]["origin_name"] == "cat/test_001.jpg"
+        assert existing[1]["origin"] == origin
+        assert existing[1]["embedding"] is fake_embedding
+
+    def test_ingest_via_resolver_returns_neg1_for_unknown_media_type(self):
+        """_ingest_via_resolver returns -1 when media type can't be determined."""
+        from vtsearch.datasets.ingest import _ingest_via_resolver
+
+        origin = {"importer": "unknown_xyz", "params": {}}
+        entries = [{"origin": origin, "origin_name": "x", "md5": "m", "label": "good"}]
+
+        def noop_progress(status, message, current, total):
+            pass
+
+        result = _ingest_via_resolver(origin, entries, {}, noop_progress)
+        assert result == -1
+
     def test_ingest_with_folder_importer(self, tmp_path):
         """Ingest missing medias from a real folder origin."""
         import hashlib

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -797,7 +797,7 @@ class TestIngestMissingClips:
         from vtsearch.datasets.ingest import _media_type_from_origin
 
         origin = {"importer": "folder", "params": {"path": "/tmp/x", "media_type": "paragraphs"}}
-        assert _media_type_from_origin(origin) == "text"
+        assert _media_type_from_origin(origin) == "paragraph"
 
     def test_media_type_from_origin_demo(self):
         """Demo origins resolve media type from DEMO_DATASETS config."""
@@ -858,13 +858,14 @@ class TestIngestMissingClips:
 
         # Patch resolve_file_from_origin to return our test file,
         # embed_file to return a fake embedding, and _media_type_from_origin
-        # to return "image"
+        # to return "image".  The resolver imports are lazy (inside the
+        # function), so patch at the source module.
         from unittest.mock import patch
 
         with (
             patch("vtsearch.datasets.ingest._media_type_from_origin", return_value="image"),
-            patch("vtsearch.datasets.ingest.resolve_file_from_origin", return_value=img_path),
-            patch("vtsearch.datasets.ingest.embed_file", return_value=fake_embedding),
+            patch("vtsearch.models.resolver.resolve_file_from_origin", return_value=img_path),
+            patch("vtsearch.models.resolver.embed_file", return_value=fake_embedding),
         ):
             result = _ingest_via_resolver(origin, entries, existing, noop_progress)
 

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -52,6 +52,37 @@ def _group_by_origin(
     return groups
 
 
+def _media_type_from_origin(origin_dict: dict[str, Any]) -> str:
+    """Determine the media type ID from an origin dict.
+
+    Checks origin params (``media_type`` for folder origins) and falls back
+    to the ``DEMO_DATASETS`` config for demo origins.  Returns an empty
+    string if the media type cannot be determined.
+    """
+    params = origin_dict.get("params", {})
+    importer_name = origin_dict.get("importer", "")
+
+    # Folder origins store the folder-import name (e.g. "sounds" → "audio")
+    folder_import_name = params.get("media_type", "")
+    if folder_import_name:
+        try:
+            from vtsearch.media import get_by_folder_name
+
+            return get_by_folder_name(folder_import_name).type_id
+        except (KeyError, ValueError):
+            pass
+
+    # Demo origins: look up from DEMO_DATASETS config
+    if importer_name == "demo":
+        from vtsearch.datasets.config import DEMO_DATASETS
+
+        demo_name = params.get("name", "")
+        if demo_name in DEMO_DATASETS:
+            return DEMO_DATASETS[demo_name].get("media_type", "")
+
+    return ""
+
+
 def _ingest_via_source(
     origin_dict: dict[str, Any],
     entries: list[dict[str, Any]],
@@ -70,17 +101,7 @@ def _ingest_via_source(
     if source is None:
         return -1
 
-    # Resolve the media type from the folder_import_name (e.g. "sounds" → "audio").
-    folder_import_name = origin_dict.get("params", {}).get("media_type", "")
-    media_type_id = ""
-    if folder_import_name:
-        try:
-            from vtsearch.media import get_by_folder_name
-
-            mt = get_by_folder_name(folder_import_name)
-            media_type_id = mt.type_id
-        except (KeyError, ValueError):
-            pass
+    media_type_id = _media_type_from_origin(origin_dict)
 
     from vtsearch.models.resolver import embed_file
 
@@ -134,6 +155,71 @@ def _ingest_via_source(
     return ingested
 
 
+def _ingest_via_resolver(
+    origin_dict: dict[str, Any],
+    entries: list[dict[str, Any]],
+    medias: dict[int, dict[str, Any]],
+    on_progress: ProgressCallback,
+) -> int:
+    """Try to ingest missing entries using resolve_file_from_origin (item-by-item).
+
+    Uses the importer-registry-based file resolver, which handles demo,
+    folder, converter, dupe_set, and any other origin type that has a
+    ``resolve_file()`` method on its importer.
+
+    Returns the number of successfully ingested medias, or -1 if the
+    media type cannot be determined (caller should fall back to the
+    full-importer path).
+    """
+    media_type_id = _media_type_from_origin(origin_dict)
+    if not media_type_id:
+        return -1
+
+    from vtsearch.models.resolver import embed_file, resolve_file_from_origin
+
+    ingested = 0
+    cid = next_media_id(medias)
+
+    for entry in entries:
+        origin_name = entry.get("origin_name", "")
+        filename = entry.get("filename", "")
+
+        file_path = resolve_file_from_origin(origin_dict, origin_name, filename)
+        if file_path is None:
+            continue
+
+        embedding = embed_file(file_path, media_type_id)
+        if embedding is None:
+            continue
+
+        file_bytes = file_path.read_bytes()
+        md5 = hashlib.md5(file_bytes).hexdigest()
+
+        media_data: dict[str, Any] = {
+            "id": cid,
+            "filename": origin_name or file_path.name,
+            "origin": origin_dict,
+            "origin_name": origin_name or file_path.name,
+            "md5": md5,
+            "embedding": embedding,
+            "media_bytes": file_bytes,
+            "media_path": str(file_path),
+        }
+
+        medias[cid] = media_data
+        cid += 1
+        ingested += 1
+
+        on_progress(
+            "ingesting",
+            f"Resolved {origin_name or filename} ({ingested}/{len(entries)})...",
+            ingested,
+            len(entries),
+        )
+
+    return ingested
+
+
 def ingest_missing_medias(
     missing_entries: list[dict[str, Any]],
     medias: dict[int, dict[str, Any]],
@@ -145,7 +231,10 @@ def ingest_missing_medias(
 
     1. If a :class:`~vtsearch.datasets.sources.base.MediaSource` is
        available, fetch only the needed files individually (fast path).
-    2. Otherwise, fall back to running the full dataset importer and
+    2. If :func:`~vtsearch.models.resolver.resolve_file_from_origin` can
+       locate individual files (e.g. demo datasets with files on disk),
+       embed and ingest them one-by-one (medium path).
+    3. Otherwise, fall back to running the full dataset importer and
        cherry-picking matching medias (legacy path).
 
     Args:
@@ -183,6 +272,13 @@ def ingest_missing_medias(
         source_result = _ingest_via_source(origin_dict, entries, medias, on_progress)
         if source_result >= 0:
             total_ingested += source_result
+            continue
+
+        # Medium path: use resolve_file_from_origin for item-by-item resolution
+        # (handles demo datasets, importers with resolve_file, etc.)
+        resolver_result = _ingest_via_resolver(origin_dict, entries, medias, on_progress)
+        if resolver_result >= 0:
+            total_ingested += resolver_result
             continue
 
         # Legacy path: run the full importer


### PR DESCRIPTION
## Summary
This PR adds a new medium-path ingestion strategy that uses the file resolver to ingest missing medias item-by-item, falling back to the full importer only when necessary. This improves performance for demo datasets and other origins that support individual file resolution.

## Key Changes
- **Extract media type resolution logic**: Created `_media_type_from_origin()` helper function to determine media type from origin dicts, supporting both folder origins (via `get_by_folder_name`) and demo origins (via `DEMO_DATASETS` config)
- **Add resolver-based ingestion path**: Implemented `_ingest_via_resolver()` function that resolves and embeds individual files using `resolve_file_from_origin()`, enabling efficient item-by-item ingestion for demo datasets and other resolver-capable origins
- **Update ingestion strategy**: Modified `ingest_missing_medias()` to try three paths in order:
  1. Fast path: Use MediaSource if available
  2. Medium path: Use resolver for item-by-item ingestion (new)
  3. Legacy path: Fall back to full importer
- **Add comprehensive tests**: Included unit tests for media type resolution from folder and demo origins, resolver-based ingestion with demo datasets, and error handling for unknown media types

## Implementation Details
- `_media_type_from_origin()` returns an empty string if media type cannot be determined, allowing callers to fall back gracefully
- `_ingest_via_resolver()` returns -1 on failure (unknown media type) to signal the caller to try the next strategy
- The resolver path handles demo, folder, converter, dupe_set, and any other origin type with a `resolve_file()` method on its importer
- File resolution is done item-by-item with progress callbacks, matching the pattern of the source-based path

https://claude.ai/code/session_0119gvrMVR1MrmWdfxMfu817