### PR TITLE
Remove focus ring from mouse clicks in voting overlay

### DIFF
--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -28,6 +28,10 @@ button {
   gap: 6px;
   line-height: 1;
 
+  // Remove focus ring from mouse clicks; keep it for keyboard navigation.
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
 }
 
 @keyframes icon-spin-cw {


### PR DESCRIPTION
## Summary
Updated the voting overlay button styling to remove the focus outline when activated by mouse clicks, while preserving the focus ring for keyboard navigation accessibility.

## Key Changes
- Added `:focus:not(:focus-visible)` pseudo-selector rule to suppress the outline on mouse-triggered focus
- Maintains keyboard navigation visibility by keeping the focus ring when `:focus-visible` is active

## Implementation Details
This change improves the visual experience for mouse users by eliminating the focus ring after clicking, which is typically not needed for pointer-based interaction. The `:focus-visible` pseudo-class ensures that keyboard users still see the focus indicator, maintaining accessibility standards and keyboard navigation clarity.

https://claude.ai/code/session_01GJTAGjWq2e22q81fmqgQC3