### PR TITLE
Fix stale comment about conftest resetting _click_counter

### DIFF
--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -393,10 +393,12 @@ def _set_inclusion(value: int | None) -> None:
 
 # NOTE: These module-level variables are DEAD CODE.  All production code
 # uses the getter/setter helpers above (which delegate to the active
-# DatasetContext).  The conftest reset_state fixture resets per-dataset
-# scalars by creating a fresh context via clear_all_contexts().
-# These names are kept only to avoid import errors if any external code
-# references them; they are never read or written by VTSearch itself.
+# DatasetContext).  The conftest reset_state fixture does NOT reset these
+# module-level variables — nor does it need to, since they are never read
+# or written.  Conftest resets the *DatasetContext* fields (e.g.
+# DatasetContext.click_counter) by creating a fresh context via
+# clear_all_contexts().  These names are kept only to avoid import errors
+# if any external code references them.
 _click_counter: int = 0
 _dataset_display_name: str | None = None
 _diversity_tree: Any = None


### PR DESCRIPTION
## Summary
- Clarifies the comment near the dead module-level `_click_counter` variable in `state_core.py`
- The old comment implied conftest's `reset_state` resets these module-level variables; it doesn't — and doesn't need to
- Conftest resets the `DatasetContext` fields (e.g. `DatasetContext.click_counter`) via `clear_all_contexts()`, which is the correct mechanism

## Test plan
- [ ] Documentation-only change — no behavioral impact
- [ ] Verify `./run-tests.sh core` still passes

https://claude.ai/code/session_01Bh4odVPcL3DycpEGf9Sw2J