### PR TITLE
Use active dataset's media type as default in New Model dialog

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -180,6 +180,7 @@
 
 @if (newModelModalOpen) {
   <vt-new-model-modal
+    [defaultMediaType]="activeDatasetMediaType"
     (closed)="closeNewModelModal()"
     (created)="onModelCreated()"
   />

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -547,6 +547,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- New model modal ---
 
+  /** Media type of the currently active dataset (used as default for new models). */
+  get activeDatasetMediaType(): string {
+    const active = this.datasets.find((d) => d.active);
+    return active?.media_type || '';
+  }
+
   openNewModelModal(): void {
     this.newModelModalOpen = true;
   }

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -31,6 +31,9 @@ type ModalView = 'main' | 'media-picker';
   styleUrl: './new-model-modal.component.scss',
 })
 export class NewModelModalComponent implements OnInit {
+  /** Media type of the currently active dataset, if any. */
+  @Input() defaultMediaType = '';
+
   @Output() closed = new EventEmitter<void>();
   @Output() created = new EventEmitter<void>();
 
@@ -83,16 +86,22 @@ export class NewModelModalComponent implements OnInit {
         this.mediaTypes = this.mediaTypeInfos.map((t) => t.type_id || t.name);
       },
     });
-    this.datasetsApi.getRegistry().subscribe({
-      next: (res) => {
-        const types = new Set(
-          (res.datasets || []).map((d) => d['media_type'] as string).filter(Boolean),
-        );
-        if (types.size === 1) {
-          this.mediaType = [...types][0];
-        }
-      },
-    });
+
+    // Prefer the explicit default (active dataset's type) over the all-datasets guess.
+    if (this.defaultMediaType) {
+      this.mediaType = this.defaultMediaType;
+    } else {
+      this.datasetsApi.getRegistry().subscribe({
+        next: (res) => {
+          const types = new Set(
+            (res.datasets || []).map((d) => d['media_type'] as string).filter(Boolean),
+          );
+          if (types.size === 1) {
+            this.mediaType = [...types][0];
+          }
+        },
+      });
+    }
   }
 
   get hasExample(): boolean {


### PR DESCRIPTION
## Summary

- When opening the "New Model" dialog from the Dashboard, the media type dropdown now defaults to the **active dataset's** media type instead of requiring all loaded datasets to share a single type.
- Adds `activeDatasetMediaType` getter to the dashboard component and passes it as `[defaultMediaType]` input to the new model modal.
- Falls back to the previous all-datasets guess when no active dataset is present.

## Test plan

- [x] Frontend TypeScript build passes
- [x] Core test group passes (335 tests)
- [ ] Manual: Load two datasets with different media types (e.g., audio + images), select one, click "Add" for Models — verify the dropdown defaults to the selected dataset's type
- [ ] Manual: With no datasets loaded, verify the dropdown still defaults to "audio"

https://claude.ai/code/session_01VD8kNNisyyycwtfSmyYTEW