### PR TITLE
Fix flaky test: unbounded slow_load loop in cancel test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,27 @@ thread.start()
 time.sleep(0.2)  # FLAKY — may not be enough on a loaded machine
 ```
 
+### 3. Never use bounded loops to simulate "cancellable" or "interruptible" work
+A `for i in range(100): sleep(0.05)` loop finishes in 5 seconds — but on a loaded machine the code that's supposed to interrupt it (e.g. setting a cancel flag) can take longer than 5 seconds to run. If the loop completes before the interrupt arrives, the test follows the wrong code path and fails.
+
+**Do this:**
+```python
+def slow_load():
+    started.set()
+    while True:                            # exits ONLY via CancelledError
+        dataset_progress.check_cancelled()
+        time.sleep(0.05)
+```
+
+**Not this:**
+```python
+def slow_load():
+    started.set()
+    for i in range(100):                   # FLAKY — can finish before cancel arrives
+        dataset_progress.check_cancelled()
+        time.sleep(0.05)
+```
+
 ## Environment Notes (Claude Code on the web)
 - **No Chrome/Chromium available.** The cloud container (Ubuntu 24.04) does not have Chrome or Chromium installed, and they cannot be installed (`chromium` is snap-only on 24.04, snap is unavailable in containers, and Google's download servers are unreachable). Frontend Karma tests (`ng test`) will fail. Do NOT spend time trying to install Chrome/Chromium — it won't work. The Python backend tests (`./run-tests.sh`) work fine without a browser.
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1087,10 +1087,14 @@ class TestCancelIngest:
         try:
             started = threading.Event()
 
-            # Simulate a slow importer that checks cancellation via progress
+            # Simulate a slow importer that checks cancellation via progress.
+            # Use ``while True`` so the function can only exit via
+            # CancelledError — a bounded loop (e.g. ``range(100)``) can
+            # finish before the cancel is processed on a loaded machine,
+            # making the test flaky.
             def slow_load():
                 started.set()
-                for i in range(100):
+                while True:
                     dataset_progress.check_cancelled()
                     time.sleep(0.05)
 


### PR DESCRIPTION
## Summary

- **Fix `test_cancel_clears_medias_on_background_load` flaky failure** — the test's `slow_load()` used a bounded loop (`for i in range(100)` = 5 seconds), which could complete before `client.post("/api/dataset/cancel")` set the cancel event on a loaded machine. The task would then follow the success path, setting progress to `idle` without `error="Cancelled"`, failing the assertion.
- Changed from `for i in range(100)` to `while True` so `slow_load()` can only exit via `CancelledError`, making the test deterministic regardless of system load.

## Test plan

- [x] `./run-tests.sh` — all 2465 tests pass
- [x] 10 consecutive full-suite runs under CPU stress (4 background `yes` processes) — all passed
- [x] Previously reproduced the failure ~2 out of 25 runs before the fix

https://claude.ai/code/session_01338u6yUuHuqjQYmehWwcKb