### PR TITLE
Keep progress bar visible when left panel is disabled

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -8,7 +8,18 @@
 
   &.disabled {
     pointer-events: none;
-    opacity: 0.45;
+
+    // Dim individual sections but keep the progress bar bright & visible
+    .left-tabs,
+    .images-header,
+    .media-list-container,
+    vt-sort-bar,
+    vt-select-mode,
+    vt-inclusion-slider,
+    .label-divider,
+    vt-autopilot-panel {
+      opacity: 0.45;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Modified the disabled state styling of the left panel to selectively dim individual sections while keeping the progress bar bright and visible.

## Key Changes
- Changed the disabled state from applying a blanket `opacity: 0.45` to the entire panel
- Now applies reduced opacity only to specific child components and sections:
  - `.left-tabs`
  - `.images-header`
  - `.media-list-container`
  - `vt-sort-bar`
  - `vt-select-mode`
  - `vt-inclusion-slider`
  - `.label-divider`
  - `vt-autopilot-panel`
- This allows the progress bar (not included in the list) to remain fully visible and prominent when the panel is disabled

## Implementation Details
The progress bar component is intentionally excluded from the opacity reduction, ensuring it remains clearly visible to users even when the left panel is in a disabled state. This improves UX by maintaining visibility of progress information while indicating that other panel controls are unavailable.

https://claude.ai/code/session_01ASecw99YzrsGVUMavY73uC