### PR TITLE
Add spinning animation to voting icons on vote cast

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -80,6 +80,7 @@
       [isGood]="isGood"
       [isBad]="isBad"
       [disabled]="isVoting || disabled"
+      [spinningVote]="spinningVote"
       (voted)="castVote($event)"
     ></vt-voting-overlay>
   }

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -43,6 +43,9 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   swipeAnimation = true;
   showMetadata = true;
   swipeClass = '';
+  spinningVote: 'good' | 'bad' | null = null;
+
+  private spinTimer: ReturnType<typeof setTimeout> | null = null;
 
   private subs: Subscription[] = [];
 
@@ -63,6 +66,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.stopPlayback();
     this.keyboard.stop();
     this.subs.forEach((s) => s.unsubscribe());
+    if (this.spinTimer) clearTimeout(this.spinTimer);
   }
 
   /** Stop all media playback (used on navigation away). */
@@ -148,6 +152,9 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
       next: () => {
         if (this.swipeAnimation && this.media) {
           this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
+          this.spinningVote = vote;
+          if (this.spinTimer) clearTimeout(this.spinTimer);
+          this.spinTimer = setTimeout(() => (this.spinningVote = null), 300);
           setTimeout(() => {
             this.mediaVoted.emit({ id: this.media!.id, vote });
             this.isVoting = false;

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
@@ -7,7 +7,7 @@
     (click)="onVoteBad()"
     title="Mark this media as a Bad example."
   >
-    <vt-icon type="thumbs-down" [size]="18"></vt-icon>
+    <vt-icon type="thumbs-down" [size]="18" [class.icon-spinning]="spinningVote === 'bad'"></vt-icon>
     Bad
   </button>
   <button
@@ -18,7 +18,7 @@
     (click)="onVoteGood()"
     title="Mark this media as a Good example."
   >
-    <vt-icon type="thumbs-up" [size]="18"></vt-icon>
+    <vt-icon type="thumbs-up" [size]="18" [class.icon-spinning]="spinningVote === 'good'"></vt-icon>
     Good
   </button>
 </div>

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -33,6 +33,16 @@ button {
   }
 }
 
+@keyframes icon-spin-cw {
+  0%   { transform: rotate(0deg); }
+  50%  { transform: rotate(90deg); }
+  100% { transform: rotate(0deg); }
+}
+
+vt-icon.icon-spinning {
+  animation: icon-spin-cw 0.3s ease-in-out;
+}
+
 .btn-good {
   color: var(--color-good);
   border-color: var(--color-good);

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.ts
@@ -12,6 +12,7 @@ export class VotingOverlayComponent implements OnDestroy {
   @Input() isGood = false;
   @Input() isBad = false;
   @Input() disabled = false;
+  @Input() spinningVote: 'good' | 'bad' | null = null;
   @Output() voted = new EventEmitter<'good' | 'bad'>();
 
   goodFlash = false;


### PR DESCRIPTION
## Summary
This PR adds a brief spinning animation to the voting icons (thumbs up/down) when a user casts a vote, providing visual feedback during the voting action.

## Key Changes
- **Added CSS animation**: Created `icon-spin-cw` keyframe animation that rotates icons 90 degrees and back over 0.3 seconds
- **Added spinning state tracking**: Introduced `spinningVote` property in `CenterPanelComponent` to track which vote type is currently animating
- **Added timer management**: Implemented `spinTimer` to automatically clear the spinning state after the animation completes (300ms)
- **Connected animation to UI**: Passed `spinningVote` state to `VotingOverlayComponent` and conditionally applied `icon-spinning` class to the appropriate icon
- **Cleanup on destroy**: Added timer cleanup in component's `ngOnDestroy` to prevent memory leaks

## Implementation Details
- The animation is triggered immediately when a vote is cast and automatically clears after 300ms (matching the CSS animation duration)
- The spinning state is vote-type specific, so only the voted icon animates (good or bad, not both)
- Timer is properly cleared before setting a new one to prevent multiple concurrent timers
- All timers are cleaned up when the component is destroyed

https://claude.ai/code/session_014FpGyciEAWC6dnMwdqACjj