### PR TITLE
Prevent duplicate polling and resume active polling on page load

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -98,6 +98,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private knownModelIds = new Set<string>();
   private completedTaskIds = new Set<string>();
   private completedModelTaskIds = new Set<string>();
+  private datasetPollingActive = false;
+  private modelPollingActive = false;
 
   currentUser = '';
   isDefaultLogin = true;
@@ -169,6 +171,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.pushTopBarLabels();
       });
     this.refresh();
+    this.resumeActivePolling();
+  }
+
+  /** Check for in-progress loading tasks (e.g. after a page reload) and resume polling. */
+  private resumeActivePolling(): void {
+    this.datasetsApi.getLoadingTasks().subscribe((tasks) => {
+      if (tasks.some((t) => t.status !== 'idle')) {
+        this.startProgressPolling();
+      }
+    });
+    this.modelsApi.getModelLoadingTasks().subscribe((resp) => {
+      if ((resp.tasks ?? []).some((t: LoadingTask) => t.status !== 'idle')) {
+        this.startModelProgressPolling();
+      }
+    });
   }
 
   // --- Column resize ---
@@ -680,7 +697,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   startProgressPolling(onComplete?: () => void): void {
     this.datasetState.setErrorMessage('');
-    this.polling$.next(); // cancel previous polling
+
+    // If polling is already active, don't restart — the existing loop
+    // already covers all tasks.  This avoids clearing completedTaskIds
+    // and losing track of tasks that just finished.
+    if (this.datasetPollingActive) {
+      return;
+    }
+    this.datasetPollingActive = true;
     this.completedTaskIds.clear();
 
     timer(0, 1000)
@@ -725,6 +749,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           if (active.length === 0) {
             // No more active tasks — stop polling
             this.polling$.next();
+            this.datasetPollingActive = false;
             // Refresh unless we just did (justFinished already triggered it)
             if (justFinished.length === 0) {
               this.datasetState.refresh();
@@ -738,7 +763,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   startModelProgressPolling(onComplete?: () => void): void {
-    this.modelPolling$.next(); // cancel previous polling
+    if (this.modelPollingActive) {
+      return;
+    }
+    this.modelPollingActive = true;
     this.completedModelTaskIds.clear();
 
     timer(0, 1000)
@@ -775,6 +803,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
           if (active.length === 0) {
             this.modelPolling$.next();
+            this.modelPollingActive = false;
             if (justFinished.length === 0) {
               this.datasetState.refresh();
             }


### PR DESCRIPTION
## Summary
This PR improves the polling mechanism in the dashboard component by preventing duplicate polling loops and automatically resuming polling for in-progress tasks after a page reload.

## Key Changes
- Added `datasetPollingActive` and `modelPollingActive` flags to track polling state
- Modified `startProgressPolling()` and `startModelProgressPolling()` to check if polling is already active before starting a new loop, preventing duplicate concurrent polling
- Added `resumeActivePolling()` method that checks for in-progress loading tasks on component initialization and resumes polling if needed
- Updated polling completion logic to properly reset the active flags when no more tasks are pending

## Implementation Details
- The polling guard prevents clearing `completedTaskIds` and `completedModelTaskIds` when polling is already running, which would cause loss of tracking for recently completed tasks
- `resumeActivePolling()` is called during `ngOnInit()` to handle cases where users reload the page while tasks are still loading
- The active flags are set to `false` only when polling stops (when `active.length === 0`), ensuring the state accurately reflects whether polling is currently running

https://claude.ai/code/session_014CEb7SfyB2VZypY5SYdB3W