### PR TITLE
Reduce pencil icon size in dataset and model card components

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -86,7 +86,7 @@
       </button>
     }
     <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-      <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
         <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
         <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -95,7 +95,7 @@
 <td>
   <div class="actions-cell">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
-    <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
       <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
       <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>


### PR DESCRIPTION
## Summary
This PR reduces the size of the pencil (edit) icons in the dataset and model card components for a more refined UI appearance.

## Changes
- **dataset-card.component.html**: Reduced pencil icon dimensions from 16x16 to 14x14 pixels
- **model-card.component.html**: Reduced pencil icon dimensions from 16x16 to 14x14 pixels

## Details
The SVG width and height attributes were updated from `16` to `14` in both the dataset card and model card rename buttons. This maintains visual consistency across the dashboard while providing a more compact icon size. The viewBox remains unchanged at `0 0 24 24`, ensuring the icon scales properly while preserving all animation and styling functionality.

https://claude.ai/code/session_013ZvESJFvnhnjT81MV26e3f