### PR TITLE
Avoid network hangs during model loading with local-first preference

### DIFF
--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -7,6 +7,9 @@ happening during the (potentially long) startup phase.
 Also tests ``intercept_weight_loading_progress`` which tracks tensor-level
 progress during model weight loading via ``set_module_tensor_to_device``
 and ``load_state_dict``.
+
+Also tests ``load_pretrained_local_first`` which avoids network hangs by
+preferring locally cached model files.
 """
 
 from unittest.mock import MagicMock, patch
@@ -14,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch.nn as nn
 
-from vtsearch.media.base import intercept_weight_loading_progress
+from vtsearch.media.base import intercept_weight_loading_progress, load_pretrained_local_first
 from vtsearch.models.loader import _make_console_progress, preload_autoload_media_types
 
 
@@ -365,3 +368,87 @@ class TestInterceptWeightLoadingProgress:
         assert len(weight_calls) == 5
         assert weight_calls[-1][2] == 5
         assert weight_calls[-1][3] == 5
+
+
+class TestLoadPretrainedLocalFirst:
+    """Unit tests for load_pretrained_local_first."""
+
+    def test_returns_result_from_local_only_when_available(self):
+        """When local_files_only=True succeeds, the result is returned directly."""
+        sentinel = object()
+
+        def fake_load(*args, **kwargs):
+            assert kwargs.get("local_files_only") is True
+            return sentinel
+
+        result = load_pretrained_local_first(fake_load, "model-id", cache_dir="/tmp")
+        assert result is sentinel
+
+    def test_falls_back_to_network_on_oserror(self):
+        """When local_files_only=True raises OSError, retry without it."""
+        call_count = [0]
+        sentinel = object()
+
+        def fake_load(*args, **kwargs):
+            call_count[0] += 1
+            if kwargs.get("local_files_only"):
+                raise OSError("model not cached")
+            return sentinel
+
+        result = load_pretrained_local_first(fake_load, "model-id", cache_dir="/tmp")
+        assert result is sentinel
+        assert call_count[0] == 2
+
+    def test_falls_back_on_file_not_found_error(self):
+        """FileNotFoundError (subclass of OSError) should also trigger fallback."""
+        call_count = [0]
+        sentinel = object()
+
+        def fake_load(*args, **kwargs):
+            call_count[0] += 1
+            if kwargs.get("local_files_only"):
+                raise FileNotFoundError("No cached files")
+            return sentinel
+
+        result = load_pretrained_local_first(fake_load, "model-id")
+        assert result is sentinel
+        assert call_count[0] == 2
+
+    def test_passes_through_all_args_and_kwargs(self):
+        """Positional and keyword arguments should be forwarded to load_fn."""
+        captured = {}
+
+        def fake_load(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = {k: v for k, v in kwargs.items() if k != "local_files_only"}
+            return "ok"
+
+        load_pretrained_local_first(fake_load, "model-id", low_cpu_mem_usage=True, token=False)
+        assert captured["args"] == ("model-id",)
+        assert captured["kwargs"] == {"low_cpu_mem_usage": True, "token": False}
+
+    def test_non_oserror_exceptions_propagate(self):
+        """Non-OSError exceptions (e.g. ImportError) should not be caught."""
+
+        def fake_load(*args, **kwargs):
+            raise ImportError("missing transformers")
+
+        try:
+            load_pretrained_local_first(fake_load, "model-id")
+            assert False, "Should have raised ImportError"
+        except ImportError:
+            pass
+
+    def test_network_fallback_error_propagates(self):
+        """If both local and network attempts fail, the network error propagates."""
+
+        def fake_load(*args, **kwargs):
+            if kwargs.get("local_files_only"):
+                raise OSError("not cached")
+            raise ConnectionError("network down")
+
+        try:
+            load_pretrained_local_first(fake_load, "model-id")
+            assert False, "Should have raised ConnectionError"
+        except ConnectionError:
+            pass

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, load_pretrained_local_first
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -50,14 +50,16 @@ class AudioClapEmbedder(MediaEmbedder):
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP model weights…")
         with intercept_tqdm_progress(self._on_progress):
-            self._model = ClapModel.from_pretrained(
-                CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            self._model = load_pretrained_local_first(
+                ClapModel.from_pretrained, CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
         # Materialize any tensors left on the ``meta`` device.
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLAP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir, token=False)
+            self._processor = load_pretrained_local_first(
+                ClapProcessor.from_pretrained, CLAP_MODEL_ID, cache_dir=cache_dir, token=False
+            )
 
         # Warmup: import librosa (heavy — pulls in numba, scipy, etc.),
         # trigger the numba JIT for audio resampling, and run a single

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MUSIC_MODEL_ID, CLAP_SAMPLE_RATE
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, load_pretrained_local_first
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -54,13 +54,15 @@ class AudioClapMusicEmbedder(MediaEmbedder):
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP Music model weights…")
         with intercept_tqdm_progress(self._on_progress):
-            self._model = ClapModel.from_pretrained(
-                CLAP_MUSIC_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            self._model = load_pretrained_local_first(
+                ClapModel.from_pretrained, CLAP_MUSIC_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLAP Music processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = ClapProcessor.from_pretrained(CLAP_MUSIC_MODEL_ID, cache_dir=cache_dir, token=False)
+            self._processor = load_pretrained_local_first(
+                ClapProcessor.from_pretrained, CLAP_MUSIC_MODEL_ID, cache_dir=cache_dir, token=False
+            )
 
         # Warmup: import librosa and run a dummy forward pass
         self._on_progress("loading", "Warming up CLAP Music pipeline: importing libraries…", 1, 3)

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -46,6 +46,7 @@ __all__ = [
     "extract_tensor",
     "intercept_tqdm_progress",
     "intercept_weight_loading_progress",
+    "load_pretrained_local_first",
 ]
 
 
@@ -96,6 +97,25 @@ def embedder_load_setup(on_progress: ProgressCallback, message: str) -> str:
     gc.collect()
     on_progress("loading", message, 0, 0)
     return str(MODELS_CACHE_DIR)
+
+
+def load_pretrained_local_first(load_fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call *load_fn* preferring cached model files, falling back to download.
+
+    HuggingFace ``from_pretrained`` (and ``SentenceTransformer()``) contact the
+    Hub to check for updates **even when model files are already cached**.  If
+    the network is unreachable or slow this HTTP request hangs indefinitely,
+    making the UI appear frozen on "Loading … model weights".
+
+    This helper tries ``local_files_only=True`` first.  If that raises
+    ``OSError`` (model not yet cached), it retries without the flag so the
+    model can be downloaded normally.
+    """
+    try:
+        return load_fn(*args, local_files_only=True, **kwargs)
+    except OSError:
+        # Model not in local cache — allow network download.
+        return load_fn(*args, **kwargs)
 
 
 @contextlib.contextmanager

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -14,6 +14,7 @@ from vtsearch.media.base import (
     extract_tensor as _extract_tensor,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
+    load_pretrained_local_first,
 )
 
 if TYPE_CHECKING:
