### PR TITLE
Add gear icon spin animation for settings modal open/close

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -65,7 +65,9 @@
     aria-label="Settings"
     title="Settings"
     (click)="onSettings()"
-  ><svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  ><svg [class.gear-open]="showSettings" [class.gear-close]="gearClosing"
+       (animationend)="onGearAnimationEnd()"
+       viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M6.7 2.2h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 6.2l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
       <circle cx="8" cy="8" r="1.6" fill="currentColor"/>
     </svg></button>
@@ -74,7 +76,7 @@
   <router-outlet />
 </div>
 @if (showSettings) {
-  <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="showSettings = false" />
+  <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="onSettingsClosed()" />
 }
 <vt-dialog-host />
 }

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -175,6 +175,14 @@ header {
     width: 20px;
     height: 20px;
     color: var(--header-text-dim);
+
+    &.gear-open {
+      animation: gear-spin-open 0.4s ease-in-out forwards;
+    }
+
+    &.gear-close {
+      animation: gear-spin-close 0.4s ease-in-out forwards;
+    }
   }
 
   &:hover {
@@ -218,4 +226,16 @@ header {
   text-align: center;
   margin-top: 40%;
   font-style: italic;
+}
+
+@keyframes gear-spin-open {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(15deg); }
+  100% { transform: rotate(30deg); }
+}
+
+@keyframes gear-spin-close {
+  0% { transform: rotate(30deg); }
+  50% { transform: rotate(15deg); }
+  100% { transform: rotate(0deg); }
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -20,6 +20,7 @@ export class AppComponent {
   title = 'VTSearch';
   menuOpen = false;
   showSettings = false;
+  gearClosing = false;
   isOnLabelView = false;
   settingsViewTab = '';
   datasetDisplayName = '';
@@ -122,8 +123,18 @@ export class AppComponent {
 
   onSettings(): void {
     this.menuOpen = false;
+    this.gearClosing = false;
     this.settingsViewTab = this.inferMediaType();
     this.showSettings = true;
+  }
+
+  onSettingsClosed(): void {
+    this.showSettings = false;
+    this.gearClosing = true;
+  }
+
+  onGearAnimationEnd(): void {
+    this.gearClosing = false;
   }
 
   private inferMediaType(): string {


### PR DESCRIPTION
## Summary
Added smooth spin animations to the settings gear icon that play when the settings modal opens and closes, improving the visual feedback for user interactions.

## Key Changes
- **SCSS animations**: Added two new keyframe animations (`gear-spin-open` and `gear-spin-close`) that rotate the gear icon 30 degrees in opposite directions over 0.4 seconds
- **Component state**: Introduced `gearClosing` boolean flag to track when the settings modal is closing and the gear animation should play in reverse
- **Event handlers**: 
  - Added `onSettingsClosed()` method to set the `gearClosing` flag when the settings modal closes
  - Added `onGearAnimationEnd()` method to reset the `gearClosing` flag after the animation completes
- **Template bindings**: 
  - Applied conditional CSS classes (`gear-open` and `gear-close`) to the settings gear SVG based on modal state
  - Added `animationend` event listener to trigger cleanup after animation completes
  - Updated settings modal closed event to call `onSettingsClosed()` instead of directly setting `showSettings = false`

## Implementation Details
The animation uses a two-state approach: when opening, the gear rotates from 0° to 30°; when closing, it rotates back from 30° to 0°. The `gearClosing` flag ensures the close animation plays even after `showSettings` is set to false, and the `animationend` event handler cleans up the flag to prevent animation loops.

https://claude.ai/code/session_01Rr4AriGsJ8p1pYpqrXDzjm