### PR TITLE
Add dataset ingest statistics modal

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -72,6 +72,7 @@
                 [loadingTask]="getInlineTask(dataset.id)"
                 (rowClick)="toggleDatasetSelection(dataset.id, $event)"
                 (rename)="renameDataset(dataset, $event)"
+                (stats)="showDatasetStats(dataset)"
                 (delete)="deleteDataset(dataset)"
                 (load)="loadDataset(dataset)"
                 (security)="editDatasetSecurity(dataset)"
@@ -211,5 +212,13 @@
   <vt-autodetect-results-modal
     [data]="findResultsData"
     (closed)="closeFindResults()"
+  />
+}
+
+@if (statsModalOpen) {
+  <vt-dataset-stats-modal
+    [datasetId]="statsDatasetId"
+    [datasetName]="statsDatasetName"
+    (closed)="closeStatsModal()"
   />
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -21,6 +21,7 @@ import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-
 import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
 import { DetectorExportModalComponent } from '../modals/detector-export-modal/detector-export-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
+import { DatasetStatsModalComponent } from '../modals/dataset-stats-modal/dataset-stats-modal.component';
 import { IconComponent } from '../icon/icon.component';
 
 @Component({
@@ -36,6 +37,7 @@ import { IconComponent } from '../icon/icon.component';
     NewModelModalComponent,
     DetectorExportModalComponent,
     LabelImporterModalComponent,
+    DatasetStatsModalComponent,
     IconComponent,
   ],
   templateUrl: './dashboard.component.html',
@@ -60,6 +62,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   addLabelsModelName = '';
   findResultsOpen = false;
   findResultsData: AutoDetectResultsData = { results: {} };
+  statsModalOpen = false;
+  statsDatasetId = '';
+  statsDatasetName = '';
 
   datasetSortColumn = 'name';
   datasetSortAsc = true;
@@ -463,6 +468,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetsApi.updateReaders(dataset.id, readers).subscribe({
       next: () => this.datasetState.refresh(),
     });
+  }
+
+  showDatasetStats(dataset: DatasetRegistryEntry): void {
+    this.statsDatasetId = dataset.id;
+    this.statsDatasetName = dataset.name;
+    this.statsModalOpen = true;
+  }
+
+  closeStatsModal(): void {
+    this.statsModalOpen = false;
+    this.statsDatasetId = '';
+    this.statsDatasetName = '';
   }
 
   // --- Model actions ---

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -90,6 +90,14 @@
         <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
       </svg>
     </button>
+    <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M12 2a10 10 0 0 1 0 20"/>
+        <line x1="12" y1="12" x2="12" y2="2"/>
+        <line x1="12" y1="12" x2="20.66" y2="17"/>
+      </svg>
+    </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -121,6 +121,24 @@ td {
   }
 }
 
