### PR TITLE
Fix cross-dataset label resolution when loading detector in Train mode

### DIFF
--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -984,3 +984,190 @@ class TestSeedVotesFromExamples:
         assert data["seeded"] == 0
         assert data["skipped"] == 1
 
+
+class TestLoadModelCrossDatasetResolution:
+    """Loading a model trained on Dataset A while Dataset B is loaded should
+    still resolve labels when the underlying files are the same."""
+
+    def test_load_model_resolves_labels_via_origin(self, client, tmp_path):
+        """Labels from Dataset A should resolve by origin→MD5 on Dataset B.
+
+        Simulates: train detector on Dataset A (labels with folder origins),
+        switch to Dataset B (same files, different origin keys), open Train
+        mode.  The label restore should follow origin trails, compute MD5s,
+        and match against loaded medias.
+        """
+        import hashlib
+
+        import numpy as np
+
+        from vtsearch.models.registry import register_model, reset_for_tests
+        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
+        from vtsearch.utils import good_votes, bad_votes, medias
+
+        reset_for_tests()
+
+        # --- Build files on disk (shared content between both datasets) ---
+        label_folder = tmp_path / "dataset_a"
+        label_folder.mkdir()
+        good_file = label_folder / "good_0.wav"
+        bad_file = label_folder / "bad_0.wav"
+        good_file.write_bytes(b"shared_good_content")
+        bad_file.write_bytes(b"shared_bad_content")
+
+        good_md5 = hashlib.md5(b"shared_good_content").hexdigest()
+        bad_md5 = hashlib.md5(b"shared_bad_content").hexdigest()
+
+        label_origin = {
+            "importer": "folder",
+            "params": {"path": str(label_folder), "media_type": "sounds"},
+        }
+
+        # Labelset entries with Dataset A origin info and DIFFERENT MD5s
+        # (simulating that the labelset was saved with old/different hashes)
+        label_entries = [
+            {
+                "md5": "dataset_a_good_old_hash",
+                "label": "good",
+                "origin": label_origin,
+                "origin_name": "good_0.wav",
+                "filename": "good_0.wav",
+            },
+            {
+                "md5": "dataset_a_bad_old_hash",
+                "label": "bad",
+                "origin": label_origin,
+                "origin_name": "bad_0.wav",
+                "filename": "bad_0.wav",
+            },
+        ]
+
+        # --- Write trainable model ---
+        original_dir = get_trainable_models_dir()
+        set_trainable_models_dir(tmp_path)
+        try:
+            tm_name = "cross-dataset-load"
+            _write_model(tmp_path / f"{tm_name}.json", {
+                "name": tm_name,
+                "text_query": "",
+                "media_type": "audio",
+                "examples": [],
+                "labelset": {"labels": label_entries},
+            })
+
+            entry = register_model(
+                name="Cross Load Test",
+                media_type="audio",
+                trainable=True,
+                trainable_model_name=tm_name,
+            )
+            model_id = entry["id"]
+
+            # --- Replace medias with Dataset B (same file content, different origins) ---
+            saved = dict(medias)
+            medias.clear()
+            rng = np.random.default_rng(99)
+            medias[1] = {
+                "id": 1,
+                "type": "audio",
+                "embedding": rng.standard_normal(512).astype(np.float32),
+                "md5": good_md5,  # same content as good_0.wav
+                "filename": "completely_different_name.wav",
+                "origin": {"importer": "folder", "params": {"path": "/other/place"}},
+                "origin_name": "completely_different_name.wav",
+            }
+            medias[2] = {
+                "id": 2,
+                "type": "audio",
+                "embedding": rng.standard_normal(512).astype(np.float32),
+                "md5": bad_md5,  # same content as bad_0.wav
+                "filename": "another_file.wav",
+                "origin": {"importer": "folder", "params": {"path": "/other/place"}},
+                "origin_name": "another_file.wav",
+            }
+
+            try:
+                res = client.post("/api/models/registry/load", json={"model_id": model_id})
+                assert res.status_code == 200
+                data = res.get_json()
+                assert data["ok"] is True
+                assert data["labels_restored"] == 2, (
+                    f"Expected 2 labels restored via origin resolution, got {data['labels_restored']}"
+                )
+                assert 1 in good_votes, "good label should be applied to media 1"
+                assert 2 in bad_votes, "bad label should be applied to media 2"
+            finally:
+                medias.clear()
+                medias.update(saved)
+        finally:
+            set_trainable_models_dir(original_dir)
+
+    def test_load_model_name_fallback(self, client, tmp_path):
+        """Labels with matching origin_name should resolve even without origin/MD5 match."""
+        import numpy as np
+
+        from vtsearch.models.registry import register_model, reset_for_tests
+        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
+        from vtsearch.utils import good_votes, medias
+
+        reset_for_tests()
+
+        label_entries = [
+            {
+                "md5": "nonexistent_hash",
+                "label": "good",
+                "origin": {"importer": "folder", "params": {"path": "/gone"}},
+                "origin_name": "shared_name.wav",
+                "filename": "shared_name.wav",
+            },
+        ]
+
+        original_dir = get_trainable_models_dir()
+        set_trainable_models_dir(tmp_path)
+        try:
+            tm_name = "name-fallback"
+            _write_model(tmp_path / f"{tm_name}.json", {
+                "name": tm_name,
+                "text_query": "",
+                "media_type": "audio",
+                "examples": [],
+                "labelset": {"labels": label_entries},
+            })
+
+            entry = register_model(
+                name="Name Fallback Test",
+                media_type="audio",
+                trainable=True,
+                trainable_model_name=tm_name,
+            )
+            model_id = entry["id"]
+
+            saved = dict(medias)
+            medias.clear()
+            rng = np.random.default_rng(42)
+            medias[1] = {
+                "id": 1,
+                "type": "audio",
+                "embedding": rng.standard_normal(512).astype(np.float32),
+                "md5": "totally_different_md5",
+                "filename": "shared_name.wav",
+                "origin": {"importer": "folder", "params": {"path": "/different"}},
+                "origin_name": "shared_name.wav",
+            }
+
+            try:
+                res = client.post("/api/models/registry/load", json={"model_id": model_id})
+                assert res.status_code == 200
+                data = res.get_json()
+                assert data["labels_restored"] == 1, (
+                    "origin_name fallback should have matched the label"
+                )
+                assert 1 in good_votes
+            finally:
+                medias.clear()
+                medias.update(saved)
+        finally:
+            set_trainable_models_dir(original_dir)
+

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -233,9 +233,12 @@ def _seed_good_votes_from_examples(examples: list[dict]) -> int:
 def _restore_labels_from_trainable_model(tm_data: dict) -> int:
     """Restore saved labels from a trainable model's labelset into votes.
 
-    Matches labelset entries to loaded medias by origin+origin_name and MD5,
-    then applies each label.  Returns the number of labels successfully
-    restored.
+    Matches labelset entries to loaded medias by origin+origin_name, MD5, and
+    origin_name fallback.  For entries that still don't match (cross-dataset
+    scenario), resolves the original file from its origin trail, computes its
+    MD5, and checks for a match in the loaded dataset.
+
+    Returns the number of labels successfully restored.
     """
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.utils import (
@@ -257,17 +260,64 @@ def _restore_labels_from_trainable_model(tm_data: dict) -> int:
     if not snap:
         return 0
 
-    origin_lookup, md5_lookup, _ = build_media_lookup(snap)
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
 
     restored = 0
+    unresolved: list[tuple] = []  # (elem, label) pairs needing origin resolution
     for elem in labelset.elements:
         if elem.label not in ("good", "bad"):
             continue
-        cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup)
-        for cid in cids:
-            apply_label(cid, elem.label)
+        cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup, name_lookup)
         if cids:
