### PR TITLE
Replace radio buttons with toggle buttons in settings modals

### DIFF
--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -11,6 +11,7 @@ const KNOWN_TYPES = new Set([
   'folder', 'folder-open', 'upload',
   'graduation', 'arrow-up', 'shuffle', 'elephant', 'cloud',
   'check', 'warning', 'x-circle', 'info', 'file', 'lightbulb',
+  'list', 'grid', 'cursor-click', 'cursor-hover',
 ]);
 
 function emojiToType(icon: string): string {
@@ -127,6 +128,18 @@ function emojiToType(icon: string): string {
       }
       @case ('file') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
+      }
+      @case ('list') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
+      }
+      @case ('grid') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      }
+      @case ('cursor-click') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l6.5 16 2.5-6.5L19.5 11z"/><line x1="13" y1="13" x2="20" y2="20"/><line x1="16" y1="21" x2="21" y2="16"/><line x1="17.5" y1="17.5" x2="19.5" y2="19.5"/></svg>
+      }
+      @case ('cursor-hover') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l6.5 16 2.5-6.5L19.5 11z"/></svg>
       }
     } }
   `,

--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.html
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.html
@@ -19,28 +19,24 @@
       <div class="view-tab-content">
         <div class="form-group">
           <label class="form-label">View Mode:</label>
-          <div class="radio-group">
-            <label class="radio-row">
-              <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="list" [checked]="getViewMode(activeViewTab) === 'list'" (change)="onViewModeChange(activeViewTab, 'list')" />
-              List
-            </label>
-            <label class="radio-row">
-              <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="grid" [checked]="getViewMode(activeViewTab) === 'grid'" (change)="onViewModeChange(activeViewTab, 'grid')" />
-              Grid
-            </label>
+          <div class="toggle-group">
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'list'" (click)="onViewModeChange(activeViewTab, 'list')">
+              <vt-icon type="list" [size]="13"></vt-icon> List
+            </button>
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'grid'" (click)="onViewModeChange(activeViewTab, 'grid')">
+              <vt-icon type="grid" [size]="13"></vt-icon> Grid
+            </button>
           </div>
         </div>
         <div class="form-group">
           <label class="form-label">Focus Mode:</label>
-          <div class="radio-group">
-            <label class="radio-row">
-              <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="click" [checked]="getFocusMode(activeViewTab) === 'click'" (change)="onFocusModeChange(activeViewTab, 'click')" />
-              Click
-            </label>
-            <label class="radio-row">
-              <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="hover" [checked]="getFocusMode(activeViewTab) === 'hover'" (change)="onFocusModeChange(activeViewTab, 'hover')" />
-              Hover
-            </label>
+          <div class="toggle-group">
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'click'" (click)="onFocusModeChange(activeViewTab, 'click')">
+              <vt-icon type="cursor-click" [size]="13"></vt-icon> Click
+            </button>
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'hover'" (click)="onFocusModeChange(activeViewTab, 'hover')">
+              <vt-icon type="cursor-hover" [size]="13"></vt-icon> Hover
+            </button>
           </div>
         </div>
         <div class="form-group">

--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.scss
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.scss
@@ -74,17 +74,50 @@
   gap: 0.2rem;
 }
 
-.radio-group {
+.toggle-group {
   display: flex;
-  gap: 0.75rem;
+  gap: 0;
 }
 
-.radio-row {
-  display: flex;
+.toggle-btn {
+  display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  font-size: 0.8rem;
+  gap: 0.25rem;
+  flex: 1;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-primary, #1e1e2e);
+  border: 1px solid var(--border-color, #444);
   cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+
+  &:first-child {
+    border-radius: 4px 0 0 4px;
+  }
+
+  &:last-child {
+    border-radius: 0 4px 4px 0;
+    border-left: none;
+  }
+
+  &:hover:not(.toggle-btn--active) {
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.06));
+    color: var(--text-primary);
+  }
+
+  &--active {
+    background: var(--accent-color, #6cf);
+    color: #000;
+    border-color: var(--accent-color, #6cf);
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+
+    + .toggle-btn {
+      border-left-color: var(--accent-color, #6cf);
+    }
+  }
 }
 
 .form-select {

--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.ts
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.ts
@@ -5,12 +5,13 @@ import { forkJoin } from 'rxjs';
 import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { IconComponent } from '../../icon/icon.component';
 import { AppSettings, MediaTypeInfo } from '../../../models/api.models';
 
 @Component({
   selector: 'vt-left-view-settings-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, IconComponent],
   templateUrl: './left-view-settings-modal.component.html',
   styleUrl: './left-view-settings-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -68,28 +68,24 @@
                 <h4>Left Side</h4>
                 <div class="form-group">
                   <label class="form-label">View Mode:</label>
-                  <div class="radio-group">
-                    <label class="radio-row">
-                      <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_left', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'list')" />
-                      List
-                    </label>
-                    <label class="radio-row">
-                      <input type="radio" name="view_mode_left_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_left', activeViewTab, 'grid')" />
-                      Grid
-                    </label>
+                  <div class="toggle-group">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_left', activeViewTab) === 'list'" (click)="onViewModeChange('view_mode_left', activeViewTab, 'list')">
+                      <vt-icon type="list" [size]="14"></vt-icon> List
+                    </button>
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (click)="onViewModeChange('view_mode_left', activeViewTab, 'grid')">
+                      <vt-icon type="grid" [size]="14"></vt-icon> Grid
+                    </button>
                   </div>
                 </div>
                 <div class="form-group">
                   <label class="form-label">Focus Mode:</label>
-                  <div class="radio-group">
-                    <label class="radio-row">
-                      <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')" />
-                      Click
-                    </label>
-                    <label class="radio-row">
-                      <input type="radio" name="focus_mode_left_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')" />
-                      Hover
-                    </label>
+                  <div class="toggle-group">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (click)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')">
+                      <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
+                    </button>
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (click)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')">
+                      <vt-icon type="cursor-hover" [size]="14"></vt-icon> Hover
+                    </button>
                   </div>
                 </div>
                 <div class="form-group">
@@ -107,28 +103,24 @@
                 <h4>Right Side</h4>
                 <div class="form-group">
                   <label class="form-label">View Mode:</label>
-                  <div class="radio-group">
-                    <label class="radio-row">
-                      <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="list" [checked]="getViewMode('view_mode_right', activeViewTab) === 'list'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'list')" />
-                      List
-                    </label>
-                    <label class="radio-row">
-                      <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="grid" [checked]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (change)="onViewModeChange('view_mode_right', activeViewTab, 'grid')" />
-                      Grid
-                    </label>
+                  <div class="toggle-group">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_right', activeViewTab) === 'list'" (click)="onViewModeChange('view_mode_right', activeViewTab, 'list')">
+                      <vt-icon type="list" [size]="14"></vt-icon> List
+                    </button>
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (click)="onViewModeChange('view_mode_right', activeViewTab, 'grid')">
+                      <vt-icon type="grid" [size]="14"></vt-icon> Grid
+                    </button>
                   </div>
                 </div>
                 <div class="form-group">
                   <label class="form-label">Focus Mode:</label>
-                  <div class="radio-group">
-                    <label class="radio-row">
-                      <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="click" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')" />
-                      Click
-                    </label>
-                    <label class="radio-row">
-                      <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="hover" [checked]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (change)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')" />
-                      Hover
-                    </label>
+                  <div class="toggle-group">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (click)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')">
+                      <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
+                    </button>
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (click)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')">
+                      <vt-icon type="cursor-hover" [size]="14"></vt-icon> Hover
+                    </button>
                   </div>
                 </div>
                 <div class="form-group">

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -132,17 +132,50 @@
   }
 }
 
-.radio-group {
+.toggle-group {
   display: flex;
-  gap: 1rem;
+  gap: 0;
 }
 
-.radio-row {
-  display: flex;
+.toggle-btn {
+  display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.85rem;
+  gap: 0.3rem;
+  flex: 1;
+  justify-content: center;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-primary, #1e1e2e);
+  border: 1px solid var(--border-color, #444);
   cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+
+  &:first-child {
+    border-radius: 4px 0 0 4px;
+  }
+
+  &:last-child {
+    border-radius: 0 4px 4px 0;
+    border-left: none;
+  }
+
+  &:hover:not(.toggle-btn--active) {
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.06));
+    color: var(--text-primary);
+  }
+
+  &--active {
+    background: var(--accent-color, #6cf);
+    color: #000;
+    border-color: var(--accent-color, #6cf);
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+
+    + .toggle-btn {
+      border-left-color: var(--accent-color, #6cf);
+    }
+  }
 }
 
 

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.html
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.html
@@ -19,28 +19,24 @@
       <div class="view-tab-content">
         <div class="form-group">
           <label class="form-label">View Mode:</label>
-          <div class="radio-group">
-            <label class="radio-row">
-              <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="list" [checked]="getViewMode(activeViewTab) === 'list'" (change)="onViewModeChange(activeViewTab, 'list')" />
-              List
-            </label>
-            <label class="radio-row">
-              <input type="radio" name="view_mode_right_{{ activeViewTab }}" value="grid" [checked]="getViewMode(activeViewTab) === 'grid'" (change)="onViewModeChange(activeViewTab, 'grid')" />
-              Grid
-            </label>
+          <div class="toggle-group">
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'list'" (click)="onViewModeChange(activeViewTab, 'list')">
+              <vt-icon type="list" [size]="13"></vt-icon> List
+            </button>
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'grid'" (click)="onViewModeChange(activeViewTab, 'grid')">
+              <vt-icon type="grid" [size]="13"></vt-icon> Grid
+            </button>
           </div>
         </div>
         <div class="form-group">
           <label class="form-label">Focus Mode:</label>
-          <div class="radio-group">
-            <label class="radio-row">
-              <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="click" [checked]="getFocusMode(activeViewTab) === 'click'" (change)="onFocusModeChange(activeViewTab, 'click')" />
-              Click
-            </label>
-            <label class="radio-row">
-              <input type="radio" name="focus_mode_right_{{ activeViewTab }}" value="hover" [checked]="getFocusMode(activeViewTab) === 'hover'" (change)="onFocusModeChange(activeViewTab, 'hover')" />
-              Hover
-            </label>
+          <div class="toggle-group">
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'click'" (click)="onFocusModeChange(activeViewTab, 'click')">
+              <vt-icon type="cursor-click" [size]="13"></vt-icon> Click
+            </button>
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'hover'" (click)="onFocusModeChange(activeViewTab, 'hover')">
+              <vt-icon type="cursor-hover" [size]="13"></vt-icon> Hover
+            </button>
           </div>
         </div>
         <div class="form-group">

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.scss
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.scss
@@ -74,17 +74,50 @@
   gap: 0.2rem;
 }
 
-.radio-group {
+.toggle-group {
   display: flex;
-  gap: 0.75rem;
+  gap: 0;
 }
 
-.radio-row {
-  display: flex;
+.toggle-btn {
+  display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  font-size: 0.8rem;
+  gap: 0.25rem;
+  flex: 1;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-primary, #1e1e2e);
+  border: 1px solid var(--border-color, #444);
   cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+
+  &:first-child {
+    border-radius: 4px 0 0 4px;
+  }
+
+  &:last-child {
+    border-radius: 0 4px 4px 0;
+    border-left: none;
+  }
+
+  &:hover:not(.toggle-btn--active) {
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.06));
+    color: var(--text-primary);
+  }
+
+  &--active {
+    background: var(--accent-color, #6cf);
+    color: #000;
+    border-color: var(--accent-color, #6cf);
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+
+    + .toggle-btn {
+      border-left-color: var(--accent-color, #6cf);
+    }
+  }
 }
 
 .form-select {

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.ts
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.ts
@@ -5,12 +5,13 @@ import { forkJoin } from 'rxjs';
 import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { IconComponent } from '../../icon/icon.component';
 import { AppSettings, MediaTypeInfo } from '../../../models/api.models';
 
 @Component({
   selector: 'vt-view-settings-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, IconComponent],
   templateUrl: './view-settings-modal.component.html',
   styleUrl: './view-settings-modal.component.scss',
 })


### PR DESCRIPTION
## Summary
Refactored the settings modals to replace traditional radio button inputs with a modern toggle button UI component. This improves the visual design and user experience across multiple settings modals.

## Key Changes
- **HTML Templates**: Converted radio button groups (`radio-group` / `radio-row`) to toggle button groups (`toggle-group` / `toggle-btn`) in:
  - `settings-modal.component.html` (View Mode and Focus Mode for left and right sides)
  - `left-view-settings-modal.component.html` (View Mode and Focus Mode)
  - `view-settings-modal.component.html` (View Mode and Focus Mode)

- **Styling**: Updated SCSS files to style the new toggle button components with:
  - Segmented button layout (no gap between buttons, rounded corners on edges)
  - Active state styling with accent color background
  - Hover states for inactive buttons
  - Smooth transitions for visual feedback
  - Applied to `settings-modal.component.scss`, `left-view-settings-modal.component.scss`, and `view-settings-modal.component.scss`

- **Icons**: Added new icon types to the icon component:
  - `list` - horizontal lines icon for list view mode
  - `grid` - grid squares icon for grid view mode
  - `cursor-click` - pointer click icon for click focus mode
  - `cursor-hover` - pointer hover icon for hover focus mode

- **Component Imports**: Added `IconComponent` import to modal components to support icon rendering in toggle buttons

## Implementation Details
- Toggle buttons use `(click)` handlers instead of `(change)` events for better semantic clarity
- Active state is determined by comparing the current setting value with button value using `[class.toggle-btn--active]`
- Icons are sized appropriately for each modal (13-14px) to maintain visual consistency
- Styling uses CSS variables for theming (accent color, background, text colors) for consistency with the application theme

https://claude.ai/code/session_013irhP4QSMtnR4iAyQ8By92