### PR TITLE
Use selected dataset's media type as default in New Model modal

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -547,8 +547,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- New model modal ---
 
-  /** Media type of the currently active dataset (used as default for new models). */
+  /** Media type used as default for new models: single-selected dataset wins, then active dataset. */
   get activeDatasetMediaType(): string {
+    if (this.selectedDatasetIds.size === 1) {
+      const selId = [...this.selectedDatasetIds][0];
+      const sel = this.datasets.find((d) => d.id === selId);
+      if (sel?.media_type) return sel.media_type;
+    }
     const active = this.datasets.find((d) => d.active);
     return active?.media_type || '';
   }


### PR DESCRIPTION
## Summary
- When exactly one dataset is highlighted in the Datasets grid, its media type is now used as the default in the New Model dialog — even if a different dataset is currently active (loaded).
- Falls back to the active dataset's media type when zero or multiple datasets are selected.
- No backend changes; single-line getter update in `dashboard.component.ts`.

## Test plan
- [x] Frontend TypeScript build passes
- [x] Core test group passes (335 tests)
- [ ] Manual: load two datasets with different media types (e.g. audio + images), select only the images dataset in the grid, click "+ Add Model" → media type dropdown should default to "images"
- [ ] Manual: select both datasets (ctrl+click) → should fall back to the active dataset's type
- [ ] Manual: deselect all datasets → should fall back to the active dataset's type

https://claude.ai/code/session_01UMGtmo5dNzfYSTzF9AUBKq