### PR TITLE
Replace emoji icons with inline SVGs in file browser

### DIFF
--- a/frontend/src/app/components/file-browser/file-browser.component.html
+++ b/frontend/src/app/components/file-browser/file-browser.component.html
@@ -41,20 +41,20 @@
         } @else {
           @if (currentPath) {
             <button class="file-browser-item file-browser-dir" (click)="goUp()">
-              <span class="file-browser-icon">&#x2B06;&#xFE0F;</span>
+              <span class="file-browser-icon"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 2l5 6H9v6H7V8H3z"/></svg></span>
               <span class="file-browser-name">..</span>
             </button>
           }
           @for (dir of directories; track dir.path) {
             <button class="file-browser-item file-browser-dir" (click)="enterDirectory(dir)">
-              <span class="file-browser-icon">&#x1F4C1;</span>
+              <span class="file-browser-icon"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M1 3h5l1.5 1.5H15v9.5H1V3zm1 1v8.5h12V5.5H7.1L5.6 4H2z"/></svg></span>
               <span class="file-browser-name">{{ dir.name }}</span>
               <span class="file-browser-date">{{ dir.modified_at }}</span>
             </button>
           }
           @for (file of files; track file.path) {
             <button class="file-browser-item file-browser-file" (click)="selectFile(file)">
-              <span class="file-browser-icon">&#x1F4C4;</span>
+              <span class="file-browser-icon"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M3 1h7l4 4v10H3V1zm1 1v12h9V5.5L9.5 2H4zm6 0v3.5h3.5"/></svg></span>
               <span class="file-browser-name">{{ file.name }}</span>
               <span class="file-browser-date">{{ file.modified_at }}</span>
               <span class="file-browser-size">{{ formatSize(file.size_bytes) }}</span>

--- a/frontend/src/app/components/file-browser/file-browser.component.scss
+++ b/frontend/src/app/components/file-browser/file-browser.component.scss
@@ -98,6 +98,13 @@
   flex-shrink: 0;
   width: 20px;
   text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    vertical-align: middle;
+  }
 }
 
 .file-browser-name {


### PR DESCRIPTION
## Summary
- Replaced Unicode emoji characters (📁, 📄, ⬆️) with inline SVG icons for folder, file, and navigate-up in the file browser component
- Emoji rendered as broken image boxes in environments without emoji font support; SVGs render reliably everywhere
- SVG icons inherit `currentColor` so they automatically match the theme's text color

## Test plan
- [x] Frontend TypeScript build passes
- [x] Core test group passes (335 tests)
- [ ] Visually verify file browser icons render correctly in the browser

https://claude.ai/code/session_011ex36xVkubd8p9N24gWC9b