### PR TITLE
Add column resize functionality to demo dataset table

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -74,14 +74,14 @@
         }
 
         <div class="demo-content-area">
-          <table class="demo-table">
+          <table class="demo-table" [class.demo-table-fixed]="demoTableFixed" [style.width]="demoTableFixed ? (demoTableWidth + 'px') : '100%'">
             <thead>
               <tr>
-                <th (click)="sortDemoBy('label')" class="sortable col-name">Name{{ demoSortIndicator('label') }}</th>
-                <th (click)="sortDemoBy('num_files')" class="sortable col-num"># Media{{ demoSortIndicator('num_files') }}</th>
-                <th (click)="sortDemoBy('num_categories')" class="sortable col-num"># Cat.{{ demoSortIndicator('num_categories') }}</th>
-                <th (click)="sortDemoBy('description')" class="sortable col-desc">Description{{ demoSortIndicator('description') }}</th>
-                <th (click)="sortDemoBy('status')" class="sortable col-status">Readiness{{ demoSortIndicator('status') }}</th>
+                <th (click)="sortDemoBy('label')" class="sortable" data-col="label" [style.width.px]="demoTableFixed ? demoColWidths['label'] : null">Name<span class="sort-indicator" [class.active]="demoSortKey === 'label'">{{ demoSortIndicator('label') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'label')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('num_files')" class="sortable col-num" data-col="num_files" [style.width.px]="demoTableFixed ? demoColWidths['num_files'] : null"># Media<span class="sort-indicator" [class.active]="demoSortKey === 'num_files'">{{ demoSortIndicator('num_files') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'num_files')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('num_categories')" class="sortable col-num" data-col="num_categories" [style.width.px]="demoTableFixed ? demoColWidths['num_categories'] : null"># Cat.<span class="sort-indicator" [class.active]="demoSortKey === 'num_categories'">{{ demoSortIndicator('num_categories') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'num_categories')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('description')" class="sortable" data-col="description" [style.width.px]="demoTableFixed ? demoColWidths['description'] : null">Description<span class="sort-indicator" [class.active]="demoSortKey === 'description'">{{ demoSortIndicator('description') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'description')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('status')" class="sortable" data-col="status" [style.width.px]="demoTableFixed ? demoColWidths['status'] : null">Readiness<span class="sort-indicator" [class.active]="demoSortKey === 'status'">{{ demoSortIndicator('status') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'status')" (click)="$event.stopPropagation()"></div></th>
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -62,34 +62,99 @@
 }
 
 .demo-content-area {
-  overflow-y: auto;
-  height: 400px;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+.demo-table-fixed {
+  table-layout: fixed;
 }
 
 .demo-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: .75rem;
-  table-layout: fixed;
+  font-size: 0.83rem;
 
-  thead th {
+  th, td {
+    padding: 6px 10px;
     text-align: left;
-    padding: 5px 8px;
-    color: var(--text-secondary, var(--text-muted));
-    font-size: .7rem;
-    font-weight: 600;
-    cursor: pointer;
-    user-select: none;
+    border-bottom: 1px solid var(--border-subtle);
     white-space: nowrap;
-    border-bottom: 1px solid var(--border);
-
-    &:hover { color: var(--accent); }
   }
 
-  thead th:nth-child(1) { width: 18%; }
-  thead th:nth-child(2) { width: 7%; }
-  thead th:nth-child(3) { width: 6%; }
-  thead th:nth-child(5) { width: 10%; }
+  td {
+    padding: 6px 12px;
+  }
+
+  th {
+    padding-right: 0;
+    position: sticky;
+    top: 0;
+    background: var(--bg-surface);
+    z-index: 1;
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    user-select: none;
+    overflow: hidden;
+
+    &.sortable {
+      cursor: pointer;
+
+      &:hover {
+        color: var(--text-primary);
+      }
+    }
+
+    .sort-indicator {
+      display: inline-block;
+      width: 1em;
+      text-align: center;
+      visibility: hidden;
+
+      &.active {
+        visibility: visible;
+      }
+    }
+
+    .col-resize-handle {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 5px;
+      cursor: col-resize;
+      z-index: 2;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 20%;
+        bottom: 20%;
+        right: 0;
+        width: 2px;
+        background: var(--accent, #5b8fff);
+        opacity: 0.35;
+        transition: opacity 0.15s;
+      }
+
+      &:hover::after {
+        opacity: 0.7;
+      }
+    }
+  }
+
+  tbody tr {
+    cursor: pointer;
+    transition: background 0.1s;
+
+    &:hover {
+      background: var(--bg-hover);
+    }
+  }
 }
 
 .col-num { text-align: right; padding-right: 12px; }
@@ -100,7 +165,7 @@
   white-space: nowrap;
 }
 
