### PR TITLE
Show dataset loading progress inline on existing row

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -14,7 +14,7 @@
       </div>
     </div>
 
-    @if (datasets.length === 0 && loadingTasks.length === 0 && !loading) {
+    @if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
       <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
@@ -38,7 +38,7 @@
             </tr>
           </thead>
           <tbody>
-            @for (task of loadingTasks; track task.task_id) {
+            @for (task of orphanLoadingTasks; track task.task_id) {
               <tr class="loading-task-row" [class.loading-task-error]="!!task.error">
                 <td>
                   <span class="loading-task-name">{{ task.name || 'Loading...' }}</span>
@@ -69,11 +69,14 @@
                 [currentUser]="currentUser"
                 [isDefaultLogin]="isDefaultLogin"
                 [selected]="isDatasetSelected(dataset.id)"
+                [loadingTask]="getInlineTask(dataset.id)"
                 (rowClick)="toggleDatasetSelection(dataset.id, $event)"
                 (rename)="renameDataset(dataset, $event)"
                 (delete)="deleteDataset(dataset)"
                 (load)="loadDataset(dataset)"
                 (security)="editDatasetSecurity(dataset)"
+                (cancelTask)="cancelLoadingTask($event)"
+                (dismissTask)="dismissLoadingTask($event)"
               />
             }
           </tbody>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -341,6 +341,28 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.datasetState.errorMessage;
   }
 
+  /** Map dataset_id → LoadingTask for tasks that match an existing dataset row. */
+  get inlineTaskMap(): Map<string, LoadingTask> {
+    const map = new Map<string, LoadingTask>();
+    const datasetIds = new Set(this.datasets.map((d) => d.id));
+    for (const task of this.loadingTasks) {
+      if (task.dataset_id && datasetIds.has(task.dataset_id)) {
+        map.set(task.dataset_id, task);
+      }
+    }
+    return map;
+  }
+
+  /** Loading tasks that have no matching dataset row (new imports, etc.). */
+  get orphanLoadingTasks(): LoadingTask[] {
+    const datasetIds = new Set(this.datasets.map((d) => d.id));
+    return this.loadingTasks.filter((t) => !t.dataset_id || !datasetIds.has(t.dataset_id));
+  }
+
+  getInlineTask(datasetId: string): LoadingTask | undefined {
+    return this.inlineTaskMap.get(datasetId);
+  }
+
   dismissError(): void {
     this.datasetState.setErrorMessage('');
   }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -15,66 +15,89 @@
     </span>
   }
 </td>
