### PR TITLE
Fix silent failures when adding multiple datasets concurrently

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -39,20 +39,27 @@
           </thead>
           <tbody>
             @for (task of loadingTasks; track task.task_id) {
-              <tr class="loading-task-row">
+              <tr class="loading-task-row" [class.loading-task-error]="!!task.error">
                 <td>
                   <span class="loading-task-name">{{ task.name || 'Loading...' }}</span>
                 </td>
                 <td [attr.colspan]="isDefaultLogin ? 9 : 11">
-                  <div class="loading-task-progress">
-                    <span class="progress-msg">{{ taskProgressMessage(task) }}</span>
-                    <vt-progress-bar
-                      [value]="task.current"
-                      [max]="task.total"
-                      [indeterminate]="taskIsIndeterminate(task)"
-                    />
-                    <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
-                  </div>
+                  @if (task.error) {
+                    <div class="loading-task-progress loading-task-failed">
+                      <span class="error-msg">Failed: {{ task.error }}</span>
+                      <button class="btn btn--cancel btn--sm" (click)="dismissLoadingTask(task.task_id)" title="Dismiss this error">Dismiss</button>
+                    </div>
+                  } @else {
+                    <div class="loading-task-progress">
+                      <span class="progress-msg">{{ taskProgressMessage(task) }}</span>
+                      <vt-progress-bar
+                        [value]="task.current"
+                        [max]="task.total"
+                        [indeterminate]="taskIsIndeterminate(task)"
+                      />
+                      <button class="btn btn--cancel btn--sm" (click)="cancelLoadingTask(task.task_id)" title="Cancel this dataset load">Cancel</button>
+                    </div>
+                  }
                 </td>
               </tr>
             }

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -232,6 +232,18 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  &.loading-task-error {
+    background: var(--error-bg, rgba(220, 38, 38, 0.06));
+  }
+
+  .loading-task-failed {
+    .error-msg {
+      flex: 1;
+      font-size: 0.8rem;
+      color: var(--error-text, #991b1b);
+    }
+  }
 }
 
 .empty-state {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -436,6 +436,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetsApi.cancelTask(taskId).subscribe();
   }
 
