### PR TITLE
feat: parallel dataset loading with per-row progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
   - `test_combine_datasets.py` — Combine-datasets importer: metadata, dedup, media type validation, CLI, API routes
   - `test_corrections_export.py` — Corrections tracking: _find_initial_labels state, is_correction annotation on label export, label_filter=corrections filtering
   - `test_creation_info.py` — Legacy creation_info handling in pickle datasets
+  - `test_parallel_loading.py` — Parallel dataset loading: LoadingTasksTracker, thread-local progress, per-task cancel, loading-tasks API endpoints, build_diversity_tree_for_context
   - `test_pickle_safety.py` — Restricted pickle unpickler: RCE prevention while allowing legitimate VTSearch dataset pickles
   - `test_duplicates.py` — Duplicate-content collapsing: collapse_duplicates function, dupe counting, label export/import integration
   - `test_enrich_descriptions.py` — Enriched text-sort description embedding
@@ -131,7 +132,7 @@ Tests are auto-grouped by area. Run a focused subset instead of the full suite:
 | `core` | audio, medias, votes, inclusion, settings, frontend | Basic app functionality |
 | `api` | api_contracts, error_recovery, dashboard, path_validation, multi_user_security, multi_user_dataset_access, ssrf_validation | API contracts, error handling, security |
 | `sorting` | sorting, label_sorting, safe_thresholds, enrich_descriptions, diversity_tree* | Sort algorithms and diversity |
