### PR TITLE
Update dependency overrides in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,12 +37,9 @@
     "typescript": "~5.7.2"
   },
   "overrides": {
-    "glob": "^13.0.6",
-    "rimraf": "^6.1.3",
     "pacote": {
-      "tar": "^7.5.12"
+      "tar": "^7.5.13"
     },
-    "serialize-javascript": "^7.0.3",
-    "picomatch": "^4.0.4"
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
Updated the dependency overrides configuration in `package.json` to remove unnecessary overrides and update pinned versions for improved dependency management.

## Key Changes
- Removed override for `glob` (^13.0.6)
- Removed override for `rimraf` (^6.1.3)
- Removed override for `picomatch` (^4.0.4)
- Updated `pacote.tar` from ^7.5.12 to ^7.5.13
- Updated `serialize-javascript` from ^7.0.3 to ^7.0.5

## Details
This change streamlines the dependency overrides by removing constraints that are no longer necessary while keeping critical overrides for `pacote` and `serialize-javascript`. The version bumps for the retained overrides address potential security or compatibility issues in those transitive dependencies.

https://claude.ai/code/session_01EhPa5TPxYpR55dHStMaz6H