### PR TITLE
Add refocus functionality to active autopilot step

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -8,7 +8,9 @@
           [class.done]="step.state === 'done'"
           [class.active]="step.state === 'active'"
           [class.future]="step.state === 'future'"
-          [title]="step.label"
+          [class.clickable]="step.state === 'active'"
+          [title]="step.state === 'active' ? 'Click to reselect recommendation' : step.label"
+          (click)="step.state === 'active' && refocus.emit()"
         >
           @if (step.state === 'active') {
             <span class="collapsed-step-label">{{ step.shortLabel }}</span>
@@ -30,6 +32,8 @@
             [class.done]="step.state === 'done'"
             [class.active]="step.state === 'active'"
             [class.future]="step.state === 'future'"
+            [class.clickable]="step.state === 'active'"
+            (click)="step.state === 'active' && refocus.emit()"
           >
             <div class="ap-step-marker">
               @if (step.state === 'done') {
@@ -41,7 +45,7 @@
               }
             </div>
             <div class="ap-step-content">
-              <span class="ap-step-label" [title]="step.helpText">
+              <span class="ap-step-label" [title]="step.state === 'active' ? 'Click to reselect recommendation' : step.helpText">
                 {{ step.label }}
               </span>
               @if (step.detail || step.statusIcons.length) {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -56,6 +56,15 @@
     border: 1px solid var(--accent-highlight-border);
   }
 
+  &.clickable {
+    cursor: pointer;
+
+    &:hover {
+      background: var(--accent-highlight-hover-bg, var(--accent-highlight-bg));
+      filter: brightness(1.1);
+    }
+  }
+
   &.done {
     opacity: 0.7;
   }
@@ -145,6 +154,10 @@
   align-items: center;
   justify-content: center;
   cursor: default;
+
+  &.clickable {
+    cursor: pointer;
+  }
 
   &.done {
     opacity: 0.5;

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -209,8 +209,25 @@ describe('AutopilotPanelComponent', () => {
   it('should show tooltip on each step label via title attribute', () => {
     const stepLabels = fixture.nativeElement.querySelectorAll('.ap-step-label');
     expect(stepLabels.length).toBe(5);
-    expect(stepLabels[0].title).toContain('good');
+    // Active step shows reselect hint; future steps show help text
+    expect(stepLabels[0].title).toContain('reselect');
     expect(stepLabels[1].title).toContain('not what you want');
+  });
+
+  it('should emit refocus when clicking the active step', () => {
+    spyOn(component.refocus, 'emit');
+    fixture.detectChanges();
+    const activeStep = fixture.nativeElement.querySelector('.ap-step.active');
+    activeStep.click();
+    expect(component.refocus.emit).toHaveBeenCalled();
+  });
+
+  it('should not emit refocus when clicking a future step', () => {
+    spyOn(component.refocus, 'emit');
+    fixture.detectChanges();
+    const futureSteps = fixture.nativeElement.querySelectorAll('.ap-step.future');
+    futureSteps[0].click();
+    expect(component.refocus.emit).not.toHaveBeenCalled();
   });
 
   it('should mark current step as active and future steps as future', () => {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -41,6 +41,7 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Output() started = new EventEmitter<void>();
   @Output() stopped = new EventEmitter<void>();
   @Output() toggleCollapse = new EventEmitter<void>();
+  @Output() refocus = new EventEmitter<void>();
 
   constructor(public autopilotState: AutopilotStateService) {}
 

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -160,6 +160,7 @@
           (started)="autopilotStart.emit()"
           (stopped)="autopilotStop.emit()"
           (toggleCollapse)="autopilotToggleCollapse.emit()"
+          (refocus)="autopilotRefocus.emit()"
         />
       </div>
     }


### PR DESCRIPTION
## Summary
This PR adds the ability to click on the active autopilot step to trigger a refocus/reselection of the recommendation. The active step now displays a "Click to reselect recommendation" tooltip and emits a `refocus` event when clicked, while future steps remain non-interactive.

## Key Changes
- **New Output Event**: Added `refocus` EventEmitter to AutopilotPanelComponent that propagates up through LeftPanelComponent
- **Interactive Active Step**: Active steps now have clickable styling (pointer cursor, hover effects) and emit the refocus event on click
- **Updated Tooltips**: Changed active step tooltip from generic label to "Click to reselect recommendation" hint, while future steps continue showing their help text
- **Styling Enhancements**: Added `.clickable` CSS class with hover effects (brightness filter) for visual feedback on interactive steps
- **Test Coverage**: Added two new test cases verifying that refocus is emitted only when clicking the active step, not future steps

## Implementation Details
- The click handler uses a conditional expression `step.state === 'active' && refocus.emit()` to ensure only active steps trigger the event
- Both the collapsed and expanded step views support the refocus functionality
- The `.clickable` class is conditionally applied only to active steps to provide appropriate visual feedback

https://claude.ai/code/session_015jLNpszHBBjmFHoHZbpj23