### PR TITLE
Remove right padding from table header cells

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -142,6 +142,7 @@
   }
 
   th {
+    padding-right: 0;
     position: sticky;
     top: 0;
     background: var(--bg-surface);


### PR DESCRIPTION
## Summary
Adjusted the styling of table header cells by removing the right padding to improve layout consistency.

## Changes
- Removed `padding-right` from `th` elements in the dashboard component stylesheet by setting it to `0`

## Details
This change ensures that table header cells no longer have right padding, which may help align headers more precisely with their corresponding data cells or improve the overall table layout appearance.

https://claude.ai/code/session_01HVr7iqRG4nU8o4CGqGLsqt