### PR TITLE
Improve model loading progress reporting with granular import steps

### DIFF
--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -47,8 +47,17 @@ class AudioClapEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing audio libraries…", 0, 0)
+        self._on_progress("loading", "Importing torch…", 1, 4)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 4)
         from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+
+        self._on_progress("loading", "Importing librosa…", 3, 4)
+        import librosa  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing soundfile…", 4, 4)
+        import soundfile  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP model weights…")
         with intercept_tqdm_progress(self._on_progress):
@@ -63,19 +72,15 @@ class AudioClapEmbedder(MediaEmbedder):
                 ClapProcessor.from_pretrained, CLAP_MODEL_ID, cache_dir=cache_dir, token=False
             )
 
-        # Warmup: import librosa (heavy — pulls in numba, scipy, etc.),
-        # trigger the numba JIT for audio resampling, and run a single
-        # dummy forward pass so that the first real embed_media call runs
-        # at the same speed as every subsequent one.
-        self._on_progress("loading", "Warming up audio pipeline: importing libraries…", 1, 4)
-        import librosa  # noqa: F401, PLC0415
-        import torch  # noqa: PLC0415
-
+        # Warmup: trigger the numba JIT for audio resampling, and run a
+        # single dummy forward pass so that the first real embed_media call
+        # runs at the same speed as every subsequent one.
+        #
         # Trigger librosa/soxr resampling JIT by loading a tiny WAV at a
         # different sample rate.  Without this, the first embed_media()
         # call stalls for 10-30 s while numba compiles resampling kernels,
         # making the embedding progress bar appear frozen.
-        self._on_progress("loading", "Warming up audio pipeline: resampling JIT…", 2, 4)
+        self._on_progress("loading", "Warming up audio pipeline: resampling JIT…", 1, 3)
         import io  # noqa: PLC0415
 
         import soundfile as sf  # noqa: PLC0415
@@ -86,7 +91,7 @@ class AudioClapEmbedder(MediaEmbedder):
         _warmup_buf.seek(0)
         librosa.load(_warmup_buf, sr=CLAP_SAMPLE_RATE, mono=True)
 
-        self._on_progress("loading", "Warming up audio pipeline: preprocessing…", 3, 4)
+        self._on_progress("loading", "Warming up audio pipeline: preprocessing…", 2, 3)
         dummy_audio = np.zeros(CLAP_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
@@ -96,7 +101,7 @@ class AudioClapEmbedder(MediaEmbedder):
             max_length=480000,
             truncation=True,
         )
-        self._on_progress("loading", "Warming up audio pipeline: running model…", 4, 4)
+        self._on_progress("loading", "Warming up audio pipeline: running model…", 3, 3)
         device = next(self._model.parameters()).device
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -51,8 +51,14 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing audio libraries…", 0, 0)
+        self._on_progress("loading", "Importing torch…", 1, 3)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 3)
         from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+
+        self._on_progress("loading", "Importing librosa…", 3, 3)
+        import librosa  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP Music model weights…")
         with intercept_tqdm_progress(self._on_progress):
@@ -66,12 +72,8 @@ class AudioClapMusicEmbedder(MediaEmbedder):
                 ClapProcessor.from_pretrained, CLAP_MUSIC_MODEL_ID, cache_dir=cache_dir, token=False
             )
 
-        # Warmup: import librosa and run a dummy forward pass
-        self._on_progress("loading", "Warming up CLAP Music pipeline: importing libraries…", 1, 3)
-        import librosa  # noqa: F401, PLC0415
-        import torch  # noqa: PLC0415
-
-        self._on_progress("loading", "Warming up CLAP Music pipeline: preprocessing…", 2, 3)
+        # Warmup: run a dummy forward pass
+        self._on_progress("loading", "Warming up CLAP Music pipeline: preprocessing…", 1, 2)
         dummy_audio = np.zeros(CLAP_SAMPLE_RATE, dtype=np.float32)
         inputs = self._processor(
             audio=dummy_audio,
@@ -81,7 +83,7 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             max_length=480000,
             truncation=True,
         )
-        self._on_progress("loading", "Warming up CLAP Music pipeline: running model…", 3, 3)
+        self._on_progress("loading", "Warming up CLAP Music pipeline: running model…", 2, 2)
         device = next(self._model.parameters()).device
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -57,7 +57,10 @@ class ImageClipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing image libraries…", 0, 0)
+        self._on_progress("loading", "Importing torch…", 1, 2)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 2)
         from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLIP model weights…")

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -57,7 +57,10 @@ class ImageSiglipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing image libraries…", 0, 0)
+        self._on_progress("loading", "Importing torch…", 1, 2)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 2)
         from transformers import SiglipModel, SiglipProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading SigLIP model weights…")

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -47,9 +47,14 @@ class TextE5Embedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing text libraries…", 0, 0)
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        self._on_progress("loading", "Importing torch…", 1, 3)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 3)
         from transformers import BertModel  # noqa: PLC0415
+
+        self._on_progress("loading", "Importing sentence_transformers…", 3, 3)
+        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading E5 model…")
         BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -47,9 +47,14 @@ class TextBGEEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing text libraries…", 0, 0)
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        self._on_progress("loading", "Importing torch…", 1, 3)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 3)
         from transformers import BertModel  # noqa: PLC0415
+
+        self._on_progress("loading", "Importing sentence_transformers…", 3, 3)
+        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading BGE model…")
         BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -54,7 +54,10 @@ class VideoXClipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing video libraries…", 0, 0)
+        self._on_progress("loading", "Importing torch…", 1, 2)
+        import torch  # noqa: F401, PLC0415
+
+        self._on_progress("loading", "Importing transformers…", 2, 2)
         from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading X-CLIP model weights…")


### PR DESCRIPTION
## Summary
Refactored model loading progress reporting across all embedder modules to provide more granular and accurate progress updates during the import phase. Instead of generic "Importing libraries" messages, the progress bar now shows specific library imports (torch, transformers, librosa, etc.) with numbered steps.

## Key Changes
- **Audio embedder (`embedder.py`)**: Split generic import message into 4 distinct steps (torch, transformers, librosa, soundfile) with progress tracking (1/4 through 4/4). Reorganized warmup phase to use 3-step progress (1/3 through 3/3) instead of 4 steps.
- **Audio embedder - Music variant (`embedder_clap_music.py`)**: Split imports into 3 steps (torch, transformers, librosa) and simplified warmup to 2-step progress (1/2 through 2/2).
- **Text embedders (`embedder.py` and `embedder_bge.py`)**: Split imports into 3 steps (torch, transformers, sentence_transformers) with numbered progress tracking.
- **Image embedders (`embedder.py` and `embedder_siglip.py`)**: Split imports into 2 steps (torch, transformers) with progress tracking.
- **Video embedder (`embedder.py`)**: Split imports into 2 steps (torch, transformers) with progress tracking.

## Implementation Details
- Moved explicit `import torch` statements to the beginning of each embedder's load sequence with dedicated progress updates
- Reordered imports to show progress as each library is imported, improving user feedback during model initialization
- Updated progress counters to accurately reflect the number of steps in each phase
- Maintained all existing noqa comments and import styles
- Simplified warmup phase comments in audio embedders to reflect the actual operations being performed

https://claude.ai/code/session_01LicSU3whC1UFKApY8EM29P