### PR TITLE
Add progress reporting to clipper and deduplication operations

### DIFF
--- a/tests/test_clipper_workflow.py
+++ b/tests/test_clipper_workflow.py
@@ -692,3 +692,46 @@ class TestMultipleMediasClipped:
 
         ids = sorted(clips_dict.keys())
         assert ids == list(range(1, len(clips_dict) + 1))
+
+
+# ---------------------------------------------------------------------------
+# _apply_clipper — on_progress callback
+# ---------------------------------------------------------------------------
+
+class TestApplyClipperProgress:
+    """Verify that _apply_clipper reports progress via the on_progress callback."""
+
+    def test_progress_reports_clipping_and_embedding_phases(self):
+        from vtsearch.routes.datasets_loading import _apply_clipper
+
+        clips_dict = {
+            1: _make_audio_media(1, duration=5.1),
+            2: _make_audio_media(2, duration=4.1),
+        }
+        calls = []
+        _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0},
+                       on_progress=lambda cur, tot, phase: calls.append((cur, tot, phase)))
+
+        clipping_calls = [c for c in calls if c[2] == "clipping"]
+        embedding_calls = [c for c in calls if c[2] == "embedding"]
+
+        # Should have clipping progress calls (one per input media)
+        assert len(clipping_calls) == 2
+        assert clipping_calls[0] == (0, 2, "clipping")
+        assert clipping_calls[1] == (1, 2, "clipping")
+
+        # Should have embedding progress calls (one per output clip)
+        assert len(embedding_calls) > 0
+        # First embedding call starts at 0
+        assert embedding_calls[0][0] == 0
+        # Total should equal the number of clips produced
+        total_clips = embedding_calls[0][1]
+        assert total_clips == len(clips_dict)
+
+    def test_no_progress_without_callback(self):
+        """Passing on_progress=None doesn't break anything."""
+        from vtsearch.routes.datasets_loading import _apply_clipper
+
+        clips_dict = {1: _make_audio_media(1, duration=5.1)}
+        _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0}, on_progress=None)
+        assert len(clips_dict) >= 1  # Clips were still produced

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -127,6 +127,32 @@ class TestCollapseDuplicates:
         count = collapse_duplicates(media_dict)
         assert count == 0
 
+    def test_on_progress_callback(self):
+        """on_progress receives (current, total) during duplicate collapsing."""
+        media_dict = {
+            1: _make_media(1, md5="aaa"),
+            2: _make_media(2, md5="aaa"),
+            3: _make_media(3, md5="bbb"),
+            4: _make_media(4, md5="ccc"),
+        }
+        calls = []
+        collapse_duplicates(media_dict, on_progress=lambda cur, tot: calls.append((cur, tot)))
+        # Should have been called at least once
+        assert len(calls) >= 1
+        # Total should equal the number of MD5 groups
+        assert calls[0][1] == 3  # aaa, bbb, ccc
+        # First call starts at 0
+        assert calls[0][0] == 0
+
+    def test_on_progress_none_is_safe(self):
+        """Passing on_progress=None doesn't break anything."""
+        media_dict = {
+            1: _make_media(1, md5="aaa"),
+            2: _make_media(2, md5="aaa"),
+        }
+        count = collapse_duplicates(media_dict, on_progress=None)
+        assert count == 1
+
 
 class TestGetDupeCount:
     def test_no_dupes(self):

--- a/vtsearch/datasets/importers/folder/__init__.py
+++ b/vtsearch/datasets/importers/folder/__init__.py
@@ -207,6 +207,7 @@ class FolderDatasetImporter(DatasetImporter):
         folder = Path(field_values["path"])
         media_type = field_values.get("media_type", "sounds")
         emb_name = field_values.get("embedder", "")
+        skip_emb = bool(field_values.get("skip_embedding"))
         has_regular = True
         try:
             load_dataset_from_folder(
@@ -214,6 +215,7 @@ class FolderDatasetImporter(DatasetImporter):
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
+                skip_embedding=skip_emb,
             )
         except ValueError:
             # No regular image files found — PDFs or converters may still produce output.
@@ -247,12 +249,14 @@ class FolderDatasetImporter(DatasetImporter):
         folder = Path(field_values["path"])
         media_type = field_values.get("media_type", "sounds")
         emb_name = field_values.get("embedder", "")