@@ -62,14 +63,14 @@ class ImageClipEmbedder(MediaEmbedder):
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading CLIP model weights…"
         ):
-            self._model = CLIPModel.from_pretrained(
-                CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            self._model = load_pretrained_local_first(
+                CLIPModel.from_pretrained, CLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = CLIPProcessor.from_pretrained(
-                CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False
+            self._processor = load_pretrained_local_first(
+                CLIPProcessor.from_pretrained, CLIP_MODEL_ID, cache_dir=cache_dir, use_fast=True, token=False
             )
 
     # ------------------------------------------------------------------

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -14,6 +14,7 @@ from vtsearch.media.base import (
     extract_tensor as _extract_tensor,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
+    load_pretrained_local_first,
 )
 
 if TYPE_CHECKING:
@@ -61,13 +62,15 @@ class ImageSiglipEmbedder(MediaEmbedder):
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading SigLIP model weights…"
         ):
-            self._model = SiglipModel.from_pretrained(
-                SIGLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            self._model = load_pretrained_local_first(
+                SiglipModel.from_pretrained, SIGLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading SigLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = SiglipProcessor.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False)
+            self._processor = load_pretrained_local_first(
+                SiglipProcessor.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False
+            )
 
     # ------------------------------------------------------------------
     # Embedding

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import E5_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress, load_pretrained_local_first
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -54,7 +54,7 @@ class TextE5Embedder(MediaEmbedder):
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading E5 model…"
         ):
-            self._model = SentenceTransformer(E5_MODEL_ID, cache_folder=cache_dir, token=False)
+            self._model = load_pretrained_local_first(SentenceTransformer, E5_MODEL_ID, cache_folder=cache_dir, token=False)
 
     # ------------------------------------------------------------------
     # Embedding

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import BGE_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress, load_pretrained_local_first
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -54,7 +54,7 @@ class TextBGEEmbedder(MediaEmbedder):
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading BGE model…"
         ):
-            self._model = SentenceTransformer(BGE_MODEL_ID, cache_folder=cache_dir, token=False)
+            self._model = load_pretrained_local_first(SentenceTransformer, BGE_MODEL_ID, cache_folder=cache_dir, token=False)
 
     # ------------------------------------------------------------------
     # Embedding

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -14,6 +14,7 @@ from vtsearch.media.base import (
     extract_tensor as _extract_tensor,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
+    load_pretrained_local_first,
 )
 
 if TYPE_CHECKING:
@@ -59,14 +60,14 @@ class VideoXClipEmbedder(MediaEmbedder):
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(
             self._on_progress, "Loading X-CLIP model weights…"
         ):
-            self._model = XCLIPModel.from_pretrained(
-                XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
+            self._model = load_pretrained_local_first(
+                XCLIPModel.from_pretrained, XCLIP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir, token=False
             )
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading X-CLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = XCLIPProcessor.from_pretrained(
-                XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False
+            self._processor = load_pretrained_local_first(
+                XCLIPProcessor.from_pretrained, XCLIP_MODEL_ID, cache_dir=cache_dir, use_fast=False, token=False
             )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR introduces `load_pretrained_local_first()`, a helper function that prevents network hangs when loading pretrained models by preferring locally cached files over network requests.

## Problem
HuggingFace's `from_pretrained()` and `SentenceTransformer()` contact the Hub to check for updates **even when model files are already cached locally**. If the network is unreachable or slow, this HTTP request can hang indefinitely, causing the UI to appear frozen on "Loading … model weights".

## Solution
Implemented `load_pretrained_local_first()` that:
- Attempts to load models with `local_files_only=True` first (uses only cached files)
- Falls back to normal loading (allowing network download) if `OSError` is raised (model not yet cached)
- Propagates non-OSError exceptions and network errors as expected
- Works as a transparent wrapper around any `from_pretrained`-style callable

## Key Changes
- **vtsearch/media/base.py**: Added `load_pretrained_local_first()` function with comprehensive docstring
- **All embedder modules**: Updated model loading calls to use the new helper:
  - `vtsearch/media/audio/embedder.py` (CLAP model and processor)
  - `vtsearch/media/audio/embedder_clap_music.py` (CLAP Music model and processor)
  - `vtsearch/media/image/embedder.py` (CLIP model and processor)
  - `vtsearch/media/image/embedder_siglip.py` (SigLIP model and processor)
  - `vtsearch/media/video/embedder.py` (X-CLIP model and processor)
  - `vtsearch/media/text/embedder.py` (E5 SentenceTransformer)
  - `vtsearch/media/text/embedder_bge.py` (BGE SentenceTransformer)
- **tests/test_preload_progress.py**: Added comprehensive test suite with 6 test cases covering:
  - Successful local-only loading
  - Fallback to network on OSError and FileNotFoundError
  - Argument/kwarg forwarding
  - Non-OSError exception propagation
  - Network fallback error propagation

## Implementation Details
The helper uses a simple try-except pattern that catches `OSError` (and its subclasses like `FileNotFoundError`) to distinguish between "model not cached" and other errors. This allows graceful degradation: cached models load instantly without network contact, while uncached models still download normally.

https://claude.ai/code/session_01GXaL6EfAcYAjieD1zE6xKs