### PR TITLE
Fix image viewer background for light/all themes

### DIFF
--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -15,7 +15,7 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  background: #000;
+  background: transparent;
 }
 
 .image-element {


### PR DESCRIPTION
## Summary
- Changed image viewer background from hardcoded `#000` to `transparent` so it inherits the panel's background color
- This matches how the video and text viewers already work (they use `var(--bg-surface)`)
- Fixes the black background showing in light theme and ensures consistency across all color schemes

## Test plan
- [x] Core tests pass (335/335), including frontend TypeScript build check
- [ ] Visually verify image viewer background in dark, light, and high-contrast themes

https://claude.ai/code/session_01Y7ZbKLYF3EzdhKn2HXoHTd