-| `datasets` | datasets, dataset_split, combine_datasets, creation_info, duplicates, origin_labelset, thin/chunked_loading, memory_errors, pickle_safety, media_sources, multi_dataset | Dataset loading and management |
+| `datasets` | datasets, dataset_split, combine_datasets, creation_info, duplicates, origin_labelset, thin/chunked_loading, memory_errors, pickle_safety, media_sources, multi_dataset, parallel_loading | Dataset loading and management |
 | `io` | exporters, csv_webhook_exporters, export_options, importers, label_importers, labels, processor_importers, pdf_import, corrections_export | Import/export |
 | `models` | detectors, extractors, processors, trainable_models, clippers, eval*, resolver, new_embedders | ML models and evaluation |
 | `downloads` | ag_news, bbc_news, gtzan, image_sources, imdb, ucsf, download_and_extract | Demo dataset downloads |

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -3,17 +3,6 @@
   <div class="dashboard-section">
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="database" [size]="18"></vt-icon> Datasets</span>
-      @if (loading) {
-        <div class="dashboard-progress">
-          <span class="progress-msg">{{ progressMessage }}</span>
-          <vt-progress-bar
-            [value]="progressValue"
-            [max]="progressTotal"
-            [indeterminate]="progressIndeterminate"
-          />
-          <button class="btn btn--cancel btn--sm" (click)="onCancelIngest()" title="Cancel dataset loading">Cancel</button>
-        </div>
-      }
       @if (errorMessage) {
         <div class="dashboard-error">
           <span class="error-msg">{{ errorMessage }}</span>
@@ -25,7 +14,7 @@
       </div>
     </div>
 
-    @if (datasets.length === 0 && !loading) {
+    @if (datasets.length === 0 && loadingTasks.length === 0 && !loading) {
       <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
@@ -49,6 +38,24 @@
             </tr>
           </thead>
           <tbody>
+            @for (task of loadingTasks; track task.task_id) {
+              <tr class="loading-task-row">
+                <td>
+                  <span class="loading-task-name">{{ task.name || 'Loading...' }}</span>
+                </td>
+                <td [attr.colspan]="isDefaultLogin ? 9 : 11">
+                  <div class="loading-task-progress">
+                    <span class="progress-msg">{{ taskProgressMessage(task) }}</span>
+                    <vt-progress-bar
+                      [value]="task.current"
+                      [max]="task.total"
+                      [indeterminate]="taskIsIndeterminate(task)"
+                    />
+                    <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
+                  </div>
+                </td>
+              </tr>
+            }
             @for (dataset of sortedDatasets; track dataset.id) {
               <vt-dataset-card
                 [dataset]="dataset"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -212,6 +212,58 @@
   }
 }
 
+// Loading task rows — per-dataset progress bars inline in the table
+.loading-task-row {
+  td {
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .loading-task-name {
+    font-weight: 500;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .loading-task-progress {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .progress-msg {
+      font-size: 0.78rem;
+      color: var(--text-muted);
+      white-space: nowrap;
+      flex-shrink: 0;
+      max-width: 300px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    vt-progress-bar {
+      flex: 1;
+    }
+
+    .btn--cancel {
+      flex-shrink: 0;
+      background: var(--bg-surface);
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+      cursor: pointer;
+      font-size: 0.75rem;
+      padding: 2px 8px;
+      border-radius: 4px;
+
+      &:hover {
+        color: var(--text-primary);
+        border-color: var(--text-secondary);
+      }
+    }
+  }
+}
+
 .empty-state {
   flex: 1 1 0;
   min-height: 0;

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -11,7 +11,7 @@ import { LabelSessionService } from '../../services/label-session.service';
 import { FindSessionService } from '../../services/find-session.service';
 import { DatasetStateService } from '../../services/dataset-state.service';
 import { AuthService } from '../../services/auth.service';
-import { AutoDetectResultsData, DatasetRegistryEntry, ModelRegistryEntry } from '../../models/api.models';
+import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, ModelRegistryEntry } from '../../models/api.models';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
@@ -45,6 +45,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   progressValue = 0;
   progressTotal = 0;
   progressIndeterminate = false;
+
+  loadingTasks: LoadingTask[] = [];
 
   importerModalOpen = false;
   newModelModalOpen = false;
@@ -395,9 +397,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   onDemoSelected(demo: { label: string; name: string; embedder?: string; clipper?: string }): void {
     this.importerModalOpen = false;
-    this.datasetState.setLoading(true);
-    this.datasetState.setProgressMessage(`Loading demo: ${demo.label}...`);
-    this.progressIndeterminate = true;
     const params: Record<string, string> = {};
     if (demo.embedder) {
       params['embedder'] = demo.embedder;
@@ -408,10 +407,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetsApi.loadDemo(demo.name, params).subscribe({
       next: () => {
         this.startProgressPolling();
-      },
-      error: () => {
-        this.datasetState.setLoading(false);
-        this.progressIndeterminate = false;
       },
     });
   }
@@ -437,52 +432,48 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetsApi.cancelIngest().subscribe();
   }
 
+  cancelLoadingTask(taskId: string): void {
+    this.datasetsApi.cancelTask(taskId).subscribe();
+  }
+
   // --- Progress polling ---
 
   startProgressPolling(onComplete?: () => void): void {
-    this.datasetState.setLoading(true);
     this.datasetState.setErrorMessage('');
-    this.progressIndeterminate = true;
     this.polling$.next(); // cancel previous polling
 
     timer(0, 1000)
       .pipe(
         takeUntil(this.polling$),
         takeUntil(this.destroy$),
-        switchMap(() => this.datasetsApi.getProgress().pipe(
+        switchMap(() => this.datasetsApi.getLoadingTasks().pipe(
           catchError(() => EMPTY),
         )),
       )
       .subscribe({
-        next: (progress: any) => {
-          if (progress.current != null && progress.total != null && progress.total > 0) {
-            this.progressIndeterminate = false;
-            this.progressValue = progress.current;
-            this.progressTotal = progress.total;
-          } else {
-            this.progressIndeterminate = true;
-          }
+        next: (tasks: LoadingTask[]) => {
+          // Separate active from finished
+          const active = tasks.filter((t) => t.status !== 'idle');
+          const errored = tasks.filter((t) => t.status === 'idle' && t.error);
 
-          // Build message with step info and percentage when available
-          let msg = progress.message || 'Loading...';
-          if (progress.step != null && progress.total_steps != null && progress.total_steps > 1) {
-            msg = `[Step ${progress.step}/${progress.total_steps}] ${msg}`;
-          }
-          if (progress.current != null && progress.total != null && progress.total > 0) {
-            const pct = Math.min(100, Math.round((progress.current / progress.total) * 100));
-            msg += ` (${pct}%)`;
-          }
-          this.datasetState.setProgressMessage(msg);
+          this.loadingTasks = active;
+          this.datasetState.setLoadingTasks(active);
 
-          if (progress.status === 'idle' || progress.status === 'error') {
-            this.datasetState.setLoading(false);
-            this.progressIndeterminate = false;
-            this.polling$.next();
-            if (progress.error) {
-              this.datasetState.setErrorMessage(progress.error);
+          // Show errors from just-completed tasks
+          for (const t of errored) {
+            if (t.error && t.error !== 'Cancelled') {
+              this.datasetState.setErrorMessage(t.error);
             }
+          }
+
+          // Keep legacy loading flag for backward compat
+          this.datasetState.setLoading(active.length > 0);
+
+          if (active.length === 0) {
+            // No more active tasks — stop polling
+            this.polling$.next();
             this.datasetState.refresh();
-            if (progress.status === 'idle' && !progress.error && onComplete) {
+            if (onComplete && errored.length === 0) {
               onComplete();
             }
           }
@@ -657,18 +648,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     // Dataset not loaded — load it first, then navigate
-    this.datasetState.setLoading(true);
-    this.datasetState.setProgressMessage(`Loading ${dataset.name}...`);
-    this.progressIndeterminate = true;
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
       next: () => {
         this.startProgressPolling(() => {
           navigateToLabel();
         });
-      },
-      error: () => {
-        this.datasetState.setLoading(false);
-        this.progressIndeterminate = false;
       },
     });
   }
@@ -706,18 +690,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     // Dataset not loaded — load it first, then navigate
-    this.datasetState.setLoading(true);
-    this.datasetState.setProgressMessage(`Loading ${dataset.name}...`);
-    this.progressIndeterminate = true;
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
       next: () => {
         this.startProgressPolling(() => {
           navigateToFind();
         });
-      },
-      error: () => {
-        this.datasetState.setLoading(false);
-        this.progressIndeterminate = false;
       },
     });
   }
@@ -873,5 +850,23 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   closeFindResults(): void {
     this.findResultsOpen = false;
+  }
+
+  // --- Loading task helpers ---
+
+  taskProgressMessage(task: LoadingTask): string {
+    let msg = task.message || 'Loading...';
+    if (task.step != null && task.total_steps != null && task.total_steps > 1) {
+      msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
+    }
+    if (task.current != null && task.total != null && task.total > 0) {
+      const pct = Math.min(100, Math.round((task.current / task.total) * 100));
+      msg += ` (${pct}%)`;
+    }
+    return msg;
+  }
+
+  taskIsIndeterminate(task: LoadingTask): boolean {
+    return !(task.current != null && task.total != null && task.total > 0);
   }
 }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -142,7 +142,31 @@ export interface DatasetStatus {
 }
 
 export interface DatasetProgress {
+  status?: string;
+  message?: string;
+  current?: number;
+  total?: number;
+  step?: number;
+  total_steps?: number;
+  error?: string;
   [key: string]: unknown;
+}
+
+export interface LoadingTask {
+  task_id: string;
+  name: string;
+  status: string;
+  message: string;
+  current: number;
+  total: number;
+  step?: number;
+  total_steps?: number;
+  error?: string;
+  created_at: number;
+}
+
+export interface LoadingTasksResponse {
+  tasks: LoadingTask[];
 }
 
 export interface ImporterInfo {

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject, forkJoin } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { DatasetRegistryEntry, ModelRegistryEntry } from '../models/api.models';
+import { DatasetRegistryEntry, LoadingTask, ModelRegistryEntry } from '../models/api.models';
 import { DatasetsApiService } from './datasets-api.service';
 import { TrainableModelsApiService } from './trainable-models-api.service';
 
@@ -9,6 +9,7 @@ import { TrainableModelsApiService } from './trainable-models-api.service';
 export class DatasetStateService implements OnDestroy {
   private readonly datasetsSubject = new BehaviorSubject<DatasetRegistryEntry[]>([]);
   private readonly modelsSubject = new BehaviorSubject<ModelRegistryEntry[]>([]);
+  private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
   private readonly loadingSubject = new BehaviorSubject<boolean>(false);
   private readonly progressMessageSubject = new BehaviorSubject<string>('');
   private readonly errorMessageSubject = new BehaviorSubject<string>('');
@@ -16,6 +17,7 @@ export class DatasetStateService implements OnDestroy {
 
   readonly datasets$ = this.datasetsSubject.asObservable();
   readonly models$ = this.modelsSubject.asObservable();
+  readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
   readonly loading$ = this.loadingSubject.asObservable();
   readonly progressMessage$ = this.progressMessageSubject.asObservable();
   readonly errorMessage$ = this.errorMessageSubject.asObservable();
@@ -36,6 +38,14 @@ export class DatasetStateService implements OnDestroy {
 
   get models(): ModelRegistryEntry[] {
     return this.modelsSubject.value;
+  }
+
+  get loadingTasks(): LoadingTask[] {
+    return this.loadingTasksSubject.value;
+  }
+
+  setLoadingTasks(tasks: LoadingTask[]): void {
+    this.loadingTasksSubject.next(tasks);
   }
 
   get loading(): boolean {
@@ -79,6 +89,7 @@ export class DatasetStateService implements OnDestroy {
   clear(): void {
     this.datasetsSubject.next([]);
     this.modelsSubject.next([]);
+    this.loadingTasksSubject.next([]);
     this.loadingSubject.next(false);
     this.progressMessageSubject.next('');
     this.errorMessageSubject.next('');

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -7,6 +7,8 @@ import {
   DatasetProgress,
   ImportersResponse,
   DemoListResponse,
+  LoadingTask,
+  LoadingTasksResponse,
   MediaTypesResponse,
   DatasetRegistryResponse,
   ClipperInfo,
@@ -152,8 +154,18 @@ export class DatasetsApiService {
     return this.http.post('/api/dataset/combine', params);
   }
 
+  getLoadingTasks(): Observable<LoadingTask[]> {
+    return this.http.get<LoadingTasksResponse>('/api/dataset/loading-tasks').pipe(
+      map((res) => res.tasks),
+    );
+  }
+
   cancelIngest(): Observable<OkResponse> {
     return this.http.post<OkResponse>('/api/dataset/cancel', {});
+  }
+
+  cancelTask(taskId: string): Observable<OkResponse> {
+    return this.http.post<OkResponse>(`/api/dataset/cancel/${taskId}`, {});
   }
 
   clearDataset(): Observable<OkResponse> {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -302,10 +302,11 @@ def reset_state():
     clear_progress_cache()
 
     # Reset progress trackers
-    from vtsearch.utils.progress import dataset_progress, find_progress
+    from vtsearch.utils.progress import dataset_progress, find_progress, loading_tasks
 
     dataset_progress.reset_cancel()
     find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
+    loading_tasks.reset_for_tests()
 
     # Reset the login provider to DefaultLoginProvider
     from vtsearch.auth import DefaultLoginProvider, set_login_provider

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ _TEST_GROUPS = {
         "test_pickle_safety",
         "test_media_sources",
         "test_multi_dataset",
+        "test_parallel_loading",
     ],
     "io": [
         "test_exporters",

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -1,0 +1,351 @@
+"""Tests for parallel dataset loading: per-task progress, concurrent loads."""
+
+import threading
+import time
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from vtsearch.utils.progress import (
+    CancelledError,
+    LoadingTasksTracker,
+    ProgressTracker,
+    get_progress,
+    loading_tasks,
+    set_thread_progress,
+    get_thread_progress,
+    clear_thread_progress,
+)
+
+
+# ---------------------------------------------------------------------------
+# LoadingTasksTracker unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadingTasksTracker:
+    """Unit tests for the LoadingTasksTracker."""
+
+    def test_create_and_list(self):
+        tracker = LoadingTasksTracker()
+        pt = tracker.create_task("t1", "Dataset A")
+        pt.update("loading", "Working...", 50, 100)
+
+        tasks = tracker.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0]["task_id"] == "t1"
+        assert tasks[0]["name"] == "Dataset A"
+        assert tasks[0]["status"] == "loading"
+        assert tasks[0]["current"] == 50
+        assert tasks[0]["total"] == 100
+
+    def test_multiple_tasks(self):
+        tracker = LoadingTasksTracker()
+        tracker.create_task("t1", "A").update("loading", "A loading", 10, 100)
+        tracker.create_task("t2", "B").update("embedding", "B embedding", 50, 200)
+
+        tasks = tracker.list_tasks()
+        assert len(tasks) == 2
+        names = {t["task_id"]: t["name"] for t in tasks}
+        assert names == {"t1": "A", "t2": "B"}
+
+    def test_cancel_task(self):
+        tracker = LoadingTasksTracker()
+        pt = tracker.create_task("t1", "A")
+        assert tracker.cancel_task("t1") is True
+        with pytest.raises(CancelledError):
+            pt.check_cancelled()
+
+    def test_cancel_nonexistent(self):
+        tracker = LoadingTasksTracker()
+        assert tracker.cancel_task("nope") is False
+
+    def test_cancel_all(self):
+        tracker = LoadingTasksTracker()
+        pt1 = tracker.create_task("t1", "A")
+        pt2 = tracker.create_task("t2", "B")
+        tracker.cancel_all()
+        with pytest.raises(CancelledError):
+            pt1.check_cancelled()
+        with pytest.raises(CancelledError):
+            pt2.check_cancelled()
+
+    def test_remove_task(self):
+        tracker = LoadingTasksTracker()
+        tracker.create_task("t1", "A")
+        tracker.remove_task("t1")
+        assert tracker.list_tasks() == []
+
+    def test_mark_finished_and_auto_cleanup(self):
+        """Finished tasks older than 5s are removed from list_tasks."""
+        tracker = LoadingTasksTracker()
+        pt = tracker.create_task("t1", "A")
+        pt.update("idle", "Done")
+        # Mark as finished 10 seconds ago
+        with tracker._lock:
+            tracker._tasks["t1"]["finished_at"] = time.time() - 10
+        tasks = tracker.list_tasks()
+        assert len(tasks) == 0
+
+    def test_recently_finished_still_visible(self):
+        """Tasks finished less than 5s ago should still appear."""
+        tracker = LoadingTasksTracker()
+        pt = tracker.create_task("t1", "A")
+        pt.update("idle", "Done")
+        tracker.mark_finished("t1")
+        tasks = tracker.list_tasks()
+        assert len(tasks) == 1
+
+    def test_has_active_tasks(self):
+        tracker = LoadingTasksTracker()
+        assert tracker.has_active_tasks() is False
+        pt = tracker.create_task("t1", "A")
+        pt.update("loading", "Working")
+        assert tracker.has_active_tasks() is True
+        pt.update("idle", "Done")
+        assert tracker.has_active_tasks() is False
+
+    def test_reset_for_tests(self):
+        tracker = LoadingTasksTracker()
+        tracker.create_task("t1", "A")
+        tracker.reset_for_tests()
+        assert tracker.list_tasks() == []
+
+
+# ---------------------------------------------------------------------------
+# Thread-local progress tests
+# ---------------------------------------------------------------------------
+
+
+class TestThreadLocalProgress:
+    """Verify that per-thread progress callbacks work correctly."""
+
+    def test_default_is_none(self):
+        clear_thread_progress()
+        assert get_thread_progress() is None
+
+    def test_set_and_get(self):
+        cb = lambda s, m="", c=0, t=0: None  # noqa: E731
+        set_thread_progress(cb)
+        assert get_thread_progress() is cb
+        clear_thread_progress()
+        assert get_thread_progress() is None
+
+    def test_thread_isolation(self):
+        """Each thread has its own callback."""
+        results = {}
+        barrier = threading.Barrier(2, timeout=5)
+
+        def worker(name, cb):
+            set_thread_progress(cb)
+            barrier.wait()  # sync so both threads are alive
+            results[name] = get_thread_progress()
+            clear_thread_progress()
+
+        cb_a = lambda s, m="", c=0, t=0: "a"  # noqa: E731
+        cb_b = lambda s, m="", c=0, t=0: "b"  # noqa: E731
+
+        t1 = threading.Thread(target=worker, args=("a", cb_a))
+        t2 = threading.Thread(target=worker, args=("b", cb_b))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert results["a"] is cb_a
+        assert results["b"] is cb_b
+
+
+# ---------------------------------------------------------------------------
+# get_progress() integration with loading tasks
+# ---------------------------------------------------------------------------
+
+
+class TestGetProgressWithLoadingTasks:
+    """Verify that get_progress() checks loading tasks first."""
+
+    def test_returns_active_loading_task(self):
+        """get_progress() should return the active loading task, not the global tracker."""
+        pt = loading_tasks.create_task("test_gp", "TestDS")
+        pt.update("loading", "Embedding files", 42, 100, step=3, total_steps=4)
+        try:
+            progress = get_progress()
+            assert progress["status"] == "loading"
+            assert progress["message"] == "Embedding files"
+            assert progress["current"] == 42
+            assert progress["task_id"] == "test_gp"
+        finally:
+            loading_tasks.remove_task("test_gp")
+
+    def test_returns_errored_task(self):
+        """get_progress() should return an errored task even when idle."""
+        pt = loading_tasks.create_task("test_err", "FailDS")
+        pt.update("idle", "", error="Something went wrong")
+        try:
+            progress = get_progress()
+            assert progress["error"] == "Something went wrong"
+            assert progress["task_id"] == "test_err"
+        finally:
+            loading_tasks.remove_task("test_err")
+
+    def test_falls_back_to_global(self):
+        """With no loading tasks, get_progress() returns the global tracker."""
+        from vtsearch.utils.progress import update_progress
+
+        update_progress("idle", "Ready")
+        progress = get_progress()
+        assert progress["status"] == "idle"
+        assert "task_id" not in progress
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadingTasksEndpoint:
+    """Test the /api/dataset/loading-tasks endpoint."""
+
+    def test_returns_empty_when_no_tasks(self, client):
+        resp = client.get("/api/dataset/loading-tasks")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["tasks"] == []
+
+    def test_returns_active_tasks(self, client):
+        pt = loading_tasks.create_task("api_test", "API Test DS")
+        pt.update("loading", "Processing", 25, 50)
+        try:
+            resp = client.get("/api/dataset/loading-tasks")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert len(data["tasks"]) == 1
+            task = data["tasks"][0]
+            assert task["task_id"] == "api_test"
+            assert task["name"] == "API Test DS"
+            assert task["status"] == "loading"
+            assert task["current"] == 25
+        finally:
+            loading_tasks.remove_task("api_test")
+
+
+class TestCancelTaskEndpoint:
+    """Test the /api/dataset/cancel/<task_id> endpoint."""
+
+    def test_cancel_existing_task(self, client):
+        pt = loading_tasks.create_task("cancel_test", "CancelDS")
+        try:
+            resp = client.post("/api/dataset/cancel/cancel_test")
+            assert resp.status_code == 200
+            assert resp.get_json()["ok"] is True
+            assert pt.is_cancelled
+        finally:
+            loading_tasks.remove_task("cancel_test")
+
+    def test_cancel_nonexistent_returns_404(self, client):
+        resp = client.post("/api/dataset/cancel/nonexistent_task")
+        assert resp.status_code == 404
+
+
+class TestImportEndpointsReturnTaskId:
+    """Verify that import endpoints include task_id in the response."""
+
+    def test_load_demo_returns_task_id(self, client):
+        from vtsearch.datasets import DEMO_DATASETS
+
+        demo_name = list(DEMO_DATASETS.keys())[0]
+
+        with mock.patch("vtsearch.routes.datasets._run_importer_in_background", return_value="test_task_123"):
+            resp = client.post(
+                "/api/dataset/load-demo",
+                json={"name": demo_name},
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["task_id"] == "test_task_123"
+
+    def test_load_folder_returns_task_id(self, client, tmp_path):
+        folder = tmp_path / "test_folder"
+        folder.mkdir()
+        (folder / "test.wav").write_bytes(b"fake")
+
+        with mock.patch("vtsearch.routes.datasets._run_importer_in_background", return_value="folder_task"):
+            resp = client.post(
+                "/api/dataset/load-folder",
+                json={"path": str(folder), "media_type": "sounds"},
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["task_id"] == "folder_task"
+
+
+# ---------------------------------------------------------------------------
+# Parallel load integration test
+# ---------------------------------------------------------------------------
+
+
+class TestParallelLoadConcurrency:
+    """Test that two loads can run concurrently without interfering."""
+
+    def test_two_concurrent_loads_have_separate_progress(self):
+        """Two concurrent loading tasks must each have their own progress."""
+        pt_a = loading_tasks.create_task("load_a", "Dataset A")
+        pt_b = loading_tasks.create_task("load_b", "Dataset B")
+
+        pt_a.update("loading", "Loading A", 10, 100)
+        pt_b.update("embedding", "Embedding B", 50, 200)
+
+        try:
+            tasks = loading_tasks.list_tasks()
+            by_id = {t["task_id"]: t for t in tasks}
+
+            assert by_id["load_a"]["status"] == "loading"
+            assert by_id["load_a"]["current"] == 10
+            assert by_id["load_b"]["status"] == "embedding"
+            assert by_id["load_b"]["current"] == 50
+        finally:
+            loading_tasks.remove_task("load_a")
+            loading_tasks.remove_task("load_b")
+
+    def test_cancel_one_does_not_affect_other(self):
+        """Cancelling one task should not cancel the other."""
+        pt_a = loading_tasks.create_task("cancel_a", "A")
+        pt_b = loading_tasks.create_task("cancel_b", "B")
+
+        try:
+            loading_tasks.cancel_task("cancel_a")
+            assert pt_a.is_cancelled
+            assert not pt_b.is_cancelled
+        finally:
+            loading_tasks.remove_task("cancel_a")
+            loading_tasks.remove_task("cancel_b")
+
+
+class TestBuildDiversityTreeForContext:
+    """Test the context-specific diversity tree builder."""
+
+    def test_builds_tree_on_context(self):
+        from vtsearch.utils.state_core import DatasetContext
+        from vtsearch.utils.state_diversity import build_diversity_tree_for_context
+
+        rng = np.random.default_rng(42)
+        ctx = DatasetContext("test_diversity")
+        for i in range(10):
+            ctx.medias[i] = {
+                "id": i,
+                "embedding": rng.standard_normal(128).astype(np.float32),
+            }
+
+        build_diversity_tree_for_context(ctx)
+        assert ctx.diversity_tree is not None
+
+    def test_empty_context_sets_none(self):
+        from vtsearch.utils.state_core import DatasetContext
+        from vtsearch.utils.state_diversity import build_diversity_tree_for_context
+
+        ctx = DatasetContext("test_empty")
+        build_diversity_tree_for_context(ctx)
+        assert ctx.diversity_tree is None

--- a/vtsearch/converters/runner.py
+++ b/vtsearch/converters/runner.py
@@ -21,6 +21,11 @@ ProgressCallback = Callable[[str, str, int, int], None]
 
 
 def _default_progress() -> ProgressCallback:
+    from vtsearch.utils.progress import get_thread_progress
+
+    cb = get_thread_progress()
+    if cb is not None:
+        return cb
     from vtsearch.utils import update_progress
 
     return update_progress

--- a/vtsearch/datasets/downloader.py
+++ b/vtsearch/datasets/downloader.py
@@ -64,7 +64,12 @@ ProgressCallback = Callable[[str, str, int, int], None]
 
 
 def _default_progress() -> ProgressCallback:
-    """Lazily resolve the application-wide progress callback."""
+    """Lazily resolve the progress callback for the current thread."""
+    from vtsearch.utils.progress import get_thread_progress
+
+    cb = get_thread_progress()
+    if cb is not None:
+        return cb
     from vtsearch.utils import update_progress
 
     return update_progress

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -32,6 +32,11 @@ ProgressCallback = Callable[[str, str, int, int], None]
 
 
 def _default_progress() -> ProgressCallback:
+    from vtsearch.utils.progress import get_thread_progress
+
+    cb = get_thread_progress()
+    if cb is not None:
+        return cb
     from vtsearch.utils import update_progress
 
     return update_progress

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -26,6 +26,11 @@ ProgressCallback = Callable[[str, str, int, int], None]
 
 
 def _default_progress() -> ProgressCallback:
+    from vtsearch.utils.progress import get_thread_progress
+
+    cb = get_thread_progress()
+    if cb is not None:
+        return cb
     from vtsearch.utils import update_progress
 
     return update_progress

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -84,7 +84,16 @@ def safe_pickle_load(f: io.BufferedIOBase, **kwargs: Any) -> Any:
 
 
 def _default_progress() -> ProgressCallback:
-    """Lazily resolve the application-wide progress callback."""
+    """Lazily resolve the progress callback for the current thread.
+
+    Checks for a per-thread callback first (set during parallel dataset
+    loading) and falls back to the global singleton.
+    """
+    from vtsearch.utils.progress import get_thread_progress
+
+    cb = get_thread_progress()
+    if cb is not None:
+        return cb
     from vtsearch.utils import update_progress
 
     return update_progress

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -320,7 +320,7 @@ def combine_datasets_route():
         return jsonify({"error": "combine_datasets importer not available"}), 500
 
     task_id = _run_importer_in_background(importer, {"datasets": dataset_paths})
-    return jsonify({"ok": True, "message": "Combining datasets...", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Combining datasets...", "task_id": str(task_id) if task_id else ""})
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +480,7 @@ def import_dataset(importer_name: str):
             field_values[key] = val
 
     task_id = _run_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})
 
 
 # ---------------------------------------------------------------------------
@@ -522,7 +522,7 @@ def load_demo_dataset_route():
         field_values["embedder"] = embedder_name
 
     task_id = _run_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})
 
 
 # ---------------------------------------------------------------------------
@@ -547,7 +547,7 @@ def load_dataset_file():
     file_bytes = io.BytesIO(file.read())
     file_bytes.name = file.filename
     task_id = _run_importer_in_background(importer, {"file": file_bytes})
-    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})
 
 
 @datasets_bp.route("/api/dataset/load-folder", methods=["POST"])
@@ -574,7 +574,7 @@ def load_dataset_folder():
 
     importer = get_importer("folder")
     task_id = _run_importer_in_background(importer, {"path": str(folder), "media_type": media_type})
-    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})
 
 
 # ---------------------------------------------------------------------------
@@ -767,18 +767,11 @@ def load_registered_dataset(dataset_id: str):
             tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
         finally:
             clear_thread_progress()
-
-            def _deferred_cleanup():
-                import time
-
-                time.sleep(3)
-                _loading_tasks.remove_task(task_id)
-
-            threading.Thread(target=_deferred_cleanup, daemon=True).start()
+            _loading_tasks.mark_finished(task_id)
 
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
-    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})
 
 
 @datasets_bp.route("/api/datasets/registry/<dataset_id>/unload", methods=["POST"])
@@ -924,4 +917,4 @@ def _load_from_origin(source: dict):
                 return jsonify({"error": str(exc)}), 400
 
     task_id = _run_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -59,6 +59,7 @@ from vtsearch.utils import (
 )
 from vtsearch.utils.progress import CancelledError
 from vtsearch.utils.progress import dataset_progress as _dataset_progress_tracker
+from vtsearch.utils.progress import loading_tasks as _loading_tasks
 import vtsearch.utils.paths as _paths
 
 # Re-export loading helpers so existing importers keep working.
@@ -67,6 +68,7 @@ from vtsearch.routes.datasets_loading import (  # noqa: F401
     _apply_clipper,
     _auto_register_dataset,
     _load_embedder_for_clips,
+    _load_embedder_with_progress as _load_embedder_for_clips_with_progress,
     _origin_to_str,
     _run_importer_in_background,
     _run_origin_load_in_background,
@@ -212,19 +214,46 @@ def dataset_status():
 
 @datasets_bp.route("/api/dataset/progress")
 def dataset_progress():
-    """Return the current progress of long-running operations."""
+    """Return the current progress of long-running operations.
+
+    For backward compatibility this returns a single progress dict.
+    Prefers the first active loading task if any, otherwise falls back
+    to the legacy global tracker (used by staging operations).
+    """
+    tasks = _loading_tasks.list_tasks()
+    active = [t for t in tasks if t.get("status") != "idle"]
+    if active:
+        return jsonify(active[0])
+    # Check if any just-finished task has an error to report
+    errored = [t for t in tasks if t.get("error")]
+    if errored:
+        return jsonify(errored[0])
     return jsonify(get_progress())
+
+
+@datasets_bp.route("/api/dataset/loading-tasks")
+def dataset_loading_tasks():
+    """Return all active dataset loading tasks with their progress."""
+    return jsonify({"tasks": _loading_tasks.list_tasks()})
 
 
 @datasets_bp.route("/api/dataset/cancel", methods=["POST"])
 def cancel_dataset_load():
-    """Cancel the currently running dataset load/import operation.
+    """Cancel dataset load/import operations.
 
-    Sets a cancellation flag that is checked cooperatively by background
-    loading threads.  The thread will clean up partial state and set
-    progress to idle.
+    Cancels all active loading tasks and the legacy global tracker.
     """
+    _loading_tasks.cancel_all()
     cancel_dataset_progress()
+    return jsonify({"ok": True})
+
+
+@datasets_bp.route("/api/dataset/cancel/<task_id>", methods=["POST"])
+def cancel_dataset_load_task(task_id: str):
+    """Cancel a specific dataset loading task."""
+    ok = _loading_tasks.cancel_task(task_id)
+    if not ok:
+        return jsonify({"error": "Task not found"}), 404
     return jsonify({"ok": True})
 
 
@@ -290,8 +319,8 @@ def combine_datasets_route():
     if importer is None:
         return jsonify({"error": "combine_datasets importer not available"}), 500
 
-    _run_importer_in_background(importer, {"datasets": dataset_paths})
-    return jsonify({"ok": True, "message": "Combining datasets..."})
+    task_id = _run_importer_in_background(importer, {"datasets": dataset_paths})
+    return jsonify({"ok": True, "message": "Combining datasets...", "task_id": task_id})
 
 
 # ---------------------------------------------------------------------------
@@ -450,8 +479,8 @@ def import_dataset(importer_name: str):
         if val:
             field_values[key] = val
 
-    _run_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Loading started"})
+    task_id = _run_importer_in_background(importer, field_values)
+    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
 
 
 # ---------------------------------------------------------------------------
@@ -492,8 +521,8 @@ def load_demo_dataset_route():
     if embedder_name:
         field_values["embedder"] = embedder_name
 
-    _run_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Loading started"})
+    task_id = _run_importer_in_background(importer, field_values)
+    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
 
 
 # ---------------------------------------------------------------------------
@@ -517,8 +546,8 @@ def load_dataset_file():
     # Flask FileStorage stream is only valid during the request lifecycle.
     file_bytes = io.BytesIO(file.read())
     file_bytes.name = file.filename
-    _run_importer_in_background(importer, {"file": file_bytes})
-    return jsonify({"ok": True, "message": "Loading started"})
+    task_id = _run_importer_in_background(importer, {"file": file_bytes})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
 
 
 @datasets_bp.route("/api/dataset/load-folder", methods=["POST"])
@@ -544,8 +573,8 @@ def load_dataset_folder():
         return jsonify({"error": "Invalid folder path"}), 400
 
     importer = get_importer("folder")
-    _run_importer_in_background(importer, {"path": str(folder), "media_type": media_type})
-    return jsonify({"ok": True, "message": "Loading started"})
+    task_id = _run_importer_in_background(importer, {"path": str(folder), "media_type": media_type})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
 
 
 # ---------------------------------------------------------------------------
@@ -638,6 +667,8 @@ def load_registered_dataset(dataset_id: str):
     (made the current UI-facing dataset) without re-reading the pkl.
     """
     from vtsearch.auth import get_current_user
+    from vtsearch.utils.progress import clear_thread_progress, set_thread_progress
+    from vtsearch.utils import build_diversity_tree_for_context
 
     entry = _reg_get(dataset_id)
     if entry is None:
@@ -659,48 +690,39 @@ def load_registered_dataset(dataset_id: str):
 
     _LOAD_STEPS = 3  # read pickle + process items, build diversity index, warm up embedder
 
-    # Reset the cancellation flag so a previous cancel does not immediately
-    # abort this new operation.
-    _dataset_progress_tracker.reset_cancel()
-
-    # Set progress to "loading" synchronously so the frontend never sees a
-    # stale "idle" status from a previous operation before the thread starts.
-    update_progress("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
+    # Create a per-task tracker for this load operation.
+    task_id = f"_regload_{dataset_id[:8]}"
+    tracker = _loading_tasks.create_task(task_id, entry.get("name", dataset_id))
+    tracker.update("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):
-        _dataset_progress_tracker.check_cancelled()
-        update_progress(status, message, current, total, step=1, total_steps=_LOAD_STEPS)
+        tracker.check_cancelled()
+        tracker.update(status, message, current, total, step=1, total_steps=_LOAD_STEPS)
 
     def load_task():
         try:
-            update_progress(
-                "loading",
-                "Preparing…",
-                0,
-                0,
-                step=1,
-                total_steps=_LOAD_STEPS,
-            )
-            # Create a fresh context for this dataset and activate it.
+            tracker.update("loading", "Preparing…", 0, 0, step=1, total_steps=_LOAD_STEPS)
+            # Create a fresh context for this dataset (don't activate yet).
             ctx = DatasetContext(dataset_id)
             register_context(ctx)
-            set_active_dataset_id(dataset_id)
             gc.collect()
-            load_dataset_from_pickle(Path(pkl_path), medias, on_progress=_pickle_progress)
-            _dataset_progress_tracker.check_cancelled()
-            update_progress(
-                "loading",
-                "Removing duplicates…",
-                0,
-                0,
-                step=2,
-                total_steps=_LOAD_STEPS,
+
+            # Set thread-local progress for the pickle loader.
+            set_thread_progress(
+                lambda status, msg="", cur=0, tot=0: tracker.update(status, msg, cur, tot, step=1, total_steps=_LOAD_STEPS)
             )
-            collapse_duplicates(medias)
+            try:
+                load_dataset_from_pickle(Path(pkl_path), ctx.medias, on_progress=_pickle_progress)
+            finally:
+                clear_thread_progress()
+
+            tracker.check_cancelled()
+            tracker.update("loading", "Removing duplicates…", 0, 0, step=2, total_steps=_LOAD_STEPS)
+            collapse_duplicates(ctx.medias)
 
             def _diversity_progress(current: int, total: int) -> None:
-                _dataset_progress_tracker.check_cancelled()
-                update_progress(
+                tracker.check_cancelled()
+                tracker.update(
                     "loading",
                     "Building diversity index…",
                     current=current,
@@ -710,35 +732,53 @@ def load_registered_dataset(dataset_id: str):
                 )
 
             _diversity_progress(0, 0)
-            build_diversity_tree(on_progress=_diversity_progress)
+            build_diversity_tree_for_context(ctx, on_progress=_diversity_progress)
             _reg_set_loaded(dataset_id)
             # Update item count and dupe count in case they changed
-            _reg_update(dataset_id, num_items=len(medias), num_dupes=get_dupe_count())
-            set_dataset_display_name(entry.get("name", ""))
-            _load_embedder_for_clips(step=_LOAD_STEPS, total_steps=_LOAD_STEPS)
+            num_dupes = sum(
+                1 for m in ctx.medias.values()
+                if isinstance(m.get("origin"), dict) and m["origin"].get("importer") == "dupe_set"
+            )
+            _reg_update(dataset_id, num_items=len(ctx.medias), num_dupes=num_dupes)
+            ctx.dataset_display_name = entry.get("name", "")
+
+            # Activate if nothing else is currently active.
+            if get_active_dataset_id() is None:
+                set_active_dataset_id(dataset_id)
+
+            # Warm up the embedder using the task tracker.
+            def _task_progress(status, message="", current=0, total=0, **kw):
+                tracker.update(status, message, current, total, **kw)
+
+            _load_embedder_for_clips_with_progress(ctx.medias, _task_progress, step=_LOAD_STEPS, total_steps=_LOAD_STEPS)
         except CancelledError:
             unregister_context(dataset_id)
             _reg_remove_loaded(dataset_id)
             gc.collect()
-            update_progress("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+            tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
         except MemoryError:
             unregister_context(dataset_id)
             _reg_remove_loaded(dataset_id)
             gc.collect()
-            update_progress("idle", "", 0, 0, "Out of memory — dataset too large.", step=None, total_steps=None)
+            tracker.update("idle", "", 0, 0, error="Out of memory — dataset too large.", step=None, total_steps=None)
         except Exception as e:
             unregister_context(dataset_id)
             _reg_remove_loaded(dataset_id)
-            update_progress("idle", "", 0, 0, str(e), step=None, total_steps=None)
+            tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
+        finally:
+            clear_thread_progress()
 
-    # Signal "loading" before the thread starts so frontend polling never
-    # sees a stale "idle" from a previous load and prematurely stops.
-    # Clear stale error from any previous load.
-    update_progress("loading", "Preparing to load dataset…", 0, 0, error=None, step=1, total_steps=_LOAD_STEPS)
+            def _deferred_cleanup():
+                import time
+
+                time.sleep(3)
+                _loading_tasks.remove_task(task_id)
+
+            threading.Thread(target=_deferred_cleanup, daemon=True).start()
 
     thread = threading.Thread(target=load_task, daemon=True)
     thread.start()
-    return jsonify({"ok": True, "message": "Loading started"})
+    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})
 
 
 @datasets_bp.route("/api/datasets/registry/<dataset_id>/unload", methods=["POST"])
@@ -883,5 +923,5 @@ def _load_from_origin(source: dict):
             except ValueError as exc:
                 return jsonify({"error": str(exc)}), 400
 
-    _run_importer_in_background(importer, field_values)
-    return jsonify({"ok": True, "message": "Loading started"})
+    task_id = _run_importer_in_background(importer, field_values)
+    return jsonify({"ok": True, "message": "Loading started", "task_id": task_id})

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -20,8 +20,10 @@ from vtsearch.datasets.registry import (
 from vtsearch.utils import (
     DatasetContext,
     build_diversity_tree,
+    build_diversity_tree_for_context,
     clear_all,
     collapse_duplicates,
+    get_active_dataset_id,
     get_dataset_display_name,
     get_dupe_count,
     medias,
@@ -30,7 +32,14 @@ from vtsearch.utils import (
     snapshot_medias,
     update_progress,
 )
-from vtsearch.utils.progress import CancelledError, dataset_progress
+from vtsearch.utils.progress import (
+    CancelledError,
+    ProgressTracker,
+    clear_thread_progress,
+    dataset_progress,
+    loading_tasks,
+    set_thread_progress,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -49,24 +58,31 @@ _STATUS_TO_STEP = {
 _TOTAL_LOAD_STEPS = 4  # download, load model, embed, finalize
 
 
-def _stepped_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-    """Thin wrapper around :func:`update_progress` that injects step info.
+def _make_stepped_progress(tracker: ProgressTracker):
+    """Return a stepped-progress callback bound to *tracker*.
 
-    Translates the ``status`` value emitted by inner functions (downloader,
-    media-type ``load_demo_source``, etc.) into a step number so the
-    frontend can display "Step 1/4", "Step 2/4", etc.
+    The returned callable maps status strings emitted by inner functions
+    (downloader, media-type ``load_demo_source``, etc.) into step numbers
+    and updates the per-task *tracker* rather than the global singleton.
 
-    ``"idle"`` signals are silently dropped because the outer
-    :func:`_run_origin_load_in_background` wrapper is responsible for
-    emitting the final ``"idle"`` after registration and embedder warm-up
-    are complete.  Without this filter a cached-pickle load can briefly set
-    ``"idle"`` before the wrapper overrides it, and a frontend poll during
-    that window would stop polling prematurely — leaving the UI stuck on
-    the progress overlay.
-
-    Also checks the cancellation flag on each callback so that long-running
-    loops (embedding, downloading) abort promptly when the user cancels.
+    ``"idle"`` signals are silently dropped because the outer loading
+    wrapper is responsible for emitting the final ``"idle"`` after
+    registration and embedder warm-up are complete.
     """
+
+    def _stepped_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        tracker.check_cancelled()
+        if status == "idle":
+            return
+        step = _STATUS_TO_STEP.get(status)
+        tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+
+    return _stepped_progress
+
+
+# Keep the old module-level _stepped_progress for backward compat (staging uses it)
+def _stepped_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+    """Legacy stepped progress that updates the global dataset_progress."""
     dataset_progress.check_cancelled()
     if status == "idle":
         return
@@ -79,12 +95,11 @@ def clear_dataset():
     clear_all()
 
 
-def _get_embedder_for_clips():
-    """Return the embedder for the current dataset, or None."""
-    snap = snapshot_medias()
-    if not snap:
+def _get_embedder_for_medias(media_dict: dict):
+    """Return the embedder for the given medias dict, or None."""
+    if not media_dict:
         return None
-    first = next(iter(snap.values()))
+    first = next(iter(media_dict.values()))
     embedder_name = first.get("embedder", "")
     media_type = first.get("type", "audio")
 
@@ -100,48 +115,38 @@ def _get_embedder_for_clips():
     return avail[0] if avail else None
 
 
-def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = None) -> None:
-    """Eagerly load the embedder for the current dataset's media type.
+def _get_embedder_for_clips():
+    """Return the embedder for the current dataset, or None."""
+    snap = snapshot_medias()
+    return _get_embedder_for_medias(snap)
 
-    Called right after a dataset finishes loading so the first text sort
-    doesn't have to wait for the model download.  ``load_models()`` is
-    idempotent, so this is a no-op when the model is already warm (e.g.
-    after a folder import that already called ``embed_media()``).
 
-    After loading the model, a dummy text embedding is run to warm up the
-    text encoder branch.  Models like CLAP, CLIP, and X-CLIP have separate
-    media and text encoder sub-networks; data ingest only exercises the
-    media branch, leaving the text branch cold.  Without this warmup the
-    first user-initiated text sort would stall on PyTorch's lazy
-    initialisation for that branch.
+def _load_embedder_with_progress(
+    media_dict: dict,
+    progress_fn,
+    step: int | None = None,
+    total_steps: int | None = None,
+) -> None:
+    """Eagerly load the embedder and warm up its text encoder.
 
-    Args:
-        step: The step number to report for this phase.  Defaults to
-            ``_TOTAL_LOAD_STEPS`` (the last step of the demo/importer flow).
-        total_steps: The total number of steps to report.  Defaults to
-            ``_TOTAL_LOAD_STEPS``.
+    *progress_fn* is called as ``progress_fn(status, message, current, total, **kw)``
+    to report progress.  When *media_dict* is passed it is used to determine
+    the embedder; otherwise falls back to the active dataset.
     """
     if step is None:
         step = _TOTAL_LOAD_STEPS
     if total_steps is None:
         total_steps = _TOTAL_LOAD_STEPS
 
-    emb = _get_embedder_for_clips()
+    emb = _get_embedder_for_medias(media_dict) if media_dict else _get_embedder_for_clips()
     if emb is None:
-        update_progress("idle", "Ready", step=None, total_steps=None)
+        progress_fn("idle", "Ready", step=None, total_steps=None)
         return
 
     def _model_load_progress(status, message, current, total):
-        update_progress(status, message, current, total, step=step, total_steps=total_steps)
+        progress_fn(status, message, current, total, step=step, total_steps=total_steps)
 
-    update_progress(
-        "loading",
-        "Loading embedding model…",
-        0,
-        0,
-        step=step,
-        total_steps=total_steps,
-    )
+    progress_fn("loading", "Loading embedding model…", 0, 0, step=step, total_steps=total_steps)
     original_cb = emb._on_progress
     emb._on_progress = _model_load_progress
     try:
@@ -150,28 +155,21 @@ def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = 
         emb._on_progress = original_cb
 
     # Warm up the text encoder so the first text sort is instant.
-    update_progress(
-        "loading",
-        "Warming up text encoder…",
-        0,
-        0,
-        step=step,
-        total_steps=total_steps,
-    )
+    progress_fn("loading", "Warming up text encoder…", 0, 0, step=step, total_steps=total_steps)
     try:
         emb.embed_text("warmup")
     except Exception:
         pass
-    update_progress("idle", "Ready", step=None, total_steps=None)
+    progress_fn("idle", "Ready", step=None, total_steps=None)
+
+
+def _load_embedder_for_clips(step: int | None = None, total_steps: int | None = None) -> None:
+    """Legacy wrapper: load embedder using the global progress tracker."""
+    _load_embedder_with_progress(None, update_progress, step=step, total_steps=total_steps)
 
 
 def _set_clip_origins(clips_dict: dict, origin: dict) -> None:
-    """Set origin and origin_name on medias that don't already have them.
-
-    Called after an importer finishes populating the medias dict.  Clips
-    that already carry their own origin (e.g. loaded from a pickle that
-    recorded per-element provenance) are left untouched.
-    """
+    """Set origin and origin_name on medias that don't already have them."""
     for media in clips_dict.values():
         if media.get("origin") is None:
             media["origin"] = origin
@@ -180,11 +178,7 @@ def _set_clip_origins(clips_dict: dict, origin: dict) -> None:
 
 
 def _origin_to_str(origin: dict | None) -> str:
-    """Convert an origin dict to a human-readable string.
-
-    Delegates to the importer's :meth:`origin_display` when available,
-    falling back to a generic ``"<importer_name>:<first_param>"`` format.
-    """
+    """Convert an origin dict to a human-readable string."""
     if not origin:
         return "unknown"
     importer_name = origin.get("importer", "")
@@ -197,7 +191,6 @@ def _origin_to_str(origin: dict | None) -> str:
     if importer is not None:
         return importer.origin_display(origin)
 
-    # Unknown importer — generic fallback
     params = origin.get("params", {})
     if params:
         first_val = next(iter(params.values()))
@@ -206,15 +199,7 @@ def _origin_to_str(origin: dict | None) -> str:
 
 
 def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | None = None) -> None:
-    """Apply a clipper to all medias in *clips_dict*, replacing them in-place.
-
-    Each media is run through the clipper's ``clip()`` method.  The resulting
-    clips are assigned fresh sequential IDs and their origins are annotated
-    with the clipper name and clip index.
-
-    If *clipper_params* is provided, the registered clipper is customised via
-    its :meth:`~MediaClipper.with_params` method before clipping.
-    """
+    """Apply a clipper to all medias in *clips_dict*, replacing them in-place."""
     if not clipper_name:
         return
     from vtsearch.media import get_clipper
@@ -231,7 +216,6 @@ def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | N
     for media in list(clips_dict.values()):
         clipped = clipper.clip(media)
         for idx, clip in enumerate(clipped):
-            # Annotate origin with clipper info
             orig = clip.get("origin")
             if isinstance(orig, dict):
                 clip["origin"] = dict(orig)
@@ -248,45 +232,48 @@ def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | N
 
 
 def _auto_register_dataset(
+    media_dict: dict,
     name: str = "",
     origin_str: str = "unknown",
     source: dict | None = None,
     clipper: str = "",
     embedder: str = "",
     created_by: str = "",
+    display_name: str | None = None,
 ) -> dict | None:
-    """Save the current medias as a pkl and register in the dataset registry.
+    """Save *media_dict* as a pkl and register in the dataset registry.
 
-    Called at the end of every successful dataset load.  Skips if medias is
-    empty or if a registry entry with the same pkl path already exists (to
-    avoid duplicating on reload).
+    Unlike the old version, this accepts an explicit *media_dict* instead
+    of reading from the global ``medias`` proxy, enabling parallel loads.
 
     Returns the registry entry dict on success, or ``None`` on failure/skip.
     """
-    snap = snapshot_medias()
-    if not snap:
+    if not media_dict:
         return None
 
-    first = next(iter(snap.values()))
+    first = next(iter(media_dict.values()))
     media_type = first.get("type", "audio")
-    num_items = len(snap)
+    num_items = len(media_dict)
 
-    # Derive embedder from medias if not explicitly provided
     if not embedder:
         embedder = first.get("embedder", "")
 
-    # Derive name from display-name override, origin, or fallback
     if not name:
-        name = get_dataset_display_name() or origin_str or "Untitled"
+        name = display_name or origin_str or "Untitled"
         if ":" in name:
             name = name.split(":", 1)[1] or name
 
-    # Save to a pkl file in saved_datasets/
+    # Count dupes
+    num_dupes = sum(
+        1 for m in media_dict.values()
+        if isinstance(m.get("origin"), dict) and m["origin"].get("importer") == "dupe_set"
+    )
+
     ds_dir = get_saved_datasets_dir()
     ds_dir.mkdir(parents=True, exist_ok=True)
     pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
     try:
-        data_bytes = export_dataset_to_file(snap)
+        data_bytes = export_dataset_to_file(media_dict)
         Path(pkl_path).write_bytes(data_bytes)
         del data_bytes
     except Exception:
@@ -296,7 +283,7 @@ def _auto_register_dataset(
         name=name,
         media_type=media_type,
         num_items=num_items,
-        num_dupes=get_dupe_count(),
+        num_dupes=num_dupes,
         pkl_path=pkl_path,
         origin=origin_str,
         source=source,
@@ -320,6 +307,11 @@ def _activate_new_context(dataset_id: str) -> DatasetContext:
     return ctx
 
 
+# ---------------------------------------------------------------------------
+# Parallel-safe background loading
+# ---------------------------------------------------------------------------
+
+
 def _run_origin_load_in_background(
     load_fn,
     origin: dict,
@@ -329,82 +321,56 @@ def _run_origin_load_in_background(
     clipper_params: dict | None = None,
     embedder: str = "",
     created_by: str = "",
-) -> None:
+) -> str:
     """Run a dataset load in a background thread with standard error handling.
 
-    *load_fn* is called after a fresh DatasetContext is activated and should
-    populate ``medias`` (which now proxies to the new context).  Everything
-    after (origin tagging, clipping, dedup, diversity tree, registry,
-    embedder warm-up) is handled automatically.
+    *load_fn* is called with a single argument — the target medias dict —
+    and should populate it in-place.  Everything after (origin tagging,
+    clipping, dedup, diversity tree, registry, embedder warm-up) is handled
+    automatically.
 
-    Parameters
-    ----------
-    load_fn:
-        Callable that loads data into *medias*.
-    origin:
-        Origin dict (``{"importer": ..., "params": ...}``).
-    name:
-        Display name for the dataset registry.  Falls back to
-        ``_origin_to_str(origin)`` when empty.
-    clipper:
-        Name of the clipper to apply after loading.  Empty string means
-        no clipping.
-    clipper_params:
-        Optional dict of parameter overrides for the clipper (e.g.
-        ``{"duration": 5.0}``).
-    embedder:
-        Name of the embedder used.  When empty, derived from the medias
-        at registration time.
-    created_by:
-        Username of the user who initiated the load.  Captured before
-        the background thread starts (no Flask request context in thread).
+    The dataset context is NOT activated during loading.  It is activated
+    only upon successful completion, and only if no other dataset is
+    currently active.
+
+    Returns the task_id that can be used to poll progress or cancel.
     """
 
-    # Reset the cancellation flag so a previous cancel does not immediately
-    # abort this new operation.
-    dataset_progress.reset_cancel()
+    task_id = f"_loading_{uuid4().hex[:8]}"
+    tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin))
 
-    # Set progress to "loading" synchronously so the frontend never sees a
-    # stale "idle" status from a previous operation before the thread starts.
-    # Clear the error field so stale errors from previous loads don't persist.
-    update_progress("loading", "Preparing dataset...", error=None, step=1, total_steps=_TOTAL_LOAD_STEPS)
-
-    # Generate a temporary context ID.  It will be replaced by the real
-    # registry ID once _auto_register_dataset succeeds.
-    temp_ctx_id = f"_loading_{uuid4().hex[:8]}"
+    # Set initial progress synchronously so the first poll sees it.
+    tracker.update("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)
 
     def task():
+        ctx = DatasetContext(task_id)
+        stepped = _make_stepped_progress(tracker)
         try:
-            update_progress(
-                "loading",
-                "Preparing new dataset…",
-                0,
-                0,
-                step=1,
-                total_steps=_TOTAL_LOAD_STEPS,
-            )
-            # Create a fresh context and activate it (preserving other contexts).
-            _activate_new_context(temp_ctx_id)
+            tracker.update("loading", "Preparing new dataset…", 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
+            register_context(ctx)
             gc.collect()
-            load_fn()
-            dataset_progress.check_cancelled()
-            # Use MD5 hashes from custom_metadata when the importer
-            # provides them, before duplicate collapsing relies on them.
-            apply_custom_metadata_md5(medias)
-            update_progress(
-                "loading",
-                "Removing duplicates…",
-                step=_TOTAL_LOAD_STEPS,
-                total_steps=_TOTAL_LOAD_STEPS,
+
+            # Set thread-local progress so that loader/downloader callbacks
+            # route to this task's tracker instead of the global singleton.
+            set_thread_progress(stepped)
+            try:
+                load_fn(ctx.medias)
+            finally:
+                clear_thread_progress()
+
+            tracker.check_cancelled()
+            apply_custom_metadata_md5(ctx.medias)
+            tracker.update(
+                "loading", "Removing duplicates…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS
             )
-            _set_clip_origins(medias, origin)
+            _set_clip_origins(ctx.medias, origin)
             if clipper:
-                _apply_clipper(medias, clipper, clipper_params)
-            collapse_duplicates(medias)
+                _apply_clipper(ctx.medias, clipper, clipper_params)
+            collapse_duplicates(ctx.medias)
 
             def _diversity_progress(current: int, total: int) -> None:
-                dataset_progress.check_cancelled()
-                update_progress(
+                tracker.check_cancelled()
+                tracker.update(
                     "loading",
                     "Building diversity index…",
                     current=current,
@@ -414,52 +380,54 @@ def _run_origin_load_in_background(
                 )
 
             _diversity_progress(0, 0)
-            build_diversity_tree(on_progress=_diversity_progress)
-            dataset_progress.check_cancelled()
-            update_progress(
-                "loading",
-                "Saving to registry…",
-                step=_TOTAL_LOAD_STEPS,
-                total_steps=_TOTAL_LOAD_STEPS,
+            build_diversity_tree_for_context(ctx, on_progress=_diversity_progress)
+            tracker.check_cancelled()
+            tracker.update(
+                "loading", "Saving to registry…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS
             )
             origin_str = _origin_to_str(origin)
             entry = _auto_register_dataset(
+                ctx.medias,
                 name=name,
                 origin_str=origin_str,
                 source=origin,
                 clipper=clipper,
                 embedder=embedder,
                 created_by=created_by,
+                display_name=name,
             )
-            # Migrate the context from the temp ID to the real registry ID.
+
+            # Migrate the context from the temp task_id to the real registry ID.
             if entry is not None:
-                _migrate_context_id(temp_ctx_id, entry["id"])
-            _load_embedder_for_clips()
+                _migrate_context_id(task_id, entry["id"])
+                ctx.dataset_display_name = entry.get("name", name)
+                # Activate this dataset if nothing else is currently active.
+                if get_active_dataset_id() is None:
+                    set_active_dataset_id(entry["id"])
+
+            # Warm up the embedder.  Use a progress wrapper that updates the
+            # task tracker, not the global singleton.
+            def _task_progress(status, message="", current=0, total=0, **kw):
+                tracker.update(status, message, current, total, **kw)
+
+            _load_embedder_with_progress(ctx.medias, _task_progress)
         except CancelledError:
             from vtsearch.utils.state_core import unregister_context
 
-            unregister_context(temp_ctx_id)
+            unregister_context(task_id)
             gc.collect()
-            update_progress(
-                "idle",
-                "",
-                0,
-                0,
-                error="Cancelled",
-                step=None,
-                total_steps=None,
-            )
+            tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
         except MemoryError:
             from vtsearch.utils.state_core import unregister_context
 
-            unregister_context(temp_ctx_id)
+            unregister_context(task_id)
             gc.collect()
-            update_progress(
+            tracker.update(
                 "idle",
                 "",
                 0,
                 0,
-                "Out of memory — this dataset is too large. Try a smaller dataset or free up system RAM.",
+                error="Out of memory — this dataset is too large. Try a smaller dataset or free up system RAM.",
                 step=None,
                 total_steps=None,
             )
@@ -467,14 +435,23 @@ def _run_origin_load_in_background(
             traceback.print_exc()
             from vtsearch.utils.state_core import unregister_context
 
-            unregister_context(temp_ctx_id)
-            update_progress("idle", "", 0, 0, str(e), step=None, total_steps=None)
+            unregister_context(task_id)
+            tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
+        finally:
+            clear_thread_progress()
+            # Remove the task from the loading tasks tracker after a brief
+            # delay to let the frontend poll the final state.  The actual
+            # cleanup happens asynchronously.
+            def _deferred_cleanup():
+                import time
 
-    # Signal "loading" before the thread starts so frontend polling never
-    # sees a stale "idle" from a previous load and prematurely stops.
-    update_progress("loading", "Preparing to load dataset…", 0, 0, error=None, step=1, total_steps=_TOTAL_LOAD_STEPS)
+                time.sleep(3)
+                loading_tasks.remove_task(task_id)
+
+            threading.Thread(target=_deferred_cleanup, daemon=True).start()
 
     threading.Thread(target=task, daemon=True).start()
+    return task_id
 
 
 def _migrate_context_id(old_id: str, new_id: str) -> None:
@@ -494,8 +471,11 @@ def _migrate_context_id(old_id: str, new_id: str) -> None:
         set_active_dataset_id(new_id)
 
 
-def _run_importer_in_background(importer, field_values: dict) -> None:
-    """Start *importer*.run() in a daemon thread after clearing the dataset."""
+def _run_importer_in_background(importer, field_values: dict) -> str:
+    """Start *importer*.run() in a daemon thread.
+
+    Returns the task_id for progress tracking.
+    """
     created_by = get_current_user()
     origin = importer.build_origin(field_values)
     clipper_name = field_values.pop("clipper", "") or ""
@@ -505,25 +485,10 @@ def _run_importer_in_background(importer, field_values: dict) -> None:
     field_values["clipper"] = clipper_name
     embedder_name = field_values.get("embedder", "")
 
-    def _load():
-        # Inject step-aware progress into the importer's on_progress default
-        # by temporarily patching the module-level _default_progress resolver
-        # used by loader.py and downloader.py.
-        import vtsearch.datasets.loader as _loader_mod
-        import vtsearch.datasets.downloader as _dl_mod
+    def _load(target_medias):
+        importer.run(field_values, target_medias)
 
-        orig_loader_dp = _loader_mod._default_progress
-        orig_dl_dp = _dl_mod._default_progress
-
-        _loader_mod._default_progress = lambda: _stepped_progress
-        _dl_mod._default_progress = lambda: _stepped_progress
-        try:
-            importer.run(field_values, medias)
-        finally:
-            _loader_mod._default_progress = orig_loader_dp
-            _dl_mod._default_progress = orig_dl_dp
-
-    _run_origin_load_in_background(
+    return _run_origin_load_in_background(
         _load,
         origin,
         name=importer.resolve_display_name(field_values),

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -336,6 +336,11 @@ def _run_origin_load_in_background(
     Returns the task_id that can be used to poll progress or cancel.
     """
 
+    # Reset the legacy cancellation flag so a previous cancel does not
+    # immediately abort this new operation (backward compat for tests that
+    # check dataset_progress.is_cancelled).
+    dataset_progress.reset_cancel()
+
     task_id = f"_loading_{uuid4().hex[:8]}"
     tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin))
 
@@ -354,7 +359,13 @@ def _run_origin_load_in_background(
             # route to this task's tracker instead of the global singleton.
             set_thread_progress(stepped)
             try:
-                load_fn(ctx.medias)
+                import inspect
+
+                sig = inspect.signature(load_fn)
+                if sig.parameters:
+                    load_fn(ctx.medias)
+                else:
+                    load_fn()
             finally:
                 clear_thread_progress()
 
@@ -439,16 +450,7 @@ def _run_origin_load_in_background(
             tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
         finally:
             clear_thread_progress()
-            # Remove the task from the loading tasks tracker after a brief
-            # delay to let the frontend poll the final state.  The actual
-            # cleanup happens asynchronously.
-            def _deferred_cleanup():
-                import time
-
-                time.sleep(3)
-                loading_tasks.remove_task(task_id)
-
-            threading.Thread(target=_deferred_cleanup, daemon=True).start()
+            loading_tasks.mark_finished(task_id)
 
     threading.Thread(target=task, daemon=True).start()
     return task_id

--- a/vtsearch/utils/__init__.py
+++ b/vtsearch/utils/__init__.py
@@ -34,6 +34,7 @@ from vtsearch.utils.state import (
     bad_votes,
     build_media_lookup,
     build_diversity_tree,
+    build_diversity_tree_for_context,
     clear_all,
     clear_medias,
     clear_votes,
@@ -173,6 +174,7 @@ __all__ = [
     "apply_labels_bulk_with_click_time",
     # Diversity tree
     "build_diversity_tree",
+    "build_diversity_tree_for_context",
     "get_diversity_tree",
     "diversity_tree_next_sample",
     "diversity_tree_label",

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -1,5 +1,6 @@
 """Progress tracking for long-running operations."""
 
+import time
 import threading
 from typing import Any, Optional
 
@@ -105,6 +106,126 @@ class ProgressTracker:
         """
         with self._lock:
             return dict(self._data)
+
+
+# ---------------------------------------------------------------------------
+# Thread-local progress callback
+# ---------------------------------------------------------------------------
+# Background loading threads set a per-thread progress callback via
+# set_thread_progress().  The _default_progress() functions in loader.py,
+# downloader.py, etc. check this first, falling back to the global
+# update_progress() when no per-thread callback is set.  This avoids
+# monkey-patching module-level defaults and allows parallel loads to each
+# report to their own ProgressTracker.
+
+_thread_progress = threading.local()
+
+
+def set_thread_progress(callback) -> None:
+    """Set the progress callback for the current thread."""
+    _thread_progress.callback = callback
+
+
+def get_thread_progress():
+    """Return the per-thread progress callback, or ``None``."""
+    return getattr(_thread_progress, "callback", None)
+
+
+def clear_thread_progress() -> None:
+    """Remove the per-thread progress callback."""
+    _thread_progress.callback = None
+
+
+# ---------------------------------------------------------------------------
+# Loading tasks tracker — manages multiple concurrent loading operations
+# ---------------------------------------------------------------------------
+
+
+class LoadingTasksTracker:
+    """Manages multiple concurrent dataset loading tasks.
+
+    Each task has its own :class:`ProgressTracker`, a display name, and a
+    creation timestamp.  The dashboard polls :meth:`list_tasks` to show
+    one progress row per loading dataset.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._tasks: dict[str, dict[str, Any]] = {}
+
+    def create_task(self, task_id: str, name: str = "") -> ProgressTracker:
+        """Create and register a new loading task.
+
+        Returns the per-task :class:`ProgressTracker` instance.
+        """
+        tracker = ProgressTracker(
+            extra_fields={"error": None, "step": None, "total_steps": None}
+        )
+        with self._lock:
+            self._tasks[task_id] = {
+                "tracker": tracker,
+                "name": name,
+                "created_at": time.time(),
+            }
+        return tracker
+
+    def get_tracker(self, task_id: str) -> ProgressTracker | None:
+        """Return the ProgressTracker for *task_id*, or ``None``."""
+        with self._lock:
+            entry = self._tasks.get(task_id)
+        return entry["tracker"] if entry else None
+
+    def cancel_task(self, task_id: str) -> bool:
+        """Signal a specific task to cancel.  Returns ``True`` if found."""
+        tracker = self.get_tracker(task_id)
+        if tracker is not None:
+            tracker.cancel()
+            return True
+        return False
+
+    def cancel_all(self) -> None:
+        """Signal all active tasks to cancel."""
+        with self._lock:
+            tasks = list(self._tasks.values())
+        for entry in tasks:
+            entry["tracker"].cancel()
+
+    def remove_task(self, task_id: str) -> None:
+        """Remove a completed/cancelled task from the tracker."""
+        with self._lock:
+            self._tasks.pop(task_id, None)
+
+    def list_tasks(self) -> list[dict[str, Any]]:
+        """Return a snapshot of all active loading tasks.
+
+        Each entry includes: ``task_id``, ``name``, ``created_at``, and
+        all fields from the task's :class:`ProgressTracker`.
+        """
+        with self._lock:
+            entries = list(self._tasks.items())
+        result = []
+        for task_id, entry in entries:
+            snapshot = entry["tracker"].get()
+            snapshot["task_id"] = task_id
+            snapshot["name"] = entry["name"]
+            snapshot["created_at"] = entry["created_at"]
+            result.append(snapshot)
+        return result
+
+    def has_active_tasks(self) -> bool:
+        """Return ``True`` if any loading task is still running (not idle)."""
+        with self._lock:
+            entries = list(self._tasks.values())
+        return any(e["tracker"].get()["status"] != "idle" for e in entries)
+
+    def reset_for_tests(self) -> None:
+        """Clear all tasks.  For test isolation."""
+        with self._lock:
+            self._tasks.clear()
+
+
+#: Application-wide loading tasks tracker.
+loading_tasks = LoadingTasksTracker()
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -166,8 +166,16 @@ class LoadingTasksTracker:
                 "tracker": tracker,
                 "name": name,
                 "created_at": time.time(),
+                "finished_at": None,
             }
         return tracker
+
+    def mark_finished(self, task_id: str) -> None:
+        """Record the time a task finished (for deferred cleanup)."""
+        with self._lock:
+            entry = self._tasks.get(task_id)
+            if entry:
+                entry["finished_at"] = time.time()
 
     def get_tracker(self, task_id: str) -> ProgressTracker | None:
         """Return the ProgressTracker for *task_id*, or ``None``."""
@@ -200,16 +208,28 @@ class LoadingTasksTracker:
 
         Each entry includes: ``task_id``, ``name``, ``created_at``, and
         all fields from the task's :class:`ProgressTracker`.
+
+        Finished tasks older than 5 seconds are automatically removed.
         """
+        now = time.time()
+        stale: list[str] = []
         with self._lock:
             entries = list(self._tasks.items())
         result = []
         for task_id, entry in entries:
+            finished = entry.get("finished_at")
+            if finished is not None and (now - finished) > 5:
+                stale.append(task_id)
+                continue
             snapshot = entry["tracker"].get()
             snapshot["task_id"] = task_id
             snapshot["name"] = entry["name"]
             snapshot["created_at"] = entry["created_at"]
             result.append(snapshot)
+        if stale:
+            with self._lock:
+                for tid in stale:
+                    self._tasks.pop(tid, None)
         return result
 
     def has_active_tasks(self) -> bool:
@@ -286,12 +306,29 @@ def update_progress(
 
 
 def get_progress() -> dict[str, Any]:
-    """Return a snapshot of the current dataset progress data."""
+    """Return a snapshot of the current dataset progress data.
+
+    Checks per-task loading trackers first (used by parallel dataset
+    loading) and falls back to the legacy global singleton.
+    """
+    tasks = loading_tasks.list_tasks()
+    active = [t for t in tasks if t.get("status") != "idle"]
+    if active:
+        return active[0]
+    # Check if any just-finished task has an error to report
+    errored = [t for t in tasks if t.get("error")]
+    if errored:
+        return errored[0]
     return dataset_progress.get()
 
 
 def cancel_dataset_progress() -> None:
-    """Signal the current dataset operation to cancel."""
+    """Signal the current dataset operation(s) to cancel.
+
+    Cancels all active per-task loading trackers as well as the legacy
+    global singleton (used by staging operations).
+    """
+    loading_tasks.cancel_all()
     dataset_progress.cancel()
 
 

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -92,6 +92,7 @@ from vtsearch.utils.state_processors import (  # noqa: F401
 # Re-export diversity tree --------------------------------------------------
 from vtsearch.utils.state_diversity import (  # noqa: F401
     build_diversity_tree,
+    build_diversity_tree_for_context,
     diversity_tree_label,
     diversity_tree_next_sample,
     diversity_tree_unlabel,

--- a/vtsearch/utils/state_diversity.py
+++ b/vtsearch/utils/state_diversity.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 from vtsearch.utils.state_core import (
+    DatasetContext,
     _get_diversity_tree,
     _set_diversity_tree,
     _state_lock,
@@ -54,6 +55,35 @@ def build_diversity_tree(
         for cid in bad_votes:
             if cid in tree.vector_to_leaf:
                 tree.label(cid)
+
+
+def build_diversity_tree_for_context(
+    ctx: DatasetContext,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> None:
+    """Build a diversity tree and store it on a specific context.
+
+    Unlike :func:`build_diversity_tree` this does not touch the active
+    context — it operates entirely on *ctx*.  Used by parallel dataset
+    loading where the new dataset is not yet active.
+    """
+    import numpy as np
+
+    from vtsearch.models.diversity_tree import DiversityTree
+
+    vectors: dict[int, np.ndarray] = {}
+    for cid, media in ctx.medias.items():
+        emb = media.get("embedding")
+        if emb is not None:
+            vectors[cid] = np.asarray(emb, dtype=np.float32)
+
+    if not vectors:
+        ctx.diversity_tree = None
+        return
+
+    tree = DiversityTree(vectors, k=3, on_progress=on_progress)
+    ctx.diversity_tree = tree
+    # Fresh context has no votes — nothing to replay.
 
 
 def get_diversity_tree():


### PR DESCRIPTION
## Summary

- **Multiple datasets can now load concurrently**, each showing its own progress bar as a row in the dataset grid
- Backend uses per-task `ProgressTracker` instances and thread-local progress callbacks instead of a single global singleton, making progress reporting thread-safe across parallel loads
- Loading datasets no longer hijack the active context — they build their own `DatasetContext` in the background and only activate on completion (if nothing else is active)
- New API endpoints: `GET /api/dataset/loading-tasks` (poll all active loads), `POST /api/dataset/cancel/<task_id>` (cancel a specific load)
- All import endpoints now return `task_id` in the response
- Frontend dashboard polls loading tasks and renders each as a table row with progress bar and cancel button

## Test plan

- [x] 26 new tests in `test_parallel_loading.py` covering:
  - `LoadingTasksTracker`: create, list, cancel, cleanup, reset
  - Thread-local progress: set/get/clear, cross-thread isolation
  - `get_progress()` integration with per-task trackers
  - API endpoints: `/api/dataset/loading-tasks`, `/api/dataset/cancel/<task_id>`
  - Import endpoints return `task_id`
  - Parallel concurrency: separate progress, independent cancel
  - `build_diversity_tree_for_context`
- [x] All 2494 existing tests pass (1 skipped, 0 failed)
- [x] Frontend TypeScript builds successfully
- [ ] Manual test: start two dataset imports concurrently and verify both show independent progress rows

https://claude.ai/code/session_01TvoLPmqStb698sDrLLttZD