### PR TITLE
Surface clip metadata in display_metadata and exports

### DIFF
--- a/tests/test_clipper_workflow.py
+++ b/tests/test_clipper_workflow.py
@@ -735,3 +735,265 @@ class TestApplyClipperProgress:
         clips_dict = {1: _make_audio_media(1, duration=5.1)}
         _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0}, on_progress=None)
         assert len(clips_dict) >= 1  # Clips were still produced
+
+
+# ---------------------------------------------------------------------------
+# Clip metadata in display_metadata and enriched exports
+# ---------------------------------------------------------------------------
+
+
+class TestClipDisplayMetadata:
+    """display_metadata should include clip boundary fields when present."""
+
+    def test_audio_clip_metadata(self):
+        from vtsearch.media import get as get_media_type
+
+        mt = get_media_type("audio")
+        media = {"type": "audio", "clip_start": 0.0, "clip_end": 2.0, "clip_index": 0}
+        meta = mt.display_metadata(media)
+        assert meta["Clip Start"] == 0.0
+        assert meta["Clip End"] == 2.0
+        assert meta["Clip Index"] == 0
+
+    def test_image_clip_metadata(self):
+        from vtsearch.media import get as get_media_type
+
+        mt = get_media_type("image")
+        media = {"type": "image", "clip_box": [0, 0, 100, 100], "clip_index": 0}
+        meta = mt.display_metadata(media)
+        assert meta["Clip Box"] == "0,0,100,100"
+        assert meta["Clip Index"] == 0
+
+    def test_video_clip_metadata(self):
+        from vtsearch.media import get as get_media_type
+
+        mt = get_media_type("video")
+        media = {"type": "video", "clip_start": 1.5, "clip_end": 4.0, "clip_index": 1}
+        meta = mt.display_metadata(media)
+        assert meta["Clip Start"] == 1.5
+        assert meta["Clip End"] == 4.0
+        assert meta["Clip Index"] == 1
+
+    def test_text_clip_metadata(self):
+        from vtsearch.media import get as get_media_type
+
+        mt = get_media_type("text")
+        media = {"type": "text", "clip_index": 2}
+        meta = mt.display_metadata(media)
+        assert meta["Clip Index"] == 2
+
+    def test_no_clip_fields_when_absent(self):
+        from vtsearch.media import get as get_media_type
+
+        mt = get_media_type("audio")
+        media = {"type": "audio", "duration": 3.0}
+        meta = mt.display_metadata(media)
+        assert "Clip Start" not in meta
+        assert "Clip End" not in meta
+        assert "Clip Index" not in meta
+
+
+class TestClipFieldsInEnrichedExport:
+    """Enriched label export should surface clip boundary columns."""
+
+    def test_enriched_export_has_clip_columns(self, client):
+        saved = dict(medias)
+        medias.clear()
+        try:
+            from vtsearch.routes.datasets_loading import _apply_clipper
+
+            clips_dict = {1: _make_audio_media(1, duration=5.0)}
+            _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0})
+            for cid, clip in clips_dict.items():
+                medias[cid] = clip
+
+            # Vote on a clip
+            good_votes[1] = None
+
+            resp = client.get("/api/labels/export?enrich=1")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            cols = data["available_columns"]
+            assert "Clip Start" in cols
+            assert "Clip End" in cols
+            assert "Clip Index" in cols
+            # Clip Box should NOT be present for audio clips
+            assert "Clip Box" not in cols
+
+            # Verify custom_metadata on the label entry
+            entry = data["labels"][0]
+            meta = entry["custom_metadata"]
+            assert "Clip Start" in meta
+            assert "Clip End" in meta
+        finally:
+            medias.clear()
+            medias.update(saved)
+
+    def test_enriched_export_image_clip_box(self, client):
+        saved = dict(medias)
+        medias.clear()
+        try:
+            from vtsearch.routes.datasets_loading import _apply_clipper
+
+            clips_dict = {1: _make_image_media(1, width=300, height=100)}
+            _apply_clipper(clips_dict, "image_tiling")
+            for cid, clip in clips_dict.items():
+                medias[cid] = clip
+
+            good_votes[1] = None
+
+            resp = client.get("/api/labels/export?enrich=1")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            cols = data["available_columns"]
+            assert "Clip Box" in cols
+            assert "Clip Index" in cols
+        finally:
+            medias.clear()
+            medias.update(saved)
+
+    def test_no_clip_columns_without_clips(self, client):
+        """Unclipped media should not have clip columns in export."""
+        good_votes[1] = None  # Vote on default test media
+        resp = client.get("/api/labels/export?enrich=1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        cols = data["available_columns"]
+        assert "Clip Start" not in cols
+        assert "Clip End" not in cols
+        assert "Clip Box" not in cols
+        assert "Clip Index" not in cols
+
+
+class TestClipFieldsInBuildMediaHit:
+    """build_media_hit should include clip fields when present."""
+
+    def test_hit_includes_clip_start_end(self):
+        from vtsearch.utils.hits import build_media_hit
+
+        media = {
+            "filename": "clip.wav",
+            "category": "audio",
+            "md5": "abc123",
+            "clip_start": 0.0,
+            "clip_end": 2.5,
+            "clip_index": 0,
+        }
+        hit = build_media_hit(1, media, 0.95)
+        assert hit["clip_start"] == 0.0
+        assert hit["clip_end"] == 2.5
+        assert hit["clip_index"] == 0
+
+    def test_hit_includes_clip_box(self):
+        from vtsearch.utils.hits import build_media_hit
+
+        media = {
+            "filename": "tile.png",
+            "category": "image",
+            "md5": "def456",
+            "clip_box": [10, 20, 110, 120],
+            "clip_index": 1,
+        }
+        hit = build_media_hit(1, media, 0.8)
+        assert hit["clip_box"] == [10, 20, 110, 120]
+        assert hit["clip_index"] == 1
+
+    def test_hit_omits_clip_fields_when_absent(self):
+        from vtsearch.utils.hits import build_media_hit
+
+        media = {"filename": "full.wav", "category": "audio", "md5": "xyz"}
+        hit = build_media_hit(1, media, 0.5)
+        assert "clip_start" not in hit
+        assert "clip_end" not in hit
+        assert "clip_box" not in hit
+        assert "clip_index" not in hit
+
+
+class TestCsvExportClipColumns:
+    """CSV autodetect export should include clip columns when present."""
+
+    def test_csv_includes_clip_start_end(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exporter = ServerCsvLabelsetExporter()
+        results = {
+            "detectors_run": 1,
+            "results": {
+                "det1": {
+                    "detector_name": "det1",
+                    "threshold": 0.5,
+                    "hits": [
+                        {"filename": "a.wav", "category": "audio", "score": 0.9,
+                         "clip_start": 0.0, "clip_end": 2.0, "origin_name": "a.wav"},
+                        {"filename": "b.wav", "category": "audio", "score": 0.8,
+                         "clip_start": 2.0, "clip_end": 4.0, "origin_name": "b.wav"},
+                    ],
+                }
+            },
+        }
+        filepath = tmp_path / "results.csv"
+        exporter.export(results, {"filepath": str(filepath)})
+
+        import csv
+        with open(filepath) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert "clip_start" in rows[0]
+        assert "clip_end" in rows[0]
+        assert rows[0]["clip_start"] == "0.0"
+        assert rows[1]["clip_end"] == "4.0"
+
+    def test_csv_includes_clip_box(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exporter = ServerCsvLabelsetExporter()
+        results = {
+            "detectors_run": 1,
+            "results": {
+                "det1": {
+                    "detector_name": "det1",
+                    "threshold": 0.5,
+                    "hits": [
+                        {"filename": "tile.png", "category": "image", "score": 0.9,
+                         "clip_box": [0, 0, 100, 100], "origin_name": "tile.png"},
+                    ],
+                }
+            },
+        }
+        filepath = tmp_path / "results.csv"
+        exporter.export(results, {"filepath": str(filepath)})
+
+        import csv
+        with open(filepath) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert "clip_box" in rows[0]
+        assert rows[0]["clip_box"] == "0,0,100,100"
+
+    def test_csv_omits_clip_columns_without_clips(self, tmp_path):
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exporter = ServerCsvLabelsetExporter()
+        results = {
+            "detectors_run": 1,
+            "results": {
+                "det1": {
+                    "detector_name": "det1",
+                    "threshold": 0.5,
+                    "hits": [
+                        {"filename": "full.wav", "category": "audio", "score": 0.7,
+                         "origin_name": "full.wav"},
+                    ],
+                }
+            },
+        }
+        filepath = tmp_path / "results.csv"
+        exporter.export(results, {"filepath": str(filepath)})
+
+        import csv
+        with open(filepath) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert "clip_start" not in rows[0]
+        assert "clip_end" not in rows[0]
+        assert "clip_box" not in rows[0]

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -121,33 +121,59 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
 
     def _export_autodetect(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
         """Export autodetect results (detector hits)."""
+        # Scan all hits to determine which clip columns are present.
+        all_hits: list[tuple[str, Any, dict]] = []
+        for det_result in results.get("results", {}).values():
+            detector_name = det_result.get("detector_name", "unknown")
+            threshold = det_result.get("threshold", "")
+            for hit in det_result.get("hits", []):
+                all_hits.append((detector_name, threshold, hit))
+
+        has_clip_start = any(h.get("clip_start") is not None for _, _, h in all_hits)
+        has_clip_end = any(h.get("clip_end") is not None for _, _, h in all_hits)
+        has_clip_box = any(h.get("clip_box") is not None for _, _, h in all_hits)
+
+        base_cols = ["detector", "threshold", "filename", "category", "score"]
+        if has_clip_start:
+            base_cols.append("clip_start")
+        if has_clip_end:
+            base_cols.append("clip_end")
+        if has_clip_box:
+            base_cols.append("clip_box")
+        base_cols.extend(["origin", "origin_name"])
+
         total_hits = 0
         with open(filepath, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerow(["detector", "threshold", "filename", "category", "score", "origin", "origin_name"])
+            writer.writerow(base_cols)
 
-            for det_result in results.get("results", {}).values():
-                detector_name = det_result.get("detector_name", "unknown")
-                threshold = det_result.get("threshold", "")
-                for hit in det_result.get("hits", []):
-                    origin = hit.get("origin")
-                    origin_str = ""
-                    if origin:
-                        from vtsearch.datasets.origin import Origin
+            for detector_name, threshold, hit in all_hits:
+                origin = hit.get("origin")
+                origin_str = ""
+                if origin:
+                    from vtsearch.datasets.origin import Origin
 
-                        origin_str = Origin.from_dict(origin).display()
-                    writer.writerow(
-                        [
-                            _sanitize_csv_cell(str(detector_name)),
-                            threshold,
-                            _sanitize_csv_cell(hit.get("filename", "")),
-                            _sanitize_csv_cell(hit.get("category", "")),
-                            hit.get("score", ""),
-                            _sanitize_csv_cell(origin_str),
-                            _sanitize_csv_cell(hit.get("origin_name", "")),
-                        ]
-                    )
-                    total_hits += 1
+                    origin_str = Origin.from_dict(origin).display()
+                row = [
+                    _sanitize_csv_cell(str(detector_name)),
+                    threshold,
+                    _sanitize_csv_cell(hit.get("filename", "")),
+                    _sanitize_csv_cell(hit.get("category", "")),
+                    hit.get("score", ""),
+                ]
+                if has_clip_start:
+                    row.append(hit.get("clip_start", ""))
+                if has_clip_end:
+                    row.append(hit.get("clip_end", ""))
+                if has_clip_box:
+                    cb = hit.get("clip_box")
+                    row.append(",".join(str(v) for v in cb) if cb else "")
+                row.extend([
+                    _sanitize_csv_cell(origin_str),
+                    _sanitize_csv_cell(hit.get("origin_name", "")),
+                ])
+                writer.writerow(row)
+                total_hits += 1
 
         return {
             "message": (

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -152,6 +152,7 @@ class AudioMediaType(MediaType):
         fs = media.get("file_size")
         if fs:
             result["File Size"] = fs
+        result.update({k: v for k, v in super().display_metadata(media).items() if k not in result})
         return result
 
     # ------------------------------------------------------------------

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -709,6 +709,19 @@ class MediaType(ABC):
         fs = media.get("file_size")
         if fs:
             result["File Size"] = fs
+        # Clip boundary fields — present only on clipped sub-medias.
+        cs = media.get("clip_start")
+        if cs is not None:
+            result["Clip Start"] = cs
+        ce = media.get("clip_end")
+        if ce is not None:
+            result["Clip End"] = ce
+        cb = media.get("clip_box")
+        if cb is not None:
+            result["Clip Box"] = ",".join(str(v) for v in cb)
+        ci = media.get("clip_index")
+        if ci is not None:
+            result["Clip Index"] = ci
         return result
 
     # ------------------------------------------------------------------

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -87,6 +87,7 @@ class ImageMediaType(MediaType):
         fs = media.get("file_size")
         if fs:
             result["File Size"] = fs
+        result.update({k: v for k, v in super().display_metadata(media).items() if k not in result})
         return result
 
     # ------------------------------------------------------------------

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -82,6 +82,7 @@ class TextMediaType(MediaType):
         fs = media.get("file_size")
         if fs:
             result["File Size"] = fs
+        result.update({k: v for k, v in super().display_metadata(media).items() if k not in result})
         return result
 
     # ------------------------------------------------------------------

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -81,6 +81,7 @@ class VideoMediaType(MediaType):
         fs = media.get("file_size")
         if fs:
             result["File Size"] = fs
+        result.update({k: v for k, v in super().display_metadata(media).items() if k not in result})
         return result
 
     # ------------------------------------------------------------------

--- a/vtsearch/utils/hits.py
+++ b/vtsearch/utils/hits.py
@@ -38,6 +38,15 @@ def build_media_hit(
         hit["origin_name"] = media["origin_name"]
     if media.get("md5"):
         hit["md5"] = media["md5"]
+    # Include clip boundary fields when present (clipped sub-medias).
+    if media.get("clip_start") is not None:
+        hit["clip_start"] = media["clip_start"]
+    if media.get("clip_end") is not None:
+        hit["clip_end"] = media["clip_end"]
+    if media.get("clip_box") is not None:
+        hit["clip_box"] = media["clip_box"]
+    if media.get("clip_index") is not None:
+        hit["clip_index"] = media["clip_index"]
     if extra:
         hit.update(extra)
     return hit


### PR DESCRIPTION
## Summary
This PR adds support for displaying and exporting clip boundary metadata (clip_start, clip_end, clip_box, clip_index) throughout the application. When media is clipped using the clipper workflow, these boundary fields are now properly surfaced in display metadata, enriched label exports, search hits, and CSV exports.

## Key Changes

- **Display Metadata**: Updated `base.py` and all media type classes (audio, video, image, text) to include clip boundary fields in `display_metadata()` output when present
  - `clip_start` and `clip_end` for temporal media (audio/video)
  - `clip_box` for spatial media (image)
  - `clip_index` for all clipped media

- **Search Hits**: Modified `build_media_hit()` in `hits.py` to preserve clip boundary fields when constructing hit objects from media dictionaries

- **CSV Export**: Enhanced `ServerCsvLabelsetExporter._export_autodetect()` to:
  - Scan all hits to detect which clip columns are present
  - Dynamically include clip columns in the CSV header only when needed
  - Format `clip_box` as comma-separated values in CSV output

- **Enriched Label Export**: Clip boundary fields now appear in available columns and custom_metadata when exporting labels with enrichment

## Implementation Details

- Clip fields are only included in output when they are present in the source media (conditional inclusion)
- `clip_box` is formatted as comma-separated string in display and CSV contexts
- All media type subclasses inherit clip field handling from the base class via `super().display_metadata()`
- CSV export intelligently determines which columns to include based on actual data presence

## Tests
Comprehensive test coverage added for:
- Display metadata for all media types with and without clip fields
- Enriched export with audio and image clips
- Build media hit with clip fields
- CSV export with clip columns

https://claude.ai/code/session_01XPbs4QcAWCnDu5zyCA5fUq