### PR TITLE
Fix button text alignment in voting overlay

### DIFF
--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -26,6 +26,7 @@ button {
   align-items: center;
   justify-content: center;
   gap: 6px;
+  line-height: 1;
 
   &:disabled {
     opacity: 0.5;


### PR DESCRIPTION
## Summary
Added `line-height: 1` to the button styling in the voting overlay component to improve text alignment and prevent unwanted vertical spacing.

## Key Changes
- Added `line-height: 1` CSS property to the button element in `voting-overlay.component.scss`

## Implementation Details
This change ensures that button text is tightly aligned without extra line-height spacing, which can cause misalignment when buttons contain icons and text together (as indicated by the existing `gap: 6px` property). This is a common fix for achieving proper vertical centering of mixed content (text + icons) within flex containers.

https://claude.ai/code/session_01M1dyHQvAnH6tWyEyc6onAF