### PR TITLE
Expose media_type in loading tasks for frontend type guessing

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -515,7 +515,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Importer modal ---
 
-  /** Guess the media type the user likely wants based on existing datasets/models. */
+  /** Guess the media type the user likely wants based on existing datasets, models, and in-progress loads. */
   get guessedMediaType(): string {
     const types = new Set<string>();
     for (const d of this.datasets) {
@@ -523,6 +523,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
     for (const m of this.models) {
       if (m.media_type) types.add(m.media_type);
+    }
+    for (const t of this.loadingTasks) {
+      if (t.media_type && !t.error) types.add(t.media_type);
     }
     return types.size === 1 ? [...types][0] : '';
   }
@@ -558,7 +561,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- New model modal ---
 
-  /** Media type used as default for new models: single-selected dataset wins, then active dataset. */
+  /** Media type used as default for new models: single-selected dataset wins, then active dataset, then in-progress loads. */
   get activeDatasetMediaType(): string {
     if (this.selectedDatasetIds.size === 1) {
       const selId = [...this.selectedDatasetIds][0];
@@ -566,7 +569,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
       if (sel?.media_type) return sel.media_type;
     }
     const active = this.datasets.find((d) => d.active);
-    return active?.media_type || '';
+    if (active?.media_type) return active.media_type;
+    // Fall back to in-progress loading tasks when no dataset is fully loaded yet.
+    const loadingTypes = new Set(
+      this.loadingTasks.filter((t) => t.media_type && !t.error).map((t) => t.media_type!),
+    );
+    return loadingTypes.size === 1 ? [...loadingTypes][0] : '';
   }
 
   openNewModelModal(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -165,6 +165,7 @@ export interface LoadingTask {
   created_at: number;
   dataset_id?: string;
   model_id?: string;
+  media_type?: string;
 }
 
 export interface LoadingTasksResponse {

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -113,6 +113,29 @@ class TestLoadingTasksTracker:
         tracker.reset_for_tests()
         assert tracker.list_tasks() == []
 
+    def test_media_type_in_task(self):
+        """Tasks created with media_type expose it in list_tasks output."""
+        tracker = LoadingTasksTracker()
+        tracker.create_task("t1", "Image DS", media_type="image")
+        tracker.create_task("t2", "Audio DS", media_type="audio")
+        tracker.create_task("t3", "No Type")
+
+        tasks = {t["task_id"]: t for t in tracker.list_tasks()}
+        assert tasks["t1"]["media_type"] == "image"
+        assert tasks["t2"]["media_type"] == "audio"
+        assert "media_type" not in tasks["t3"]
+
+    def test_media_type_in_finished_task(self):
+        """media_type is still visible on recently-finished tasks."""
+        tracker = LoadingTasksTracker()
+        pt = tracker.create_task("t1", "DS", media_type="image")
+        pt.update("idle", "Done")
+        tracker.mark_finished("t1")
+
+        tasks = tracker.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0]["media_type"] == "image"
+
 
 # ---------------------------------------------------------------------------
 # Thread-local progress tests
@@ -229,6 +252,33 @@ class TestLoadingTasksEndpoint:
             assert task["current"] == 25
         finally:
             loading_tasks.remove_task("api_test")
+
+
+class TestLoadingTasksMediaType:
+    """Test that /api/dataset/loading-tasks exposes media_type."""
+
+    def test_api_returns_media_type(self, client):
+        pt = loading_tasks.create_task("mt_test", "Image DS", media_type="image")
+        pt.update("loading", "Working", 10, 100)
+        try:
+            resp = client.get("/api/dataset/loading-tasks")
+            assert resp.status_code == 200
+            tasks = resp.get_json()["tasks"]
+            assert len(tasks) == 1
+            assert tasks[0]["media_type"] == "image"
+        finally:
+            loading_tasks.remove_task("mt_test")
+
+    def test_api_omits_empty_media_type(self, client):
+        pt = loading_tasks.create_task("mt_test2", "Unknown DS")
+        pt.update("loading", "Working", 10, 100)
+        try:
+            resp = client.get("/api/dataset/loading-tasks")
+            tasks = resp.get_json()["tasks"]
+            assert len(tasks) == 1
+            assert "media_type" not in tasks[0]
+        finally:
+            loading_tasks.remove_task("mt_test2")
 
 
 class TestCancelTaskEndpoint:

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -513,9 +513,23 @@ def load_demo_dataset_route():
     if importer is None:
         return jsonify({"error": "demo importer not available"}), 500
 
+    demo_info = DEMO_DATASETS[dataset_name]
     field_values: dict = {"name": dataset_name}
+    # Inject media_type so the loading task exposes it to the frontend,
+    # allowing the "guessed type" logic to consider in-progress loads.
     if converter_name:
+        # When a converter is used, the resulting dataset has the converter's
+        # target type, not the demo's original type.
+        from vtsearch.converters import get_converter  # noqa: PLC0415
+
+        conv = get_converter(converter_name)
+        if conv is not None:
+            field_values["media_type"] = conv.target_type
+        else:
+            field_values["media_type"] = demo_info.get("media_type", "")
         field_values["converter"] = converter_name
+    else:
+        field_values["media_type"] = demo_info.get("media_type", "")
     if clipper_name:
         field_values["clipper"] = clipper_name
     if embedder_name:
@@ -692,7 +706,9 @@ def load_registered_dataset(dataset_id: str):
 
     # Create a per-task tracker for this load operation.
     task_id = f"_regload_{dataset_id[:8]}"
-    tracker = _loading_tasks.create_task(task_id, entry.get("name", dataset_id), dataset_id=dataset_id)
+    tracker = _loading_tasks.create_task(
+        task_id, entry.get("name", dataset_id), dataset_id=dataset_id, media_type=entry.get("media_type", ""),
+    )
     tracker.update("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -198,6 +198,22 @@ def _origin_to_str(origin: dict | None) -> str:
     return importer_name
 
 
+def _normalize_media_type(value: str) -> str:
+    """Normalize a media type string (folder_import_name or type_id) to a canonical type_id."""
+    value = (value or "").strip()
+    if not value:
+        return ""
+    try:
+        from vtsearch.media import get_by_folder_name, normalize_type_id  # noqa: PLC0415
+
+        try:
+            return get_by_folder_name(value).type_id
+        except KeyError:
+            return normalize_type_id(value)
+    except Exception:
+        return value
+
+
 def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | None = None) -> None:
     """Apply a clipper to all medias in *clips_dict*, replacing them in-place."""
     if not clipper_name:
@@ -322,6 +338,7 @@ def _run_origin_load_in_background(
     clipper_params: dict | None = None,
     embedder: str = "",
     created_by: str = "",
+    media_type: str = "",
 ) -> str:
     """Run a dataset load in a background thread with standard error handling.
 
@@ -345,7 +362,7 @@ def _run_origin_load_in_background(
         dataset_progress.reset_cancel()
 
     task_id = f"_loading_{uuid4().hex[:8]}"
-    tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin))
+    tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin), media_type=media_type)
 
     # Set initial progress synchronously so the first poll sees it.
     tracker.update("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)
@@ -509,6 +526,10 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     field_values["clipper"] = clipper_name
     embedder_name = field_values.get("embedder", "")
 
+    # Extract media_type from field_values so in-progress tasks can expose it
+    # to the frontend (used for guessing the type in subsequent add dialogs).
+    media_type_hint = _normalize_media_type(field_values.get("media_type", ""))
+
     def _load(target_medias):
         importer.run(field_values, target_medias)
 
@@ -520,6 +541,7 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
         clipper_params=clipper_params,
         embedder=embedder_name,
         created_by=created_by,
+        media_type=media_type_hint,
     )
 
 

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -153,7 +153,9 @@ class LoadingTasksTracker:
         self._lock = threading.Lock()
         self._tasks: dict[str, dict[str, Any]] = {}
 
-    def create_task(self, task_id: str, name: str = "", dataset_id: str = "") -> ProgressTracker:
+    def create_task(
+        self, task_id: str, name: str = "", dataset_id: str = "", media_type: str = "",
+    ) -> ProgressTracker:
         """Create and register a new loading task.
 
         Returns the per-task :class:`ProgressTracker` instance.
@@ -168,6 +170,7 @@ class LoadingTasksTracker:
                 "created_at": time.time(),
                 "finished_at": None,
                 "dataset_id": dataset_id,
+                "media_type": media_type,
             }
         return tracker
 
@@ -233,6 +236,8 @@ class LoadingTasksTracker:
                 snapshot["created_at"] = entry["created_at"]
                 if entry.get("dataset_id"):
                     snapshot["dataset_id"] = entry["dataset_id"]
+                if entry.get("media_type"):
+                    snapshot["media_type"] = entry["media_type"]
                 result.append(snapshot)
             else:
                 snapshot = entry["tracker"].get()
@@ -241,6 +246,8 @@ class LoadingTasksTracker:
                 snapshot["created_at"] = entry["created_at"]
                 if entry.get("dataset_id"):
                     snapshot["dataset_id"] = entry["dataset_id"]
+                if entry.get("media_type"):
+                    snapshot["media_type"] = entry["media_type"]
                 result.append(snapshot)
         if stale:
             with self._lock:


### PR DESCRIPTION
## Summary
This PR adds support for exposing `media_type` information in loading tasks, allowing the frontend to make better guesses about the user's intended media type when creating new datasets or models, even while datasets are still loading.

## Key Changes

- **Backend Progress Tracking**: Extended `LoadingTasksTracker.create_task()` to accept and store an optional `media_type` parameter, which is included in task snapshots returned by `list_tasks()`.

- **Dataset Loading**: Updated dataset loading endpoints to pass `media_type` information when creating loading tasks:
  - Demo dataset loads now extract media type from demo info or converter target type
  - Registered dataset loads include media type from the dataset entry
  - Importer-based loads normalize and pass media type hints from field values

- **Media Type Normalization**: Added `_normalize_media_type()` utility to convert folder import names or type IDs to canonical type IDs, with graceful fallback for unknown values.

- **Frontend Type Guessing**: Enhanced the dashboard component's media type guessing logic to consider in-progress loading tasks:
  - `guessedMediaType` now includes media types from non-errored loading tasks
  - `activeDatasetMediaType` falls back to in-progress loads when no dataset is fully loaded yet

- **API Model**: Updated `LoadingTask` interface to include optional `media_type` field.

- **Tests**: Added comprehensive test coverage for media type handling in both tracker and API endpoints.

## Implementation Details

- Media type is only included in task snapshots when explicitly set (not included for tasks without a media type)
- The frontend filters out loading tasks with errors when considering media type hints
- Converter target types take precedence over demo dataset types when a converter is applied
- The normalization function gracefully handles missing vtsearch.media module imports

https://claude.ai/code/session_011b6F74V7dmjJHtqFUTUKun