### PR TITLE
Clear progress cache on detector register/unregister

### DIFF
--- a/tests/test_multi_detector.py
+++ b/tests/test_multi_detector.py
@@ -108,6 +108,40 @@ class TestDetectorContextStore:
         clear_all_detector_contexts()
         assert list_loaded_detector_ids() == []
 
+    def test_register_clears_progress_cache(self):
+        """Registering a new detector must clear the progress cache so stale
+        training indicators from a previous detector don't carry over."""
+        from vtsearch.models.progress import _cached_steps, clear_progress_cache
+        from vtsearch.utils.state_core import DetectorContext, register_detector_context
+
+        # Seed the cache with a fake entry (simulating a previous detector's training)
+        clear_progress_cache()
+        _cached_steps.append({"model": None, "threshold": 0.5, "good_ids": set(), "bad_ids": set(), "stability": None})
+        assert len(_cached_steps) == 1
+
+        # Registering a new detector should clear the stale cache
+        register_detector_context(DetectorContext("det_progress_clear"))
+        assert len(_cached_steps) == 0
+
+    def test_unregister_clears_progress_cache(self):
+        """Unregistering a detector must clear the progress cache so stale
+        training indicators don't leak to the next detector."""
+        from vtsearch.models.progress import _cached_steps, clear_progress_cache
+        from vtsearch.utils.state_core import (
+            DetectorContext,
+            register_detector_context,
+            unregister_detector_context,
+        )
+
+        ctx = DetectorContext("det_progress_unreg")
+        register_detector_context(ctx)
+        # clear after register (since register also clears)
+        _cached_steps.append({"model": None, "threshold": 0.5, "good_ids": set(), "bad_ids": set(), "stability": None})
+        assert len(_cached_steps) == 1
+
+        unregister_detector_context("det_progress_unreg")
+        assert len(_cached_steps) == 0
+
 
 # ---------------------------------------------------------------------------
 # Vote isolation across detectors
@@ -395,3 +429,87 @@ class TestMLPCaching:
         model2 = det_ctx.model
         assert model2 is not model1
         assert len(det_ctx.training_medias) == 7  # 4 good + 3 bad
+
+
+# ---------------------------------------------------------------------------
+# Labeling-status indicator reset on detector switch
+# ---------------------------------------------------------------------------
+
+
+class TestLabelingStatusResetOnDetectorSwitch:
+    """Regression: deleting a detector and loading a new one must not
+    inherit stale training indicators from the old detector.
+
+    The progress cache is module-level, not per-detector.  Without
+    clearing it on detector switch, _ensure_cache sees
+    len(_cached_steps) >= len(new_label_history) and returns stale
+    all-green indicators, causing autopilot to skip to 'Done'.
+    """
+
+    def test_labeling_status_not_green_after_detector_switch(self, client):
+        """After building up green indicators on detector A, switching to
+        a fresh detector B must NOT return green smart/stable status."""
+        import torch
+
+        from vtsearch.models.progress import _cached_steps, _progress_lock
+        from vtsearch.utils import good_votes, bad_votes, label_history
+        from vtsearch.utils.state_core import (
+            DetectorContext,
+            register_detector_context,
+            set_thread_detector_context,
+            unregister_detector_context,
+        )
+
+        # --- Set up detector A with enough training history for green indicators ---
+        det_a = DetectorContext("det_a_status", name="Detector A", media_type="audio")
+        register_detector_context(det_a)
+        set_thread_detector_context(det_a)
+
+        # Add votes through detector A
+        good_votes[1] = None
+        good_votes[2] = None
+        good_votes[3] = None
+        good_votes[4] = None
+        good_votes[5] = None
+        bad_votes[16] = None
+        bad_votes[17] = None
+        bad_votes[18] = None
+        bad_votes[19] = None
+        bad_votes[20] = None
+
+        # Run learned-sort to build the progress cache
+        res = client.post("/api/learned-sort")
+        assert res.status_code == 200
+
+        with _progress_lock:
+            cached_before = len(_cached_steps)
+        assert cached_before > 0, "Progress cache should be populated after training"
+
+        # --- Delete detector A and create detector B ---
+        unregister_detector_context("det_a_status")
+
+        with _progress_lock:
+            cached_after_unreg = len(_cached_steps)
+        assert cached_after_unreg == 0, "Progress cache must be cleared on unregister"
+
+        det_b = DetectorContext("det_b_status", name="Detector B", media_type="audio")
+        register_detector_context(det_b)
+        set_thread_detector_context(det_b)
+
+        # Detector B has NO votes and NO label history
+        assert len(good_votes) == 0
+        assert len(bad_votes) == 0
+        assert len(label_history) == 0
+
+        # --- Check labeling-status ---
+        res = client.get("/api/labeling-status")
+        assert res.status_code == 200
+        data = res.get_json()
+
+        # With 0 good and 0 bad votes the indicators must NOT be green
+        assert data["smart"]["status"] == "red", (
+            f"smart should be red with 0 votes, got {data['smart']['status']}"
+        )
+        assert data["stable"]["status"] == "red", (
+            f"stable should be red with 0 votes, got {data['stable']['status']}"
+        )

