### PR TITLE
Add time (hh:mm) to Dashboard date columns

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -72,7 +72,8 @@ export class DatasetCardComponent {
 
   formatDate(timestamp: number | null): string {
     if (!timestamp) return '-';
-    return new Date(timestamp * 1000).toLocaleDateString();
+    const d = new Date(timestamp * 1000);
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
 
   capitalizeType(type: string | undefined): string {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -73,7 +73,8 @@ export class ModelCardComponent {
 
   formatDate(timestamp: number | null): string {
     if (!timestamp) return '-';
-    return new Date(timestamp * 1000).toLocaleDateString();
+    const d = new Date(timestamp * 1000);
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
 
   capitalizeType(type: string | undefined): string {


### PR DESCRIPTION
## Summary
- Updated `formatDate()` in both `dataset-card` and `model-card` components to include `hh:mm` time alongside the date
- Affects the **Created** column (datasets and models) and **Last Trained** column (models)
- Uses `toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })` for locale-aware time formatting

## Test plan
- [x] Frontend builds successfully
- [x] Core test group passes (335 tests)
- [ ] Verify in browser that Created and Last Trained columns show date + time (e.g. "3/24/2026 14:30")

https://claude.ai/code/session_01MRCkAMPPjDnZ8ya5Ydfo7D