-.col-desc { color: var(--text-muted); font-size: .7rem; }
+.col-desc { color: var(--text-muted); font-size: 0.78rem; }
 .col-name { font-weight: 600; color: var(--text-primary); }
 
 .sf-dir-date {
@@ -112,11 +177,6 @@
 }
 
 .demo-row {
-  cursor: pointer;
-  transition: background .15s;
-
-  td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
-  &:hover { background: var(--bg-subtle); }
   &.ready .col-name { color: var(--color-good); }
 }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -55,6 +55,19 @@ export class DatasetImporterModalComponent implements OnInit {
   demoEmbedder = '';
   demoClippers: ClipperInfo[] = [];
   selectedDemoClipper = '';
+
+  // Demo table column resize state
+  demoColWidths: Record<string, number> = {};
+  demoTableFixed = false;
+  demoTableWidth = 0;
+  private demoResizeInit = false;
+  private demoResizeState: {
+    startX: number;
+    startWidth: number;
+    col: string;
+    dragged: boolean;
+    tableEl: HTMLTableElement;
+  } | null = null;
 
   // Server folder browser state
   sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
@@ -367,6 +380,115 @@ export class DatasetImporterModalComponent implements OnInit {
   demoSortIndicator(key: string): string {
     if (this.demoSortKey !== key) return '';
     return this.demoSortAsc ? ' \u25B2' : ' \u25BC';
+  }
+
+  // --- Demo table column resize ---
+
+  startDemoResize(event: MouseEvent, col: string): void {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const th = (event.target as HTMLElement).closest('th') as HTMLElement;
+    const tableEl = th.closest('table') as HTMLTableElement;
+
+    if (!this.demoResizeInit) {
+      const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
+      let totalWidth = 0;
+      ths.forEach((t) => {
+        const colKey = t.getAttribute('data-col');
+        const w = t.offsetWidth;
+        if (colKey) this.demoColWidths[colKey] = w;
+        totalWidth += w;
+      });
+      this.demoTableWidth = totalWidth;
+      this.demoResizeInit = true;
+      this.demoTableFixed = true;
+    }
+
+    this.demoResizeState = {
+      startX: event.clientX,
+      startWidth: this.demoColWidths[col] ?? 100,
+      col,
+      dragged: false,
+      tableEl,
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onDemoResizeMove(event: MouseEvent): void {
+    if (!this.demoResizeState) return;
+    const delta = event.clientX - this.demoResizeState.startX;
+    if (Math.abs(delta) > 3) this.demoResizeState.dragged = true;
+    if (!this.demoResizeState.dragged) return;
+    const newWidth = Math.max(30, this.demoResizeState.startWidth + delta);
+    const prevWidth = this.demoColWidths[this.demoResizeState.col] ?? this.demoResizeState.startWidth;
+    this.demoColWidths[this.demoResizeState.col] = newWidth;
+    this.demoTableWidth = Math.max(100, this.demoTableWidth + (newWidth - prevWidth));
+  }
+
+  @HostListener('document:mouseup')
+  onDemoResizeEnd(): void {
+    if (!this.demoResizeState) return;
+    const state = this.demoResizeState;
+    this.demoResizeState = null;
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+
+    if (!state.dragged) {
+      this.autoSizeDemoColumn(state.tableEl, state.col);
+    }
+  }
+
+  private autoSizeDemoColumn(tableEl: HTMLTableElement, col: string): void {
+    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
+    let colIndex = -1;
+    for (let i = 0; i < ths.length; i++) {
+      if (ths[i].getAttribute('data-col') === col) {
+        colIndex = i;
+        break;
+      }
+    }
+    if (colIndex < 0) return;
+
+    const prevTableWidth = tableEl.style.width;
+    tableEl.classList.remove('demo-table-fixed');
+    tableEl.style.width = 'auto';
+    ths[colIndex].style.width = '';
+
+    let maxWidth = 0;
+    const rows = tableEl.querySelectorAll('tbody tr');
+    rows.forEach((row) => {
+      const cell = row.children[colIndex] as HTMLElement | undefined;
+      if (cell) {
+        if (cell.hasAttribute('colspan')) return;
+        maxWidth = Math.max(maxWidth, cell.scrollWidth);
+      }
+    });
+    if (maxWidth === 0) {
+      maxWidth = ths[colIndex].offsetWidth;
+    }
+    maxWidth = Math.max(30, maxWidth + 2);
+
+    this.demoColWidths[col] = maxWidth;
+    this.demoTableFixed = true;
+    this.demoResizeInit = true;
+
+    let total = 0;
+    ths.forEach((t) => {
+      const key = t.getAttribute('data-col');
+      if (key && key !== col) {
+        if (!this.demoColWidths[key]) this.demoColWidths[key] = t.offsetWidth;
+        total += this.demoColWidths[key];
+      } else if (key === col) {
+        total += maxWidth;
+      }
+    });
+    this.demoTableWidth = total;
+
+    tableEl.style.width = prevTableWidth;
+    tableEl.classList.add('demo-table-fixed');
   }
 
   /** Convert a type_id (e.g. "image") to the corresponding folder_import_name (e.g. "images"). */


### PR DESCRIPTION
## Summary
This PR adds interactive column resizing capabilities to the demo dataset table in the dataset importer modal. Users can now drag column borders to adjust column widths, with an auto-size feature triggered by clicking without dragging.

## Key Changes
- **Column Resize State Management**: Added state tracking for resize operations including `demoColWidths`, `demoTableFixed`, `demoTableWidth`, and `demoResizeState` properties
- **Resize Event Handlers**: Implemented `startDemoResize()`, `onDemoResizeMove()`, and `onDemoResizeEnd()` methods with `@HostListener` decorators for mouse events
- **Auto-Size Feature**: Added `autoSizeDemoColumn()` method that calculates optimal column width based on content when a column header is clicked without dragging
- **Table Layout Updates**: Modified table to use `table-layout: fixed` when resizing is active, with dynamic width styling applied via `[style.width.px]`
- **UI Enhancements**: 
  - Added visual resize handles (`.col-resize-handle`) with hover effects
  - Moved sort indicators into separate `<span>` elements for better layout control
  - Added `data-col` attributes to table headers for column identification
  - Improved table styling with sticky headers, better spacing, and hover effects
- **Layout Improvements**: Changed demo content area to use flexbox with `flex: 1 1 0` for better space utilization

## Implementation Details
- Resize state is tracked per-drag operation and cleared on mouse up
- A 3px drag threshold prevents accidental resizing on simple clicks
- Column widths are constrained to a minimum of 30px
- Auto-sizing temporarily removes fixed layout to measure natural content width
- Cursor and user-select styles are managed during resize operations for better UX

https://claude.ai/code/session_01SwqXkykAQ88fjJ1AwqkCEA