### PR TITLE
Replace clipper dropdowns with modal chooser interface

### DIFF
--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
@@ -1,0 +1,56 @@
+<vt-modal title="Choose MediaClipper" [open]="open" [showCloseButton]="false" (closed)="cancel()">
+  @if (clippers.length === 0) {
+    <p class="empty-state">No clippers available for this media type.</p>
+  } @else {
+    <div class="clipper-chooser">
+      <div class="clipper-tab-bar">
+        @for (clipper of clippers; track clipper.name) {
+          <button
+            class="clipper-tab"
+            [class.active]="activeTab === clipper.name"
+            (click)="selectTab(clipper.name)"
+          >{{ clipper.display_name || clipper.name }}</button>
+        }
+      </div>
+
+      <div class="clipper-tab-content">
+        @if (activeClipper) {
+          @if (activeQuestions.length > 0) {
+            @for (q of activeQuestions; track q.key) {
+              <div class="form-group">
+                <label class="form-label" [for]="'cq-' + q.key">{{ q.label }}</label>
+                @if (q.type === 'number') {
+                  <input
+                    [id]="'cq-' + q.key"
+                    type="number"
+                    class="form-input"
+                    [min]="q.min ?? null"
+                    [max]="q.max ?? null"
+                    [step]="q.step"
+                    [ngModel]="paramValues[activeTab]?.[q.key]"
+                    (ngModelChange)="paramValues[activeTab][q.key] = $event"
+                  />
+                } @else {
+                  <input
+                    [id]="'cq-' + q.key"
+                    type="text"
+                    class="form-input"
+                    [ngModel]="paramValues[activeTab]?.[q.key]"
+                    (ngModelChange)="paramValues[activeTab][q.key] = $event"
+                  />
+                }
+              </div>
+            }
+          } @else {
+            <p class="no-settings">This clipper has no configurable settings.</p>
+          }
+        }
+      </div>
+    </div>
+  }
+
+  <div class="form-actions" modal-footer>
+    <button class="btn btn--secondary" (click)="cancel()">Cancel</button>
+    <button class="btn btn--primary" (click)="confirm()" [disabled]="clippers.length === 0">OK</button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
@@ -1,0 +1,58 @@
+.clipper-chooser {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.clipper-tab-bar {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+  border-bottom: 2px solid var(--border);
+}
+
+.clipper-tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 16px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .85rem;
+  cursor: pointer;
+  transition: all .15s;
+  margin-bottom: -2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-subtle);
+  }
+
+  &.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+    font-weight: 600;
+  }
+}
+
+.clipper-tab-content {
+  min-height: 80px;
+  padding: 4px 0;
+}
+
+.no-settings {
+  color: var(--text-muted);
+  font-size: .85rem;
+  font-style: italic;
+  padding: 8px 0;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
@@ -1,0 +1,74 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../../modal/modal.component';
+import { ClipperInfo, ClipperParameter } from '../../../models/api.models';
+
+export interface ClipperSelection {
+  name: string;
+  params: Record<string, number | string>;
+}
+
+@Component({
+  selector: 'vt-clipper-chooser',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent],
+  templateUrl: './clipper-chooser.component.html',
+  styleUrl: './clipper-chooser.component.scss',
+})
+export class ClipperChooserComponent implements OnChanges {
+  @Input() open = false;
+  @Input() clippers: ClipperInfo[] = [];
+
+  @Output() selected = new EventEmitter<ClipperSelection>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  activeTab = '';
+  /** Per-clipper parameter values, keyed by clipper name then param key. */
+  paramValues: Record<string, Record<string, number | string>> = {};
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['open'] && this.open) {
+      this.initTabs();
+    }
+  }
+
+  private initTabs(): void {
+    this.paramValues = {};
+    for (const clipper of this.clippers) {
+      const questions = clipper.creation_questions || clipper.parameters || [];
+      const vals: Record<string, number | string> = {};
+      for (const q of questions) {
+        vals[q.key] = q.default;
+      }
+      this.paramValues[clipper.name] = vals;
+    }
+    // Default to first non-default clipper tab if available, else first clipper
+    if (this.clippers.length > 0) {
+      const nonDefault = this.clippers.find((c) => !c.name.endsWith('_default'));
+      this.activeTab = nonDefault ? nonDefault.name : this.clippers[0].name;
+    }
+  }
+
+  get activeClipper(): ClipperInfo | undefined {
+    return this.clippers.find((c) => c.name === this.activeTab);
+  }
+
+  get activeQuestions(): ClipperParameter[] {
+    const clipper = this.activeClipper;
+    return clipper?.creation_questions || clipper?.parameters || [];
+  }
+
+  selectTab(clipperName: string): void {
+    this.activeTab = clipperName;
+  }
+
+  confirm(): void {
+    const params = this.paramValues[this.activeTab] || {};
+    this.selected.emit({ name: this.activeTab, params: { ...params } });
+  }
+
+  cancel(): void {
+    this.cancelled.emit();
+  }
+}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -61,17 +61,9 @@
               </select>
             }
             @if (demoClippers.length > 1) {
-              <label class="form-label" for="demo-clipper" title="Pre-processing clipper that segments or trims media before embedding (e.g. audio chunking)">Clipper:</label>
-              <select
-                id="demo-clipper"
-                class="form-select form-select--inline"
-                [ngModel]="selectedDemoClipper"
-                (ngModelChange)="onDemoClipperChange($event)"
-              >
-                @for (clipper of demoClippers; track clipper.name) {
-                  <option [value]="clipper.name">{{ clipper.display_name || clipper.name }}</option>
-                }
-              </select>
+              <button class="btn btn--secondary btn--sm clipper-btn" (click)="openClipperChooser('demo')" title="Choose a MediaClipper to segment or trim media before embedding">
+                Clipper: {{ clipperDisplayName('demo') }}
+              </button>
             }
           </div>
         }
