### PR TITLE
Strip media-type prefix from clipper display names

### DIFF
--- a/tests/test_clippers.py
+++ b/tests/test_clippers.py
@@ -26,7 +26,7 @@ class TestMediaClipperABC:
         d = c.to_dict()
         assert d == {
             "name": "sound_default",
-            "display_name": "Sound Default",
+            "display_name": "Default",
             "description": "Import each audio file as-is, without splitting.",
             "media_type": "audio",
         }
@@ -35,19 +35,19 @@ class TestMediaClipperABC:
         from vtsearch.media.audio.clipper import SoundDefaultClipper
 
         c = SoundDefaultClipper()
-        assert c.display_name == "Sound Default"
+        assert c.display_name == "Default"
 
     def test_display_name_tiling(self):
         from vtsearch.media.audio.clipper import SoundTilingClipper
 
         c = SoundTilingClipper(2.0)
-        assert c.display_name == "Sound Tiling"
+        assert c.display_name == "Tiling"
 
     def test_display_name_video_scene(self):
         from vtsearch.media.video.clipper import VideoSceneClipper
 
         c = VideoSceneClipper()
-        assert c.display_name == "Video Scene"
+        assert c.display_name == "Scene"
 
     def test_creation_questions_defaults_to_parameters(self):
         from vtsearch.media.audio.clipper import SoundTilingClipper
@@ -192,7 +192,7 @@ class TestSoundTilingClipper:
         c = SoundTilingClipper(3.5)
         d = c.to_dict()
         assert d["name"] == "sound_tiling"
-        assert d["display_name"] == "Sound Tiling"
+        assert d["display_name"] == "Tiling"
         assert d["media_type"] == "audio"
         assert d["duration"] == 3.5
         assert d["min_overlap"] == 0.0
@@ -316,7 +316,7 @@ class TestVideoTilingClipper:
         c = VideoTilingClipper(3.5)
         d = c.to_dict()
         assert d["name"] == "video_tiling"
-        assert d["display_name"] == "Video Tiling"
+        assert d["display_name"] == "Tiling"
         assert d["media_type"] == "video"
         assert d["duration"] == 3.5
         assert d["min_overlap"] == 0.0
@@ -963,7 +963,7 @@ class TestDatasetRegistryClipperColumn:
         resp = client.get("/api/datasets/registry")
         data = resp.get_json()
         ds = data["datasets"][0]
-        assert ds["clipper"] == "Sound Tiling"
+        assert ds["clipper"] == "Tiling"
 
     def test_registry_clipper_defaults_to_empty(self, client):
         from vtsearch.datasets.registry import register_dataset

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -1219,11 +1219,12 @@ class MediaClipper(ABC):
     def display_name(self) -> str:
         """Human-readable name for UI dropdowns.
 
-        Defaults to title-casing the :attr:`name` with underscores replaced
-        by spaces (e.g. ``"sound_tiling"`` → ``"Sound Tiling"``).  Subclasses
-        may override for a custom label.
+        Strips the media-type prefix before the first underscore and
+        title-cases the remainder (e.g. ``"sound_tiling"`` → ``"Tiling"``).
+        Subclasses may override for a custom label.
         """
-        return self.name.replace("_", " ").title()
+        _, _, suffix = self.name.partition("_")
+        return suffix.replace("_", " ").title() if suffix else self.name.title()
 
     @property
     def description(self) -> str:


### PR DESCRIPTION
## Summary
Updated the `display_name` property in the `Clipper` base class to strip the media-type prefix (e.g., "sound_", "video_") from the clipper name before generating the human-readable display name.

## Changes
- Modified `vtsearch/media/base.py`: Updated the `display_name` property implementation to partition the name at the first underscore and only title-case the suffix, removing the media-type prefix
  - `"sound_tiling"` now displays as `"Tiling"` instead of `"Sound Tiling"`
  - `"video_scene"` now displays as `"Scene"` instead of `"Video Scene"`
  - Falls back to title-casing the full name if no underscore is present

- Updated all corresponding test assertions in `tests/test_clippers.py` to reflect the new display name format across multiple test cases

## Implementation Details
The new implementation uses `str.partition("_")` to split the name at the first underscore, then applies title-casing and space-replacement only to the suffix portion. This provides a cleaner UI by removing redundant media-type information that's already available elsewhere in the interface.

https://claude.ai/code/session_013XPNuKVJKMfwGB2THsmMaF