### PR TITLE
Fix dataset loading: clear error on missing embedding deps

### DIFF
--- a/tests/test_enrich_descriptions.py
+++ b/tests/test_enrich_descriptions.py
@@ -93,7 +93,7 @@ class TestEmbedTextEnriched:
             def media_type_id(self):
                 return "mock"
 
-            def load_models(self):
+            def _load_models_impl(self):
                 pass
 
             def embed_media(self, file_path):

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -42,14 +42,14 @@ class AudioClapEmbedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        ClapModel, ClapProcessor = require_import("transformers", "ClapModel", "ClapProcessor")
+        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, require_import
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -47,9 +47,9 @@ class AudioClapEmbedder(MediaEmbedder):
             return
         import gc
 
-        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+        ClapModel, ClapProcessor = require_import("transformers", "ClapModel", "ClapProcessor")
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MUSIC_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -46,14 +46,14 @@ class AudioClapMusicEmbedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        ClapModel, ClapProcessor = require_import("transformers", "ClapModel", "ClapProcessor")
+        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MUSIC_MODEL_ID, CLAP_SAMPLE_RATE, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, require_import
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -51,9 +51,9 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             return
         import gc
 
-        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+        ClapModel, ClapProcessor = require_import("transformers", "ClapModel", "ClapProcessor")
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -43,7 +43,6 @@ __all__ = [
     "ProgressCallback",
     "intercept_tqdm_progress",
     "intercept_weight_loading_progress",
-    "require_import",
 ]
 
 
@@ -243,37 +242,6 @@ def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "
             setattr(obj, attr, orig)
 
 
-def require_import(module: str, *names: str, package: str | None = None):
-    """Import *names* from *module*, raising a clear error on failure.
-
-    Returns a tuple of the imported objects (or a single object when only one
-    name is requested).  If the import fails, the :class:`ImportError` message
-    tells the user which pip package to install.
-    """
-    import importlib  # noqa: PLC0415
-
-    pkg_label = package or module.split(".")[0]
-    try:
-        mod = importlib.import_module(module)
-    except ImportError as exc:
-        raise ImportError(
-            f"Could not import '{module}'. "
-            f"Please install it: pip install {pkg_label}"
-        ) from exc
-
-    results = []
-    for name in names:
-        obj = getattr(mod, name, None)
-        if obj is None:
-            raise ImportError(
-                f"Cannot import '{name}' from '{module}' "
-                f"(installed version may be too old or missing PyTorch). "
-                f"Try: pip install -U {pkg_label} torch"
-            )
-        results.append(obj)
-    return results[0] if len(results) == 1 else tuple(results)
-
-
 class MediaEmbedder(ABC):
     """Abstract base class for media embedders.
 
@@ -313,12 +281,29 @@ class MediaEmbedder(ABC):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    @abstractmethod
     def load_models(self) -> None:
         """Load (and cache) the embedding model.
 
         Called lazily the first time this embedder needs to produce a vector.
         Implementations must be idempotent — a second call should be a no-op.
