### PR TITLE
Remove plugin dependency documentation from SETUP.md

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -146,8 +146,6 @@ bash install-gpu.sh cu124    # for CUDA 12.4
 
 The CPU `requirements.txt` includes `--extra-index-url` for the smaller CPU-only PyTorch wheel (~200 MB) instead of the default CUDA build (~2 GB). The `install-gpu.sh` script handles selecting the right CUDA version and runs `install-plugin-deps.sh` automatically.
 
-**Adding new plugin dependencies:** If you're developing a new plugin (importer, exporter, media type, etc.), just add a `requirements.txt` in your plugin's directory, then run `bash install-plugin-deps.sh` to regenerate the tree. The next `pip install -r requirements.txt` picks it up automatically — no need to edit any central file.
-
 ## Building the frontend
 
 The Angular frontend must be built after checking out the code — the compiled files are not committed to Git. You'll need **Node.js 18+** and **npm**.


### PR DESCRIPTION
This PR removes outdated documentation about adding new plugin dependencies from the SETUP.md file.

## Summary
Removed a paragraph from the setup documentation that described how to add new plugin dependencies by creating a `requirements.txt` file in a plugin's directory and running `install-plugin-deps.sh`.

## Changes
- Removed the "Adding new plugin dependencies" section from docs/SETUP.md that explained the plugin dependency workflow

## Rationale
This documentation appears to be outdated or no longer reflects the current plugin development process and has been removed to keep the setup guide current and accurate.

https://claude.ai/code/session_018DmmDq6mRbJ9Z2LxJdKuX1