### PR TITLE
Refactor settings and plugin discovery into reusable factories

### DIFF
--- a/vtsearch/converters/__init__.py
+++ b/vtsearch/converters/__init__.py
@@ -4,12 +4,8 @@ A :class:`~vtsearch.converters.base.MediaConverter` takes a single media dict
 of one :class:`~vtsearch.media.base.MediaType` and returns one or more media
 dicts of a *different* media type.
 
-Built-in converters
--------------------
-* :class:`Document2ImageMediaConverter` — render document pages as images.
-* :class:`Document2TextMediaConverter` — extract embedded text from documents.
-* :class:`Video2AudioMediaConverter` — extract the audio track from a video.
-* :class:`Video2ImageMediaConverter` — sample frames from a video as images.
+Built-in converters are auto-discovered via the ``CONVERTER`` sentinel
+attribute, just like exporters and importers.
 """
 
 from vtsearch.converters.base import MediaConverter
@@ -17,40 +13,38 @@ from vtsearch.converters.document2image import Document2ImageMediaConverter
 from vtsearch.converters.document2text import Document2TextMediaConverter
 from vtsearch.converters.video2audio import Video2AudioMediaConverter
 from vtsearch.converters.video2image import Video2ImageMediaConverter
+from vtsearch.utils.registry import PluginRegistry
 
 # ---------------------------------------------------------------------------
-# Converter registry
+# Converter registry (auto-discovered via CONVERTER sentinel)
 # ---------------------------------------------------------------------------
 
-_ALL_CONVERTERS: list[MediaConverter] = [
-    Document2ImageMediaConverter(),
-    Document2TextMediaConverter(),
-    Video2AudioMediaConverter(),
-    Video2ImageMediaConverter(),
-]
+_registry: PluginRegistry[MediaConverter] = PluginRegistry(
+    package="vtsearch.converters",
+    sentinel="CONVERTER",
+    label="media converter",
+    discover_modules=True,
+)
 
 
 def list_converters() -> list[MediaConverter]:
     """Return all registered converters."""
-    return list(_ALL_CONVERTERS)
+    return _registry.list()
 
 
 def get_converter(name: str) -> MediaConverter | None:
     """Return the converter with *name*, or ``None``."""
-    for c in _ALL_CONVERTERS:
-        if c.name == name:
-            return c
-    return None
+    return _registry.get(name)
 
 
 def list_converters_for_target(target_type: str) -> list[MediaConverter]:
     """Return converters that produce *target_type* (a ``type_id``)."""
-    return [c for c in _ALL_CONVERTERS if c.target_type == target_type]
+    return [c for c in _registry.list() if c.target_type == target_type]
 
 
 def list_converters_for_source(source_type: str) -> list[MediaConverter]:
     """Return converters that consume *source_type* (a ``type_id``)."""
-    return [c for c in _ALL_CONVERTERS if c.source_type == source_type]
+    return [c for c in _registry.list() if c.source_type == source_type]
 
 
 __all__ = [

--- a/vtsearch/converters/document2image.py
+++ b/vtsearch/converters/document2image.py
@@ -93,3 +93,6 @@ class Document2ImageMediaConverter(MediaConverter):
             doc.close()
 
         return results
+
+
+CONVERTER = Document2ImageMediaConverter()

--- a/vtsearch/converters/document2text.py
+++ b/vtsearch/converters/document2text.py
@@ -82,3 +82,6 @@ class Document2TextMediaConverter(MediaConverter):
             "word_count": len(full_text.split()),
             "character_count": len(full_text),
         }]
+
+
+CONVERTER = Document2TextMediaConverter()

--- a/vtsearch/converters/video2audio.py
+++ b/vtsearch/converters/video2audio.py
@@ -98,3 +98,6 @@ class Video2AudioMediaConverter(MediaConverter):
             "media_bytes": wav_bytes,
             "duration": duration,
         }]
+
+
+CONVERTER = Video2AudioMediaConverter()

--- a/vtsearch/converters/video2image.py
+++ b/vtsearch/converters/video2image.py
@@ -111,3 +111,6 @@ class Video2ImageMediaConverter(MediaConverter):
                 os.unlink(tmp_file.name)
 
         return results
+
+
+CONVERTER = Video2ImageMediaConverter()

--- a/vtsearch/datasets/sources/__init__.py
+++ b/vtsearch/datasets/sources/__init__.py
@@ -10,6 +10,9 @@ Use :func:`get_source_for_origin` to instantiate the right source for a
 given origin dict.  Sources are **stateful** (e.g. an archive source may
 download and extract on first access), so each call returns a fresh
 instance — callers should call :meth:`~MediaSource.cleanup` when done.
+
+Source factories are auto-discovered via the ``SOURCE`` sentinel attribute,
+just like exporters and importers.
 """
 
 from __future__ import annotations
@@ -17,8 +20,16 @@ from __future__ import annotations
 from typing import Any
 
 from vtsearch.datasets.sources.base import MediaItem, MediaSource
+from vtsearch.utils.registry import PluginRegistry
 
 __all__ = ["MediaItem", "MediaSource", "get_source_for_origin"]
+
+_registry: PluginRegistry = PluginRegistry(
+    package="vtsearch.datasets.sources",
+    sentinel="SOURCE",
+    label="media source",
+    discover_modules=True,
+)
 
 
 def get_source_for_origin(origin: dict[str, Any] | None) -> MediaSource | None:
@@ -31,20 +42,7 @@ def get_source_for_origin(origin: dict[str, Any] | None) -> MediaSource | None:
         return None
 
     importer = origin.get("importer", "")
