### PR TITLE
Adjust settings icon center point and size

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -41,7 +41,7 @@
         (click)="onSettings()"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M6.7 1.5h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 5.5l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
-          <circle cx="8" cy="8" r="1.3" fill="currentColor"/>
+          <circle cx="8" cy="7.85" r="1.6" fill="currentColor"/>
         </svg> Settings</div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
Updated the settings gear icon in the navigation menu to improve visual alignment and prominence.

## Changes
- Adjusted the center circle's vertical position from `cy="8"` to `cy="7.85"` for better visual centering
- Increased the circle radius from `r="1.3"` to `r="1.6"` to make the icon's center point more prominent

## Details
These adjustments refine the visual appearance of the settings icon SVG, ensuring it aligns properly within the gear graphic and has appropriate visual weight relative to the surrounding elements.

https://claude.ai/code/session_01KxxaBtNGGJ69Dk9cbKeQeZ