### PR TITLE
Add animated plus button transitions for modal open/close

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -177,11 +177,11 @@ header {
     color: var(--header-text-dim);
 
     &.gear-open {
-      animation: gear-spin-open 0.4s ease-in-out forwards;
+      animation: gear-spin-open 0.3s ease-in-out forwards;
     }
 
     &.gear-close {
-      animation: gear-spin-close 0.4s ease-in-out forwards;
+      animation: gear-spin-close 0.3s ease-in-out forwards;
     }
   }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -10,7 +10,11 @@
         </div>
       }
       <div class="dashboard-section-actions">
-        <button class="btn btn--primary btn--sm" (click)="openImporterModal()" title="Import a new dataset">+</button>
+        <button class="btn btn--primary btn--sm"
+          [class.plus-open]="importerModalOpen"
+          [class.plus-close]="importerClosing"
+          (animationend)="onImporterAnimationEnd()"
+          (click)="openImporterModal()" title="Import a new dataset">+</button>
       </div>
     </div>
 
@@ -91,7 +95,11 @@
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="lightbulb" [size]="18"></vt-icon> Models</span>
       <div class="dashboard-section-actions">
-        <button class="btn btn--primary btn--sm" (click)="openNewModelModal()" title="Create a new model">+</button>
+        <button class="btn btn--primary btn--sm"
+          [class.plus-open]="newModelModalOpen"
+          [class.plus-close]="newModelClosing"
+          (animationend)="onNewModelAnimationEnd()"
+          (click)="openNewModelModal()" title="Create a new model">+</button>
       </div>
     </div>
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -113,6 +113,26 @@
   padding: 2px 10px;
   font-size: 1rem;
   min-width: 28px;
+
+  &.plus-open {
+    animation: plus-spin-open 0.4s ease-in-out forwards;
+  }
+
+  &.plus-close {
+    animation: plus-spin-close 0.4s ease-in-out forwards;
+  }
+}
+
+@keyframes plus-spin-open {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(22.5deg); }
+  100% { transform: rotate(45deg); }
+}
+
+@keyframes plus-spin-close {
+  0% { transform: rotate(45deg); }
+  50% { transform: rotate(22.5deg); }
+  100% { transform: rotate(0deg); }
 }
 
 .dashboard-grid {

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -115,11 +115,11 @@
   min-width: 28px;
 
   &.plus-open {
-    animation: plus-spin-open 0.4s ease-in-out forwards;
+    animation: plus-spin-open 0.3s ease-in-out forwards;
   }
 
   &.plus-close {
-    animation: plus-spin-close 0.4s ease-in-out forwards;
+    animation: plus-spin-close 0.3s ease-in-out forwards;
   }
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -57,7 +57,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   modelLoadingTasks: LoadingTask[] = [];
 
   importerModalOpen = false;
+  importerClosing = false;
   newModelModalOpen = false;
+  newModelClosing = false;
   exportModalOpen = false;
   exportModelName = '';
   addLabelsModalOpen = false;
@@ -613,20 +615,28 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   openImporterModal(): void {
+    this.importerClosing = false;
     this.importerModalOpen = true;
   }
 
   closeImporterModal(): void {
     this.importerModalOpen = false;
+    this.importerClosing = true;
+  }
+
+  onImporterAnimationEnd(): void {
+    this.importerClosing = false;
   }
 
   onImportComplete(): void {
     this.importerModalOpen = false;
+    this.importerClosing = true;
     this.startProgressPolling();
   }
 
   onDemoSelected(demo: { label: string; name: string; embedder?: string; clipper?: string }): void {
     this.importerModalOpen = false;
+    this.importerClosing = true;
     const params: Record<string, string> = {};
     if (demo.embedder) {
       params['embedder'] = demo.embedder;
@@ -660,15 +670,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   openNewModelModal(): void {
+    this.newModelClosing = false;
     this.newModelModalOpen = true;
   }
 
   closeNewModelModal(): void {
     this.newModelModalOpen = false;
+    this.newModelClosing = true;
+  }
+
+  onNewModelAnimationEnd(): void {
+    this.newModelClosing = false;
   }
 
   onModelCreated(): void {
     this.newModelModalOpen = false;
+    this.newModelClosing = true;
     this.datasetState.refresh();
   }
 


### PR DESCRIPTION
## Summary
This PR adds smooth rotation animations to the plus buttons that open modals in the dashboard, improving the visual feedback when users interact with these controls.

## Key Changes
- **Dashboard component**: Added state tracking for modal closing animations
  - Introduced `importerClosing` and `newModelClosing` flags to manage animation states
  - Added `onImporterAnimationEnd()` and `onNewModelAnimationEnd()` callbacks to reset animation states after completion
  - Updated modal open/close methods to properly set animation states

- **Dashboard template**: Enhanced plus buttons with animation classes and event handlers
  - Added dynamic CSS class binding for `plus-open` and `plus-close` animations
  - Wired up `animationend` event listeners to trigger animation state cleanup
  - Applied changes to both the importer and new model modal buttons

- **Dashboard styles**: Implemented rotation keyframe animations
  - Created `plus-spin-open` animation: rotates from 0° to 45° over 0.3s
  - Created `plus-spin-close` animation: rotates from 45° back to 0° over 0.3s
  - Both animations use ease-in-out timing for smooth motion

- **App component styles**: Standardized animation duration
  - Updated gear icon animations from 0.4s to 0.3s for consistency with new plus button animations

## Implementation Details
The animation system uses a two-state approach:
- When a modal opens, the `plus-open` class triggers a rotation to 45°
- When a modal closes, the `plus-close` class triggers a rotation back to 0°
- Animation state flags are reset via the `animationend` event to ensure clean state management
- This prevents animation conflicts if users rapidly open/close modals

https://claude.ai/code/session_01RpB4P3sfqCZq8ZuUqqzWK3