### PR TITLE
Improve voting buttons with icons and better hover states

### DIFF
--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
@@ -6,8 +6,8 @@
     [disabled]="disabled"
     (click)="onVoteBad()"
     title="Mark this media as a Bad example."
-    data-label="Bad"
   >
+    <vt-icon type="thumbs-down" [size]="18"></vt-icon>
     Bad
   </button>
   <button
@@ -17,8 +17,8 @@
     [disabled]="disabled"
     (click)="onVoteGood()"
     title="Mark this media as a Good example."
-    data-label="Good"
   >
+    <vt-icon type="thumbs-up" [size]="18"></vt-icon>
     Good
   </button>
 </div>

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -13,6 +13,7 @@
 }
 
 button {
+  min-width: 120px;
   padding: 8px 24px;
   border: 2px solid;
   border-radius: 6px;
@@ -20,22 +21,11 @@ button {
   font-weight: 500;
   cursor: pointer;
   background: transparent;
-  transition: background 0.15s, color 0.15s;
-
-  // Reserve space for bold text so buttons don't resize on hover.
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
   display: inline-flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-
-  &::after {
-    content: attr(data-label);
-    font-weight: 700;
-    height: 0;
-    overflow: hidden;
-    visibility: hidden;
-    pointer-events: none;
-  }
+  gap: 6px;
 
   &:disabled {
     opacity: 0.5;
@@ -48,7 +38,7 @@ button {
   border-color: var(--color-good);
 
   &:hover:not(:disabled) {
-    font-weight: 700;
+    background: var(--good-bg);
   }
 
   &.voted,
@@ -63,7 +53,7 @@ button {
   border-color: var(--color-bad);
 
   &:hover:not(:disabled) {
-    font-weight: 700;
+    background: var(--bad-bg);
   }
 
   &.voted,

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
@@ -1,8 +1,10 @@
 import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { IconComponent } from '../../icon/icon.component';
 
 @Component({
   selector: 'vt-voting-overlay',
   standalone: true,
+  imports: [IconComponent],
   templateUrl: './voting-overlay.component.html',
   styleUrl: './voting-overlay.component.scss',
 })

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -13,6 +13,7 @@ const KNOWN_TYPES = new Set([
   'check', 'warning', 'x-circle', 'info', 'file', 'lightbulb',
   'list', 'grid', 'cursor-click', 'cursor-hover',
   'palette', 'sort-descending', 'steering-wheel', 'cloud-upload',
+  'thumbs-up', 'thumbs-down',
 ]);
 
 function emojiToType(icon: string): string {
@@ -153,6 +154,12 @@ function emojiToType(icon: string): string {
       }
       @case ('cloud-upload') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/><polyline points="16 14 12 10 8 14"/><line x1="12" y1="10" x2="12" y2="20"/></svg>
+      }
+      @case ('thumbs-up') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>
+      }
+      @case ('thumbs-down') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z"/><path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/></svg>
       }
     } }
   `,


### PR DESCRIPTION
## Summary
Enhanced the voting overlay buttons with thumbs-up/thumbs-down icons and improved the visual feedback on hover by replacing font-weight changes with background color transitions.

## Key Changes
- **Added icon support**: Integrated `thumbs-up` and `thumbs-down` SVG icons to the icon component and added them to the voting buttons
- **Improved button styling**: 
  - Added `min-width: 120px` to prevent button resizing
  - Changed hover state from `font-weight: 700` to background color changes (`var(--good-bg)` and `var(--bad-bg)`)
  - Added `border-color` to the transition property for smoother animations
  - Added `gap: 6px` for spacing between icon and text
- **Removed space-reservation technique**: Eliminated the `::after` pseudo-element that was reserving space for bold text, as it's no longer needed with the `min-width` approach
- **Updated component imports**: Added `IconComponent` to the voting overlay component's imports

## Implementation Details
- The voting buttons now display inline icons alongside the text labels for better visual clarity
- The hover effect now uses background color changes instead of font-weight changes, providing a more polished and consistent user experience
- The `min-width` constraint ensures buttons maintain a consistent size regardless of content changes

https://claude.ai/code/session_01HBVqnrj6vNopq6sYH8dxiB