### PR TITLE
Add UrbanSound8K small and medium demo dataset variants

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -14,6 +14,9 @@ When the app is running, click the hamburger menu in the top-left corner to open
 | **speech_commands_v2_m** | One-second keyword utterances across 35 Speech Commands v2 categories (medium) |
 | **speech_commands_v2_l** | One-second keyword utterances across 35 Speech Commands v2 categories (large) |
 | **speech_commands_v2_a** | One-second keyword utterances across 35 Google Speech Commands v2 categories (all) |
+| **urbansound8k_s** | Real urban field recordings across 10 UrbanSound8K categories (small) |
+| **urbansound8k_m** | Real urban field recordings across 10 UrbanSound8K categories (medium) |
+| **urbansound8k_l** | Real urban field recordings across 10 UrbanSound8K categories (large) |
 | **urbansound8k_a** | Real urban field recordings across 10 UrbanSound8K categories — air conditioner, car horn, children playing, dog bark, and more |
 
 ## Image

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -183,6 +183,24 @@ class AudioMediaType(MediaType):
                 slice_start=0, slice_end=3000, download_size_mb=SPEECH_COMMANDS_V2_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
+                id="urbansound8k_s", label="UrbanSound8K (S)",
+                description="Real urban field recordings, pre-segmented into labeled sounds.",
+                categories=self._URBANSOUND8K_CATEGORIES, source="urbansound8k",
+                slice_start=0, slice_end=125, download_size_mb=URBANSOUND8K_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="urbansound8k_m", label="UrbanSound8K (M)",
+                description="Real urban field recordings, pre-segmented into labeled sounds.",
+                categories=self._URBANSOUND8K_CATEGORIES, source="urbansound8k",
+                slice_start=125, slice_end=374, download_size_mb=URBANSOUND8K_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="urbansound8k_l", label="UrbanSound8K (L)",
+                description="Real urban field recordings, pre-segmented into labeled sounds.",
+                categories=self._URBANSOUND8K_CATEGORIES, source="urbansound8k",
+                slice_start=374, slice_end=873, download_size_mb=URBANSOUND8K_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
                 id="urbansound8k_a", label="UrbanSound8K (A)",
                 description="Real urban field recordings, pre-segmented into labeled sounds.",
                 categories=self._URBANSOUND8K_CATEGORIES, source="urbansound8k",


### PR DESCRIPTION
## Summary
This PR adds two new demo dataset variants for UrbanSound8K (small and medium sizes) to complement the existing large and all variants, providing users with more granular options for dataset size when exploring audio search capabilities.

## Changes
- **media_type.py**: Added three new `DemoDataset` entries for UrbanSound8K with different size tiers:
  - `urbansound8k_s` (small): 125 samples
  - `urbansound8k_m` (medium): 249 samples (125-374)
  - `urbansound8k_l` (large): 499 samples (374-873)
  - Existing `urbansound8k_a` (all) remains unchanged
  
- **docs/demos.md**: Updated documentation to list the new small and medium UrbanSound8K variants alongside the existing large and all variants

## Implementation Details
- The new variants follow the same pattern as the existing Speech Commands v2 dataset tiers (small, medium, large, all)
- Each variant uses the same categories (`_URBANSOUND8K_CATEGORIES`) and download size constant (`URBANSOUND8K_DOWNLOAD_SIZE_MB`)
- Slice ranges are non-overlapping and sequential, allowing users to progressively explore larger datasets

https://claude.ai/code/session_01LBSgerA9vngs8cc254Lfb4