### PR TITLE
Update Stanford Dogs dataset to use tar.gz format from HuggingFace

### DIFF
--- a/tests/test_image_sources_download.py
+++ b/tests/test_image_sources_download.py
@@ -72,8 +72,8 @@ def _make_eurosat_zip(tmp_path: Path) -> Path:
 
 
 def _make_stanford_dogs_tar(tmp_path: Path) -> Path:
-    """Create a minimal Stanford Dogs tar fixture."""
-    tar_path = tmp_path / "stanford_dogs_images.tar"
+    """Create a minimal Stanford Dogs tar.gz fixture."""
+    tar_path = tmp_path / "stanford_dogs_images.tar.gz"
 
     tree_root = tmp_path / "tar_staging" / "Images"
     for breed_dir_name in ("n02085620-Chihuahua", "n02099601-golden_retriever"):
@@ -82,7 +82,7 @@ def _make_stanford_dogs_tar(tmp_path: Path) -> Path:
         for i in range(3):
             (d / f"{breed_dir_name}_{i:04d}.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
 
-    with tarfile.open(tar_path, "w:") as tf:
+    with tarfile.open(tar_path, "w:gz") as tf:
         tf.add(tree_root, arcname="Images")
 
     return tar_path

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -40,7 +40,7 @@ OXFORD_FLOWERS_URL = "https://www.robots.ox.ac.uk/~vgg/data/flowers/102/102flowe
 OXFORD_FLOWERS_LABELS_URL = "https://www.robots.ox.ac.uk/~vgg/data/flowers/102/imagelabels.mat"
 FOOD101_URL = "http://data.vision.ee.ethz.ch/cvl/food-101.tar.gz"
 EUROSAT_URL = "https://huggingface.co/datasets/blanchon/EuroSAT_RGB/resolve/main/EuroSAT_RGB.zip"
-STANFORD_DOGS_URL = "http://vision.stanford.edu/aditya86/ImageNetDogDataset/images.tar"
+STANFORD_DOGS_URL = "https://huggingface.co/datasets/Alanox/stanford-dogs/resolve/main/images.tar.gz"
 UCSF_IDL_API_URL = "https://metadata.idl.ucsf.edu/solr/ltdl3/query"
 UCSF_IDL_DOWNLOAD_URL = "https://download.industrydocuments.ucsf.edu"
 

--- a/vtsearch/datasets/downloader/images.py
+++ b/vtsearch/datasets/downloader/images.py
@@ -326,7 +326,7 @@ def download_stanford_dogs(on_progress: Optional[ProgressCallback] = None) -> Pa
     images_dir = _core.DATA_DIR / "stanford_dogs" / "Images"
     _core._download_and_extract(
         url=_core.STANFORD_DOGS_URL,
-        archive_name="stanford_dogs_images.tar",
+        archive_name="stanford_dogs_images.tar.gz",
         extract_to=_core.DATA_DIR / "stanford_dogs",
         check_path=images_dir,
         download_size_mb=_core.STANFORD_DOGS_DOWNLOAD_SIZE_MB,


### PR DESCRIPTION
## Summary
Updates the Stanford Dogs dataset download to use a gzip-compressed tar archive hosted on HuggingFace instead of the original uncompressed tar file from Stanford's servers.

## Key Changes
- Updated `STANFORD_DOGS_URL` to point to the HuggingFace hosted `images.tar.gz` file instead of the original Stanford URL
- Changed the archive format from `tar` to `tar.gz` in the downloader implementation
- Updated test fixture to create `tar.gz` files instead of uncompressed `tar` files to match the actual download format
- Updated all references to the archive filename from `stanford_dogs_images.tar` to `stanford_dogs_images.tar.gz`

## Implementation Details
- The URL change uses HTTPS and points to a HuggingFace dataset mirror, which may provide better reliability and availability
- The tar extraction mode was updated from `"w:"` (uncompressed write) to `"w:gz"` (gzip write) in the test fixture
- All three files (test fixture, core downloader config, and images downloader) were updated consistently to maintain compatibility

https://claude.ai/code/session_01MCWTvLMxUHvjbL1tgzGZ4k