@@ -196,47 +188,11 @@
 
       @if (availableClippers.length > 1) {
         <div class="form-group">
-          <label class="form-label" for="field-clipper" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-          <select
-            id="field-clipper"
-            class="form-select"
-            [ngModel]="selectedClipper"
-            (ngModelChange)="onClipperChange($event)"
-          >
-            @for (clipper of availableClippers; track clipper.name) {
-              <option [value]="clipper.name">{{ clipper.display_name || clipper.name }}</option>
-            }
-          </select>
+          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('form')" title="Choose a MediaClipper to segment or trim media before embedding">
+            Use MediaClipper: {{ clipperDisplayName('form') }}
+          </button>
         </div>
-        @if (selectedClipperParams.length > 0) {
-          <div class="clipper-params">
-            @for (param of selectedClipperParams; track param.key) {
-              <div class="form-group">
-                <label class="form-label" [for]="'clipper-param-' + param.key">{{ param.label }}</label>
-                @if (param.type === 'number') {
-                  <input
-                    [id]="'clipper-param-' + param.key"
-                    type="number"
-                    class="form-input"
-                    [min]="param.min ?? null"
-                    [max]="param.max ?? null"
-                    [step]="param.step"
-                    [ngModel]="clipperParamValues[param.key]"
-                    (ngModelChange)="clipperParamValues[param.key] = $event"
-                  />
-                } @else {
-                  <input
-                    [id]="'clipper-param-' + param.key"
-                    type="text"
-                    class="form-input"
-                    [ngModel]="clipperParamValues[param.key]"
-                    (ngModelChange)="clipperParamValues[param.key] = $event"
-                  />
-                }
-              </div>
-            }
-          </div>
-        }
       }
 
       @if (error) {
@@ -334,17 +290,10 @@
 
       @if (sfClippers.length > 1) {
         <div class="form-group">
-          <label class="form-label" for="sf-clipper" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-          <select
-            id="sf-clipper"
-            class="form-select"
-            [ngModel]="sfSelectedClipper"
-            (ngModelChange)="sfOnClipperChange($event)"
-          >
-            @for (clipper of sfClippers; track clipper.name) {
-              <option [value]="clipper.name">{{ clipper.name }}</option>
-            }
-          </select>
+          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('sf')" title="Choose a MediaClipper to segment or trim media before embedding">
+            Use MediaClipper: {{ clipperDisplayName('sf') }}
+          </button>
         </div>
       }
 
@@ -366,4 +315,10 @@
       </button>
     </div>
   }
+  <vt-clipper-chooser
+    [open]="clipperChooserOpen"
+    [clippers]="clipperChooserClippers"
+    (selected)="onClipperChooserSelected($event)"
+    (cancelled)="onClipperChooserCancelled()"
+  />
 </vt-modal>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -192,6 +192,11 @@
 .badge-embedding { background: var(--badge-embedding, var(--accent)); }
 .badge-download { background: var(--border); color: var(--text-muted); }
 
+.clipper-btn {
+  text-align: left;
+  white-space: nowrap;
+}
+
 .server-folder-browser { gap: 12px; }
 .sf-browse-section { gap: 6px; }
 .sf-breadcrumbs { display: flex; align-items: center; gap: 2px; font-size: .8rem; flex-wrap: wrap; }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
