### PR TITLE
Support query params for context resolution in browser-native requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,13 +105,16 @@ def _set_request_context():
         get_detector_context,
     )
 
-    ds_id = request.headers.get("X-Dataset-Id")
+    # Headers (Angular HttpClient interceptor) take priority, with query
+    # params as fallback for browser-native requests (<img src>, <audio src>,
+    # <video src>, etc.) that bypass Angular's interceptor.
+    ds_id = request.headers.get("X-Dataset-Id") or request.args.get("dataset_id")
     if ds_id:
         ctx = get_context(ds_id)
         if ctx is not None:
             g._dataset_context = ctx
 
-    model_id = request.headers.get("X-Model-Id")
+    model_id = request.headers.get("X-Model-Id") or request.args.get("model_id")
     if model_id:
         det_ctx = get_detector_context(model_id)
         if det_ctx is not None:

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayerComponent } from './audio-player.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('AudioPlayerComponent', () => {
@@ -17,6 +18,7 @@ describe('AudioPlayerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AudioPlayerComponent],
+      providers: [ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(AudioPlayerComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -11,6 +11,7 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import { MediaItem } from '../../../models/api.models';
+import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
   selector: 'vt-audio-player',
@@ -33,6 +34,8 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   private audioCtx: AudioContext | null = null;
   private viewReady = false;
 
+  constructor(private activeContext: ActiveContextService) {}
+
   ngAfterViewInit(): void {
     this.viewReady = true;
     this.loadAudio();
@@ -40,7 +43,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
-      this.audioSrc = `/api/medias/${this.media.id}/audio`;
+      this.audioSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/audio`);
       if (this.viewReady) {
         this.loadAudio();
       }
@@ -136,7 +139,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
     ctx.fillRect(0, 0, width, height);
 
     try {
-      const response = await fetch(`/api/medias/${mediaId}/audio`);
+      const response = await fetch(this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`));
       const arrayBuffer = await response.arrayBuffer();
 
       if (!this.audioCtx || this.audioCtx.state === 'closed') {

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DocumentViewerComponent } from './document-viewer.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('DocumentViewerComponent', () => {
@@ -17,6 +18,7 @@ describe('DocumentViewerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DocumentViewerComponent],
+      providers: [ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(DocumentViewerComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { MediaItem } from '../../../models/api.models';
+import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
   selector: 'vt-document-viewer',
@@ -12,9 +13,11 @@ export class DocumentViewerComponent implements OnChanges {
 
   mediaSrc = '';
 
+  constructor(private activeContext: ActiveContextService) {}
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
-      this.mediaSrc = `/api/medias/${this.media.id}/media`;
+      this.mediaSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/media`);
     }
   }
 }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ImageViewerComponent } from './image-viewer.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('ImageViewerComponent', () => {
@@ -17,6 +18,7 @@ describe('ImageViewerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ImageViewerComponent],
+      providers: [ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(ImageViewerComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { MediaItem } from '../../../models/api.models';
+import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
   selector: 'vt-image-viewer',
@@ -22,6 +23,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   @ViewChild('imageEl') imageRef!: ElementRef<HTMLImageElement>;
 
   imageSrc = '';
+
+  constructor(private activeContext: ActiveContextService) {}
   imageReady = false;
   zoom = 1;
   rotation = 0;
@@ -44,7 +47,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
       this.imageReady = false;
-      this.imageSrc = `/api/medias/${this.media.id}/image`;
+      this.imageSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
       this.resetView();
     }
   }

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VideoPlayerComponent } from './video-player.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('VideoPlayerComponent', () => {
@@ -17,6 +18,7 @@ describe('VideoPlayerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [VideoPlayerComponent],
+      providers: [ActiveContextService],
     }).compileComponents();
     fixture = TestBed.createComponent(VideoPlayerComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MediaItem } from '../../../models/api.models';
+import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
   selector: 'vt-video-player',
@@ -17,9 +18,11 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
 
   videoSrc = '';
 
+  constructor(private activeContext: ActiveContextService) {}
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
-      this.videoSrc = `/api/medias/${this.media.id}/video`;
+      this.videoSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/video`);
     }
     if (changes['volume'] && this.videoRef?.nativeElement) {
       this.videoRef.nativeElement.volume = this.volume;

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MediaItemComponent } from './media-item.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('MediaItemComponent', () => {
@@ -17,6 +18,7 @@ describe('MediaItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MediaItemComponent],
+      providers: [ActiveContextService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MediaItemComponent);

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MediaItem } from '../../../models/api.models';
+import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
   selector: 'vt-media-item',
@@ -20,6 +21,8 @@ export class MediaItemComponent {
   @Output() select = new EventEmitter<number>();
   @Output() vote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
+  constructor(private activeContext: ActiveContextService) {}
+
   get isGrid(): boolean {
     return this.viewMode === 'grid';
   }
@@ -27,7 +30,7 @@ export class MediaItemComponent {
   get thumbnailUrl(): string | null {
     if (!this.isGrid) return null;
     if (this.media.type === 'image' || this.media.type === 'video' || this.media.type === 'document') {
-      return `/api/medias/${this.media.id}/image`;
+      return this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
     }
     return null;
   }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LabelListComponent, LabelEntry } from './label-list.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('LabelListComponent', () => {
@@ -15,6 +16,7 @@ describe('LabelListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LabelListComponent],
+      providers: [ActiveContextService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LabelListComponent);

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChange
 import { CommonModule } from '@angular/common';
 import { MediaItem } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
+import { ActiveContextService } from '../../../services/active-context.service';
 
 export interface LabelEntry {
   id: number;
@@ -37,6 +38,8 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   private pendingScrollPct: number | null = null;
   /** Pre-built Map for O(1) media lookups by id (rebuilt when medias input changes). */
   private mediaMap = new Map<number, MediaItem>();
+
+  constructor(private activeContext: ActiveContextService) {}
 
   ngOnInit(): void {
     this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
@@ -128,8 +131,8 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   thumbnailUrl(id: number): string {
     const media = this.mediaMap.get(id);
     if (!media) return '';
-    if (media.type === 'video') return `/api/medias/${id}/video`;
-    return `/api/medias/${id}/image`;
+    if (media.type === 'video') return this.activeContext.mediaUrl(`/api/medias/${id}/video`);
+    return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
   }
 
   placeholderIcon(id: number): string | null {

--- a/frontend/src/app/services/active-context.service.ts
+++ b/frontend/src/app/services/active-context.service.ts
@@ -37,4 +37,20 @@ export class ActiveContextService {
     this.datasetIdSubject.next('');
     this.modelIdSubject.next('');
   }
+
+  /**
+   * Build a media URL with context query params so browser-native requests
+   * (`<img src>`, `<audio src>`, `<video src>`) resolve the correct dataset.
+   *
+   * Angular HttpClient requests use the interceptor to send headers, but
+   * native element `src` attributes bypass it entirely.
+   */
+  mediaUrl(path: string): string {
+    const params: string[] = [];
+    const ds = this.datasetIdSubject.value;
+    if (ds) params.push(`dataset_id=${encodeURIComponent(ds)}`);
+    const model = this.modelIdSubject.value;
+    if (model) params.push(`model_id=${encodeURIComponent(model)}`);
+    return params.length ? `${path}?${params.join('&')}` : path;
+  }
 }

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -252,3 +252,62 @@ class TestRequestIsolation:
         # Thread-local pointer untouched
         assert get_thread_dataset_context().dataset_id == "req_nomut_a"
         assert 800 in medias
+
+
+# ---------------------------------------------------------------------------
+# Tests: Query-param context resolution (for browser-native requests)
+# ---------------------------------------------------------------------------
+
+
+class TestQueryParamContext:
+    """Query params ``dataset_id`` / ``model_id`` work as fallback for
+    browser-native requests (``<img src>``, ``<audio src>``, etc.) that
+    bypass Angular's HttpClient interceptor and therefore cannot send
+    custom headers.
+    """
+
+    def test_dataset_id_query_param(self, client):
+        """?dataset_id= resolves the correct dataset context."""
+        _make_dataset("qp_ds_a", [1000])
+        _make_dataset("qp_ds_b", [2000])
+        set_thread_dataset_context(get_context("qp_ds_a"))
+
+        from app import app
+
+        with app.test_request_context("/?dataset_id=qp_ds_b"):
+            app.preprocess_request()
+            assert get_active_context().dataset_id == "qp_ds_b"
+            assert 2000 in medias
+            assert 1000 not in medias
+
+    def test_model_id_query_param(self, client):
+        """?model_id= resolves the correct detector context."""
+        det_a = _make_detector("qp_det_a")
+        det_b = _make_detector("qp_det_b")
+        det_a.good_votes[10] = None
+        det_b.good_votes[20] = None
+        from vtsearch.utils.state_core import get_detector_context
+        set_thread_detector_context(get_detector_context("qp_det_a"))
+
+        from app import app
+
+        with app.test_request_context("/?model_id=qp_det_b"):
+            app.preprocess_request()
+            assert get_active_detector_context().detector_id == "qp_det_b"
+            assert 20 in good_votes
+            assert 10 not in good_votes
+
+    def test_header_takes_precedence_over_query_param(self, client):
+        """X-Dataset-Id header wins over ?dataset_id= query param."""
+        _make_dataset("qp_hdr", [3000])
+        _make_dataset("qp_qp", [4000])
+
+        from app import app
+
+        with app.test_request_context(
+            "/?dataset_id=qp_qp",
+            headers={"X-Dataset-Id": "qp_hdr"},
+        ):
+            app.preprocess_request()
+            assert get_active_context().dataset_id == "qp_hdr"
+            assert 3000 in medias


### PR DESCRIPTION
## Summary
Add support for `dataset_id` and `model_id` query parameters as a fallback mechanism for resolving request context in browser-native requests (e.g., `<img src>`, `<audio src>`, `<video src>`). These requests bypass Angular's HttpClient interceptor and cannot send custom headers, so query parameters provide an alternative way to pass context information to the backend.

## Key Changes

- **Backend (app.py)**: Modified `_set_request_context()` to check query parameters (`dataset_id`, `model_id`) as a fallback when headers are not present. Headers take priority over query parameters.

- **Frontend Service (active-context.service.ts)**: Added `mediaUrl()` method that constructs media URLs with context query parameters appended when a dataset or model is active.

- **Component Updates**: Updated all media-serving components to use `activeContext.mediaUrl()` when constructing URLs for browser-native element `src` attributes:
  - AudioPlayerComponent
  - ImageViewerComponent
  - VideoPlayerComponent
  - DocumentViewerComponent
  - LabelListComponent
  - MediaItemComponent

- **Test Coverage**: Added comprehensive test suite (`TestQueryParamContext`) covering:
  - Dataset ID resolution via query parameter
  - Model ID resolution via query parameter
  - Header precedence over query parameters

- **Test Updates**: Updated all component spec files to provide `ActiveContextService` as a dependency.

## Implementation Details

- Query parameters are URL-encoded to handle special characters safely
- The fallback mechanism maintains backward compatibility—existing header-based requests continue to work unchanged
- Headers always take precedence, ensuring the interceptor-based approach (used by Angular HttpClient) remains the primary mechanism

https://claude.ai/code/session_01AG5gnuDkpAixSsNGrw7cc5