### PR TITLE
Add icons to Train and Find action buttons

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -169,6 +169,7 @@
         [title]="labelHint || 'Open the labeling view to vote on items and train the selected model on the selected dataset'"
         (click)="onLabel()"
       >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
         Train
       </button>
       <span class="btn-disabled-reason" [style.visibility]="(!labelEnabled && labelHint) ? 'visible' : 'hidden'">{{ labelHint || '&nbsp;' }}</span>
@@ -180,6 +181,7 @@
         [title]="findHint || 'Score every item in the selected dataset using the selected model and show ranked results'"
         (click)="onFind()"
       >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
         Find
       </button>
       <span class="btn-disabled-reason" [style.visibility]="(!findEnabled && findHint) ? 'visible' : 'hidden'">{{ findHint || '&nbsp;' }}</span>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -290,6 +290,14 @@
     min-width: 120px;
     padding: 10px 24px;
     font-size: 1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+
+    svg {
+      flex-shrink: 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Enhanced the dashboard action buttons by adding SVG icons next to the "Train" and "Find" button labels, improving visual clarity and user experience.

## Key Changes
- **HTML**: Added inline SVG icons to the Train and Find buttons
  - Train button: Added a box/layers icon (14x14px)
  - Find button: Added a search/magnifying glass icon (14x14px)
- **Styles**: Updated button styling to properly display icons alongside text
  - Added `display: inline-flex` for flexbox layout
  - Added `align-items: center` and `justify-content: center` for vertical alignment
  - Added `gap: 6px` for spacing between icon and text
  - Added `flex-shrink: 0` to SVG to prevent icon compression

## Implementation Details
The icons are styled to maintain consistent sizing (14x14px) and use `currentColor` to inherit the button's text color, ensuring they adapt to different button states. The flexbox layout ensures proper alignment of the icon and text within the button.

https://claude.ai/code/session_01NaU9tdFvceMe7pE29be9uA