### PR TITLE
Fix pytest hook ordering to preserve test output before force exit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,7 +377,7 @@ def client():
 
 
 @pytest.hookimpl(trylast=True)
-def pytest_sessionfinish(session, exitstatus):
+def pytest_unconfigure(config):
     """Force-exit to avoid SIGABRT (exit code 134) from native library cleanup.
 
     PyTorch, OpenMP, numba (via librosa), and other native libraries spin up
@@ -388,13 +388,17 @@ def pytest_sessionfinish(session, exitstatus):
     ``os._exit()`` skips the normal interpreter teardown (atexit handlers,
     C++ static destructors) so the problematic cleanup never runs.
 
-    Prints a clear PASS/FAIL summary right before exiting, since os._exit()
-    prevents the normal pytest summary from being flushed.
+    We use ``pytest_unconfigure`` (the very last hook) instead of
+    ``pytest_sessionfinish`` so that ``pytest_terminal_summary`` still runs
+    first — ensuring failure tracebacks and the short test summary are fully
+    printed before we force-exit.
+
+    Prints an additional PASS/FAIL summary right before exiting for clarity.
     """
     import sys
 
     # Grab stats from the terminal reporter (if available)
-    reporter = session.config.pluginmanager.getplugin("terminalreporter")
+    reporter = config.pluginmanager.getplugin("terminalreporter")
     if reporter:
         passed = len(reporter.stats.get("passed", []))
         failed = len(reporter.stats.get("failed", []))
@@ -418,4 +422,12 @@ def pytest_sessionfinish(session, exitstatus):
 
     sys.stdout.flush()
     sys.stderr.flush()
+
+    # Retrieve the exit status stashed by pytest_sessionfinish.
+    exitstatus = getattr(config, "_vtsearch_exitstatus", 0)
     os._exit(exitstatus)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Stash the exit status so pytest_unconfigure can use it."""
+    session.config._vtsearch_exitstatus = exitstatus


### PR DESCRIPTION
## Summary
Changed the force-exit mechanism from `pytest_sessionfinish` to `pytest_unconfigure` to ensure pytest's terminal summary (including failure tracebacks and test results) is fully printed before the process is forcefully terminated.

## Changes
- **Migrated hook**: Replaced `pytest_sessionfinish(session, exitstatus)` with `pytest_unconfigure(config)` as the primary force-exit hook
- **Exit status handling**: Introduced a two-hook pattern where `pytest_sessionfinish` now stashes the exit status on the config object, which `pytest_unconfigure` retrieves before calling `os._exit()`
- **Hook ordering**: By using `pytest_unconfigure` (the very last pytest hook), we ensure `pytest_terminal_summary` runs first, allowing pytest to print failure tracebacks and the short test summary before the force exit occurs
- **Updated documentation**: Clarified in docstrings why this hook ordering is necessary

## Implementation Details
The solution works around the issue where native library cleanup (PyTorch, OpenMP, numba, etc.) can cause SIGABRT (exit code 134) by using `os._exit()` to skip normal interpreter teardown. However, this must happen after pytest's normal output is complete. The new approach:
1. `pytest_sessionfinish` captures the exit status and stores it on the config object
2. `pytest_unconfigure` (marked with `trylast=True`) retrieves this status and performs the force exit
3. This ensures all pytest reporting hooks complete before the process terminates

https://claude.ai/code/session_01RJM7zkVGidMSWEzT1cxZdb