### PR TITLE
Fix hard mode selection to use index distance instead of score distance

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -388,6 +388,35 @@ describe('LabelViewComponent', () => {
     expect(sortState.sortBusy).toBeFalse();
   }));
 
+  it('should select hard items by index distance, not score distance', () => {
+    flushInitialRequests();
+
+    // Scores cluster above the threshold — by score distance, id 4 (0.55) is
+    // closest to 0.5, but by index the threshold sits between id 4 and id 5.
+    // Both sides of the boundary should get equal consideration.
+    component.sortState.setSortResults(
+      [
+        { id: 1, score: 0.95 },
+        { id: 2, score: 0.90 },
+        { id: 3, score: 0.80 },
+        { id: 4, score: 0.55 },  // index 3 — just above threshold
+        { id: 5, score: 0.10 },  // index 4 — just below threshold
+        { id: 6, score: 0.05 },  // index 5
+      ],
+      0.5,
+    );
+
+    // Vote on id 4 (the one right at the boundary). With score-based selection
+    // the next pick would be id 3 (score 0.80, dist=0.30) over id 5 (score 0.10,
+    // dist=0.40) — biasing toward goods. Index-based should pick id 5 (index 4,
+    // one step from threshold index 4) over id 3 (index 2, two steps away).
+    component.voteState.loadVotes();
+    httpMock.expectOne('/api/votes').flush({ good: [4], bad: [], click_times: {}, learned_scores: {} });
+
+    component.onSelectModeChange('hard');
+    expect(component.mediaState.selectedId).toBe(5);
+  });
+
   it('should advance past just-voted item even when vote state is stale', () => {
     flushInitialRequests();
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -748,14 +748,26 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       }
     } else if (this.sortState.selectMode === 'hard' && this.sortState.threshold !== null) {
+      const threshold = this.sortState.threshold!;
+      // Find the index where the threshold falls in the sorted (descending) list.
+      // This is the first position whose score is at or below the threshold.
+      let thresholdIndex = sortOrder.length;
+      for (let i = 0; i < sortOrder.length; i++) {
+        if (sortOrder[i].score <= threshold) {
+          thresholdIndex = i;
+          break;
+        }
+      }
+      // Pick the unlabeled item whose index is closest to the threshold index.
+      // This avoids biasing toward one side when scores cluster unevenly.
       let best: SortedItem | null = null;
       let bestDist = Infinity;
-      for (const s of sortOrder) {
-        if (isVoted(s.id)) continue;
-        const dist = Math.abs(s.score - this.sortState.threshold!);
+      for (let i = 0; i < sortOrder.length; i++) {
+        if (isVoted(sortOrder[i].id)) continue;
+        const dist = Math.abs(i - thresholdIndex);
         if (dist < bestDist) {
           bestDist = dist;
-          best = s;
+          best = sortOrder[i];
         }
       }
       if (best) this.mediaState.selectMedia(best.id);


### PR DESCRIPTION
## Summary
Changed the "hard" selection mode to pick items based on their index distance from the threshold boundary rather than their score distance. This prevents bias when scores cluster unevenly around the threshold.

## Key Changes
- Modified the hard mode selection algorithm in `LabelViewComponent.onSelectModeChange()` to:
  - Calculate the threshold index (the position in the sorted list where the threshold falls)
  - Select the unlabeled item whose index is closest to the threshold index
  - Replace score-based distance calculation with index-based distance calculation
- Added comprehensive test case validating the new behavior with a score cluster scenario

## Implementation Details
The previous implementation selected items by minimizing `Math.abs(score - threshold)`, which could bias selection toward one side when scores clustered unevenly. For example, with scores [0.95, 0.90, 0.80, 0.55, 0.10, 0.05] and threshold 0.5, the score at 0.55 is closer by score distance (0.05) than 0.10 (0.40), even though 0.10 is only one index away from the threshold boundary.

The new implementation:
1. Finds `thresholdIndex` - the first position in the sorted list where score ≤ threshold
2. Calculates distance as `Math.abs(itemIndex - thresholdIndex)` instead of score distance
3. Ensures equal consideration for items on both sides of the boundary

https://claude.ai/code/session_0116uFzwrFh811mJiU5ssGJ3