### PR TITLE
Fix datasets disappearing during concurrent loading

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -81,6 +81,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private findPolling$ = new Subject<void>();
   private knownDatasetIds = new Set<string>();
   private knownModelIds = new Set<string>();
+  private completedTaskIds = new Set<string>();
 
   currentUser = '';
   isDefaultLogin = true;
@@ -441,6 +442,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   startProgressPolling(onComplete?: () => void): void {
     this.datasetState.setErrorMessage('');
     this.polling$.next(); // cancel previous polling
+    this.completedTaskIds.clear();
 
     timer(0, 1000)
       .pipe(
@@ -459,6 +461,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
           this.loadingTasks = active;
           this.datasetState.setLoadingTasks(active);
 
+          // Detect tasks that just completed successfully so we can
+          // refresh the registry immediately (not only when ALL finish).
+          const justFinished = tasks.filter(
+            (t) => t.status === 'idle' && !t.error && !this.completedTaskIds.has(t.task_id),
+          );
+          for (const t of justFinished) {
+            this.completedTaskIds.add(t.task_id);
+          }
+          if (justFinished.length > 0) {
+            this.datasetState.refresh();
+          }
+
           // Show errors from just-completed tasks
           for (const t of errored) {
             if (t.error && t.error !== 'Cancelled') {
@@ -472,7 +486,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
           if (active.length === 0) {
             // No more active tasks — stop polling
             this.polling$.next();
-            this.datasetState.refresh();
+            // Refresh unless we just did (justFinished already triggered it)
+            if (justFinished.length === 0) {
+              this.datasetState.refresh();
+            }
             if (onComplete && errored.length === 0) {
               onComplete();
             }


### PR DESCRIPTION
## Summary

- When multiple datasets load concurrently, datasets that finish first disappear from the dashboard list because the frontend only refreshes the registry when **all** loading tasks complete
- Now the polling loop detects individual task completions and refreshes the registry immediately, so each dataset appears in the list as soon as it finishes loading

## Root Cause

The dashboard's `startProgressPolling()` polls `/api/dataset/loading-tasks` every second. It filters tasks into "active" (still loading) and "idle" (finished). The registry refresh (`datasetState.refresh()`) was only called when `active.length === 0` — i.e., when every concurrent task had finished. A dataset that finished while others were still loading would vanish from the loading tasks display (filtered out as idle) but never appear in the dataset table (registry not yet refreshed).

## Fix

Track completed task IDs during polling. When a task transitions to idle without error and hasn't been seen before, trigger an immediate registry refresh. This ensures each dataset appears in the table as soon as its loading task completes, regardless of whether other tasks are still running.

## Test plan

- [x] Frontend builds successfully (`npm run build:prod`)
- [x] Core tests pass (335/335)
- [x] Dataset tests pass (371/371)
- [ ] Manual: start 3+ demo datasets concurrently → each should appear in the dashboard table as it finishes, without disappearing

https://claude.ai/code/session_01TENJznzhp1Eb384jK7k48j