### PR TITLE
Fix find-label scoring wrong dataset

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -777,9 +777,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const model = this.models.find((m) => this.selectedModelIds.has(m.id));
     if (!model) return;
 
-    // Store model info in the find session service
+    // Store model and dataset info in the find session service
     this.findSession.modelId = model.id;
     this.findSession.modelName = model.name;
+    this.findSession.datasetId = dataset.id;
 
     const navigateToFind = (): void => {
       this.router.navigate(['/find']);

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -145,7 +145,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Start polling for progress concurrently
     this.startProgressPolling();
 
-    this.detectorsApi.findLabel({ model_id: modelId })
+    const datasetId = this.findSession.datasetId;
+    this.detectorsApi.findLabel({ model_id: modelId, ...(datasetId ? { dataset_id: datasetId } : {}) })
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response: any) => {

--- a/frontend/src/app/services/find-session.service.ts
+++ b/frontend/src/app/services/find-session.service.ts
@@ -8,4 +8,5 @@ import { Injectable } from '@angular/core';
 export class FindSessionService {
   modelId = '';
   modelName = '';
+  datasetId = '';
 }

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -431,14 +431,14 @@ class TestFindLabel:
 
         # Create a second dataset with different (fewer) items
         rng = np.random.default_rng(99)
-        ctx_b = DatasetContext()
+        ctx_b = DatasetContext("dataset_b")
         for i in range(1, 4):
             ctx_b.medias[i] = {
                 "id": i,
                 "md5": f"dataset_b_{i}",
                 "embedding": rng.standard_normal(512).astype(np.float32),
             }
-        register_context("dataset_b", ctx_b)
+        register_context(ctx_b)
 
         try:
             # Switch active to dataset_b — simulates user browsing Dataset B

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -407,6 +407,59 @@ class TestFindLabel:
         total = data["good_count"] + data["bad_count"]
         assert total == app_module.NUM_MEDIAS
 
+    def test_find_label_activates_selected_dataset(self, client):
+        """find-label with dataset_id should score against that dataset, not the active one.
+
+        Reproduces the bug: user selects Dataset A + Detector 1 on the dashboard
+        and clicks Find, but scoring runs against Dataset B because it was the
+        most recently loaded into the labeling interface.
+        """
+        from vtsearch.utils import (
+            DatasetContext,
+            get_active_dataset_id,
+            register_context,
+            set_active_dataset_id,
+            snapshot_medias,
+            unregister_context,
+        )
+
+        model_id = self._create_model_with_detector(client)
+
+        # Remember the default dataset (has test medias)
+        original_id = get_active_dataset_id()
+        original_count = len(snapshot_medias())
+
+        # Create a second dataset with different (fewer) items
+        rng = np.random.default_rng(99)
+        ctx_b = DatasetContext()
+        for i in range(1, 4):
+            ctx_b.medias[i] = {
+                "id": i,
+                "md5": f"dataset_b_{i}",
+                "embedding": rng.standard_normal(512).astype(np.float32),
+            }
+        register_context("dataset_b", ctx_b)
+
+        try:
+            # Switch active to dataset_b — simulates user browsing Dataset B
+            set_active_dataset_id("dataset_b")
+            assert get_active_dataset_id() == "dataset_b"
+
+            # Call find-label with dataset_id pointing to the ORIGINAL dataset
+            resp = client.post(
+                "/api/find-label",
+                json={"model_id": model_id, "dataset_id": original_id},
+            )
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["ok"] is True
+            # Should have scored the original dataset's items, not dataset_b's 3 items
+            total = data["good_count"] + data["bad_count"]
+            assert total == original_count
+        finally:
+            set_active_dataset_id(original_id)
+            unregister_context("dataset_b")
+
     def test_find_label_overwrites_existing_votes(self, client):
         """find-label must mark ALL items even when votes already exist.
 

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -129,9 +129,9 @@ def find_label():
     # correct context instead of whichever dataset happens to be active.
     dataset_id = body.get("dataset_id")
     if dataset_id:
-        from vtsearch.datasets.registry import is_loaded as _ds_is_loaded
+        from vtsearch.utils import get_context
 
-        if _ds_is_loaded(dataset_id):
+        if get_context(dataset_id) is not None:
             set_active_dataset_id(dataset_id)
 
     update_find_progress(

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -13,6 +13,7 @@ from vtsearch.utils import (
     get_autodetect_detectors_by_media,
     get_autorun_extractors_by_media,
     get_autorun_localizers_by_media,
+    set_active_dataset_id,
     snapshot_medias,
 )
 from vtsearch.utils.progress import update_find_progress
@@ -123,6 +124,15 @@ def find_label():
     if not model_id:
         update_find_progress("idle", "")
         return jsonify({"error": "model_id is required"}), 400
+
+    # Activate the explicitly selected dataset so scoring runs against the
+    # correct context instead of whichever dataset happens to be active.
+    dataset_id = body.get("dataset_id")
+    if dataset_id:
+        from vtsearch.datasets.registry import is_loaded as _ds_is_loaded
+
+        if _ds_is_loaded(dataset_id):
+            set_active_dataset_id(dataset_id)
 
     update_find_progress(
         "running", "Resolving model…",


### PR DESCRIPTION
## Summary
- **Bug**: Clicking "Find" with Dataset A selected would score against Dataset B if B was the most recently active in the labeling interface. The frontend never passed the selected dataset ID to the backend, so `/api/find-label` just used whichever dataset context happened to be active.
- **Fix**: Pass `dataset_id` through the full chain: `FindSessionService` → `findLabel()` API call → `/api/find-label` endpoint. The backend now activates the correct dataset context before scoring.
- The multi-dataset `/api/find` ("Old Find") endpoint was already correct — it loads datasets explicitly from pkl files.

## Changes
- `frontend/src/app/services/find-session.service.ts` — Added `datasetId` field
- `frontend/src/app/components/dashboard/dashboard.component.ts` — Store selected dataset ID in `FindSessionService`
- `frontend/src/app/components/find-view/find-view.component.ts` — Pass `dataset_id` in the API call
- `vtsearch/routes/detectors_scoring.py` — Accept `dataset_id`, activate the correct dataset context before `snapshot_medias()`
- `tests/test_detectors.py` — New test: `test_find_label_activates_selected_dataset` verifies scoring uses the explicitly selected dataset

## Test plan
- [x] New test creates two dataset contexts, switches active to B, calls find-label with A's ID, verifies A's items are scored
- [x] All 2512 tests pass (full suite)
- [ ] Manual: load two datasets, select the non-active one on dashboard, click Find, verify correct dataset is scored

https://claude.ai/code/session_01TGvsRyDsDizNzxUwvae15E