### PR TITLE
Update .gitignore to exclude venv and symbolic links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ frontend/node_modules/
 frontend/dist/
 frontend/.angular/
 frontend/package-lock.json
+
+/venv/
+*symbolic_link


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude Python virtual environment directories and symbolic links from version control.

## Changes
- Added `/venv/` to ignore Python virtual environment directories
- Added `*symbolic_link` pattern to ignore all symbolic links

## Details
These additions help keep the repository clean by preventing local development environment files and symbolic links from being accidentally committed. This is a common practice for Python projects that use virtual environments for dependency isolation.

https://claude.ai/code/session_018kvfyZRSdG6eUV6ShCB2eX