### PR TITLE
Dev

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,14 +8,15 @@ unless otherwise noted. File uploads use `multipart/form-data`.
 | Section | Description |
 |---------|-------------|
 | [Authentication & UI](api/auth.md) | Auth status, login/logout, static assets |
-| [Medias & Sorting](api/medias.md) | Media listing/streaming, text/learned/example sort, votes & labels |
+| [Medias & Sorting](api/medias.md) | Media listing/streaming, text/learned/example sort, votes & labels, pile upload |
 | [Labeling & Diversity](api/labeling.md) | Inclusion, thresholds, labeling progress, diversity tree |
 | [Detectors & Processors](api/detectors.md) | Detectors, extractors, localizers, pre-generated processors |
-| [Datasets](api/datasets.md) | Loading, importers, demos, staging, registry, media types, embedders, clippers, converters |
+| [Datasets](api/datasets.md) | Loading, importers, demos, staging, registry, media types, embedders, clippers, converters, file browsing |
 | [Import & Export](api/io.md) | Result exporters, label importers, processor importers |
 | [Settings](api/settings.md) | App settings, autorun processors, settings sources, labelset sources |
 | [Models](api/models.md) | Trainable models, model registry |
-| [Dashboard & Lookup](api/dashboard.md) | Dashboard info, media lookup, multi-dataset find |
+| [Dashboard & Lookup](api/dashboard.md) | Dashboard info, multi-dataset find, find progress |
+| [File Browser](api/file-browser.md) | Server filesystem browsing |
 
 ## Conventions
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -50,9 +50,10 @@ deployments. Runs locally or in Docker.
 | [EXTENDING.md](EXTENDING.md) | Plugin authoring guide (importers, exporters, media types) |
 | [demos.md](demos.md) | Available demo datasets |
 | [old_io.md](old_io.md) | Retired IO module reference implementations |
+| [REFACTORING.md](REFACTORING.md) | Structural refactoring plan with completion status |
 | [plan-media-sources.md](plan-media-sources.md) | MediaSource abstraction design document (implemented) |
-| [plan-sync-sources.md](plan-sync-sources.md) | Sync sources design (bidirectional settings/labelset sync) |
-| [design/](design/) | Architecture design documents (CLI detector-converter pipeline) |
+| [plan-sync-sources.md](plan-sync-sources.md) | Sync sources design (implemented, two enhancements pending) |
+| [design/cli-detector-converter.md](design/cli-detector-converter.md) | CLI autodetect with converters/clippers (design proposal, not yet implemented) |
 
 ---
 
