### PR TITLE
Add video playback error handling with user-friendly messaging

### DIFF
--- a/frontend/src/app/components/center-panel/video-player/video-player.component.html
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.html
@@ -5,7 +5,13 @@
   [src]="videoSrc"
   [attr.aria-label]="media.filename || 'Video media'"
   class="video-element"
+  [class.hidden]="videoError"
   (loadedmetadata)="onLoadedMetadata()"
   (play)="onPlay()"
   (pause)="onPause()"
+  (error)="onError()"
 ></video>
+<div *ngIf="videoError" class="video-error">
+  <span class="error-icon">&#9888;</span>
+  <span>Video cannot be played. The format may require transcoding — install ffmpeg on the server.</span>
+</div>

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.scss
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.scss
@@ -15,4 +15,24 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-surface);
+
+  &.hidden {
+    display: none;
+  }
+}
+
+.video-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 0.9em;
+
+  .error-icon {
+    font-size: 2em;
+    color: var(--text-warning, #e6a700);
+  }
 }

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,10 +1,12 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { NgIf } from '@angular/common';
 import { MediaItem } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
   selector: 'vt-video-player',
   standalone: true,
+  imports: [NgIf],
   templateUrl: './video-player.component.html',
   styleUrl: './video-player.component.scss',
 })
@@ -17,6 +19,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   @ViewChild('videoEl') videoRef!: ElementRef<HTMLVideoElement>;
 
   videoSrc = '';
+  videoError = false;
 
   private clipCheckInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -24,6 +27,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
+      this.videoError = false;
       this.videoSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/video`);
     }
     if (changes['volume'] && this.videoRef?.nativeElement) {
@@ -48,6 +52,10 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
     if (!this.audioPlaying) {
       this.playingChanged.emit(true);
     }
+  }
+
+  onError(): void {
+    this.videoError = true;
   }
 
   onPause(): void {

--- a/vtsearch/media/video/requirements.txt
+++ b/vtsearch/media/video/requirements.txt
@@ -1,3 +1,3 @@
 # Video media type dependencies
 # These packages are required to decode video files and extract frames.
-opencv-python-headless<4.10
+opencv-python-headless

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -352,8 +352,8 @@ def media_video(media_id: int) -> tuple[Response, int] | Response:
         if transcoded is not None:
             c["_transcoded_mp4"] = transcoded
             return _send_video_bytes(transcoded, "video/mp4", f"media_{media_id}.mp4")
-        # ffmpeg unavailable — serve raw bytes as best-effort fallback
-        return _send_video_bytes(media_bytes, "video/mp4", f"media_{media_id}{ext}")
+        # ffmpeg and OpenCV both unavailable — cannot transcode
+        return jsonify({"error": f"Cannot play {ext} videos: install ffmpeg or opencv-python-headless to enable transcoding"}), 415
 
     media_bytes = _resolve_bytes(c)
     if media_bytes is None:


### PR DESCRIPTION
## Summary
This PR improves the video player experience by adding proper error handling for unsupported video formats. When a video cannot be played, users now see a helpful error message instead of a blank player, and the server returns an appropriate HTTP error response instead of attempting a best-effort fallback.

## Key Changes
- **Frontend error UI**: Added a `.video-error` component that displays when video playback fails, with a warning icon and message explaining that ffmpeg may need to be installed
- **Error state management**: Added `videoError` property to track playback failures and conditionally hide/show the video element and error message
- **Error event handling**: Connected the video element's `error` event to trigger the error state
- **Backend error response**: Changed the server to return a 415 (Unsupported Media Type) error with a descriptive JSON message instead of serving raw bytes when transcoding is unavailable
- **Styling**: Added `.hidden` class to hide the video element when an error occurs, and styled the error message with centered layout, muted text color, and a warning icon

## Implementation Details
- The error message guides users to install ffmpeg or opencv-python-headless for transcoding support
- The frontend gracefully handles the error response and displays user-friendly messaging
- The `videoError` flag is reset whenever new media is loaded, allowing users to try different videos

https://claude.ai/code/session_01AW4BoyAJXCuX7z2J17vaF9