### PR TITLE
Wrap action cells in div containers for better layout control

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -76,7 +76,8 @@
       <span class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">-</span>
     }
   </td>
-  <td class="actions-cell">
+  <td>
+    <div class="actions-cell">
     @if (!isDefaultLogin) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -109,5 +110,6 @@
         <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
       </svg>
     </button>
+    </div>
   </td>
 }

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -92,7 +92,8 @@
     }
   </td>
 }
-<td class="actions-cell">
+<td>
+  <div class="actions-cell">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
     <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
@@ -118,4 +119,5 @@
       <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
     </svg>
   </button>
+  </div>
 </td>


### PR DESCRIPTION
## Summary
This PR wraps the action cell contents in `<div>` elements with the `actions-cell` class, moving the class from the `<td>` element to an inner container. This change improves layout flexibility and CSS styling capabilities for the action buttons in both dataset and model cards.

## Changes
- **dataset-card.component.html**: Wrapped action buttons in a `<div class="actions-cell">` container within the `<td>` element
- **model-card.component.html**: Wrapped action buttons in a `<div class="actions-cell">` container within the `<td>` element

## Implementation Details
- The `actions-cell` class is now applied to a `<div>` child element instead of directly to the `<td>` element
- This allows for better control over padding, alignment, and spacing of action buttons
- The semantic structure remains intact with proper table cell hierarchy (`<td>` > `<div>`)
- No functional changes to button behavior or accessibility

https://claude.ai/code/session_01WPQfMzUaXzP6fbnvLq2TkF