### PR TITLE
docs: clarify branch policy by removing master references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 
 ## Branch Policy (CRITICAL)
 
-- **All pull requests MUST target `dev`**, never `main` or `master`.
-- **Claude must NEVER open a PR that merges into `main` or `master`.** The `main`/`master` branch is protected and only updated by human maintainers.
+- **All pull requests MUST target `dev`**, never `main`.
+- **Claude must NEVER open a PR that merges into `main`.** The `main` branch is protected and only updated by human maintainers.
 - When creating a PR, always use `--base dev` (e.g., `gh pr create --base dev ...` or the equivalent MCP tool parameter).
-- If your feature branch was forked from `master`/`main` instead of `dev`, rebase or merge onto `dev` before opening a PR.
+- If your feature branch was forked from `main` instead of `dev`, rebase or merge onto `dev` before opening a PR.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Summary
Updated the branch policy documentation to remove references to `master` branch, clarifying that `main` is the only protected production branch.

## Changes
- Removed `master` from branch policy statements, keeping only `main` as the protected production branch
- Updated three instances where `master`/`main` was mentioned to reference only `main`
- Simplified language for clarity while maintaining the same policy intent

## Details
The documentation previously mentioned both `master` and `main` branches interchangeably. This update standardizes on `main` as the single protected branch, reducing confusion about which branch is actually used for production releases. The policy requirements remain unchanged—all PRs must target `dev` and Claude must never open PRs merging into `main`.

https://claude.ai/code/session_014UFm2DrJK3Z2LBA1NHdGNF