### PR TITLE
Replace brain icon with lightbulb for Models

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -77,7 +77,7 @@
   <!-- Model Section -->
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="brain" [size]="18"></vt-icon> Models</span>
+      <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="lightbulb" [size]="18"></vt-icon> Models</span>
       <div class="dashboard-section-actions">
         <button class="btn btn--primary btn--sm" (click)="openNewModelModal()" title="Create a new model">+</button>
       </div>

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -10,7 +10,7 @@ const KNOWN_TYPES = new Set([
   'server', 'globe', 'email', 'satellite',
   'folder', 'folder-open', 'upload',
   'graduation', 'arrow-up', 'shuffle', 'elephant', 'cloud',
-  'check', 'warning', 'x-circle', 'info', 'file', 'brain',
+  'check', 'warning', 'x-circle', 'info', 'file', 'lightbulb',
 ]);
 
 function emojiToType(icon: string): string {
@@ -122,8 +122,8 @@ function emojiToType(icon: string): string {
       @case ('info') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
       }
-      @case ('brain') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C9.5 2 7.5 3 6 4.5 4 6.5 3 9 3 11.5c0 2.5 1 5 3 7 1.5 1.5 3.5 2.5 6 3.5V2z"/><path d="M12 2c2.5 0 4.5 1 6 2.5 2 2 3 4.5 3 7 0 2.5-1 5-3 7-1.5 1.5-3.5 2.5-6 3.5V2z"/><path d="M7.5 7c1.5.5 3 1.5 4 3"/><path d="M6 13c2 0 4-.5 5.5-2"/><path d="M16.5 7c-1.5.5-3 1.5-4 3"/><path d="M18 13c-2 0-4-.5-5.5-2"/></svg>
+      @case ('lightbulb') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z"/></svg>
       }
       @case ('file') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>


### PR DESCRIPTION
## Summary
- Replaced the "brain" SVG icon with a "lightbulb" SVG icon for the Models section in the dashboard
- Updated the icon component type name from `brain` to `lightbulb`

## Test plan
- [x] Core tests pass (335/335), including frontend TypeScript build check

https://claude.ai/code/session_01Xs3W5xioMwjuqZV4uDp3nM