### PR TITLE
Disable dashboard interactions while loading operations

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -11,6 +11,7 @@
       }
       <div class="dashboard-section-actions">
         <button class="btn btn--primary btn--sm"
+          [disabled]="isLoading"
           (click)="openImporterModal()" title="Import a new dataset"><span class="plus-icon"
             [class.plus-open]="importerModalOpen"
             [class.plus-close]="importerClosing"
@@ -76,7 +77,7 @@
                 [loadingTask]="getInlineTask(dataset.id)"
                 [statsOpen]="statsModalOpen && statsDatasetId === dataset.id"
                 [deleteConfirmOpen]="deletingDatasetId === dataset.id"
-                (rowClick)="toggleDatasetSelection(dataset.id, $event)"
+                (rowClick)="!isLoading && toggleDatasetSelection(dataset.id, $event)"
                 (rename)="renameDataset(dataset, $event)"
                 (stats)="showDatasetStats(dataset)"
                 (delete)="deleteDataset(dataset)"
@@ -98,6 +99,7 @@
       <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="lightbulb" [size]="18"></vt-icon> Models</span>
       <div class="dashboard-section-actions">
         <button class="btn btn--primary btn--sm"
+          [disabled]="isLoading"
           (click)="openNewModelModal()" title="Create a new model"><span class="plus-icon"
             [class.plus-open]="newModelModalOpen"
             [class.plus-close]="newModelClosing"
@@ -131,7 +133,7 @@
                 [loadingTask]="getInlineModelTask(model.id)"
                 [deleteConfirmOpen]="deletingModelId === model.id"
                 [addLabelsOpen]="addLabelsModalOpen && addLabelsModelId === model.id"
-                (rowClick)="toggleModelSelection(model.id, $event)"
+                (rowClick)="!isLoading && toggleModelSelection(model.id, $event)"
                 (rename)="renameModel(model, $event)"
                 (delete)="deleteModel(model)"
                 (load)="loadModel(model)"
@@ -165,7 +167,7 @@
     <div class="action-btn-group">
       <button
         class="btn btn--primary"
-        [disabled]="!labelEnabled"
+        [disabled]="!labelEnabled || findLoading"
         [title]="labelHint || 'Open the labeling view to vote on items and train the selected model on the selected dataset'"
         (click)="onLabel()"
       >
@@ -177,7 +179,7 @@
     <div class="action-btn-group">
       <button
         class="btn btn--primary"
-        [disabled]="!findEnabled"
+        [disabled]="!findEnabled || trainLoading"
         [title]="findHint || 'Score every item in the selected dataset using the selected model and show ranked results'"
         (click)="onFind()"
       >

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -906,6 +906,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Button state ---
 
+  get isLoading(): boolean {
+    return this.trainLoading || this.findLoading;
+  }
+
   get labelEnabled(): boolean {
     const selectedDatasets = this.resolvedSelectedDatasets;
     const selectedModels = this.resolvedSelectedModels;


### PR DESCRIPTION
## Summary
This PR prevents user interactions with the dashboard while training or finding operations are in progress, improving UX by blocking actions that would conflict with ongoing async operations.

## Key Changes
- Added `isLoading` getter that returns `true` when either `trainLoading` or `findLoading` is active
- Disabled "Import dataset" button when loading
- Disabled "Create model" button when loading
- Prevented dataset row selection when loading
- Prevented model row selection when loading
- Disabled "Label" button when finding is in progress
- Disabled "Find" button when training is in progress

## Implementation Details
- The `isLoading` computed property consolidates the loading state checks, making it reusable across multiple UI elements
- Row click handlers now use conditional logic (`!isLoading &&`) to prevent selection during operations
- Action buttons use the `[disabled]` binding with the appropriate loading state flags
- This prevents users from accidentally triggering conflicting operations while async tasks are executing

https://claude.ai/code/session_01Sy4tz4hzHAWqsWXakv75GG