### PR TITLE
Add descriptions to clippers and their parameters

### DIFF
--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1361,16 +1361,16 @@ clippers return **new media dicts** that can replace the original.
 
 | Clipper | Name | Media Type | Description |
 |---------|------|------------|-------------|
-| `SoundDefaultClipper` | `sound_default` | `audio` | Returns audio unchanged |
-| `SoundTilingClipper` | `sound_tiling_2.0s` | `audio` | Tiles into 2s segments |
-| `ImageDefaultClipper` | `image_default` | `image` | Returns image unchanged |
-| `ImageTilingClipper` | `image_tiling` | `image` | Tiles tall images into squares |
-| `TextDefaultClipper` | `text_default` | `text` | Returns text unchanged |
-| `TextSentenceClipper` | `text_sentence` | `text` | Splits into individual sentences |
-| `VideoDefaultClipper` | `video_default` | `video` | Returns video unchanged |
-| `VideoTilingClipper` | `video_tiling_2.0s` | `video` | Tiles into 2s segments |
-| `VideoSceneClipper` | `video_scene` | `video` | Splits at detected scene boundaries |
-| `DocumentDefaultClipper` | `document_default` | `document` | Returns document unchanged |
+| `SoundDefaultClipper` | `sound_default` | `audio` | Import each audio file as-is, without splitting |
+| `SoundTilingClipper` | `sound_tiling_2.0s` | `audio` | Split each audio file into fixed-length overlapping segments |
+| `ImageDefaultClipper` | `image_default` | `image` | Import each image as-is, without splitting |
+| `ImageTilingClipper` | `image_tiling` | `image` | Tile each image into equidistant square crops along the longer axis |
+| `TextDefaultClipper` | `text_default` | `text` | Import each text entry as-is, without splitting |
+| `TextSentenceClipper` | `text_sentence` | `text` | Split each text entry into individual sentences |
+| `VideoDefaultClipper` | `video_default` | `video` | Import each video as-is, without splitting |
+| `VideoTilingClipper` | `video_tiling_2.0s` | `video` | Split each video into fixed-length overlapping segments |
+| `VideoSceneClipper` | `video_scene` | `video` | Automatically split each video at detected scene changes |
+| `DocumentDefaultClipper` | `document_default` | `document` | Import each document as-is, without splitting |
 
 ### What to implement
 
@@ -1398,6 +1398,11 @@ class SoundOverlapClipper(MediaClipper):
     def media_type(self) -> str:
         """The type_id this clipper operates on."""
         return "audio"