@@ -212,6 +213,20 @@ python -m pytest tests/test_gpu.py -v -m gpu
 # All tests
 python -m pytest tests/ -v -m ''
 ```
+
+### Test groups
+
+For faster iteration, run tests by area instead of the full suite:
+
+```bash
+./run-tests.sh core          # basic app functionality
+./run-tests.sh api           # API contracts and security
+./run-tests.sh sorting       # sort algorithms and diversity
+./run-tests.sh datasets      # dataset loading and management
+./run-tests.sh io            # import/export and sync
+```
+
+See `CLAUDE.md` for the complete group-to-file mapping.
 
 ### Test markers
 

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -1,6 +1,9 @@
 # Refactoring Plan
 
-Structural improvements identified March 2026. Each section is a self-contained task that can be implemented and merged independently. Ordered by impact and risk.
+Structural improvements identified March 2026. Each section is a self-contained
+task that can be implemented and merged independently. Ordered by impact and risk.
+
+**Progress:** 5 of 14 items complete (Phase 1 done, Phase 2–5 mostly pending).
 
 ---
 
@@ -33,9 +36,9 @@ Completed. `_seed_good_votes_from_examples()` moved to
 
 ---
 
-## Phase 2: Eliminate Duplication
+## Phase 2: Eliminate Duplication (all pending)
 
-### 2.1 Consolidate the training pipeline
+### 2.1 Consolidate the training pipeline ⬜
 
 **Problem:** The pattern of collecting embeddings, validating splits, training a model, and computing a threshold is reimplemented in `detectors_training.py` (4 handlers), `sorting.py` (`learned_sort`, `label_file_sort`), and `trainable_models.py` (`_apply_and_retrain`).
 
@@ -48,7 +51,7 @@ Completed. `_seed_good_votes_from_examples()` moved to
 
 ---
 
-### 2.2 Consolidate legacy detector weight fallback
+### 2.2 Consolidate legacy detector weight fallback ⬜
 
 **Problem:** Identical legacy weight format handling in 3 locations.
 
@@ -60,7 +63,7 @@ Completed. `_seed_good_votes_from_examples()` moved to
 
 ---
 
-### 2.3 Deduplicate embedder boilerplate
+### 2.3 Deduplicate embedder boilerplate ⬜
 
 **Problem:** All 7 embedders repeat the same `_load_models_impl()` ceremony. `_extract_tensor()` is copy-pasted between image and video embedders.
 
@@ -73,7 +76,7 @@ Completed. `_seed_good_votes_from_examples()` moved to
 
 ---
 
-### 2.4 Create shared route helpers for plugin lookup and JSON extraction
+### 2.4 Create shared route helpers for plugin lookup and JSON extraction ⬜
 
 **Problem:** "Unknown plugin" error handling duplicated in 5+ routes with minor inconsistencies. `request.get_json(force=True, silent=True) or {}` appears 30+ times with variations.
 
@@ -87,9 +90,9 @@ Completed. `_seed_good_votes_from_examples()` moved to
 
 ---
 
-## Phase 3: Architectural Improvements
+## Phase 3: Architectural Improvements (1 of 4 done)
 
-### 3.1 Break the `models/` ↔ `datasets/` circular dependency
+### 3.1 Break the `models/` ↔ `datasets/` circular dependency ⬜
 
 **Problem:** `models/resolver.py` does late imports from `datasets/sources/` and `datasets/importers/`. `datasets/ingest.py` imports from `models/resolver.py`.
 
@@ -111,7 +114,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 3.3 Reduce `settings.py` boilerplate (~839 lines)
+### 3.3 Reduce `settings.py` boilerplate (~839 lines) ⬜
 
 **Problem:** ~70% of the file is copy-pasted accessor patterns for left/right per-media-type settings, each with legacy scalar coercion.
 
@@ -126,7 +129,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 3.4 Clean up `utils/state_core.py` proxy complexity
+### 3.4 Clean up `utils/state_core.py` proxy complexity ⬜
 
 **Problem:** 35+ manually overridden proxy methods and hidden data dependencies.
 
@@ -139,9 +142,9 @@ auto-discovered like all other plugin families.
 
 ---
 
-## Phase 4: Cleanup
+## Phase 4: Cleanup (all pending)
 
-### 4.1 Move `_build_extractor`/`_build_localizer` out of `detectors_crud.py`
+### 4.1 Move `_build_extractor`/`_build_localizer` out of `detectors_crud.py` ⬜
 
 **Problem:** Private functions in a CRUD module are imported by `detectors_scoring.py` and `detectors.py`.
 
@@ -153,7 +156,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 4.2 Review autoload media embedder settings functions
+### 4.2 Review autoload media embedder settings functions ⬜
 
 **Problem:** `get_autoload_media_embedders`, `set_autoload_media_embedders`, `toggle_autoload_media_embedder` in `settings.py` may have limited usage.
 
@@ -166,7 +169,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 4.3 Relocate `medias.py` test infrastructure
+### 4.3 Relocate `medias.py` test infrastructure ⬜
 
 **Problem:** `vtsearch/medias.py` (91 lines) generates test media and embeddings. It's only used by `conftest.py` and `app.py` demo mode.
 
@@ -178,9 +181,9 @@ auto-discovered like all other plugin families.
 
 ---
 
-## Phase 5: Frontend
+## Phase 5: Frontend (all pending)
 
-### 5.1 Split `dashboard.component.ts` (1,173 lines)
+### 5.1 Split `dashboard.component.ts` (1,173 lines) ⬜
 
 **Problem:** Manages dataset selection, model selection, loading tasks, column resizing, sorting state, and modal orchestration in one component.
 
@@ -192,7 +195,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 5.2 Split `label-view.component.ts` (784 lines)
+### 5.2 Split `label-view.component.ts` (784 lines) ⬜
 
 **Problem:** Manages panel layout, resize, polling, keyboard shortcuts, and autopilot in one component.
 
@@ -203,7 +206,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 5.3 Extract `BaseImporterComponent` for modal reuse
+### 5.3 Extract `BaseImporterComponent` for modal reuse ⬜
 
 **Problem:** `dataset-importer-modal`, `label-importer-modal`, and `processor-importer-modal` independently implement the same picker→form flow, form state, file selection, and submission logic.
 
@@ -213,7 +216,7 @@ auto-discovered like all other plugin families.
 
 ---
 
-### 5.4 Add barrel files
+### 5.4 Add barrel files ⬜
 
 **Steps:**
 1. Create `frontend/src/app/services/index.ts` re-exporting all services

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -37,6 +37,36 @@ PUT /api/dashboard/dataset-rename
 
 ## Multi-dataset Find
 
+### Check label resolution (pre-flight)
+
+```
+POST /api/find/check-labels
+```
+
+**Body:** `{"dataset_ids": ["id1", "id2"], "model_ids": ["m1"]}`
+
+Pre-flight check that reports how many trainable-model labels can be resolved
+for the given models and datasets. Call this before starting a Find to warn
+the user about unresolved labels.
+
+→ ```json
+{
+  "warnings": [
+    {
+      "model_name": "Mammals",
+      "total_labels": 82,
+      "resolved_labels": 60,
+      "failed_labels": 22
+    }
+  ]
+}
+```
+
+`warnings` only contains entries for models with at least one unresolved label.
+An empty `warnings` list means everything is fine.
+
+### Run find
+
 ```
 POST /api/find
 ```
@@ -55,3 +85,24 @@ POST /api/find
   "total_hits": 42
 }
 ```
