### PR TITLE
Always include origin column in CSV label export

### DIFF
--- a/tests/test_csv_webhook_exporters.py
+++ b/tests/test_csv_webhook_exporters.py
@@ -326,7 +326,8 @@ class TestCsvExporterLabelsFormat:
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             header = next(reader)
-        assert header == ["label", "filename", "category"]
+        # origin is always appended as last column for re-import
+        assert header == ["label", "filename", "category", "origin"]
 
     def test_labels_format_correct_row_count(self, tmp_path):
         from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
@@ -358,7 +359,8 @@ class TestCsvExporterLabelsFormat:
             reader = csv.reader(f)
             next(reader)  # skip header
             first_row = next(reader)
-        assert first_row == ["good", "clip1.wav", "birds"]
+        # origin column is always appended (empty when not present on entry)
+        assert first_row == ["good", "clip1.wav", "birds", ""]
 
     def test_labels_format_includes_metadata_columns(self, tmp_path):
         from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
@@ -375,8 +377,8 @@ class TestCsvExporterLabelsFormat:
             reader = csv.reader(f)
             header = next(reader)
             first_row = next(reader)
-        assert header == ["filename", "source", "quality"]
-        assert first_row == ["clip1.wav", "field", "high"]
+        assert header == ["filename", "source", "quality", "origin"]
+        assert first_row == ["clip1.wav", "field", "high", ""]
 
     def test_labels_format_missing_metadata_gives_empty(self, tmp_path):
         """When a metadata column is missing from an entry, output empty string."""
@@ -392,8 +394,8 @@ class TestCsvExporterLabelsFormat:
         exp.export(results, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f))
-        # Third entry (clip3.wav) has no "quality" in metadata
-        assert rows[3] == ["clip3.wav", ""]
+        # Third entry (clip3.wav) has no "quality" in metadata; origin also empty
+        assert rows[3] == ["clip3.wav", "", ""]
 
     def test_labels_format_changed_columns_reflected(self, tmp_path):
         """Changing selected_columns between exports produces different output."""
@@ -422,8 +424,9 @@ class TestCsvExporterLabelsFormat:
         with open(filepath2, newline="", encoding="utf-8") as f:
             header2 = next(csv.reader(f))
 
-        assert header1 == ["label", "md5", "origin_name", "filename", "category"]
-        assert header2 == ["source"]
+        # origin is always the last column
+        assert header1 == ["label", "md5", "origin_name", "filename", "category", "origin"]
+        assert header2 == ["source", "origin"]
 
     def test_labels_format_no_selected_columns_uses_defaults(self, tmp_path):
         """When selected_columns is absent, fall back to base columns."""

--- a/tests/test_export_options.py
+++ b/tests/test_export_options.py
@@ -442,9 +442,10 @@ class TestExportWithSelectedColumns:
 
             with open(fpath, newline="", encoding="utf-8") as f:
                 rows = list(csv.reader(f))
-            assert rows[0] == ["label", "filename"]
-            assert rows[1] == ["good", "a.wav"]
-            assert rows[2] == ["bad", "b.wav"]
+            # origin is always appended as last column for re-import
+            assert rows[0] == ["label", "filename", "origin"]
+            assert rows[1] == ["good", "a.wav", ""]
+            assert rows[2] == ["bad", "b.wav", ""]
 
     def test_json_export_with_selected_columns(self, client):
         """POST /api/exporters/export with labels + selected_columns filters JSON."""
@@ -499,8 +500,9 @@ class TestExportWithSelectedColumns:
             with open(fpath2, newline="", encoding="utf-8") as f:
                 header2 = next(csv.reader(f))
 
-            assert header1 == ["label", "md5", "filename"]
-            assert header2 == ["category"]
+            # origin is always appended as last column
+            assert header1 == ["label", "md5", "filename", "origin"]
+            assert header2 == ["category", "origin"]
 
 
 class TestAvailableColumnsNoDuplicates:

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -46,7 +46,8 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
     ]
 
     #: Base columns for label exports (used when no selected_columns provided).
-    _LABEL_BASE_COLUMNS = ["label", "md5", "origin_name", "filename", "category", "origin"]
+    #: ``origin`` is always appended as the last column (not listed here).
+    _LABEL_BASE_COLUMNS = ["label", "md5", "origin_name", "filename", "category"]
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
         filepath_str = field_values.get("filepath", "").strip()
@@ -64,9 +65,18 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         return self._export_autodetect(results, filepath)
 
     def _export_labels(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
-        """Export labels with user-selected columns."""
+        """Export labels with user-selected columns.
+
+        The ``origin`` column is always written as the last column so
+        that the CSV can be re-imported without data loss.
+        """
         labels = results.get("labels", [])
-        columns: list[str] = results.get("selected_columns") or self._LABEL_BASE_COLUMNS
+        columns: list[str] = list(results.get("selected_columns") or self._LABEL_BASE_COLUMNS)
+
+        # Ensure origin is always the last column (required for re-import).
+        if "origin" in columns:
+            columns.remove("origin")
+        columns.append("origin")
 
         total_rows = 0
         with open(filepath, "w", newline="", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Make the `origin` column mandatory in CSV label exports — it is always appended as the last column regardless of user column selection
- Without `origin`, exported CSVs cannot be re-imported successfully
- The `origin` column is excluded from the frontend preview grid (it contains JSON-serialized data not useful for visual inspection)

## Test plan
- [x] All 372 io group tests pass
- [x] CSV exporter tests verify origin is always the last column
- [x] Round-trip test (export → import) confirms origin dict survives CSV serialization

https://claude.ai/code/session_014Lgf5nSdAxdPKGCDqHEDYh