### PR TITLE
Fix settings gear icon center dot alignment

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -41,7 +41,7 @@
         (click)="onSettings()"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M6.7 1.5h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 5.5l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
-          <circle cx="8" cy="7.85" r="1.6" fill="currentColor"/>
+          <circle cx="8" cy="8" r="1.6" fill="currentColor"/>
         </svg> Settings</div>
     </div>
   </nav>
@@ -64,7 +64,7 @@
     (click)="onSettings()"
   ><svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M6.7 1.5h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 5.5l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
-      <circle cx="8" cy="7.85" r="1.6" fill="currentColor"/>
+      <circle cx="8" cy="8" r="1.6" fill="currentColor"/>
     </svg></button>
 </header>
 <div class="main-content" role="main">


### PR DESCRIPTION
## Summary
- Fix the settings gear icon's center dot being visually off-center (too low)
- The SVG `<circle>` element had `cy="7.85"` instead of `cy="8"` in a 16×16 viewBox, causing a 0.15px downward offset
- Fixed both instances (header button and burger menu)

## Test plan
- [ ] Visually verify the settings gear icon in the header bar
- [ ] Visually verify the settings gear icon in the burger/hamburger menu
- [ ] Confirm the center dot appears centered within the gear at various zoom levels

https://claude.ai/code/session_01PnZf6TARy2DjpuuhnNDJo9