### PR TITLE
Capitalize embedder names in Dashboard datasets grid

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -42,7 +42,7 @@
 <td>{{ formatDate(dataset.created_at) }}</td>
 <td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
 <td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
-<td class="embedder-cell">{{ dataset.embedder || '-' }}</td>
+<td class="embedder-cell">{{ (dataset.embedder | titlecase) || '-' }}</td>
 @if (!isDefaultLogin) {
   <td>{{ dataset.created_by || '-' }}</td>
   <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>


### PR DESCRIPTION
## Summary
- Apply Angular's `titlecase` pipe to the embedder column in the dataset card table so names display capitalized (e.g. "Clip" instead of "clip")

## Test plan
- [x] Core tests pass (335/335), including frontend TypeScript build check

https://claude.ai/code/session_01TfcxQbhKLd322T9VoxvYTf