### PR TITLE
Pad video frames to 8 for X-CLIP model compatibility

### DIFF
--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -123,6 +123,10 @@ class VideoXClipEmbedder(MediaEmbedder):
                 print(f"Error: could not extract frames from {file_path}")
                 return None
 
+            # X-CLIP expects exactly 8 frames; pad by repeating if we have fewer
+            while len(frames) < 8:
+                frames.append(frames[-1])
+
             inputs = self._processor(images=[list(frames)], return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}


### PR DESCRIPTION
## Summary
Added frame padding logic to ensure X-CLIP model receives exactly 8 frames, which is required by the model architecture.

## Key Changes
- Added validation and padding mechanism in `embed_media()` method to guarantee 8 frames are provided to the X-CLIP processor
- When fewer than 8 frames are extracted from a video, the last frame is repeated until the required count is reached
- This prevents model inference errors when processing videos with fewer than 8 extractable frames

## Implementation Details
- The padding occurs after frame extraction but before model processing
- Uses a simple while loop to append the final frame repeatedly until the frame list reaches length 8
- This approach maintains temporal consistency by repeating the last available frame rather than using blank frames or other interpolation methods

https://claude.ai/code/session_01Coz3X1UPeHt73nGWZg2esD