### PR TITLE
Fix progress tracking to weight k-means work by vector count

### DIFF
--- a/tests/test_diversity_tree.py
+++ b/tests/test_diversity_tree.py
@@ -603,7 +603,7 @@ class TestKmeansProgress:
         assert calls[1][0] > 0, "Progress should advance after root k-means"
 
     def test_progress_total_reflects_estimated_work(self):
-        """Total should be based on estimated clustering fits (nodes × N_INIT)."""
+        """Total should be based on num_levels × num_vectors × N_INIT."""
         vecs = _make_vectors(200)
         calls = []
         DiversityTree(vecs, k=2, min_node_size=10, on_progress=lambda c, t: calls.append((c, t)))
@@ -611,9 +611,8 @@ class TestKmeansProgress:
         from vtsearch.models.diversity_tree import _N_INIT
 
         # With k=2, 200 vectors, min_node_size=10 → 5 levels.
-        # Estimated internal nodes = (2^5 - 1) / (2 - 1) = 31.
-        # Estimated total = 31 * _N_INIT = 310.
-        assert total == 31 * _N_INIT, f"Expected 31 * {_N_INIT} = {31 * _N_INIT}, got {total}"
+        # Estimated total = 5 * 200 * _N_INIT = 10000.
+        assert total == 5 * 200 * _N_INIT, f"Expected {5 * 200 * _N_INIT}, got {total}"
 
     def test_no_progress_for_small_input(self):
         """Vectors below min_node_size should not trigger k-means progress."""

--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -74,22 +74,20 @@ class DiversityTree:
             total = len(ids)
             vecs = np.array([vectors[i] for i in ids], dtype=np.float32)
             self._on_progress = on_progress
-            # Estimate total k-means work: count the expected number of
-            # clustering operations (k-means fits).  Each internal node runs
-            # _N_INIT fits.  The number of internal (splitting) nodes in a
-            # balanced k-ary tree of *num_levels* levels is
-            # (k^num_levels - 1) / (k - 1).  Progress increments by 1 per
-            # fit so that every clustering contributes equally — this keeps
-            # the bar moving during the expensive root clustering instead of
-            # weighting by vector count (which bunches progress into the
-            # many tiny leaf-adjacent nodes).
+            # Estimate total k-means work, weighted by vector count.
+            # K-means cost is proportional to the number of vectors being
+            # clustered, so we weight each fit by len(vectors).  At each
+            # level of a balanced k-ary tree the total vectors processed
+            # equals *total* (all vectors are partitioned among nodes at
+            # that level), so estimated_total ≈ num_levels * total * _N_INIT.
+            # This keeps the progress bar proportional to wall-clock time
+            # instead of sitting near 0% during the expensive root clustering.
             if total >= min_node_size and total >= 2 * k:
                 num_levels = max(1, math.ceil(math.log(total / min_node_size, k)))
                 num_levels = min(num_levels, max_depth)
             else:
                 num_levels = 0
-            estimated_nodes = (k**num_levels - 1) // (k - 1) if num_levels > 0 else 0
-            self._estimated_total_work = max(estimated_nodes * _N_INIT, 1)
+            self._estimated_total_work = max(num_levels * total * _N_INIT, 1)
             self._work_done = 0
             if on_progress:
                 on_progress(0, self._estimated_total_work)
@@ -147,8 +145,9 @@ class DiversityTree:
                 best_inertia = km.inertia_
                 best_labels = candidate_labels
 
-            # Report progress after each init (one fit = one unit of work)
-            self._work_done += 1
+            # Report progress after each init, weighted by vector count
+            # (k-means cost is proportional to the number of vectors).
+            self._work_done += len(ids)
             if self._on_progress:
                 self._on_progress(
                     min(self._work_done, self._estimated_total_work),


### PR DESCRIPTION
## Summary
Changed the progress tracking in DiversityTree to estimate work based on the number of vectors being clustered rather than the number of clustering operations. This provides more accurate progress reporting that correlates with actual wall-clock time.

## Key Changes
- **Progress estimation formula**: Changed from counting internal nodes `(k^num_levels - 1) / (k - 1)` to a simpler formula `num_levels * total * _N_INIT` that accounts for vector count at each tree level
- **Work increment**: Modified progress updates to increment by the number of vectors in each node (`len(ids)`) instead of a fixed unit of 1 per k-means fit
- **Updated test expectations**: Adjusted test assertions to reflect the new estimation method (5 * 200 * _N_INIT instead of 31 * _N_INIT for the test case)

## Implementation Details
The key insight is that k-means clustering cost is proportional to the number of vectors being clustered. In a balanced k-ary tree, all vectors are partitioned among nodes at each level, so the total work per level is constant. This means:
- Old approach: Progress bunched up during expensive root clustering (few large nodes)
- New approach: Progress advances proportionally to actual computational cost across all levels

The new formula is simpler and more intuitive: `estimated_total_work = num_levels * total_vectors * _N_INIT`, where each level processes all vectors once across its nodes.

https://claude.ai/code/session_01KZFFG9kUyJa3SzP5hDK1YU