### PR TITLE
Train MLP model during load to enable direct inference

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12595,9 +12595,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "pacote": {
       "tar": "^7.5.13"
     },
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "vite": "^6.4.2"
   }
 }

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -669,7 +669,7 @@ def load_model_route():
     )
     register_detector_context(det_ctx)
 
-    _LOAD_STEPS = 2  # restore labels, seed examples
+    _LOAD_STEPS = 3  # restore labels, seed examples, train MLP
     task_id = f"_modload_{model_id[:8]}"
     tracker = model_loading_tasks.create_task(
         task_id, entry.get("name", model_id), model_id=model_id,
@@ -711,6 +711,35 @@ def load_model_route():
                     _seed_good_votes_from_examples(
                         tm_data.get("examples", [])
                     )
+
+                    # Train the MLP from restored votes so that Find can use
+                    # det_ctx.model directly without re-resolving label origins.
+                    tracker.check_cancelled()
+                    from vtsearch.utils import good_votes as _gv, bad_votes as _bv, snapshot_medias as _snap_medias
+
+                    if _gv and _bv:
+                        tracker.update(
+                            "loading", "Training model…", 0, 0,
+                            step=3, total_steps=_LOAD_STEPS,
+                        )
+                        from vtsearch.routes.detectors_helpers import train_and_threshold
+
+                        snap = _snap_medias()
+                        X_list = []
+                        y_list: list[float] = []
+                        for cid in _gv:
+                            if cid in snap:
+                                X_list.append(snap[cid]["embedding"])
+                                y_list.append(1.0)
+                        for cid in _bv:
+                            if cid in snap:
+                                X_list.append(snap[cid]["embedding"])
+                                y_list.append(0.0)
+
+                        if X_list and any(v == 1.0 for v in y_list) and any(v == 0.0 for v in y_list):
+                            trained_model, threshold = train_and_threshold(X_list, y_list, snap=snap)
+                            det_ctx.model = trained_model
+                            det_ctx.threshold = threshold
 
             # Mark as fully loaded so the registry shows detector_loaded=True.
             add_loaded_model_id(model_id)


### PR DESCRIPTION
## Summary
This PR adds MLP model training as part of the model loading process, allowing the detector to use a trained model directly during inference without needing to re-resolve label origins each time.

## Key Changes
- **Increased load steps from 2 to 3**: Added a new step for MLP training during model loading
- **Implemented MLP training during load**: After restoring labels and seed examples, the loader now:
  - Collects embeddings from good and bad votes
  - Trains an MLP classifier using the `train_and_threshold` helper
  - Stores the trained model and threshold in the detector context
  - Only trains if both positive and negative examples are available
- **Added Vite dependency**: Updated frontend package.json to include Vite ^6.4.2

## Implementation Details
- The MLP training step is skipped if good or bad votes are empty, or if either class has no examples
- Training uses embeddings from the snapshot media cache, filtering for entries that exist in the snapshot
- The trained model replaces the detector's model reference, enabling direct inference in Find operations
- Includes proper cancellation checks and progress tracking via the task tracker

https://claude.ai/code/session_01CmiRHcfx3M9FVgoPDADkX9