+
+    @property
+    def description(self) -> str:
+        """Short tooltip shown on hover in the clipper chooser UI."""
+        return "Tile audio with 50% overlap between consecutive segments."
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         """Split media into one or more media dicts of the same type.
@@ -1445,11 +1450,18 @@ CLIPPERS = [SoundDefaultClipper(), SoundTilingClipper(2.0), SoundOverlapClipper(
 
 **Optional overridable methods/properties:**
 
-| Method/Property  | Signature / Returns      | Description                                              |
-|------------------|--------------------------|----------------------------------------------------------|
-| `to_dict()`      | `() -> dict`             | JSON-serialisable metadata (default: name + media_type)  |
-| `parameters`     | `list[dict[str, Any]]`   | Configurable parameters (key, label, type, default, etc.) |
-| `with_params(p)` | `(dict) -> MediaClipper` | Return new clipper with overridden parameters             |
+| Method/Property      | Signature / Returns      | Description                                                       |
+|----------------------|--------------------------|-------------------------------------------------------------------|
+| `display_name`       | `str`                    | Human-readable name for UI tabs (default: title-cased `name`)     |
+| `description`        | `str`                    | Short tooltip text shown on hover in the clipper chooser UI       |
+| `to_dict()`          | `() -> dict`             | JSON-serialisable metadata (default: name + media_type)           |
+| `parameters`         | `list[dict[str, Any]]`   | Configurable parameters (key, label, type, default, description)  |
+| `creation_questions` | `list[dict[str, Any]]`   | Questions shown at creation time (defaults to `parameters`)       |
+| `with_params(p)`     | `(dict) -> MediaClipper` | Return new clipper with overridden parameters                     |
+
+Parameter dicts support an optional `description` key alongside `label`
+— this is shown as a tooltip when the user hovers over the setting in
+the clipper chooser dialog.
 
 ### Clip method contract
 
@@ -1981,6 +1993,8 @@ missing dependencies degrade gracefully.
 
 - [ ] Create or add to `vtsearch/media/<type>/clipper.py`
 - [ ] Subclass `MediaClipper`, implement `name`, `media_type`, `clip()`
+- [ ] Override `description` with a short tooltip string for the chooser UI
+- [ ] If adding `parameters`, include a `description` key in each param dict
 - [ ] Add to the `CLIPPERS` list in the media type's `__init__.py`
 - [ ] Test: verify `clip()` returns valid media dicts
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -48,7 +48,13 @@ GET /api/clippers
 **Query:** `?media_type=audio` — optional, filter by `type_id` or
 `folder_import_name`.
 
-→ `{"clippers": [{"name": "sound_default", "media_type": "audio", ...}]}`
+→ `{"clippers": [{"name": "sound_default", "media_type": "audio", "display_name": "Sound Default", "description": "Import each audio file as-is, without splitting.", ...}]}`
+
+Each clipper object includes `name`, `display_name`, `media_type`, and
+an optional `description` (short tooltip text). Clippers with
+configurable settings also include `parameters` and
+`creation_questions` arrays, where each parameter has `key`, `label`,
+`type`, `default`, and an optional `description` for hover tooltips.
 
 ### Converters
 

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.html
@@ -8,6 +8,7 @@
           <button
             class="clipper-tab"
             [class.active]="activeTab === clipper.name"
+            [title]="clipper.description || ''"
             (click)="selectTab(clipper.name)"
           >{{ clipper.display_name || clipper.name }}</button>
         }
@@ -15,10 +16,13 @@
 
       <div class="clipper-tab-content">
         @if (activeClipper) {
+          @if (activeClipper.description) {
+            <p class="clipper-description">{{ activeClipper.description }}</p>
+          }
           @if (activeQuestions.length > 0) {
             @for (q of activeQuestions; track q.key) {
               <div class="form-group">
-                <label class="form-label" [for]="'cq-' + q.key">{{ q.label }}</label>
+                <label class="form-label" [for]="'cq-' + q.key" [title]="q.description || ''">{{ q.label }}</label>
                 @if (q.type === 'number') {
                   <input
                     [id]="'cq-' + q.key"

--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
@@ -43,6 +43,12 @@
   padding: 4px 0;
 }
 
+.clipper-description {
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .82rem;
+  margin: 0 0 8px;
+}
+
 .no-settings {
   color: var(--text-muted);
   font-size: .85rem;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -793,7 +793,9 @@ export class DatasetImporterModalComponent implements OnInit {
       selected = this.sfSelectedClipper;
     }
     const clipper = clippers.find((c) => c.name === selected);
-    return clipper?.display_name || clipper?.name || 'Default';
+    if (!clipper) return 'None';
+    if (clipper.name.endsWith('_default')) return 'None';
+    return clipper.display_name || clipper.name;
   }
 
   sfSubmit(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -390,6 +390,7 @@ export interface ProcessorImporterInfo {
 export interface ClipperParameter {
   key: string;
   label: string;
+  description?: string;
   type: 'number' | 'string';
   default: number | string;
   min?: number;
@@ -400,6 +401,7 @@ export interface ClipperParameter {
 export interface ClipperInfo {
   name: string;
   display_name?: string;
+  description?: string;
   media_type: string;
   parameters?: ClipperParameter[];
   creation_questions?: ClipperParameter[];

--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -24,7 +24,12 @@ class TestMediaClipperABC:
 
         c = SoundDefaultClipper()
         d = c.to_dict()
-        assert d == {"name": "sound_default", "display_name": "Sound Default", "media_type": "audio"}
+        assert d == {
+            "name": "sound_default",
+            "display_name": "Sound Default",
+            "description": "Import each audio file as-is, without splitting.",
+            "media_type": "audio",
+        }
 
     def test_display_name_default(self):
         from vtsearch.media.audio.clipper import SoundDefaultClipper

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -53,6 +53,10 @@ class SoundDefaultClipper(MediaClipper):
     def media_type(self) -> str:
         return "audio"
 
+    @property
+    def description(self) -> str:
+        return "Import each audio file as-is, without splitting."
+
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]
 
@@ -89,6 +93,10 @@ class SoundTilingClipper(MediaClipper):
     @property
     def media_type(self) -> str:
         return "audio"
+
+    @property
+    def description(self) -> str:
+        return "Split each audio file into fixed-length overlapping segments."
 
     @property
     def duration(self) -> float:
@@ -138,6 +146,7 @@ class SoundTilingClipper(MediaClipper):
             {
                 "key": "duration",
                 "label": "Clip length (seconds)",
+                "description": "Duration of each audio segment in seconds.",
                 "type": "number",
                 "default": self._duration,
                 "min": 0.1,
@@ -147,6 +156,7 @@ class SoundTilingClipper(MediaClipper):
             {
                 "key": "min_overlap",
                 "label": "Minimum overlap (seconds)",
+                "description": "Minimum overlap between consecutive segments. Higher values produce more tiles.",
                 "type": "number",
                 "default": self._min_overlap,
                 "min": 0,

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -1205,6 +1205,15 @@ class MediaClipper(ABC):
         """
         return self.name.replace("_", " ").title()
 