--- a/tests/test_multi_detector.py
+++ b/tests/test_multi_detector.py
@@ -447,10 +447,8 @@ class TestLabelingStatusResetOnDetectorSwitch:
     """
 
     def test_labeling_status_not_green_after_detector_switch(self, client):
-        """After building up green indicators on detector A, switching to
+        """After building up cached progress on detector A, switching to
         a fresh detector B must NOT return green smart/stable status."""
-        import torch
-
         from vtsearch.models.progress import _cached_steps, _progress_lock
         from vtsearch.utils import good_votes, bad_votes, label_history
         from vtsearch.utils.state_core import (
@@ -460,30 +458,25 @@ class TestLabelingStatusResetOnDetectorSwitch:
             unregister_detector_context,
         )
 
-        # --- Set up detector A with enough training history for green indicators ---
+        # --- Set up detector A with votes and build progress cache ---
         det_a = DetectorContext("det_a_status", name="Detector A", media_type="audio")
         register_detector_context(det_a)
         set_thread_detector_context(det_a)
 
-        # Add votes through detector A
-        good_votes[1] = None
-        good_votes[2] = None
-        good_votes[3] = None
-        good_votes[4] = None
-        good_votes[5] = None
-        bad_votes[16] = None
-        bad_votes[17] = None
-        bad_votes[18] = None
-        bad_votes[19] = None
-        bad_votes[20] = None
+        # Add votes through apply_label so label_history is also populated
+        from vtsearch.utils import apply_label
+        for mid in [1, 2, 3, 4, 5]:
+            apply_label(mid, "good")
+        for mid in [16, 17, 18, 19, 20]:
+            apply_label(mid, "bad")
 
-        # Run learned-sort to build the progress cache
-        res = client.post("/api/learned-sort")
+        # Call labeling-status to populate the progress cache
+        res = client.get("/api/labeling-status")
         assert res.status_code == 200
 
         with _progress_lock:
             cached_before = len(_cached_steps)
-        assert cached_before > 0, "Progress cache should be populated after training"
+        assert cached_before > 0, "Progress cache should be populated after labeling-status call"
 
         # --- Delete detector A and create detector B ---
         unregister_detector_context("det_a_status")

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -277,16 +277,30 @@ def get_thread_detector_context() -> DetectorContext | None:
 
 
 def register_detector_context(ctx: DetectorContext) -> None:
-    """Add *ctx* to the detector context store, keyed by its ``detector_id``."""
+    """Add *ctx* to the detector context store, keyed by its ``detector_id``.
+
+    Also clears the module-level progress cache so that stale training
+    indicators from a previously-active detector are not reused.
+    """
+    from vtsearch.models.progress import clear_progress_cache
+
     _detector_contexts[ctx.detector_id] = ctx
+    clear_progress_cache()
 
 
 def unregister_detector_context(detector_id: str) -> DetectorContext | None:
-    """Remove and return the detector context for *detector_id*, or ``None``."""
+    """Remove and return the detector context for *detector_id*, or ``None``.
+
+    Also clears the progress cache so stale cached steps from the removed
+    detector are not used by a subsequent detector.
+    """
+    from vtsearch.models.progress import clear_progress_cache
+
     ctx = _detector_contexts.pop(detector_id, None)
     tl_ctx = getattr(_thread_local, "detector_context", None)
     if tl_ctx is not None and tl_ctx.detector_id == detector_id:
         _thread_local.detector_context = None
+    clear_progress_cache()
     return ctx
 
 


### PR DESCRIPTION
## Summary
Fix a regression where stale training progress indicators from a previous detector would carry over when switching to a new detector, causing the labeling-status endpoint to incorrectly report "green" status for a fresh detector with no votes.

## Changes
- **vtsearch/utils/state_core.py**: Modified `register_detector_context()` and `unregister_detector_context()` to clear the module-level progress cache
  - `register_detector_context()` now calls `clear_progress_cache()` after adding the new detector context
  - `unregister_detector_context()` now calls `clear_progress_cache()` after removing the detector context
  - Added docstring updates explaining the cache-clearing behavior

- **tests/test_multi_detector.py**: Added comprehensive test coverage
  - `test_register_clears_progress_cache()`: Verifies that registering a new detector clears stale cache entries
  - `test_unregister_clears_progress_cache()`: Verifies that unregistering a detector clears its cache entries
  - `TestLabelingStatusResetOnDetectorSwitch` class: Integration test that reproduces the original bug and verifies the fix
    - Tests that switching from a detector with votes to a fresh detector correctly reports red status indicators instead of inheriting green status from the previous detector

## Implementation Details
The progress cache (`_cached_steps`) is module-level rather than per-detector. Without clearing it on detector transitions, the `_ensure_cache()` function would see `len(_cached_steps) >= len(new_label_history)` and incorrectly return cached all-green indicators, causing autopilot to skip to 'Done' status prematurely on a fresh detector.

https://claude.ai/code/session_012UBeu3BvTrqZxZBW2dRPzi