### PR TITLE
Format progress fractions with human-readable byte units

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -14,6 +14,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
 import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, LoadingTasksResponse, ModelRegistryEntry } from '../../models/api.models';
+import { formatProgressFraction } from '../../utils/format-progress';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
@@ -1074,7 +1075,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             msg = `[Step ${progress.step}/${progress.total_steps}] ${msg}`;
           }
           if (progress.current != null && progress.total != null && progress.total > 0) {
-            const fraction = `(${progress.current}/${progress.total})`;
+            const fraction = `(${formatProgressFraction(progress.current, progress.total)})`;
             const stepEnd = msg.indexOf('] ');
             if (stepEnd !== -1) {
               msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
@@ -1177,7 +1178,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
     }
     if (task.current != null && task.total != null && task.total > 0) {
-      const fraction = `(${task.current}/${task.total})`;
+      const fraction = `(${formatProgressFraction(task.current, task.total)})`;
       const stepEnd = msg.indexOf('] ');
       if (stepEnd !== -1) {
         msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { formatProgressFraction } from '../../../utils/format-progress';
 
 @Component({
   selector: 'vt-dataset-card',
@@ -111,7 +112,7 @@ export class DatasetCardComponent {
       msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
     }
     if (task.current != null && task.total != null && task.total > 0) {
-      const fraction = `(${task.current}/${task.total})`;
+      const fraction = `(${formatProgressFraction(task.current, task.total)})`;
       const stepEnd = msg.indexOf('] ');
       if (stepEnd !== -1) {
         msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -23,7 +23,7 @@
         }
         {{ loadingTask.message }}
         @if (loadingTask.current && loadingTask.total) {
-          ({{ loadingTask.current }}/{{ loadingTask.total }})
+          ({{ formatFraction(loadingTask.current, loadingTask.total) }})
         }
       </span>
       <vt-progress-bar

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { formatProgressFraction } from '../../../utils/format-progress';
 
 @Component({
   selector: 'vt-model-card',
@@ -128,5 +129,9 @@ export class ModelCardComponent {
   taskIsIndeterminate(): boolean {
     const t = this.loadingTask;
     return !(t && t.current != null && t.total != null && t.total > 0);
+  }
+
+  formatFraction(current: number, total: number): string {
+    return formatProgressFraction(current, total);
   }
 }

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -1,0 +1,23 @@
+/**
+ * Format a current/total progress fraction for display.
+ *
+ * When both values are large enough to be byte counts (>= 1 MB),
+ * renders them in human-readable units (e.g. "497 MB / 1.10 GB").
+ * Otherwise returns a plain "current/total" string.
+ */
+export function formatProgressFraction(current: number, total: number): string {
+  const MB = 1_048_576;
+  if (total >= MB) {
+    return `${formatBytes(current)} / ${formatBytes(total)}`;
+  }
+  return `${current}/${total}`;
+}
+
+function formatBytes(bytes: number): string {
+  const GB = 1_073_741_824;
+  const MB = 1_048_576;
+  if (bytes >= GB) {
+    return `${(bytes / GB).toFixed(2)} GB`;
+  }
+  return `${Math.round(bytes / MB)} MB`;
+}


### PR DESCRIPTION
## Summary
This PR improves the display of progress indicators by formatting byte-based progress fractions in human-readable units (MB/GB) instead of raw byte counts.

## Key Changes
- **New utility function**: Added `formatProgressFraction()` in `frontend/src/app/utils/format-progress.ts` that intelligently formats progress fractions:
  - When total >= 1 MB, displays both current and total in human-readable units (e.g., "497 MB / 1.10 GB")
  - Otherwise, displays plain "current/total" format
  - Includes helper `formatBytes()` function that converts bytes to GB (with 2 decimal places) or MB (rounded)

- **Updated dashboard component**: Replaced hardcoded progress fraction formatting with calls to `formatProgressFraction()` in two locations where loading task progress is displayed

- **Updated model card component**: 
  - Added `formatFraction()` wrapper method to expose the utility function to the template
  - Updated template to use the new formatting method for progress display

- **Updated dataset card component**: Replaced hardcoded progress fraction formatting with the new utility function

## Implementation Details
- The threshold for using human-readable units is set at 1 MB (1,048,576 bytes) to avoid unnecessary formatting for small file operations
- GB values are formatted to 2 decimal places for precision, while MB values are rounded to whole numbers for cleaner display
- The utility function is reusable across components and can be easily extended for other progress display scenarios

https://claude.ai/code/session_01XAkmvj6tW2vLb5oogYy2Db