### PR TITLE
Fix dashboard model selection to clear previous selections on new items

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -148,7 +148,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
         }
         const newIds = [...currentIds].filter((id) => !this.knownModelIds.has(id));
         if (newIds.length > 0 && this.knownModelIds.size > 0) {
-          // Items were added after initial load — select the new ones
+          // Items were added after initial load — select only the new ones
+          this.selectedModelIds.clear();
           for (const id of newIds) {
             this.selectedModelIds.add(id);
           }


### PR DESCRIPTION
## Summary
Fixed the dashboard component's model selection logic to properly handle cases where new items are added after initial load. Previously, new items were added to the selection without clearing previously selected items, leading to unexpected multi-selection behavior.

## Key Changes
- Clear the `selectedModelIds` set before adding newly detected models
- Updated the comment to clarify that only new items should be selected (not accumulated with previous selections)

## Implementation Details
When new models are detected after the initial dashboard load, the component now:
1. Clears any previously selected model IDs
2. Selects only the newly added models

This ensures that the selection state is reset when new items appear, preventing unintended accumulation of selected items across multiple load cycles.

https://claude.ai/code/session_01LiNT71zU4L1xJMVCWLtuNK