+
+### Find progress
+
+```
+GET /api/find/progress
+```
+
+→ ```json
+{
+  "status": "running",
+  "message": "Scoring with \"ModelName\" on \"DatasetName\"...",
+  "cur": 150,
+  "total": 300,
+  "step": 2,
+  "total_steps": 3,
+  "error": null
+}
+```
+
+`status` is `"idle"` or `"running"`. `step` / `total_steps` track the
+high-level Find phases (prepare models, load data, score).

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -229,6 +229,56 @@ GET /api/dataset/demo-list
 
 `status`: `"ready"`, `"needs_embedding"`, or `"needs_download"`.
 
+### Demo categories
+
+```
+GET /api/dataset/demo-categories/{name}
+```
+
+Lists the categories within a specific demo dataset.
+
+→ `{"categories": ["dog", "cat", "bird", "traffic"]}`
+404 if the demo name is not recognized.
+
+---
+
+## File Browsing
+
+### Browse media files
+
+```
+GET /api/browse-media-files
+```
+
+**Query:**
+- `source` (required): `"demo:<name>"` (a demo dataset) or `"folder"` (the
+  configured `saved_datasets_dir`).
+- `path` (optional): relative sub-path within the root (default `""`).
+
+Lists files and subdirectories within an allowed root, filtered to only
+media files with recognized extensions.
+
+→ ```json
+{
+  "directories": [{"name": "dog", "path": "dog", "modified_at": "2025-03-31T10:15:00"}],
+  "files": [{"name": "bark.wav", "path": "dog/bark.wav", "size_bytes": 12345, "modified_at": "2025-03-31T10:15:00"}],
+  "root_path": "/absolute/path/to/root"
+}
+```
+
+### Select browsed file
+
+```
+POST /api/browse-media-files/select
+```
+
+**Body:** `{"source": "demo:esc50_s", "path": "dog/1-100032-A-0.wav"}`
+
+Copies a file from a browse source into `data/example_media/` with a unique
+prefix to avoid collisions.
+
+→ `{"filename": "abc123_bark.wav", "original_name": "bark.wav"}` (201)
+
 ---
 
 ## Staging (for combine-datasets flow)
@@ -351,6 +401,26 @@ PUT /api/datasets/registry/{dataset_id}/rename
 **Body:** `{"name": "New Name"}`
 
 → `{"ok": true, "name": "New Name"}`
+
+### Dataset statistics
+
+```
+GET /api/datasets/registry/{dataset_id}/stats
+```
+
+Returns ingest statistics for a registered dataset.
+
+→ ```json
+{
+  "num_items": 1250,
+  "num_dupes": 45,
+  "file_type_counts": {"audio/wav": 800, "audio/mp3": 450},
+  "ingest_started_at": "2025-03-31T10:15:00",
+  "ingest_finished_at": "2025-03-31T10:45:00"
+}
+```
+
+404 if the dataset does not exist.
 
 ### Set dataset readers
 

