### PR TITLE
Show Corrections radio as disabled when no corrections exist

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -41,12 +41,10 @@
         <input type="radio" name="labelFilter" value="bad" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         Bad
       </label>
-      @if (hasCorrections) {
-        <label class="delimiter-option">
-          <input type="radio" name="labelFilter" value="corrections" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
-          Corrections
-        </label>
-      }
+      <label class="delimiter-option" [class.disabled]="!hasCorrections" [title]="hasCorrections ? '' : 'No corrections to export.'">
+        <input type="radio" name="labelFilter" value="corrections" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" [disabled]="!hasCorrections" />
+        Corrections
+      </label>
     </div>
   </div>
 

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -57,6 +57,15 @@
   input[type='radio'] {
     cursor: pointer;
   }
+
+  &.disabled {
+    opacity: 0.5;
+    cursor: default;
+
+    input[type='radio'] {
+      cursor: default;
+    }
+  }
 }
 
 // --- Data preview table ---


### PR DESCRIPTION
## Summary
- Always show the Corrections radio button in the Export modal instead of hiding it when no corrections exist
- When there are no corrections, the radio is disabled with reduced opacity and a tooltip: "No corrections to export."
- Users can now discover the feature exists even before they have corrections

## Test plan
- [x] Frontend TypeScript build passes
- [x] Core test suite passes (335 tests)
- [x] Manual: Open Export modal with no detector corrections — verify Corrections radio is visible but grayed out and disabled
- [ ] Manual: Hover over disabled Corrections radio — verify tooltip "No corrections to export." appears
- [ ] Manual: Open Export modal after making corrections to detector labels — verify Corrections radio is enabled and functional

https://claude.ai/code/session_01LUoQgd3bhNqeVMwcgngBGX