### PR TITLE
Replace os.devnull with StringIO for tqdm output redirection

### DIFF
--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -19,6 +19,7 @@ the registry.
 from __future__ import annotations
 
 import contextlib
+import io
 import os
 import threading
 from abc import ABC, abstractmethod
@@ -162,44 +163,45 @@ def intercept_tqdm_progress(callback: ProgressCallback) -> Any:
         desc = (getattr(bar, "desc", "") or "Loading…").rstrip(": ")
         callback("loading", desc, current, int(total))
 
-    # Redirect intercepted bars' output to devnull so they don't print
-    # to the console.  The callback receives all progress updates instead.
-    _devnull = open(os.devnull, "w")  # noqa: SIM115
-    try:
+    # Redirect intercepted bars' output to a StringIO sink so they don't
+    # print to the console.  The callback receives all progress updates
+    # instead.  We use StringIO rather than open(os.devnull) because tqdm
+    # bars can outlive this context (held by transformers/huggingface_hub
+    # internals).  A closed devnull file causes "I/O operation on closed
+    # file" when those zombie bars attempt writes later.
+    _sink = io.StringIO()
 
-        def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
-            # Force file=devnull so tqdm never writes to the console.
-            # huggingface_hub's tqdm wrapper passes file=sys.stderr explicitly,
-            # so we must override unconditionally (not just when absent).
-            kwargs["file"] = _devnull
-            _orig_init(self, *args, **kwargs)
-            total = getattr(self, "total", None)
-            if total and total > 0 and not getattr(self, "disable", False):
-                _bars.append(self)
-                if _primary_bar() is self:
-                    _report(self)
-
-        def _patched_update(self: Any, n: int = 1) -> None:
-            _orig_update(self, n)
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        # Force file=_sink so tqdm never writes to the console.
+        # huggingface_hub's tqdm wrapper passes file=sys.stderr explicitly,
+        # so we must override unconditionally (not just when absent).
+        kwargs["file"] = _sink
+        _orig_init(self, *args, **kwargs)
+        total = getattr(self, "total", None)
+        if total and total > 0 and not getattr(self, "disable", False):
+            _bars.append(self)
             if _primary_bar() is self:
                 _report(self)
 
-        def _patched_close(self: Any) -> None:
-            _orig_close(self)
-            if self in _bars:
-                _bars.remove(self)
+    def _patched_update(self: Any, n: int = 1) -> None:
+        _orig_update(self, n)
+        if _primary_bar() is self:
+            _report(self)
 
-        tqdm.std.tqdm.__init__ = _patched_init  # type: ignore[assignment]
-        tqdm.std.tqdm.update = _patched_update  # type: ignore[assignment]
-        tqdm.std.tqdm.close = _patched_close  # type: ignore[assignment]
-        try:
-            yield
-        finally:
-            tqdm.std.tqdm.__init__ = _orig_init  # type: ignore[assignment]
-            tqdm.std.tqdm.update = _orig_update  # type: ignore[assignment]
-            tqdm.std.tqdm.close = _orig_close  # type: ignore[assignment]
+    def _patched_close(self: Any) -> None:
+        _orig_close(self)
+        if self in _bars:
+            _bars.remove(self)
+
+    tqdm.std.tqdm.__init__ = _patched_init  # type: ignore[assignment]
+    tqdm.std.tqdm.update = _patched_update  # type: ignore[assignment]
+    tqdm.std.tqdm.close = _patched_close  # type: ignore[assignment]
+    try:
+        yield
     finally:
-        _devnull.close()
+        tqdm.std.tqdm.__init__ = _orig_init  # type: ignore[assignment]
+        tqdm.std.tqdm.update = _orig_update  # type: ignore[assignment]
+        tqdm.std.tqdm.close = _orig_close  # type: ignore[assignment]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary
Fixed a bug where tqdm progress bars held by external libraries (transformers/huggingface_hub) would crash with "I/O operation on closed file" errors after the context manager exited. The fix replaces the closed file handle approach with a StringIO sink that remains valid for the lifetime of the application.

## Key Changes
- Added `import io` to support StringIO usage
- Replaced `open(os.devnull, "w")` with `io.StringIO()` for redirecting tqdm output
- Removed the `try/finally` block that was closing the devnull file, since StringIO doesn't need explicit closure
- Restructured the code to remove unnecessary nesting (moved function definitions and patching outside the try block)

## Implementation Details
The previous implementation opened a file handle to `/dev/null` and closed it in the finally block. However, tqdm bars created by external libraries can outlive the context manager and retain references to this file. When those "zombie" bars attempt to write after the file is closed, they raise an I/O error.

Using `io.StringIO()` instead solves this problem because:
- StringIO objects don't need to be closed to remain functional
- They can safely accept writes from any tqdm bar, regardless of when it was created
- The string buffer is automatically garbage collected when no longer referenced

This approach maintains the same behavior of suppressing console output while preventing crashes from delayed writes by external library internals.

https://claude.ai/code/session_01AbHZhMpDNYnacQJYpV4Gc7