### PR TITLE
Fix multi-dataset training: activate dataset and protect labels

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -780,11 +780,19 @@ export class DashboardComponent implements OnInit, OnDestroy {
       return;
     }
 
-    // Dataset not loaded — load it first, then navigate
+    // Dataset not loaded — load it first, then activate and navigate.
+    // The background loader only auto-activates when no other dataset is
+    // active, so we must explicitly activate after loading completes.
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
       next: () => {
         this.startProgressPolling(() => {
-          navigateToLabel();
+          this.datasetsApi.activateRegistered(dataset.id).subscribe({
+            next: () => {
+              this.datasetState.refresh();
+              navigateToLabel();
+            },
+            error: () => navigateToLabel(),
+          });
         });
       },
     });
@@ -823,11 +831,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
       return;
     }
 
-    // Dataset not loaded — load it first, then navigate
+    // Dataset not loaded — load it first, then activate and navigate.
     this.datasetsApi.loadRegistered(dataset.id).subscribe({
       next: () => {
         this.startProgressPolling(() => {
-          navigateToFind();
+          this.datasetsApi.activateRegistered(dataset.id).subscribe({
+            next: () => {
+              this.datasetState.refresh();
+              navigateToFind();
+            },
+            error: () => navigateToFind(),
+          });
         });
       },
     });

--- a/tests/test_multi_dataset.py
+++ b/tests/test_multi_dataset.py
@@ -583,3 +583,138 @@ class TestEmptyContextFallback:
         set_active_dataset_id(None)
         assert len(good_votes) == 0
         assert len(bad_votes) == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-dataset training: sync_labels protection
+# ---------------------------------------------------------------------------
+
+
+class TestSyncLabelsAcrossDatasets:
+    """sync_labels_to_loaded_model must not destroy training data when the
+    active dataset has been switched (no votes in the new context)."""
+
+    def test_sync_skips_when_votes_empty_after_dataset_switch(self, client, tmp_path):
+        """Train on Dataset A, switch to Dataset B (empty votes),
+        call sync → model's labelset must still have A's labels."""
+        from vtsearch.datasets.labelset import LabelSet
+        from vtsearch.models.registry import register_model, reset_for_tests, set_loaded_id
+        from vtsearch.routes.trainable_models import _read_model, _write_model, sync_labels_to_loaded_model
+        from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
+        from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+
+        reset_for_tests()
+
+        # Phase 1: simulate training on "Dataset A" (6 labels)
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
+
+        snap = snapshot_medias()
+        labelset = LabelSet.from_clips_and_votes(snap, good_votes, bad_votes, expand_dupes=False)
+        original_label_count = len(labelset)
+        assert original_label_count == 6
+
+        original_dir = get_trainable_models_dir()
+        set_trainable_models_dir(tmp_path)
+        try:
+            tm_name = "sync-protect-test"
+            tm_path = tmp_path / f"{tm_name}.json"
+            _write_model(
+                tm_path,
+                {
+                    "name": tm_name,
+                    "text_query": "",
+                    "examples": [],
+                    "labelset": labelset.to_dict(),
+                },
+            )
+
+            entry = register_model(
+                name="Sync Protect Test",
+                media_type="audio",
+                trainable=True,
+                trainable_model_name=tm_name,
+            )
+            model_id = entry["id"]
+            set_loaded_id(model_id)
+
+            # Phase 2: simulate switching to Dataset B (clear votes)
+            good_votes.clear()
+            bad_votes.clear()
+
+            # Phase 3: trigger sync — must NOT overwrite training labels
+            sync_labels_to_loaded_model()
+
+            saved = _read_model(tm_path)
+            saved_labels = saved["labelset"]["labels"]
+            assert len(saved_labels) == original_label_count, (
+                f"Expected {original_label_count} training labels but sync "
+                f"overwrote them with {len(saved_labels)} (empty votes)"
+            )
+        finally:
+            set_trainable_models_dir(original_dir)
+
+    def test_load_model_on_new_dataset_preserves_labels(self, client, tmp_path):
+        """Load a trained model on Dataset B via /api/models/registry/load.
+
+        The model's saved labelset from Dataset A must survive the load
+        even though Dataset B has no votes."""
+        from vtsearch.datasets.labelset import LabelSet
+        from vtsearch.models.registry import register_model, reset_for_tests, set_loaded_id
+        from vtsearch.routes.trainable_models import _read_model, _write_model
+        from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
+        from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+
+        reset_for_tests()
+
+        # Phase 1: simulate training on "Dataset A" (4 labels)
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [19, 20]})
+
+        snap = snapshot_medias()
+        labelset = LabelSet.from_clips_and_votes(snap, good_votes, bad_votes, expand_dupes=False)
+        original_label_count = len(labelset)
+        assert original_label_count == 4
+
+        original_dir = get_trainable_models_dir()
+        set_trainable_models_dir(tmp_path)
+        try:
+            tm_name = "load-protect-test"
+            tm_path = tmp_path / f"{tm_name}.json"
+            _write_model(
+                tm_path,
+                {
+                    "name": tm_name,
+                    "text_query": "",
+                    "media_type": "audio",
+                    "examples": [],
+                    "labelset": labelset.to_dict(),
+                },
+            )
+
+            entry = register_model(
+                name="Load Protect Test",
+                media_type="audio",
+                trainable=True,
+                trainable_model_name=tm_name,
+            )
+            model_id = entry["id"]
+            set_loaded_id(model_id)
+
+            # Phase 2: simulate switching to Dataset B (clear votes)
+            good_votes.clear()
+            bad_votes.clear()
+
+            # Phase 3: re-load the same model (as the dashboard would)
+            resp = client.post("/api/models/registry/load", json={"model_id": model_id})
+            assert resp.status_code == 200
+
+            # The model file must still have the original labels
+            saved = _read_model(tm_path)
+            saved_labels = saved["labelset"]["labels"]
+            assert len(saved_labels) == original_label_count, (
+                f"Expected {original_label_count} training labels but load_model "
+                f"overwrote them — got {len(saved_labels)}"
+            )
+        finally:
+            set_trainable_models_dir(original_dir)

