### PR TITLE
Snap panel widths to grid columns on resize completion

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -13,7 +13,7 @@ import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
-import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
   selector: 'vt-find-view',
@@ -221,6 +221,18 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dragging = false;
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
+    const leftPanelEl = this.layoutRef.nativeElement.querySelector('vt-left-panel') as HTMLElement | null;
+    if (leftPanelEl) {
+      const snapped = snapPanelWidthToGridColumns(leftPanelEl, this.leftWidth);
+      if (snapped !== null) {
+        const leftMax = this.layoutRef.nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
+        const clamped = Math.max(this.LEFT_MIN, Math.min(leftMax, snapped));
+        this.ngZone.run(() => {
+          this.leftWidth = clamped;
+          this.layoutRef.nativeElement.style.setProperty('--left-width', `${clamped}px`);
+        });
+      }
+    }
     this.savePanelPx('left');
   }
 
@@ -251,6 +263,19 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.draggingRight = false;
     document.removeEventListener('mousemove', this.boundRightMouseMove);
     document.removeEventListener('mouseup', this.boundRightMouseUp);
+    const rightPanelEl = this.layoutRef.nativeElement.querySelector('vt-right-panel') as HTMLElement | null;
+    if (rightPanelEl) {
+      const snapped = snapPanelWidthToGridColumns(rightPanelEl, this.rightWidth);
+      if (snapped !== null) {
+        const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
+        const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
+        const clamped = Math.max(this.RIGHT_MIN, Math.min(rightMax, snapped));
+        this.ngZone.run(() => {
+          this.rightWidth = clamped;
+          this.layoutRef.nativeElement.style.setProperty('--right-width', `${clamped}px`);
+        });
+      }
+    }
     this.savePanelPx('right');
   }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -18,7 +18,7 @@ import { AutopilotStateService } from '../../services/autopilot-state.service';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
 import { LabelingStatusResponse } from '../../models/api.models';
-import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
   selector: 'vt-label-view',
@@ -194,6 +194,19 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dragging = false;
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
+    const leftPanelEl = this.layoutRef.nativeElement.querySelector('vt-left-panel') as HTMLElement | null;
+    if (leftPanelEl) {
+      const snapped = snapPanelWidthToGridColumns(leftPanelEl, this.leftWidth);
+      if (snapped !== null) {
+        const minWidth = this.autopilotCollapsed ? this.COLLAPSED_WIDTH : this.LEFT_MIN;
+        const leftMax = this.layoutRef.nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
+        const clamped = Math.max(minWidth, Math.min(leftMax, snapped));
+        this.ngZone.run(() => {
+          this.leftWidth = clamped;
+          this.layoutRef.nativeElement.style.setProperty('--left-width', `${clamped}px`);
+        });
+      }
+    }
     this.savePanelPx('left');
   }
 
@@ -224,6 +237,19 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.draggingRight = false;
     document.removeEventListener('mousemove', this.boundRightMouseMove);
     document.removeEventListener('mouseup', this.boundRightMouseUp);
+    const rightPanelEl = this.layoutRef.nativeElement.querySelector('vt-right-panel') as HTMLElement | null;
+    if (rightPanelEl) {
+      const snapped = snapPanelWidthToGridColumns(rightPanelEl, this.rightWidth);
+      if (snapped !== null) {
+        const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
+        const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
+        const clamped = Math.max(this.RIGHT_MIN, Math.min(rightMax, snapped));
+        this.ngZone.run(() => {
+          this.rightWidth = clamped;
+          this.layoutRef.nativeElement.style.setProperty('--right-width', `${clamped}px`);
+        });
+      }
+    }
     this.savePanelPx('right');
   }
 

