### PR TITLE
Add pencil icon rotation animation to dataset and model cards

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -85,9 +85,8 @@
       </button>
     }
     <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+      <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M17 3a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L17 3z"></path>
       </svg>
     </button>
     <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -51,6 +51,26 @@ td {
     color: var(--text-primary);
     background: var(--bg-hover);
   }
+
+  .pencil-active {
+    animation: pencil-rotate-open 0.3s ease-in-out forwards;
+  }
+
+  .pencil-inactive {
+    animation: pencil-rotate-close 0.3s ease-in-out forwards;
+  }
+}
+
+@keyframes pencil-rotate-open {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(15deg); }
+  100% { transform: rotate(30deg); }
+}
+
+@keyframes pencil-rotate-close {
+  0% { transform: rotate(30deg); }
+  50% { transform: rotate(15deg); }
+  100% { transform: rotate(0deg); }
 }
 
 .inline-edit {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -44,11 +44,13 @@ export class DatasetCardComponent {
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 
   editing = false;
+  wasEditing = false;
   editName = '';
 
   startRename(event: MouseEvent): void {
     event.stopPropagation();
     this.editing = true;
+    this.wasEditing = true;
     this.editName = this.dataset.name;
     setTimeout(() => this.renameInput?.nativeElement.focus());
   }
@@ -63,6 +65,12 @@ export class DatasetCardComponent {
 
   cancelRename(): void {
     this.editing = false;
+  }
+
+  onPencilAnimationEnd(): void {
+    if (!this.editing) {
+      this.wasEditing = false;
+    }
   }
 
   onRenameKeydown(event: KeyboardEvent): void {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -94,9 +94,8 @@
 }
 <td class="actions-cell">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
-    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+    <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M17 3a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L17 3z"></path>
     </svg>
   </button>
   <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -47,6 +47,26 @@ td {
     color: var(--text-primary);
     background: var(--bg-hover);
   }
+
+  .pencil-active {
+    animation: pencil-rotate-open 0.3s ease-in-out forwards;
+  }
+
+  .pencil-inactive {
+    animation: pencil-rotate-close 0.3s ease-in-out forwards;
+  }
+}
+
+@keyframes pencil-rotate-open {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(15deg); }
+  100% { transform: rotate(30deg); }
+}
+
+@keyframes pencil-rotate-close {
+  0% { transform: rotate(30deg); }
+  50% { transform: rotate(15deg); }
+  100% { transform: rotate(0deg); }
 }
 
 .inline-edit {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -41,11 +41,13 @@ export class ModelCardComponent {
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 
   editing = false;
+  wasEditing = false;
   editName = '';
 
   startRename(event: MouseEvent): void {
     event.stopPropagation();
     this.editing = true;
+    this.wasEditing = true;
     this.editName = this.model.name;
     setTimeout(() => this.renameInput?.nativeElement.focus());
   }
@@ -60,6 +62,12 @@ export class ModelCardComponent {
 
   cancelRename(): void {
     this.editing = false;
+  }
+
+  onPencilAnimationEnd(): void {
+    if (!this.editing) {
+      this.wasEditing = false;
+    }
   }
 
   onRenameKeydown(event: KeyboardEvent): void {


### PR DESCRIPTION
## Summary
Added smooth rotation animations to the pencil/edit icons in dataset and model card components. The icons now rotate when entering and exiting edit mode, providing visual feedback to users during the rename operation.

## Key Changes
- **Animation Styles**: Added `pencil-rotate-open` and `pencil-rotate-close` keyframe animations to both dataset-card and model-card SCSS files
  - Open animation: rotates from 0° to 30° over 0.3s
  - Close animation: rotates from 30° back to 0° over 0.3s
  
- **Component Logic**: Updated both DatasetCardComponent and ModelCardComponent TypeScript files
  - Added `wasEditing` state variable to track if the component was previously in edit mode
  - Added `onPencilAnimationEnd()` method to reset `wasEditing` flag when animation completes
  - Set `wasEditing = true` when `startRename()` is called

- **Template Updates**: Modified SVG pencil icons in both component templates
  - Added dynamic class bindings: `[class.pencil-active]="editing"` and `[class.pencil-inactive]="!editing && wasEditing"`
  - Added `(animationend)` event listener to trigger cleanup after animation completes
  - Updated SVG dimensions from 14x14 to 16x16 and simplified the icon path for a cleaner appearance

## Implementation Details
The animation state is managed through two flags:
- `editing`: indicates current edit mode state
- `wasEditing`: tracks if the component was recently in edit mode, enabling the close animation to play when exiting edit mode
- The `onPencilAnimationEnd()` callback resets `wasEditing` after the animation completes, preventing the animation from replaying unnecessarily

https://claude.ai/code/session_01BeRRc9dgVFJhMsbHxBpSGs