--- a/docs/api/file-browser.md
+++ b/docs/api/file-browser.md
@@ -1,0 +1,43 @@
+# File Browser
+
+[← Back to API index](../API.md)
+
+---
+
+## General File Browser
+
+### Browse files
+
+```
+GET /api/browse
+```
+
+**Query:**
+- `path` (optional): relative path within the allowed root (default `""`).
+- `extensions` (optional): comma-separated list of file extensions to show,
+  e.g. `".csv,.json"`. When omitted, all files are listed.
+
+Lists directories and files at a relative path within the allowed root
+directory. In single-user mode the root is the current working directory;
+in multi-user mode it is the current user's data directory. Hidden files
+(names starting with `.`) are excluded.
+
+→ ```json
+{
+  "directories": [
+    {"name": "subdir", "path": "subdir", "modified_at": "2025-03-31T10:15:00"}
+  ],
+  "files": [
+    {"name": "labels.csv", "path": "labels.csv", "size_bytes": 1234, "modified_at": "2025-03-31T10:15:00"}
+  ],
+  "current_path": "data/labels"
+}
+```
+
+400 if the path escapes the allowed root (path traversal prevention).
+403 if permission is denied. 404 if the directory does not exist.
+
+---
+
+The media-specific file browser endpoints (`/api/browse-media-files` and
+`/api/browse-media-files/select`) are documented in [Datasets](datasets.md#file-browsing).

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -67,14 +67,18 @@ GET /api/medias/{media_id}/image
 `image/bmp` based on filename extension).
 400 if not an image. 404 if not found.
 
-### Get paragraph text
+### Get text content
 
 ```
 GET /api/medias/{media_id}/paragraph
+GET /api/medias/{media_id}/text
 ```
 
+Both paths serve the same handler. Returns the text content and statistics
+for a text media item.
+
 → `{"content": "...", "word_count": 150, "character_count": 900}`
-400 if not a paragraph. 404 if not found.
+400 if not a text media. 404 if not found.
 
 ### Generic media endpoint
 
@@ -307,6 +311,26 @@ POST /api/labels/import
 Matches by origin+origin_name first, falls back to MD5.
 
 → `{"applied": 8, "skipped": 2}`
+
+### Upload media to pile
+
+```
+POST /api/medias/add-to-pile
+```
+
+**Form:**
+- `file` — the media file to upload.
+- `label` — `"good"` or `"bad"`.
+
+Uploads a media file and adds it to the Good or Bad pile. If a media with
+the same MD5 already exists, the existing media is voted accordingly.
+Otherwise, the file is embedded using the dataset's embedder, inserted as
+a new media item, and then voted.
+
+→ `{"ok": true, "media_id": 123, "is_new": true}` (201 if new, 200 if existing)
+400 if no file, empty file, or invalid label. 400 if no dataset loaded.
+
+---
 
 ### Fill labels from sort results
 

--- a/docs/design/cli-detector-converter.md
+++ b/docs/design/cli-detector-converter.md
@@ -1,9 +1,10 @@
 # Design: CLI Autodetect with Converters and Clippers
 
-> **Status: Design proposal.** This document outlines a planned approach for
-> handling converters and clippers in the CLI autodetect pipeline. The
-> converter registry exists in `vtsearch/converters/`, but the `input_spec`
-> field in detector JSON described here is not yet implemented.
+> **Status: Design proposal (not yet implemented).** The converter registry
+> exists in `vtsearch/converters/` and is fully functional for dataset
+> import-time conversion. However, the `input_spec` field on detector JSON
+> and the CLI autodetect pipeline changes described here are **not yet
+> implemented**. This document captures the design for future work.
 
 ## Problem
 

--- a/docs/plan-media-sources.md
+++ b/docs/plan-media-sources.md
@@ -1,10 +1,13 @@
-# MediaSource Abstraction — Implementation Plan
+# MediaSource Abstraction — Design Document
 
