### PR TITLE
Add global lock to serialize concurrent embed_media calls

### DIFF
--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1257,8 +1257,12 @@ class CodeBertEmbedder(MediaEmbedder):
 
     # --- Embedding (required abstract method) ---
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         """Return a fixed-size embedding vector for the file.
+
+        Override ``_embed_media_impl`` (not ``embed_media``).
+        The public ``embed_media()`` wrapper acquires a global lock
+        so that only one forward pass runs at a time.
 
         Returns None if embedding fails. The vector dimensionality
         must be consistent and must match embed_text().

--- a/tests/test_enrich_descriptions.py
+++ b/tests/test_enrich_descriptions.py
@@ -96,7 +96,7 @@ class TestEmbedTextEnriched:
             def _load_models_impl(self):
                 pass
 
-            def embed_media(self, file_path):
+            def _embed_media_impl(self, file_path):
                 return None
 
             def embed_text(self, text):

--- a/tests/test_new_embedders.py
+++ b/tests/test_new_embedders.py
@@ -4,6 +4,9 @@ These tests verify class structure, registration, and property correctness
 without downloading model weights.
 """
 
+import threading
+from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -381,3 +384,103 @@ class TestNewEmbeddersInheritance:
             result = emb.embed_text_enriched("a cat")
         assert result is not None
         assert result.shape == (768,)
+
+
+class TestEmbedMediaLock:
+    """Verify that embed_media serialises concurrent calls via _embed_lock."""
+
+    def test_concurrent_embed_media_serialised(self):
+        """Two threads calling embed_media must not overlap (global lock)."""
+        from vtsearch.media.base import MediaEmbedder
+
+        inside = threading.Event()
+        proceed = threading.Event()
+        overlap_detected = False
+
+        class SlowEmbedder(MediaEmbedder):
+            @property
+            def name(self):
+                return "slow_test"
+
+            @property
+            def media_type_id(self):
+                return "test"
+
+            def _load_models_impl(self):
+                pass
+
+            def _embed_media_impl(self, file_path):
+                nonlocal overlap_detected
+                if inside.is_set():
+                    overlap_detected = True
+                inside.set()
+                proceed.wait(timeout=5)
+                inside.clear()
+                return np.zeros(8, dtype=np.float32)
+
+            def embed_text(self, text):
+                return None
+
+        emb = SlowEmbedder()
+        results = [None, None]
+
+        def call_embed(idx):
+            results[idx] = emb.embed_media(Path("/fake"))
+
+        t1 = threading.Thread(target=call_embed, args=(0,))
+        t2 = threading.Thread(target=call_embed, args=(1,))
+
+        # Save and replace the lock with a fresh one so we don't interfere
+        # with other tests (the class attr is shared).
+        original_lock = MediaEmbedder._embed_lock
+        MediaEmbedder._embed_lock = threading.Lock()
+        try:
+            t1.start()
+            # Wait for t1 to be inside _embed_media_impl
+            inside.wait(timeout=5)
+            assert inside.is_set(), "t1 should be inside _embed_media_impl"
+
+            t2.start()
+            # Give t2 a moment to hit the lock
+            import time
+            time.sleep(0.1)
+            # t2 should be blocked on the lock — inside should still be set by t1 only
+            assert not overlap_detected, "t2 entered _embed_media_impl while t1 was still inside"
+
+            # Let t1 finish
+            proceed.set()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+            assert not overlap_detected, "Concurrent embed_media calls overlapped"
+            assert results[0] is not None
+            assert results[1] is not None
+        finally:
+            MediaEmbedder._embed_lock = original_lock
+
+    def test_embed_media_delegates_to_impl(self):
+        """embed_media() should call _embed_media_impl() and return its result."""
+        from vtsearch.media.base import MediaEmbedder
+
+        class SimpleEmbedder(MediaEmbedder):
+            @property
+            def name(self):
+                return "simple_test"
+
+            @property
+            def media_type_id(self):
+                return "test"
+
+            def _load_models_impl(self):
+                pass
+
+            def _embed_media_impl(self, file_path):
+                return np.ones(4, dtype=np.float32)
+
+            def embed_text(self, text):
+                return None
+
+        emb = SimpleEmbedder()
+        result = emb.embed_media(Path("/fake"))
+        assert result is not None
+        np.testing.assert_array_equal(result, np.ones(4, dtype=np.float32))

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -539,7 +539,7 @@ class TestConcurrentModelLoading:
                 call_count += 1
                 self._model = "loaded"
 