+.stats-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
 .delete-btn {
   background: none;
   border: none;

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -29,6 +29,7 @@ export class DatasetCardComponent {
     this.rowClick.emit(event);
   }
   @Output() rename = new EventEmitter<string>();
+  @Output() stats = new EventEmitter<void>();
   @Output() delete = new EventEmitter<void>();
   @Output() load = new EventEmitter<void>();
   @Output() security = new EventEmitter<void>();
@@ -69,6 +70,11 @@ export class DatasetCardComponent {
     } else if (event.key === 'Escape') {
       this.cancelRename();
     }
+  }
+
+  onStats(event: MouseEvent): void {
+    event.stopPropagation();
+    this.stats.emit();
   }
 
   onSecurity(event: MouseEvent): void {

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -1,0 +1,56 @@
+<vt-modal [open]="true" [title]="'Stats: ' + datasetName" (closed)="close()">
+  @if (loading) {
+    <p class="loading-text">Loading stats...</p>
+  } @else if (error) {
+    <p class="error-text">{{ error }}</p>
+  } @else if (stats) {
+    <table class="stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label">Media items</td>
+          <td class="stat-value">{{ stats.num_items }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label">Duplicate groups</td>
+          <td class="stat-value">{{ stats.num_dupes }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label">Ingest started</td>
+          <td class="stat-value">{{ formatTimestamp(stats.ingest_started_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label">Ingest finished</td>
+          <td class="stat-value">{{ formatTimestamp(stats.ingest_finished_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label">Duration</td>
+          <td class="stat-value">{{ duration }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    @if (fileTypes.length > 0) {
+      <h3 class="section-title">File Types</h3>
+      <table class="stats-table">
+        <thead>
+          <tr>
+            <th>Extension</th>
+            <th>Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (ft of fileTypes; track ft.ext) {
+            <tr>
+              <td>.{{ ft.ext }}</td>
+              <td>{{ ft.count }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    }
+  }
+
+  <div modal-footer>
+    <button class="btn btn--secondary" (click)="close()">Close</button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
@@ -1,0 +1,44 @@
+.loading-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.error-text {
+  color: var(--error-text, #991b1b);
+}
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 12px;
+
+  th,
+  td {
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  th {
+    font-weight: 600;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+}
+
+.stat-label {
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.stat-value {
+  color: var(--text-primary);
+}
+
+.section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 16px 0 8px;
+  color: var(--text-primary);
+}

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -1,0 +1,66 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalComponent } from '../../modal/modal.component';
+import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { DatasetStatsResponse } from '../../../models/api.models';
+
+@Component({
+  selector: 'vt-dataset-stats-modal',
+  standalone: true,
+  imports: [CommonModule, ModalComponent],
+  templateUrl: './dataset-stats-modal.component.html',
+  styleUrl: './dataset-stats-modal.component.scss',
+})
+export class DatasetStatsModalComponent implements OnInit {
+  @Input() datasetId = '';
+  @Input() datasetName = '';
+  @Output() closed = new EventEmitter<void>();
+
+  loading = true;
+  error = '';
+  stats: DatasetStatsResponse | null = null;
+
+  constructor(private datasetsApi: DatasetsApiService) {}
+
+  ngOnInit(): void {
+    this.datasetsApi.getDatasetStats(this.datasetId).subscribe({
+      next: (data) => {
+        this.stats = data;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err.error?.error || 'Failed to load stats';
+        this.loading = false;
+      },
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  get fileTypes(): { ext: string; count: number }[] {
+    if (!this.stats?.file_type_counts) return [];
+    return Object.entries(this.stats.file_type_counts)
+      .sort(([, a], [, b]) => b - a)
+      .map(([ext, count]) => ({ ext, count }));
+  }
+
+  formatTimestamp(ts: number | null): string {
+    if (!ts) return '-';
+    const d = new Date(ts * 1000);
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+
+  get duration(): string {
+    if (!this.stats?.ingest_started_at || !this.stats?.ingest_finished_at) return '-';
+    const seconds = Math.round(this.stats.ingest_finished_at - this.stats.ingest_started_at);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    if (minutes < 60) return `${minutes}m ${secs}s`;
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `${hours}h ${mins}m ${secs}s`;
+  }
+}

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -237,6 +237,14 @@ export interface DatasetRegistryEntry {
   [key: string]: unknown;
 }
 
+export interface DatasetStatsResponse {
+  num_items: number;
+  num_dupes: number;
+  file_type_counts: Record<string, number>;
+  ingest_started_at: number | null;
+  ingest_finished_at: number | null;
+}
+
 export interface DatasetRegistryResponse {
   datasets: DatasetRegistryEntry[];
 }

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import {
   DatasetStatus,
   DatasetProgress,
+  DatasetStatsResponse,
   ImportersResponse,
   DemoListResponse,
   LoadingTask,
@@ -202,5 +203,9 @@ export class DatasetsApiService {
 
   loadSource(params: Record<string, unknown>): Observable<unknown> {
     return this.http.post('/api/dataset/load-source', params);
+  }
+
+  getDatasetStats(datasetId: string): Observable<DatasetStatsResponse> {
+    return this.http.get<DatasetStatsResponse>(`/api/datasets/registry/${datasetId}/stats`);
   }
 }

--- a/vtsearch/datasets/registry.py
+++ b/vtsearch/datasets/registry.py
@@ -113,6 +113,8 @@ def register_dataset(
     embedder: str = "",
     created_by: str = "default",
     readers: list[str] | None = None,
+    file_type_counts: dict[str, int] | None = None,
+    ingest_started_at: float | None = None,
 ) -> dict[str, Any]:
     """Add a new dataset to the registry and persist.
 
@@ -121,11 +123,14 @@ def register_dataset(
         readers: List of usernames granted read access.  An empty list
             (the default) means only the creator can see the dataset.
             Include ``"*"`` to make it visible to all users.
+        file_type_counts: Mapping of file extension to count.
+        ingest_started_at: Unix timestamp when ingest began.
 
     Returns the newly created entry (with a generated ``id``).
     """
     import uuid
 
+    now = time.time()
     entry: dict[str, Any] = {
         "id": uuid.uuid4().hex,
         "name": name,
@@ -138,8 +143,11 @@ def register_dataset(
         "clipper": clipper,
         "embedder": embedder,
         "created_by": created_by,
-        "created_at": time.time(),
+        "created_at": now,
         "readers": readers or [],
+        "file_type_counts": file_type_counts or {},
+        "ingest_started_at": ingest_started_at,
+        "ingest_finished_at": now,
     }
     with _lock:
         entries = _ensure_loaded()

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -857,6 +857,23 @@ def update_dataset_readers(dataset_id: str):
     return jsonify({"ok": True, "readers": readers})
 
 
+@datasets_bp.route("/api/datasets/registry/<dataset_id>/stats")
+def get_dataset_stats(dataset_id: str):
+    """Return ingest statistics for a registered dataset."""
+    from vtsearch.datasets.registry import get_dataset as _reg_get
+
+    entry = _reg_get(dataset_id)
+    if entry is None:
+        return jsonify({"error": "Dataset not found"}), 404
+    return jsonify({
+        "num_items": entry.get("num_items", 0),
+        "num_dupes": entry.get("num_dupes", 0),
+        "file_type_counts": entry.get("file_type_counts", {}),
+        "ingest_started_at": entry.get("ingest_started_at"),
+        "ingest_finished_at": entry.get("ingest_finished_at"),
+    })
+
+
 @datasets_bp.route("/api/dataset/load-source", methods=["POST"])
 def load_dataset_from_source():
     """Reload a dataset from a stored source origin dict."""

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -232,6 +232,7 @@ def _auto_register_dataset(
     embedder: str = "",
     created_by: str = "",
     display_name: str | None = None,
+    ingest_started_at: float | None = None,
 ) -> dict | None:
     """Save *media_dict* as a pkl and register in the dataset registry.
 
@@ -261,6 +262,18 @@ def _auto_register_dataset(
         if isinstance(m.get("origin"), dict) and m["origin"].get("importer") == "dupe_set"
     )
 
+    # Count file types by extension
+    from collections import Counter
+
+    ext_counter: Counter[str] = Counter()
+    for m in media_dict.values():
+        fn = m.get("filename", "")
+        if fn and "." in fn:
+            ext_counter[fn.rsplit(".", 1)[-1].lower()] += 1
+        else:
+            ext_counter["(no extension)"] += 1
+    file_type_counts = dict(ext_counter.most_common())
+
     ds_dir = get_saved_datasets_dir()
     ds_dir.mkdir(parents=True, exist_ok=True)
     pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
@@ -283,6 +296,8 @@ def _auto_register_dataset(
         clipper=clipper,
         embedder=embedder,
         created_by=created_by,
+        file_type_counts=file_type_counts,
+        ingest_started_at=ingest_started_at,
     )
     _reg_add_loaded(entry["id"])
     return entry
@@ -336,7 +351,10 @@ def _run_origin_load_in_background(
     if not loading_tasks.has_active_tasks():
         dataset_progress.reset_cancel()
 
+    import time as _time
+
     task_id = f"_loading_{uuid4().hex[:8]}"
+    ingest_started_at = _time.time()
     tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin), media_type=media_type)
 
     # Set initial progress synchronously so the first poll sees it.
@@ -407,6 +425,7 @@ def _run_origin_load_in_background(
                 embedder=embedder,
                 created_by=created_by,
                 display_name=name,
+                ingest_started_at=ingest_started_at,
             )
 
             # Migrate the context from the temp task_id to the real registry ID.


### PR DESCRIPTION
## Summary
This PR adds a new dataset statistics modal that displays ingest metadata and file type information for datasets. Users can now view detailed statistics about their datasets including media item counts, duplicate groups, ingest timing, and file type distribution.

## Key Changes

**Backend (Python)**
- Added `file_type_counts` tracking during dataset registration to count files by extension
- Added `ingest_started_at` timestamp parameter to track when ingest begins
- Added `ingest_finished_at` timestamp (set at registration time) to track when ingest completes
- Created new `/api/datasets/registry/<dataset_id>/stats` endpoint to retrieve dataset statistics
- Updated `register_dataset()` and `_auto_register_dataset()` functions to store and pass statistics metadata

**Frontend (Angular)**
- Created new `DatasetStatsModalComponent` to display dataset statistics in a modal dialog
- Added stats button to dataset card UI with icon
- Integrated stats modal into dashboard component with open/close handlers
- Created `DatasetStatsResponse` interface for type-safe API responses
- Added `getDatasetStats()` method to `DatasetsApiService`
- Implemented helper methods for formatting timestamps and calculating ingest duration
- Added styling for stats table and modal content

## Notable Implementation Details
- File type counting uses the file extension from the filename, with a fallback for files without extensions
- Ingest duration is calculated from start/finish timestamps and formatted as human-readable (e.g., "1h 23m 45s")
- Statistics are fetched on modal open with loading and error states
- File types are sorted by count in descending order for better visibility

https://claude.ai/code/session_01XHdBqN8q6DA9EfvQEhpMPQ