### PR TITLE
Dim unselected cards during loading operations

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -74,6 +74,7 @@
                 [currentUser]="currentUser"
                 [isDefaultLogin]="isDefaultLogin"
                 [selected]="isDatasetSelected(dataset.id)"
+                [dimmed]="isLoading && !isDatasetSelected(dataset.id)"
                 [loadingTask]="getInlineTask(dataset.id)"
                 [statsOpen]="statsModalOpen && statsDatasetId === dataset.id"
                 [deleteConfirmOpen]="deletingDatasetId === dataset.id"
@@ -130,6 +131,7 @@
               <vt-model-card
                 [model]="model"
                 [selected]="isModelSelected(model.id)"
+                [dimmed]="isLoading && !isModelSelected(model.id)"
                 [loadingTask]="getInlineModelTask(model.id)"
                 [deleteConfirmOpen]="deletingModelId === model.id"
                 [addLabelsOpen]="addLabelsModalOpen && addLabelsModelId === model.id"
@@ -167,7 +169,8 @@
     <div class="action-btn-group">
       <button
         class="btn btn--primary"
-        [disabled]="!labelEnabled || findLoading"
+        [class.loading-active]="trainLoading"
+        [disabled]="!labelEnabled || isLoading"
         [title]="labelHint || 'Open the labeling view to vote on items and train the selected model on the selected dataset'"
         (click)="onLabel()"
       >
@@ -179,7 +182,8 @@
     <div class="action-btn-group">
       <button
         class="btn btn--primary"
-        [disabled]="!findEnabled || trainLoading"
+        [class.loading-active]="findLoading"
+        [disabled]="!findEnabled || isLoading"
         [title]="findHint || 'Score every item in the selected dataset using the selected model and show ranked results'"
         (click)="onFind()"
       >

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -295,6 +295,13 @@
     justify-content: center;
     gap: 6px;
 
+    // Keep full opacity on the active loading button (waggling icon)
+    // even though it's disabled to block new clicks.
+    &.loading-active:disabled {
+      opacity: 1;
+      cursor: wait;
+    }
+
     svg {
       flex-shrink: 0;
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -14,6 +14,16 @@
   &.loading-error {
     background: var(--error-bg, rgba(220, 38, 38, 0.06));
   }
+
+  &.dimmed {
+    opacity: 0.35;
+    pointer-events: none;
+    cursor: default;
+
+    &:hover {
+      background: none;
+    }
+  }
 }
 
 td {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -17,6 +17,7 @@ export class DatasetCardComponent implements OnChanges {
   @Input() currentUser = '';
   @Input() isDefaultLogin = true;
   @Input() @HostBinding('class.selected') selected = false;
+  @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;
 
   @HostBinding('class.loading-error')

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -10,6 +10,16 @@
   &.selected {
     background: var(--accent-highlight-bg);
   }
+
+  &.dimmed {
+    opacity: 0.35;
+    pointer-events: none;
+    cursor: default;
+
+    &:hover {
+      background: none;
+    }
+  }
 }
 
 td {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -15,6 +15,7 @@ import { formatProgressFraction } from '../../../utils/format-progress';
 export class ModelCardComponent implements OnChanges {
   @Input() model: any;
   @Input() @HostBinding('class.selected') selected = false;
+  @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;
 
   @HostBinding('class.loading-error')


### PR DESCRIPTION
## Summary
This PR improves the user experience during loading operations by visually dimming unselected dataset and model cards, making it clear which items are involved in the current operation.

## Key Changes
- **Card dimming**: Added `.dimmed` CSS class to both dataset and model cards that reduces opacity to 0.35, disables pointer events, and removes hover effects
- **Dimming logic**: Cards are dimmed when a loading operation is in progress (`isLoading`) and the card is not selected
- **Button state improvements**: 
  - Updated label and find buttons to use a unified `isLoading` flag instead of separate `findLoading`/`trainLoading` checks
  - Added `.loading-active` class to maintain full opacity on the currently active loading button (with waggling icon) while other controls are disabled
  - Changed cursor to `wait` on the active loading button for better UX feedback
- **Component inputs**: Added `@Input() dimmed` property to both `DatasetCardComponent` and `ModelCardComponent` with `@HostBinding` to apply the CSS class

## Implementation Details
- The dimming effect uses `pointer-events: none` to prevent interaction with dimmed cards
- The active loading button retains full opacity and `cursor: wait` to indicate an ongoing operation
- All unselected cards are dimmed during any loading operation, providing clear visual feedback about which items are involved

https://claude.ai/code/session_017i9qDezByZoQ8wHHdLWwcQ