### PR TITLE
Adjust table cell padding and action cell alignment

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -162,7 +162,7 @@
   }
 
   td {
-    padding: 6px 12px;
+    padding: 6px 10px;
   }
 
   th {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -41,7 +41,6 @@ td {
 .actions-cell {
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 4px;
 }
 

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -37,7 +37,6 @@ td {
 .actions-cell {
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 4px;
 }
 


### PR DESCRIPTION
## Summary
This PR makes minor styling adjustments to the dashboard table components to improve spacing and alignment consistency.

## Key Changes
- Reduced table cell (`td`) horizontal padding from 12px to 10px in the main dashboard component
- Removed `justify-content: center` from `.actions-cell` in both dataset-card and model-card components, allowing actions to align to the start of the flex container instead of being centered

## Implementation Details
These changes affect the visual layout of:
- Dashboard table cells (tighter horizontal spacing)
- Action button cells in dataset and model cards (left-aligned instead of center-aligned)

The modifications maintain the existing flex layout structure while adjusting alignment behavior for a more compact and consistent UI appearance.

https://claude.ai/code/session_01JDvg86CrMYgQHLZzJk5fn8