### PR TITLE
Add missing line to compass icon in dataset card

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -96,6 +96,7 @@
         <path d="M12 2a10 10 0 0 1 0 20"/>
         <line x1="12" y1="12" x2="12" y2="2"/>
         <line x1="12" y1="12" x2="20.66" y2="17"/>
+        <line x1="12" y1="12" x2="2" y2="12"/>
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">


### PR DESCRIPTION
## Summary
Added a missing SVG line element to complete the compass icon visualization in the dataset card component.

## Key Changes
- Added a horizontal line (`<line x1="12" y1="12" x2="2" y2="12"/>`) to the compass SVG icon in the dataset card component
- This line completes the compass needle design by adding the left-pointing direction indicator

## Implementation Details
The compass icon previously had three lines representing the compass needle directions (up, down-right, and down-left). The added line completes the cardinal directions by adding the left (west) direction, creating a more balanced and complete compass visualization.

https://claude.ai/code/session_01KymUBZBpkZgqn5PTk897H3