### PR TITLE
Hide npm funding message

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+fund=false


### PR DESCRIPTION
## Summary
- Adds `frontend/.npmrc` with `fund=false` to suppress the "X packages are looking for funding" message during `npm install`/`npm ci`

## Test plan
- [ ] Run `cd frontend && npm install` and confirm no funding message appears

https://claude.ai/code/session_01QnRzAdUPmqAGADMxBL3RKM