### PR TITLE
Review and fix documentation errors across all docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ which pieces you need and how to pull them out.
 4. [Extractability matrix](#extractability-matrix)
 5. [How to extract specific components](#how-to-extract-specific-components)
 6. [Plugin architecture details](#plugin-architecture-details)
-7. [State management](#state-management)
+7. [State management](#state-management) (includes [Multi-dataset support](#multi-dataset-support))
 8. [Authentication and multi-user support](#authentication-and-multi-user-support)
 9. [Element-level origin tracking](#element-level-origin-tracking)
 
@@ -58,11 +58,15 @@ VTSearch/
 │   │   ├── audio/embedder.py       AudioClapEmbedder (LAION CLAP, 512-d)
 │   │   ├── audio/embedder_clap_music.py  AudioClapMusicEmbedder (CLAP Music, 512-d)
 │   │   ├── audio/clipper.py        SoundDefaultClipper, SoundTilingClipper
+│   │   ├── audio/speech_extractor.py  SpeechExtractor processor
 │   │   ├── image/media_type.py     Image media type (JPEG/PNG serving)
 │   │   ├── image/embedder.py       ImageClipEmbedder (OpenAI CLIP, 768-d)
 │   │   ├── image/embedder_siglip.py  ImageSiglipEmbedder (SigLIP, 768-d)
 │   │   ├── image/clipper.py        ImageDefaultClipper, ImageTilingClipper
-│   │   ├── text/media_type.py      Text/paragraph media type (JSON serving)
+│   │   ├── image/extractor.py      ImageClassExtractor (YOLO-based)
+│   │   ├── image/face_localizer.py FaceLocalizer (MediaPipe-based)
+│   │   ├── image/ocr_extractor.py  OCRExtractor
+│   │   ├── text/media_type.py      Text media type (JSON serving, type_id="text")
 │   │   ├── text/embedder.py        TextE5Embedder (E5-base-v2, 768-d)
 │   │   ├── text/embedder_bge.py    TextBGEEmbedder (BGE-base-en-v1.5, 768-d)
 │   │   ├── text/clipper.py         TextDefaultClipper, TextSentenceClipper
@@ -87,7 +91,11 @@ VTSearch/
 │   │   ├── loader.py               Model initialisation (delegates to media)
 │   │   ├── diversity_tree.py       Hierarchical k-means tree for diverse sampling
 │   │   ├── registry.py             Persistent model registry/manifest management
-│   │   └── resolver.py             Label resolution by following origin trails
+│   │   ├── resolver.py             Label resolution by following origin trails
+│   │   ├── media_seeding.py        Media seeding utilities
+│   │   ├── label_restoration.py    Label restoration functionality
+│   │   ├── training_workflow.py    Training workflow orchestration
+│   │   └── weights_compat.py       Model weights compatibility layer
 │   │
 │   ├── datasets/                   Dataset loading & downloading
 │   │   ├── origin.py               Origin dataclass (per-element provenance)
@@ -101,9 +109,17 @@ VTSearch/
 │   │   │   ├── video.py            UCF-101 subset
 │   │   │   ├── text.py             20 Newsgroups, BBC News, AG News, IMDB
 │   │   │   └── documents.py        UCSF Industry Documents
+│   │   ├── registry.py             Persistent dataset registry (data/dataset_registry.json)
+│   │   ├── pickle_security.py      Restricted pickle unpickler (RCE prevention)
+│   │   ├── metadata.py             Metadata extraction (CSV, MAT, CIFAR, folders)
+│   │   ├── pdf.py                  PDF rendering (render_pdf_pages)
 │   │   ├── ingest.py               Clip ingestion (file → clip dict)
 │   │   ├── config.py               Demo dataset catalogue
 │   │   ├── split.py                Train/test splitting
+│   │   ├── sources/                MediaSource abstraction for resolving media files
+│   │   │   ├── base.py             MediaSource ABC (list_items, fetch_item, resolve_path)
+│   │   │   ├── local_folder.py     LocalFolderSource implementation
+│   │   │   └── http_archive.py     HTTP archive source implementation
 │   │   └── importers/              Plugin system for data sources
 │   │       ├── base.py             DatasetImporter ABC + ImporterField
 │   │       ├── folder/             Local directory importer
@@ -147,9 +163,13 @@ VTSearch/
 │   │   ├── detectors_crud.py       Detector CRUD operations (create, rename, delete)
 │   │   ├── detectors_scoring.py    Detector scoring and autodetect execution
 │   │   ├── detectors_training.py   Detector training from votes
+│   │   ├── detectors_helpers.py    Shared helpers for detector routes
 │   │   ├── datasets.py             Dataset loading, demos, dashboard
 │   │   ├── datasets_loading.py     Dataset loading and import orchestration
 │   │   ├── datasets_ui.py          Dataset UI helpers and demo listing
+│   │   ├── labels.py               Label export, import, fill-from-sort
+│   │   ├── eval.py                 Evaluation and labeling progress routes
+│   │   ├── media_server.py         Server media file management, example-sort by origin
 │   │   ├── exporters.py            Exporter registry & execution
 │   │   ├── label_importers.py      Label importer registry & execution
 │   │   ├── processor_importers.py  Processor importer registry & execution
@@ -462,6 +482,43 @@ dicts.
 | `state_media_lookup.py` | Media ID resolution, duplicate collapsing, origin tracking |
 
 All are imported and re-exported by `state.py` so call-sites remain unchanged.
+
+### Multi-dataset support
+
+Multiple datasets can be loaded simultaneously. Per-dataset state is
+bundled in `DatasetContext` objects (`state_core.py`), and per-detector
+state in `DetectorContext` objects:
+
+| Context | Key state |
+|---------|-----------|
+| `DatasetContext` | `medias`, `diversity_tree`, `dataset_display_name` |
+| `DetectorContext` | `good_votes`, `bad_votes`, `label_history`, `vote_click_times`, `click_counter`, `last_learned_scores`, `textsort_suggestions`, `find_initial_labels`, `inclusion`, `training_medias`, `model`, `threshold` |
+
+The module-level names (`medias`, `good_votes`, etc.) are **proxy
+objects** (`_ProxyDict` / `_ProxyList`) that delegate to the context
+resolved per-request:
+
+1. **Inside a Flask request** — the `before_request` handler reads
+   `X-Dataset-Id` and `X-Model-Id` headers, resolves the matching
+   contexts, and stashes them on Flask's `g`. Proxies check `g` first.
+2. **Outside a request** (background threads, CLI, tests) — proxies
+   fall back to a thread-local context set via
+   `set_thread_dataset_context()` / `set_thread_detector_context()`.
+
+There is no single global "active" pointer. Key functions:
+`register_context()`, `unregister_context()`, `get_context()`,
+`list_loaded_dataset_ids()`.
+
+**Dataset registry** (`datasets/registry.py`) maintains a persistent
+JSON manifest at `data/dataset_registry.json` tracking which datasets
+are available and which are currently loaded in memory (`_loaded_ids`).
+
+API endpoints: `POST /api/datasets/registry/<id>/load` (load from pkl),
+`POST /api/datasets/registry/<id>/unload` (free RAM).
+
+The Angular frontend's `ActiveContextService` tracks which dataset/model
+the user selected, and `activeContextInterceptor` attaches
+`X-Dataset-Id` / `X-Model-Id` headers to every API request.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -65,12 +65,14 @@ Available exporters: `server_json_file` (JSON to server path), `server_csv_file`
 ```
 Predicted Good (5 items):
 
-  1-34094-A-6.wav  (score: 0.9832, category: cat)
-  1-30226-A-0.wav  (score: 0.9541, category: dog)
-  1-17150-B-2.wav  (score: 0.8923, category: cat)
-  1-22694-A-4.wav  (score: 0.7612, category: dog)
-  1-77445-A-1.wav  (score: 0.6204, category: cat)
+  1-34094-A-6.wav
+  1-30226-A-0.wav
+  1-17150-B-2.wav
+  1-22694-A-4.wav
+  1-77445-A-1.wav
 ```
+
+Items with origin information include the origin display string before the filename.
 
 ## Web server modes
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -830,7 +830,7 @@ Each media type has one default embedder in `embedder.py`. To add an
 |------|----------|-----------|
 | `audio/embedder_clap_music.py` | `AudioClapMusicEmbedder` | audio |
 | `image/embedder_siglip.py` | `ImageSiglipEmbedder` | image |
-| `text/embedder_bge.py` | `TextBGEEmbedder` | paragraph |
+| `text/embedder_bge.py` | `TextBGEEmbedder` | text |
 
 ### What to implement
 
@@ -961,8 +961,8 @@ register_embedder(CodeBertEmbedder())
 | `AudioClapMusicEmbedder` | `clap_music` | `audio` | CLAP Music & Speech (laion/larger_clap_music_and_speech) | 512 |
 | `ImageClipEmbedder` | `clip` | `image` | OpenAI CLIP (openai/clip-vit-base-patch32) | 768 |
 | `ImageSiglipEmbedder` | `siglip` | `image` | SigLIP (google/siglip-base-patch16-224) | 768 |
-| `TextE5Embedder` | `e5` | `paragraph` | E5-base-v2 (intfloat/e5-base-v2) | 768 |
-| `TextBGEEmbedder` | `bge` | `paragraph` | BGE-base-en-v1.5 (BAAI/bge-base-en-v1.5) | 768 |
+| `TextE5Embedder` | `e5` | `text` | E5-base-v2 (intfloat/e5-base-v2) | 768 |
+| `TextBGEEmbedder` | `bge` | `text` | BGE-base-en-v1.5 (BAAI/bge-base-en-v1.5) | 768 |
 | `VideoXClipEmbedder` | `xclip` | `video` | X-CLIP (microsoft/xclip-base-patch32) | 768 |
 
 ---
@@ -981,8 +981,8 @@ clippers return **new media dicts** that can replace the original.
 | `SoundTilingClipper` | `sound_tiling_2.0s` | `audio` | Tiles into 2s segments |
 | `ImageDefaultClipper` | `image_default` | `image` | Returns image unchanged |
 | `ImageTilingClipper` | `image_tiling` | `image` | Tiles tall images into squares |
-| `TextDefaultClipper` | `text_default` | `paragraph` | Returns text unchanged |
-| `TextSentenceClipper` | `text_sentence` | `paragraph` | Splits into individual sentences |
+| `TextDefaultClipper` | `text_default` | `text` | Returns text unchanged |
+| `TextSentenceClipper` | `text_sentence` | `text` | Splits into individual sentences |
 | `VideoDefaultClipper` | `video_default` | `video` | Returns video unchanged |
 | `VideoTilingClipper` | `video_tiling_2.0s` | `video` | Tiles into 2s segments |
 | `DocumentDefaultClipper` | `document_default` | `document` | Returns document unchanged |
@@ -1117,7 +1117,7 @@ class Audio2TextMediaConverter(MediaConverter):
     @property
     def target_type(self) -> str:
         """The type_id of the output media type."""
-        return "paragraph"
+        return "text"
 
     def convert(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         """Convert one media dict into one or more target-type media dicts.

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -78,8 +78,8 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Image (`image`) | `clip` (default) | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 768 |
 | Image (`image`) | `siglip` | SigLIP (`google/siglip-base-patch16-224`) | 768 |
 | Video (`video`) | `xclip` (default) | Microsoft X-CLIP (`microsoft/xclip-base-patch32`) | 768 |
-| Text (`paragraph`) | `e5` (default) | E5 (`intfloat/e5-base-v2`) | 768 |
-| Text (`paragraph`) | `bge` | BGE (`BAAI/bge-base-en-v1.5`) | 768 |
+| Text (`text`) | `e5` (default) | E5 (`intfloat/e5-base-v2`) | 768 |
+| Text (`text`) | `bge` | BGE (`BAAI/bge-base-en-v1.5`) | 768 |
 | Document (`document`) | — | None (no embedder) | N/A |
 
 Audio, image, and text media types each have an **alternative embedder** in addition to the default. Alternative embedders are registered in `vtsearch/media/__init__.py` and live in files like `embedder_clap_music.py`, `embedder_siglip.py`, and `embedder_bge.py` alongside the primary `embedder.py` in each media type directory.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -137,7 +137,7 @@ pip install --extra-index-url https://download.pytorch.org/whl/cpu -e ".[cpu,dev
 **For GPU** (NVIDIA CUDA-compatible systems):
 
 ```bash
-bash install-gpu.sh          # defaults to CUDA 11.8
+bash install-gpu.sh          # defaults to CUDA 11.8 (cu118)
 bash install-gpu.sh cu121    # for CUDA 12.1
 bash install-gpu.sh cu124    # for CUDA 12.4
 ```
@@ -282,7 +282,7 @@ dependencies automatically and supports grouped test subsets:
 ```
 
 Available groups: `core`, `api`, `sorting`, `datasets`, `io`, `models`,
-`downloads`, `integration`, `cli`, `converters`. See `CLAUDE.md` for the
+`downloads`, `integration`, `cli`, `converters`. See [`CLAUDE.md`](../CLAUDE.md) for the
 full group-to-file mapping.
 
 You can also run pytest directly:
@@ -310,6 +310,18 @@ python -m pytest tests/test_gpu.py -v -m gpu
 ```bash
 python -m pytest tests/ -v -m ''
 ```
+
+## Environment variables
+
+VTSearch reads several optional environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VTSEARCH_SECRET_KEY` | `vtsearch-dev-key-change-in-production` | Flask session secret key (set this in production) |
+| `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for additional deployment-specific configuration.
 
 ## Next steps
 

--- a/docs/old_io.md
+++ b/docs/old_io.md
@@ -5,8 +5,9 @@ as reference implementations for developers building new IO plugins.  They are
 **not loaded, tested, or supported** — treat them as code samples.
 
 > **Warning:** These code samples may be outdated. In particular, the current
-> codebase uses the media type ID `"text"` (not `"paragraph"`). Review and
-> test thoroughly before reusing any of this code.
+> codebase uses the media type ID `"text"` (not `"paragraph"`). Several code
+> examples below still use `"paragraph"` — substitute `"text"` if reusing
+> any of this code. Review and test thoroughly.
 
 See [EXTENDING.md](EXTENDING.md) for the current plugin interfaces and the
 S3 importer skeleton.


### PR DESCRIPTION
## Summary

- **ML.md / EXTENDING.md / old_io.md**: Fix text media type ID from `"paragraph"` to `"text"` (8 occurrences total)
- **CLI.md**: Correct example output — remove fictitious score/category columns that don't exist in `export_cli()`
- **SETUP.md**: Clarify default CUDA version, fix relative path to `CLAUDE.md`, add environment variables section (`VTSEARCH_MODELS_DIR`, `VTSEARCH_LOG_LEVEL`, `VTSEARCH_SECRET_KEY`)
- **ARCHITECTURE.md**: Add 15+ missing files to directory map (datasets/sources/, registry.py, pickle_security.py, metadata.py, pdf.py, model submodules, concrete processors, route files); add entire Multi-dataset support section documenting DatasetContext, DetectorContext, proxy objects, per-request header resolution, and dataset registry

## Test plan

- [x] Verify all internal doc links still resolve
- [x] Confirm no code changes — documentation only

https://claude.ai/code/session_01GnK8k4o6qsUR8xkq844ZpP