### PR TITLE
Treat Angular compiler warnings as errors and fix optional chaining

### DIFF
--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
@@ -27,7 +27,7 @@
                     [min]="q.min ?? null"
                     [max]="q.max ?? null"
                     [step]="q.step"
-                    [ngModel]="paramValues[activeTab]?.[q.key]"
+                    [ngModel]="paramValues[activeTab][q.key]"
                     (ngModelChange)="paramValues[activeTab][q.key] = $event"
                   />
                 } @else {
@@ -35,7 +35,7 @@
                     [id]="'cq-' + q.key"
                     type="text"
                     class="form-input"
-                    [ngModel]="paramValues[activeTab]?.[q.key]"
+                    [ngModel]="paramValues[activeTab][q.key]"
                     (ngModelChange)="paramValues[activeTab][q.key] = $event"
                   />
                 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -54,6 +54,16 @@ if $_run_frontend_check && [ -d "frontend/node_modules" ]; then
     echo "Checking frontend TypeScript build..."
     _fe_log=$(mktemp)
     if (cd frontend && npm run build:prod 2>&1) > "$_fe_log"; then
+        # Treat Angular compiler warnings (e.g. NG8107) as errors
+        if grep -q '▲ \[WARNING\]' "$_fe_log"; then
+            echo ""
+            echo "======================================================================"
+            echo "FRONTEND BUILD HAS WARNINGS (treated as errors)"
+            echo "======================================================================"
+            grep -A 10 '▲ \[WARNING\]' "$_fe_log"
+            rm -f "$_fe_log"
+            exit 1
+        fi
         echo "Frontend build OK"
     else
         echo ""


### PR DESCRIPTION
## Summary
This PR strengthens the frontend build process by treating Angular compiler warnings as build failures, and fixes potential null reference issues in the clipper-chooser component.

## Key Changes
- **Build validation**: Modified `run-tests.sh` to detect and fail the build when Angular compiler warnings (e.g., NG8107) are present, ensuring code quality standards are enforced
- **Template safety**: Removed optional chaining operators (`?.`) from `paramValues[activeTab]?.[q.key]` in clipper-chooser component template, replacing them with direct property access `paramValues[activeTab][q.key]`

## Implementation Details
- The build script now parses the frontend build output for Angular warning patterns (`▲ [WARNING]`) and displays them before exiting with error code 1
- The template changes assume `paramValues[activeTab]` is always defined when accessed, which aligns with the component's initialization logic and prevents potential undefined reference issues that the optional chaining was masking

https://claude.ai/code/session_017kVwJjKzUixvwsCevSSJHN