### PR TITLE
Fix demo grid height collapse and format numbers with commas

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -59,8 +59,8 @@
       {{ capitalizeType(dataset.media_type) }}
     </span>
   </td>
-  <td>{{ dataset.num_items ?? '-' }}</td>
-  <td>{{ dataset.num_dupes ?? 0 }}</td>
+  <td>{{ dataset.num_items != null ? (dataset.num_items | number) : '-' }}</td>
+  <td>{{ (dataset.num_dupes ?? 0) | number }}</td>
   <td>{{ formatDate(dataset.created_at) }}</td>
   <td class="origin-cell" [title]="dataset.origin || ''">{{ dataset.origin || '-' }}</td>
   <td class="clipper-cell">{{ dataset.clipper || '-' }}</td>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -62,8 +62,8 @@
 }
 
 .demo-content-area {
-  flex: 1 1 0;
-  min-height: 0;
+  min-height: 200px;
+  max-height: 50vh;
   overflow: auto;
 }
 

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -64,7 +64,7 @@
       {{ capitalizeType(model.media_type) }}
     </span>
   </td>
-  <td>{{ model.num_training ?? 0 }}</td>
+  <td>{{ (model.num_training ?? 0) | number }}</td>
   <td>
     @if (model.trainable) {
       <span class="check" aria-label="Trainable">&#10003;</span>


### PR DESCRIPTION
## Summary
- Fix demo dataset grid collapsing to zero height after the styling alignment merged — `flex: 1 1 0` doesn't work inside the modal (no constrained height chain), replaced with `min-height: 200px; max-height: 50vh`
- Format `num_items`, `num_dupes` (dataset card) and `num_training` (model card) with commas using Angular's `number` pipe, matching the demo table which already had this

## Test plan
- [ ] Open Load Demo Dataset modal — grid should be visible with rows, not empty
- [ ] Verify grid scrolls when there are many entries
- [ ] Check dataset grid shows comma-formatted numbers (e.g. "1,234" not "1234")
- [ ] Check model grid shows comma-formatted # Training with commas

https://claude.ai/code/session_01SwqXkykAQ88fjJ1AwqkCEA