### PR TITLE
Add completion alert dialog when autopilot reaches done phase

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -6,6 +6,7 @@ import {
   AutopilotPhase,
   AutopilotState,
 } from '../../../services/autopilot-state.service';
+import { VtDialogService } from '../../../services/dialog.service';
 
 export type { AutopilotPhase, AutopilotState };
 
@@ -42,7 +43,12 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Output() stopped = new EventEmitter<void>();
   @Output() toggleCollapse = new EventEmitter<void>();
 
-  constructor(public autopilotState: AutopilotStateService) {}
+  private completionAlerted = false;
+
+  constructor(
+    public autopilotState: AutopilotStateService,
+    private dialogService: VtDialogService,
+  ) {}
 
   get state(): AutopilotState {
     return this.autopilotState.state;
@@ -87,12 +93,21 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
     }
 
     if (changes['goodVotes'] || changes['badVotes'] || changes['labelingStatus']) {
+      const prevPhase = this.autopilotState.state.phase;
       this.autopilotState.checkPhaseTransition(this.goodVotes.size, this.badVotes.size);
+      if (prevPhase !== 'done' && this.autopilotState.state.phase === 'done' && !this.completionAlerted) {
+        this.completionAlerted = true;
+        this.dialogService.alert(
+          'Autopilot is complete! All quality indicators are green. You can continue labeling or export your results.',
+          'success',
+        );
+      }
     }
   }
 
   activate(): void {
     if (this.running) return;
+    this.completionAlerted = false;
     this.autopilotState.activate();
     // Immediately check whether existing votes already satisfy early phases
     // (e.g. user labeled 23 goods in Manual mode before switching to Autopilot).


### PR DESCRIPTION
## Summary
Added a completion alert notification that displays when the autopilot process transitions to the "done" phase, informing users that all quality indicators are green and they can continue labeling or export results.

## Key Changes
- Injected `VtDialogService` into `AutopilotPanelComponent` to enable dialog notifications
- Added `completionAlerted` flag to track whether the completion alert has been shown, preventing duplicate alerts
- Enhanced `ngOnChanges` to detect phase transitions to "done" and trigger the success alert dialog
- Reset the `completionAlerted` flag when autopilot is activated, allowing the alert to be shown again on subsequent runs

## Implementation Details
- The alert is only shown once per autopilot session (tracked via `completionAlerted` flag)
- The transition detection compares the previous phase with the current phase to ensure the alert only fires when transitioning *to* "done", not when already in that state
- The alert message provides clear guidance on next steps: continuing to label or exporting results

https://claude.ai/code/session_016Jwk9s5LvBA4pEGSa1n91c