+            for cid in cids:
+                apply_label(cid, elem.label)
             restored += 1
+        else:
+            unresolved.append(elem)
+
+    # Second pass: resolve unmatched labels from their origin files.
+    # When a detector was trained on Dataset A and we're now on Dataset B,
+    # the origin+name keys won't match.  But if the same underlying file
+    # exists in both datasets, resolving the origin file and computing its
+    # MD5 lets us match by content hash.
+    if unresolved:
+        import hashlib
+        import logging
+
+        from vtsearch.models.resolver import resolve_file_from_origin
+
+        _log = logging.getLogger(__name__)
+
+        for elem in unresolved:
+            entry = elem.to_dict()
+            origin = entry.get("origin")
+            origin_name = entry.get("origin_name", "")
+            filename = entry.get("filename", "")
+            resolved_path = resolve_file_from_origin(origin, origin_name, filename)
+            if resolved_path is None:
+                continue
+
+            # Compute MD5 of the resolved file and check against loaded medias
+            try:
+                h = hashlib.md5()
+                with open(resolved_path, "rb") as f:
+                    for chunk in iter(lambda: f.read(8192), b""):
+                        h.update(chunk)
+                resolved_md5 = h.hexdigest()
+            except OSError:
+                _log.debug("restore-labels: could not read resolved file %s", resolved_path)
+                continue
+
+            cids = md5_lookup.get(resolved_md5, [])
+            if cids:
+                for cid in cids:
+                    apply_label(cid, elem.label)
+                restored += 1
+            else:
+                _log.debug(
+                    "restore-labels: resolved %s but MD5 %s not in loaded dataset",
+                    resolved_path, resolved_md5,
+                )
 
     return restored
 


### PR DESCRIPTION
_restore_labels_from_trainable_model only matched labels by origin key and MD5 against loaded medias. When a detector was trained on dataset A and loaded in Train mode on dataset B, no labels resolved because the origin keys and MD5s didn't overlap.

Two fixes:
1. Pass name_lookup to resolve_media_ids so origin_name fallback works
2. For still-unmatched labels, resolve the original file from its origin trail, compute its MD5, and match against loaded medias by content hash

https://claude.ai/code/session_01DiY5n9BKBYvNXEsiLJZ3wM