### PR TITLE
Add name-based fallback for cross-dataset label imports

### DIFF
--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -479,7 +479,7 @@ class TestResolveClipIdsUnion:
 
         # Entry with only md5, no origin — should match by md5
         md5 = app_module.medias[1]["md5"]
-        origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entry = {"md5": md5, "label": "good"}
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert 1 in cids
@@ -487,7 +487,7 @@ class TestResolveClipIdsUnion:
     def test_origin_match_only(self):
         from vtsearch.utils import build_media_lookup, resolve_media_ids
 
-        origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         media = app_module.medias[1]
         entry = {"origin": media["origin"], "origin_name": media["origin_name"], "label": "good"}
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
@@ -501,7 +501,7 @@ class TestResolveClipIdsUnion:
         orig_md5 = app_module.medias[2]["md5"]
         app_module.medias[2]["md5"] = app_module.medias[1]["md5"]
         try:
-            origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+            origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
             clip1 = app_module.medias[1]
             # Entry: origin matches media 1, md5 also matches media 1 AND media 2
             entry = {
@@ -519,7 +519,7 @@ class TestResolveClipIdsUnion:
     def test_no_match_returns_empty(self):
         from vtsearch.utils import build_media_lookup, resolve_media_ids
 
-        origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entry = {
             "md5": "nonexistent",
             "origin": {"importer": "nope", "params": {}},
@@ -539,7 +539,7 @@ class TestFindMissingEntries:
     def test_all_present_returns_empty(self):
         from vtsearch.utils import build_media_lookup, find_missing_entries
 
-        origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entries = [{"md5": app_module.medias[i]["md5"], "label": "good"} for i in [1, 2, 3]]
         missing = find_missing_entries(entries, origin_lookup, md5_lookup)
         assert missing == []
@@ -547,7 +547,7 @@ class TestFindMissingEntries:
     def test_unknown_entries_returned(self):
         from vtsearch.utils import build_media_lookup, find_missing_entries
 
-        origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entries = [
             {"md5": app_module.medias[1]["md5"], "label": "good"},
             {"md5": "totally_unknown", "label": "bad"},
@@ -559,7 +559,7 @@ class TestFindMissingEntries:
     def test_invalid_labels_excluded(self):
         from vtsearch.utils import build_media_lookup, find_missing_entries
 
-        origin_lookup, md5_lookup = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entries = [
             {"md5": "unknown1", "label": "good"},
             {"md5": "unknown2", "label": "meh"},  # invalid label — excluded

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -529,6 +529,42 @@ class TestResolveClipIdsUnion:
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert cids == []
 
+    def test_name_fallback_matches_by_origin_name(self):
+        """When md5 and origin don't match, name_lookup matches by origin_name alone."""
+        from vtsearch.utils import build_media_lookup, resolve_media_ids
+
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
+        origin_name = app_module.medias[1].get("origin_name", "")
+        assert origin_name, "Test media 1 must have origin_name"
+        entry = {"md5": "wrong_md5", "origin_name": origin_name, "label": "good"}
+        # Without name_lookup — no match
+        cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
+        assert cids == []
+        # With name_lookup — matches by origin_name
+        cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
+        assert 1 in cids
+
+    def test_name_fallback_uses_filename_when_no_origin_name(self):
+        """name_lookup falls back to 'filename' key when origin_name is absent."""
+        from vtsearch.utils import build_media_lookup, resolve_media_ids
+
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
+        origin_name = app_module.medias[1].get("origin_name", "")
+        assert origin_name
+        entry = {"md5": "wrong_md5", "filename": origin_name, "label": "good"}
+        cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
+        assert 1 in cids
+
+    def test_name_fallback_skipped_when_md5_matches(self):
+        """Name fallback is NOT used when md5 already matches (avoids false positives)."""
+        from vtsearch.utils import build_media_lookup, resolve_media_ids
+
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
+        md5 = app_module.medias[1]["md5"]
+        entry = {"md5": md5, "origin_name": "some_other_name", "label": "good"}
+        cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
+        assert 1 in cids
+
 
 # ---------------------------------------------------------------------------
 # find_missing_entries
@@ -1082,5 +1118,35 @@ class TestServerCsvLabelImporter:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 2
+        assert 1 in app_module.good_votes
+        assert 2 in app_module.bad_votes
+
+    def test_csv_importer_preserves_origin_name(self, tmp_path):
+        """CSV importer reads origin_name/filename/category columns."""
+        from vtsearch.labels.importers.server_csv_file import _parse_csv_bytes
+
+        csv_text = "label,md5,origin_name,filename,category\ngood,abc123,clip.wav,clip.wav,music\n"
+        result = _parse_csv_bytes(csv_text.encode())
+        assert len(result) == 1
+        assert result[0]["origin_name"] == "clip.wav"
+        assert result[0]["filename"] == "clip.wav"
+        assert result[0]["category"] == "music"
+
+    def test_csv_cross_dataset_import_matches_by_origin_name(self, client, tmp_path):
+        """CSV labels with different MD5s match current dataset elements by origin_name."""
+        origin_name_1 = app_module.medias[1].get("origin_name", "")
+        origin_name_2 = app_module.medias[2].get("origin_name", "")
+        assert origin_name_1, "Test media 1 must have an origin_name"
+        csv_text = f"label,md5,origin_name\ngood,wrong_md5_1,{origin_name_1}\nbad,wrong_md5_2,{origin_name_2}\n"
+        p = tmp_path / "cross_dataset.csv"
+        p.write_text(csv_text)
+        res = client.post(
+            "/api/label-importers/import/server_csv_file",
+            json={"filepath": str(p)},
+        )
+        assert res.status_code == 200
+        result = res.get_json()
+        assert result["applied"] == 2
+        assert result["missing_count"] == 0
         assert 1 in app_module.good_votes
         assert 2 in app_module.bad_votes

--- a/tests/test_origin_labelset.py
+++ b/tests/test_origin_labelset.py
@@ -445,7 +445,7 @@ class TestBuildClipLookup:
             1: {"id": 1, "md5": "h1", "origin": {"importer": "folder", "params": {"path": "/a"}}, "origin_name": "a.wav"},
             2: {"id": 2, "md5": "h2", "origin": {"importer": "folder", "params": {"path": "/a"}}, "origin_name": "b.wav"},
         }
-        origin_lookup, md5_lookup = build_media_lookup(medias)
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias)
         assert len(origin_lookup) == 2
         assert len(md5_lookup) == 2
 
@@ -455,14 +455,14 @@ class TestBuildClipLookup:
             1: {"id": 1, "md5": "same_hash", "origin": {"importer": "folder", "params": {}}, "origin_name": "a.wav"},
             2: {"id": 2, "md5": "same_hash", "origin": {"importer": "folder", "params": {}}, "origin_name": "b.wav"},
         }
-        _, md5_lookup = build_media_lookup(medias)
+        _, md5_lookup, _ = build_media_lookup(medias)
         assert sorted(md5_lookup["same_hash"]) == [1, 2]
 
     def test_clips_without_origin_only_in_md5_lookup(self):
         medias = {
             1: {"id": 1, "md5": "h1"},
         }
-        origin_lookup, md5_lookup = build_media_lookup(medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
         assert len(origin_lookup) == 0
         assert md5_lookup["h1"] == [1]
 
@@ -477,33 +477,33 @@ class TestResolveClipIds:
         return build_media_lookup(medias)
 
     def test_match_by_origin(self):
-        origin_lookup, md5_lookup = self._make_lookups()
+        origin_lookup, md5_lookup, _ = self._make_lookups()
         entry = {"md5": "wrong", "origin": {"importer": "folder", "params": {"path": "/a"}}, "origin_name": "a.wav"}
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert ids == [1]
 
     def test_fallback_to_md5(self):
-        origin_lookup, md5_lookup = self._make_lookups()
+        origin_lookup, md5_lookup, _ = self._make_lookups()
         entry = {"md5": "h2"}
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert ids == [2]
 
     def test_md5_fallback_returns_all_duplicates(self):
         """When falling back to MD5, all medias with that hash are returned."""
-        origin_lookup, md5_lookup = self._make_lookups()
+        origin_lookup, md5_lookup, _ = self._make_lookups()
         entry = {"md5": "h1"}
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert sorted(ids) == [1, 3]
 
     def test_no_match_returns_empty(self):
-        origin_lookup, md5_lookup = self._make_lookups()
+        origin_lookup, md5_lookup, _ = self._make_lookups()
         entry = {"md5": "nonexistent"}
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert ids == []
 
     def test_union_of_origin_and_md5(self):
         """Origin and MD5 matches are unioned: all matching medias are returned."""
-        origin_lookup, md5_lookup = self._make_lookups()
+        origin_lookup, md5_lookup, _ = self._make_lookups()
         # Origin matches media 1, md5 "h1" matches medias 1 and 3 → union is [1, 3]
         entry = {"md5": "h1", "origin": {"importer": "folder", "params": {"path": "/a"}}, "origin_name": "a.wav"}
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)

--- a/vtsearch/labels/importers/server_csv_file/__init__.py
+++ b/vtsearch/labels/importers/server_csv_file/__init__.py
@@ -93,12 +93,21 @@ def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
     if "md5" not in normalised or "label" not in normalised:
         raise ValueError("CSV must have 'md5' and 'label' column headers.")
 
+    # Optional columns that enrich resolution (origin_name, filename, category)
+    optional_cols = ("origin_name", "filename", "category")
+
     results = []
     for row in reader:
         md5 = row.get(normalised["md5"], "").strip()
         label = row.get(normalised["label"], "").strip().lower()
         if md5 and label:
-            results.append({"md5": md5, "label": label})
+            entry: dict[str, str] = {"md5": md5, "label": label}
+            for col in optional_cols:
+                if col in normalised:
+                    val = row.get(normalised[col], "").strip()
+                    if val:
+                        entry[col] = val
+            results.append(entry)
     return results
 
 

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -351,7 +351,7 @@ def train_from_label_import(importer_name: str):
     # Match md5s to loaded medias and collect embeddings
     from vtsearch.utils import build_media_lookup, resolve_media_ids
 
-    origin_lookup, md5_lookup = build_media_lookup(snap)
+    origin_lookup, md5_lookup, _ = build_media_lookup(snap)
 
     X_list: list = []
     y_list: list = []
@@ -520,7 +520,7 @@ def find_check_labels():
 
             from vtsearch.utils import build_media_lookup, resolve_media_ids
 
-            origin_lookup, md5_lookup = build_media_lookup(temp_medias)
+            origin_lookup, md5_lookup, _ = build_media_lookup(temp_medias)
             matched = 0
             for lbl in labels:
                 if resolve_media_ids(lbl, origin_lookup, md5_lookup):
@@ -785,7 +785,7 @@ def multi_find():
                 try:
                     from vtsearch.utils import build_media_lookup, resolve_media_ids
 
-                    origin_lookup, md5_lookup = build_media_lookup(temp_medias)
+                    origin_lookup, md5_lookup, _ = build_media_lookup(temp_medias)
                     good_ids, bad_ids = [], []
                     for lbl in labels:
                         matched = resolve_media_ids(lbl, origin_lookup, md5_lookup)

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -52,6 +52,7 @@ def _apply_labels(
     label_entries: list[dict],
     origin_lookup: dict[str, list[int]],
     md5_lookup: dict[str, list[int]],
+    name_lookup: dict[str, list[int]] | None = None,
 ) -> tuple[int, int]:
     """Apply label entries to the global vote state.
 
@@ -65,7 +66,7 @@ def _apply_labels(
         if label not in ("good", "bad"):
             skipped += 1
             continue
-        cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
+        cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
         if not cids:
             skipped += 1
             continue
@@ -133,11 +134,11 @@ def run_label_import(importer_name: str):
         return jsonify({"error": "Importer did not return a list of label dicts."}), 500
 
     # Apply labels to global vote state
-    origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
-    applied, skipped = _apply_labels(label_entries, origin_lookup, md5_lookup)
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+    applied, skipped = _apply_labels(label_entries, origin_lookup, md5_lookup, name_lookup)
 
     # Detect entries that could not be matched at all
-    missing = find_missing_entries(label_entries, origin_lookup, md5_lookup)
+    missing = find_missing_entries(label_entries, origin_lookup, md5_lookup, name_lookup)
     # Adjust skipped count: missing entries were already counted as skipped
     # by _apply_labels, but we report them separately now.
     skipped -= len(missing)
@@ -153,14 +154,14 @@ def run_label_import(importer_name: str):
 
         if ingested > 0:
             # Re-apply labels now that new medias are available
-            origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
-            resolved_applied, _ = _apply_labels(missing, origin_lookup, md5_lookup)
+            origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+            resolved_applied, _ = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
             applied += resolved_applied
 
         # Check which entries still couldn't be resolved
         if ingested < len(missing):
-            origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
-            unresolved = find_missing_entries(missing, origin_lookup, md5_lookup)
+            origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+            unresolved = find_missing_entries(missing, origin_lookup, md5_lookup, name_lookup)
 
     msg = f"Applied {applied} label(s), skipped {skipped}."
     if ingested > 0:
@@ -212,8 +213,8 @@ def ingest_missing():
     ingested = ingest_missing_medias(entries, medias)
 
     # Now apply labels to the newly ingested medias
-    origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
-    applied, _ = _apply_labels(entries, origin_lookup, md5_lookup)
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+    applied, _ = _apply_labels(entries, origin_lookup, md5_lookup, name_lookup)
 
     return jsonify(
         {

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -449,7 +449,7 @@ def add_media_to_pile() -> tuple[Response, int] | Response:
 
     # Check if a media with this MD5 already exists
     snap = snapshot_medias()
-    _, md5_lookup = build_media_lookup(snap)
+    _, md5_lookup, _ = build_media_lookup(snap)
     existing_cids = md5_lookup.get(file_md5, [])
 
     if existing_cids:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -395,7 +395,7 @@ def import_labels():
     if not isinstance(labels, list):
         return jsonify({"error": "labels must be a list"}), 400
 
-    origin_lookup, md5_lookup = build_media_lookup(snapshot_medias())
+    origin_lookup, md5_lookup, _ = build_media_lookup(snapshot_medias())
 
     applied = 0
     skipped = 0

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -153,7 +153,7 @@ def _seed_good_votes_from_examples(examples: list[dict]) -> int:
     if not snap:
         return 0
 
-    _, md5_lookup = build_media_lookup(snap)
+    _, md5_lookup, _ = build_media_lookup(snap)
     server_media_dir = DATA_DIR / "example_media"
 
     # Determine the embedder and media type from the loaded dataset so we
@@ -257,7 +257,7 @@ def _restore_labels_from_trainable_model(tm_data: dict) -> int:
     if not snap:
         return 0
 
-    origin_lookup, md5_lookup = build_media_lookup(snap)
+    origin_lookup, md5_lookup, _ = build_media_lookup(snap)
 
     restored = 0
     for elem in labelset.elements:

--- a/vtsearch/utils/state_media_lookup.py
+++ b/vtsearch/utils/state_media_lookup.py
@@ -15,21 +15,25 @@ def _origin_key(origin: dict[str, Any], origin_name: str) -> str:
 
 def build_media_lookup(
     media_dict: dict[int, dict[str, Any]],
-) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
+) -> tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]]:
     """Build lookup tables for matching label entries to medias.
 
-    Returns ``(origin_lookup, md5_lookup)`` where:
+    Returns ``(origin_lookup, md5_lookup, name_lookup)`` where:
 
     * **origin_lookup** maps ``_origin_key(origin, origin_name)`` to a list of
       media IDs that share that origin+name pair.
     * **md5_lookup** maps an MD5 hex string to a list of media IDs whose
       content hash matches.
+    * **name_lookup** maps an ``origin_name`` string to a list of media IDs
+      that share that name.  Used as a fallback when the full origin dict is
+      not available (e.g. CSV label imports across datasets).
 
-    Both lookups map to *lists* because the same key can match multiple medias
+    All lookups map to *lists* because the same key can match multiple medias
     (e.g. duplicate files with the same MD5).
     """
     origin_lookup: dict[str, list[int]] = {}
     md5_lookup: dict[str, list[int]] = {}
+    name_lookup: dict[str, list[int]] = {}
 
     for media in media_dict.values():
         cid = media["id"]
@@ -40,17 +44,21 @@ def build_media_lookup(
             key = _origin_key(origin, origin_name)
             origin_lookup.setdefault(key, []).append(cid)
 
+        if origin_name:
+            name_lookup.setdefault(origin_name, []).append(cid)
+
         md5 = media.get("md5", "")
         if md5:
             md5_lookup.setdefault(md5, []).append(cid)
 
-    return origin_lookup, md5_lookup
+    return origin_lookup, md5_lookup, name_lookup
 
 
 def resolve_media_ids(
     entry: dict[str, Any],
     origin_lookup: dict[str, list[int]],
     md5_lookup: dict[str, list[int]],
+    name_lookup: dict[str, list[int]] | None = None,
 ) -> list[int]:
     """Resolve a label entry to matching media ID(s).
 
@@ -59,6 +67,11 @@ def resolve_media_ids(
     a label is applied to every element in the dataset that corresponds to
     the entry, regardless of whether it was matched by provenance or by
     content hash.  Duplicate IDs are removed.
+
+    When *name_lookup* is provided and neither origin+name nor MD5 produced a
+    match, ``origin_name`` (or ``filename``) is used as a last-resort
+    fallback.  This enables cross-dataset label transfer from CSV files that
+    lack the full origin dict.
     """
     matched: dict[int, None] = {}
 
@@ -75,6 +88,14 @@ def resolve_media_ids(
         for cid in md5_lookup.get(md5, []):
             matched[cid] = None
 
+    # Fallback: match by origin_name alone (or filename) when the full origin
+    # dict is not available, e.g. CSV label imports across datasets.
+    if not matched and name_lookup is not None:
+        name = origin_name or entry.get("filename", "")
+        if name:
+            for cid in name_lookup.get(name, []):
+                matched[cid] = None
+
     return list(matched)
 
 
@@ -82,6 +103,7 @@ def find_missing_entries(
     label_entries: list[dict[str, Any]],
     origin_lookup: dict[str, list[int]],
     md5_lookup: dict[str, list[int]],
+    name_lookup: dict[str, list[int]] | None = None,
 ) -> list[dict[str, Any]]:
     """Return label entries that do not match any media by origin+name or md5.
 
@@ -94,7 +116,7 @@ def find_missing_entries(
         label = entry.get("label", "")
         if label not in ("good", "bad"):
             continue
-        cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
+        cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
         if not cids:
             missing.append(entry)
     return missing


### PR DESCRIPTION
## Summary
This PR extends the media lookup system to support name-based matching as a fallback mechanism, enabling label imports from CSV files across different datasets where the full origin metadata may not be available.

## Key Changes

- **Enhanced `build_media_lookup()`**: Now returns a third lookup table (`name_lookup`) that maps `origin_name` strings to media IDs, in addition to the existing `origin_lookup` and `md5_lookup`.

- **Extended `resolve_media_ids()`**: Added optional `name_lookup` parameter that enables fallback matching by `origin_name` (or `filename` if `origin_name` is absent) when neither origin+name nor MD5 produce matches. This fallback is only used when no other matches are found, preventing false positives.

- **Updated `find_missing_entries()`**: Now accepts and passes through the `name_lookup` parameter to support consistent matching behavior.

- **CSV importer enhancement**: Modified `_parse_csv_bytes()` to preserve optional columns (`origin_name`, `filename`, `category`) from CSV files, allowing richer metadata to be used during label resolution.

- **Updated all call sites**: Modified all invocations of `build_media_lookup()`, `resolve_media_ids()`, and `find_missing_entries()` throughout the codebase to handle the new return value and parameter.

## Implementation Details

- The name-based fallback is conservative: it only activates when neither origin+name nor MD5 matching succeeds, avoiding unintended matches.
- The `name_lookup` parameter is optional (defaults to `None`) for backward compatibility.
- CSV imports can now transfer labels across datasets by matching on `origin_name` or `filename` fields, enabling cross-dataset label reuse scenarios.
- All existing tests updated to unpack the third return value from `build_media_lookup()`.
- New test cases added to verify name-based fallback behavior and CSV cross-dataset import functionality.

https://claude.ai/code/session_017MDdsHzHaW99NWUCuENCoy