+    @property
+    def description(self) -> str:
+        """Short tooltip description shown on hover in the clipper chooser.
+
+        Subclasses should override to provide a brief explanation of what
+        the clipper does.  Defaults to an empty string.
+        """
+        return ""
+
     # ------------------------------------------------------------------
     # Parameters
     # ------------------------------------------------------------------
@@ -1285,6 +1294,9 @@ class MediaClipper(ABC):
             "display_name": self.display_name,
             "media_type": self.media_type,
         }
+        desc = self.description
+        if desc:
+            d["description"] = desc
         params = self.parameters
         if params:
             d["parameters"] = params

--- a/vtsearch/media/document/clipper.py
+++ b/vtsearch/media/document/clipper.py
@@ -18,5 +18,9 @@ class DocumentDefaultClipper(MediaClipper):
     def media_type(self) -> str:
         return "document"
 
+    @property
+    def description(self) -> str:
+        return "Import each document as-is, without splitting."
+
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]

--- a/vtsearch/media/image/clipper.py
+++ b/vtsearch/media/image/clipper.py
@@ -20,6 +20,10 @@ class ImageDefaultClipper(MediaClipper):
     def media_type(self) -> str:
         return "image"
 
+    @property
+    def description(self) -> str:
+        return "Import each image as-is, without splitting."
+
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]
 
@@ -43,6 +47,10 @@ class ImageTilingClipper(MediaClipper):
     @property
     def media_type(self) -> str:
         return "image"
+
+    @property
+    def description(self) -> str:
+        return "Tile each image into equidistant square crops along the longer axis."
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         from PIL import Image  # noqa: PLC0415

--- a/vtsearch/media/text/clipper.py
+++ b/vtsearch/media/text/clipper.py
@@ -19,6 +19,10 @@ class TextDefaultClipper(MediaClipper):
     def media_type(self) -> str:
         return "text"
 
+    @property
+    def description(self) -> str:
+        return "Import each text entry as-is, without splitting."
+
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]
 
@@ -42,6 +46,10 @@ class TextSentenceClipper(MediaClipper):
     @property
     def media_type(self) -> str:
         return "text"
+
+    @property
+    def description(self) -> str:
+        return "Split each text entry into individual sentences."
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         text = media.get("media_string") or ""

--- a/vtsearch/media/video/clipper.py
+++ b/vtsearch/media/video/clipper.py
@@ -19,6 +19,10 @@ class VideoDefaultClipper(MediaClipper):
     def media_type(self) -> str:
         return "video"
 