-> **Status: Implemented.** The `MediaSource` abstraction described in this
-> document has been fully implemented. Sources live in
-> `vtsearch/datasets/sources/` and use `PluginRegistry` auto-discovery
-> (with the `SOURCE` sentinel) rather than the hardcoded factory proposed
-> below. See `tests/test_media_sources.py` for test coverage.
+> **Status: Implemented.** This design has been fully implemented. The
+> code lives in `vtsearch/datasets/sources/` with `PluginRegistry`
+> auto-discovery (using the `SOURCE` sentinel) rather than the hardcoded
+> factory originally proposed. Tests are in `tests/test_media_sources.py`.
+>
+> This document is preserved as a design reference — it explains the
+> reasoning behind the architecture. For current usage, see
+> [EXTENDING.md](EXTENDING.md) and [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Problem
 

--- a/docs/plan-sync-sources.md
+++ b/docs/plan-sync-sources.md
@@ -1,5 +1,13 @@
 # Sync Sources: Persistent Bidirectional Sync for Settings and Labelsets
 
+> **Status: Implemented.** The core sync source system (all 7 implementation
+> steps) is complete and tested. See `vtsearch/settings_io/sources/`,
+> `vtsearch/labels/sources/`, and `tests/test_sync_sources.py`. Two additive
+> enhancements remain unimplemented (see [Not yet implemented](#not-yet-implemented)).
+>
+> This document is preserved as a design reference. For current usage, see
+> [EXTENDING.md](EXTENDING.md) and the [Settings API docs](api/settings.md).
+
 ## Problem
 
 Currently, importing settings or labels is a **one-shot** operation. If you import labelset A into detector A and then add labels (making detector A'), the original labelset A is stale. You'd have to manually re-export. Same for settings: import from a file, tweak a setting, and the file is out of date.
@@ -199,10 +207,11 @@ For network-based sources, the `save()` method should be debounced (batch writes
 
 ### Not yet implemented
 
+These are additive enhancements that don't affect the current implementation.
+They can be added independently without breaking existing functionality:
+
 - **Auto-import on detector load**: When a detector is loaded and has a linked labelset source, auto-pull labels from the source.
 - **Auto-attach on label import**: When a label import comes from a source-capable importer, auto-link the source to the detector.
-
-These are additive enhancements that don't affect the current implementation.
 
 ## Test Plan
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,16 +1,22 @@
 # VTSearch Frontend
 
-Angular SPA for the VTSearch media explorer. Built with Angular CLI 19.2 and TypeScript.
+Angular SPA for the VTSearch media explorer. Built with Angular CLI 19.2 and TypeScript 5.7.
+
+## Prerequisites
+
+- **Node.js 18+** (LTS recommended)
+- **npm** (bundled with Node.js)
 
 ## Development server
 
 Start the Flask backend first (`python app.py --local` from the project root), then:
 
 ```bash
+npm install   # first time only
 npm start
 ```
 
-This starts the Angular dev server at `http://localhost:4200/` with a proxy that forwards `/api/*` requests to the Flask backend at `localhost:5000`. The application automatically reloads when source files change.
+This starts the Angular dev server at `http://localhost:4200/` with a proxy that forwards `/api/*` requests to the Flask backend at `localhost:5000` (configured in `proxy.conf.json`). The application automatically reloads when source files change.
 
 ## Building for production
 
@@ -20,13 +26,49 @@ npm run build:prod
 
 This compiles the Angular app and outputs the build artifacts to `../static/` (the project root's `static/` directory), where Flask serves them. Output files: `index.html`, `main.js`, `polyfills.js`, `styles.css`.
 
-You must run `npm install` before the first build to install Angular CLI and other dependencies locally.
+## Project structure
+
+```
+src/app/
+├── app.component.ts          # Root component
+├── app.routes.ts              # Route definitions
+├── components/                # UI components
+│   ├── center-panel/          # Media viewer (image, text, video, audio, document)
+│   ├── left-panel/            # Media list, sort bar, inclusion slider, autopilot
+│   ├── right-panel/           # Labels and detector context
+│   ├── dashboard/             # Dataset and model management UI
+│   ├── label-view/            # Main labeling view (orchestrates left/center/right panels)
+│   ├── find-view/             # Multi-dataset search interface
+│   ├── login/                 # Authentication screen
+│   ├── modals/                # 17+ modal dialogs (export, import, settings, progress, etc.)
+│   ├── dialog-host/           # Modal container
+│   ├── file-browser/          # Server file picker
+│   ├── progress-bar/          # Progress indicators
+│   └── icon/                  # Icon system
+├── services/                  # State management and API communication
+│   ├── *-api.service.ts       # API services (one per backend module)
+│   ├── *-state.service.ts     # Client-side state services
+│   ├── active-context.service.ts  # Tracks selected dataset/model
+│   ├── dialog.service.ts      # Modal management
+│   ├── keyboard.service.ts    # Keyboard shortcuts
+│   └── theme.service.ts       # Theme (light/dark) switching
+├── interceptors/
+│   └── active-context.interceptor.ts  # Attaches X-Dataset-Id/X-Model-Id headers
+└── models/
+    └── api.models.ts          # TypeScript interfaces for API responses
+```
+
+### Key architecture patterns
+
+- **ActiveContextService** tracks which dataset and model the user has selected. The `activeContextInterceptor` attaches `X-Dataset-Id` and `X-Model-Id` headers to every API request so the backend resolves the correct per-dataset state.
+- **State services** (`media-state`, `dataset-state`, `detector-state`, `vote-state`, `sort-state`, `settings-state`) hold client-side state and expose observables for reactive UI updates.
+- **API services** (`medias-api`, `datasets-api`, `detectors-api`, etc.) wrap HTTP calls to the Flask backend. Each maps to a backend route module.
 
 ## Running unit tests
 
 Karma has been removed from this project. There is currently no browser-based
-frontend test runner configured. The Python backend tests (`./run-tests.sh`)
-include a frontend TypeScript build check.
+frontend test runner configured. The Python backend tests (`./run-tests.sh core`)
+include a frontend TypeScript build check to catch type errors.
 
 ## Code scaffolding
 

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1338,6 +1338,56 @@ class TestSymlinkedImporterDiscovery:
                     del sys.modules[key]
 
 
+    def test_dotted_symlink_name_is_skipped(self, tmp_path):
+        """A symlink whose name contains a dot (e.g. 'foo.symbolic_link')
+        should be silently skipped — dots in directory names break importlib
+        module path construction."""
+        import os
+        import sys
+
+        from vtsearch.utils.registry import PluginRegistry
+
+        # Create a valid importer package.
+        ext_pkg = tmp_path / "dotted_imp"
+        ext_pkg.mkdir()
+        (ext_pkg / "__init__.py").write_text(
+            "from vtsearch.datasets.importers.base import DatasetImporter\n"
+            "from vtsearch.utils.registry import PluginField\n"
+            "\n"
+            "class _Imp(DatasetImporter):\n"
+            '    name = "dotted_symlink_test"\n'
+            '    display_name = "Dotted Symlink Test"\n'
+            '    description = "Should not be loaded"\n'
+            "    fields = [PluginField(key='path', label='Path', field_type='folder')]\n"
+            "    def run(self, field_values, medias): return []\n"
+            "\n"
+            "IMPORTER = _Imp()\n"
+        )
+
+        # Symlink with a dotted name into the importers directory.
+        import importlib
+
+        parent = importlib.import_module("vtsearch.datasets.importers")
+        pkg_dir = os.path.dirname(parent.__file__)
+        link = os.path.join(pkg_dir, "dx_uuid.symbolic_link")
+        os.symlink(str(ext_pkg), link)
+
+        try:
+            reg = PluginRegistry(
+                package="vtsearch.datasets.importers",
+                sentinel="IMPORTER",
+                label="dataset importer",
+            )
+            names = [p.name for p in reg.list()]
+            # The dotted-name symlink must NOT appear.
+            assert "dotted_symlink_test" not in names
+        finally:
+            os.unlink(link)
+            for key in list(sys.modules):
+                if "dx_uuid" in key:
+                    del sys.modules[key]
+
+
 class TestRglobFollowSymlinks:
     """rglob_follow_symlinks should descend into symlinked directories."""
 

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -252,7 +252,7 @@ def _discover_media_plugins() -> None:
     for entry in sorted(package_dir.iterdir()):
         if entry.name.startswith((".", "_")):
             continue
-        if not entry.is_dir() or not (entry / "__init__.py").exists():
+        if not entry.is_dir() or "." in entry.name or not (entry / "__init__.py").exists():
             continue
         try:
             mod = importlib.import_module(f"vtsearch.media.{entry.name}")

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -238,6 +238,13 @@ class PluginRegistry(Generic[T]):
 
             # Sub-packages (directories with __init__.py)
             if entry.is_dir():
+                # Skip names containing dots — they aren't valid Python
+                # identifiers and would be misinterpreted as nested module
+                # paths by importlib (e.g. "foo.symbolic_link" would try to
+                # import package "foo" first).  This commonly happens with
+                # symlinks whose names include an extension or suffix.
+                if "." in entry.name:
+                    continue
                 if not (entry / "__init__.py").exists():
                     continue
                 self._try_load(entry.name)


### PR DESCRIPTION
Bug Fix — Symlink plugin discovery (#1062): Fixed dotted symlink names (e.g. my.plugin) breaking media type plugin discovery. Updated vtsearch/media/__init__.py to handle dotted directory names and vtsearch/utils/registry.py to skip non-package directories. Added tests for symlink loading in test_importers.py.

Documentation improvements (#1063): Added missing API endpoint docs for dashboard, datasets, file-browser, and medias. Expanded frontend/README.md with architecture details. Cleaned up design docs (cli-detector-converter.md, plan-media-sources.md, plan-sync-sources.md). Updated HANDOFF.md and API.md with current state. Updated REFACTORING.md.