### PR TITLE
Improve top bar field text truncation with flex layout

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -54,8 +54,8 @@
     [disabled]="!isOnLabelView"
     (click)="onDashboard()"
   >Dashboard</button>
-  <span class="top-bar-field">Data: {{ datasetDisplayName }}</span>
-  <span class="top-bar-field">Model: {{ modelDisplayName }}</span>
+  <span class="top-bar-field"><strong>Data:</strong> <span class="top-bar-value">{{ datasetDisplayName }}</span></span>
+  <span class="top-bar-field"><strong>Model:</strong> <span class="top-bar-value">{{ modelDisplayName }}</span></span>
   <span class="top-bar-spacer"></span>
   <button
     class="settings-btn"

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -139,6 +139,20 @@ header {
   color: rgba(255, 255, 255, 0.85);
   font-size: 0.8rem;
   white-space: nowrap;
+  width: 160px;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+
+  strong {
+    flex-shrink: 0;
+    margin-right: 4px;
+  }
+}
+
+.top-bar-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .top-bar-spacer {


### PR DESCRIPTION
## Summary
Enhanced the top bar field styling to properly handle text truncation when dataset or model names are too long, preventing layout overflow.

## Key Changes
- Updated `.top-bar-field` styling to use flexbox layout with fixed width (160px) and `min-width: 0` to enable proper text truncation
- Separated the label ("Data:", "Model:") from the value by wrapping the label in a `<strong>` tag with `flex-shrink: 0` to keep it visible
- Added new `.top-bar-value` class with `overflow: hidden` and `text-overflow: ellipsis` to truncate long dataset/model names
- Updated HTML markup to structure labels and values separately for better control over truncation behavior

## Implementation Details
The key to enabling text truncation in flexbox is setting `min-width: 0` on the flex container. This allows the flex item to shrink below its content size. The label is prevented from shrinking with `flex-shrink: 0`, ensuring it always remains visible while the value can be truncated with ellipsis when space is limited.

https://claude.ai/code/session_018218XhHrabJxxCGLaJFrku