### PR TITLE
Remove disabled state handling from voting buttons

### DIFF
--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.html
@@ -3,7 +3,6 @@
     class="btn-bad"
     [class.voted]="isBad"
     [class.vote-flash]="badFlash"
-    [disabled]="disabled"
     (click)="onVoteBad()"
     title="Mark this media as a Bad example."
   >
@@ -14,7 +13,6 @@
     class="btn-good"
     [class.voted]="isGood"
     [class.vote-flash]="goodFlash"
-    [disabled]="disabled"
     (click)="onVoteGood()"
     title="Mark this media as a Good example."
   >

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -28,10 +28,6 @@ button {
   gap: 6px;
   line-height: 1;
 
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
 }
 
 @keyframes icon-spin-cw {
@@ -48,7 +44,7 @@ vt-icon.icon-spinning {
   color: var(--color-good);
   border-color: var(--color-good);
 
-  &:hover:not(:disabled) {
+  &:hover {
     background: var(--good-bg);
   }
 
@@ -58,8 +54,8 @@ vt-icon.icon-spinning {
     color: var(--header-text, #fff);
   }
 
-  &.voted:hover:not(:disabled),
-  &.vote-flash:hover:not(:disabled) {
+  &.voted:hover,
+  &.vote-flash:hover {
     background: color-mix(in srgb, var(--color-good) 85%, black);
   }
 }
@@ -68,7 +64,7 @@ vt-icon.icon-spinning {
   color: var(--color-bad);
   border-color: var(--color-bad);
 
-  &:hover:not(:disabled) {
+  &:hover {
     background: var(--bad-bg);
   }
 
@@ -78,8 +74,8 @@ vt-icon.icon-spinning {
     color: var(--header-text, #fff);
   }
 
-  &.voted:hover:not(:disabled),
-  &.vote-flash:hover:not(:disabled) {
+  &.voted:hover,
+  &.vote-flash:hover {
     background: color-mix(in srgb, var(--color-bad) 85%, black);
   }
 }


### PR DESCRIPTION
## Summary
Removed the disabled state functionality from the voting overlay buttons, including the disabled attribute binding and associated styling for disabled buttons.

## Key Changes
- Removed `[disabled]="disabled"` binding from both "bad" and "good" voting buttons in the template
- Removed the `:disabled` style rule that applied `opacity: 0.5` and `cursor: not-allowed` styling
- Simplified hover state selectors by removing `:not(:disabled)` pseudo-class conditions from all button hover states (`.btn-good:hover`, `.btn-bad:hover`, and their `.voted` and `.vote-flash` variants)

## Implementation Details
The changes indicate that the voting buttons should no longer support or display a disabled state. All hover effects now apply unconditionally without checking for a disabled state, and the disabled attribute is no longer bound to the component's disabled property. This suggests the voting functionality should always be available to users.

https://claude.ai/code/session_01M4G9W7JhMrfP7Z1VWhkzk8