### PR TITLE
Add hover state styling for voted and vote-flash buttons

### DIFF
--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -46,6 +46,11 @@ button {
     background: var(--color-good);
     color: var(--header-text, #fff);
   }
+
+  &.voted:hover:not(:disabled),
+  &.vote-flash:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--color-good) 85%, black);
+  }
 }
 
 .btn-bad {
@@ -60,5 +65,10 @@ button {
   &.vote-flash {
     background: var(--color-bad);
     color: var(--header-text, #fff);
+  }
+
+  &.voted:hover:not(:disabled),
+  &.vote-flash:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--color-bad) 85%, black);
   }
 }


### PR DESCRIPTION
## Summary
Enhanced the visual feedback for voting buttons by adding hover state styles to the `.btn-good` and `.btn-bad` button classes when they have the `voted` or `vote-flash` states applied.

## Key Changes
- Added hover state styling to `.btn-good.voted` and `.btn-good.vote-flash` buttons that darkens the background color by mixing 85% of the good color with black
- Added matching hover state styling to `.btn-bad.voted` and `.btn-bad.vote-flash` buttons that darkens the background color by mixing 85% of the bad color with black
- Both hover states respect the `:not(:disabled)` pseudo-class to avoid styling disabled buttons

## Implementation Details
- Uses CSS `color-mix()` function with `srgb` color space to create a darkened version of the button colors on hover
- The 85% color ratio provides a subtle darkening effect while maintaining color integrity
- Styling is applied consistently across both good and bad button variants

https://claude.ai/code/session_01YUqMbimhPeSFfkX8pnf6xw