### PR TITLE
Fix CSV label import failing to resolve across datasets

### DIFF
--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -422,7 +422,7 @@ class TestCsvExporterLabelsFormat:
         with open(filepath2, newline="", encoding="utf-8") as f:
             header2 = next(csv.reader(f))
 
-        assert header1 == ["label", "md5", "origin_name", "filename", "category"]
+        assert header1 == ["label", "md5", "origin_name", "filename", "category", "origin"]
         assert header2 == ["source"]
 
     def test_labels_format_no_selected_columns_uses_defaults(self, tmp_path):
@@ -436,7 +436,7 @@ class TestCsvExporterLabelsFormat:
         exp.export(results, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             header = next(csv.reader(f))
-        assert header == ["label", "md5", "origin_name", "filename", "category"]
+        assert header == ["label", "md5", "origin_name", "filename", "category", "origin"]
 
     def test_labels_format_message(self, tmp_path):
         from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
@@ -463,6 +463,25 @@ class TestCsvExporterLabelsFormat:
         with open(filepath, newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f))
         assert len(rows) == 1  # header only
+
+    def test_labels_format_origin_dict_serialised_as_json(self, tmp_path):
+        """Origin dicts are JSON-serialised in CSV so they survive round-trip."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        origin = {"importer": "demo", "params": {"name": "flowers102"}}
+        labels = [{"label": "good", "md5": "abc", "origin_name": "rose.jpg", "filename": "rose.jpg", "category": "", "origin": origin}]
+        results = {"labels": labels}
+        filepath = tmp_path / "with_origin.csv"
+
+        exp.export(results, {"filepath": str(filepath)})
+
+        # Read back and verify origin column is valid JSON
+        from vtsearch.labels.importers.server_csv_file import _parse_csv_bytes
+
+        parsed = _parse_csv_bytes(filepath.read_bytes())
+        assert len(parsed) == 1
+        assert parsed[0]["origin"] == origin
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -422,7 +422,7 @@ class TestCsvExporterLabelsFormat:
         with open(filepath2, newline="", encoding="utf-8") as f:
             header2 = next(csv.reader(f))
 
-        assert header1 == ["label", "md5", "origin_name", "filename", "category", "origin"]
+        assert header1 == ["label", "md5", "origin_name", "filename", "category"]
         assert header2 == ["source"]
 
     def test_labels_format_no_selected_columns_uses_defaults(self, tmp_path):

--- a/tests/test_label_importers.py
+++ b/tests/test_label_importers.py
@@ -441,6 +441,28 @@ class TestServerCsvLabelImporter:
         assert result[0]["filename"] == "clip.wav"
         assert result[0]["category"] == "music"
 
+    def test_csv_importer_parses_origin_json(self, tmp_path):
+        """CSV importer parses a JSON-serialised origin dict column."""
+        import json
+
+        from vtsearch.labels.importers.server_csv_file import _parse_csv_bytes
+
+        origin = {"importer": "demo", "params": {"name": "flowers102"}}
+        origin_json = json.dumps(origin, sort_keys=True)
+        csv_text = f'label,md5,origin_name,origin\ngood,abc123,rose.jpg,"{origin_json.replace(chr(34), chr(34)+chr(34))}"\n'
+        result = _parse_csv_bytes(csv_text.encode())
+        assert len(result) == 1
+        assert result[0]["origin"] == origin
+
+    def test_csv_importer_ignores_invalid_origin_json(self, tmp_path):
+        """Non-JSON origin column values are silently ignored."""
+        from vtsearch.labels.importers.server_csv_file import _parse_csv_bytes
+
+        csv_text = "label,md5,origin_name,origin\ngood,abc123,rose.jpg,not-json\n"
+        result = _parse_csv_bytes(csv_text.encode())
+        assert len(result) == 1
+        assert "origin" not in result[0]
+
     def test_csv_cross_dataset_import_matches_by_origin_name(self, client, tmp_path):
         """CSV labels with different MD5s match current dataset elements by origin_name."""
         origin_name_1 = app_module.medias[1].get("origin_name", "")

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -11,6 +11,7 @@ No additional pip packages are required; uses only Python's ``csv`` and
 from __future__ import annotations
 
 import csv
+import json
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +46,7 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
     ]
 
     #: Base columns for label exports (used when no selected_columns provided).
-    _LABEL_BASE_COLUMNS = ["label", "md5", "origin_name", "filename", "category"]
+    _LABEL_BASE_COLUMNS = ["label", "md5", "origin_name", "filename", "category", "origin"]
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
         filepath_str = field_values.get("filepath", "").strip()
@@ -77,7 +78,13 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                 row = []
                 for col in columns:
                     if col in entry:
-                        row.append(str(entry[col] if entry[col] is not None else ""))
+                        val = entry[col]
+                        # Serialize dicts (e.g. origin) as JSON so they
+                        # survive the CSV round-trip.
+                        if isinstance(val, dict):
+                            row.append(json.dumps(val, sort_keys=True))
+                        else:
+                            row.append(str(val if val is not None else ""))
                     elif col in meta:
                         row.append(str(meta[col] if meta[col] is not None else ""))
                     else:

--- a/vtsearch/labels/importers/server_csv_file/__init__.py
+++ b/vtsearch/labels/importers/server_csv_file/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 from pathlib import Path
 from typing import Any
 
@@ -44,7 +45,7 @@ class ServerCsvLabelImporter(LabelImporter):
         ),
     ]
 
-    def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+    def run(self, field_values: dict[str, Any]) -> list[dict[str, Any]]:
         """Read and parse the CSV labels file from the server filesystem."""
         filepath = (field_values.get("filepath") or "").strip()
         if not filepath:
@@ -59,7 +60,7 @@ class ServerCsvLabelImporter(LabelImporter):
         raw = path.read_bytes()
         return _parse_csv_bytes(raw)
 
-    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
+    def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, Any]]:
         """Load labels from a file-path string (CLI usage)."""
         return self.run(field_values)
 
@@ -72,7 +73,7 @@ class ServerCsvLabelImporter(LabelImporter):
         )
 
 
-def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
+def _parse_csv_bytes(raw: bytes) -> list[dict[str, Any]]:
     """Decode *raw* bytes as CSV and extract ``md5``/``label`` pairs."""
     try:
         text = raw.decode("utf-8-sig")  # strip BOM if present
@@ -93,7 +94,7 @@ def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
     if "md5" not in normalised or "label" not in normalised:
         raise ValueError("CSV must have 'md5' and 'label' column headers.")
 
-    # Optional columns that enrich resolution (origin_name, filename, category)
+    # Optional columns that enrich resolution (origin_name, filename, category, origin)
     optional_cols = ("origin_name", "filename", "category")
 
     results = []
@@ -101,12 +102,22 @@ def _parse_csv_bytes(raw: bytes) -> list[dict[str, str]]:
         md5 = row.get(normalised["md5"], "").strip()
         label = row.get(normalised["label"], "").strip().lower()
         if md5 and label:
-            entry: dict[str, str] = {"md5": md5, "label": label}
+            entry: dict[str, Any] = {"md5": md5, "label": label}
             for col in optional_cols:
                 if col in normalised:
                     val = row.get(normalised[col], "").strip()
                     if val:
                         entry[col] = val
+            # Parse origin dict from JSON if present
+            if "origin" in normalised:
+                origin_raw = row.get(normalised["origin"], "").strip()
+                if origin_raw:
+                    try:
+                        origin = json.loads(origin_raw)
+                        if isinstance(origin, dict):
+                            entry["origin"] = origin
+                    except (json.JSONDecodeError, ValueError):
+                        pass
             results.append(entry)
     return results
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -376,7 +376,7 @@ def export_labels():
                 entry["custom_metadata"] = meta
                 all_meta_keys.update(meta.keys())
 
-        base_columns = ["label", "md5", "origin_name", "filename", "category"]
+        base_columns = ["label", "md5", "origin_name", "filename", "category", "origin"]
         base_lower = {c.lower() for c in base_columns}
         extra_keys = sorted(k for k in all_meta_keys if k.lower() not in base_lower)
         result["available_columns"] = base_columns + extra_keys


### PR DESCRIPTION
## Summary

- **Root cause**: CSV label export only wrote `origin_name` (a string) but not the `origin` dict. When importing corrections CSV into a different dataset, MD5 matching fails (different files), origin+name matching fails (no origin dict), and re-ingestion from sources fails (`_group_by_origin` skips entries where `origin is None`). Result: 0 applied, all unresolved.
- **Fix**: The CSV exporter now serializes the `origin` dict as a JSON string in a new `origin` column. The CSV importer parses it back on import. This enables cross-dataset CSV imports to re-ingest missing media from their original sources (e.g. demo datasets).
- Backward compatible: existing CSVs without an `origin` column still parse correctly — they just won't have origin info (same as before).

## Test plan

- [x] `test_csv_importer_parses_origin_json` — verifies JSON origin column is parsed back into a dict
- [x] `test_csv_importer_ignores_invalid_origin_json` — non-JSON origin values are silently ignored
- [x] `test_labels_format_origin_dict_serialised_as_json` — verifies CSV export→import round-trip preserves origin
- [x] `test_labels_format_no_selected_columns_uses_defaults` — default columns now include `origin`
- [x] All 2424 tests pass (0 failures, 0 errors)

https://claude.ai/code/session_01NNv2bYqe4bsSZQ1Pd5aM7x