### PR TITLE
Rename text media type_id from "paragraph" to "text"

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -13,7 +13,7 @@
         @case ('video') {
           <vt-video-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" (playingChanged)="onPlayingChanged($event)"></vt-video-player>
         }
-        @case ('paragraph') {
+        @case ('text') {
           <vt-text-viewer [media]="media"></vt-text-viewer>
         }
         @case ('document') {

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -58,8 +58,8 @@ describe('CenterPanelComponent', () => {
     expect(fixture.nativeElement.querySelector('vt-video-player')).toBeTruthy();
   });
 
-  it('should show text viewer for paragraph media', () => {
-    component.media = { ...mockMedia, type: 'paragraph' };
+  it('should show text viewer for text media', () => {
+    component.media = { ...mockMedia, type: 'text' };
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('vt-text-viewer')).toBeTruthy();
   });

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -11,7 +11,7 @@ describe('TextViewerComponent', () => {
 
   const mockMedia: MediaItem = {
     id: 4,
-    type: 'paragraph',
+    type: 'text',
     filename: 'test.txt',
     md5: 'jkl012',
     custom_metadata: {},
@@ -51,7 +51,7 @@ describe('TextViewerComponent', () => {
     });
     fixture.detectChanges();
 
-    const req = httpMock.expectOne('/api/medias/4/paragraph');
+    const req = httpMock.expectOne('/api/medias/4/text');
     req.flush({ content: 'Hello world', word_count: 2, character_count: 11 });
     fixture.detectChanges();
 
@@ -66,7 +66,7 @@ describe('TextViewerComponent', () => {
     });
     fixture.detectChanges();
 
-    const req = httpMock.expectOne('/api/medias/4/paragraph');
+    const req = httpMock.expectOne('/api/medias/4/text');
     req.error(new ProgressEvent('error'));
     fixture.detectChanges();
 

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -30,7 +30,7 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
   private loadText(): void {
     this.sub?.unsubscribe();
     this.text = 'Loading...';
-    this.sub = this.mediasApi.getParagraph(this.media.id).subscribe({
+    this.sub = this.mediasApi.getText(this.media.id).subscribe({
       next: (data) => {
         this.text = data.content || '';
       },

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -36,7 +36,7 @@ export class MediaItemComponent {
     if (!this.isGrid) return null;
     if (this.thumbnailUrl) return null;
     if (this.media.type === 'audio') return '\u266B';
-    if (this.media.type === 'paragraph') return '\u00B6';
+    if (this.media.type === 'text') return '\u00B6';
     return '\u25A1';
   }
 

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -132,7 +132,7 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     if (!media) return null;
     if (media.type === 'image' || media.type === 'video' || media.type === 'document') return null;
     if (media.type === 'audio') return '\u266B';
-    if (media.type === 'paragraph') return '\u00B6';
+    if (media.type === 'text') return '\u00B6';
     return '\u25A1';
   }
 

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -12,7 +12,7 @@ export interface MediaItem {
   description?: string;
 }
 
-export interface ParagraphResponse {
+export interface TextResponse {
   content: string;
   word_count?: number;
   character_count?: number;

--- a/frontend/src/app/services/medias-api.service.spec.ts
+++ b/frontend/src/app/services/medias-api.service.spec.ts
@@ -51,9 +51,9 @@ describe('MediasApiService', () => {
     req.flush(new Blob());
   });
 
-  it('getParagraph should GET json', () => {
-    service.getParagraph(4).subscribe(data => expect(data.content).toBe('hello'));
-    const req = httpMock.expectOne('/api/medias/4/paragraph');
+  it('getText should GET json', () => {
+    service.getText(4).subscribe(data => expect(data.content).toBe('hello'));
+    const req = httpMock.expectOne('/api/medias/4/text');
     expect(req.request.method).toBe('GET');
     req.flush({ content: 'hello', word_count: 1, character_count: 5 });
   });

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
   MediaItem,
-  ParagraphResponse,
+  TextResponse,
   VoteResponse,
 } from '../models/api.models';
 
@@ -27,8 +27,8 @@ export class MediasApiService {
     return this.http.get(`/api/medias/${id}/image`, { responseType: 'blob' });
   }
 
-  getParagraph(id: number): Observable<ParagraphResponse> {
-    return this.http.get<ParagraphResponse>(`/api/medias/${id}/paragraph`);
+  getText(id: number): Observable<TextResponse> {
+    return this.http.get<TextResponse>(`/api/medias/${id}/text`);
   }
 
   getMedia(id: number): Observable<Blob> {

--- a/tests/test_chunked_loading.py
+++ b/tests/test_chunked_loading.py
@@ -277,7 +277,7 @@ class TestPickleChunked:
         """Text-specific fields (word_count, character_count) are preserved via the registry."""
         medias_data = {
             1: {
-                "type": "paragraph",
+                "type": "text",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "media_string": "Hello world",
                 "media_bytes": b"Hello world",
@@ -294,7 +294,7 @@ class TestPickleChunked:
         # Full mode
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         media = chunks[0][1]
-        assert media["type"] == "paragraph"
+        assert media["type"] == "text"
         assert media["word_count"] == 2
         assert media["character_count"] == 11
 
@@ -392,10 +392,10 @@ class TestPickleChunked:
         assert "report.pdf" in media["media_path"]
 
     def test_text_legacy_key_via_registry(self, tmp_path):
-        """Legacy text_content key is resolved via the registry for paragraph type."""
+        """Legacy text_content key is resolved via the registry for text type."""
         medias_data = {
             1: {
-                "type": "paragraph",
+                "type": "text",
                 "embedding": np.random.RandomState(42).randn(512).tolist(),
                 "text_content": "Some text paragraph",
                 "filename": "para.txt",
@@ -409,7 +409,7 @@ class TestPickleChunked:
         chunks = list(load_dataset_from_pickle_chunked(pkl_path, chunk_size=10, thin=False))
         assert len(chunks) == 1
         media = chunks[0][1]
-        assert media["type"] == "paragraph"
+        assert media["type"] == "text"
         assert media["media_string"] == "Some text paragraph"
         assert media["media_bytes"] == b"Some text paragraph"
 

--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -446,7 +446,7 @@ class TestTextDefaultClipper:
     def test_returns_media_unchanged(self):
         from vtsearch.media.text.clipper import TextDefaultClipper
 
-        media = {"id": 1, "type": "paragraph", "media_string": "Hello world."}
+        media = {"id": 1, "type": "text", "media_string": "Hello world."}
         result = TextDefaultClipper().clip(media)
         assert result == [media]
 
@@ -455,7 +455,7 @@ class TestTextDefaultClipper:
 
         c = TextDefaultClipper()
         assert c.name == "text_default"
-        assert c.media_type == "paragraph"
+        assert c.media_type == "text"
         assert isinstance(c, MediaClipper)
 
 
@@ -470,13 +470,13 @@ class TestTextSentenceClipper:
 
         c = TextSentenceClipper()
         assert c.name == "text_sentence"
-        assert c.media_type == "paragraph"
+        assert c.media_type == "text"
         assert isinstance(c, MediaClipper)
 
     def test_single_sentence_unchanged(self):
         from vtsearch.media.text.clipper import TextSentenceClipper
 
-        media = {"id": 1, "type": "paragraph", "media_string": "Hello world."}
+        media = {"id": 1, "type": "text", "media_string": "Hello world."}
         result = TextSentenceClipper().clip(media)
         assert len(result) == 1
         assert result[0] is media
@@ -485,7 +485,7 @@ class TestTextSentenceClipper:
         from vtsearch.media.text.clipper import TextSentenceClipper
 
         text = "First sentence. Second sentence. Third one!"
-        media = {"id": 1, "type": "paragraph", "media_string": text, "word_count": 7, "character_count": len(text)}
+        media = {"id": 1, "type": "text", "media_string": text, "word_count": 7, "character_count": len(text)}
         result = TextSentenceClipper().clip(media)
         assert len(result) == 3
         assert result[0]["media_string"] == "First sentence."
@@ -500,7 +500,7 @@ class TestTextSentenceClipper:
         from vtsearch.media.text.clipper import TextSentenceClipper
 
         text = "Is this a test? Yes it is! Great."
-        media = {"id": 1, "type": "paragraph", "media_string": text}
+        media = {"id": 1, "type": "text", "media_string": text}
         result = TextSentenceClipper().clip(media)
         assert len(result) == 3
         assert result[0]["media_string"] == "Is this a test?"
@@ -510,14 +510,14 @@ class TestTextSentenceClipper:
     def test_empty_string_returns_unchanged(self):
         from vtsearch.media.text.clipper import TextSentenceClipper
 
-        media = {"id": 1, "type": "paragraph", "media_string": ""}
+        media = {"id": 1, "type": "text", "media_string": ""}
         result = TextSentenceClipper().clip(media)
         assert result == [media]
 
     def test_no_media_string_returns_unchanged(self):
         from vtsearch.media.text.clipper import TextSentenceClipper
 
-        media = {"id": 1, "type": "paragraph"}
+        media = {"id": 1, "type": "text"}
         result = TextSentenceClipper().clip(media)
         assert result == [media]
 
@@ -764,7 +764,7 @@ class TestClipperRegistry:
     def test_clippers_for_type_paragraph(self):
         from vtsearch.media import clippers_for_type
 
-        text_clippers = clippers_for_type("paragraph")
+        text_clippers = clippers_for_type("text")
         names = [c.name for c in text_clippers]
         assert "text_default" in names
         assert "text_sentence" in names
@@ -877,7 +877,7 @@ class TestApplyClipper:
 
         media = {
             "id": 1,
-            "type": "paragraph",
+            "type": "text",
             "media_string": "First sentence. Second sentence.",
             "word_count": 4,
             "character_count": 32,

--- a/tests/test_converter_selection.py
+++ b/tests/test_converter_selection.py
@@ -63,7 +63,7 @@ class TestConverterRegistry:
         assert len(converters) >= 4
         names = [c.name for c in converters]
         assert "document2image" in names
-        assert "document2paragraph" in names
+        assert "document2text" in names
         assert "video2audio" in names
         assert "video2image" in names
 
@@ -98,12 +98,12 @@ class TestConverterRegistry:
         assert "video2audio" in names
         assert "video2image" not in names
 
-    def test_list_converters_for_target_paragraph(self):
+    def test_list_converters_for_target_text(self):
         from vtsearch.converters import list_converters_for_target
 
-        converters = list_converters_for_target("paragraph")
+        converters = list_converters_for_target("text")
         names = [c.name for c in converters]
-        assert "document2paragraph" in names
+        assert "document2text" in names
 
     def test_list_converters_for_target_none(self):
         from vtsearch.converters import list_converters_for_target
@@ -184,7 +184,7 @@ class TestConvertersAPI:
         assert "video2image" in names
         assert "video2audio" in names
         assert "document2image" in names
-        assert "document2paragraph" in names
+        assert "document2text" in names
 
     def test_filter_by_target_type_id(self, client):
         resp = client.get("/api/converters?target=image")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -198,10 +198,10 @@ class TestGuessMediaType:
         data = resp.get_json()
         assert len(data["datasets"]) == 0
         # Set a single autoload type
-        client.put("/api/settings", json={"autoload_media_types": ["paragraph"]})
+        client.put("/api/settings", json={"autoload_media_types": ["text"]})
         resp = client.get("/api/settings")
         data = resp.get_json()
-        assert data["autoload_media_types"] == ["paragraph"]
+        assert data["autoload_media_types"] == ["text"]
 
 
 class TestDashboardDatasetRegistryColumns:

--- a/tests/test_document_and_converters.py
+++ b/tests/test_document_and_converters.py
@@ -310,7 +310,7 @@ class TestDocument2TextMediaConverter:
 
         c = Document2TextMediaConverter()
         assert c.source_type == "document"
-        assert c.target_type == "paragraph"
+        assert c.target_type == "text"
 
     def test_extract_text_from_pdf(self):
         from vtsearch.converters.document2text import Document2TextMediaConverter
@@ -539,7 +539,7 @@ class TestConverterRegistrySourceFilter:
         results = list_converters_for_source("document")
         names = [c.name for c in results]
         assert "document2image" in names
-        assert "document2paragraph" in names
+        assert "document2text" in names
         assert "video2image" not in names
 
     def test_list_converters_for_source_nonexistent(self):
@@ -585,7 +585,7 @@ class TestConvertersAPISourceFilter:
         assert "video2image" in names
 
     def test_converters_filter_by_source_no_results(self, client):
-        resp = client.get("/api/converters?source=paragraph")
+        resp = client.get("/api/converters?source=text")
         data = resp.get_json()
         assert data["converters"] == []
 

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -489,7 +489,7 @@ class TestMediaTypeMismatch:
     def test_paragraph_endpoint_on_audio_media(self):
         resp = self.client.get("/api/medias/1/paragraph")
         assert resp.status_code == 400
-        assert "not a paragraph" in resp.get_json()["error"]
+        assert "not a text media" in resp.get_json()["error"]
 
 
 class TestBoundaryValues:

--- a/tests/test_label_import_ingestion.py
+++ b/tests/test_label_import_ingestion.py
@@ -94,7 +94,7 @@ class TestIngestMissingClips:
         from vtsearch.datasets.ingest import _media_type_from_origin
 
         origin = {"importer": "folder", "params": {"path": "/tmp/x", "media_type": "paragraphs"}}
-        assert _media_type_from_origin(origin) == "paragraph"
+        assert _media_type_from_origin(origin) == "text"
 
     def test_media_type_from_origin_demo(self):
         """Demo origins resolve media type from DEMO_DATASETS config."""
@@ -205,7 +205,7 @@ class TestIngestMissingClips:
         existing_clips: dict = {
             1: {
                 "id": 1,
-                "type": "paragraph",
+                "type": "text",
                 "duration": 0,
                 "file_size": 10,
                 "md5": "existing_md5",

--- a/tests/test_memory_errors.py
+++ b/tests/test_memory_errors.py
@@ -88,7 +88,7 @@ class TestPickleMemoryError:
 
         medias_data = {
             1: {
-                "type": "paragraph",
+                "type": "text",
                 "embedding": [0.0] * 10,
                 "media_string": "hello",
                 "filename": "t.txt",

--- a/tests/test_new_embedders.py
+++ b/tests/test_new_embedders.py
@@ -189,7 +189,7 @@ class TestTextBGEEmbedderProperties:
         from vtsearch.media.text.embedder_bge import TextBGEEmbedder
 
         emb = TextBGEEmbedder()
-        assert emb.media_type_id == "paragraph"
+        assert emb.media_type_id == "text"
 
     def test_description_wrappers_non_empty(self):
         from vtsearch.media.text.embedder_bge import TextBGEEmbedder
@@ -204,12 +204,12 @@ class TestTextBGEEmbedderProperties:
 
         emb = get_embedder("bge")
         assert emb.name == "bge"
-        assert emb.media_type_id == "paragraph"
+        assert emb.media_type_id == "text"
 
     def test_listed_in_embedders_for_type(self):
         from vtsearch.media import embedders_for_type
 
-        embedders = embedders_for_type("paragraph")
+        embedders = embedders_for_type("text")
         names = [e.name for e in embedders]
         assert "bge" in names
 
@@ -218,7 +218,7 @@ class TestTextBGEEmbedderProperties:
 
         emb = TextBGEEmbedder()
         d = emb.to_dict()
-        assert d == {"name": "bge", "media_type_id": "paragraph"}
+        assert d == {"name": "bge", "media_type_id": "text"}
 
     def test_load_models_idempotent(self):
         from vtsearch.media.text.embedder_bge import TextBGEEmbedder
@@ -328,10 +328,10 @@ class TestAllEmbeddersRegistration:
         names = {e.name for e in embedders_for_type("image")}
         assert names == {"clip", "siglip"}
 
-    def test_embedders_for_paragraph(self):
+    def test_embedders_for_text(self):
         from vtsearch.media import embedders_for_type
 
-        names = {e.name for e in embedders_for_type("paragraph")}
+        names = {e.name for e in embedders_for_type("text")}
         assert names == {"e5", "bge"}
 
     def test_embedders_for_video(self):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -132,10 +132,10 @@ class TestDetectorABC:
         assert det.media_type == "audio"
 
     def test_to_dict(self):
-        det = StubDetector(name="test-det", media_type="paragraph")
+        det = StubDetector(name="test-det", media_type="text")
         d = det.to_dict()
         assert d["name"] == "test-det"
-        assert d["media_type"] == "paragraph"
+        assert d["media_type"] == "text"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -601,8 +601,8 @@ class TestSettingsModule:
         assert settings_mod.get_autoload_media_types() == ["image", "audio"]
 
     def test_autoload_media_types_all_valid_types(self):
-        settings_mod.set_autoload_media_types(["audio", "image", "paragraph", "video"])
-        assert settings_mod.get_autoload_media_types() == ["audio", "image", "paragraph", "video"]
+        settings_mod.set_autoload_media_types(["audio", "image", "text", "video"])
+        assert settings_mod.get_autoload_media_types() == ["audio", "image", "text", "video"]
 
     def test_toggle_autoload_media_type(self):
         result = settings_mod.toggle_autoload_media_type("audio")
@@ -1199,9 +1199,9 @@ class TestSettingsAPI:
         assert res2.get_json()["autoload_media_types"] == ["audio", "video"]
 
     def test_update_autoload_media_types_all_types(self, client):
-        res = client.put("/api/settings", json={"autoload_media_types": ["audio", "image", "paragraph", "video"]})
+        res = client.put("/api/settings", json={"autoload_media_types": ["audio", "image", "text", "video"]})
         assert res.status_code == 200
-        assert res.get_json()["autoload_media_types"] == ["audio", "image", "paragraph", "video"]
+        assert res.get_json()["autoload_media_types"] == ["audio", "image", "text", "video"]
 
     def test_update_autoload_media_types_clear(self, client):
         client.put("/api/settings", json={"autoload_media_types": ["video"]})

--- a/vtsearch/converters/document2text.py
+++ b/vtsearch/converters/document2text.py
@@ -33,7 +33,7 @@ class Document2TextMediaConverter(MediaConverter):
 
     @property
     def target_type(self) -> str:
-        return "paragraph"
+        return "text"
 
     def convert(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         media_bytes = media.get("media_bytes")

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -999,8 +999,10 @@ def load_dataset_from_pickle(
         on_progress("loading", f"Processing 0 of {total_count} items…", 0, total_count)
     try:
         for media_id, media_info in medias_data.items():
-            # Determine media type
-            media_type = media_info.get("type", "audio")
+            # Determine media type (normalize legacy IDs like "paragraph" → "text")
+            from vtsearch.media import normalize_type_id
+
+            media_type = normalize_type_id(media_info.get("type", "audio"))
 
             if thin:
                 # ── Thin mode: skip bytes, store media_path if available ──
@@ -1209,7 +1211,7 @@ def load_dataset_from_pickle_chunked(
 
         for media_id in batch_ids:
             media_info = medias_data[media_id]
-            media_type = media_info.get("type", "audio")
+            media_type = normalize_type_id(media_info.get("type", "audio"))
 
             if thin:
                 media_path: str | None = media_info.get("media_path")

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -979,7 +979,7 @@ def load_dataset_from_pickle(
         }
 
     # Build lookup tables dynamically from the media type registry.
-    from vtsearch.media import all_types
+    from vtsearch.media import all_types, normalize_type_id
 
     _dir_keys: dict[str, str] = {}
     _legacy_bytes: dict[str, list[str]] = {}
@@ -1000,8 +1000,6 @@ def load_dataset_from_pickle(
     try:
         for media_id, media_info in medias_data.items():
             # Determine media type (normalize legacy IDs like "paragraph" → "text")
-            from vtsearch.media import normalize_type_id
-
             media_type = normalize_type_id(media_info.get("type", "audio"))
 
             if thin:
@@ -1192,7 +1190,7 @@ def load_dataset_from_pickle_chunked(
 
     # Build lookup tables dynamically from the media type registry,
     # matching the approach used by load_dataset_from_pickle.
-    from vtsearch.media import all_types
+    from vtsearch.media import all_types, normalize_type_id
 
     _dir_keys: dict[str, str] = {}
     _legacy_bytes: dict[str, list[str]] = {}

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -36,6 +36,17 @@ from vtsearch.media.base import (
 
 _registry: dict[str, "MediaType"] = {}
 
+# Legacy type_id aliases for backward compatibility (e.g. pickles, settings,
+# API parameters that still use the old name).
+_LEGACY_TYPE_IDS: dict[str, str] = {
+    "paragraph": "text",
+}
+
+
+def normalize_type_id(type_id: str) -> str:
+    """Map legacy type IDs to their current canonical names."""
+    return _LEGACY_TYPE_IDS.get(type_id, type_id)
+
 
 def register(media_type: "MediaType") -> None:
     """Add *media_type* to the registry, keyed by :attr:`~MediaType.type_id`."""
@@ -45,8 +56,10 @@ def register(media_type: "MediaType") -> None:
 def get(type_id: str) -> "MediaType":
     """Return the :class:`MediaType` registered under *type_id*.
 
+    Accepts legacy type IDs (e.g. ``"paragraph"`` → ``"text"``).
     Raises :class:`KeyError` if *type_id* is not registered.
     """
+    type_id = normalize_type_id(type_id)
     if type_id not in _registry:
         raise KeyError(f"Unknown media type: {type_id!r}")
     return _registry[type_id]
@@ -314,5 +327,6 @@ __all__ = [
     "all_clippers_dict",
     "embedders_for_type",
     "clippers_for_type",
+    "normalize_type_id",
     "set_progress_callback",
 ]

--- a/vtsearch/media/text/clipper.py
+++ b/vtsearch/media/text/clipper.py
@@ -17,7 +17,7 @@ class TextDefaultClipper(MediaClipper):
 
     @property
     def media_type(self) -> str:
-        return "paragraph"
+        return "text"
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]
@@ -41,7 +41,7 @@ class TextSentenceClipper(MediaClipper):
 
     @property
     def media_type(self) -> str:
-        return "paragraph"
+        return "text"
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         text = media.get("media_string") or ""

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -36,7 +36,7 @@ class TextE5Embedder(MediaEmbedder):
 
     @property
     def media_type_id(self) -> str:
-        return "paragraph"
+        return "text"
 
     # ------------------------------------------------------------------
     # Model lifecycle

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -36,7 +36,7 @@ class TextBGEEmbedder(MediaEmbedder):
 
     @property
     def media_type_id(self) -> str:
-        return "paragraph"
+        return "text"
 
     # ------------------------------------------------------------------
     # Model lifecycle

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -31,7 +31,7 @@ class TextMediaType(MediaType):
 
     @property
     def type_id(self) -> str:
-        return "paragraph"
+        return "text"
 
     @property
     def name(self) -> str:

--- a/vtsearch/models/embeddings.py
+++ b/vtsearch/models/embeddings.py
@@ -41,7 +41,7 @@ def embed_image_file(image_path: Path) -> Optional[np.ndarray]:
 
 def embed_paragraph_file(text_path: Path) -> Optional[np.ndarray]:
     """Generate an E5-base-v2 embedding for *text_path*."""
-    emb = _get_embedder_for_media_type("paragraph")
+    emb = _get_embedder_for_media_type("text")
     return emb.embed_media(text_path) if emb else None
 
 

--- a/vtsearch/models/registry.py
+++ b/vtsearch/models/registry.py
@@ -111,7 +111,7 @@ def register_model(
 
     Args:
         name: Display name for the dashboard.
-        media_type: ``"audio"``, ``"image"``, ``"video"``, ``"paragraph"``, etc.
+        media_type: ``"audio"``, ``"image"``, ``"video"``, ``"text"``, etc.
         trainable: Whether the model has a labelset that can be extended.
         num_training: Number of training examples (label count or "-" marker).
         detector_name: The key used in ``autorun_detectors`` (for non-trainable).

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -86,12 +86,12 @@ def _normalize_media_type_param(value: str) -> str:
     value = value.strip()
     if not value:
         return ""
-    from vtsearch.media import get_by_folder_name
+    from vtsearch.media import get_by_folder_name, normalize_type_id
 
     try:
         return get_by_folder_name(value).type_id
     except KeyError:
-        return value  # assume it is already a type_id
+        return normalize_type_id(value)  # normalize legacy IDs like "paragraph" → "text"
 
 
 # Register the UI sub-blueprint.

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -350,8 +350,9 @@ def media_image(media_id: int) -> tuple[Response, int] | Response:
 
 
 @medias_bp.route("/api/medias/<int:media_id>/paragraph")
+@medias_bp.route("/api/medias/<int:media_id>/text")
 def media_paragraph(media_id: int) -> tuple[Response, int] | Response:
-    """Return the text content and statistics for a single paragraph media item.
+    """Return the text content and statistics for a single text media item.
 
     Args:
         media_id: Integer media ID from the URL path.
@@ -360,13 +361,13 @@ def media_paragraph(media_id: int) -> tuple[Response, int] | Response:
         A JSON object with keys ``"content"`` (str), ``"word_count"`` (int),
         and ``"character_count"`` (int) on success (HTTP 200), a JSON 404
         error if the media does not exist, or a JSON 400 error if the media
-        exists but is not of type ``"paragraph"``.
+        exists but is not of type ``"text"``.
     """
     c = get_media(media_id)
     if not c:
         return jsonify({"error": "not found"}), 404
-    if c.get("type") != "paragraph":
-        return jsonify({"error": "not a paragraph"}), 400
+    if c.get("type") not in ("text", "paragraph"):
+        return jsonify({"error": "not a text media"}), 400
 
     content = _resolve_string(c)
     if content is None:

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -574,11 +574,13 @@ def get_autoload_media_types() -> list[str]:
 
     .. deprecated:: Use :func:`get_autoload_media_embedders` instead.
     """
+    from vtsearch.media import normalize_type_id
+
     valid = _valid_media_types()
     with _settings_lock:
         raw = _ensure_loaded().get("autoload_media_types", _DEFAULTS["autoload_media_types"])
         if isinstance(raw, list):
-            return [v for v in raw if v in valid]
+            return [normalize_type_id(v) for v in raw if normalize_type_id(v) in valid]
         return []
 
 

--- a/vtsearch/utils/state_processors.py
+++ b/vtsearch/utils/state_processors.py
@@ -38,7 +38,7 @@ def add_autorun_detector(
     Args:
         name: Unique human-readable name for the detector (e.g. ``"dog barks"``).
         media_type: The media type the detector was trained on (``"audio"``,
-            ``"video"``, ``"image"``, or ``"paragraph"``).
+            ``"video"``, ``"image"``, or ``"text"``).
         weights: Dict mapping layer-parameter names (e.g. ``"0.weight"``) to
             lists of float values, representing the serialised MLP state dict.
             May be ``None`` for an untrained detector stub.


### PR DESCRIPTION
## Summary

- Renames the internal `type_id` for the text media type from `"paragraph"` to `"text"`, so it displays as "Text" (not "Paragraph") throughout the UI — including the Datasets grid, model cards, and metadata tray
- Adds backward compatibility via `normalize_type_id()` so legacy pickle files and settings containing `"paragraph"` continue to work
- Adds `/api/medias/{id}/text` endpoint (keeps `/paragraph` as an alias)
- Renames frontend `ParagraphResponse` → `TextResponse`, `getParagraph()` → `getText()`
- Updates all frontend component type checks, backend tests, and spec files

## Test plan

- [x] Full backend test suite passes (2512 tests, 0 failures)
- [x] Frontend TypeScript build passes
- [ ] Verify text datasets show "[TextIcon] Text" in the dashboard grid
- [ ] Verify old pickle files with `"type": "paragraph"` load correctly
- [ ] Verify settings with `"paragraph"` in `autoload_media_types` are normalized

https://claude.ai/code/session_01XmAYzVKpt9YLfnLQgcSGLR