--- a/tests/test_multi_dataset.py
+++ b/tests/test_multi_dataset.py
@@ -594,12 +594,13 @@ class TestSyncLabelsAcrossDatasets:
     """sync_labels_to_loaded_model must not destroy training data when the
     active dataset has been switched (no votes in the new context)."""
 
-    def test_sync_skips_when_votes_empty_after_dataset_switch(self, client, tmp_path):
-        """Train on Dataset A, switch to Dataset B (empty votes),
-        call sync → model's labelset must still have A's labels."""
+    def test_load_model_route_skips_sync_when_no_votes(self, client, tmp_path):
+        """load_model_route must skip sync when the active context has no
+        votes, preventing destruction of the model's saved labelset from a
+        prior training session on a different dataset."""
         from vtsearch.datasets.labelset import LabelSet
         from vtsearch.models.registry import register_model, reset_for_tests, set_loaded_id
-        from vtsearch.routes.trainable_models import _read_model, _write_model, sync_labels_to_loaded_model
+        from vtsearch.routes.trainable_models import _read_model, _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import bad_votes, good_votes, snapshot_medias
 
@@ -624,6 +625,7 @@ class TestSyncLabelsAcrossDatasets:
                 {
                     "name": tm_name,
                     "text_query": "",
+                    "media_type": "audio",
                     "examples": [],
                     "labelset": labelset.to_dict(),
                 },
@@ -642,14 +644,15 @@ class TestSyncLabelsAcrossDatasets:
             good_votes.clear()
             bad_votes.clear()
 
-            # Phase 3: trigger sync — must NOT overwrite training labels
-            sync_labels_to_loaded_model()
+            # Phase 3: re-load the same model via the API endpoint
+            resp = client.post("/api/models/registry/load", json={"model_id": model_id})
+            assert resp.status_code == 200
 
             saved = _read_model(tm_path)
             saved_labels = saved["labelset"]["labels"]
             assert len(saved_labels) == original_label_count, (
-                f"Expected {original_label_count} training labels but sync "
-                f"overwrote them with {len(saved_labels)} (empty votes)"
+                f"Expected {original_label_count} training labels but load_model "
+                f"overwrote them with {len(saved_labels)} (empty votes context)"
             )
         finally:
             set_trainable_models_dir(original_dir)

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -81,10 +81,6 @@ def sync_labels_to_loaded_model() -> None:
     Skipped when the model is in "find mode" (after ``/api/find-label``),
     because the global votes reflect scoring results on a different dataset,
     not the model's original training labels.
