### PR TITLE
Add comprehensive tooltips across UI components

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -27,6 +27,7 @@
         role="menuitem"
         tabindex="-1"
         (click)="onDashboard()"
+        title="Return to the Dashboard to manage datasets and models"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="1" y="1" width="14" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
           <rect x="3.5" y="3" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
@@ -39,6 +40,7 @@
         role="menuitem"
         tabindex="-1"
         (click)="onSettings()"
+        title="Open the Settings panel to configure appearance, sorting, autopilot, and autoload"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M6.7 2.2h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 6.2l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
           <circle cx="8" cy="8" r="1.6" fill="currentColor"/>
@@ -53,9 +55,10 @@
     [class.disabled]="!isOnLabelView"
     [disabled]="!isOnLabelView"
     (click)="onDashboard()"
+    title="Return to the Dashboard to manage datasets and models"
   >Dashboard</button>
-  <span class="top-bar-field"><strong>Data:</strong> <span class="top-bar-value">{{ datasetDisplayName }}</span></span>
-  <span class="top-bar-field"><strong>Model:</strong> <span class="top-bar-value">{{ modelDisplayName }}</span></span>
+  <span class="top-bar-field" title="The currently active dataset being browsed and labeled"><strong>Data:</strong> <span class="top-bar-value">{{ datasetDisplayName }}</span></span>
+  <span class="top-bar-field" title="The currently active model used for scoring and sorting"><strong>Model:</strong> <span class="top-bar-value">{{ modelDisplayName }}</span></span>
   <span class="top-bar-spacer"></span>
   <button
     class="settings-btn"

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -154,7 +154,7 @@
       <button
         class="btn btn--primary"
         [disabled]="!labelEnabled"
-        [title]="labelHint"
+        [title]="labelHint || 'Open the labeling view to vote on items and train the selected model on the selected dataset'"
         (click)="onLabel()"
       >
         Train
@@ -165,7 +165,7 @@
       <button
         class="btn btn--primary"
         [disabled]="!findEnabled"
