### PR TITLE
Handle TypeError and ValueError in load_pretrained_local_first fallback

### DIFF
--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -427,6 +427,36 @@ class TestLoadPretrainedLocalFirst:
         assert captured["args"] == ("model-id",)
         assert captured["kwargs"] == {"low_cpu_mem_usage": True, "token": False}
 
+    def test_falls_back_on_type_error(self):
+        """TypeError (e.g. sentencepiece gets None vocab_file) should trigger fallback."""
+        call_count = [0]
+        sentinel = object()
+
+        def fake_load(*args, **kwargs):
+            call_count[0] += 1
+            if kwargs.get("local_files_only"):
+                raise TypeError("not a string")
+            return sentinel
+
+        result = load_pretrained_local_first(fake_load, "model-id")
+        assert result is sentinel
+        assert call_count[0] == 2
+
+    def test_falls_back_on_value_error(self):
+        """ValueError from partial cache should trigger fallback."""
+        call_count = [0]
+        sentinel = object()
+
+        def fake_load(*args, **kwargs):
+            call_count[0] += 1
+            if kwargs.get("local_files_only"):
+                raise ValueError("invalid vocab path")
+            return sentinel
+
+        result = load_pretrained_local_first(fake_load, "model-id")
+        assert result is sentinel
+        assert call_count[0] == 2
+
     def test_non_oserror_exceptions_propagate(self):
         """Non-OSError exceptions (e.g. ImportError) should not be caught."""
 

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -114,8 +114,11 @@ def load_pretrained_local_first(load_fn: Callable[..., Any], *args: Any, **kwarg
     """
     try:
         return load_fn(*args, local_files_only=True, **kwargs)
-    except OSError:
+    except (OSError, TypeError, ValueError):
         # Model not in local cache — allow network download.
+        # OSError: model files missing entirely.
+        # TypeError/ValueError: partial cache where a resolved path is None
+        # or invalid (e.g. sentencepiece receives None instead of a string).
         return load_fn(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
Extended the exception handling in `load_pretrained_local_first` to catch `TypeError` and `ValueError` in addition to `OSError`, enabling graceful fallback to network downloads when local cache is partially corrupted or invalid.

## Changes
- **Exception handling expansion**: Modified `load_pretrained_local_first` to catch `TypeError` and `ValueError` alongside `OSError`
  - `TypeError`: Handles cases where tokenizers like sentencepiece receive `None` instead of expected string arguments due to partial cache
  - `ValueError`: Handles invalid paths or values from partially cached models
  - `OSError`: Continues to handle missing model files

- **Documentation**: Added inline comments explaining each exception type and its cause

- **Test coverage**: Added two new test cases
  - `test_falls_back_on_type_error`: Verifies fallback behavior when `TypeError` is raised during local-only load
  - `test_falls_back_on_value_error`: Verifies fallback behavior when `ValueError` is raised during local-only load

## Implementation Details
The change ensures that when a model is partially cached (e.g., some files present but others missing or corrupted), the function will attempt a fresh download rather than propagating the error. This is particularly important for tokenizers that validate their inputs strictly.

https://claude.ai/code/session_01B2Ev31jJE6GuZNh2z4ezAU