### PR TITLE
Auto-guess embedder selection in dataset importer modal

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -198,6 +198,7 @@
 @if (importerModalOpen) {
   <vt-dataset-importer-modal
     [guessedMediaType]="guessedMediaType"
+    [guessedMediaEmbedder]="guessedMediaEmbedder"
     (closed)="closeImporterModal()"
     (importStarted)="onImportComplete()"
     (demoSelected)="onDemoSelected($event)"

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -625,6 +625,19 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return types.size === 1 ? [...types][0] : '';
   }
 
+  /** Guess the media embedder the user likely wants based on existing datasets and in-progress loads. */
+  get guessedMediaEmbedder(): string {
+    const embedders = new Set<string>();
+    for (const d of this.datasets) {
+      const emb = d['embedder'] as string;
+      if (emb) embedders.add(emb);
+    }
+    for (const t of this.loadingTasks) {
+      if (t.embedder && !t.error) embedders.add(t.embedder);
+    }
+    return embedders.size === 1 ? [...embedders][0] : '';
+  }
+
   openImporterModal(): void {
     this.importerClosing = false;
     this.importerModalOpen = true;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -19,6 +19,8 @@ type ModalView = 'picker' | 'form' | 'demo' | 'server_folder';
 export class DatasetImporterModalComponent implements OnInit {
   /** Media type_id guessed from existing datasets/models (e.g. "image"). */
   @Input() guessedMediaType = '';
+  /** Embedder name guessed from existing datasets/in-progress loads (e.g. "siglip"). */
+  @Input() guessedMediaEmbedder = '';
 
   @Output() closed = new EventEmitter<void>();
   @Output() importStarted = new EventEmitter<void>();
@@ -217,8 +219,11 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.availableEmbedders = embedders;
-        // Default to the first embedder
-        this.selectedEmbedder = embedders.length > 0 ? embedders[0].name : '';
+        // Prefer guessed embedder when it's available for this media type
+        const guessedMatch = this.guessedMediaEmbedder
+          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
+          : null;
+        this.selectedEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
       },
     });
   }
@@ -287,7 +292,11 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.demoEmbedders = embedders;
-        this.selectedDemoEmbedder = embedders.length > 0 ? embedders[0].name : '';
+        // Prefer guessed embedder when it's available for this media type
+        const guessedMatch = this.guessedMediaEmbedder
+          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
+          : null;
+        this.selectedDemoEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
         this.demoEmbedder = this.selectedDemoEmbedder;
         this.updateDemoStatuses();
         // The initial demo fetch had no embedder/clipper context, so re-fetch
@@ -674,7 +683,11 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.sfEmbedders = embedders;
-        this.sfSelectedEmbedder = embedders.length > 0 ? embedders[0].name : '';
+        // Prefer guessed embedder when it's available for this media type
+        const guessedMatch = this.guessedMediaEmbedder
+          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
+          : null;
+        this.sfSelectedEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
       },
     });
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -166,6 +166,7 @@ export interface LoadingTask {
   dataset_id?: string;
   model_id?: string;
   media_type?: string;
+  embedder?: string;
 }
 
 export interface LoadingTasksResponse {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -191,10 +191,14 @@ class TestGuessMediaEmbedder:
         assert "embedder" not in task
 
     def test_js_contains_embedder_guessing_logic(self, client):
-        """main.js should include the embedder guessing code."""
-        resp = client.get("/static/main.js")
-        text = resp.data.decode("utf-8")
-        assert "guessedMediaEmbedder" in text
+        """The Angular bundle should include the embedder guessing code."""
+        import glob as globmod
+
+        combined = ""
+        for path in globmod.glob("static/*.js"):
+            resp = client.get(f"/{path}")
+            combined += resp.data.decode("utf-8")
+        assert "guessedMediaEmbedder" in combined
 
 
 class TestGuessMediaType:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -131,6 +131,72 @@ class TestDashboardHtmlPresent:
         assert b"<app-root>" in resp.data
 
 
+class TestGuessMediaEmbedder:
+    """Frontend auto-populates the embedder dropdown when creating a new dataset.
+
+    The guessing logic lives in the Angular frontend (dashboard component):
+    collect embedder names from datasets in the registry and in-progress loading
+    tasks. If exactly one unique embedder exists, pre-select it.
+
+    These tests verify the underlying data contracts that the frontend logic relies on.
+    """
+
+    def test_single_dataset_embedder_in_registry(self, client):
+        """When the registry has one dataset with an embedder, the field is available."""
+        register_dataset(
+            name="test-siglip", media_type="image", num_items=10,
+            pkl_path="/tmp/siglip.pkl", embedder="siglip",
+        )
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["embedder"] == "siglip"
+
+    def test_multiple_same_embedder_datasets_in_registry(self, client):
+        """Multiple datasets with the same embedder yield a single unique embedder."""
+        register_dataset(name="ds1", media_type="image", num_items=5, pkl_path="/tmp/a.pkl", embedder="siglip")
+        register_dataset(name="ds2", media_type="image", num_items=3, pkl_path="/tmp/b.pkl", embedder="siglip")
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        embedders = {d["embedder"] for d in data["datasets"]}
+        assert embedders == {"siglip"}
+
+    def test_mixed_embedder_datasets_no_single_guess(self, client):
+        """Multiple datasets with different embedders produce more than one unique embedder."""
+        register_dataset(name="ds1", media_type="image", num_items=5, pkl_path="/tmp/a.pkl", embedder="clip")
+        register_dataset(name="ds2", media_type="image", num_items=3, pkl_path="/tmp/b.pkl", embedder="siglip")
+        resp = client.get("/api/datasets/registry")
+        data = resp.get_json()
+        embedders = {d["embedder"] for d in data["datasets"]}
+        assert len(embedders) > 1
+
+    def test_loading_task_includes_embedder(self, client):
+        """Loading tasks expose the embedder field for in-progress guessing."""
+        from vtsearch.utils.progress import loading_tasks
+
+        tracker = loading_tasks.create_task("test_emb_task", "test-ds", media_type="image", embedder="siglip")
+        tracker.update("loading", "Embedding...", 0, 10)
+        tasks = loading_tasks.list_tasks()
+        task = next(t for t in tasks if t["task_id"] == "test_emb_task")
+        assert task["embedder"] == "siglip"
+
+    def test_loading_task_omits_empty_embedder(self, client):
+        """Loading tasks without an embedder do not include the field."""
+        from vtsearch.utils.progress import loading_tasks
+
+        tracker = loading_tasks.create_task("test_no_emb", "test-ds", media_type="image")
+        tracker.update("loading", "Loading...", 0, 10)
+        tasks = loading_tasks.list_tasks()
+        task = next(t for t in tasks if t["task_id"] == "test_no_emb")
+        assert "embedder" not in task
+
+    def test_js_contains_embedder_guessing_logic(self, client):
+        """main.js should include the embedder guessing code."""
+        resp = client.get("/static/main.js")
+        text = resp.data.decode("utf-8")
+        assert "guessedMediaEmbedder" in text
+
+
 class TestGuessMediaType:
     """Frontend auto-populates the media-type dropdown when creating a new model.
 

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -693,6 +693,7 @@ def load_registered_dataset(dataset_id: str):
     task_id = f"_regload_{dataset_id[:8]}"
     tracker = _loading_tasks.create_task(
         task_id, entry.get("name", dataset_id), dataset_id=dataset_id, media_type=entry.get("media_type", ""),
+        embedder=entry.get("embedder", ""),
     )
     tracker.update("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -355,7 +355,7 @@ def _run_origin_load_in_background(
 
     task_id = f"_loading_{uuid4().hex[:8]}"
     ingest_started_at = _time.time()
-    tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin), media_type=media_type)
+    tracker = loading_tasks.create_task(task_id, name or _origin_to_str(origin), media_type=media_type, embedder=embedder)
 
     # Set initial progress synchronously so the first poll sees it.
     tracker.update("loading", "Preparing dataset...", step=1, total_steps=_TOTAL_LOAD_STEPS)

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -155,7 +155,7 @@ class LoadingTasksTracker:
 
     def create_task(
         self, task_id: str, name: str = "", dataset_id: str = "", media_type: str = "",
-        model_id: str = "",
+        model_id: str = "", embedder: str = "",
     ) -> ProgressTracker:
         """Create and register a new loading task.
 
@@ -173,6 +173,7 @@ class LoadingTasksTracker:
                 "dataset_id": dataset_id,
                 "media_type": media_type,
                 "model_id": model_id,
+                "embedder": embedder,
             }
         return tracker
 
