### PR TITLE
Fix column width measurement in dashboard table resizing

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -164,12 +164,12 @@
 
     .sort-indicator {
       display: inline-block;
-      width: 1em;
+      width: 0;
+      overflow: hidden;
       text-align: center;
-      visibility: hidden;
 
       &.active {
-        visibility: visible;
+        width: 1em;
       }
     }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -164,12 +164,12 @@
 
     .sort-indicator {
       display: inline-block;
-      width: 0;
-      overflow: hidden;
+      width: 1em;
       text-align: center;
+      visibility: hidden;
 
       &.active {
-        width: 1em;
+        visibility: visible;
       }
     }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -249,8 +249,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     tableEl.style.width = '';
     ths[colIndex].style.width = '';
 
-    // Measure the natural width of the column (header + all body cells)
-    let maxWidth = ths[colIndex].offsetWidth;
+    // Measure the natural width of body cells (not the header, whose uppercase
+    // text, letter-spacing, and sort-indicator inflate the width beyond what
+    // the data needs).
+    let maxWidth = 0;
     const rows = tableEl.querySelectorAll('tbody tr');
     rows.forEach((row) => {
       const cell = row.children[colIndex] as HTMLElement | undefined;
@@ -260,6 +262,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
         maxWidth = Math.max(maxWidth, cell.scrollWidth);
       }
     });
+    // Fall back to header width only when the table has no body rows
+    if (maxWidth === 0) {
+      maxWidth = ths[colIndex].offsetWidth;
+    }
 
     // Add a small buffer for padding
     maxWidth = Math.max(30, maxWidth + 2);

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -246,12 +246,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const prevColWidth = ths[colIndex].style.width;
 
     tableEl.classList.remove('table-fixed');
-    tableEl.style.width = '';
+    // Force width:auto so the table shrinks to content instead of stretching
+    // to 100% (the CSS class default).  Without this, the browser distributes
+    // extra container space across columns, inflating every measurement.
+    tableEl.style.width = 'auto';
     ths[colIndex].style.width = '';
 
-    // Measure the natural width of body cells (not the header, whose uppercase
-    // text, letter-spacing, and sort-indicator inflate the width beyond what
-    // the data needs).
+    // Measure the natural width of the column from body cells.
     let maxWidth = 0;
     const rows = tableEl.querySelectorAll('tbody tr');
     rows.forEach((row) => {
@@ -305,10 +306,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.modelsTableWidth = total;
     }
 
-    // Restore fixed layout (Angular binding will apply on next change detection)
+    // Restore layout (Angular binding will apply on next change detection).
+    // Clear the temporary 'auto' override so Angular bindings take over.
+    tableEl.style.width = prevTableWidth;
     if (wasFixed) {
       tableEl.classList.add('table-fixed');
-      tableEl.style.width = prevTableWidth;
     }
   }
 


### PR DESCRIPTION
## Summary
Improved the column width auto-sizing logic in the dashboard table component to more accurately measure natural column widths by measuring only body cell content rather than including header width in the initial measurement.

## Key Changes
- Changed table width from empty string to `'auto'` during measurement to prevent the browser from distributing container space across columns, which was inflating width measurements
- Modified the maxWidth calculation to start from 0 and measure only body cell widths using `scrollWidth`, providing more accurate content-based sizing
- Added a fallback to use header width only when the table has no body rows (empty state)
- Improved code organization by restoring `tableEl.style.width` unconditionally before conditionally re-applying the fixed layout class
- Enhanced comments to clarify the measurement strategy and layout restoration logic

## Implementation Details
The key insight is that setting `width: auto` on the table during measurement allows it to shrink to its natural content size, preventing the browser from artificially inflating column widths by distributing available container space. The measurement now focuses on actual body cell content (`scrollWidth`) with a header-only fallback for empty tables, resulting in more predictable and accurate column sizing.

https://claude.ai/code/session_01WE8JwQGVYxjds3c1jW4YHU