-    params = origin.get("params", {})
-
-    if importer == "folder":
-        path = params.get("path", "")
-        if path:
-            from vtsearch.datasets.sources.local_folder import LocalFolderSource
-
-            return LocalFolderSource(path)
-
-    if importer == "http_archive":
-        url = params.get("url", "")
-        if url:
-            from vtsearch.datasets.sources.http_archive import HttpArchiveSource
-
-            return HttpArchiveSource(url)
-
+    factory = _registry.get(importer)
+    if factory is not None:
+        return factory.create_from_origin(origin)
     return None

--- a/vtsearch/datasets/sources/http_archive.py
+++ b/vtsearch/datasets/sources/http_archive.py
@@ -127,3 +127,17 @@ class HttpArchiveSource(MediaSource):
                 shutil.rmtree(self._extract_dir, ignore_errors=True)
         self._extract_dir = None
         self._inner = None
+
+
+class _HttpArchiveSourceFactory:
+    """Factory for auto-discovery by :class:`~vtsearch.utils.registry.PluginRegistry`."""
+
+    name = "http_archive"
+
+    def create_from_origin(self, origin: dict) -> HttpArchiveSource | None:
+        params = origin.get("params", {})
+        url = params.get("url", "")
+        return HttpArchiveSource(url) if url else None
+
+
+SOURCE = _HttpArchiveSourceFactory()

--- a/vtsearch/datasets/sources/local_folder.py
+++ b/vtsearch/datasets/sources/local_folder.py
@@ -77,3 +77,17 @@ class LocalFolderSource(MediaSource):
                 if result is not None:
                     return result
         return None
+
+
+class _LocalFolderSourceFactory:
+    """Factory for auto-discovery by :class:`~vtsearch.utils.registry.PluginRegistry`."""
+
+    name = "folder"
+
+    def create_from_origin(self, origin: dict) -> LocalFolderSource | None:
+        params = origin.get("params", {})
+        path = params.get("path", "")
+        return LocalFolderSource(path) if path else None
+
+
+SOURCE = _LocalFolderSourceFactory()

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -8,12 +8,18 @@ embeddings for training.  This module handles that resolution:
 2. Embed the file using the appropriate embedder for the media type.
 3. Return resolved embeddings with availability stats.
 
-File resolution is **not** hardcoded to specific importers.  Instead,
-:func:`resolve_file_from_origin` looks up the importer by name from the
-auto-discovered registry and calls its
-:meth:`~vtsearch.datasets.importers.base.DatasetImporter.resolve_file` method.
-Adding a new ``DatasetImporter`` with a ``resolve_file`` override automatically
-extends the resolution capability — no changes to this module required.
+File resolution uses a pluggable :class:`FileResolver` protocol.  Two
+resolver implementations are auto-wired on first use:
+
+- **Source resolver** — delegates to
+  :func:`~vtsearch.datasets.sources.get_source_for_origin` and calls
+  :meth:`~MediaSource.resolve_path`.
+- **Importer resolver** — delegates to
+  :func:`~vtsearch.datasets.importers.get_importer` and calls
+  :meth:`~DatasetImporter.resolve_file`.
+
+External code can replace or extend these via
+:func:`register_source_resolver` and :func:`register_importer_resolver`.
 
 Two synthetic origin types (``dupe_set`` and ``converter``) are handled inline
 because they are not importers in the registry — they delegate to real
@@ -25,11 +31,111 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# FileResolver protocol — the contract for pluggable file resolution
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FileResolver(Protocol):
+    """Callable that resolves a media file from origin metadata.
+
+    Implementations receive the origin dict, origin_name, and filename,
+    and return a :class:`~pathlib.Path` to the resolved file on disk
+    (or ``None`` if resolution fails).
+    """
+
+    def __call__(
+        self,
+        origin: dict[str, Any],
+        origin_name: str,
+        filename: str,
+    ) -> Path | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Pluggable resolver registry
+# ---------------------------------------------------------------------------
+
+_source_resolver: FileResolver | None = None
+_importer_resolver: FileResolver | None = None
+_auto_wired = False
+
+
+def register_source_resolver(fn: FileResolver) -> None:
+    """Register a source-based file resolver.
+
+    The resolver is called with ``(origin, origin_name, filename)`` and
+    should return a :class:`~pathlib.Path` or ``None``.
+    """
+    global _source_resolver
+    _source_resolver = fn
+
+
+def register_importer_resolver(fn: FileResolver) -> None:
+    """Register an importer-based file resolver.
+
+    The resolver is called with ``(origin, origin_name, filename)`` and
+    should return a :class:`~pathlib.Path` or ``None``.
+    """
+    global _importer_resolver
+    _importer_resolver = fn
+
+
+def _auto_wire_resolvers() -> None:
+    """Auto-wire the default resolvers on first use.
+
+    Imports the datasets source and importer packages lazily and registers
+    them as the default resolvers.  This avoids hard-coding cross-package
+    imports throughout :func:`resolve_file_from_origin` while still
+    providing zero-config behaviour.
+    """
+    global _auto_wired
+    if _auto_wired:
+        return
+    _auto_wired = True
+
+    # Source-based resolver
+    if _source_resolver is None:
+        try:
+            from vtsearch.datasets.sources import get_source_for_origin
+
+            def _default_source_resolver(
+                origin: dict[str, Any], origin_name: str, filename: str,
+            ) -> Path | None:
+                source = get_source_for_origin(origin)
+                if source is not None:
+                    return source.resolve_path(origin_name, filename)
+                return None
+
+            register_source_resolver(_default_source_resolver)
+        except ImportError:
+            pass
+
+    # Importer-based resolver
+    if _importer_resolver is None:
+        try:
+            from vtsearch.datasets.importers import get_importer
+
+            def _default_importer_resolver(
+                origin: dict[str, Any], origin_name: str, filename: str,
+            ) -> Path | None:
+                importer_name = origin.get("importer", "")
+                importer = get_importer(importer_name)
+                if importer is not None:
+                    return importer.resolve_file(origin, origin_name, filename)
+                return None
+
+            register_importer_resolver(_default_importer_resolver)
+        except ImportError:
+            pass
 
 
 @dataclass
