### PR TITLE
Skip directories with dots in names during plugin discovery

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1338,6 +1338,56 @@ class TestSymlinkedImporterDiscovery:
                     del sys.modules[key]
 
 
+    def test_dotted_symlink_name_is_skipped(self, tmp_path):
+        """A symlink whose name contains a dot (e.g. 'foo.symbolic_link')
+        should be silently skipped — dots in directory names break importlib
+        module path construction."""
+        import os
+        import sys
+
+        from vtsearch.utils.registry import PluginRegistry
+
+        # Create a valid importer package.
+        ext_pkg = tmp_path / "dotted_imp"
+        ext_pkg.mkdir()
+        (ext_pkg / "__init__.py").write_text(
+            "from vtsearch.datasets.importers.base import DatasetImporter\n"
+            "from vtsearch.utils.registry import PluginField\n"
+            "\n"
+            "class _Imp(DatasetImporter):\n"
+            '    name = "dotted_symlink_test"\n'
+            '    display_name = "Dotted Symlink Test"\n'
+            '    description = "Should not be loaded"\n'
+            "    fields = [PluginField(key='path', label='Path', field_type='folder')]\n"
+            "    def run(self, field_values, medias): return []\n"
+            "\n"
+            "IMPORTER = _Imp()\n"
+        )
+
+        # Symlink with a dotted name into the importers directory.
+        import importlib
+
+        parent = importlib.import_module("vtsearch.datasets.importers")
+        pkg_dir = os.path.dirname(parent.__file__)
+        link = os.path.join(pkg_dir, "dx_uuid.symbolic_link")
+        os.symlink(str(ext_pkg), link)
+
+        try:
+            reg = PluginRegistry(
+                package="vtsearch.datasets.importers",
+                sentinel="IMPORTER",
+                label="dataset importer",
+            )
+            names = [p.name for p in reg.list()]
+            # The dotted-name symlink must NOT appear.
+            assert "dotted_symlink_test" not in names
+        finally:
+            os.unlink(link)
+            for key in list(sys.modules):
+                if "dx_uuid" in key:
+                    del sys.modules[key]
+
+
 class TestRglobFollowSymlinks:
     """rglob_follow_symlinks should descend into symlinked directories."""
 

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -252,7 +252,7 @@ def _discover_media_plugins() -> None:
     for entry in sorted(package_dir.iterdir()):
         if entry.name.startswith((".", "_")):
             continue
-        if not entry.is_dir() or not (entry / "__init__.py").exists():
+        if not entry.is_dir() or "." in entry.name or not (entry / "__init__.py").exists():
             continue
         try:
             mod = importlib.import_module(f"vtsearch.media.{entry.name}")

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -238,6 +238,13 @@ class PluginRegistry(Generic[T]):
 
             # Sub-packages (directories with __init__.py)
             if entry.is_dir():
+                # Skip names containing dots — they aren't valid Python
+                # identifiers and would be misinterpreted as nested module
+                # paths by importlib (e.g. "foo.symbolic_link" would try to
+                # import package "foo" first).  This commonly happens with
+                # symlinks whose names include an extension or suffix.
+                if "." in entry.name:
+                    continue
                 if not (entry / "__init__.py").exists():
                     continue
                 self._try_load(entry.name)


### PR DESCRIPTION
## Summary
This PR adds validation to skip directories containing dots in their names during plugin discovery. This prevents importlib errors that occur when directory names contain dots, which are commonly found in symlinks with extensions or suffixes.

## Key Changes
- **vtsearch/utils/registry.py**: Added a check in the `_discover()` method to skip any directory entries whose names contain dots before attempting to load them as plugins
- **vtsearch/media/__init__.py**: Added the same dot-name validation check to the `_discover_media_plugins()` function for consistency
- **tests/test_importers.py**: Added `test_dotted_symlink_name_is_skipped()` test case to verify that symlinks with dotted names (e.g., `foo.symbolic_link`) are properly skipped during plugin discovery

## Implementation Details
- Dots in directory names break importlib's module path construction because they're interpreted as nested module separators (e.g., `foo.symbolic_link` would attempt to import package `foo` first)
- The fix uses a simple `"." in entry.name` check before attempting to load directories as plugins
- This commonly occurs with symlinks that include file extensions or UUID-based suffixes
- The validation is applied consistently across both the generic `PluginRegistry` class and the media-specific plugin discovery function

https://claude.ai/code/session_011xEgu12abw7j9rpfkAJE64