### PR TITLE
Update brain icon SVG with improved symmetrical design

### DIFF
--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -123,7 +123,7 @@ function emojiToType(icon: string): string {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
       }
       @case ('brain') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C7 2 3 6 3 10.5c0 2.5 1.2 4.8 3 6.2V20a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2v-1c2.7-1.2 5-4.5 5-8C19 6 16 2 12 2z"/><path d="M8 12c1.5-1 3-3 3-5"/><path d="M7 15c2-1 4-3.5 4.5-6"/><path d="M12 11c1.5 1 3 3.5 3.5 5.5"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C9.5 2 7.5 3 6 4.5 4 6.5 3 9 3 11.5c0 2.5 1 5 3 7 1.5 1.5 3.5 2.5 6 3.5V2z"/><path d="M12 2c2.5 0 4.5 1 6 2.5 2 2 3 4.5 3 7 0 2.5-1 5-3 7-1.5 1.5-3.5 2.5-6 3.5V2z"/><path d="M7.5 7c1.5.5 3 1.5 4 3"/><path d="M6 13c2 0 4-.5 5.5-2"/><path d="M16.5 7c-1.5.5-3 1.5-4 3"/><path d="M18 13c-2 0-4-.5-5.5-2"/></svg>
       }
       @case ('file') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>


### PR DESCRIPTION
## Summary
Updated the brain icon SVG in the icon component with a new, more symmetrical design that better represents the left and right hemispheres of the brain.

## Changes
- Replaced the brain icon SVG path with an improved version featuring:
  - Explicit left and right hemisphere paths for better visual symmetry
  - Updated coordinate values for more balanced proportions
  - Additional path elements to represent neural connections on both sides
  - Better alignment with the 24x24 viewBox dimensions

## Implementation Details
The new brain icon design uses separate path definitions for the left and right sides, making the icon more visually balanced and recognizable. The updated paths maintain the same stroke styling and SVG attributes as the original while providing a clearer representation of brain anatomy.

https://claude.ai/code/session_01HqoVfAAT5VKhmUgDzbkPKE