### PR TITLE
Add label import directly into trainable models

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -124,6 +124,7 @@
                 (load)="loadModel(model)"
                 (unload)="unloadModel(model)"
                 (export)="openExportModal(model)"
+                (addLabels)="openAddLabelsModal(model)"
                 (autorunToggle)="toggleAutorun(model, $event)"
                 (cancelTask)="cancelModelLoadingTask($event)"
                 (dismissTask)="dismissModelLoadingTask($event)"
@@ -195,6 +196,14 @@
     [detectorName]="exportModelName"
     (closed)="closeExportModal()"
     (exported)="closeExportModal()"
+  />
+}
+
+@if (addLabelsModalOpen) {
+  <vt-label-importer-modal
+    [targetModelName]="addLabelsModelName"
+    (closed)="closeAddLabelsModal()"
+    (imported)="onAddLabelsImported()"
   />
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -19,6 +19,7 @@ import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
 import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
 import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
+import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 import { IconComponent } from '../icon/icon.component';
 
 @Component({
@@ -33,6 +34,7 @@ import { IconComponent } from '../icon/icon.component';
     DatasetImporterModalComponent,
     NewModelModalComponent,
     DetectorExportModalComponent,
+    LabelImporterModalComponent,
     IconComponent,
   ],
   templateUrl: './dashboard.component.html',
@@ -53,6 +55,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   newModelModalOpen = false;
   exportModalOpen = false;
   exportModelName = '';
+  addLabelsModalOpen = false;
+  addLabelsModelName = '';
   findResultsOpen = false;
   findResultsData: AutoDetectResultsData = { results: {} };
 
@@ -511,6 +515,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
   closeExportModal(): void {
     this.exportModalOpen = false;
     this.exportModelName = '';
+  }
+
+  // --- Add Labels modal ---
+
+  openAddLabelsModal(model: ModelRegistryEntry): void {
+    this.addLabelsModelName = model.trainable_model_name || model.name;
+    this.addLabelsModalOpen = true;
+  }
+
+  closeAddLabelsModal(): void {
+    this.addLabelsModalOpen = false;
+    this.addLabelsModelName = '';
+  }
+
+  onAddLabelsImported(): void {
+    this.datasetState.refresh();
   }
 
   // --- Importer modal ---

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -520,7 +520,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   // --- Add Labels modal ---
 
   openAddLabelsModal(model: ModelRegistryEntry): void {
-    this.addLabelsModelName = model.trainable_model_name || model.name;
+    this.addLabelsModelName = (model['trainable_model_name'] as string) || model.name;
     this.addLabelsModalOpen = true;
   }
 

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -99,6 +99,9 @@
       <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
     </svg>
   </button>
+  <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
+  </button>
   <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="15 14 20 9 15 4"></polyline>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -93,6 +93,24 @@ td {
   font-size: 0.75rem;
 }
 
+.add-labels-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
 .export-btn {
   background: none;
   border: none;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -30,6 +30,7 @@ export class ModelCardComponent {
   @Output() rename = new EventEmitter<string>();
   @Output() delete = new EventEmitter<void>();
   @Output() export = new EventEmitter<void>();
+  @Output() addLabels = new EventEmitter<void>();
   @Output() load = new EventEmitter<void>();
   @Output() unload = new EventEmitter<void>();
   @Output() cancelTask = new EventEmitter<string>();
@@ -76,6 +77,11 @@ export class ModelCardComponent {
   onDelete(event: MouseEvent): void {
     event.stopPropagation();
     this.delete.emit();
+  }
+
+  onAddLabels(event: MouseEvent): void {
+    event.stopPropagation();
+    this.addLabels.emit();
   }
 
   onExport(event: MouseEvent): void {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -17,6 +17,7 @@
       }
     </div>
 
+    @if (!targetModelName) {
     <div class="add-media-section">
       <p class="add-media-heading">Add media directly</p>
       <div class="add-media-buttons">
@@ -50,6 +51,7 @@
         </button>
       </div>
     </div>
+    }
 
     @if (error) {
       <p class="error-text">{{ error }}</p>

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -29,6 +29,10 @@ type ModalView = 'picker' | 'form';
   styleUrl: './label-importer-modal.component.scss',
 })
 export class LabelImporterModalComponent implements OnInit {
+  /** When set, labels are imported directly into this trainable model
+   *  instead of into the active dataset's vote state. */
+  @Input() targetModelName: string | null = null;
+
   @Output() closed = new EventEmitter<void>();
   @Output() imported = new EventEmitter<void>();
 
@@ -62,7 +66,7 @@ export class LabelImporterModalComponent implements OnInit {
     if (this.view === 'form' && this.selectedImporter) {
       return this.selectedImporter.display_name || this.selectedImporter.name;
     }
-    return 'Import Labels';
+    return this.targetModelName ? 'Add Labels to Model' : 'Import Labels';
   }
 
   ngOnInit(): void {
@@ -115,12 +119,22 @@ export class LabelImporterModalComponent implements OnInit {
     this.error = '';
     this.successMessage = '';
 
-    this.labelImportersApi.runImport(
-      this.selectedImporter.name,
-      this.formValues,
-      this.selectedFile ?? undefined,
-      this.selectedFileFieldKey ?? undefined,
-    ).subscribe({
+    const request$ = this.targetModelName
+      ? this.labelImportersApi.runModelImport(
+          this.targetModelName,
+          this.selectedImporter.name,
+          this.formValues,
+          this.selectedFile ?? undefined,
+          this.selectedFileFieldKey ?? undefined,
+        )
+      : this.labelImportersApi.runImport(
+          this.selectedImporter.name,
+          this.formValues,
+          this.selectedFile ?? undefined,
+          this.selectedFileFieldKey ?? undefined,
+        );
+
+    request$.subscribe({
       next: (res: any) => {
         this.submitting = false;
         this.successMessage = res.message || `Applied ${res.applied ?? 0} labels`;

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -25,6 +25,27 @@ export class LabelImportersApiService {
     return this.http.post(`/api/label-importers/import/${importerName}`, params);
   }
 
+  runModelImport(
+    modelName: string,
+    importerName: string,
+    params: Record<string, unknown>,
+    file?: File,
+    fileFieldKey?: string,
+  ): Observable<unknown> {
+    const url = `/api/trainable-models/${encodeURIComponent(modelName)}/import-labels/${importerName}`;
+    if (file && fileFieldKey) {
+      const formData = new FormData();
+      formData.append(fileFieldKey, file, file.name);
+      for (const [key, value] of Object.entries(params)) {
+        if (key !== fileFieldKey) {
+          formData.append(key, String(value ?? ''));
+        }
+      }
+      return this.http.post(url, formData);
+    }
+    return this.http.post(url, params);
+  }
+
   ingestMissing(entries: unknown[]): Observable<unknown> {
     return this.http.post('/api/label-importers/ingest-missing', { entries });
   }

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -565,6 +565,103 @@ def save_trainable_model_labels(name: str):
 
 
 # ---------------------------------------------------------------------------
+# POST /api/trainable-models/<name>/import-labels/<importer_name>
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route(
+    "/api/trainable-models/<name>/import-labels/<importer_name>",
+    methods=["POST"],
+)
+def import_labels_into_model(name: str, importer_name: str):
+    """Run a label importer and merge results into this model's labelset.
+
+    Unlike the regular ``/api/label-importers/import/`` route, this does
+    **not** require a dataset to be loaded.  The imported label entries are
+    merged directly into the trainable model's persisted labelset, and the
+    model-registry entry is updated so the dashboard reflects the new count.
+
+    Returns JSON with ``applied``, ``skipped``, ``num_labels``, and
+    ``message`` keys.
+    """
+    path = _model_path(name)
+    data = _read_model(path)
+    if data is None:
+        return jsonify({"error": f"Trainable model '{name}' not found"}), 404
+
+    from vtsearch.labels.importers import get_label_importer, list_label_importers
+    from vtsearch.routes.helpers import extract_plugin_fields, run_plugin_or_error, validate_filepath_field, validate_required_fields
+
+    importer = get_label_importer(importer_name)
+    if importer is None:
+        known = [imp.name for imp in list_label_importers()]
+        return (
+            jsonify({"error": f"Unknown label importer '{importer_name}'. Available: {known}"}),
+            404,
+        )
+
+    field_values = extract_plugin_fields(importer)
+    err = validate_required_fields(importer, field_values)
+    if err:
+        return err
+    err = validate_filepath_field(field_values)
+    if err:
+        return err
+
+    label_entries, err = run_plugin_or_error(importer, "run", field_values)
+    if err:
+        return err
+    if not isinstance(label_entries, list):
+        return jsonify({"error": "Importer did not return a list of label dicts."}), 500
+
+    # Load the model's existing labelset
+    from vtsearch.datasets.labelset import LabeledElement, LabelSet
+
+    existing_ls = LabelSet.from_dict(data.get("labelset") or {})
+
+    # Build a set of existing (md5, label) pairs for dedup
+    existing_keys: set[tuple[str, str]] = set()
+    for el in existing_ls.elements:
+        if el.md5:
+            existing_keys.add((el.md5, el.label))
+
+    applied = 0
+    skipped = 0
+    for entry in label_entries:
+        label = entry.get("label", "")
+        if label not in ("good", "bad"):
+            skipped += 1
+            continue
+        md5 = entry.get("md5", "")
+        if md5 and (md5, label) in existing_keys:
+            skipped += 1
+            continue
+        elem = LabeledElement.from_dict(entry)
+        existing_ls.elements.append(elem)
+        if md5:
+            existing_keys.add((md5, label))
+        applied += 1
+
+    data["labelset"] = existing_ls.to_dict()
+    _write_model(path, data)
+
+    # Update the model registry entry
+    from vtsearch.models.registry import find_by_trainable_model_name, update_model
+
+    reg_entry = find_by_trainable_model_name(name)
+    if reg_entry:
+        update_model(reg_entry["id"], num_training=len(existing_ls), last_trained_at=time.time())
+
+    msg = f"Added {applied} label(s) to model '{name}', skipped {skipped}."
+    return jsonify({
+        "applied": applied,
+        "skipped": skipped,
+        "num_labels": len(existing_ls),
+        "message": msg,
+    })
+
+
+# ---------------------------------------------------------------------------
 # Model registry endpoints
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -916,8 +916,6 @@ def load_model_route():
     from vtsearch.utils import (
         DetectorContext,
         bad_votes,
-        clear_votes,
-        get_active_detector_id,
         get_detector_context,
         good_votes,
         register_detector_context,
@@ -1028,7 +1026,6 @@ def unload_model_route(model_id: str):
         bad_votes,
         get_active_detector_id,
         good_votes,
-        set_active_detector_id,
         unregister_detector_context,
     )
 

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -581,6 +581,11 @@ def import_labels_into_model(name: str, importer_name: str):
     merged directly into the trainable model's persisted labelset, and the
     model-registry entry is updated so the dashboard reflects the new count.
 
+    When the model's detector context **is** loaded, the new labels are also
+    resolved against the loaded dataset's medias, applied to the detector's
+    votes, and a fresh MLP is trained with a cross-validated threshold — all
+    inside the loaded detector context.
+
     Returns JSON with ``applied``, ``skipped``, ``num_labels``, and
     ``message`` keys.
     """
@@ -614,7 +619,9 @@ def import_labels_into_model(name: str, importer_name: str):
     if not isinstance(label_entries, list):
         return jsonify({"error": "Importer did not return a list of label dicts."}), 500
 
-    # Load the model's existing labelset
+    # ------------------------------------------------------------------
+    # 1) Merge into the persisted labelset (always, whether loaded or not)
+    # ------------------------------------------------------------------
     from vtsearch.datasets.labelset import LabeledElement, LabelSet
 
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
@@ -627,6 +634,7 @@ def import_labels_into_model(name: str, importer_name: str):
 
     applied = 0
     skipped = 0
+    new_entries: list[dict] = []
     for entry in label_entries:
         label = entry.get("label", "")
         if label not in ("good", "bad"):
@@ -638,6 +646,7 @@ def import_labels_into_model(name: str, importer_name: str):
             continue
         elem = LabeledElement.from_dict(entry)
         existing_ls.elements.append(elem)
+        new_entries.append(entry)
         if md5:
             existing_keys.add((md5, label))
         applied += 1
@@ -652,13 +661,129 @@ def import_labels_into_model(name: str, importer_name: str):
     if reg_entry:
         update_model(reg_entry["id"], num_training=len(existing_ls), last_trained_at=time.time())
 
+    # ------------------------------------------------------------------
+    # 2) If the detector is loaded, resolve + apply + retrain in context
+    # ------------------------------------------------------------------
+    resolved = 0
+    trained = False
+    if applied > 0 and reg_entry:
+        from vtsearch.utils.state_core import get_detector_context
+
+        det_ctx = get_detector_context(reg_entry["id"])
+        if det_ctx is not None:
+            resolved, trained = _apply_and_retrain(
+                reg_entry["id"], det_ctx, new_entries, name,
+            )
+
     msg = f"Added {applied} label(s) to model '{name}', skipped {skipped}."
+    if resolved > 0:
+        msg += f" Resolved {resolved} into the loaded detector."
+    if trained:
+        msg += " Retrained MLP."
     return jsonify({
         "applied": applied,
         "skipped": skipped,
+        "resolved": resolved,
+        "trained": trained,
         "num_labels": len(existing_ls),
         "message": msg,
     })
+
+
+def _apply_and_retrain(
+    model_id: str,
+    det_ctx: object,
+    new_entries: list[dict],
+    tm_name: str,
+) -> tuple[int, bool]:
+    """Resolve new label entries into a loaded detector and retrain its MLP.
+
+    Temporarily switches the active detector context to *model_id*, resolves
+    the entries against the loaded dataset's medias, applies matching labels,
+    retrains the MLP with cross-validated threshold, then restores the
+    previously active context.
+
+    Returns ``(resolved_count, trained_bool)``.
+    """
+    from vtsearch.utils import (
+        apply_label,
+        build_media_lookup,
+        resolve_media_ids,
+        snapshot_medias,
+    )
+    from vtsearch.utils.state_core import (
+        get_active_detector_id,
+        set_active_detector_id,
+    )
+
+    # Save the current active context so we can restore it afterwards.
+    prev_active_id = get_active_detector_id()
+
+    try:
+        set_active_detector_id(model_id)
+
+        snap = snapshot_medias()
+        if not snap:
+            return 0, False
+
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+
+        resolved = 0
+        for entry in new_entries:
+            label = entry.get("label", "")
+            if label not in ("good", "bad"):
+                continue
+            cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
+            for cid in cids:
+                apply_label(cid, label)
+            if cids:
+                resolved += 1
+
+        # Persist the updated votes back to the trainable-model file so the
+        # labelset reflects any newly-resolved medias.
+        sync_labels_to_loaded_model()
+
+        # Retrain MLP if we have at least one good and one bad vote.
+        from vtsearch.utils import bad_votes, good_votes
+
+        trained = False
+        if good_votes and bad_votes:
+            from vtsearch.models.training import train_and_score
+            from vtsearch.utils import (
+                get_calibrate_count,
+                get_calibration_fraction,
+                get_inclusion,
+                get_safe_thresholds,
+            )
+
+            _, threshold, model = train_and_score(
+                snap,
+                dict(good_votes),
+                dict(bad_votes),
+                get_inclusion(),
+                safe_thresholds=get_safe_thresholds(),
+                calibrate_count=get_calibrate_count(),
+                calibration_fraction=get_calibration_fraction(),
+            )
+            if model is not None:
+                det_ctx.model = model
+                det_ctx.threshold = threshold
+                # Cache voted media items with embeddings.
+                training = {}
+                for cid in list(good_votes) + list(bad_votes):
+                    if cid in snap:
+                        training[cid] = snap[cid]
+                det_ctx.training_medias = training
+                if snap:
+                    first = next(iter(snap.values()), {})
+                    det_ctx.embedder = first.get("embedder", "")
+                    det_ctx.media_type = first.get("type", "")
+                trained = True
+
+        return resolved, trained
+
+    finally:
+        set_active_detector_id(prev_active_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds the ability to import labels directly into trainable models without requiring a dataset to be loaded. A new API endpoint allows merging imported label entries into a model's persisted labelset, with automatic MLP retraining if the detector context is active.

## Key Changes

**Backend (Python)**
- Added `POST /api/trainable-models/<name>/import-labels/<importer_name>` endpoint to import labels directly into a trainable model's labelset
- Implemented `_apply_and_retrain()` helper function that:
  - Temporarily switches the active detector context to the target model
  - Resolves imported label entries against loaded dataset medias
  - Applies matching labels to the detector's votes
  - Retrains the MLP with cross-validated threshold if sufficient good/bad votes exist
  - Restores the previously active detector context
- Updated model registry entry with new label count and training timestamp
- Returns detailed response with `applied`, `skipped`, `resolved`, `trained`, and `num_labels` fields

**Frontend (Angular)**
- Added `targetModelName` input to `LabelImporterModalComponent` to support model-specific imports
- Added `runModelImport()` method to `LabelImportersApiService` for the new endpoint
- Updated modal title to "Add Labels to Model" when importing into a specific model
- Added "Add Labels" button to model cards with associated styling
- Integrated label import modal into dashboard with proper event handling
- Hides the "Add media directly" section when importing into a model (since no dataset is loaded)

## Implementation Details
- Label deduplication is performed using (md5, label) pairs to prevent duplicate entries
- The import process works whether or not the detector context is loaded:
  - Always persists to the trainable model's labelset file
  - Optionally applies and retrains if the detector is currently active
- Context switching ensures the correct detector is active during label resolution and retraining
- Unused imports (`clear_votes`, `set_active_detector_id`) were removed from existing code

https://claude.ai/code/session_01VXKjEQu7RD6LTYoeLrA3bu