+
+        Subclasses should override :meth:`_load_models_impl` (not this method).
+        This wrapper catches :class:`ImportError` and re-raises with an
+        actionable message so that missing dependencies surface clearly.
+        """
+        try:
+            self._load_models_impl()
+        except ImportError as exc:
+            raise ImportError(
+                f"{exc} — required by the '{self.name}' embedder. "
+                f"Install dependencies with: pip install -e '.[cpu,dev]'"
+            ) from exc
+
+    @abstractmethod
+    def _load_models_impl(self) -> None:
+        """Subclass hook: load the embedding model.
+
+        Override this instead of :meth:`load_models`.
         """
 
     # ------------------------------------------------------------------

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -43,6 +43,7 @@ __all__ = [
     "ProgressCallback",
     "intercept_tqdm_progress",
     "intercept_weight_loading_progress",
+    "require_import",
 ]
 
 
@@ -240,6 +241,37 @@ def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "
     finally:
         for obj, attr, orig in _patches:
             setattr(obj, attr, orig)
+
+
+def require_import(module: str, *names: str, package: str | None = None):
+    """Import *names* from *module*, raising a clear error on failure.
+
+    Returns a tuple of the imported objects (or a single object when only one
+    name is requested).  If the import fails, the :class:`ImportError` message
+    tells the user which pip package to install.
+    """
+    import importlib  # noqa: PLC0415
+
+    pkg_label = package or module.split(".")[0]
+    try:
+        mod = importlib.import_module(module)
+    except ImportError as exc:
+        raise ImportError(
+            f"Could not import '{module}'. "
+            f"Please install it: pip install {pkg_label}"
+        ) from exc
+
+    results = []
+    for name in names:
+        obj = getattr(mod, name, None)
+        if obj is None:
+            raise ImportError(
+                f"Cannot import '{name}' from '{module}' "
+                f"(installed version may be too old or missing PyTorch). "
+                f"Try: pip install -U {pkg_label} torch"
+            )
+        results.append(obj)
+    return results[0] if len(results) == 1 else tuple(results)
 
 
 class MediaEmbedder(ABC):

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLIP_MODEL_ID, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
 
 if TYPE_CHECKING:
     import torch
@@ -65,14 +65,14 @@ class ImageClipEmbedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        CLIPModel, CLIPProcessor = require_import("transformers", "CLIPModel", "CLIPProcessor")
+        from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLIP_MODEL_ID, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
 
 if TYPE_CHECKING:
     import torch
@@ -70,9 +70,9 @@ class ImageClipEmbedder(MediaEmbedder):
             return
         import gc
 
-        from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
+        CLIPModel, CLIPProcessor = require_import("transformers", "CLIPModel", "CLIPProcessor")
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import MODELS_CACHE_DIR, SIGLIP_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
 
 if TYPE_CHECKING:
     import torch
@@ -68,9 +68,9 @@ class ImageSiglipEmbedder(MediaEmbedder):
             return
         import gc
 
-        from transformers import SiglipModel, SiglipProcessor  # noqa: PLC0415
+        SiglipModel, SiglipProcessor = require_import("transformers", "SiglipModel", "SiglipProcessor")
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import MODELS_CACHE_DIR, SIGLIP_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
 
 if TYPE_CHECKING:
     import torch
@@ -63,14 +63,14 @@ class ImageSiglipEmbedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        SiglipModel, SiglipProcessor = require_import("transformers", "SiglipModel", "SiglipProcessor")
+        from transformers import SiglipModel, SiglipProcessor  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import E5_MODEL_ID, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -42,16 +42,14 @@ class TextE5Embedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        SentenceTransformer = require_import(  # noqa: N806
-            "sentence_transformers", "SentenceTransformer", package="sentence-transformers"
-        )
+        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import E5_MODEL_ID, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -47,9 +47,11 @@ class TextE5Embedder(MediaEmbedder):
             return
         import gc
 
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        SentenceTransformer = require_import(  # noqa: N806
+            "sentence_transformers", "SentenceTransformer", package="sentence-transformers"
+        )
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import BGE_MODEL_ID, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -47,9 +47,11 @@ class TextBGEEmbedder(MediaEmbedder):
             return
         import gc
 
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        SentenceTransformer = require_import(  # noqa: N806
+            "sentence_transformers", "SentenceTransformer", package="sentence-transformers"
+        )
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import BGE_MODEL_ID, MODELS_CACHE_DIR
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -42,16 +42,14 @@ class TextBGEEmbedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        SentenceTransformer = require_import(  # noqa: N806
-            "sentence_transformers", "SentenceTransformer", package="sentence-transformers"
-        )
+        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import MODELS_CACHE_DIR, XCLIP_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
 
 if TYPE_CHECKING:
     import torch
@@ -62,14 +62,14 @@ class VideoXClipEmbedder(MediaEmbedder):
     # Model lifecycle
     # ------------------------------------------------------------------
 
-    def load_models(self) -> None:
+    def _load_models_impl(self) -> None:
         if self._model is not None:
             return
         import gc
 
-        XCLIPModel, XCLIPProcessor = require_import("transformers", "XCLIPModel", "XCLIPProcessor")
+        from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
 
-        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
+        from vtsearch.models.loader import ensure_torch_configured
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import MODELS_CACHE_DIR, XCLIP_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, intercept_tqdm_progress, intercept_weight_loading_progress, require_import
 
 if TYPE_CHECKING:
     import torch
@@ -67,9 +67,9 @@ class VideoXClipEmbedder(MediaEmbedder):
             return
         import gc
 
-        from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
+        XCLIPModel, XCLIPProcessor = require_import("transformers", "XCLIPModel", "XCLIPProcessor")
 
-        from vtsearch.models.loader import ensure_torch_configured
+        from vtsearch.models.loader import ensure_torch_configured  # noqa: PLC0415
 
         ensure_torch_configured()
         gc.collect()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -428,6 +428,24 @@ def _run_origin_load_in_background(
             unregister_context(task_id)
             gc.collect()
             tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+        except ImportError as e:
+            traceback.print_exc()
+            from vtsearch.utils.state_core import unregister_context
+
+            unregister_context(task_id)
+            gc.collect()
+            tracker.update(
+                "idle",
+                "",
+                0,
+                0,
+                error=(
+                    f"Missing dependency: {e}. "
+                    "Install all required packages with: pip install -e '.[cpu,dev]'"
+                ),
+                step=None,
+                total_steps=None,
+            )
         except MemoryError:
             from vtsearch.utils.state_core import unregister_context
 
@@ -548,6 +566,16 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 100,
                 100,
                 staging_result={"path": str(staging_path), "name": name, "count": count, "media_type": media_type},
+            )
+        except ImportError as e:
+            traceback.print_exc()
+            gc.collect()
+            update_progress(
+                "idle",
+                "",
+                0,
+                0,
+                f"Missing dependency: {e}. Install all required packages with: pip install -e '.[cpu,dev]'",
             )
         except MemoryError:
             gc.collect()


### PR DESCRIPTION
## Summary
- Uses template method pattern in `MediaEmbedder`: `load_models()` is now a concrete wrapper that catches `ImportError` from the new abstract `_load_models_impl()` and re-raises with an actionable message including the embedder name and install instructions
- All 7 existing embedders (CLIP, SigLIP, X-CLIP, CLAP, CLAP Music, E5, BGE) override `_load_models_impl()` — future embedders get the same protection automatically without needing to remember any special import pattern
- Adds `ImportError`-specific exception handling in both dataset loading paths (`_run_origin_load_in_background` and `_stage_importer_in_background`) to surface install instructions to the user

## Test plan
- [x] All 2492 tests pass (3 skipped)
- [x] Linter passes on all changed files
- [ ] Verify error message clarity by running with a missing `transformers` or `torch` install

https://claude.ai/code/session_016hY3UpLtXBF9NsaaTADqL2