### PR TITLE
Format numeric columns in dataset importer demo table

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -97,8 +97,8 @@
                   (keydown.space)="$event.preventDefault(); selectDemo(demo)"
                 >
                   <td class="col-name">{{ demo.label }}</td>
-                  <td class="col-num">{{ demo.num_files }}</td>
-                  <td class="col-num">{{ demo.num_categories }}</td>
+                  <td class="col-num">{{ demo.num_files | number }}</td>
+                  <td class="col-num">{{ demo.num_categories | number }}</td>
                   <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
                   <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
                 </tr>


### PR DESCRIPTION
## Summary
Applied Angular's `number` pipe to numeric columns in the dataset importer modal to ensure consistent formatting of file and category counts.

## Changes
- Added `| number` pipe to `demo.num_files` display in the demo datasets table
- Added `| number` pipe to `demo.num_categories` display in the demo datasets table

## Details
This change ensures that numeric values in the dataset importer modal are formatted consistently according to the user's locale settings. The `number` pipe will apply proper thousand separators and decimal formatting as appropriate for the user's region.

https://claude.ai/code/session_01UUPxeDfrKJw9ksegAQbnK2