+        skip_emb = bool(field_values.get("skip_embedding"))
         try:
             yield from load_dataset_from_folder_chunked(
                 folder, media_type, chunk_size, thin=thin, embedder_name=emb_name,
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
+                skip_embedding=skip_emb,
             )
         except ValueError:
             if media_type != "images" and not field_values.get("converters"):

--- a/vtsearch/datasets/importers/http_zip/__init__.py
+++ b/vtsearch/datasets/importers/http_zip/__init__.py
@@ -228,12 +228,14 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         archive_path.unlink(missing_ok=True)
 
         emb_name = field_values.get("embedder", "")
+        skip_emb = bool(field_values.get("skip_embedding"))
         try:
             load_dataset_from_folder(
                 extract_dir, media_type, medias, on_progress=progress, thin=thin, embedder_name=emb_name,
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
+                skip_embedding=skip_emb,
             )
             # Run any user-selected converters on the extracted folder.
             _run_selected_converters(extract_dir, media_type, field_values, medias, thin=thin)
@@ -287,12 +289,14 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         extract_dir = self._download_and_extract(field_values)
         media_type = field_values.get("media_type", "sounds")
         emb_name = field_values.get("embedder", "")
+        skip_emb = bool(field_values.get("skip_embedding"))
         try:
             yield from load_dataset_from_folder_chunked(
                 extract_dir, media_type, chunk_size, thin=thin, embedder_name=emb_name,
                 content_vectors=self.content_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
+                skip_embedding=skip_emb,
             )
             # Run converters on the extracted folder and yield as a chunk.
             converters_str = field_values.get("converters", "")

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -719,8 +719,17 @@ def load_registered_dataset(dataset_id: str):
                 clear_thread_progress()
 
             tracker.check_cancelled()
-            tracker.update("loading", "Removing duplicates…", 0, 0, step=2, total_steps=_LOAD_STEPS)
-            collapse_duplicates(ctx.medias)
+
+            def _dedup_progress(current: int, total: int) -> None:
+                tracker.check_cancelled()
+                tracker.update(
+                    "loading", "Removing duplicates…",
+                    current=current, total=total,
+                    step=2, total_steps=_LOAD_STEPS,
+                )
+
+            _dedup_progress(0, 0)
+            collapse_duplicates(ctx.medias, on_progress=_dedup_progress)
 
             def _diversity_progress(current: int, total: int) -> None:
                 tracker.check_cancelled()

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -286,13 +286,16 @@ def _fixup_clip_md5_and_embeddings(
     media_type: str,
     on_progress: Callable[[int, int, str], None] | None = None,
 ) -> None:
-    """Recompute MD5 and embeddings for clips that are genuine sub-items.
+    """Recompute MD5 and embeddings for clips that need it.
 