-<td>
-  <span class="type-cell">
-    @switch (dataset.media_type) {
-      @case ('audio') {
-        <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+@if (loadingTask && !loadingTask.error) {
+  <!-- Inline progress: replace remaining columns with a progress bar -->
+  <td [attr.colspan]="isDefaultLogin ? 9 : 11">
+    <div class="inline-loading-progress">
+      <span class="progress-msg">{{ taskProgressMessage }}</span>
+      <vt-progress-bar
+        [value]="loadingTask.current"
+        [max]="loadingTask.total"
+        [indeterminate]="taskIsIndeterminate"
+      />
+      <button class="btn btn--cancel btn--sm" (click)="onCancelTask($event)" title="Cancel this dataset load">Cancel</button>
+    </div>
+  </td>
+} @else if (loadingTask && loadingTask.error) {
+  <!-- Inline error: replace remaining columns with error message -->
+  <td [attr.colspan]="isDefaultLogin ? 9 : 11">
+    <div class="inline-loading-progress inline-loading-failed">
+      <span class="error-msg">Failed: {{ loadingTask.error }}</span>
+      <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss this error">Dismiss</button>
+    </div>
+  </td>
+} @else {
+  <td>
+    <span class="type-cell">
+      @switch (dataset.media_type) {
+        @case ('audio') {
+          <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+        }
+        @case ('image') {
+          <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+        }
+        @case ('text') {
+          <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+        }
+        @case ('video') {
+          <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+        }
+        @case ('document') {
+          <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
+        }
       }
-      @case ('image') {
-        <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-      }
-      @case ('text') {
-        <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-      }
-      @case ('video') {
-        <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-      }
-      @case ('document') {
-        <svg class="type-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-      }
-    }
-    {{ capitalizeType(dataset.media_type) }}
-  </span>
-</td>
-<td>{{ dataset.num_items ?? '-' }}</td>
-<td>{{ dataset.num_dupes ?? 0 }}</td>
-<td>{{ formatDate(dataset.created_at) }}</td>
-<td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
-<td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
-<td class="embedder-cell">{{ (dataset.embedder | titlecase) || '-' }}</td>
-@if (!isDefaultLogin) {
-  <td>{{ dataset.created_by || '-' }}</td>
-  <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>
-}
-<td>
-  @if (dataset.loaded) {
-    <span class="status-loaded" aria-label="Loaded">&#10003;</span>
-  } @else {
-    <span class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">-</span>
-  }
-</td>
-<td class="actions-cell">
+      {{ capitalizeType(dataset.media_type) }}
+    </span>
+  </td>
+  <td>{{ dataset.num_items ?? '-' }}</td>
+  <td>{{ dataset.num_dupes ?? 0 }}</td>
+  <td>{{ formatDate(dataset.created_at) }}</td>
+  <td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
+  <td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
+  <td class="embedder-cell">{{ (dataset.embedder | titlecase) || '-' }}</td>
   @if (!isDefaultLogin) {
-    <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
+    <td>{{ dataset.created_by || '-' }}</td>
+    <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>
+  }
+  <td>
+    @if (dataset.loaded) {
+      <span class="status-loaded" aria-label="Loaded">&#10003;</span>
+    } @else {
+      <span class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">-</span>
+    }
+  </td>
+  <td class="actions-cell">
+    @if (!isDefaultLogin) {
+      <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+        </svg>
+      </button>
+    }
+    <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
       </svg>
     </button>
-  }
-  <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-    </svg>
-  </button>
-  <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
-    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="3 6 5 6 21 6"></polyline>
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-      <path d="M10 11v6"></path>
-      <path d="M14 11v6"></path>
-      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-    </svg>
-  </button>
-</td>
+    <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+        <path d="M10 11v6"></path>
+        <path d="M14 11v6"></path>
+        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+      </svg>
+    </button>
+  </td>
+}

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -10,6 +10,10 @@
   &.selected {
     background: var(--accent-highlight-bg);
   }
+
+  &.loading-error {
+    background: var(--error-bg, rgba(220, 38, 38, 0.06));
+  }
 }
 
 td {
@@ -132,5 +136,61 @@ td {
   &:hover {
     color: var(--color-bad);
     background: var(--bad-bg);
+  }
+}
+
+// Inline loading progress (replaces data columns while loading)
+.inline-loading-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .progress-msg {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  vt-progress-bar {
+    flex: 1;
+  }
+
+  .btn--cancel {
+    flex-shrink: 0;
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--text-secondary);
+    }
+  }
+
+  &.inline-loading-failed {
+    .error-msg {
+      flex: 1;
+      font-size: 0.8rem;
+      color: var(--error-text, #991b1b);
+    }
+
+    .btn--cancel {
+      background: transparent;
+      color: var(--error-text, #991b1b);
+      border: 1px solid var(--error-border, #fca5a5);
+
+      &:hover {
+        background: var(--error-border, #fca5a5);
+        color: #fff;
+      }
+    }
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,11 +1,13 @@
 import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { LoadingTask } from '../../../models/api.models';
+import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 
 @Component({
   selector: 'vt-dataset-card',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ProgressBarComponent],
   templateUrl: './dataset-card.component.html',
   styleUrl: './dataset-card.component.scss',
 })
@@ -14,6 +16,12 @@ export class DatasetCardComponent {
   @Input() currentUser = '';
   @Input() isDefaultLogin = true;
   @Input() @HostBinding('class.selected') selected = false;
+  @Input() loadingTask?: LoadingTask;
+
+  @HostBinding('class.loading-error')
+  get hasLoadingError(): boolean {
+    return !!this.loadingTask?.error;
+  }
   @Output() rowClick = new EventEmitter<MouseEvent>();
 
   @HostListener('click', ['$event'])
@@ -24,6 +32,8 @@ export class DatasetCardComponent {
   @Output() delete = new EventEmitter<void>();
   @Output() load = new EventEmitter<void>();
   @Output() security = new EventEmitter<void>();
+  @Output() cancelTask = new EventEmitter<string>();
+  @Output() dismissTask = new EventEmitter<string>();
 
   get isOwner(): boolean {
     return this.dataset?.created_by === this.currentUser;
@@ -85,5 +95,43 @@ export class DatasetCardComponent {
   capitalizeType(type: string | undefined): string {
     if (!type) return '-';
     return type.charAt(0).toUpperCase() + type.slice(1);
+  }
+
+  get taskProgressMessage(): string {
+    const task = this.loadingTask;
+    if (!task) return '';
+    let msg = task.message || 'Loading...';
+    if (task.step != null && task.total_steps != null && task.total_steps > 1) {
+      msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
+    }
+    if (task.current != null && task.total != null && task.total > 0) {
+      const fraction = `(${task.current}/${task.total})`;
+      const stepEnd = msg.indexOf('] ');
+      if (stepEnd !== -1) {
+        msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
+      } else {
+        msg = fraction + ' ' + msg;
+      }
+    }
+    return msg;
+  }
+
+  get taskIsIndeterminate(): boolean {
+    const task = this.loadingTask;
+    return !(task && task.current != null && task.total != null && task.total > 0);
+  }
+
+  onCancelTask(event: MouseEvent): void {
+    event.stopPropagation();
+    if (this.loadingTask) {
+      this.cancelTask.emit(this.loadingTask.task_id);
+    }
+  }
+
+  onDismissTask(event: MouseEvent): void {
+    event.stopPropagation();
+    if (this.loadingTask) {
+      this.dismissTask.emit(this.loadingTask.task_id);
+    }
   }
 }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -163,6 +163,7 @@ export interface LoadingTask {
   total_steps?: number;
   error?: string;
   created_at: number;
+  dataset_id?: string;
 }
 
 export interface LoadingTasksResponse {

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -692,7 +692,7 @@ def load_registered_dataset(dataset_id: str):
 
     # Create a per-task tracker for this load operation.
     task_id = f"_regload_{dataset_id[:8]}"
-    tracker = _loading_tasks.create_task(task_id, entry.get("name", dataset_id))
+    tracker = _loading_tasks.create_task(task_id, entry.get("name", dataset_id), dataset_id=dataset_id)
     tracker.update("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -153,7 +153,7 @@ class LoadingTasksTracker:
         self._lock = threading.Lock()
         self._tasks: dict[str, dict[str, Any]] = {}
 
-    def create_task(self, task_id: str, name: str = "") -> ProgressTracker:
+    def create_task(self, task_id: str, name: str = "", dataset_id: str = "") -> ProgressTracker:
         """Create and register a new loading task.
 
         Returns the per-task :class:`ProgressTracker` instance.
@@ -167,6 +167,7 @@ class LoadingTasksTracker:
                 "name": name,
                 "created_at": time.time(),
                 "finished_at": None,
+                "dataset_id": dataset_id,
             }
         return tracker
 
@@ -230,12 +231,16 @@ class LoadingTasksTracker:
                 snapshot["task_id"] = task_id
                 snapshot["name"] = entry["name"]
                 snapshot["created_at"] = entry["created_at"]
+                if entry.get("dataset_id"):
+                    snapshot["dataset_id"] = entry["dataset_id"]
                 result.append(snapshot)
             else:
                 snapshot = entry["tracker"].get()
                 snapshot["task_id"] = task_id
                 snapshot["name"] = entry["name"]
                 snapshot["created_at"] = entry["created_at"]
+                if entry.get("dataset_id"):
+                    snapshot["dataset_id"] = entry["dataset_id"]
                 result.append(snapshot)
         if stale:
             with self._lock:


### PR DESCRIPTION
## Summary
- When loading an existing dataset from the Dashboard, progress is now displayed **inline on the dataset's own row** (replacing the data columns with a progress bar), instead of adding a separate row above the grid.
- Only "orphan" loading tasks (new imports that don't yet have a dataset row) still get their own separate progress row.
- Backend exposes `dataset_id` on loading task snapshots so the frontend can match tasks to existing dataset rows.

## Test plan
- [x] All 2512 tests pass (including parallel loading, dataset, and frontend build tests)
- [ ] Manually verify: load an existing dataset from Dashboard → progress bar appears inline on that dataset's row
- [ ] Manually verify: import a new dataset → progress bar still appears as a separate row (no existing row to match)
- [ ] Manually verify: loading error state shows inline with dismiss button on the dataset row
- [ ] Manually verify: cancel button works from the inline progress bar

https://claude.ai/code/session_011QeYDzhFK2UkT8PnXMTuve