### PR TITLE
Add skip_embedding flag to load_dataset_from_folder

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -741,7 +741,7 @@ class TestLoadDatasetSkipEmbedding:
             )
 
         # The per-file progress calls should use "loading" phase, not "embedding".
-        per_file = [c for c in progress_calls if c[2] > 0]  # non-zero current
+        per_file = [c for c in progress_calls if len(c) >= 4 and c[2] > 0]
         assert len(per_file) >= 1
         assert per_file[0][0] == "loading"
         assert "Loading" in per_file[0][1]

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -637,6 +637,153 @@ class TestLoadDatasetContentVectors:
 
 
 # ---------------------------------------------------------------------------
+# load_dataset_from_folder – skip_embedding support
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDatasetSkipEmbedding:
+    """Verify that load_dataset_from_folder respects skip_embedding=True."""
+
+    def _write_wav(self, path):
+        """Write a minimal WAV file to *path*."""
+        path.write_bytes(_make_wav_bytes())
+
+    def test_skip_embedding_with_content_vectors(self, tmp_path):
+        """Pre-computed vectors are used; no embedder is resolved."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        wav = tmp_path / "a.wav"
+        self._write_wav(wav)
+
+        pre_vector = np.array([1.0, 2.0, 3.0])
+        medias: dict = {}
+
+        mt = mock.MagicMock()
+        mt.type_id = "audio"
+        mt.file_extensions = ["*.wav"]
+        mt.load_media_data.return_value = {"duration": 1.0}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), \
+             mock.patch("vtsearch.media.embedders_for_type") as mock_emb_for_type, \
+             mock.patch("vtsearch.media.get_embedder") as mock_get_emb:
+            load_dataset_from_folder(
+                tmp_path, "sounds", medias,
+                content_vectors={"a.wav": pre_vector},
+                on_progress=lambda *a: None,
+                skip_embedding=True,
+            )
+
+        assert len(medias) == 1
+        np.testing.assert_array_equal(medias[1]["embedding"], pre_vector)
+        # Embedder registry should never be consulted.
+        mock_emb_for_type.assert_not_called()
+        mock_get_emb.assert_not_called()
+
+    def test_skip_embedding_without_vectors_sets_none(self, tmp_path):
+        """Files without pre-computed vectors get embedding=None."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        wav = tmp_path / "a.wav"
+        self._write_wav(wav)
+
+        medias: dict = {}
+
+        mt = mock.MagicMock()
+        mt.type_id = "audio"
+        mt.file_extensions = ["*.wav"]
+        mt.load_media_data.return_value = {"duration": 1.0}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), \
+             mock.patch("vtsearch.media.embedders_for_type") as mock_emb_for_type:
+            load_dataset_from_folder(
+                tmp_path, "sounds", medias,
+                on_progress=lambda *a: None,
+                skip_embedding=True,
+            )
+
+        assert len(medias) == 1
+        assert medias[1]["embedding"] is None
+        assert medias[1]["embedder"] == ""
+        mock_emb_for_type.assert_not_called()
+
+    def test_skip_embedding_progress_says_loading(self, tmp_path):
+        """Progress messages should say 'Loading' not 'Embedding'."""
+        import unittest.mock as mock
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        wav = tmp_path / "a.wav"
+        self._write_wav(wav)
+
+        mt = mock.MagicMock()
+        mt.type_id = "audio"
+        mt.file_extensions = ["*.wav"]
+        mt.load_media_data.return_value = {"duration": 1.0}
+
+        progress_calls: list = []
+
+        def track_progress(*args):
+            progress_calls.append(args)
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), \
+             mock.patch("vtsearch.media.embedders_for_type"):
+            load_dataset_from_folder(
+                tmp_path, "sounds", medias,
+                on_progress=track_progress,
+                skip_embedding=True,
+            )
+
+        # The per-file progress calls should use "loading" phase, not "embedding".
+        per_file = [c for c in progress_calls if c[2] > 0]  # non-zero current
+        assert len(per_file) >= 1
+        assert per_file[0][0] == "loading"
+        assert "Loading" in per_file[0][1]
+
+    def test_skip_embedding_chunked(self, tmp_path):
+        """skip_embedding works with the chunked variant too."""
+        import unittest.mock as mock
+
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        for name in ("a.wav", "b.wav"):
+            self._write_wav(tmp_path / name)
+
+        vectors = {
+            "a.wav": np.array([1.0, 2.0]),
+            "b.wav": np.array([3.0, 4.0]),
+        }
+
+        mt = mock.MagicMock()
+        mt.type_id = "audio"
+        mt.file_extensions = ["*.wav"]
+        mt.load_media_data.return_value = {"duration": 1.0}
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), \
+             mock.patch("vtsearch.media.embedders_for_type") as mock_emb_for_type:
+            chunks = list(load_dataset_from_folder_chunked(
+                tmp_path, "sounds", chunk_size=10,
+                content_vectors=vectors,
+                on_progress=lambda *a: None,
+                skip_embedding=True,
+            ))
+
+        all_medias = {}
+        for chunk in chunks:
+            all_medias.update(chunk)
+        assert len(all_medias) == 2
+        mock_emb_for_type.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # load_dataset_from_folder – content_md5s support
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -444,6 +444,7 @@ def load_dataset_from_folder(
     thin: bool = False,
     embedder_name: str = "",
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
+    skip_embedding: bool = False,
 ) -> None:
     """Generate a dataset in-place from a flat folder of media files.
 
@@ -496,6 +497,11 @@ def load_dataset_from_folder(
             non-empty ``"md5"`` key, that value is used as the media's MD5
             instead of computing it from the file contents.  The metadata dict
             is also attached to the media as ``custom_metadata``.
+        skip_embedding: When ``True``, skip embedder resolution and model
+            loading entirely.  Files with pre-computed vectors in
+            ``content_vectors`` use those; files without are included with
+            ``embedding=None``.  Useful when vectors have already been
+            downloaded or computed externally.
 
     Raises:
         ValueError: If ``media_type`` is not recognised, or if no matching
@@ -513,28 +519,29 @@ def load_dataset_from_folder(
     except KeyError:
         raise ValueError(f"Invalid media type: {media_type}")
 
-    # Resolve the embedder
+    # Resolve the embedder (skipped entirely when skip_embedding=True).
     emb = None
-    if embedder_name:
-        try:
-            emb = get_embedder(embedder_name)
-        except KeyError:
-            raise ValueError(f"Unknown embedder: {embedder_name}")
-    else:
-        avail = embedders_for_type(mt.type_id)
-        if avail:
-            emb = avail[0]
+    if not skip_embedding:
+        if embedder_name:
+            try:
+                emb = get_embedder(embedder_name)
+            except KeyError:
+                raise ValueError(f"Unknown embedder: {embedder_name}")
+        else:
+            avail = embedders_for_type(mt.type_id)
+            if avail:
+                emb = avail[0]
 
-    # Eagerly load models before starting the embedding timer so that
-    # download / weight-loading time does not pollute the progress bar.
-    if emb is not None and getattr(emb, "_model", None) is None:
-        on_progress("loading", "Loading embedding model…", 0, 0)
-        original_cb = emb._on_progress
-        emb._on_progress = on_progress
-        try:
-            emb.load_models()
-        finally:
-            emb._on_progress = original_cb
+        # Eagerly load models before starting the embedding timer so that
+        # download / weight-loading time does not pollute the progress bar.
+        if emb is not None and getattr(emb, "_model", None) is None:
+            on_progress("loading", "Loading embedding model…", 0, 0)
+            original_cb = emb._on_progress
+            emb._on_progress = on_progress
+            try:
+                emb.load_models()
+            finally:
+                emb._on_progress = original_cb
 
     # Find all files of the specified media type (recursive so that
     # subdirectory structures are preserved).
@@ -555,9 +562,10 @@ def load_dataset_from_folder(
             # different subdirectories with the same basename stay distinct.
             rel_path = file_path.relative_to(folder_path).as_posix()
 
+            phase = "loading" if skip_embedding else "embedding"
             on_progress(
-                "embedding",
-                f"Embedding {media_type} {rel_path}...",
+                phase,
+                f"{'Loading' if skip_embedding else 'Embedding'} {media_type} {rel_path}...",
                 i + 1,
                 total_files,
             )
@@ -568,6 +576,8 @@ def load_dataset_from_folder(
                 embedding = content_vectors[rel_path]
             elif content_vectors and file_path.name in content_vectors:
                 embedding = content_vectors[file_path.name]
+            elif skip_embedding:
+                embedding = None
             else:
                 if emb is None:
                     continue
@@ -706,6 +716,7 @@ def load_dataset_from_folder_chunked(
     thin: bool = False,
     embedder_name: str = "",
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
+    skip_embedding: bool = False,
 ) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield chunks of medias from a folder of media files.
 
@@ -730,6 +741,7 @@ def load_dataset_from_folder_chunked(
             is used.
         custom_metadata_map: Optional mapping of filename to a metadata dict.
             Same semantics as in :func:`load_dataset_from_folder`.
+        skip_embedding: Same semantics as in :func:`load_dataset_from_folder`.
 
     Yields:
         A dict mapping int media IDs (starting at 1) to media data dicts.
@@ -751,28 +763,29 @@ def load_dataset_from_folder_chunked(
     except KeyError:
         raise ValueError(f"Invalid media type: {media_type}")
 
-    # Resolve the embedder
+    # Resolve the embedder (skipped entirely when skip_embedding=True).
     emb = None
-    if embedder_name:
-        try:
-            emb = get_embedder(embedder_name)
-        except KeyError:
-            raise ValueError(f"Unknown embedder: {embedder_name}")
-    else:
-        avail = embedders_for_type(mt.type_id)
-        if avail:
-            emb = avail[0]
+    if not skip_embedding:
+        if embedder_name:
+            try:
+                emb = get_embedder(embedder_name)
+            except KeyError:
+                raise ValueError(f"Unknown embedder: {embedder_name}")
+        else:
+            avail = embedders_for_type(mt.type_id)
+            if avail:
+                emb = avail[0]
 
-    # Eagerly load models before starting the embedding timer so that
-    # download / weight-loading time does not pollute the progress bar.
-    if emb is not None and getattr(emb, "_model", None) is None:
-        on_progress("loading", "Loading embedding model…", 0, 0)
-        original_cb = emb._on_progress
-        emb._on_progress = on_progress
-        try:
-            emb.load_models()
-        finally:
-            emb._on_progress = original_cb
+        # Eagerly load models before starting the embedding timer so that
+        # download / weight-loading time does not pollute the progress bar.
+        if emb is not None and getattr(emb, "_model", None) is None:
+            on_progress("loading", "Loading embedding model…", 0, 0)
+            original_cb = emb._on_progress
+            emb._on_progress = on_progress
+            try:
+                emb.load_models()
+            finally:
+                emb._on_progress = original_cb
 
     # Find all files of the specified media type (recursive so that
     # subdirectory structures are preserved).
@@ -796,9 +809,10 @@ def load_dataset_from_folder_chunked(
             global_idx = start + i
             rel_path = file_path.relative_to(folder_path).as_posix()
 
+            phase = "loading" if skip_embedding else "embedding"
             on_progress(
-                "embedding",
-                f"Embedding {media_type} {rel_path} (chunk {start // chunk_size + 1})...",
+                phase,
+                f"{'Loading' if skip_embedding else 'Embedding'} {media_type} {rel_path} (chunk {start // chunk_size + 1})...",
                 global_idx + 1,
                 total_files,
             )
@@ -807,6 +821,8 @@ def load_dataset_from_folder_chunked(
                 embedding = content_vectors[rel_path]
             elif content_vectors and file_path.name in content_vectors:
                 embedding = content_vectors[file_path.name]
+            elif skip_embedding:
+                embedding = None
             else:
                 if emb is None:
                     continue


### PR DESCRIPTION
## Summary
- Adds a `skip_embedding=True` parameter to both `load_dataset_from_folder` and `load_dataset_from_folder_chunked`
- When set, skips embedder resolution and model loading entirely — no registry lookups, no weight downloads
- Files with pre-computed vectors in `content_vectors` use those; files without get `embedding=None`
- Progress messages say "Loading" instead of "Embedding" when skip_embedding is active

## Motivation
Future data importers that download media and vectors from a server can reuse `load_dataset_from_folder` without paying the cost of re-embedding. Previously the function always resolved an embedder and loaded model weights even when all vectors were already available.

## Test plan
- [x] New test: `skip_embedding=True` with `content_vectors` uses pre-computed vectors, never touches embedder registry
- [x] New test: `skip_embedding=True` without vectors sets `embedding=None` (file still included)
- [x] New test: progress phase is "loading" not "embedding" when skipping
- [x] New test: chunked variant respects `skip_embedding` flag
- [x] Full test suite passes (2500 tests)

https://claude.ai/code/session_01UbMB5PjPJPy2mnV2BjHAYK