### PR TITLE
Fix documentation accuracy, completeness, and organization

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -79,6 +79,25 @@ Returns the active login provider name, current user, whether the request
 is authenticated, and whether the frontend should show a login screen.
 With `DefaultLoginProvider`, every request is authenticated as `"default"`.
 
+### Login
+
+```
+POST /api/auth/login
+```
+
+**Body:** `{"username": "...", "password": "..."}`
+
+→ Provider-specific response. With `DefaultLoginProvider`, returns 404.
+With `TrivialLoginProvider`, authenticates and returns `{"ok": true, "user": "..."}`.
+
+### Logout
+
+```
+POST /api/auth/logout
+```
+
+→ Provider-specific response. With `DefaultLoginProvider`, returns 404.
+
 ---
 
 ## Static / UI
@@ -905,6 +924,36 @@ GET /api/dataset/progress
 {"status": "loading", "message": "Embedding medias…", "cur": 50, "total": 500}
 ```
 
+### Loading tasks
+
+```
+GET /api/dataset/loading-tasks
+```
+
+→ All active dataset loading tasks with their progress:
+
+```json
+{"tasks": [{"id": "task_abc", "name": "ESC-50", "status": "loading", "message": "...", "cur": 50, "total": 500}]}
+```
+
+### Cancel loading
+
+```
+POST /api/dataset/cancel
+```
+
+Cancels all active loading tasks.
+
+→ `{"ok": true}`
+
+```
+POST /api/dataset/cancel/{task_id}
+```
+
+Cancels a specific loading task.
+
+→ `{"ok": true}` or `{"error": "Task not found"}` (404)
+
 ### List importers
 
 ```
@@ -1104,6 +1153,17 @@ POST /api/datasets/registry/{dataset_id}/load
 
 → `{"ok": true, "message": "Loading started"}`
 
+### Activate registered dataset
+
+```
+POST /api/datasets/registry/{dataset_id}/activate
+```
+
+Switches the active dataset context to the specified dataset (must already
+be loaded). This is an instant operation — no re-embedding.
+
+→ `{"ok": true}`
+
 ### Unload registered dataset
 
 ```
@@ -1129,6 +1189,19 @@ PUT /api/datasets/registry/{dataset_id}/rename
 **Body:** `{"name": "New Name"}`
 
 → `{"ok": true, "name": "New Name"}`
+
+### Set dataset readers
+
+```
+PUT /api/datasets/registry/{dataset_id}/readers
+```
+
+**Body:** `{"readers": ["user1", "user2"]}`
+
+Sets which users can access a dataset (multi-user deployments). Only the
+dataset owner or an admin can modify readers.
+
+→ `{"ok": true, "readers": ["user1", "user2"]}`
 
 ---
 
@@ -1259,8 +1332,8 @@ GET /api/settings
   "view_mode_right": {},
   "focus_mode_left": {},
   "focus_mode_right": {},
-  "grid_columns_left": {},
-  "grid_columns_right": {},
+  "grid_icon_size_left": {},
+  "grid_icon_size_right": {},
   "panel_pct_left": {},
   "panel_pct_right": {},
   "autoload_media_types": [],
@@ -1270,14 +1343,16 @@ GET /api/settings
   "hide_autopilot": false,
   "autopilot_top_greens": 3,
   "autopilot_hard_reds": 4,
+  "autopilot_resort_interval": 10,
   "autopilot_goal_diversity": 40,
+  "autorun_detector_names": [],
   "saved_datasets_dir": "data/saved_datasets",
   "detectors_dir": "data/detectors",
   "trainable_models_dir": "data/trainable_models"
 }
 ```
 
