### PR TITLE
Fix column resize handle alignment in dashboard and modal

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -200,7 +200,7 @@
     .col-resize-handle {
       position: absolute;
       top: 0;
-      right: -6px;
+      right: 0;
       bottom: 0;
       width: 12px;
       cursor: col-resize;
@@ -211,8 +211,7 @@
         position: absolute;
         top: 20%;
         bottom: 20%;
-        left: 50%;
-        transform: translateX(-50%);
+        right: 0;
         width: 2px;
         background: var(--accent, #5b8fff);
         opacity: 0.35;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -123,7 +123,7 @@
     .col-resize-handle {
       position: absolute;
       top: 0;
-      right: -6px;
+      right: 0;
       bottom: 0;
       width: 12px;
       cursor: col-resize;
@@ -134,8 +134,7 @@
         position: absolute;
         top: 20%;
         bottom: 20%;
-        left: 50%;
-        transform: translateX(-50%);
+        right: 0;
         width: 2px;
         background: var(--accent, #5b8fff);
         opacity: 0.35;


### PR DESCRIPTION
## Summary
Adjusted the positioning of column resize handles and their visual indicators to align properly with the right edge of resizable columns.

## Key Changes
- Updated `.col-resize-handle` positioning from `right: -6px` to `right: 0` in both dashboard and dataset-importer-modal components
- Simplified the resize handle visual indicator (`.resize-handle-line`) positioning:
  - Removed `left: 50%` and `transform: translateX(-50%)` centering approach
  - Changed to `right: 0` for direct right-edge alignment

## Implementation Details
These changes ensure the resize handle and its visual indicator are consistently positioned at the right edge of the column, improving the visual alignment and user experience when interacting with resizable columns. The same fix was applied to both the main dashboard component and the dataset-importer-modal component to maintain consistency across the application.

https://claude.ai/code/session_01FfPNN3cdHyvCsVwRvZRA8Q