+    @property
+    def description(self) -> str:
+        return "Import each video as-is, without splitting."
+
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         return [media]
 
@@ -63,6 +67,10 @@ class VideoTilingClipper(MediaClipper):
         return "video"
 
     @property
+    def description(self) -> str:
+        return "Split each video into fixed-length overlapping segments."
+
+    @property
     def duration(self) -> float:
         return self._duration
 
@@ -101,6 +109,7 @@ class VideoTilingClipper(MediaClipper):
             {
                 "key": "duration",
                 "label": "Clip length (seconds)",
+                "description": "Duration of each video segment in seconds.",
                 "type": "number",
                 "default": self._duration,
                 "min": 0.1,
@@ -110,6 +119,7 @@ class VideoTilingClipper(MediaClipper):
             {
                 "key": "min_overlap",
                 "label": "Minimum overlap (seconds)",
+                "description": "Minimum overlap between consecutive segments. Higher values produce more tiles.",
                 "type": "number",
                 "default": self._min_overlap,
                 "min": 0,
@@ -247,6 +257,10 @@ class VideoSceneClipper(MediaClipper):
         return "video"
 
     @property
+    def description(self) -> str:
+        return "Automatically split each video at detected scene changes."
+
+    @property
     def threshold(self) -> float:
         return self._threshold
 
@@ -317,6 +331,7 @@ class VideoSceneClipper(MediaClipper):
             {
                 "key": "threshold",
                 "label": "Sensitivity (0\u20131)",
+                "description": "Histogram correlation threshold. Lower values require more dramatic visual change to trigger a scene break.",
                 "type": "number",
                 "default": self._threshold,
                 "min": 0,
@@ -326,6 +341,7 @@ class VideoSceneClipper(MediaClipper):
             {
                 "key": "min_scene_duration",
                 "label": "Min scene length (seconds)",
+                "description": "Minimum duration for a scene. Boundaries that would create shorter scenes are suppressed.",
                 "type": "number",
                 "default": self._min_scene_duration,
                 "min": 0.1,


### PR DESCRIPTION
## Summary
This PR adds user-facing descriptions to all clipper types and their configurable parameters. Descriptions are displayed as tooltips in the UI to help users understand what each clipper does and what each parameter controls.

## Key Changes

**Backend (Python)**
- Added `description` property to base `Clipper` class in `vtsearch/media/base.py` with default empty string implementation
- Implemented `description` property for all concrete clipper classes:
  - Video clippers: `VideoDefaultClipper`, `VideoSegmentClipper`, `VideoSceneClipper`
  - Audio clippers: `SoundDefaultClipper`, `SoundSegmentClipper`
  - Image clippers: `ImageDefaultClipper`, `ImageTileClipper`
  - Text clippers: `TextDefaultClipper`, `TextSentenceClipper`
  - Document clipper: `DocumentDefaultClipper`
- Added `description` field to parameter definitions for `VideoSegmentClipper`, `VideoSceneClipper`, `SoundSegmentClipper`
- Updated `to_dict()` method to include description in serialized output (only when non-empty)
- Updated test expectations to include descriptions in clipper serialization

**Frontend (TypeScript/Angular)**
- Updated `ClipperInfo` and `ClipperParameter` interfaces in `api.models.ts` to include optional `description` field
- Enhanced `clipper-chooser.component.html` to:
  - Display clipper description below the tab content
  - Add `title` attribute to clipper tabs for hover tooltips
  - Add `title` attribute to parameter labels for hover tooltips
- Added `.clipper-description` styling in `clipper-chooser.component.scss` for secondary text color and spacing
- Updated `dataset-importer-modal.component.ts` to display "None" for default clippers instead of their display names

## Implementation Details
- Descriptions follow a consistent pattern: brief, action-oriented explanations of what each clipper does
- Parameter descriptions explain the purpose and effect of each setting
- All descriptions are optional in the API contract to maintain backward compatibility
- The UI gracefully handles missing descriptions by using empty strings and conditional rendering

https://claude.ai/code/session_01YEax78nCLV8LirxhJXNkTM