### PR TITLE
Refactor media dependencies into feature-specific requirement files

### DIFF
--- a/install-plugin-deps.sh
+++ b/install-plugin-deps.sh
@@ -28,7 +28,7 @@ fi
 REQ_FILES=()
 while IFS= read -r -d '' f; do
     REQ_FILES+=("$f")
-done < <(find "$SCRIPT_DIR/vtsearch" -name "requirements.txt" -print0 | sort -z)
+done < <(find "$SCRIPT_DIR/vtsearch" -name "requirements*.txt" -print0 | sort -z)
 
 # Write requirements-plugins.txt with -r references.
 {

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -15,8 +15,11 @@
 -r vtsearch/exporters/webhook/requirements.txt
 -r vtsearch/labels/importers/server_csv_file/requirements.txt
 -r vtsearch/labels/importers/server_json_file/requirements.txt
+-r vtsearch/media/audio/requirements-clap.txt
 -r vtsearch/media/audio/requirements.txt
 -r vtsearch/media/document/requirements.txt
+-r vtsearch/media/image/requirements-extractor.txt
+-r vtsearch/media/image/requirements-siglip.txt
 -r vtsearch/media/image/requirements.txt
 -r vtsearch/media/text/requirements.txt
 -r vtsearch/media/video/requirements.txt

--- a/vtsearch/media/audio/requirements-clap.txt
+++ b/vtsearch/media/audio/requirements-clap.txt
@@ -1,0 +1,2 @@
+# CLAP embedder dependencies
+soundfile

--- a/vtsearch/media/audio/requirements.txt
+++ b/vtsearch/media/audio/requirements.txt
@@ -1,4 +1,2 @@
-# Audio media type dependencies
-# These packages are required to load and embed audio files.
+# Audio media type — shared dependencies
 librosa
-soundfile

--- a/vtsearch/media/image/requirements-extractor.txt
+++ b/vtsearch/media/image/requirements-extractor.txt
@@ -1,0 +1,2 @@
+# YOLO extractor / face localizer dependencies
+ultralytics

--- a/vtsearch/media/image/requirements-siglip.txt
+++ b/vtsearch/media/image/requirements-siglip.txt
@@ -1,0 +1,3 @@
+# SigLIP embedder dependencies
+sentencepiece
+protobuf

--- a/vtsearch/media/image/requirements.txt
+++ b/vtsearch/media/image/requirements.txt
@@ -3,3 +3,4 @@
 Pillow
 ultralytics
 sentencepiece
+protobuf

--- a/vtsearch/media/image/requirements.txt
+++ b/vtsearch/media/image/requirements.txt
@@ -1,6 +1,2 @@
-# Image media type dependencies
-# These packages are required to open and process image files.
+# Image media type — shared dependencies
 Pillow
-ultralytics
-sentencepiece
-protobuf


### PR DESCRIPTION
## Summary
Reorganized media type dependencies to separate shared/core dependencies from optional feature-specific dependencies. This allows for more granular dependency management and cleaner installation of only required components.

## Key Changes
- **Image media**: Split `requirements.txt` into:
  - `requirements.txt` - Core dependency (Pillow only)
  - `requirements-extractor.txt` - YOLO extractor/face localizer (ultralytics)
  - `requirements-siglip.txt` - SigLIP embedder (sentencepiece, protobuf)

- **Audio media**: Split `requirements.txt` into:
  - `requirements.txt` - Core dependency (librosa only)
  - `requirements-clap.txt` - CLAP embedder (soundfile)

- **Build system**: Updated `install-plugin-deps.sh` to discover all `requirements*.txt` files (not just `requirements.txt`) using glob pattern matching

- **Plugin aggregation**: Updated `requirements-plugins.txt` to include all new feature-specific requirement files alongside the base media requirements

## Implementation Details
The refactoring maintains backward compatibility by keeping shared dependencies in the base `requirements.txt` files while extracting optional feature dependencies into separate files. The installation script now automatically discovers and includes all requirement files matching the `requirements*.txt` pattern, making it easy to add new feature-specific dependencies in the future.

https://claude.ai/code/session_01Gu3pY2FwdZAev5p7hxMQ8D