### PR TITLE
Make unloaded dataset/model indicators clickable to load

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -72,6 +72,7 @@
                 (rowClick)="toggleDatasetSelection(dataset.id, $event)"
                 (rename)="renameDataset(dataset, $event)"
                 (delete)="deleteDataset(dataset)"
+                (load)="loadDataset(dataset)"
                 (security)="editDatasetSecurity(dataset)"
               />
             }
@@ -116,6 +117,7 @@
                 (rowClick)="toggleModelSelection(model.id, $event)"
                 (rename)="renameModel(model, $event)"
                 (delete)="deleteModel(model)"
+                (load)="loadModel(model)"
                 (export)="openExportModal(model)"
                 (autorunToggle)="toggleAutorun(model, $event)"
               />

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -441,6 +441,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+  loadDataset(dataset: DatasetRegistryEntry): void {
+    this.datasetsApi.loadRegistered(dataset.id).subscribe({
+      next: () => this.startProgressPolling(),
+    });
+  }
+
+  loadModel(model: ModelRegistryEntry): void {
+    this.modelsApi.loadModel(model.id).subscribe({
+      next: () => this.datasetState.refresh(),
+    });
+  }
+
   toggleAutorun(model: ModelRegistryEntry, autorun: boolean): void {
     const detectorName = model.detector_name || model.name;
     this.detectorsApi.setAutodetect(detectorName, autorun).subscribe({

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -51,7 +51,7 @@
   @if (dataset.loaded) {
     <span class="status-loaded" aria-label="Loaded">&#10003;</span>
   } @else {
-    <span class="dim">-</span>
+    <span class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">-</span>
   }
 </td>
 <td class="actions-cell">

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -76,6 +76,19 @@ td {
   color: var(--color-good);
 }
 
+.load-action {
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
 .btn--xs {
   padding: 1px 6px;
   font-size: 0.75rem;

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -22,6 +22,7 @@ export class DatasetCardComponent {
   }
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
+  @Output() load = new EventEmitter<void>();
   @Output() security = new EventEmitter<void>();
 
   get isOwner(): boolean {
@@ -63,6 +64,11 @@ export class DatasetCardComponent {
   onSecurity(event: MouseEvent): void {
     event.stopPropagation();
     this.security.emit();
+  }
+
+  onLoad(event: MouseEvent): void {
+    event.stopPropagation();
+    this.load.emit();
   }
 
   onDelete(event: MouseEvent): void {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -60,7 +60,7 @@
   @if (model.detector_loaded) {
     <span class="status-loaded" aria-label="Loaded">&#10003;</span>
   } @else {
-    <span class="dim">-</span>
+    <span class="load-action" (click)="onLoad($event)" title="Click to load this model" aria-label="Load model">-</span>
   }
 </td>
 <td class="actions-cell">

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -75,6 +75,19 @@ td {
   color: var(--text-dim);
 }
 
+.load-action {
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
 .btn--xs {
   padding: 1px 6px;
   font-size: 0.75rem;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -21,6 +21,7 @@ export class ModelCardComponent {
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
   @Output() export = new EventEmitter<void>();
+  @Output() load = new EventEmitter<void>();
   @Output() autorunToggle = new EventEmitter<boolean>();
 
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
@@ -53,6 +54,11 @@ export class ModelCardComponent {
     } else if (event.key === 'Escape') {
       this.cancelRename();
     }
+  }
+
+  onLoad(event: MouseEvent): void {
+    event.stopPropagation();
+    this.load.emit();
   }
 
   onDelete(event: MouseEvent): void {


### PR DESCRIPTION
## Summary
- The "-" in the "Loaded?" column for both Datasets and Models tables is now clickable
- Clicking it triggers loading for that dataset (with progress polling) or model, matching the existing load-on-demand behavior used by Train/Find buttons
- Added hover styling (cursor change + highlight) to make the clickable state discoverable

## Test plan
- [x] Core tests pass (335/335)
- [ ] Verify clicking "-" on an unloaded dataset starts loading with progress bar
- [ ] Verify clicking "-" on an unloaded model loads its inference data
- [ ] Verify the checkmark still displays correctly for already-loaded items
- [ ] Verify click doesn't also trigger row selection (stopPropagation)

https://claude.ai/code/session_01MzGT5QU5WT8kVHHkFarjso