@@ -99,36 +205,32 @@ def resolve_file_from_origin(
 
     # -- Source-based dispatch (preferred) --
 
-    from vtsearch.datasets.sources import get_source_for_origin
+    _auto_wire_resolvers()
 
-    source = get_source_for_origin(origin)
-    if source is not None:
-        result = source.resolve_path(origin_name, filename)
+    if _source_resolver is not None:
+        result = _source_resolver(origin, origin_name, filename)
         if result is not None:
             log.debug("resolve_file: source-based dispatch succeeded → %s", result)
             return result
         log.debug(
-            "resolve_file: source %s returned None for origin_name=%r, filename=%r",
-            type(source).__name__, origin_name, filename,
+            "resolve_file: source resolver returned None for origin_name=%r, filename=%r",
+            origin_name, filename,
         )
 
     # -- Registry-based dispatch (fallback for importers without a source) --
 
-    from vtsearch.datasets.importers import get_importer
-
-    importer = get_importer(importer_name)
-    if importer is not None:
-        result = importer.resolve_file(origin, origin_name, filename)
+    if _importer_resolver is not None:
+        result = _importer_resolver(origin, origin_name, filename)
         if result is not None:
-            log.debug("resolve_file: registry dispatch (%s) succeeded → %s", importer_name, result)
+            log.debug("resolve_file: importer dispatch (%s) succeeded → %s", importer_name, result)
             return result
         log.debug(
-            "resolve_file: %s.resolve_file() returned None "
-            "(origin_name=%r, filename=%r, params=%r)",
-            type(importer).__name__, origin_name, filename, params,
+            "resolve_file: importer resolver returned None "
+            "(importer=%r, origin_name=%r, filename=%r, params=%r)",
+            importer_name, origin_name, filename, params,
         )
     else:
-        log.debug("resolve_file: no importer registered for %r", importer_name)
+        log.debug("resolve_file: no importer resolver registered")
 
     # -- Generic fallback for unregistered origins with a path param --
     # Handles synthetic origins like "pdf" that store a direct file path.

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -253,7 +253,7 @@ del _key, _cast, _coerce, _g, _s
 
 
 # -------------------------------------------------------------------
-# Per-media-type view mode settings
+# Per-media-type per-side settings factory
 # -------------------------------------------------------------------
 
 _VIEW_MODE_DEFAULTS = {"left": "list", "right": "grid"}
@@ -263,142 +263,6 @@ _PANEL_PX_DEFAULTS: dict[str, int] = {"left": 260, "right": 300}
 VALID_PANEL_PX = (150, 500)  # pixel range matching frontend LEFT/RIGHT_MIN/MAX
 
 
-def _get_view_mode_dict(key: str) -> dict[str, str]:
-    """Return the per-media-type view mode dict for *key* (``view_mode_left`` or ``view_mode_right``).
-
-    Handles backward compatibility: if the stored value is a plain string
-    (old format), it is treated as the mode for all known media types.
-    """
-    side = key.replace("view_mode_", "")
-    default_mode = _VIEW_MODE_DEFAULTS.get(side, "list")
-    with _settings_lock:
-        raw = _ensure_loaded().get(key, _DEFAULTS[key])
-    if isinstance(raw, str):
-        # Legacy scalar value — expand to dict for all known types
-        return {tid: raw for tid in _valid_media_types()}
-    if isinstance(raw, dict):
-        # Fill in missing types with the side default
-        result = {}
-        for tid in _valid_media_types():
-            val = raw.get(tid, default_mode)
-            result[tid] = val if val in VALID_VIEW_MODES else default_mode
-        return result
-    return {tid: default_mode for tid in _valid_media_types()}
-
-
-def get_view_mode_left() -> dict[str, str]:
-    """Return a dict mapping media type ID -> view mode for the left panel."""
-    return _get_view_mode_dict("view_mode_left")
-
-
-def get_view_mode_right() -> dict[str, str]:
-    """Return a dict mapping media type ID -> view mode for the right panel."""
-    return _get_view_mode_dict("view_mode_right")
-
-
-def set_view_mode_left(value: dict[str, str] | str) -> None:
-    """Set the left panel view mode (per-media-type dict or legacy scalar)."""
-    _set_view_mode_dict("view_mode_left", value)
-
-
-def set_view_mode_right(value: dict[str, str] | str) -> None:
-    """Set the right panel view mode (per-media-type dict or legacy scalar)."""
-    _set_view_mode_dict("view_mode_right", value)
-
-
-def _set_view_mode_dict(key: str, value: dict[str, str] | str) -> None:
-    """Persist the per-media-type view mode dict for *key*."""
-    valid_types = _valid_media_types()
-    if isinstance(value, str):
-        # Legacy scalar — expand to all types
-        if value not in VALID_VIEW_MODES:
-            raise ValueError(f"Invalid {key}: {value!r}")
-        value = {tid: value for tid in valid_types}
-    if not isinstance(value, dict):
-        raise ValueError(f"{key} must be a dict or string")
-    for tid, mode in value.items():
-        if tid not in valid_types:
-            raise ValueError(f"Invalid media type: {tid!r}")
-        if mode not in VALID_VIEW_MODES:
-            raise ValueError(f"Invalid {key} value for {tid}: {mode!r}")
-    with _settings_lock:
-        s = _ensure_loaded()
-        s[key] = dict(value)
-        _save(s)
-
-
-def _get_grid_icon_size_dict(key: str) -> dict[str, str]:
-    """Return the per-media-type grid icon size dict for *key*.
-
-    Handles backward compatibility: if the stored value is a plain string
-    (not a dict), it is treated as the size for all known media types.
-    Legacy integer values (old grid_columns format) fall back to the default.
-    """
-    with _settings_lock:
-        raw = _ensure_loaded().get(key, _DEFAULTS[key])
-    if isinstance(raw, str):
-        val = raw.upper()
-        if val not in VALID_GRID_ICON_SIZES:
-            val = _GRID_ICON_SIZE_DEFAULT
-        return {tid: val for tid in _valid_media_types()}
-    if isinstance(raw, dict):
-        result = {}
-        for tid in _valid_media_types():
-            v = raw.get(tid, _GRID_ICON_SIZE_DEFAULT)
-            if isinstance(v, str):
-                v = v.upper()
-            if v not in VALID_GRID_ICON_SIZES:
-                v = _GRID_ICON_SIZE_DEFAULT
-            result[tid] = v
-        return result
-    return {tid: _GRID_ICON_SIZE_DEFAULT for tid in _valid_media_types()}
-
-
-def get_grid_icon_size_left() -> dict[str, str]:
-    """Return a dict mapping media type ID -> grid icon size for the left panel."""
-    return _get_grid_icon_size_dict("grid_icon_size_left")
-
-
-def get_grid_icon_size_right() -> dict[str, str]:
-    """Return a dict mapping media type ID -> grid icon size for the right panel."""
-    return _get_grid_icon_size_dict("grid_icon_size_right")
-
-
-def set_grid_icon_size_left(value: dict[str, str] | str) -> None:
-    """Set the left panel grid icon size (per-media-type dict or scalar)."""
-    _set_grid_icon_size_dict("grid_icon_size_left", value)
-
-
-def set_grid_icon_size_right(value: dict[str, str] | str) -> None:
-    """Set the right panel grid icon size (per-media-type dict or scalar)."""
-    _set_grid_icon_size_dict("grid_icon_size_right", value)
-
-
-def _set_grid_icon_size_dict(key: str, value: dict[str, str] | str) -> None:
-    """Persist the per-media-type grid icon size dict for *key*."""
-    valid_types = _valid_media_types()
-    if isinstance(value, str):
-        value = value.upper()
-        if value not in VALID_GRID_ICON_SIZES:
-            raise ValueError(f"Invalid {key}: {value!r}")
-        value = {tid: value for tid in valid_types}
-    if not isinstance(value, dict):
-        raise ValueError(f"{key} must be a dict or string")
-    coerced = {}
-    for tid, size in value.items():
-        if tid not in valid_types:
-            raise ValueError(f"Invalid media type: {tid!r}")
-        if isinstance(size, str):
-            size = size.upper()
-        if size not in VALID_GRID_ICON_SIZES:
-            raise ValueError(f"Invalid {key} value for {tid}: {size!r}")
-        coerced[tid] = size
-    with _settings_lock:
-        s = _ensure_loaded()
-        s[key] = coerced
-        _save(s)
-
-
 def _valid_media_types() -> tuple[str, ...]:
     """Return valid media type IDs from the media registry."""
     from vtsearch.media import all_type_ids
@@ -406,105 +270,158 @@ def _valid_media_types() -> tuple[str, ...]:
     return tuple(all_type_ids())
 
 
-# -------------------------------------------------------------------
-# Per-media-type focus mode settings
-# -------------------------------------------------------------------
+def _make_per_side_setting(
+    key_base: str,
+    defaults: dict[str, Any],
+    valid_values: tuple[str, ...] | None = None,
+    *,
+    read_coerce=None,
+    write_coerce=None,
+    value_type: str = "str",
+):
+    """Factory for per-media-type per-side settings.
 
+    Generates ``get_<key_base>_left()``, ``get_<key_base>_right()``,
+    ``set_<key_base>_left()``, ``set_<key_base>_right()`` and the
+    internal ``_get_<key_base>_dict()`` / ``_set_<key_base>_dict()``.
 
-def _get_focus_mode_dict(key: str) -> dict[str, str]:
-    """Return the per-media-type focus mode dict for *key* (``focus_mode_left`` or ``focus_mode_right``).
-
-    Handles backward compatibility: if the stored value is a plain string
-    (old format), it is treated as the mode for all known media types.
+    Parameters
+    ----------
+    key_base:
+        Setting name without the side suffix, e.g. ``"view_mode"``.
+    defaults:
+        ``{"left": default_value, "right": default_value}``.
+    valid_values:
+        Tuple of allowed string values (for enum-like settings).
+        ``None`` skips membership validation (for numeric settings).
+    read_coerce:
+        Optional ``(raw_value, default) -> coerced_value`` applied when
+        reading each per-type entry from storage.  Useful for legacy
+        format handling (e.g. uppercasing, integer → default).
+    write_coerce:
+        Optional ``(value, key) -> coerced_value`` applied to each entry
+        on write before persisting.  Should raise ``ValueError`` on
+        invalid input.  When ``None``, membership in *valid_values* is
+        checked directly.
+    value_type:
+        ``"str"`` or ``"int"`` — controls the setter's scalar expansion
+        and validation logic.
     """
-    side = key.replace("focus_mode_", "")
-    default_mode = _FOCUS_MODE_DEFAULTS.get(side, "click")
-    with _settings_lock:
-        raw = _ensure_loaded().get(key, _DEFAULTS[key])
-    if isinstance(raw, str):
-        # Legacy scalar value — expand to dict for all known types
-        mode = raw if raw in VALID_FOCUS_MODES else default_mode
-        return {tid: mode for tid in _valid_media_types()}
-    if isinstance(raw, dict):
-        # Fill in missing types with the side default
-        result = {}
-        for tid in _valid_media_types():
-            val = raw.get(tid, default_mode)
-            result[tid] = val if val in VALID_FOCUS_MODES else default_mode
-        return result
-    return {tid: default_mode for tid in _valid_media_types()}
 
+    def _get_dict(key: str) -> dict[str, Any]:
+        side = key[len(key_base) + 1:]  # strip "<key_base>_" prefix
+        default_val = defaults.get(side, next(iter(defaults.values())))
+        with _settings_lock:
+            raw = _ensure_loaded().get(key, _DEFAULTS[key])
 
-def get_focus_mode_left() -> dict[str, str]:
-    """Return a dict mapping media type ID -> focus mode for the left panel."""
-    return _get_focus_mode_dict("focus_mode_left")
+        types = _valid_media_types()
 
+        # Scalar legacy value — expand to all types
+        if not isinstance(raw, dict):
+            if read_coerce is not None:
+                val = read_coerce(raw, default_val)
+            elif valid_values is not None and isinstance(raw, str):
+                val = raw if raw in valid_values else default_val
+            else:
+                val = default_val
+            return {tid: val for tid in types}
 
-def get_focus_mode_right() -> dict[str, str]:
-    """Return a dict mapping media type ID -> focus mode for the right panel."""
-    return _get_focus_mode_dict("focus_mode_right")
-
-
-def set_focus_mode_left(value: dict[str, str] | str) -> None:
-    """Set the left panel focus mode (per-media-type dict or legacy scalar)."""
-    _set_focus_mode_dict("focus_mode_left", value)
-
-
-def set_focus_mode_right(value: dict[str, str] | str) -> None:
-    """Set the right panel focus mode (per-media-type dict or legacy scalar)."""
-    _set_focus_mode_dict("focus_mode_right", value)
-
-
-def _set_focus_mode_dict(key: str, value: dict[str, str] | str) -> None:
-    """Persist the per-media-type focus mode dict for *key*."""
-    valid_types = _valid_media_types()
-    if isinstance(value, str):
-        # Legacy scalar — expand to all types
-        if value not in VALID_FOCUS_MODES:
-            raise ValueError(f"Invalid {key}: {value!r}")
-        value = {tid: value for tid in valid_types}
-    if not isinstance(value, dict):
-        raise ValueError(f"{key} must be a dict or string")
-    for tid, mode in value.items():
-        if tid not in valid_types:
-            raise ValueError(f"Invalid media type: {tid!r}")
-        if mode not in VALID_FOCUS_MODES:
-            raise ValueError(f"Invalid {key} value for {tid}: {mode!r}")
-    with _settings_lock:
-        s = _ensure_loaded()
-        s[key] = dict(value)
-        _save(s)
-
-
-# -------------------------------------------------------------------
-# Per-media-type panel percentage settings
-# -------------------------------------------------------------------
-
-
-def _get_panel_pct_dict(key: str) -> dict[str, int]:
-    """Return the per-media-type panel width dict for *key*.
-
-    Values are integers in [150, 500] representing pixel widths.
-    """
-    side = key.replace("panel_pct_", "")
-    default_val = _PANEL_PX_DEFAULTS.get(side, 260)
-    with _settings_lock:
-        raw = _ensure_loaded().get(key, _DEFAULTS[key])
-    lo, hi = VALID_PANEL_PX
-    if isinstance(raw, (int, float)):
-        # Scalar — expand to all types
-        val = _coerce_panel_px(raw, default_val, lo, hi)
-        return {tid: val for tid in _valid_media_types()}
-    if isinstance(raw, dict):
-        result: dict[str, int] = {}
-        for tid in _valid_media_types():
+        # Dict value — fill missing types, coerce each entry
+        result: dict[str, Any] = {}
+        for tid in types:
             v = raw.get(tid, default_val)
-            result[tid] = _coerce_panel_px(v, default_val, lo, hi)
+            if read_coerce is not None:
+                v = read_coerce(v, default_val)
+            elif valid_values is not None:
+                v = v if v in valid_values else default_val
+            result[tid] = v
         return result
-    return {tid: default_val for tid in _valid_media_types()}
+
+    def _set_dict(key: str, value) -> None:
+        valid_types = _valid_media_types()
+        lo_hi = VALID_PANEL_PX if value_type == "int" else None
+
+        # Scalar expansion
+        if value_type == "str" and isinstance(value, str):
+            if write_coerce is not None:
+                value = write_coerce(value, key)
+            elif valid_values is not None and value not in valid_values:
+                raise ValueError(f"Invalid {key}: {value!r}")
+            value = {tid: value for tid in valid_types}
+        elif value_type == "int" and isinstance(value, (int, float)):
+            iv = int(round(float(value)))
+            lo, hi = lo_hi  # type: ignore[misc]
+            if not (lo <= iv <= hi):
+                raise ValueError(f"Invalid {key}: {value!r} (must be between {lo} and {hi})")
+            value = {tid: iv for tid in valid_types}
+
+        if not isinstance(value, dict):
+            expected = "dict or string" if value_type == "str" else "dict or number"
+            raise ValueError(f"{key} must be a {expected}")
+
+        coerced: dict[str, Any] = {}
+        for tid, v in value.items():
+            if tid not in valid_types:
+                raise ValueError(f"Invalid media type: {tid!r}")
+            if write_coerce is not None:
+                v = write_coerce(v, key, tid)
+            elif value_type == "int":
+                lo, hi = lo_hi  # type: ignore[misc]
+                try:
+                    v = int(round(float(v)))
+                except (ValueError, TypeError):
+                    raise ValueError(f"Invalid {key} value for {tid}: {v!r}")
+                if not (lo <= v <= hi):
+                    raise ValueError(f"Invalid {key} value for {tid}: {v} (must be between {lo} and {hi})")
+            elif valid_values is not None and v not in valid_values:
+                raise ValueError(f"Invalid {key} value for {tid}: {v!r}")
+            coerced[tid] = v
+
+        with _settings_lock:
+            s = _ensure_loaded()
+            s[key] = coerced
+            _save(s)
+
+    def get_left():
+        return _get_dict(f"{key_base}_left")
+
+    def get_right():
+        return _get_dict(f"{key_base}_right")
+
+    def set_left(value):
+        _set_dict(f"{key_base}_left", value)
+
+    def set_right(value):
+        _set_dict(f"{key_base}_right", value)
+
+    get_left.__name__ = f"get_{key_base}_left"
+    get_right.__name__ = f"get_{key_base}_right"
+    set_left.__name__ = f"set_{key_base}_left"
+    set_right.__name__ = f"set_{key_base}_right"
+    return get_left, get_right, set_left, set_right
 
 
-def _coerce_panel_px(v: Any, default: int, lo: int, hi: int) -> int:
+# -- grid_icon_size: legacy coercion (uppercase, old int grid_columns → default)
+
+def _read_coerce_grid_icon_size(v, default):
+    if isinstance(v, str):
+        v = v.upper()
+        return v if v in VALID_GRID_ICON_SIZES else default
+    return default  # legacy int or other type → default
+
+
+def _write_coerce_grid_icon_size(v, key, tid=None):
+    if isinstance(v, str):
+        v = v.upper()
+    if v not in VALID_GRID_ICON_SIZES:
+        label = f"{key} value for {tid}" if tid else key
+        raise ValueError(f"Invalid {label}: {v!r}")
+    return v
+
+
+# -- panel_pct: legacy coercion (percentage < 2.0 → default, clamp to [150, 500])
+
+def _coerce_panel_px(v: Any, default: int, lo: int = VALID_PANEL_PX[0], hi: int = VALID_PANEL_PX[1]) -> int:
     """Coerce a panel width value to a valid pixel integer.
 
     Legacy percentage values (< 2.0) are replaced with *default*.
@@ -516,57 +433,39 @@ def _coerce_panel_px(v: Any, default: int, lo: int, hi: int) -> int:
     except (ValueError, TypeError):
         return default
     if fv < 2.0:
-        # Legacy percentage value — replace with default
         return default
     return max(lo, min(hi, int(round(fv))))
 
 
-def get_panel_pct_left() -> dict[str, int]:
-    """Return a dict mapping media type ID -> panel pixel width for the left panel."""
-    return _get_panel_pct_dict("panel_pct_left")
+def _read_coerce_panel_pct(v, default):
+    return _coerce_panel_px(v, default)
 
 
-def get_panel_pct_right() -> dict[str, int]:
-    """Return a dict mapping media type ID -> panel pixel width for the right panel."""
-    return _get_panel_pct_dict("panel_pct_right")
+# Generate all four per-side settings
 
+get_view_mode_left, get_view_mode_right, set_view_mode_left, set_view_mode_right = _make_per_side_setting(
+    "view_mode", _VIEW_MODE_DEFAULTS, VALID_VIEW_MODES,
+)
 
-def set_panel_pct_left(value: dict[str, int | float] | int | float) -> None:
-    """Set the left panel pixel width (per-media-type dict or scalar)."""
-    _set_panel_pct_dict("panel_pct_left", value)
+get_grid_icon_size_left, get_grid_icon_size_right, set_grid_icon_size_left, set_grid_icon_size_right = (
+    _make_per_side_setting(
+        "grid_icon_size",
+        {"left": _GRID_ICON_SIZE_DEFAULT, "right": _GRID_ICON_SIZE_DEFAULT},
+        VALID_GRID_ICON_SIZES,
+        read_coerce=_read_coerce_grid_icon_size,
+        write_coerce=_write_coerce_grid_icon_size,
+    )
+)
 
+get_focus_mode_left, get_focus_mode_right, set_focus_mode_left, set_focus_mode_right = _make_per_side_setting(
+    "focus_mode", _FOCUS_MODE_DEFAULTS, VALID_FOCUS_MODES,
+)
 
-def set_panel_pct_right(value: dict[str, int | float] | int | float) -> None:
-    """Set the right panel pixel width (per-media-type dict or scalar)."""
-    _set_panel_pct_dict("panel_pct_right", value)
-
-
-def _set_panel_pct_dict(key: str, value: dict[str, int | float] | int | float) -> None:
-    """Persist the per-media-type panel pixel width dict for *key*."""
-    valid_types = _valid_media_types()
-    lo, hi = VALID_PANEL_PX
-    if isinstance(value, (int, float)):
-        iv = int(round(float(value)))
-        if not (lo <= iv <= hi):
-            raise ValueError(f"Invalid {key}: {value!r} (must be between {lo} and {hi})")
-        value = {tid: iv for tid in valid_types}
-    if not isinstance(value, dict):
-        raise ValueError(f"{key} must be a dict or number")
-    coerced: dict[str, int] = {}
-    for tid, px in value.items():
-        if tid not in valid_types:
-            raise ValueError(f"Invalid media type: {tid!r}")
-        try:
-            iv = int(round(float(px)))
-        except (ValueError, TypeError):
-            raise ValueError(f"Invalid {key} value for {tid}: {px!r}")
-        if not (lo <= iv <= hi):
-            raise ValueError(f"Invalid {key} value for {tid}: {iv} (must be between {lo} and {hi})")
-        coerced[tid] = iv
-    with _settings_lock:
-        s = _ensure_loaded()
-        s[key] = coerced
-        _save(s)
+get_panel_pct_left, get_panel_pct_right, set_panel_pct_left, set_panel_pct_right = _make_per_side_setting(
+    "panel_pct", _PANEL_PX_DEFAULTS, None,
+    read_coerce=_read_coerce_panel_pct,
+    value_type="int",
+)
 
 
 def get_autoload_media_types() -> list[str]:

--- a/vtsearch/utils/__init__.py
+++ b/vtsearch/utils/__init__.py
@@ -31,6 +31,8 @@ from vtsearch.utils.state import (
     set_active_detector_id,
     unregister_context,
     unregister_detector_context,
+    with_dataset_context,
+    with_detector_context,
     add_autorun_detector,
     add_autorun_extractor,
     add_autorun_localizer,
@@ -210,4 +212,7 @@ __all__ = [
     "get_detector_context",
     "list_loaded_detector_ids",
     "clear_all_detector_contexts",
+    # Scoped context managers
+    "with_dataset_context",
+    "with_detector_context",
 ]

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -200,54 +200,84 @@ class PluginRegistry(Generic[T]):
         ``"EXPORTER"``.
     label:
         Human-readable noun used in warning messages, e.g. ``"exporter"``.
+    discover_modules:
+        When ``True``, also scan flat ``.py`` files (not just sub-packages)
+        for the sentinel.  Useful for plugin families where each plugin is
+        a single module rather than a sub-package (e.g. converters, sources).
     """
 
-    def __init__(self, package: str, sentinel: str, label: str) -> None:
+    def __init__(self, package: str, sentinel: str, label: str, *,
+                 discover_modules: bool = False) -> None:
         self._package = package
         self._sentinel = sentinel
         self._label = label
+        self._discover_modules = discover_modules
         self._items: dict[str, T] = {}
         self._discovered = False
+        self._discovering = False
         self._lock = threading.Lock()
 
     # -- Discovery ----------------------------------------------------------
 
     def _discover(self) -> None:
-        """Scan sub-packages for sentinel objects and register them.
+        """Scan sub-packages (and optionally flat modules) for sentinel objects.
 
         Uses direct filesystem scanning instead of :func:`pkgutil.iter_modules`
         so that symlinked directories are reliably discovered.  A symlink to a
         package directory (containing ``__init__.py``) is treated identically to
         a regular sub-package.
+
+        When :attr:`_discover_modules` is ``True``, also scans ``.py`` files
+        (excluding ``__init__.py`` and ``base.py``) for the sentinel.
         """
         parent = importlib.import_module(self._package)
         package_dir = Path(parent.__file__).parent
         for entry in sorted(package_dir.iterdir()):
-            # Accept both real directories and symlinks that resolve to
-            # directories.  entry.is_dir() follows symlinks by default.
-            if not entry.is_dir() or entry.name.startswith((".", "_")):
+            if entry.name.startswith((".", "_")):
                 continue
-            # Must contain __init__.py to be a proper Python package.
-            if not (entry / "__init__.py").exists():
-                continue
-            module_name = entry.name
-            try:
-                mod = importlib.import_module(f"{self._package}.{module_name}")
-                plugin = getattr(mod, self._sentinel, None)
-                if plugin is not None:
-                    self._items[plugin.name] = plugin
-            except Exception as exc:  # pragma: no cover
-                warnings.warn(
-                    f"Failed to load {self._label} '{module_name}': {exc}",
-                    stacklevel=2,
-                )
+
+            # Sub-packages (directories with __init__.py)
+            if entry.is_dir():
+                if not (entry / "__init__.py").exists():
+                    continue
+                self._try_load(entry.name)
+            # Flat modules (.py files)
+            elif self._discover_modules and entry.is_file() and entry.suffix == ".py":
+                if entry.name in ("__init__.py", "base.py"):
+                    continue
+                self._try_load(entry.stem)
+
+    def _try_load(self, module_name: str) -> None:
+        """Import *module_name* under this registry's package and register its sentinel."""
+        try:
+            mod = importlib.import_module(f"{self._package}.{module_name}")
+            plugin = getattr(mod, self._sentinel, None)
+            if plugin is not None:
+                self._items[plugin.name] = plugin
+        except Exception as exc:  # pragma: no cover
+            warnings.warn(
+                f"Failed to load {self._label} '{module_name}': {exc}",
+                stacklevel=2,
+            )
 
     def _ensure_discovered(self) -> None:
         if self._discovered:
             return
         with self._lock:
             if not self._discovered:
-                self._discover()
+                # Guard against re-entrant discovery.  When discover_modules
+                # is True, importing a sibling module may trigger get()/list()
+                # on this registry before discovery finishes (e.g. runner.py
+                # importing from its own package's __init__).  In that case
+                # we return early with a partial registry — the ongoing
+                # discovery will complete shortly and fill in the rest.
+                if self._discovering:
+                    return
+                self._discovering = True
+                try:
+                    self._discover()
+                finally:
+                    self._discovering = False
                 self._discovered = True
 
     # -- Public API ---------------------------------------------------------

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -53,6 +53,11 @@ from vtsearch.utils.state_core import (  # noqa: F401
     set_active_detector_id,
     unregister_detector_context,
 )
+# Scoped context managers ---------------------------------------------------
+from vtsearch.utils.state_core import (  # noqa: F401
+    with_dataset_context,
+    with_detector_context,
+)
 import vtsearch.utils.state_core as _core  # noqa: F401 — for conftest direct access
 
 # Re-export click tracking ------------------------------------------------

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -504,12 +504,77 @@ def _set_inclusion(value: int | None) -> None:
     get_active_detector_context().inclusion = value
 
 
-# NOTE: These module-level variables are DEAD CODE.  Kept only to avoid
-# import errors if any external code references them.
-_click_counter: int = 0
-_dataset_display_name: str | None = None
-_diversity_tree: Any = None
-inclusion: int | None = None
+# ---------------------------------------------------------------------------
+# Context managers for explicit, scoped context switching
+# ---------------------------------------------------------------------------
+
+
+class with_dataset_context:
+    """Context manager for temporarily switching the active dataset.
+
+    Saves the current active dataset ID on entry, switches to the
+    requested *dataset_id*, and restores the original on exit —
+    even if an exception occurs.
+
+    Usage::
+
+        with with_dataset_context("my_dataset"):
+            # code here sees my_dataset's medias, diversity tree, etc.
+            print(len(medias))
+        # original dataset is restored here
+
+    .. warning::
+        This is NOT thread-safe.  Only use from a single thread or
+        protect with ``_state_lock`` externally.
+    """
+
+    __slots__ = ("_target_id", "_previous_id")
+
+    def __init__(self, dataset_id: str) -> None:
+        self._target_id = dataset_id
+        self._previous_id: str | None = None
+
+    def __enter__(self) -> DatasetContext:
+        self._previous_id = get_active_dataset_id()
+        set_active_dataset_id(self._target_id)
+        return get_active_context()
+
+    def __exit__(self, *exc_info: object) -> None:
+        set_active_dataset_id(self._previous_id)
+
+
+class with_detector_context:
+    """Context manager for temporarily switching the active detector.
+
+    Saves the current active detector ID on entry, switches to the
+    requested *detector_id*, and restores the original on exit.
+
+    Usage::
+
+        with with_detector_context("my_detector"):
+            # code here sees my_detector's votes, scores, etc.
+            print(len(good_votes))
+        # original detector is restored here
+
+    .. warning::
+        This is NOT thread-safe.  Only use from a single thread or
+        protect with ``_state_lock`` externally.
+    """
+
+    __slots__ = ("_target_id", "_previous_id")
+
+    def __init__(self, detector_id: str) -> None:
+        self._target_id = detector_id
+        self._previous_id: str | None = None
+
+    def __enter__(self) -> DetectorContext:
+        self._previous_id = get_active_detector_id()
+        set_active_detector_id(self._target_id)
+        return get_active_detector_context()
+
+    def __exit__(self, *exc_info: object) -> None:
+        set_active_detector_id(self._previous_id)
+
 
 # Autorun detectors/extractors/localizers are GLOBAL (not per-dataset).
 autorun_detectors: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
## Summary

This PR consolidates repetitive per-side settings code into a single factory function and upgrades the plugin registry to support flat module discovery. It also introduces pluggable file resolvers and context managers for explicit scope switching.

## Key Changes

### Settings Refactoring (`vtsearch/settings.py`)
- **Introduced `_make_per_side_setting()` factory** — generates all four getter/setter functions (`get_*_left()`, `get_*_right()`, `set_*_left()`, `set_*_right()`) for any per-media-type per-side setting
  - Supports custom read/write coercion for legacy format handling (e.g., uppercasing, percentage → default)
  - Handles both string enum-like settings and integer range settings
  - Eliminates ~250 lines of duplicated getter/setter/validation code
- **Replaced 8 separate functions** with 4 factory calls:
  - `view_mode` (left/right)
  - `grid_icon_size` (left/right, with legacy uppercase coercion)
  - `focus_mode` (left/right)
  - `panel_pct` (left/right, with legacy percentage coercion)

### Plugin Registry Enhancement (`vtsearch/utils/registry.py`)
- **Added `discover_modules` parameter** — when `True`, scans flat `.py` files (not just sub-packages) for the sentinel
  - Enables single-file plugins (e.g., converters, sources) without requiring sub-package structure
- **Refactored discovery logic** — extracted `_try_load()` method for cleaner module loading
- **Added re-entrancy guard** — prevents infinite loops during discovery when imports trigger circular dependencies

### File Resolution Pluggability (`vtsearch/models/resolver.py`)
- **Introduced `FileResolver` protocol** — defines the contract for pluggable file resolution
- **Added resolver registration functions** — `register_source_resolver()` and `register_importer_resolver()` allow external code to replace or extend resolution
- **Implemented lazy auto-wiring** — `_auto_wire_resolvers()` imports and registers default resolvers on first use, avoiding hard-coded cross-package imports
- **Updated `resolve_file_from_origin()`** — now delegates to registered resolvers instead of direct imports

### Context Managers (`vtsearch/utils/state_core.py`)
- **Added `with_dataset_context`** — context manager for temporarily switching the active dataset
- **Added `with_detector_context`** — context manager for temporarily switching the active detector
- Both save/restore the previous context on entry/exit, even if exceptions occur
- Replaced dead code module-level variables with functional context switching

### Converter Auto-Discovery (`vtsearch/converters/`)
- **Migrated to registry-based discovery** — converters now use `PluginRegistry` with `discover_modules=True`
- **Added `CONVERTER` sentinel** to each converter module (`document2image.py`, `document2text.py`, `video2audio.py`, `video2image.py`)
- Replaced hardcoded `_ALL_CONVERTERS` list with dynamic registry

### Source Auto-Discovery (`vtsearch/datasets/sources/`)
- **Migrated to registry-based discovery** — sources now use `PluginRegistry` with `discover_modules=True`
- **Added factory classes** — `_LocalFolderSourceFactory` and `_HttpArchiveSourceFactory` with `create_from_origin()` method
- **Added `SOURCE` sentinel** to each source module
- Replaced hardcoded importer name checks with registry lookup

## Notable Implementation Details

- **Backward compatibility preserved** — legacy scalar settings (strings/numbers) are automatically expanded to per-media-type dicts
- **Coercion pipeline** — read/write coercers allow flexible handling of legacy formats without polluting core logic
- **Thread-safe discovery** — registry uses locks to prevent race conditions during lazy discovery
- **Zero-config behavior** — auto-wiring of resolvers and converters means existing code works without changes
- **Extensibility** — external code can now register custom resolvers, converters

https://claude.ai/code/session_017B19xNG3uzaCxxFwPDzJyA