### PR TITLE
Fix security and auth bugs from codebase review

### DIFF
--- a/tests/test_label_sorting.py
+++ b/tests/test_label_sorting.py
@@ -119,7 +119,7 @@ class TestClearVotesResetsState:
         assert len(vote_click_times) == 1
         _state.clear_votes()
         assert len(vote_click_times) == 0
-        assert _core._click_counter == 0
+        assert _core._get_click_counter() == 0
 
     def test_clear_votes_clears_learned_scores(self, client):
         _state.last_learned_scores[1] = 0.9

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -92,7 +92,7 @@ class TestToggleVote:
     def test_toggle_off_removes_click_time(self):
         good_votes[1] = None
         vote_click_times[1] = 1
-        _core._click_counter = 1
+        _core._set_click_counter(1)
         toggle_vote(1, "good")
         assert 1 not in vote_click_times
 

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -1396,7 +1396,7 @@ def read_pkl_embedder(pkl_path: Path) -> str | None:
         return None
     try:
         with open(pkl_path, "rb") as f:
-            data = pickle.load(f)  # noqa: S301
+            data = safe_pickle_load(f)
         medias_dict = data.get("medias", {}) if isinstance(data, dict) else {}
         for media in medias_dict.values():
             name = media.get("embedder", "")

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -17,6 +17,16 @@ from typing import Any
 
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
+# Characters that trigger formula execution in spreadsheet applications.
+_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _sanitize_csv_cell(value: str) -> str:
+    """Prefix formula-like cell values with a single quote to prevent injection."""
+    if value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
 
 class ServerCsvLabelsetExporter(LabelsetExporter):
     """Save auto-detect results as a CSV file on the server filesystem.
@@ -94,9 +104,11 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                         if isinstance(val, dict):
                             row.append(json.dumps(val, sort_keys=True))
                         else:
-                            row.append(str(val if val is not None else ""))
+                            cell = str(val if val is not None else "")
+                            row.append(_sanitize_csv_cell(cell))
                     elif col in meta:
-                        row.append(str(meta[col] if meta[col] is not None else ""))
+                        cell = str(meta[col] if meta[col] is not None else "")
+                        row.append(_sanitize_csv_cell(cell))
                     else:
                         row.append("")
                 writer.writerow(row)
@@ -126,13 +138,13 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                         origin_str = Origin.from_dict(origin).display()
                     writer.writerow(
                         [
-                            detector_name,
+                            _sanitize_csv_cell(str(detector_name)),
                             threshold,
-                            hit.get("filename", ""),
-                            hit.get("category", ""),
+                            _sanitize_csv_cell(hit.get("filename", "")),
+                            _sanitize_csv_cell(hit.get("category", "")),
                             hit.get("score", ""),
-                            origin_str,
-                            hit.get("origin_name", ""),
+                            _sanitize_csv_cell(origin_str),
+                            _sanitize_csv_cell(hit.get("origin_name", "")),
                         ]
                     )
                     total_hits += 1

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -785,6 +785,10 @@ def unload_registered_dataset(dataset_id: str):
     The dataset's context is removed, freeing its RAM.  If it was the
     active dataset, the active pointer is cleared.
     """
+    from vtsearch.auth import get_current_user
+
+    if not _reg_is_owner(dataset_id, get_current_user()):
+        return jsonify({"error": "Only the dataset creator can unload it"}), 403
     if not _reg_is_loaded(dataset_id):
         return jsonify({"error": "This dataset is not currently loaded"}), 400
     unregister_context(dataset_id)
