### PR TITLE
Support uppercase MD5 key in custom metadata

### DIFF
--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -147,6 +147,32 @@ class TestApplyCustomMetadataMD5:
         assert count == 0
         assert media_dict[1]["md5"] == "calculated_hash"
 
+    def test_replaces_md5_from_uppercase_key(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash", "custom_metadata": {"MD5": "upper_hash", "title": "foo"}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 1
+        assert media_dict[1]["md5"] == "upper_hash"
+        assert "MD5" not in media_dict[1]["custom_metadata"]
+        assert media_dict[1]["custom_metadata"]["title"] == "foo"
+
+    def test_lowercase_md5_takes_priority_over_uppercase(self):
+        from vtsearch.datasets.loader import apply_custom_metadata_md5
+
+        media_dict = {
+            1: {"md5": "calculated_hash", "custom_metadata": {"md5": "lower_hash", "MD5": "upper_hash"}},
+        }
+        count = apply_custom_metadata_md5(media_dict)
+        assert count == 1
+        # lowercase "md5" should win
+        assert media_dict[1]["md5"] == "lower_hash"
+        assert "md5" not in media_dict[1]["custom_metadata"]
+        # uppercase key remains since lowercase was used
+        assert media_dict[1]["custom_metadata"]["MD5"] == "upper_hash"
+
 
 class TestCustomMetadataMapInLoader:
     """Tests that custom_metadata_map in load_dataset_from_folder skips MD5 calculation."""
@@ -235,6 +261,27 @@ class TestCustomMetadataMapInLoader:
 
         media = next(iter(medias_dict.values()))
         assert media["md5"] == custom_md5
+
+    def test_uppercase_md5_key_in_custom_metadata_map(self, tmp_path):
+        """When custom_metadata_map provides MD5 (uppercase), the loader uses it."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+        from vtsearch.audio.generator import generate_wav
+
+        wav_path = tmp_path / "test.wav"
+        wav_path.write_bytes(generate_wav(440, 0.5))
+
+        medias_dict: dict = {}
+        custom_md5 = "uppercase_provided_md5"
+        cm_map = {"test.wav": {"MD5": custom_md5, "source": "external_db"}}
+
+        load_dataset_from_folder(
+            tmp_path, "sounds", medias_dict, custom_metadata_map=cm_map,
+        )
+
+        assert len(medias_dict) == 1
+        media = next(iter(medias_dict.values()))
+        assert media["md5"] == custom_md5
+        assert media["custom_metadata"]["source"] == "external_db"
 
 
 class TestListMedias:

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -58,6 +58,28 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
+def _pop_md5_key(d: dict[str, Any]) -> str:
+    """Pop and return the MD5 value from *d*, trying both ``"md5"`` and ``"MD5"`` keys.
+
+    Returns the value (or ``""`` if neither key is present) and removes the
+    matched key from *d* so it doesn't leak into downstream metadata.
+    """
+    for key in ("md5", "MD5"):
+        val = d.get(key)
+        if val:
+            del d[key]
+            return val
+    return ""
+
+
+def _get_md5_value(d: dict[str, Any]) -> str:
+    """Return the MD5 value from *d*, trying both ``"md5"`` and ``"MD5"`` keys.
+
+    Unlike :func:`_pop_md5_key` this does **not** mutate *d*.
+    """
+    return d.get("md5") or d.get("MD5") or ""
+
+
 def _streaming_md5(file_path: Path) -> str:
     """Compute MD5 hash of a file using constant memory."""
     h = hashlib.md5()
@@ -231,7 +253,7 @@ def load_dataset_from_folder(
                     file_cm = custom_metadata_map[file_path.name]
 
             # Resolve MD5: custom_metadata > content_md5s > computed
-            cm_md5 = (file_cm.get("md5") or "") if file_cm else ""
+            cm_md5 = _get_md5_value(file_cm) if file_cm else ""
 
             if thin:
                 # Thin mode: store file path reference, skip loading bytes.
@@ -315,10 +337,10 @@ def load_dataset_from_folder(
 def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
     """Use MD5 hashes from custom_metadata when available.
 
-    If a media item's ``custom_metadata`` contains a non-empty ``"md5"`` key,
-    that value is used as the item's ``"md5"`` instead of whatever was
-    calculated during loading.  This lets importers supply authoritative hashes
-    from their data source without recalculation.
+    If a media item's ``custom_metadata`` contains a non-empty ``"md5"`` (or
+    ``"MD5"``) key, that value is used as the item's ``"md5"`` instead of
+    whatever was calculated during loading.  This lets importers supply
+    authoritative hashes from their data source without recalculation.
 
     Args:
         media_dict: The mutable medias dict.  Modified in place.
@@ -331,10 +353,9 @@ def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
         cm = media.get("custom_metadata")
         if not cm:
             continue
-        cm_md5 = cm.get("md5")
+        cm_md5 = _pop_md5_key(cm)
         if cm_md5:
             media["md5"] = cm_md5
-            del cm["md5"]
             count += 1
     return count
 
@@ -472,7 +493,7 @@ def load_dataset_from_folder_chunked(
                 elif file_path.name in custom_metadata_map:
                     file_cm = custom_metadata_map[file_path.name]
 
-            cm_md5 = (file_cm.get("md5") or "") if file_cm else ""
+            cm_md5 = _get_md5_value(file_cm) if file_cm else ""
 
             if thin:
                 if cm_md5:


### PR DESCRIPTION
## Summary
This PR adds support for handling MD5 hashes provided with uppercase "MD5" keys in custom metadata, in addition to the existing lowercase "md5" key support. This improves flexibility when integrating with external data sources that may use different casing conventions.

## Key Changes
- Added `_pop_md5_key()` helper function that extracts MD5 values from dictionaries, checking both "md5" and "MD5" keys (with lowercase taking priority) and removing the matched key to prevent metadata leakage
- Added `_get_md5_value()` helper function that retrieves MD5 values without mutating the dictionary, used when reading from custom_metadata_map
- Updated `apply_custom_metadata_md5()` to use `_pop_md5_key()` for case-insensitive MD5 extraction from custom_metadata
- Updated `load_dataset_from_folder()` and `load_dataset_from_folder_chunked()` to use `_get_md5_value()` when reading MD5 from custom_metadata_map
- Added comprehensive test coverage for uppercase MD5 key handling and priority resolution (lowercase takes precedence when both keys exist)

## Implementation Details
- The helper functions implement a priority system where lowercase "md5" is preferred over uppercase "MD5" when both are present
- The `_pop_md5_key()` function removes the matched key from the dictionary to ensure it doesn't leak into downstream metadata processing
- The `_get_md5_value()` function is read-only, suitable for checking values without side effects
- Updated docstring for `apply_custom_metadata_md5()` to document support for both key variants

https://claude.ai/code/session_01CGps53fzjzrPdqN4e69Box