+  dismissLoadingTask(taskId: string): void {
+    this.loadingTasks = this.loadingTasks.filter((t) => t.task_id !== taskId);
+  }
+
   // --- Progress polling ---
 
   startProgressPolling(onComplete?: () => void): void {
@@ -454,16 +458,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
         next: (tasks: LoadingTask[]) => {
           // Separate active from finished
           const active = tasks.filter((t) => t.status !== 'idle');
-          const errored = tasks.filter((t) => t.status === 'idle' && t.error);
+          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
+          const cancelled = errored.filter((t) => t.error === 'Cancelled');
+          const failed = errored.filter((t) => t.error !== 'Cancelled');
 
-          this.loadingTasks = active;
+          // Show both active tasks and failed tasks (so users see the error)
+          this.loadingTasks = [...active, ...failed];
           this.datasetState.setLoadingTasks(active);
 
-          // Show errors from just-completed tasks
-          for (const t of errored) {
-            if (t.error && t.error !== 'Cancelled') {
-              this.datasetState.setErrorMessage(t.error);
-            }
+          // Also set the top-level error banner for failed tasks
+          for (const t of failed) {
+            this.datasetState.setErrorMessage(t.error!);
           }
 
           // Keep legacy loading flag for backward compat
@@ -473,7 +478,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             // No more active tasks — stop polling
             this.polling$.next();
             this.datasetState.refresh();
-            if (onComplete && errored.length === 0) {
+            if (onComplete && failed.length === 0) {
               onComplete();
             }
           }

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -324,6 +324,143 @@ class TestParallelLoadConcurrency:
             loading_tasks.remove_task("cancel_b")
 
 
+class TestErrorVisibility:
+    """Verify that loading errors are visible to the polling frontend."""
+
+    def test_error_message_always_non_empty(self):
+        """Exception handlers must produce non-empty error strings."""
+        pt = loading_tasks.create_task("err_test", "Fail")
+        # Simulate the backend error handler with an exception that has
+        # an empty str() representation:
+        e = Exception()
+        error_msg = str(e) or repr(e) or "Unknown error during dataset loading"
+        pt.update("idle", "", 0, 0, error=error_msg)
+        try:
+            tasks = loading_tasks.list_tasks()
+            assert len(tasks) == 1
+            assert tasks[0]["error"]  # must be truthy
+            assert tasks[0]["error"] != ""
+        finally:
+            loading_tasks.remove_task("err_test")
+
+    def test_errored_task_visible_after_finish(self):
+        """Errored tasks stay visible in list_tasks longer than success tasks."""
+        pt = loading_tasks.create_task("err_vis", "ErrorDS")
+        pt.update("idle", "", 0, 0, error="Something broke")
+        # Mark finished 10 seconds ago — non-error tasks would be cleaned up
+        with loading_tasks._lock:
+            loading_tasks._tasks["err_vis"]["finished_at"] = time.time() - 10
+        try:
+            tasks = loading_tasks.list_tasks()
+            assert len(tasks) == 1
+            assert tasks[0]["error"] == "Something broke"
+        finally:
+            loading_tasks.remove_task("err_vis")
+
+    def test_errored_task_cleaned_after_30s(self):
+        """Errored tasks are eventually cleaned up after 30 seconds."""
+        pt = loading_tasks.create_task("err_old", "OldError")
+        pt.update("idle", "", 0, 0, error="Old error")
+        with loading_tasks._lock:
+            loading_tasks._tasks["err_old"]["finished_at"] = time.time() - 35
+        tasks = loading_tasks.list_tasks()
+        assert len(tasks) == 0
+
+    def test_errored_task_in_api_response(self, client):
+        """GET /api/dataset/loading-tasks returns errored tasks."""
+        pt = loading_tasks.create_task("api_err", "API Err DS")
+        pt.update("idle", "", 0, 0, error="Load failed")
+        loading_tasks.mark_finished("api_err")
+        try:
+            resp = client.get("/api/dataset/loading-tasks")
+            data = resp.get_json()
+            errored = [t for t in data["tasks"] if t.get("error")]
+            assert len(errored) == 1
+            assert errored[0]["error"] == "Load failed"
+        finally:
+            loading_tasks.remove_task("api_err")
+
+    def test_concurrent_load_one_fails_other_succeeds(self):
+        """When two tasks run and one errors, the error is visible while the other continues."""
+        pt_ok = loading_tasks.create_task("ok_task", "Good DS")
+        pt_fail = loading_tasks.create_task("fail_task", "Bad DS")
+
+        pt_ok.update("loading", "Still working", 50, 100)
+        pt_fail.update("idle", "", 0, 0, error="Download failed")
+        loading_tasks.mark_finished("fail_task")
+
+        try:
+            tasks = loading_tasks.list_tasks()
+            by_id = {t["task_id"]: t for t in tasks}
+
+            assert "ok_task" in by_id
+            assert by_id["ok_task"]["status"] == "loading"
+
+            assert "fail_task" in by_id
+            assert by_id["fail_task"]["error"] == "Download failed"
+        finally:
+            loading_tasks.remove_task("ok_task")
+            loading_tasks.remove_task("fail_task")
+
+
+class TestResetCancelSafety:
+    """Verify that starting a new load does not interfere with running loads."""
+
+    def test_reset_cancel_skipped_when_tasks_active(self):
+        """dataset_progress.reset_cancel() must not fire when loads are in progress."""
+        from vtsearch.utils.progress import dataset_progress
+
+        # Create an active task
+        pt = loading_tasks.create_task("active_task", "Running")
+        pt.update("loading", "Downloading", 10, 100)
+
+        # Cancel the global tracker (simulating user cancel of a previous load)
+        dataset_progress.cancel()
+        assert dataset_progress.is_cancelled
+
+        try:
+            # Start a new load — should NOT reset global cancel since a task is active
+            from unittest.mock import patch
+
+            from vtsearch.routes.datasets_loading import _run_origin_load_in_background
+
+            with patch("vtsearch.routes.datasets_loading.threading.Thread"):
+                _run_origin_load_in_background(
+                    lambda: None,
+                    {"importer": "test", "params": {}},
+                )
+
+            # The global cancel should still be set (not reset)
+            assert dataset_progress.is_cancelled
+        finally:
+            loading_tasks.remove_task("active_task")
+            dataset_progress.reset_cancel()
+
+    def test_reset_cancel_allowed_when_no_tasks_active(self):
+        """dataset_progress.reset_cancel() fires when no loads are in progress."""
+        from vtsearch.utils.progress import dataset_progress
+
+        dataset_progress.cancel()
+        assert dataset_progress.is_cancelled
+
+        from unittest.mock import patch
+
+        from vtsearch.routes.datasets_loading import _run_origin_load_in_background
+
+        with patch("vtsearch.routes.datasets_loading.threading.Thread"):
+            task_id = _run_origin_load_in_background(
+                lambda: None,
+                {"importer": "test", "params": {}},
+            )
+
+        try:
+            # The global cancel should have been reset
+            assert not dataset_progress.is_cancelled
+        finally:
+            loading_tasks.remove_task(task_id)
+            dataset_progress.reset_cancel()
+
+
 class TestBuildDiversityTreeForContext:
     """Test the context-specific diversity tree builder."""
 

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -762,9 +762,13 @@ def load_registered_dataset(dataset_id: str):
             gc.collect()
             tracker.update("idle", "", 0, 0, error="Out of memory — dataset too large.", step=None, total_steps=None)
         except Exception as e:
+            import traceback as _tb
+
+            _tb.print_exc()
             unregister_context(dataset_id)
             _reg_remove_loaded(dataset_id)
-            tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
+            error_msg = str(e) or repr(e) or "Unknown error during dataset loading"
+            tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
         finally:
             clear_thread_progress()
             _loading_tasks.mark_finished(task_id)

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -277,6 +277,7 @@ def _auto_register_dataset(
         Path(pkl_path).write_bytes(data_bytes)
         del data_bytes
     except Exception:
+        traceback.print_exc()
         return None
 
     entry = _reg_register(
@@ -337,9 +338,11 @@ def _run_origin_load_in_background(
     """
 
     # Reset the legacy cancellation flag so a previous cancel does not
-    # immediately abort this new operation (backward compat for tests that
-    # check dataset_progress.is_cancelled).
-    dataset_progress.reset_cancel()
+    # immediately abort this new operation — but only when no other
+    # parallel loads are running (otherwise we would clear cancellation
+    # that might still be intended for those in-flight tasks).
+    if not loading_tasks.has_active_tasks():
+        dataset_progress.reset_cancel()
 
     task_id = f"_loading_{uuid4().hex[:8]}"
     tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin))
@@ -465,7 +468,8 @@ def _run_origin_load_in_background(
             from vtsearch.utils.state_core import unregister_context
 
             unregister_context(task_id)
-            tracker.update("idle", "", 0, 0, error=str(e), step=None, total_steps=None)
+            error_msg = str(e) or repr(e) or "Unknown error during dataset loading"
+            tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
         finally:
             clear_thread_progress()
             loading_tasks.mark_finished(task_id)
@@ -588,7 +592,8 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
             )
         except Exception as e:
             traceback.print_exc()
-            update_progress("idle", "", 0, 0, str(e))
+            error_msg = str(e) or repr(e) or "Unknown error during staging"
+            update_progress("idle", "", 0, 0, error_msg)
 
     thread = threading.Thread(target=stage_task, daemon=True)
     thread.start()

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -209,7 +209,9 @@ class LoadingTasksTracker:
         Each entry includes: ``task_id``, ``name``, ``created_at``, and
         all fields from the task's :class:`ProgressTracker`.
 
-        Finished tasks older than 5 seconds are automatically removed.
+        Finished tasks without errors are removed after 5 seconds.
+        Finished tasks *with* errors are kept for 30 seconds so that
+        the polling frontend has time to display them.
         """
         now = time.time()
         stale: list[str] = []
@@ -218,14 +220,23 @@ class LoadingTasksTracker:
         result = []
         for task_id, entry in entries:
             finished = entry.get("finished_at")
-            if finished is not None and (now - finished) > 5:
-                stale.append(task_id)
-                continue
-            snapshot = entry["tracker"].get()
-            snapshot["task_id"] = task_id
-            snapshot["name"] = entry["name"]
-            snapshot["created_at"] = entry["created_at"]
-            result.append(snapshot)
+            if finished is not None:
+                snapshot = entry["tracker"].get()
+                has_error = bool(snapshot.get("error"))
+                max_age = 30 if has_error else 5
+                if (now - finished) > max_age:
+                    stale.append(task_id)
+                    continue
+                snapshot["task_id"] = task_id
+                snapshot["name"] = entry["name"]
+                snapshot["created_at"] = entry["created_at"]
+                result.append(snapshot)
+            else:
+                snapshot = entry["tracker"].get()
+                snapshot["task_id"] = task_id
+                snapshot["name"] = entry["name"]
+                snapshot["created_at"] = entry["created_at"]
+                result.append(snapshot)
         if stale:
             with self._lock:
                 for tid in stale:


### PR DESCRIPTION
## Summary

- **Errored loading tasks no longer silently disappear** — failed tasks are now shown inline in the dashboard table with a visible error message and dismiss button, instead of vanishing when they transition to idle status
- **Error messages are always non-empty** — exception handlers now fall back to `repr(e)` or a default message when `str(e)` is empty, preventing invisible errors in both backend API responses and frontend display
- **Concurrent load safety** — `dataset_progress.reset_cancel()` is no longer called when other loading tasks are active, preventing potential interference between parallel loads
- **Better debugging** — `_auto_register_dataset` now logs tracebacks instead of silently swallowing exceptions; errored tasks persist in the tracker for 30 seconds (up from 5) so the polling frontend reliably catches them

## Test plan

- [x] `./run-tests.sh datasets` — all 379 pass (1 skip, 1 pre-existing frontend build failure unrelated to this PR)
- [x] `./run-tests.sh core sorting api` — all 914 pass
- [x] `./run-tests.sh io models` — all 1225 pass (1 skip)
- [x] `./run-tests.sh integration cli converters` — all 330 pass
- [x] New tests in `test_parallel_loading.py`: error visibility, errored task retention, concurrent load error isolation, reset-cancel safety
- [ ] Manual: start Audio Demo load, then start Image Demo load — both should show progress; if one fails, its error should be visible inline

https://claude.ai/code/session_01DJzeKNbbgJmoR4C8t4zARq