@@ -242,6 +243,8 @@ class LoadingTasksTracker:
                     snapshot["model_id"] = entry["model_id"]
                 if entry.get("media_type"):
                     snapshot["media_type"] = entry["media_type"]
+                if entry.get("embedder"):
+                    snapshot["embedder"] = entry["embedder"]
                 result.append(snapshot)
             else:
                 snapshot = entry["tracker"].get()
@@ -254,6 +257,8 @@ class LoadingTasksTracker:
                     snapshot["model_id"] = entry["model_id"]
                 if entry.get("media_type"):
                     snapshot["media_type"] = entry["media_type"]
+                if entry.get("embedder"):
+                    snapshot["embedder"] = entry["embedder"]
                 result.append(snapshot)
         if stale:
             with self._lock:


### PR DESCRIPTION
## Summary
This PR extends the dataset importer modal to intelligently pre-select embedders based on existing datasets and in-progress loading tasks, similar to the existing media type guessing functionality.

## Key Changes

- **Backend Progress Tracking**: Extended `ProgressTracker.create_task()` to accept an optional `embedder` parameter and expose it in task snapshots via `list_tasks()`

- **Dataset Loading Integration**: Updated dataset loading routes to pass the embedder information when creating progress tracking tasks, enabling the frontend to discover embedders from in-progress loads

- **Frontend Guessing Logic**: Added `guessedMediaEmbedder` computed property to `DashboardComponent` that:
  - Collects unique embedders from registered datasets
  - Collects unique embedders from non-errored loading tasks
  - Returns the single embedder if exactly one unique embedder exists, otherwise returns empty string

- **Modal Selection Logic**: Updated `DatasetImporterModalComponent` to:
  - Accept `guessedMediaEmbedder` as an input property
  - Prefer the guessed embedder when available for the selected media type
  - Fall back to the first available embedder if no match or no guess
  - Applied consistently across three embedder selection points (standard form, demo picker, server folder)

- **Type Definitions**: Added `embedder?: string` field to the `LoadingTask` API model

- **Test Coverage**: Added comprehensive test suite (`TestGuessMediaEmbedder`) verifying:
  - Single dataset embedder availability
  - Multiple datasets with same embedder
  - Multiple datasets with different embedders
  - Loading task embedder exposure
  - Omission of empty embedder fields
  - Frontend bundle includes guessing logic

## Implementation Details

The embedder guessing follows the same pattern as media type guessing: collect all available values from existing data sources and auto-select only when exactly one unique value exists. This prevents incorrect assumptions when multiple embedders are in use.

https://claude.ai/code/session_01CcogtS4jKMLxiDYA5DNrYw