### PR TITLE
Remove md5 from custom_metadata after applying to media

### DIFF
--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -85,6 +85,9 @@ class TestApplyCustomMetadataMD5:
         count = apply_custom_metadata_md5(media_dict)
         assert count == 1
         assert media_dict[1]["md5"] == "provided_hash"
+        # md5 should be removed from custom_metadata to avoid duplicate display
+        assert "md5" not in media_dict[1]["custom_metadata"]
+        assert media_dict[1]["custom_metadata"]["title"] == "foo"
 
     def test_skips_when_no_custom_metadata(self):
         from vtsearch.datasets.loader import apply_custom_metadata_md5
@@ -128,9 +131,11 @@ class TestApplyCustomMetadataMD5:
         count = apply_custom_metadata_md5(media_dict)
         assert count == 2
         assert media_dict[1]["md5"] == "provided1"
+        assert "md5" not in media_dict[1]["custom_metadata"]
         assert media_dict[2]["md5"] == "calc2"
         assert media_dict[3]["md5"] == "calc3"
         assert media_dict[4]["md5"] == "provided4"
+        assert "md5" not in media_dict[4]["custom_metadata"]
 
     def test_skips_when_custom_metadata_md5_is_none(self):
         from vtsearch.datasets.loader import apply_custom_metadata_md5

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -680,6 +680,7 @@ def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
         cm_md5 = cm.get("md5")
         if cm_md5:
             media["md5"] = cm_md5
+            del cm["md5"]
             count += 1
     return count
 


### PR DESCRIPTION
## Summary
This change prevents duplicate display of md5 hashes by removing the md5 field from custom_metadata after it has been promoted to the media object's top-level md5 field.

## Key Changes
- Modified `apply_custom_metadata_md5()` in `vtsearch/datasets/loader.py` to delete the md5 entry from custom_metadata after copying it to the media's md5 field
- Added test assertions to verify that md5 is removed from custom_metadata while other custom_metadata fields are preserved
- Updated tests in `test_replaces_md5_from_custom_metadata()` and `test_handles_mixed_medias()` to validate the cleanup behavior

## Implementation Details
When a custom_metadata object contains an md5 hash, it is now:
1. Copied to the media object's top-level `md5` field
2. Deleted from the `custom_metadata` dictionary to avoid duplication

This ensures a single source of truth for the md5 value and prevents confusion from having the same hash displayed in multiple locations.

https://claude.ai/code/session_012RXmwZg46YphkqMqNVqHGp