### PR TITLE
Show dataset name at top of Labeling interface

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -20,6 +20,7 @@
       [focusMode]="focusModeLeft"
       [loadSortLabel]="sortState.loadSortLabel"
       [textQuery]="sortState.textQuery"
+      [datasetName]="datasetName"
       [panelMode]="'find'"
       [disabled]="sortState.sortBusy"
       [autopilotCollapsed]="false"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -7,6 +7,7 @@ import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
 import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
+import { DatasetsApiService } from '../../services/datasets-api.service';
 import { FindSessionService } from '../../services/find-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
@@ -25,6 +26,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
   @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
 
+  datasetName = '';
   viewModeLeft: 'grid' | 'list' = 'list';
   gridGoalWidthLeft: number = 80;
   focusModeLeft: 'click' | 'hover' = 'click';
@@ -54,6 +56,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   constructor(
     private mediasApi: MediasApiService,
     private detectorsApi: DetectorsApiService,
+    private datasetsApi: DatasetsApiService,
     private ngZone: NgZone,
     private findSession: FindSessionService,
     public mediaState: MediaStateService,
@@ -68,6 +71,9 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
     this.loadSettings();
+    this.datasetsApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (status) => { this.datasetName = status.display_name || ''; },
+    });
 
     // When medias arrive, run the find-label scoring
     this.mediaState.medias$

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -31,6 +31,7 @@
       (mediaSelect)="onMediaSelect($event)"
       (mediaVote)="onHoverVote($event)"
       (indicatorClick)="onIndicatorClick($event)"
+      [datasetName]="datasetName"
       [autopilotCollapsed]="autopilotCollapsed"
       [autopilotEnabled]="autopilotEnabled"
       (autopilotStart)="onAutopilotStart()"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -8,6 +8,7 @@ import { RightPanelComponent } from '../right-panel/right-panel.component';
 import { SortingApiService } from '../../services/sorting-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
 import { MediasApiService } from '../../services/medias-api.service';
+import { DatasetsApiService } from '../../services/datasets-api.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
@@ -30,6 +31,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
   @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
 
+  datasetName = '';
   labelingStatus: LabelingStatusResponse | null = null;
   viewModeLeft: 'grid' | 'list' = 'list';
   gridGoalWidthLeft: number = 80;
@@ -83,6 +85,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private sortingApi: SortingApiService,
     private detectorsApi: DetectorsApiService,
     private mediasApi: MediasApiService,
+    private datasetsApi: DatasetsApiService,
     private ngZone: NgZone,
     private labelSession: LabelSessionService,
     public mediaState: MediaStateService,
@@ -101,6 +104,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.voteState.loadVotes();
     this.loadSettings();
     this.startStatusPolling();
+    this.datasetsApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (status) => { this.datasetName = status.display_name || ''; },
+    });
 
     this.mediaState.medias$
       .pipe(takeUntil(this.destroy$))

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -1,4 +1,7 @@
 <div class="left-panel" [class.collapsed-autopilot]="panelMode === 'label' && activeTab === 'autopilot' && autopilotCollapsed" [class.disabled]="disabled">
+  @if (datasetName && !(panelMode === 'label' && activeTab === 'autopilot' && autopilotCollapsed)) {
+    <div class="dataset-name" [title]="datasetName">{{ datasetName }}</div>
+  }
   @if (panelMode === 'find') {
     <!-- Find mode: simplified view — just the media list header + media + stripe -->
     <div class="tab-panel-manual" role="region" aria-label="Find results">

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -10,6 +10,7 @@
     pointer-events: none;
 
     // Dim individual sections but keep the progress bar bright & visible
+    .dataset-name,
     .left-tabs,
     .images-header,
     .media-list-container,
@@ -21,6 +22,18 @@
       opacity: 0.45;
     }
   }
+}
+
+.dataset-name {
+  padding: 6px 8px 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
 }
 
 .left-tabs {

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -57,6 +57,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() panelMode: 'label' | 'find' = 'label';
   /** Disable all interaction (used during Find scoring). */
   @Input() disabled = false;
+  /** Display name of the current dataset. */
+  @Input() datasetName = '';
 
   @Output() sortModeChange = new EventEmitter<SortMode>();
   @Output() selectModeChange = new EventEmitter<SelectMode>();


### PR DESCRIPTION
## Summary
- Displays the current dataset's `display_name` at the top-left of the Labeling interface, above the Manual/Autopilot tabs in Train mode and above the media list in Find mode
- Fetches the name from `/api/dataset/status` on view initialization
- Truncates with ellipsis when the panel is narrow; hidden when autopilot is collapsed

## Test plan
- [x] Frontend TypeScript build passes
- [x] Core test group passes (335 tests)
- [ ] Verify dataset name appears in Train mode above Manual/Autopilot tabs
- [ ] Verify dataset name appears in Find mode above the media list
- [ ] Verify long names truncate with ellipsis and show full name on hover

https://claude.ai/code/session_01EFEr9MDXWuJ5CASiBxK9Zf