-        [title]="findHint"
+        [title]="findHint || 'Score every item in the selected dataset using the selected model and show ranked results'"
         (click)="onFind()"
       >
         Find

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -45,7 +45,7 @@
         @if (demoEmbedders.length > 1 || demoClippers.length > 1) {
           <div class="demo-embedder-row">
             @if (demoEmbedders.length > 1) {
-              <label class="form-label" for="demo-embedder">Embedder:</label>
+              <label class="form-label" for="demo-embedder" title="Embedding model used to compute vector representations of each media item">Embedder:</label>
               <select
                 id="demo-embedder"
                 class="form-select form-select--inline"
@@ -58,7 +58,7 @@
               </select>
             }
             @if (demoClippers.length > 1) {
-              <label class="form-label" for="demo-clipper">Clipper:</label>
+              <label class="form-label" for="demo-clipper" title="Pre-processing clipper that segments or trims media before embedding (e.g. audio chunking)">Clipper:</label>
               <select
                 id="demo-clipper"
                 class="form-select form-select--inline"
@@ -77,11 +77,11 @@
           <table class="demo-table" [class.demo-table-fixed]="demoTableFixed" [style.width]="demoTableFixed ? (demoTableWidth + 'px') : '100%'">
             <thead>
               <tr>
-                <th (click)="sortDemoBy('label')" class="sortable" data-col="label" [style.width.px]="demoTableFixed ? demoColWidths['label'] : null">Name<span class="sort-indicator" [class.active]="demoSortKey === 'label'">{{ demoSortIndicator('label') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'label')" (click)="$event.stopPropagation()"></div></th>
-                <th (click)="sortDemoBy('num_files')" class="sortable col-num" data-col="num_files" [style.width.px]="demoTableFixed ? demoColWidths['num_files'] : null"># Media<span class="sort-indicator" [class.active]="demoSortKey === 'num_files'">{{ demoSortIndicator('num_files') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'num_files')" (click)="$event.stopPropagation()"></div></th>
-                <th (click)="sortDemoBy('num_categories')" class="sortable col-num" data-col="num_categories" [style.width.px]="demoTableFixed ? demoColWidths['num_categories'] : null"># Cat.<span class="sort-indicator" [class.active]="demoSortKey === 'num_categories'">{{ demoSortIndicator('num_categories') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'num_categories')" (click)="$event.stopPropagation()"></div></th>
-                <th (click)="sortDemoBy('description')" class="sortable" data-col="description" [style.width.px]="demoTableFixed ? demoColWidths['description'] : null">Description<span class="sort-indicator" [class.active]="demoSortKey === 'description'">{{ demoSortIndicator('description') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'description')" (click)="$event.stopPropagation()"></div></th>
-                <th (click)="sortDemoBy('status')" class="sortable" data-col="status" [style.width.px]="demoTableFixed ? demoColWidths['status'] : null">Readiness<span class="sort-indicator" [class.active]="demoSortKey === 'status'">{{ demoSortIndicator('status') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'status')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('label')" class="sortable" title="Demo dataset name (click to sort)" data-col="label" [style.width.px]="demoTableFixed ? demoColWidths['label'] : null">Name<span class="sort-indicator" [class.active]="demoSortKey === 'label'">{{ demoSortIndicator('label') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'label')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('num_files')" class="sortable col-num" title="Number of media files in the demo dataset (click to sort)" data-col="num_files" [style.width.px]="demoTableFixed ? demoColWidths['num_files'] : null"># Media<span class="sort-indicator" [class.active]="demoSortKey === 'num_files'">{{ demoSortIndicator('num_files') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'num_files')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('num_categories')" class="sortable col-num" title="Number of distinct categories or classes in the dataset (click to sort)" data-col="num_categories" [style.width.px]="demoTableFixed ? demoColWidths['num_categories'] : null"># Cat.<span class="sort-indicator" [class.active]="demoSortKey === 'num_categories'">{{ demoSortIndicator('num_categories') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'num_categories')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('description')" class="sortable" title="Short description of the demo dataset contents (click to sort)" data-col="description" [style.width.px]="demoTableFixed ? demoColWidths['description'] : null">Description<span class="sort-indicator" [class.active]="demoSortKey === 'description'">{{ demoSortIndicator('description') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'description')" (click)="$event.stopPropagation()"></div></th>
+                <th (click)="sortDemoBy('status')" class="sortable" title="Whether the dataset is pre-downloaded and ready to load immediately, or needs to be fetched first (click to sort)" data-col="status" [style.width.px]="demoTableFixed ? demoColWidths['status'] : null">Readiness<span class="sort-indicator" [class.active]="demoSortKey === 'status'">{{ demoSortIndicator('status') }}</span><div class="col-resize-handle" (mousedown)="startDemoResize($event, 'status')" (click)="$event.stopPropagation()"></div></th>
               </tr>
             </thead>
             <tbody>
@@ -178,7 +178,7 @@
 
       @if (availableEmbedders.length > 1) {
         <div class="form-group">
-          <label class="form-label" for="field-embedder">Embedder</label>
+          <label class="form-label" for="field-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
           <select
             id="field-embedder"
             class="form-select"
@@ -193,7 +193,7 @@
 
       @if (availableClippers.length > 1) {
         <div class="form-group">
-          <label class="form-label" for="field-clipper">Clipper</label>
+          <label class="form-label" for="field-clipper" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
           <select
             id="field-clipper"
             class="form-select"
@@ -260,7 +260,7 @@
       <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
 
       <div class="form-group">
-        <label class="form-label" for="sf-media-type">Media Type</label>
+        <label class="form-label" for="sf-media-type" title="The type of media files in the folder (audio, image, text, video, or document)">Media Type</label>
         <select
           id="sf-media-type"
           class="form-select"
@@ -316,7 +316,7 @@
 
       @if (sfEmbedders.length > 1) {
         <div class="form-group">
-          <label class="form-label" for="sf-embedder">Embedder</label>
+          <label class="form-label" for="sf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
           <select
             id="sf-embedder"
             class="form-select"
@@ -331,7 +331,7 @@
 
       @if (sfClippers.length > 1) {
         <div class="form-group">
-          <label class="form-label" for="sf-clipper">Clipper</label>
+          <label class="form-label" for="sf-clipper" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
           <select
             id="sf-clipper"
             class="form-select"

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -10,7 +10,7 @@
           {{ mediaTypeName }}s ({{ medias.length }})
         </h3>
         <div class="view-btn-wrapper">
-          <button class="view-btn" (click)="showLeftViewSettings = true">View</button>
+          <button class="view-btn" (click)="showLeftViewSettings = true" title="Change display layout: list vs. grid, focus mode, and icon size">View</button>
           @if (showLeftViewSettings) {
             <vt-left-view-settings-modal [currentMediaType]="medias.length > 0 ? medias[0].type : ''" (closed)="showLeftViewSettings = false" />
           }
@@ -63,6 +63,7 @@
           [class.active]="activeTab === 'manual'"
           [attr.aria-selected]="activeTab === 'manual'"
           (click)="setTab('manual')"
+          title="Browse and label items manually with full control over sort mode, selection strategy, and inclusion."
         >Manual</button>
         <button
           class="left-tab"
@@ -117,7 +118,7 @@
             {{ mediaTypeName }}s ({{ medias.length }})
           </h3>
           <div class="view-btn-wrapper">
-            <button class="view-btn" (click)="showLeftViewSettings = true">View</button>
+            <button class="view-btn" (click)="showLeftViewSettings = true" title="Change display layout: list vs. grid, focus mode, and icon size">View</button>
             @if (showLeftViewSettings) {
               <vt-left-view-settings-modal [currentMediaType]="medias.length > 0 ? medias[0].type : ''" (closed)="showLeftViewSettings = false" />
             }

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
@@ -1,5 +1,5 @@
 @if (visible) {
-  <div class="stripe-overview" aria-label="Media minimap" (click)="onStripeClick($event)">
+  <div class="stripe-overview" aria-label="Media minimap" title="Minimap of all items in sort order. Green = good votes, red = bad votes, white = selected. Click to jump." (click)="onStripeClick($event)">
     <div class="stripe-container">
       @for (dot of cachedDots; track $index) {
         <div

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -7,23 +7,23 @@
     <table class="stats-table">
       <tbody>
         <tr>
-          <td class="stat-label">Media items</td>
+          <td class="stat-label" title="Total number of unique media items in this dataset">Media items</td>
           <td class="stat-value">{{ stats.num_items }}</td>
         </tr>
         <tr>
-          <td class="stat-label">Duplicate groups</td>
+          <td class="stat-label" title="Number of duplicate items that were detected and collapsed">Duplicate groups</td>
           <td class="stat-value">{{ stats.num_dupes }}</td>
         </tr>
         <tr>
-          <td class="stat-label">Ingest started</td>
+          <td class="stat-label" title="Timestamp when the dataset import process began">Ingest started</td>
           <td class="stat-value">{{ formatTimestamp(stats.ingest_started_at) }}</td>
         </tr>
         <tr>
-          <td class="stat-label">Ingest finished</td>
+          <td class="stat-label" title="Timestamp when the dataset import process completed">Ingest finished</td>
           <td class="stat-value">{{ formatTimestamp(stats.ingest_finished_at) }}</td>
         </tr>
         <tr>
-          <td class="stat-label">Duration</td>
+          <td class="stat-label" title="Total time taken to import the dataset">Duration</td>
           <td class="stat-value">{{ duration }}</td>
         </tr>
       </tbody>
@@ -34,8 +34,8 @@
       <table class="stats-table">
         <thead>
           <tr>
-            <th>Extension</th>
-            <th>Count</th>
+            <th title="File extension of media items">Extension</th>
+            <th title="Number of items with this file extension">Count</th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/app/components/modals/detector-export-modal/detector-export-modal.component.html
+++ b/frontend/src/app/components/modals/detector-export-modal/detector-export-modal.component.html
@@ -1,15 +1,15 @@
 <vt-modal [title]="title" [open]="true" (closed)="close()">
   <div class="export-section">
-    <h3>Export Detector Weights</h3>
+    <h3 title="Save the trained neural network weights so the model can be reloaded later">Export Detector Weights</h3>
     <div class="export-options">
-      <button class="btn btn--primary" (click)="exportBrowser()">Browser Download</button>
-      <button class="btn btn--secondary" (click)="exportServer()">Save to Server</button>
+      <button class="btn btn--primary" (click)="exportBrowser()" title="Download the detector weights file to your local machine via the browser">Browser Download</button>
+      <button class="btn btn--secondary" (click)="exportServer()" title="Save the detector weights file to the server's detectors directory">Save to Server</button>
     </div>
   </div>
 
   @if (labelExporters.length > 0) {
     <div class="export-section">
-      <h3>Export Detector Labels</h3>
+      <h3 title="Export the good/bad labels used to train this detector">Export Detector Labels</h3>
       <div class="exporter-picker">
         @for (exp of labelExporters; track exp.name) {
           <button class="exporter-card" (click)="exportLabels(exp)">

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
@@ -15,7 +15,7 @@
             }
           }
         </div>
-        <label class="btn btn--secondary btn--sm add-btn">
+        <label class="btn btn--secondary btn--sm add-btn" title="Upload a media file to use as a good (positive) example">
           + Add Good
           <input type="file" (change)="onFileSelected($event, 'good')" hidden />
         </label>
@@ -33,7 +33,7 @@
             }
           }
         </div>
-        <label class="btn btn--secondary btn--sm add-btn">
+        <label class="btn btn--secondary btn--sm add-btn" title="Upload a media file to use as a bad (negative) example">
           + Add Bad
           <input type="file" (change)="onFileSelected($event, 'bad')" hidden />
         </label>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -1,21 +1,21 @@
 <vt-modal title="Export" [open]="true" (closed)="close()">
   <!-- Category Filter -->
   <div class="export-section">
-    <h3>Categories</h3>
+    <h3 title="Filter which labeled items to include in the export">Categories</h3>
     <div class="delimiter-row">
-      <label class="delimiter-option">
+      <label class="delimiter-option" title="Include both good and bad labeled items">
         <input type="radio" name="labelFilter" value="both" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         All
       </label>
-      <label class="delimiter-option">
+      <label class="delimiter-option" title="Include only items labeled as good (positive examples)">
         <input type="radio" name="labelFilter" value="good" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         Good
       </label>
-      <label class="delimiter-option">
+      <label class="delimiter-option" title="Include only items labeled as bad (negative examples)">
         <input type="radio" name="labelFilter" value="bad" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         Bad
       </label>
-      <label class="delimiter-option" [class.disabled]="!hasCorrections" [title]="hasCorrections ? '' : 'No corrections to export.'">
+      <label class="delimiter-option" [class.disabled]="!hasCorrections" [title]="hasCorrections ? 'Include only items whose label was changed (corrected) after initial import' : 'No corrections to export.'">
         <input type="radio" name="labelFilter" value="corrections" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" [disabled]="!hasCorrections" />
         Corrections
       </label>
@@ -24,7 +24,7 @@
 
   <!-- Column Selection -->
   <div class="export-section">
-    <h3>Columns</h3>
+    <h3 title="Choose which data fields to include in the exported output">Columns</h3>
     <div class="column-checkboxes">
       @for (col of columns; track col.key) {
         <label class="column-toggle">
@@ -83,7 +83,7 @@
 
   <!-- Delimiter -->
   <div class="export-section">
-    <h3>Delimiter</h3>
+    <h3 title="Character used to separate columns in the exported text (comma, tab, or pipe)">Delimiter</h3>
     <div class="delimiter-row">
       @for (opt of delimiterOptions; track opt.value) {
         <label class="delimiter-option">
@@ -102,6 +102,7 @@
         class="export-tab"
         [class.active]="activeTab === 'clipboard'"
         (click)="activeTab = 'clipboard'"
+        title="Copy the exported data to your clipboard as delimited text"
       >
         <svg class="tab-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg> Clipboard
       </button>
@@ -234,10 +235,10 @@
   <!-- Detector Export (Labeling mode only) -->
   @if (showDetectorSection) {
     <div class="export-section">
-      <h3>Export Detector Weights</h3>
+      <h3 title="Save the trained neural network weights so the model can be reloaded later">Export Detector Weights</h3>
       <div class="export-buttons">
-        <button class="btn btn--primary" (click)="exportDetectorBrowser()">Browser Download</button>
-        <button class="btn btn--secondary" (click)="exportDetectorServer()">Save to Server</button>
+        <button class="btn btn--primary" (click)="exportDetectorBrowser()" title="Download the detector weights file to your local machine via the browser">Browser Download</button>
+        <button class="btn btn--secondary" (click)="exportDetectorServer()" title="Save the detector weights file to the server's detectors directory">Save to Server</button>
       </div>
     </div>
   }

--- a/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.html
+++ b/frontend/src/app/components/modals/left-view-settings-modal/left-view-settings-modal.component.html
@@ -18,30 +18,30 @@
       }
       <div class="view-tab-content">
         <div class="form-group">
-          <label class="form-label">View Mode:</label>
+          <label class="form-label" title="Display media as a vertical list or a thumbnail grid">View Mode:</label>
           <div class="toggle-group">
-            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'list'" (click)="onViewModeChange(activeViewTab, 'list')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'list'" (click)="onViewModeChange(activeViewTab, 'list')" title="Show items as a single-column list with names">
               <vt-icon type="list" [size]="13"></vt-icon> List
             </button>
-            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'grid'" (click)="onViewModeChange(activeViewTab, 'grid')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'grid'" (click)="onViewModeChange(activeViewTab, 'grid')" title="Show items as a thumbnail grid">
               <vt-icon type="grid" [size]="13"></vt-icon> Grid
             </button>
           </div>
         </div>
         <div class="form-group">
-          <label class="form-label">Focus Mode:</label>
+          <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
           <div class="toggle-group">
-            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'click'" (click)="onFocusModeChange(activeViewTab, 'click')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'click'" (click)="onFocusModeChange(activeViewTab, 'click')" title="Click an item to preview it in the center panel">
               <vt-icon type="cursor-click" [size]="13"></vt-icon> Click
             </button>
-            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'hover'" (click)="onFocusModeChange(activeViewTab, 'hover')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'hover'" (click)="onFocusModeChange(activeViewTab, 'hover')" title="Hover over an item to immediately preview it">
               <vt-icon type="cursor-hover" [size]="13"></vt-icon> Hover
             </button>
           </div>
         </div>
         <div class="form-group">
-          <label class="form-label">Grid Icon Size:</label>
-          <select class="form-select" [ngModel]="getGridIconSize(activeViewTab)" (ngModelChange)="onGridIconSizeChange(activeViewTab, $event)">
+          <label class="form-label" title="Thumbnail size when in grid view mode">Grid Icon Size:</label>
+          <select class="form-select" [ngModel]="getGridIconSize(activeViewTab)" (ngModelChange)="onGridIconSizeChange(activeViewTab, $event)" title="Choose thumbnail size for the grid view">
             <option value="XS">XS</option>
             <option value="S">S</option>
             <option value="M">M</option>

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -93,8 +93,8 @@
     <div class="load-sort-sections">
       <!-- Sort by Detector -->
       <div class="sort-section">
-        <h3>Sort by Detector</h3>
-        <h4>Server Detectors</h4>
+        <h3 title="Load a saved detector model and rank all items by its predicted scores">Sort by Detector</h3>
+        <h4 title="Detector weight files saved on the server">Server Detectors</h4>
         @if (serverDetectors.length > 0) {
           <div class="file-list">
             @for (det of serverDetectors; track det.name) {
@@ -104,7 +104,7 @@
         } @else {
           <p class="empty-state">No server detector files found.</p>
         }
-        <h4>Dashboard Models</h4>
+        <h4 title="Trained models created from the Dashboard">Dashboard Models</h4>
         @if (registryModels.length > 0) {
           <div class="file-list">
             @for (model of registryModels; track model.id) {
@@ -123,14 +123,14 @@
 
       <!-- Sort by Examples -->
       <div class="sort-section">
-        <h3>Sort by Examples</h3>
-        <label class="btn btn--secondary file-btn">
+        <h3 title="Upload or select an example media file and rank all items by similarity to it">Sort by Examples</h3>
+        <label class="btn btn--secondary file-btn" title="Upload a media file from your computer to use as the sort example">
           Local example media
           <input type="file" (change)="onMediaFileSelected($event)" hidden />
         </label>
-        <button class="btn btn--secondary file-btn" (click)="openMediaPicker()">Browse media sources...</button>
+        <button class="btn btn--secondary file-btn" (click)="openMediaPicker()" title="Browse server media sources to pick an example file">Browse media sources...</button>
         @if (serverMediaFiles.length > 0) {
-          <h4>Server Example Media</h4>
+          <h4 title="Example media files available on the server">Server Example Media</h4>
           <div class="file-list">
             @for (file of serverMediaFiles; track file.name) {
               <button class="file-item" (click)="loadServerMedia(file.filename || file.name)">{{ file.filename || file.name }}</button>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -7,25 +7,29 @@
         <button
           class="settings-tab"
           [class.settings-tab--active]="activeSettingsTab === 'appearance'"
-          (click)="activeSettingsTab = 'appearance'">
+          (click)="activeSettingsTab = 'appearance'"
+          title="Theme, animations, and view layout options">
           Appearance
         </button>
         <button
           class="settings-tab"
           [class.settings-tab--active]="activeSettingsTab === 'sorting'"
-          (click)="activeSettingsTab = 'sorting'">
+          (click)="activeSettingsTab = 'sorting'"
+          title="Options that control how learned sorting and calibration behave">
           Sorting
         </button>
         <button
           class="settings-tab"
           [class.settings-tab--active]="activeSettingsTab === 'autopilot'"
-          (click)="activeSettingsTab = 'autopilot'">
+          (click)="activeSettingsTab = 'autopilot'"
+          title="Configure the guided autopilot labeling workflow">
           Autopilot
         </button>
         <button
           class="settings-tab"
           [class.settings-tab--active]="activeSettingsTab === 'autoload'"
-          (click)="activeSettingsTab = 'autoload'">
+          (click)="activeSettingsTab = 'autoload'"
+          title="Choose which embedding models to load automatically when a dataset is opened">
           Autoload
         </button>
       </nav>
@@ -35,24 +39,24 @@
         @if (activeSettingsTab === 'appearance') {
           <h3>Appearance</h3>
           <div class="form-group">
-            <label class="form-label">Theme</label>
-            <select class="form-select" [ngModel]="settings.theme" (ngModelChange)="onThemeChange($event)">
+            <label class="form-label" title="Color theme for the application interface">Theme</label>
+            <select class="form-select" [ngModel]="settings.theme" (ngModelChange)="onThemeChange($event)" title="Choose the visual color scheme">
               <option value="dark">Dark</option>
               <option value="light">Light</option>
               <option value="highviz">High Visibility</option>
             </select>
           </div>
-          <label class="checkbox-row">
+          <label class="checkbox-row" title="Animate media transitions when voting (swipe left/right effect)">
             <input type="checkbox" [ngModel]="settings.swipe_animation" (ngModelChange)="onToggle('swipe_animation', $event)" />
             Swipe animation
           </label>
-          <label class="checkbox-row">
+          <label class="checkbox-row" title="Show the collapsible metadata tray below the media viewer (name, type, MD5, custom fields)">
             <input type="checkbox" [ngModel]="settings.show_metadata" (ngModelChange)="onToggle('show_metadata', $event)" />
             Show metadata panel
           </label>
 
           @if (mediaTypes.length > 0) {
-            <h4>Scroll Style</h4>
+            <h4 title="Configure how media items are displayed and selected in each panel, per media type">Scroll Style</h4>
             <div class="view-tabs">
               @for (mt of mediaTypes; track mt.type_id) {
                 <button
@@ -65,32 +69,32 @@
             </div>
             <div class="view-tab-content">
               <div class="view-side-section">
-                <h4>Left Side</h4>
+                <h4 title="Display settings for the left panel (unlabeled media list)">Left Side</h4>
                 <div class="form-group">
-                  <label class="form-label">View Mode:</label>
+                  <label class="form-label" title="Display media as a vertical list or a thumbnail grid">View Mode:</label>
                   <div class="toggle-group">
-                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_left', activeViewTab) === 'list'" (click)="onViewModeChange('view_mode_left', activeViewTab, 'list')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_left', activeViewTab) === 'list'" (click)="onViewModeChange('view_mode_left', activeViewTab, 'list')" title="Show items as a single-column list with names">
                       <vt-icon type="list" [size]="14"></vt-icon> List
                     </button>
-                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (click)="onViewModeChange('view_mode_left', activeViewTab, 'grid')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_left', activeViewTab) === 'grid'" (click)="onViewModeChange('view_mode_left', activeViewTab, 'grid')" title="Show items as a thumbnail grid">
                       <vt-icon type="grid" [size]="14"></vt-icon> Grid
                     </button>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label">Focus Mode:</label>
+                  <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
                   <div class="toggle-group">
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (click)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab) === 'click'" (click)="onFocusModeChange('focus_mode_left', activeViewTab, 'click')" title="Click an item to preview it in the center panel">
                       <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
                     </button>
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (click)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab) === 'hover'" (click)="onFocusModeChange('focus_mode_left', activeViewTab, 'hover')" title="Hover over an item to immediately preview it">
                       <vt-icon type="cursor-hover" [size]="14"></vt-icon> Hover
                     </button>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label">Grid Icon Size:</label>
-                  <select class="form-select" [ngModel]="getGridIconSize('grid_icon_size_left', activeViewTab)" (ngModelChange)="onGridIconSizeChange('grid_icon_size_left', activeViewTab, $event)">
+                  <label class="form-label" title="Thumbnail size when in grid view mode">Grid Icon Size:</label>
+                  <select class="form-select" [ngModel]="getGridIconSize('grid_icon_size_left', activeViewTab)" (ngModelChange)="onGridIconSizeChange('grid_icon_size_left', activeViewTab, $event)" title="Choose thumbnail size for the grid view">
                     <option value="XS">XS</option>
                     <option value="S">S</option>
                     <option value="M">M</option>
@@ -100,32 +104,32 @@
                 </div>
               </div>
               <div class="view-side-section">
-                <h4>Right Side</h4>
+                <h4 title="Display settings for the right panel (labeled goods and bads)">Right Side</h4>
                 <div class="form-group">
-                  <label class="form-label">View Mode:</label>
+                  <label class="form-label" title="Display labeled items as a vertical list or a thumbnail grid">View Mode:</label>
                   <div class="toggle-group">
-                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_right', activeViewTab) === 'list'" (click)="onViewModeChange('view_mode_right', activeViewTab, 'list')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_right', activeViewTab) === 'list'" (click)="onViewModeChange('view_mode_right', activeViewTab, 'list')" title="Show items as a single-column list with names">
                       <vt-icon type="list" [size]="14"></vt-icon> List
                     </button>
-                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (click)="onViewModeChange('view_mode_right', activeViewTab, 'grid')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getViewMode('view_mode_right', activeViewTab) === 'grid'" (click)="onViewModeChange('view_mode_right', activeViewTab, 'grid')" title="Show items as a thumbnail grid">
                       <vt-icon type="grid" [size]="14"></vt-icon> Grid
                     </button>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label">Focus Mode:</label>
+                  <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
                   <div class="toggle-group">
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (click)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab) === 'click'" (click)="onFocusModeChange('focus_mode_right', activeViewTab, 'click')" title="Click an item to preview it in the center panel">
                       <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
                     </button>
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (click)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')">
+                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab) === 'hover'" (click)="onFocusModeChange('focus_mode_right', activeViewTab, 'hover')" title="Hover over an item to immediately preview it">
                       <vt-icon type="cursor-hover" [size]="14"></vt-icon> Hover
                     </button>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label">Grid Icon Size:</label>
-                  <select class="form-select" [ngModel]="getGridIconSize('grid_icon_size_right', activeViewTab)" (ngModelChange)="onGridIconSizeChange('grid_icon_size_right', activeViewTab, $event)">
+                  <label class="form-label" title="Thumbnail size when in grid view mode">Grid Icon Size:</label>
+                  <select class="form-select" [ngModel]="getGridIconSize('grid_icon_size_right', activeViewTab)" (ngModelChange)="onGridIconSizeChange('grid_icon_size_right', activeViewTab, $event)" title="Choose thumbnail size for the grid view">
                     <option value="XS">XS</option>
                     <option value="S">S</option>
                     <option value="M">M</option>
@@ -141,46 +145,46 @@
         <!-- Sorting & Calibration -->
         @if (activeSettingsTab === 'sorting') {
           <h3>Sorting &amp; Calibration</h3>
-          <label class="checkbox-row">
+          <label class="checkbox-row" title="Prepend item filenames to text-sort queries to improve semantic matching for named items">
             <input type="checkbox" [ngModel]="settings.enrich_descriptions" (ngModelChange)="onToggle('enrich_descriptions', $event)" />
             Enrich descriptions
           </label>
-          <label class="checkbox-row">
+          <label class="checkbox-row" title="Blend the learned threshold toward 0.5 to reduce aggressive inclusion/exclusion. Useful when the model has few training examples.">
             <input type="checkbox" [ngModel]="settings.safe_thresholds" (ngModelChange)="onToggle('safe_thresholds', $event)" />
             Safe thresholds
           </label>
           <div class="form-group">
-            <label class="form-label">Calibrate count</label>
-            <input type="number" class="form-input" [ngModel]="settings.calibrate_count" (ngModelChange)="onNumberChange('calibrate_count', $event)" min="0" />
+            <label class="form-label" title="Number of items to evaluate when calibrating the decision threshold after training">Calibrate count</label>
+            <input type="number" class="form-input" [ngModel]="settings.calibrate_count" (ngModelChange)="onNumberChange('calibrate_count', $event)" min="0" title="Number of items to evaluate during threshold calibration" />
           </div>
           <div class="form-group">
-            <label class="form-label">Calibration fraction</label>
-            <input type="number" class="form-input" [ngModel]="settings.calibration_fraction" (ngModelChange)="onNumberChange('calibration_fraction', $event)" min="0" max="1" step="0.05" />
+            <label class="form-label" title="Fraction of labeled items to hold out for calibration (0 = none, 1 = all)">Calibration fraction</label>
+            <input type="number" class="form-input" [ngModel]="settings.calibration_fraction" (ngModelChange)="onNumberChange('calibration_fraction', $event)" min="0" max="1" step="0.05" title="Hold-out fraction for threshold calibration (0.0 to 1.0)" />
           </div>
         }
 
         <!-- Autopilot & Actions -->
         @if (activeSettingsTab === 'autopilot') {
           <h3>Autopilot &amp; Actions</h3>
-          <label class="checkbox-row">
+          <label class="checkbox-row" title="Hide the Autopilot tab from the left panel in labeling mode">
             <input type="checkbox" [ngModel]="settings.hide_autopilot" (ngModelChange)="onToggle('hide_autopilot', $event)" />
             Hide autopilot panel
           </label>
           <div class="form-group">
-            <label class="form-label"># Good to start</label>
-            <input type="number" class="form-input" [ngModel]="settings.autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" />
+            <label class="form-label" title="Number of Good votes needed before autopilot moves past the initial good-examples phase"># Good to start</label>
+            <input type="number" class="form-input" [ngModel]="settings.autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" title="Good votes required to advance past the first phase" />
           </div>
           <div class="form-group">
-            <label class="form-label"># Bad to start</label>
-            <input type="number" class="form-input" [ngModel]="settings.autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" />
+            <label class="form-label" title="Number of Bad votes needed before autopilot moves past the bad-examples phase"># Bad to start</label>
+            <input type="number" class="form-input" [ngModel]="settings.autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" title="Bad votes required to advance past the second phase" />
           </div>
           <div class="form-group">
-            <label class="form-label"># Start to re-sort</label>
-            <input type="number" class="form-input" [ngModel]="settings.autopilot_resort_interval" (ngModelChange)="onNumberChange('autopilot_resort_interval', $event)" min="1" />
+            <label class="form-label" title="How many new votes to collect before autopilot triggers a re-sort (retrain + re-rank)"># Start to re-sort</label>
+            <input type="number" class="form-input" [ngModel]="settings.autopilot_resort_interval" (ngModelChange)="onNumberChange('autopilot_resort_interval', $event)" min="1" title="Votes between automatic re-sorts" />
           </div>
           <div class="form-group">
-            <label class="form-label">Goal Diversity</label>
-            <input type="number" class="form-input" [ngModel]="settings.autopilot_goal_diversity" (ngModelChange)="onNumberChange('autopilot_goal_diversity', $event)" min="1" />
+            <label class="form-label" title="Target diversity level for the exploration phase. Higher values mean autopilot will push you to sample from more distinct regions of the dataset.">Goal Diversity</label>
+            <input type="number" class="form-input" [ngModel]="settings.autopilot_goal_diversity" (ngModelChange)="onNumberChange('autopilot_goal_diversity', $event)" min="1" title="Target diversity level for the exploration phase" />
           </div>
 
         }
@@ -191,8 +195,8 @@
           @if (embedders.length > 0) {
             <div class="embedder-grid">
               <div class="embedder-grid-header">
-                <span>Embedder</span>
-                <span>Media Type</span>
+                <span title="Name of the embedding model (e.g. CLIP, CLAP, E5)">Embedder</span>
+                <span title="Which media type this embedder processes (audio, image, text, video, document)">Media Type</span>
               </div>
               @for (embedder of embedders; track embedder.name) {
                 <label class="embedder-row">
@@ -215,12 +219,12 @@
   }
 
   <div class="settings-actions" modal-footer>
-    <button class="btn btn--secondary" (click)="resetDefaults()">Default</button>
-    <label class="btn btn--secondary">
+    <button class="btn btn--secondary" (click)="resetDefaults()" title="Reset all settings to their factory defaults">Default</button>
+    <label class="btn btn--secondary" title="Import settings from a previously exported JSON file">
       Import
       <input type="file" accept=".json" (change)="importSettings($event)" hidden />
     </label>
-    <button class="btn btn--secondary" (click)="exportSettings()">Export</button>
-    <button class="btn btn--primary" (click)="close()">Close</button>
+    <button class="btn btn--secondary" (click)="exportSettings()" title="Download current settings as a JSON file for backup or sharing">Export</button>
+    <button class="btn btn--primary" (click)="close()" title="Close the settings panel">Close</button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.html
+++ b/frontend/src/app/components/modals/view-settings-modal/view-settings-modal.component.html
@@ -18,30 +18,30 @@
       }
       <div class="view-tab-content">
         <div class="form-group">
-          <label class="form-label">View Mode:</label>
+          <label class="form-label" title="Display labeled items as a vertical list or a thumbnail grid">View Mode:</label>
           <div class="toggle-group">
-            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'list'" (click)="onViewModeChange(activeViewTab, 'list')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'list'" (click)="onViewModeChange(activeViewTab, 'list')" title="Show items as a single-column list with names">
               <vt-icon type="list" [size]="13"></vt-icon> List
             </button>
-            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'grid'" (click)="onViewModeChange(activeViewTab, 'grid')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getViewMode(activeViewTab) === 'grid'" (click)="onViewModeChange(activeViewTab, 'grid')" title="Show items as a thumbnail grid">
               <vt-icon type="grid" [size]="13"></vt-icon> Grid
             </button>
           </div>
         </div>
         <div class="form-group">
-          <label class="form-label">Focus Mode:</label>
+          <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
           <div class="toggle-group">
-            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'click'" (click)="onFocusModeChange(activeViewTab, 'click')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'click'" (click)="onFocusModeChange(activeViewTab, 'click')" title="Click an item to preview it in the center panel">
               <vt-icon type="cursor-click" [size]="13"></vt-icon> Click
             </button>
-            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'hover'" (click)="onFocusModeChange(activeViewTab, 'hover')">
+            <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode(activeViewTab) === 'hover'" (click)="onFocusModeChange(activeViewTab, 'hover')" title="Hover over an item to immediately preview it">
               <vt-icon type="cursor-hover" [size]="13"></vt-icon> Hover
             </button>
           </div>
         </div>
         <div class="form-group">
-          <label class="form-label">Grid Icon Size:</label>
-          <select class="form-select" [ngModel]="getGridIconSize(activeViewTab)" (ngModelChange)="onGridIconSizeChange(activeViewTab, $event)">
+          <label class="form-label" title="Thumbnail size when in grid view mode">Grid Icon Size:</label>
+          <select class="form-select" [ngModel]="getGridIconSize(activeViewTab)" (ngModelChange)="onGridIconSizeChange(activeViewTab, $event)" title="Choose thumbnail size for the grid view">
             <option value="XS">XS</option>
             <option value="S">S</option>
             <option value="M">M</option>

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
@@ -2,7 +2,7 @@
   <div class="train-context-bar">
     <div class="train-context-header">
       <div>
-        <span class="train-context-label">Detector</span>
+        <span class="train-context-label" title="The model being trained on your good/bad votes in this session">Detector</span>
         @if (!editing) {
           <span class="train-context-name">{{ detectorName }}</span>
           <button

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -1,5 +1,5 @@
 <div class="vote-section">
-  <h3 [class]="label">
+  <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
     {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length }})
   </h3>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
@@ -1,11 +1,12 @@
 <div class="label-sort-bar">
-  <span class="sort-label">Sort:</span>
+  <span class="sort-label" title="Choose how the labeled items in the Good and Bad lists are ordered">Sort:</span>
   <label for="label-sort-select" class="sr-only">Sort labels</label>
   <select
     id="label-sort-select"
     class="label-sort-select"
     [ngModel]="mode"
     (ngModelChange)="onSortChange($event)"
+    title="Order labeled items by time, name, model confidence, or ID"
   >
     <option value="time-desc">Newest first</option>
     <option value="time-asc">Oldest first</option>

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -7,7 +7,7 @@
 
   @if (mode !== 'find') {
     <div class="import-row">
-      <button class="panel-btn import-btn" [disabled]="disabled" (click)="onImportLabels()">Import Labels</button>
+      <button class="panel-btn import-btn" [disabled]="disabled" (click)="onImportLabels()" title="Import good/bad labels from a file or add media directly to the good or bad pile">Import Labels</button>
     </div>
   }
 
@@ -17,7 +17,7 @@
       (modeChange)="onSortModeChange($event)"
     />
     <div class="view-btn-wrapper">
-      <button class="view-btn" (click)="onViewSettings()">View</button>
+      <button class="view-btn" (click)="onViewSettings()" title="Change display layout for labeled items: list vs. grid, focus mode, and icon size">View</button>
       @if (showViewSettings) {
         <vt-view-settings-modal [currentMediaType]="currentMediaType" (closed)="showViewSettings = false" />
       }
@@ -55,7 +55,7 @@
   />
 
   <div class="export-row">
-    <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()">Export</button>
+    <button class="panel-btn export-btn" [disabled]="disabled" (click)="onExport()" title="Export labeled items to clipboard, file, email, or webhook">Export</button>
   </div>
 </aside>
 


### PR DESCRIPTION
## Summary
This PR adds descriptive `title` attributes (tooltips) to numerous UI elements across the application to improve user experience and provide contextual help without cluttering the interface.

## Key Changes
- **Settings Modal**: Added tooltips to all settings tabs, form labels, checkboxes, buttons, and input fields explaining their purpose and behavior
- **Dataset Importer Modal**: Added tooltips to embedder/clipper selectors and demo table column headers
- **Export Modal**: Added tooltips to category filters, column selection headers, delimiter options, and export buttons
- **View Settings Modals**: Added tooltips to view mode, focus mode, and grid icon size controls (left, right, and standalone variants)
- **Dataset Stats Modal**: Added tooltips to all statistics labels and table headers
- **Load/Sort Modal**: Added tooltips to detector sections, example sorting options, and file browser buttons
- **Detector Export Modal**: Added tooltips to export options and labels section
- **Dashboard Components**: Added tooltips to main navigation buttons, train/find action buttons, and panel controls
- **Left/Right Panels**: Added tooltips to import/export buttons, view settings buttons, and sort controls
- **Additional Components**: Added tooltips to stripe overview minimap, label lists, detector context bar, and examples editor

## Implementation Details
- All tooltips use the standard HTML `title` attribute for native browser tooltip support
- Tooltips provide clear, concise descriptions of functionality (typically 5-15 words)
- Tooltips explain both what a control does and why a user might use it
- Conditional tooltips added where appropriate (e.g., corrections export only when corrections exist)
- No functional changes to component logic or styling, purely additive UX enhancement

https://claude.ai/code/session_01RvYVT7ffPUR19MucMRgwyU