-
-    Also skipped when the active dataset context has no votes, which avoids
-    overwriting existing training labels with an empty labelset after the
-    user switches to a different dataset.
     """
     from vtsearch.models.registry import get_loaded_id, get_model, is_find_mode, update_model
 
@@ -99,14 +95,6 @@ def sync_labels_to_loaded_model() -> None:
     if not entry or not entry.get("trainable") or not entry.get("trainable_model_name"):
         return
 
-    from vtsearch.utils import bad_votes, good_votes
-
-    # Skip sync when there are no votes in the active dataset context.
-    # This prevents overwriting existing training labels with an empty
-    # labelset after the user switches to a different dataset.
-    if not good_votes and not bad_votes:
-        return
-
     tm_name = entry["trainable_model_name"]
     path = _model_path(tm_name)
     data = _read_model(path)
@@ -114,7 +102,7 @@ def sync_labels_to_loaded_model() -> None:
         return
 
     from vtsearch.datasets.labelset import LabelSet
-    from vtsearch.utils import snapshot_medias
+    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
 
     labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bad_votes, expand_dupes=False)
     data["labelset"] = labelset.to_dict()
@@ -703,8 +691,15 @@ def load_model_route():
         if entry is None:
             return jsonify({"error": "Model not found"}), 404
 
-    # Save current model's labels before switching.
-    sync_labels_to_loaded_model()
+    # Save current model's labels before switching — but only if there
+    # are votes in the active context.  When the user has switched to a
+    # different dataset the active context may have no votes at all;
+    # syncing in that situation would overwrite the model's saved
+    # training labels with an empty labelset.
+    from vtsearch.utils import bad_votes, good_votes
+
+    if good_votes or bad_votes:
+        sync_labels_to_loaded_model()
 
     # Clear votes so labels from the previous session don't carry over.
     clear_votes()

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -81,6 +81,10 @@ def sync_labels_to_loaded_model() -> None:
     Skipped when the model is in "find mode" (after ``/api/find-label``),
     because the global votes reflect scoring results on a different dataset,
     not the model's original training labels.
+
+    Also skipped when the active dataset context has no votes, which avoids
+    overwriting existing training labels with an empty labelset after the
+    user switches to a different dataset.
     """
     from vtsearch.models.registry import get_loaded_id, get_model, is_find_mode, update_model
 
@@ -95,6 +99,14 @@ def sync_labels_to_loaded_model() -> None:
     if not entry or not entry.get("trainable") or not entry.get("trainable_model_name"):
         return
 
+    from vtsearch.utils import bad_votes, good_votes
+
+    # Skip sync when there are no votes in the active dataset context.
+    # This prevents overwriting existing training labels with an empty
+    # labelset after the user switches to a different dataset.
+    if not good_votes and not bad_votes:
+        return
+
     tm_name = entry["trainable_model_name"]
     path = _model_path(tm_name)
     data = _read_model(path)
@@ -102,7 +114,7 @@ def sync_labels_to_loaded_model() -> None:
         return
 
     from vtsearch.datasets.labelset import LabelSet
-    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+    from vtsearch.utils import snapshot_medias
 
     labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bad_votes, expand_dupes=False)
     data["labelset"] = labelset.to_dict()


### PR DESCRIPTION
## Summary

- **Fix dataset activation on Label/Find**: When the dashboard's `onLabel()` or `onFind()` loaded an unloaded dataset via `loadRegistered` (background thread), it navigated to the training/find view without activating the dataset first. The background loader only auto-activates when no other dataset is active (`get_active_dataset_id() is None`), so the previous dataset remained active and the user saw its medias instead of the newly selected dataset's.
- **Fix training label preservation**: When `load_model_route` re-loaded a model after the user switched datasets, `sync_labels_to_loaded_model()` ran against the new (empty-vote) context and overwrote the model's saved training labels with an empty labelset, destroying training data from the previous dataset.

## Test plan

- [x] New test `TestSyncLabelsAcrossDatasets::test_load_model_route_skips_sync_when_no_votes` — verifies `load_model_route` skips sync when votes are empty, preserving existing labels
- [x] New test `TestSyncLabelsAcrossDatasets::test_load_model_on_new_dataset_preserves_labels` — end-to-end: train on Dataset A, clear votes (simulate dataset switch), re-load model via API, verify labels survive
- [x] Existing `test_vote_toggle_off_updates_model` still passes — toggling off all votes during active training correctly saves an empty labelset (sync guard is scoped to `load_model_route`, not global)
- [x] Full test suite: 2514 passed, 1 skipped

https://claude.ai/code/session_01CmkP5rxDmQJ6oe8VoDgZQQ