### PR TITLE
Refactor SigLIP processor loading to use component-based approach

### DIFF
--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -69,9 +69,15 @@ class ImageSiglipEmbedder(MediaEmbedder):
         self._model = self._model.to("cpu")
         self._on_progress("loading", "Loading SigLIP processor…", 0, 0)
         with intercept_tqdm_progress(self._on_progress):
-            self._processor = load_pretrained_local_first(
-                SiglipProcessor.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False
+            from transformers import SiglipImageProcessor, SiglipTokenizer  # noqa: PLC0415
+
+            image_processor = load_pretrained_local_first(
+                SiglipImageProcessor.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False
             )
+            tokenizer = load_pretrained_local_first(
+                SiglipTokenizer.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=False
+            )
+            self._processor = SiglipProcessor(image_processor=image_processor, tokenizer=tokenizer)
 
     # ------------------------------------------------------------------
     # Embedding


### PR DESCRIPTION
## Summary
Refactored the SigLIP processor initialization to load image processor and tokenizer components separately, then compose them into a `SiglipProcessor` instance, rather than loading the processor directly.

## Key Changes
- Changed from loading `SiglipProcessor` directly via `from_pretrained` to loading its components separately:
  - Load `SiglipImageProcessor` independently
  - Load `SiglipTokenizer` independently
  - Instantiate `SiglipProcessor` by passing both components
- Added local imports for `SiglipImageProcessor` and `SiglipTokenizer` from the `transformers` library

## Implementation Details
This approach provides more granular control over processor initialization and allows for potential customization of individual components before composition. The change maintains the same caching behavior and token handling through the `load_pretrained_local_first` utility function.

https://claude.ai/code/session_01H15ZJowPXuAJ77ojhAxYAT