### PR TITLE
Fix diversity level drop after vote-polarity switch

### DIFF
--- a/tests/test_diversity_tree_integration.py
+++ b/tests/test_diversity_tree_integration.py
@@ -435,6 +435,43 @@ class TestDiversityLevelOverTime:
         for i in range(1, len(levels)):
             assert levels[i] >= levels[i - 1], f"Diversity level decreased at step {i}: {levels[i - 1]} -> {levels[i]}"
 
+    def test_diversity_level_no_drop_after_vote_polarity_switch(self, client):
+        """Switching a vote from bad→good must not cause a diversity dip in the progress cache."""
+        tree = _build_tree()
+
+        # Label several medias to build up diversity — need both good and bad
+        cids = sorted(tree.vector_to_leaf.keys())[:6]
+        for i, cid in enumerate(cids):
+            if i % 2 == 0:
+                client.post(f"/api/medias/{cid}/vote", json={"vote": "good"})
+            else:
+                client.post(f"/api/medias/{cid}/vote", json={"vote": "bad"})
+
+        # Record the diversity level before the switch
+        resp = client.post("/api/labeling-progress")
+        data = resp.get_json()
+        levels_before = [e["diversity_level"] for e in data["diversity_level_over_time"]]
+        assert len(levels_before) > 0, "Expected diversity history entries"
+        peak_before = max(levels_before)
+
+        # Switch the last bad vote to good (polarity switch triggers cache invalidation)
+        switch_cid = cids[1]  # was voted bad
+        client.post(f"/api/medias/{switch_cid}/vote", json={"vote": "good"})
+
+        # Fetch diversity history again — no entry should be below the pre-switch peak
+        resp = client.post("/api/labeling-progress")
+        data = resp.get_json()
+        levels_after = [e["diversity_level"] for e in data["diversity_level_over_time"]]
+        for i, level in enumerate(levels_after):
+            if i < len(levels_before):
+                # Kept entries should be unchanged
+                continue
+            # New entries should not dip below the peak
+            assert level >= peak_before, (
+                f"Diversity level dropped to {level} at step {i} after vote polarity switch "
+                f"(peak before switch was {peak_before}). Full history: {levels_after}"
+            )
+
     def test_labeling_status_includes_diversity_level(self, client):
         """The /api/labeling-status span info should include diversity_level."""
         _build_tree()

--- a/vtsearch/models/progress.py
+++ b/vtsearch/models/progress.py
@@ -316,6 +316,14 @@ def _ensure_cache(
 
     if _cache_diversity_tree is None:
         _cache_diversity_tree = _build_diversity_tree(clips_dict)
+        # After a partial invalidation (_cache_diversity_tree was set to None
+        # but _cache_good_ids/_cache_bad_ids still contain IDs from kept
+        # steps), seed the fresh tree with those pre-existing labels so that
+        # diversity_level() is correct for subsequently replayed events.
+        if _cache_diversity_tree is not None:
+            for mid in _cache_good_ids | _cache_bad_ids:
+                if mid in _cache_diversity_tree.vector_to_leaf:
+                    _cache_diversity_tree.label(mid)
 
     for t in range(start, len(label_history)):
         media_id, label, _ = label_history[t]


### PR DESCRIPTION
## Summary
- **Fix**: When a vote switched polarity (e.g. bad→good), `invalidate_progress_cache_from()` set `_cache_diversity_tree = None` but kept `_cache_good_ids`/`_cache_bad_ids` intact. When `_ensure_cache()` rebuilt the tree, it started with zero labels — losing all pre-truncation labels. This caused the diversity line graph to show a false dip and diverge from the live tooltip value.
- **Fix**: After rebuilding the diversity tree in `_ensure_cache()`, seed it with all labels already in `_cache_good_ids | _cache_bad_ids` so the tree state matches the kept cache steps.
- **Test**: Added regression test that votes on several items, switches one vote's polarity, and verifies no diversity dip appears in the progress history.

## Test plan
- [x] `./run-tests.sh sorting` — all 216 tests pass (includes diversity tree unit + integration tests)
- [x] `./run-tests.sh` — all 2501 tests pass
- [ ] Manual: vote on items, switch a vote from bad→good, verify the diversity line graph doesn't dip and matches the tooltip

https://claude.ai/code/session_016GyuPa5YRdioyzsXdqw7pr