--- a/frontend/src/app/utils/grid-icon-size.ts
+++ b/frontend/src/app/utils/grid-icon-size.ts
@@ -9,3 +9,53 @@ const ICON_SIZE_GOAL_WIDTH: Record<string, number> = {
 export function iconSizeToGoalWidth(size: string): number {
   return ICON_SIZE_GOAL_WIDTH[size] ?? ICON_SIZE_GOAL_WIDTH['M'];
 }
+
+const GRID_GAP = 4;
+
+/**
+ * When the user releases the panel resize divider, snap the panel width down to
+ * the minimum width that still shows the same number of grid columns.
+ *
+ * Finds the active grid container (.media-list.grid-layout or .vote-list.grid-layout)
+ * inside panelEl, reads the current column count from the live DOM (so scrollbar width
+ * and all structural offsets are automatically accounted for), and returns the snapped
+ * panel width. Returns null if the panel is not in grid mode or the element is not found.
+ */
+export function snapPanelWidthToGridColumns(panelEl: HTMLElement, currentPanelWidth: number): number | null {
+  const gridEl = (
+    panelEl.querySelector('.media-list.grid-layout') ??
+    panelEl.querySelector('.vote-list.grid-layout')
+  ) as HTMLElement | null;
+  if (!gridEl) return null;
+
+  const goalWidthStr = gridEl.style.getPropertyValue('--grid-goal-width');
+  const goalWidth = parseFloat(goalWidthStr);
+  if (!goalWidth || isNaN(goalWidth)) return null;
+
+  // clientWidth excludes the scrollbar but includes padding
+  const clientWidth = gridEl.clientWidth;
+  if (clientWidth <= 0) return null;
+
+  const style = window.getComputedStyle(gridEl);
+  const paddingH = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+
+  const contentWidth = clientWidth - paddingH;
+  if (contentWidth <= 0) return null;
+
+  const cols = Math.floor((contentWidth + GRID_GAP) / (goalWidth + GRID_GAP));
+  if (cols <= 0) return null;
+
+  // Minimum content width to still show `cols` columns
+  const minContentWidth = cols * (goalWidth + GRID_GAP) - GRID_GAP;
+  const minClientWidth = minContentWidth + paddingH;
+
+  // Re-add scrollbar width (getBoundingClientRect includes it, clientWidth does not)
+  const boundingWidth = gridEl.getBoundingClientRect().width;
+  const scrollbarWidth = Math.max(0, boundingWidth - clientWidth);
+  const minBoundingWidth = minClientWidth + scrollbarWidth;
+
+  // Preserve any structural offset between the panel edge and the grid element edge
+  const offset = currentPanelWidth - boundingWidth;
+
+  return Math.round(minBoundingWidth + offset);
+}


### PR DESCRIPTION
## Summary
Add intelligent panel width snapping to grid-based layouts. When users finish resizing left or right panels, the panel width now automatically snaps to the minimum width that still displays the same number of grid columns, providing a cleaner visual alignment.

## Key Changes
- **New utility function** `snapPanelWidthToGridColumns()` in `grid-icon-size.ts`:
  - Calculates the current number of grid columns based on the grid's goal width and available space
  - Computes the minimum panel width needed to maintain that column count
  - Accounts for padding, scrollbar width, and structural offsets
  - Returns `null` if the panel is not in grid mode or element is not found

- **Updated `LabelViewComponent`**:
  - Integrated snapping logic into left panel resize completion handler
  - Integrated snapping logic into right panel resize completion handler
  - Snapped widths are clamped to respect minimum/maximum panel constraints

- **Updated `FindViewComponent`**:
  - Applied same snapping logic to both left and right panel resize handlers
  - Maintains consistency with label view behavior

## Implementation Details
- The snapping calculation reads live DOM values (clientWidth, computed styles) to automatically account for scrollbar width and all structural offsets
- Snapped widths are clamped within valid ranges (respecting `LEFT_MIN`, `RIGHT_MIN`, and layout constraints)
- Uses `ngZone.run()` to ensure Angular change detection is triggered when updating panel widths
- Grid gap constant (4px) is factored into column calculations to match CSS grid layout behavior

https://claude.ai/code/session_01PsD9XHj1DxDtd2UZewU8Ni