### PR TITLE
Fix Find skipping cached model, causing unnecessary label resolution

### DIFF
--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -166,6 +166,19 @@ def find_label():
             weights = tm_data["weights"]
             threshold = tm_data.get("threshold", 0.5)
 
+    # Check the in-memory DetectorContext for a cached trained model.
+    # learned_sort() caches the MLP here after each sort, so if the user
+    # trained on Dataset A and then switched to Dataset B, the model is
+    # still available without expensive label-origin resolution.
+    if weights is None:
+        from vtsearch.routes.detectors_helpers import serialize_weights as _ser_weights
+        from vtsearch.utils.state_core import get_detector_context
+
+        det_ctx = get_detector_context(model_id)
+        if det_ctx is not None and det_ctx.model is not None:
+            weights = _ser_weights(det_ctx.model)
+            threshold = det_ctx.threshold
+
     # If still no weights, try training on-the-fly from the trainable model's
     # labelset.  This handles the cross-dataset scenario: user trains on
     # Dataset A (labels saved), loads Dataset B, runs Find.  The labelset's

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -219,23 +219,6 @@ def learned_sort():
             det_ctx.embedder = first.get("embedder", "")
             det_ctx.media_type = first.get("type", "")
 
-        # Persist trained weights into the trainable model file so they
-        # survive restarts and Find can skip expensive label resolution.
-        from vtsearch.models.registry import get_model as _get_model
-
-        _entry = _get_model(det_ctx.detector_id)
-        _tm_name = _entry.get("trainable_model_name", "") if _entry else ""
-        if _tm_name:
-            from vtsearch.routes.detectors_helpers import serialize_weights as _ser
-            from vtsearch.routes.trainable_models import _model_path, _read_model, _write_model
-
-            _tm_path = _model_path(_tm_name)
-            _tm_data = _read_model(_tm_path)
-            if _tm_data is not None:
-                _tm_data["weights"] = _ser(model)
-                _tm_data["threshold"] = round(threshold, 4)
-                _write_model(_tm_path, _tm_data)
-
     return jsonify({"results": results, "threshold": round(threshold, 4)})
 
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -219,6 +219,23 @@ def learned_sort():
             det_ctx.embedder = first.get("embedder", "")
             det_ctx.media_type = first.get("type", "")
 
+        # Persist trained weights into the trainable model file so they
+        # survive restarts and Find can skip expensive label resolution.
+        from vtsearch.models.registry import get_model as _get_model
+
+        _entry = _get_model(det_ctx.detector_id)
+        _tm_name = _entry.get("trainable_model_name", "") if _entry else ""
+        if _tm_name:
+            from vtsearch.routes.detectors_helpers import serialize_weights as _ser
+            from vtsearch.routes.trainable_models import _model_path, _read_model, _write_model
+
+            _tm_path = _model_path(_tm_name)
+            _tm_data = _read_model(_tm_path)
+            if _tm_data is not None:
+                _tm_data["weights"] = _ser(model)
+                _tm_data["threshold"] = round(threshold, 4)
+                _write_model(_tm_path, _tm_data)
+
     return jsonify({"results": results, "threshold": round(threshold, 4)})
 
 


### PR DESCRIPTION
## Summary
- **Check in-memory DetectorContext before label resolution** (`detectors_scoring.py`): `find_label()` now checks the `DetectorContext` for a cached trained model before falling back to expensive label-origin resolution. Since `learned_sort()` caches the MLP and threshold in the DetectorContext after each sort, this lets Find reuse the already-trained model when switching datasets — no re-resolving needed.

## Problem
When a detector is trained via `learned_sort()` on Dataset A, the MLP and threshold are cached in the DetectorContext. But `find_label()` never checked there — it only looked at:
1. `autorun_detectors` (weights=None for trainable models)
2. The trainable model file (stores labelset only, not weights)
3. Fallback: resolve all label origins, re-embed files, retrain MLP ← the slow path

This caused the unnecessary "Resolving 153 label origins..." wait every time Find was run, even though the trained model was already in memory.

## Test plan
- [x] `./run-tests.sh sorting models` — 720 tests pass
- [x] `./run-tests.sh` — full suite, 2550 tests pass

https://claude.ai/code/session_01Bu84EBYLP22MSW8QKxiCnn