### PR TITLE
Simplify settings icon animation with direct rotation

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -240,22 +240,10 @@
 }
 
 .settings-tab-icon {
-  transition: transform 0.3s ease;
+  transition: transform 0.4s ease;
   transform: rotate(0deg);
 
   &--active {
-    animation: wheel-settle 0.4s ease forwards;
-  }
-}
-
-@keyframes wheel-settle {
-  0% {
-    transform: rotate(0deg);
-  }
-  50% {
-    transform: rotate(11.25deg);
-  }
-  100% {
     transform: rotate(22.5deg);
   }
 }


### PR DESCRIPTION
## Summary
Refactored the settings tab icon animation to use a simpler, more direct approach by removing the intermediate keyframe animation and applying the final rotation state directly to the active state.

## Key Changes
- Increased transition duration from 0.3s to 0.4s for consistency with the removed animation timing
- Removed the `wheel-settle` keyframe animation that previously rotated the icon through 0° → 11.25° → 22.5°
- Applied the final 22.5deg rotation directly to the `.settings-tab-icon--active` state, allowing the CSS transition to handle the animation smoothly

## Implementation Details
This change simplifies the animation logic while maintaining the same visual result. The icon will now smoothly transition to 22.5deg rotation when active, using the CSS transition property instead of a multi-step keyframe animation. This reduces code complexity and makes the animation behavior more predictable and maintainable.

https://claude.ai/code/session_01KptKXJBtXNT8WvZEmByCpS