### PR TITLE
Improve column resize handle positioning and hitbox

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -173,7 +173,6 @@
     text-transform: uppercase;
     letter-spacing: 0.03em;
     user-select: none;
-    overflow: hidden;
 
     &.sortable {
       cursor: pointer;
@@ -197,9 +196,9 @@
     .col-resize-handle {
       position: absolute;
       top: 0;
-      right: 0;
+      right: -6px;
       bottom: 0;
-      width: 5px;
+      width: 12px;
       cursor: col-resize;
       z-index: 2;
 
@@ -208,7 +207,8 @@
         position: absolute;
         top: 20%;
         bottom: 20%;
-        right: 0;
+        left: 50%;
+        transform: translateX(-50%);
         width: 2px;
         background: var(--accent, #5b8fff);
         opacity: 0.35;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -100,7 +100,6 @@
     text-transform: uppercase;
     letter-spacing: 0.03em;
     user-select: none;
-    overflow: hidden;
 
     &.sortable {
       cursor: pointer;
@@ -124,9 +123,9 @@
     .col-resize-handle {
       position: absolute;
       top: 0;
-      right: 0;
+      right: -6px;
       bottom: 0;
-      width: 5px;
+      width: 12px;
       cursor: col-resize;
       z-index: 2;
 
@@ -135,7 +134,8 @@
         position: absolute;
         top: 20%;
         bottom: 20%;
-        right: 0;
+        left: 50%;
+        transform: translateX(-50%);
         width: 2px;
         background: var(--accent, #5b8fff);
         opacity: 0.35;


### PR DESCRIPTION
## Summary
Improved the usability of the column resize handle in data tables by expanding its clickable area and centering the visual indicator for better UX.

## Key Changes
- **Expanded resize handle hitbox**: Increased width from 5px to 12px and repositioned from `right: 0` to `right: -6px` to create a larger, more accessible click target
- **Centered resize indicator**: Changed the visual resize line from `right: 0` positioning to `left: 50%` with `transform: translateX(-50%)` for proper centering within the expanded hitbox
- **Removed overflow hidden**: Removed `overflow: hidden` from table header cells to allow the expanded resize handle to extend beyond cell boundaries without being clipped

## Implementation Details
These changes were applied consistently across two components:
- `dashboard.component.scss`
- `dataset-importer-modal/dataset-importer-modal.component.scss`

The resize handle is now easier to target while maintaining a visually centered indicator line, improving the overall column resizing experience without affecting the visual layout of the table headers.

https://claude.ai/code/session_012NvSa8qVC6dJK7cZvFzskB