### PR TITLE
Hide HuggingFace download progress bars from console in GUI mode

### DIFF
--- a/tests/test_tqdm_progress.py
+++ b/tests/test_tqdm_progress.py
@@ -150,6 +150,28 @@ class TestInterceptTqdmProgress:
         # But the callback should still have received the progress
         assert len(calls) >= 3
 
+    def test_suppresses_console_output_with_explicit_stderr(self, capsys):
+        """Bars created with file=sys.stderr (like huggingface_hub) should still be suppressed."""
+        import sys
+
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append((status, message, current, total))
+
+        with intercept_tqdm_progress(cb):
+            # huggingface_hub's tqdm wrapper passes file=sys.stderr explicitly
+            bar = tqdm.auto.tqdm(total=100, desc="model.safetensors", file=sys.stderr)
+            bar.update(50)
+            bar.update(50)
+            bar.close()
+
+        captured = capsys.readouterr()
+        assert "model.safetensors" not in captured.out
+        assert "model.safetensors" not in captured.err
+        # Callback should still receive progress
+        assert len(calls) >= 3
+
     def test_callback_receives_status_loading(self):
         """All forwarded calls should use status='loading'."""
         calls = []

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -95,10 +95,10 @@ def intercept_tqdm_progress(callback: ProgressCallback) -> Any:
     _devnull = open(os.devnull, "w")  # noqa: SIM115
 
     def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
-        # Inject file=devnull so tqdm wraps it in its DisableOnWriteError
-        # wrapper during init — suppresses all console output from the bar.
-        if "file" not in kwargs:
-            kwargs["file"] = _devnull
+        # Force file=devnull so tqdm never writes to the console.
+        # huggingface_hub's tqdm wrapper passes file=sys.stderr explicitly,
+        # so we must override unconditionally (not just when absent).
+        kwargs["file"] = _devnull
         _orig_init(self, *args, **kwargs)
         total = getattr(self, "total", None)
         if total and total > 0 and not getattr(self, "disable", False):


### PR DESCRIPTION
## Summary

- Fix `intercept_tqdm_progress` to unconditionally redirect tqdm output to `/dev/null`, suppressing download progress bars like `model.safetensors: 100%|███...` from the console in GUI mode
- The previous code only overrode the `file` parameter when it wasn't explicitly passed, but `huggingface_hub`'s tqdm wrapper passes `file=sys.stderr` explicitly, bypassing the suppression
- Add test verifying that bars created with explicit `file=sys.stderr` are still suppressed

## Test plan

- [x] `./run-tests.sh cli` — all 143 tests pass (includes tqdm progress tests)
- [x] `./run-tests.sh core` — all 335 tests pass
- [ ] Manual: start app in GUI mode with an uncached model, verify no tqdm download bars appear on console

https://claude.ai/code/session_01CGRN4n32ACdZ7GpgntMum9