-Per-media-type settings (`view_mode_*`, `focus_mode_*`, `grid_columns_*`,
+Per-media-type settings (`view_mode_*`, `focus_mode_*`, `grid_icon_size_*`,
 `panel_pct_*`) use dicts keyed by media type ID (e.g. `{"audio": "list"}`).
 
 ### Update settings
@@ -1299,12 +1374,13 @@ Supported keys: `volume` (number), `theme` (`"dark"` / `"light"` /
 `safe_thresholds` (bool), `calibrate_count` (int), `calibration_fraction`
 (number), `audio_playing` (bool), `swipe_animation` (bool),
 `show_metadata` (bool), `view_mode_left` (dict), `view_mode_right` (dict),
-`focus_mode_left` (dict), `focus_mode_right` (dict), `grid_columns_left`
-(dict), `grid_columns_right` (dict), `panel_pct_left` (dict),
+`focus_mode_left` (dict), `focus_mode_right` (dict), `grid_icon_size_left`
+(dict), `grid_icon_size_right` (dict), `panel_pct_left` (dict),
 `panel_pct_right` (dict), `autoload_media_types` (list of strings),
 `autoload_media_embedders` (list of strings), `autopilot_enabled` (bool),
 `hide_autopilot` (bool), `autopilot_top_greens` (int),
-`autopilot_hard_reds` (int), `autopilot_goal_diversity` (int),
+`autopilot_hard_reds` (int), `autopilot_resort_interval` (int),
+`autopilot_goal_diversity` (int), `autorun_detector_names` (list of strings),
 `saved_datasets_dir` (string path), `detectors_dir` (string path),
 `trainable_models_dir` (string path).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,7 @@ VTSearch/
 │   │
 │   ├── converters/                 Media type converters
 │   │   ├── base.py                 MediaConverter ABC
+│   │   ├── runner.py               Converter orchestration (run_converters_on_folder)
 │   │   ├── document2image.py       Render document pages as images
 │   │   ├── document2text.py        Extract text from documents
 │   │   ├── video2audio.py          Extract audio track from video
@@ -84,7 +85,9 @@ VTSearch/
 │   │   ├── progress.py             Labelling-progress cache & analysis
 │   │   ├── embeddings.py           Thin wrappers around media-type embed()
 │   │   ├── loader.py               Model initialisation (delegates to media)
-│   │   └── diversity_tree.py       Hierarchical k-means tree for diverse sampling
+│   │   ├── diversity_tree.py       Hierarchical k-means tree for diverse sampling
+│   │   ├── registry.py             Persistent model registry/manifest management
+│   │   └── resolver.py             Label resolution by following origin trails
 │   │
 │   ├── datasets/                   Dataset loading & downloading
 │   │   ├── origin.py               Origin dataclass (per-element provenance)
@@ -151,12 +154,22 @@ VTSearch/
 │   │   ├── label_importers.py      Label importer registry & execution
 │   │   ├── processor_importers.py  Processor importer registry & execution
 │   │   ├── settings.py             Settings persistence (volume, theme, etc.)
+│   │   ├── file_browser.py         File browser API for directory navigation
 │   │   └── trainable_models.py     Persistent trainable model definitions (CRUD)
 │   │
 │   ├── utils/
-│   │   ├── state.py                Global state (medias, votes, autorun config, history)
+│   │   ├── state.py                Re-export facade over state_*.py submodules
+│   │   ├── state_core.py           Core variables (medias, votes, inclusion) and _state_lock
+│   │   ├── state_votes.py          Vote operations, label history, learned scores
+│   │   ├── state_clicks.py         Click-time tracking for vote sequence analysis
+│   │   ├── state_processors.py     Autorun detector/extractor/localizer CRUD
+│   │   ├── state_diversity.py      Diversity tree construction and sampling
+│   │   ├── state_media_lookup.py   Media ID resolution, duplicate collapsing, origins
 │   │   ├── progress.py             Thread-safe progress tracking
-│   │   └── registry.py             PluginBase, PluginField, PluginRegistry (shared plugin infra)
+│   │   ├── registry.py             PluginBase, PluginField, PluginRegistry (shared plugin infra)
+│   │   ├── hits.py                 Helpers for building media hit dicts
+│   │   ├── paths.py                Path utilities
+│   │   └── url_validation.py       SSRF URL validation
 │   │
 │   └── audio/                      WAV/tone generation utilities
 │
@@ -417,7 +430,7 @@ Persistent settings live separately in `vtsearch/settings.py` and are
 auto-saved to `data/settings.json`.  Keys include: `volume`, `theme`,
 `inclusion`, `enrich_descriptions`, `safe_thresholds`, `calibrate_count`,
 `calibration_fraction`, `audio_playing`, `swipe_animation`,
-`show_metadata`, `view_mode_*`, `grid_columns_*`, `focus_mode_*`,
+`show_metadata`, `view_mode_*`, `grid_icon_size_*`, `focus_mode_*`,
 `panel_pct_*` (per-media-type layout), `autoload_media_types`,
 `autoload_media_embedders`, `autopilot_enabled`, `hide_autopilot`,
 `autopilot_top_greens`, `autopilot_hard_reds`, `autopilot_goal_diversity`,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -92,3 +92,11 @@ python app.py --local
 
 Production mode binds to `127.0.0.1:5000` (localhost only).  `--local` mode
 binds to `0.0.0.0:5000` (accessible from other devices on the network).
+
+**Authentication mode** (`--login`) — select the login provider:
+
+```bash
+python app.py --login trivial    # multi-user mode with simple username auth
+```
+
+Without `--login`, the app uses `DefaultLoginProvider` (single-user, always authenticated).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -246,7 +246,9 @@ and auto-saved on every change. Schema:
   "hide_autopilot": false,
   "autopilot_top_greens": 3,
   "autopilot_hard_reds": 4,
+  "autopilot_resort_interval": 10,
   "autopilot_goal_diversity": 40,
+  "autorun_detector_names": [],
   "saved_datasets_dir": "data/saved_datasets",
   "detectors_dir": "data/detectors",
   "trainable_models_dir": "data/trainable_models"

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -22,10 +22,10 @@ This will:
 Install dependencies (if you haven't already):
 
 ```bash
-pip install -r requirements-cpu.txt   # or requirements-gpu.txt
+pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[cpu,dev]"
 ```
 
-Matplotlib and pandas are required for plot generation and are included in the requirements file.
+Matplotlib and pandas are required for plot generation and are included in the dev dependencies.
 
 ## CLI reference
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -272,7 +272,20 @@ Install dev dependencies (includes pytest):
 pip install -e ".[dev]"
 ```
 
-Then run:
+The recommended way to run tests uses the helper script, which installs
+dependencies automatically and supports grouped test subsets:
+
+```bash
+./run-tests.sh              # full fast CPU suite
+./run-tests.sh core         # basic app functionality only
+./run-tests.sh sorting api  # multiple groups
+```
+
+Available groups: `core`, `api`, `sorting`, `datasets`, `io`, `models`,
+`downloads`, `integration`, `cli`, `converters`. See `CLAUDE.md` for the
+full group-to-file mapping.
+
+You can also run pytest directly:
 
 ```bash
 python -m pytest tests/ -v

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -41,8 +41,10 @@ When the app is running, click the hamburger menu in the top-left corner to open
 
 | Demo | Description |
 |------|-------------|
-| **ucf101_s** | ~150 clips across 10 UCF-101 action categories — personal activities and sports (manual download) |
-| **ucf101_m** | ~250 clips across 10 UCF-101 action categories (manual download) |
-| **ucf101_l** | ~600 clips across 10 UCF-101 action categories (manual download) |
+| **ucf101_s** | ~150 clips across 10 UCF-101 action categories — personal activities and sports |
+| **ucf101_m** | ~250 clips across 10 UCF-101 action categories |
+| **ucf101_l** | ~600 clips across 10 UCF-101 action categories |
+
+> **Note:** UCF-101 demos are downloaded from HuggingFace Datasets. On some networks or air-gapped systems this may require manual setup — see [DEPLOYMENT.md](DEPLOYMENT.md) for offline deployment instructions.
 
 You can also load your own data from pickle files or folders via the same menu.

--- a/docs/design/cli-detector-converter.md
+++ b/docs/design/cli-detector-converter.md
@@ -1,5 +1,10 @@
 # Design: CLI Autodetect with Converters and Clippers
 
+> **Status: Design proposal.** This document outlines a planned approach for
+> handling converters and clippers in the CLI autodetect pipeline. The
+> converter registry exists in `vtsearch/converters/`, but the `input_spec`
+> field in detector JSON described here is not yet implemented.
+
 ## Problem
 
 The CLI autodetect pipeline currently works like this:

--- a/docs/old_io.md
+++ b/docs/old_io.md
@@ -4,6 +4,10 @@ These importers and exporters were removed from the UI but are preserved here
 as reference implementations for developers building new IO plugins.  They are
 **not loaded, tested, or supported** — treat them as code samples.
 
+> **Warning:** These code samples may be outdated. In particular, the current
+> codebase uses the media type ID `"text"` (not `"paragraph"`). Review and
+> test thoroughly before reusing any of this code.
+
 See [EXTENDING.md](EXTENDING.md) for the current plugin interfaces and the
 S3 importer skeleton.
 

--- a/docs/plan-media-sources.md
+++ b/docs/plan-media-sources.md
@@ -1,5 +1,11 @@
 # MediaSource Abstraction — Implementation Plan
 
+> **Status: Proposal — not yet implemented.** This document describes a
+> planned design that has not been built. The current codebase uses
+> `resolve_file_from_origin()` in `vtsearch/models/resolver.py` for
+> individual file resolution. See [ARCHITECTURE.md](ARCHITECTURE.md) for
+> the current architecture.
+
 ## Problem
 
 Users want to supply **individual media examples** for sorting during labeling (not just text descriptions). Today, the only way to get media into VTSearch is through dataset importers, which are designed for bulk ingestion — there's no standard way to say "give me just `audio123.wav` from that folder" or "fetch this one file from that S3 bucket."

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,6 +30,10 @@ ng test --watch=false
 
 Uses [Karma](https://karma-runner.github.io) as the test runner.
 
+> **Note:** Karma requires Chrome or Chromium. In cloud/container
+> environments where a browser is not available, frontend unit tests will
+> fail. The Python backend tests (`./run-tests.sh`) work without a browser.
+
 ## Code scaffolding
 
 ```bash


### PR DESCRIPTION
## Summary

Comprehensive documentation review and fix across all 11 doc files. Fixes factual errors, adds missing content, and improves clarity for both new users and developers.

### Critical fixes
- **EVAL.md**: Replace reference to nonexistent `requirements-cpu.txt` / `requirements-gpu.txt` with correct `pyproject.toml` install command — users following the guide would get `FileNotFoundError`
- **API.md**: Fix `grid_columns_*` → `grid_icon_size_*` (3 occurrences) to match actual `settings.py` field names — clients using the documented names would get silent failures
- **API.md**: Add 6 missing endpoint docs: auth login/logout, dataset activate (critical for multi-dataset), loading-tasks, cancel, dataset readers

### Completeness improvements
- **API.md & DEPLOYMENT.md**: Add missing settings fields `autopilot_resort_interval` and `autorun_detector_names` to schema
- **ARCHITECTURE.md**: Add 12 missing modules to directory map (models/registry.py, models/resolver.py, converters/runner.py, routes/file_browser.py, all 6 utils/ state submodules, utils/hits.py, utils/paths.py, utils/url_validation.py)
- **CLI.md**: Document the `--login` argument for authentication mode
- **SETUP.md**: Add `./run-tests.sh` as the recommended test runner with group support

### Clarity improvements
- **demos.md**: Replace confusing "(manual download)" on UCF-101 with link to deployment docs
- **old_io.md**: Add warning that code samples may be outdated (`paragraph` → `text` media type)
- **plan-media-sources.md**: Add "Status: Proposal — not yet implemented" header
- **design/cli-detector-converter.md**: Add "Status: Design proposal" header
- **frontend/README.md**: Add Chrome/Chromium requirement caveat for unit tests

## Test plan
- [ ] Documentation-only changes — no code modified
- [ ] Verify all referenced file paths and endpoint names match codebase
- [ ] Spot-check settings field names against `vtsearch/settings.py`

https://claude.ai/code/session_017ZUeZXe3RBjpXS57Uyc2Ei