### PR TITLE
Remove Karma test runner and add npm audit to CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Breaking backwards compatibility is acceptable — do not add shims, feature fla
 - **Install deps (GPU)**: `bash install-gpu.sh` (or `bash install-gpu.sh cu121` for CUDA 12.1)
 - **Build frontend**: `cd frontend && npm install && npm run build:prod` (builds Angular app to `static/`)
 - **Frontend dev server**: `cd frontend && npm start` (proxies `/api/*` to Flask at localhost:5000)
-- **Frontend tests**: `cd frontend && ng test --watch=false` (requires Chrome/Chromium; see Environment Notes below)
+- **Frontend audit**: `cd frontend && npm audit` (checks for known vulnerabilities in dependencies)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`
 
@@ -263,7 +263,7 @@ def slow_load():
 ```
 
 ## Environment Notes (Claude Code on the web)
-- **No Chrome/Chromium available.** The cloud container (Ubuntu 24.04) does not have Chrome or Chromium installed, and they cannot be installed (`chromium` is snap-only on 24.04, snap is unavailable in containers, and Google's download servers are unreachable). Frontend Karma tests (`ng test`) will fail. Do NOT spend time trying to install Chrome/Chromium — it won't work. The Python backend tests (`./run-tests.sh`) work fine without a browser.
+- **No Chrome/Chromium available.** The cloud container (Ubuntu 24.04) does not have Chrome or Chromium installed. Karma has been removed from frontend devDependencies. The Python backend tests (`./run-tests.sh`) work fine without a browser.
 
 ## Key Details
 - **Multi-dataset support**: Multiple datasets can be loaded in memory simultaneously. Per-dataset state is bundled in `DatasetContext` objects (`vtsearch/utils/state_core.py`). The module-level names `medias`, `good_votes`, `bad_votes`, etc. are **proxy objects** (`_ProxyDict`/`_ProxyList`) that delegate to the context resolved per-request. The frontend sends `X-Dataset-Id` and `X-Model-Id` HTTP headers to specify which loaded dataset/model each request operates on (see `ActiveContextService` and `activeContextInterceptor` in the Angular frontend). The `before_request` handler in `app.py` stashes the resolved contexts on Flask's `g`, and the proxy objects check `g` first. Outside a request context (background threads, tests), proxies fall back to a **thread-local** context set via `set_thread_dataset_context()` / `set_thread_detector_context()`. There is no global "active" pointer. Key functions: `register_context()`, `unregister_context()`, `get_context()`, `list_loaded_dataset_ids()`. Global (non-per-dataset) state: `autorun_detectors`, `autorun_extractors`, `autorun_localizers`. API: `POST /api/datasets/registry/<id>/load` (load from pkl), `POST /api/datasets/registry/<id>/unload` (free RAM). Registry tracks `_loaded_ids` (set of in-memory dataset IDs).

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -81,27 +81,6 @@
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n"
-        },
-        "test": {
-          "builder": "@angular-devkit/build-angular:karma",
-          "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
-            "tsConfig": "tsconfig.spec.json",
-            "inlineStyleLanguage": "scss",
-            "assets": [
-              {
-                "glob": "**/*",
-                "input": "public"
-              }
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": []
-          }
         }
       }
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "build:prod": "NG_CLI_ANALYTICS=false ng build --configuration production",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "echo 'Karma removed — no browser-based test runner configured. Run backend tests via ./run-tests.sh'"
   },
   "private": true,
   "dependencies": {
@@ -27,13 +27,6 @@
     "@angular-devkit/build-angular": "^19.2.22",
     "@angular/cli": "^19.2.22",
     "@angular/compiler-cli": "^19.2.0",
-    "@types/jasmine": "~5.1.0",
-    "jasmine-core": "~5.6.0",
-    "karma": "~6.4.0",
-    "karma-chrome-launcher": "~3.2.0",
-    "karma-coverage": "~2.2.0",
-    "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.7.2"
   },
   "overrides": {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -65,6 +65,21 @@ if $_run_frontend_check && [ -d "frontend/node_modules" ]; then
         exit 1
     fi
     rm -f "$_fe_log"
+
+    echo "Checking frontend dependencies for vulnerabilities..."
+    _audit_log=$(mktemp)
+    if (cd frontend && npm audit 2>&1) > "$_audit_log"; then
+        echo "Frontend audit OK (0 vulnerabilities)"
+    else
+        echo ""
+        echo "======================================================================"
+        echo "FRONTEND AUDIT FAILED — npm dependencies have known vulnerabilities"
+        echo "======================================================================"
+        cat "$_audit_log"
+        rm -f "$_audit_log"
+        exit 1
+    fi
+    rm -f "$_audit_log"
 elif $_run_frontend_check && [ ! -d "frontend/node_modules" ]; then
     echo "Skipping frontend build check (node_modules not installed; run: cd frontend && npm install)"
 fi


### PR DESCRIPTION
## Summary
Removes the Karma/Jasmine browser-based test runner from the Angular frontend and replaces it with an npm audit vulnerability check in the CI pipeline. This aligns with the cloud environment constraints where Chrome/Chromium is unavailable.

## Key Changes
- **Removed Karma configuration** from `angular.json`: Deleted the entire `test` builder configuration that was configured for Karma with Chrome launcher and Jasmine
- **Removed test dependencies** from `package.json`: Removed `@types/jasmine`, `jasmine-core`, `karma`, `karma-chrome-launcher`, `karma-coverage`, `karma-jasmine`, and `karma-jasmine-html-reporter`
- **Updated test script** in `package.json`: Changed `npm test` to output a message indicating Karma has been removed and directing users to run backend tests via `./run-tests.sh`
- **Added npm audit check** to `run-tests.sh`: Integrated a new vulnerability scanning step in the frontend CI checks that runs `npm audit` and fails the build if vulnerabilities are detected
- **Updated documentation** in `CLAUDE.md`: Replaced the frontend test command documentation with npm audit guidance and clarified that Karma has been removed from devDependencies

## Implementation Details
The npm audit check in `run-tests.sh` follows the existing pattern for frontend checks:
- Creates a temporary log file to capture audit output
- Runs `npm audit` in the frontend directory
- Displays a clear error message with the audit results if vulnerabilities are found
- Properly cleans up temporary files in all code paths
- Exits with status 1 on failure to block CI/CD pipeline progression

https://claude.ai/code/session_01KZBQMSwGaT6A3FiF5SHWYg