### PR TITLE
Fix BertModel position_ids unexpected key warning

### DIFF
--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -48,6 +48,7 @@ class TextE5Embedder(MediaEmbedder):
         import gc
 
         from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        from transformers import BertModel  # noqa: PLC0415
 
         from vtsearch.models.loader import ensure_torch_configured
 
@@ -55,6 +56,7 @@ class TextE5Embedder(MediaEmbedder):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading E5 model…", 0, 0)
+        BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading E5 model…"
         ):

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -48,6 +48,7 @@ class TextBGEEmbedder(MediaEmbedder):
         import gc
 
         from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        from transformers import BertModel  # noqa: PLC0415
 
         from vtsearch.models.loader import ensure_torch_configured
 
@@ -55,6 +56,7 @@ class TextBGEEmbedder(MediaEmbedder):
         gc.collect()
         cache_dir = str(MODELS_CACHE_DIR)
         self._on_progress("loading", "Loading BGE model…", 0, 0)
+        BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading BGE model…"
         ):


### PR DESCRIPTION
## Summary
- Suppress `embeddings.position_ids` UNEXPECTED key warning when loading E5 and BGE text embedders
- Newer transformers versions removed `position_ids` from BertModel's persistent buffers, causing the warning during SentenceTransformer model loading
- Adds `BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]` before loading, matching the existing pattern used by CLIP and X-CLIP embedders

## Test plan
- [x] `./run-tests.sh models` — all 480 tests pass

https://claude.ai/code/session_01EoR4RGmrMRmEbN31vcuxuK