-    Without this, all clips from the same parent would share the parent's
-    MD5 (causing ``collapse_duplicates`` to merge them) and the parent's
-    embedding (degrading ML training quality).  Importer-supplied MD5 and
-    embedding values are also stale for sub-items, so they are replaced
-    unconditionally when the clipper produced multiple outputs.
+    A clip needs recomputation when:
+    - ``needs_recompute`` is ``True`` (genuine sub-item from a multi-output
+      clipper — the parent's MD5 and embedding are stale), **or**
+    - the clip has no embedding at all (import phase was skipped because a
+      clipper was going to re-embed anyway).
+
+    Without the MD5 fix, all clips from the same parent would share the
+    parent's MD5 (causing ``collapse_duplicates`` to merge them).
     """
     import hashlib
 
@@ -300,14 +303,19 @@ def _fixup_clip_md5_and_embeddings(
     for clip_idx, (clip, recompute) in enumerate(zip(clips, needs_recompute)):
         if on_progress:
             on_progress(clip_idx, total_clips, "embedding")
-        if not recompute:
+
+        # Also embed clips that have no embedding (e.g. when the import
+        # phase skipped embedding because a clipper was specified).
+        needs_embed = recompute or clip.get("embedding") is None
+        if not needs_embed:
             continue
 
         content_bytes = _clip_content_bytes(clip, media_type)
         if content_bytes is not None:
-            clip["md5"] = hashlib.md5(content_bytes).hexdigest()
+            if recompute:
+                clip["md5"] = hashlib.md5(content_bytes).hexdigest()
             _reembed_clip(clip, content_bytes, media_type)
-        else:
+        elif recompute:
             # Metadata-only clips (e.g. video): bytes unchanged but
             # boundaries differ — create a unique MD5 by hashing the
             # parent bytes + clip boundaries so dedup doesn't collapse
@@ -685,6 +693,14 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # importer writes a .clipper sidecar for readiness tracking).
     field_values["clipper"] = clipper_name
     embedder_name = field_values.get("embedder", "")
+
+    # When a multi-output clipper is selected, skip embedding during the
+    # import phase.  The clipper step will re-embed every clip anyway, so
+    # computing parent embeddings up front is wasted work.  Default
+    # clippers (pass-through, single output) still need the parent
+    # embedding since it won't be recomputed.
+    if clipper_name and not clipper_name.endswith("_default"):
+        field_values["skip_embedding"] = True
 
     # Extract media_type from field_values so in-progress tasks can expose it
     # to the frontend (used for guessing the type in subsequent add dialogs).

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -190,7 +190,12 @@ def _normalize_media_type(value: str) -> str:
         return value
 
 
-def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | None = None) -> None:
+def _apply_clipper(
+    clips_dict: dict,
+    clipper_name: str,
+    clipper_params: dict | None = None,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> None:
     """Apply a clipper to all medias in *clips_dict*, replacing them in-place.
 
     After clipping, each clip gets:
@@ -204,6 +209,10 @@ def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | N
     Any importer-provided MD5 or embedding on the *parent* media is
     discarded for clips produced by a non-trivial clipper, since those
     values describe the full media item, not the sub-item.
+
+    Args:
+        on_progress: Optional callback ``(current, total, phase)`` invoked
+            during clipping and re-embedding so callers can report progress.
     """
     if not clipper_name:
         return
@@ -231,7 +240,11 @@ def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | N
     # inherited MD5 and embedding describe the *parent*, not the clip.
     needs_recompute: list[bool] = []
 
-    for media in list(clips_dict.values()):
+    media_list = list(clips_dict.values())
+    total_medias = len(media_list)
+    for media_idx, media in enumerate(media_list):
+        if on_progress:
+            on_progress(media_idx, total_medias, "clipping")
         clipped = clipper.clip(media)
         is_real_clip = len(clipped) > 1
         for idx, clip in enumerate(clipped):
@@ -259,7 +272,7 @@ def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | N
             needs_recompute.append(is_real_clip)
 
     # Recompute MD5 and re-embed every genuine sub-item.
-    _fixup_clip_md5_and_embeddings(all_clipped, needs_recompute, clipper.media_type)
+    _fixup_clip_md5_and_embeddings(all_clipped, needs_recompute, clipper.media_type, on_progress=on_progress)
 
     clips_dict.clear()
     for new_id, clip in enumerate(all_clipped, 1):
@@ -268,7 +281,10 @@ def _apply_clipper(clips_dict: dict, clipper_name: str, clipper_params: dict | N
 
 
 def _fixup_clip_md5_and_embeddings(
-    clips: list[dict], needs_recompute: list[bool], media_type: str,
+    clips: list[dict],
+    needs_recompute: list[bool],
+    media_type: str,
+    on_progress: Callable[[int, int, str], None] | None = None,
 ) -> None:
     """Recompute MD5 and embeddings for clips that are genuine sub-items.
 
@@ -280,7 +296,10 @@ def _fixup_clip_md5_and_embeddings(
     """
     import hashlib
 
-    for clip, recompute in zip(clips, needs_recompute):
+    total_clips = len(clips)
+    for clip_idx, (clip, recompute) in enumerate(zip(clips, needs_recompute)):
+        if on_progress:
+            on_progress(clip_idx, total_clips, "embedding")
         if not recompute:
             continue
 
@@ -511,18 +530,40 @@ def _run_origin_load_in_background(
 
             tracker.check_cancelled()
             apply_custom_metadata_md5(ctx.medias)
-            tracker.update(
-                "loading", "Removing duplicates…", step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS
-            )
+
             # Tag medias that don't already have an origin.
             for media in ctx.medias.values():
                 if media.get("origin") is None:
                     media["origin"] = origin
                 if not media.get("origin_name"):
                     media["origin_name"] = media.get("filename", "")
+
             if clipper:
-                _apply_clipper(ctx.medias, clipper, clipper_params)
-            collapse_duplicates(ctx.medias)
+                def _clipper_progress(current: int, total: int, phase: str) -> None:
+                    tracker.check_cancelled()
+                    if phase == "clipping":
+                        msg = "Clipping media…"
+                    else:
+                        msg = "Embedding clips…"
+                    tracker.update(
+                        "loading", msg,
+                        current=current, total=total,
+                        step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,
+                    )
+
+                _clipper_progress(0, 0, "clipping")
+                _apply_clipper(ctx.medias, clipper, clipper_params, on_progress=_clipper_progress)
+
+            def _dedup_progress(current: int, total: int) -> None:
+                tracker.check_cancelled()
+                tracker.update(
+                    "loading", "Removing duplicates…",
+                    current=current, total=total,
+                    step=_TOTAL_LOAD_STEPS, total_steps=_TOTAL_LOAD_STEPS,
+                )
+
+            _dedup_progress(0, 0)
+            collapse_duplicates(ctx.medias, on_progress=_dedup_progress)
 
             def _diversity_progress(current: int, total: int) -> None:
                 tracker.check_cancelled()

--- a/vtsearch/utils/state_media_lookup.py
+++ b/vtsearch/utils/state_media_lookup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Callable
 
 from vtsearch.utils.state_core import _state_lock, medias
 
@@ -122,7 +122,10 @@ def find_missing_entries(
     return missing
 
 
-def collapse_duplicates(media_dict: dict[int, dict[str, Any]]) -> int:
+def collapse_duplicates(
+    media_dict: dict[int, dict[str, Any]],
+    on_progress: Callable[[int, int], None] | None = None,
+) -> int:
     """Collapse duplicate medias (same MD5) into single representative items.
 
     For each group of medias sharing the same MD5, the first media becomes
@@ -133,6 +136,7 @@ def collapse_duplicates(media_dict: dict[int, dict[str, Any]]) -> int:
 
     Args:
         media_dict: The mutable medias dict.  Modified in place.
+        on_progress: Optional ``(current, total)`` callback for progress.
 
     Returns:
         The number of duplicate groups collapsed (i.e. groups of size >= 2).
@@ -144,7 +148,10 @@ def collapse_duplicates(media_dict: dict[int, dict[str, Any]]) -> int:
             md5_groups.setdefault(md5, []).append(cid)
 
     dupe_count = 0
-    for md5, cids in md5_groups.items():
+    total_groups = len(md5_groups)
+    for group_idx, (md5, cids) in enumerate(md5_groups.items()):
+        if on_progress and group_idx % 200 == 0:
+            on_progress(group_idx, total_groups)
         if len(cids) < 2:
             continue
         dupe_count += 1


### PR DESCRIPTION
## Summary
This PR adds progress reporting callbacks to the clipper and duplicate collapsing operations, allowing the UI to display real-time progress during these potentially long-running tasks. It also optimizes the import workflow by skipping embedding during the import phase when a multi-output clipper is selected, since the clipper will re-embed all clips anyway.

## Key Changes

- **Progress reporting for clipping**: Added `on_progress` callback parameter to `_apply_clipper()` that reports progress during both the "clipping" and "embedding" phases, with current/total counts for each phase.

- **Progress reporting for deduplication**: Added `on_progress` callback parameter to `collapse_duplicates()` that reports progress as duplicate groups are processed (sampled every 200 groups to avoid excessive callback overhead).

- **Improved embedding logic**: Modified `_fixup_clip_md5_and_embeddings()` to embed clips that have no embedding at all, not just those marked for recomputation. This handles cases where the import phase skipped embedding because a clipper was specified.

- **Skip embedding optimization**: When a multi-output clipper is selected, the import phase now sets `skip_embedding=True` to avoid computing parent embeddings that will be discarded. Default clippers (pass-through, single output) still compute parent embeddings since they won't be recomputed.

- **Updated callers**: Modified `datasets_loading.py` and `datasets.py` to pass progress callbacks to `_apply_clipper()` and `collapse_duplicates()`, displaying appropriate status messages ("Clipping media…", "Embedding clips…", "Removing duplicates…").

- **Importer updates**: Updated folder and HTTP ZIP importers to respect the `skip_embedding` field value when loading datasets.

## Implementation Details

- Progress callbacks use a `(current, total, phase)` signature for clipping and `(current, total)` for deduplication
- Callbacks are optional (can be `None`) and are checked before invocation to avoid overhead
- MD5 recomputation is now conditional: only recomputed for genuine sub-items from multi-output clippers, while embeddings are computed for any clip lacking one
- Deduplication progress is sampled (every 200 groups) to minimize callback overhead during large operations

https://claude.ai/code/session_013QJP5P8KpvU1wDys3dZ5dK