+import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 
@@ -12,7 +13,7 @@ type ModalView = 'picker' | 'form' | 'demo' | 'server_folder';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent, ClipperChooserComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -86,6 +87,12 @@ export class DatasetImporterModalComponent implements OnInit {
   sfClipperParams: ClipperParameter[] = [];
   sfClipperParamValues: Record<string, number | string> = {};
   sfSubmitting = false;
+
+  // Clipper chooser modal state
+  clipperChooserOpen = false;
+  /** Which context opened the chooser: 'form' | 'demo' | 'sf' */
+  clipperChooserContext: 'form' | 'demo' | 'sf' = 'form';
+  clipperChooserClippers: ClipperInfo[] = [];
 
   constructor(private datasetsApi: DatasetsApiService) {}
 
@@ -719,6 +726,74 @@ export class DatasetImporterModalComponent implements OnInit {
     for (const param of this.sfClipperParams) {
       this.sfClipperParamValues[param.key] = param.default;
     }
+  }
+
+  // --- Clipper chooser ---
+
+  openClipperChooser(context: 'form' | 'demo' | 'sf'): void {
+    this.clipperChooserContext = context;
+    if (context === 'form') {
+      this.clipperChooserClippers = this.availableClippers;
+    } else if (context === 'demo') {
+      this.clipperChooserClippers = this.demoClippers;
+    } else {
+      this.clipperChooserClippers = this.sfClippers;
+    }
+    this.clipperChooserOpen = true;
+  }
+
+  onClipperChooserSelected(selection: ClipperSelection): void {
+    this.clipperChooserOpen = false;
+    const ctx = this.clipperChooserContext;
+    if (ctx === 'form') {
+      this.selectedClipper = selection.name;
+      this.clipperParamValues = { ...selection.params };
+    } else if (ctx === 'demo') {
+      this.selectedDemoClipper = selection.name;
+      this.updateDemoStatuses();
+      this.refetchDemoStatuses(this.selectedDemoEmbedder, this.selectedDemoClipper);
+    } else {
+      this.sfSelectedClipper = selection.name;
+      this.sfClipperParamValues = { ...selection.params };
+    }
+  }
+
+  onClipperChooserCancelled(): void {
+    this.clipperChooserOpen = false;
+    // Cancel returns the default clipper for the media type
+    const ctx = this.clipperChooserContext;
+    const clippers = this.clipperChooserClippers;
+    const defaultClipper = clippers.find((c) => c.name.endsWith('_default')) || clippers[0];
+    const defaultName = defaultClipper?.name || '';
+    if (ctx === 'form') {
+      this.selectedClipper = defaultName;
+      this.resetClipperParams();
+    } else if (ctx === 'demo') {
+      this.selectedDemoClipper = defaultName;
+      this.updateDemoStatuses();
+      this.refetchDemoStatuses(this.selectedDemoEmbedder, this.selectedDemoClipper);
+    } else {
+      this.sfSelectedClipper = defaultName;
+      this.sfResetClipperParams();
+    }
+  }
+
+  /** Display name for the currently selected clipper in a given context. */
+  clipperDisplayName(context: 'form' | 'demo' | 'sf'): string {
+    let clippers: ClipperInfo[];
+    let selected: string;
+    if (context === 'form') {
+      clippers = this.availableClippers;
+      selected = this.selectedClipper;
+    } else if (context === 'demo') {
+      clippers = this.demoClippers;
+      selected = this.selectedDemoClipper;
+    } else {
+      clippers = this.sfClippers;
+      selected = this.sfSelectedClipper;
+    }
+    const clipper = clippers.find((c) => c.name === selected);
+    return clipper?.display_name || clipper?.name || 'Default';
   }
 
   sfSubmit(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -402,6 +402,7 @@ export interface ClipperInfo {
   display_name?: string;
   media_type: string;
   parameters?: ClipperParameter[];
+  creation_questions?: ClipperParameter[];
   [key: string]: unknown;
 }
 

--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -44,6 +44,36 @@ class TestMediaClipperABC:
         c = VideoSceneClipper()
         assert c.display_name == "Video Scene"
 
+    def test_creation_questions_defaults_to_parameters(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        assert c.creation_questions == c.parameters
+        assert len(c.creation_questions) == 2
+
+    def test_creation_questions_empty_for_default_clipper(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        assert c.creation_questions == []
+        assert c.creation_questions == c.parameters
+
+    def test_to_dict_includes_creation_questions_when_present(self):
+        from vtsearch.media.audio.clipper import SoundTilingClipper
+
+        c = SoundTilingClipper(2.0)
+        d = c.to_dict()
+        assert "creation_questions" in d
+        assert len(d["creation_questions"]) == 2
+        assert d["creation_questions"][0]["key"] == "duration"
+
+    def test_to_dict_omits_creation_questions_when_empty(self):
+        from vtsearch.media.audio.clipper import SoundDefaultClipper
+
+        c = SoundDefaultClipper()
+        d = c.to_dict()
+        assert "creation_questions" not in d
+
 
 # ---------------------------------------------------------------------------
 # SoundDefaultClipper
@@ -841,6 +871,20 @@ class TestClippersApiEndpoint:
         clippers = data["clippers"]
         assert len(clippers) >= 1
         assert all(c["media_type"] == "document" for c in clippers)
+
+    def test_creation_questions_in_api_response(self, client):
+        resp = client.get("/api/clippers?media_type=audio")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        clippers = data["clippers"]
+        tiling = next(c for c in clippers if c["name"] == "sound_tiling")
+        assert "creation_questions" in tiling
+        assert len(tiling["creation_questions"]) == 2
+        keys = [q["key"] for q in tiling["creation_questions"]]
+        assert "duration" in keys
+        # Default clipper should not have creation_questions
+        default = next(c for c in clippers if c["name"] == "sound_default")
+        assert "creation_questions" not in default
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -1212,6 +1212,26 @@ class MediaClipper(ABC):
         """
         return []
 
+    @property
+    def creation_questions(self) -> list[dict[str, Any]]:
+        """Return a list of questions to present when the user chooses this clipper.
+
+        Each question is a dict with the same schema as :attr:`parameters`
+        descriptors:
+
+        * ``key`` — parameter name (used in :meth:`with_params`).
+        * ``label`` — human-readable label / question for the UI.
+        * ``type`` — ``"number"`` or ``"string"``.
+        * ``default`` — current/default value.
+        * ``min`` / ``max`` / ``step`` — optional numeric constraints.
+
+        By default this returns :attr:`parameters`, so any clipper that
+        already declares parameters automatically exposes them as creation
+        questions.  Subclasses may override to present a different (richer
+        or reduced) set of questions at creation time.
+        """
+        return self.parameters
+
     def with_params(self, params: dict[str, Any]) -> "MediaClipper":
         """Return a **new** clipper of the same type with overridden parameters.
 
@@ -1255,4 +1275,7 @@ class MediaClipper(ABC):
         params = self.parameters
         if params:
             d["parameters"] = params
+        cq = self.creation_questions
+        if cq:
+            d["creation_questions"] = cq
         return d


### PR DESCRIPTION
## Summary
Refactors the clipper selection UI across the dataset importer modal from dropdown selects to a dedicated modal dialog with tabbed interface. This provides a better UX for configuring clipper parameters at selection time.

## Key Changes

- **New ClipperChooserComponent**: Created a reusable modal component (`clipper-chooser/`) that presents available clippers as tabs, allowing users to configure parameters before confirming selection
  - Displays clippers in a tab bar interface
  - Shows configurable parameters/creation questions for the active clipper
  - Emits `ClipperSelection` with both clipper name and configured parameters

- **Updated DatasetImporterModalComponent**:
  - Replaced three separate clipper dropdown selects (form, demo, server_folder contexts) with button triggers that open the clipper chooser modal
  - Added clipper chooser state management (`clipperChooserOpen`, `clipperChooserContext`, `clipperChooserClippers`)
  - Implemented `openClipperChooser()`, `onClipperChooserSelected()`, and `onClipperChooserCancelled()` methods to handle modal interactions
  - Added `clipperDisplayName()` helper to show the currently selected clipper in each context
  - Removed inline clipper parameter form sections (now handled by the modal)

- **Backend API Model Updates**:
  - Added `creation_questions` property to `MediaClipper` base class that defaults to `parameters`
  - Updated `ClipperInfo` interface to include optional `creation_questions` field
  - Modified `to_dict()` to include `creation_questions` in API responses when present

- **Tests**: Added comprehensive test coverage for the new `creation_questions` property and API response serialization

## Implementation Details

- The clipper chooser modal defaults to the first non-default clipper tab (or first clipper if all are defaults)
- Parameter values are tracked per-clipper to preserve user selections when switching tabs
- Cancelling the modal resets to the default clipper for that media type
- The UI now clearly separates clipper selection from parameter configuration through the modal workflow

https://claude.ai/code/session_01CmJ2gsimByhM2YFpRJVeC3