### PR TITLE
Put progress fraction before message to prevent truncation

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -762,8 +762,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
             msg = `[Step ${progress.step}/${progress.total_steps}] ${msg}`;
           }
           if (progress.current != null && progress.total != null && progress.total > 0) {
-            const pct = Math.min(100, Math.round((progress.current / progress.total) * 100));
-            msg += ` (${pct}%)`;
+            const fraction = `(${progress.current}/${progress.total})`;
+            const stepEnd = msg.indexOf('] ');
+            if (stepEnd !== -1) {
+              msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
+            } else {
+              msg = fraction + ' ' + msg;
+            }
           }
           this.datasetState.setProgressMessage(msg);
         },
@@ -860,8 +865,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
       msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
     }
     if (task.current != null && task.total != null && task.total > 0) {
-      const pct = Math.min(100, Math.round((task.current / task.total) * 100));
-      msg += ` (${pct}%)`;
+      const fraction = `(${task.current}/${task.total})`;
+      const stepEnd = msg.indexOf('] ');
+      if (stepEnd !== -1) {
+        msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
+      } else {
+        msg = fraction + ' ' + msg;
+      }
     }
     return msg;
   }

--- a/vtsearch/datasets/downloader/documents.py
+++ b/vtsearch/datasets/downloader/documents.py
@@ -98,7 +98,7 @@ def download_ucsf_documents(
             pdf_path = cat_dir / f"{doc_id}.pdf"
             if pdf_path.exists():
                 downloaded += 1
-                on_progress("downloading", f"Cached {doc_id}.pdf ({downloaded}/{total_docs})", downloaded, total_docs)
+                on_progress("downloading", f"Cached {doc_id}.pdf", downloaded, total_docs)
                 continue
 
             url = (

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -150,7 +150,7 @@ def _ingest_via_source(
 
             on_progress(
                 "ingesting",
-                f"Fetched {origin_name or filename} ({ingested}/{len(entries)})...",
+                f"Fetched {origin_name or filename}",
                 ingested,
                 len(entries),
             )
@@ -217,7 +217,7 @@ def _ingest_via_resolver(
 
         on_progress(
             "ingesting",
-            f"Resolved {origin_name or filename} ({ingested}/{len(entries)})...",
+            f"Resolved {origin_name or filename}",
             ingested,
             len(entries),
         )

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -291,7 +291,7 @@ class AudioMediaType(MediaType):
 
         for i, (audio_path, meta) in enumerate(audio_files):
             rel_name = f"{meta['category']}/{audio_path.name}"
-            on_progress("embedding", f"Embedding {rel_name} ({i + 1}/{total})", i + 1, total)
+            on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
             embedding = embedder.embed_media(audio_path)
             if embedding is None:
                 continue

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -325,7 +325,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (img_path, category) in enumerate(selected):
-                on_progress("embedding", f"Embedding {category}/{img_path.name} ({i + 1}/{total})", i + 1, total)
+                on_progress("embedding", f"Embedding {category}/{img_path.name}", i + 1, total)
                 embedding = embedder.embed_media(img_path)
                 if embedding is None:
                     continue
@@ -487,7 +487,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} document pages...", 0, total)
 
             for i, (page_name, pil_image, category) in enumerate(selected_pages):
-                on_progress("embedding", f"Embedding {page_name} ({i + 1}/{total})", i + 1, total)
+                on_progress("embedding", f"Embedding {page_name}", i + 1, total)
                 embedding = embedder.embed_pil_image(pil_image)
                 if embedding is None:
                     continue
@@ -548,7 +548,7 @@ class ImageMediaType(MediaType):
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
             for i, (image_array, category) in enumerate(zip(selected_images, selected_labels)):
-                on_progress("embedding", f"Embedding {category}: image {i + 1}/{total}", i + 1, total)
+                on_progress("embedding", f"Embedding {category}", i + 1, total)
                 img = Image.fromarray(image_array.astype("uint8"), "RGB")
                 img_buffer = _io.BytesIO()
                 img.save(img_buffer, format="PNG")

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -242,7 +242,7 @@ class TextMediaType(MediaType):
         demo_origin_template: dict = {"importer": "demo", "params": {}}
 
         for i, (text_content, category) in enumerate(zip(selected_texts, selected_categories)):
-            on_progress("embedding", f"Embedding {category}: paragraph {i + 1}/{total}", i + 1, total)
+            on_progress("embedding", f"Embedding {category}", i + 1, total)
             text_content = text_content[:1000].strip()
             if not text_content:
                 continue

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -185,7 +185,7 @@ class VideoMediaType(MediaType):
 
         for i, (video_path, meta) in enumerate(video_files):
             rel_name = f"{meta['category']}/{video_path.name}"
-            on_progress("embedding", f"Embedding {rel_name} ({i + 1}/{total})", i + 1, total)
+            on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
             embedding = embedder.embed_media(video_path)
             if embedding is None:
                 continue


### PR DESCRIPTION
## Summary
- Progress bars now show `[Step 3/4] (123/1000) Embedding 024.butter...` instead of `[Step 3/4] Embedding 024.butterfly/024_0066.jpg (1... (0%)`
- The `(current/total)` fraction is inserted right after the `[Step X/Y]` prefix in both frontend progress formatters (find-progress and loading-task)
- Redundant inline counts removed from backend progress messages (image/audio/video/text/document embedding, ingest fetching/resolving, document download caching) to avoid duplication

## Test plan
- [x] Core tests pass (335/335)
- [x] Datasets + IO tests pass (739/740, 1 skipped)
- [ ] Visually verify progress bar shows fraction before message during dataset loading

https://claude.ai/code/session_01MenyW6b2aLhwq211KAEpjA