@@ -799,6 +803,10 @@ def activate_registered_dataset(dataset_id: str):
     The dataset must already be loaded in memory.  This is an instant
     operation — no data is re-read or re-embedded.
     """
+    from vtsearch.auth import get_current_user
+
+    if not _reg_can_access(dataset_id, get_current_user()):
+        return jsonify({"error": "Access denied"}), 403
     if not _reg_is_loaded(dataset_id):
         return jsonify({"error": "Dataset is not loaded in memory; load it first"}), 400
     set_active_dataset_id(dataset_id)

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -348,25 +348,14 @@ _find_initial_labels: dict[int, str] = _ProxyDict("find_initial_labels")  # type
 
 
 # ---------------------------------------------------------------------------
-# Scalar per-dataset state — accessed via properties on the active context.
-# These use module-level *properties* via a descriptor protocol so that
-# ``import state_core; state_core._click_counter`` still works.
-# For simplicity, we keep them as module-level getters/setters and update
-# the active context directly.
-# ---------------------------------------------------------------------------
-
-# ---------------------------------------------------------------------------
 # Scalar per-dataset state accessors
 # ---------------------------------------------------------------------------
 # _click_counter, inclusion, _dataset_display_name, _diversity_tree are
-# scalar fields on DatasetContext.  Code in state submodules accesses them
-# via ``_core._click_counter`` etc.  We keep backward-compatible module-
-# level names that resolve to the active context via property-like access.
-#
-# For *writes*, submodules do ``_core._click_counter += 1``.  Python's
-# module attribute protocol means ``_core._click_counter`` reads the
-# module-level name.  To redirect these to the active context we provide
-# explicit getter/setter helpers and update the call-sites.
+# scalar fields on DatasetContext.  All production code accesses them via
+# the getter/setter helpers below (e.g. _get_click_counter()), which
+# delegate to the active context.  The conftest reset_state fixture resets
+# these by calling clear_all_contexts(), which creates a fresh
+# DatasetContext with all fields at their defaults.
 # ---------------------------------------------------------------------------
 
 
@@ -402,10 +391,12 @@ def _set_inclusion(value: int | None) -> None:
     get_active_context().inclusion = value
 
 
-# Legacy module-level names — these are still used by conftest.py's
-# reset_state fixture which does ``_core._click_counter = 0``.
-# We keep them for backward compat but they are NOT used by the
-# proxy-aware submodules anymore (those call the getters/setters above).
+# NOTE: These module-level variables are DEAD CODE.  All production code
+# uses the getter/setter helpers above (which delegate to the active
+# DatasetContext).  The conftest reset_state fixture resets per-dataset
+# scalars by creating a fresh context via clear_all_contexts().
+# These names are kept only to avoid import errors if any external code
+# references them; they are never read or written by VTSearch itself.
 _click_counter: int = 0
 _dataset_display_name: str | None = None
 _diversity_tree: Any = None


### PR DESCRIPTION
## Summary

- **Security: Use `safe_pickle_load()` in `read_pkl_embedder()`** — This function used raw `pickle.load()` (with a `# noqa` suppression) instead of the project's `safe_pickle_load()` which uses `RestrictedUnpickler`. A malicious pickle file could achieve arbitrary code execution through this path.

- **Auth: Add missing access control on dataset unload/activate endpoints** — `DELETE` and `PUT /rename` already check ownership, and `POST /load` checks `can_user_access()`, but `POST /unload` and `POST /activate` had no authorization checks. In multi-user mode, any user could unload or activate any other user's dataset.

- **CSV formula injection: Sanitize cell values in CSV exporter** — Cell values starting with `=`, `+`, `-`, `@`, `\t`, or `\r` are now prefixed with a single quote to prevent formula injection when CSVs are opened in spreadsheet applications.

## Test plan

- [x] All 2514 default tests pass (`./run-tests.sh`)
- [x] Pickle safety tests pass (`test_pickle_safety.py`)
- [x] Multi-user security/access tests pass (`test_multi_user_security.py`, `test_multi_user_dataset_access.py`)
- [x] CSV/webhook exporter tests pass (`test_csv_webhook_exporters.py`, `test_exporters.py`)

https://claude.ai/code/session_01KCKiHGtMmBDXDSPQDy3WMU