-            def embed_media(self, file_path):
+            def _embed_media_impl(self, file_path):
                 return None
 
             def embed_text(self, text):

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -122,7 +122,7 @@ class AudioClapEmbedder(MediaEmbedder):
             "the noise of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -104,7 +104,7 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             "the noise of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -389,6 +389,14 @@ class MediaEmbedder(ABC):
 
     _model_load_lock: threading.Lock
 
+    # Global lock that serialises all ``embed_media`` calls across every
+    # embedder type.  Without this, concurrent dataset imports each run
+    # PyTorch forward passes in parallel on the same (singleton) model,
+    # which is not thread-safe and causes massive memory spikes — enough
+    # to push a 16 GB machine into swap-thrash and freeze the entire
+    # process (including Flask and signal handling).
+    _embed_lock = threading.Lock()
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         # Each concrete embedder class gets its own lock so that concurrent
@@ -458,11 +466,23 @@ class MediaEmbedder(ABC):
     # Embedding
     # ------------------------------------------------------------------
 
-    @abstractmethod
     def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
         """Return a fixed-size embedding vector for the media file at *file_path*.
 
+        Acquires :attr:`_embed_lock` so that only one forward pass runs at a
+        time across all embedder types.  Subclasses must override
+        :meth:`_embed_media_impl` (not this method).
+
         Returns ``None`` if the file cannot be embedded.
+        """
+        with self._embed_lock:
+            return self._embed_media_impl(file_path)
+
+    @abstractmethod
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+        """Subclass hook: embed a single media file.
+
+        Override this instead of :meth:`embed_media`.
         """
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -92,7 +92,7 @@ class ImageClipEmbedder(MediaEmbedder):
             "a picture of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -97,7 +97,7 @@ class ImageSiglipEmbedder(MediaEmbedder):
             "a picture of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -77,7 +77,7 @@ class TextE5Embedder(MediaEmbedder):
             "writing on the topic of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None:

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -77,7 +77,7 @@ class TextBGEEmbedder(MediaEmbedder):
             "writing on the topic of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None:

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -89,7 +89,7 @@ class VideoXClipEmbedder(MediaEmbedder):
             "a video media of {text}",
         ]
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:


### PR DESCRIPTION
## Summary
This PR introduces a global lock mechanism to serialize all `embed_media()` calls across all embedder types, preventing concurrent PyTorch forward passes that cause memory spikes and system freezes during parallel dataset imports.

## Key Changes

- **Added `_embed_lock` class variable** to `MediaEmbedder` base class: A global `threading.Lock` that serializes all embedding operations across all embedder instances and types.

- **Refactored `embed_media()` method**: Changed from abstract method to concrete implementation that acquires `_embed_lock` before delegating to a new abstract method `_embed_media_impl()`.

- **Introduced `_embed_media_impl()` abstract method**: New hook that subclasses must override instead of `embed_media()`. This allows the base class to control synchronization while subclasses focus on the actual embedding logic.

- **Updated all embedder implementations**: Modified 8 concrete embedder classes to override `_embed_media_impl()` instead of `embed_media()`:
  - Audio embedders (2 classes)
  - Image embedders (2 classes)
  - Text embedders (2 classes)
  - Video embedder (1 class)

- **Updated documentation and tests**: 
  - Updated `EXTENDING.md` to reflect the new pattern for custom embedders
  - Updated test mocks to use `_embed_media_impl()` instead of `embed_media()`
  - Added comprehensive test suite (`TestEmbedMediaLock`) with two test cases verifying lock behavior and delegation

## Implementation Details

The global lock prevents the memory spike issue that occurs when multiple threads run PyTorch forward passes simultaneously on singleton models. Without this lock, concurrent dataset imports can cause massive memory spikes (enough to push a 16 GB machine into swap-thrash and freeze the entire process including Flask and signal handling).

The lock is acquired at the public API boundary (`embed_media()`) before calling the implementation method, ensuring all embedder types respect the serialization regardless of their specific implementation.

https://claude.ai/code/session_01HXk6gTRfUuH2CGbTB6JUjP