### PR TITLE
Default CSV/JSON exports to data/ folder

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -253,7 +253,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
       // Derive extension from the static default (e.g. ".json", ".csv") or fall back
       const extMatch = staticDefault.match(/\.(\w+)$/);
       const ext = extMatch ? extMatch[1] : 'json';
-      this.formValues['filepath'] = this.buildDefaultFilename(ext);
+      this.formValues['filepath'] = `data/${this.buildDefaultFilename(ext)}`;
     }
   }
 

--- a/tests/test_cli_autodetect.py
+++ b/tests/test_cli_autodetect.py
@@ -854,7 +854,7 @@ class TestExporterCLIArguments:
         exp.add_cli_arguments(parser)
 
         args = parser.parse_args([])
-        assert args.filepath == "autodetect_results.json"
+        assert args.filepath == "data/autodetect_results.json"
 
     def test_email_smtp_exporter_adds_expected_args(self):
         from vtsearch.exporters.email_smtp import EmailLabelsetExporter

--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -152,7 +152,7 @@ class TestCsvExporterCLI:
         exp.add_cli_arguments(parser)
 
         args = parser.parse_args([])
-        assert args.filepath == "autodetect_results.csv"
+        assert args.filepath == "data/autodetect_results.csv"
 
     def test_validate_passes(self):
         from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -40,8 +40,8 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                 "results file will be written.  Parent directories are "
                 "created automatically."
             ),
-            placeholder="/home/user/autodetect_results.csv",
-            default="autodetect_results.csv",
+            placeholder="data/autodetect_results.csv",
+            default="data/autodetect_results.csv",
         ),
     ]
 

--- a/vtsearch/exporters/server_json_file/__init__.py
+++ b/vtsearch/exporters/server_json_file/__init__.py
@@ -39,8 +39,8 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
                 "results file will be written.  Parent directories are "
                 "created automatically."
             ),
-            placeholder="/home/user/autodetect_results.json",
-            default="autodetect_results.json",
+            placeholder="data/autodetect_results.json",
+            default="data/autodetect_results.json",
         ),
     ]
 


### PR DESCRIPTION
## Summary
- Changed default export paths for server JSON and CSV exporters from project root to `data/` folder (e.g. `data/autodetect_results.json`)
- Updated frontend `applyDefaultFilename` to prepend `data/` to dynamically generated filenames
- Updated placeholders to reflect the new default location

## Test plan
- [x] `io` and `cli` test groups pass (510 tests)
- [ ] Verify export modal shows `data/` prefixed paths in the file browser
- [ ] Verify CLI `--autodetect` exports default to `data/` folder

https://claude.ai/code/session_019dZLBCLfB1bwpQjq2rKhrJ