### PR TITLE
Add ffmpeg binary resolution with imageio-ffmpeg fallback

### DIFF
--- a/vtsearch/converters/video2audio.py
+++ b/vtsearch/converters/video2audio.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from vtsearch.converters.base import MediaConverter
+from vtsearch.utils.ffmpeg import get_ffmpeg_exe
 
 
 class Video2AudioMediaConverter(MediaConverter):
@@ -54,9 +55,10 @@ class Video2AudioMediaConverter(MediaConverter):
             wav_path = str(Path(tmpdir) / "output.wav")
 
             try:
+                ffmpeg = get_ffmpeg_exe()
                 subprocess.run(
                     [
-                        "ffmpeg", "-y",
+                        ffmpeg, "-y",
                         "-i", str(src_path),
                         "-vn",
                         "-acodec", "pcm_s16le",
@@ -67,7 +69,7 @@ class Video2AudioMediaConverter(MediaConverter):
                     check=True,
                 )
             except FileNotFoundError:
-                print("Video2AudioMediaConverter requires ffmpeg on $PATH")
+                print("Video2AudioMediaConverter requires ffmpeg — install it or 'pip install imageio-ffmpeg'")
                 return []
             except subprocess.CalledProcessError as e:
                 stderr_text = e.stderr[:500].decode(errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or "")[:500]

--- a/vtsearch/media/video/requirements.txt
+++ b/vtsearch/media/video/requirements.txt
@@ -1,3 +1,6 @@
 # Video media type dependencies
 # These packages are required to decode video files and extract frames.
 opencv-python-headless
+# Bundles a static ffmpeg binary so video transcoding and audio extraction
+# work out of the box without a separate system install.
+imageio-ffmpeg

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -13,6 +13,7 @@ from flask import Blueprint, Response, jsonify, make_response, request, send_fil
 
 from vtsearch.media.base import MediaResponse
 from vtsearch.routes.helpers import get_json_or_400
+from vtsearch.utils.ffmpeg import get_ffmpeg_exe
 from vtsearch.utils import (
     _state_lock,
     apply_label,
@@ -47,9 +48,10 @@ def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:
 
         # --- Attempt 1: ffmpeg (best quality, preserves audio) -----------
         try:
+            ffmpeg = get_ffmpeg_exe()
             subprocess.run(
                 [
-                    "ffmpeg", "-y",
+                    ffmpeg, "-y",
                     "-i", str(src_path),
                     "-c:v", "libx264",
                     "-preset", "ultrafast",

--- a/vtsearch/utils/ffmpeg.py
+++ b/vtsearch/utils/ffmpeg.py
@@ -1,0 +1,36 @@
+"""Locate the ffmpeg binary.
+
+Checks the system ``$PATH`` first, then falls back to the static binary
+bundled by the ``imageio-ffmpeg`` Python package (installed automatically
+as part of the video plugin dependencies).
+"""
+
+from __future__ import annotations
+
+import shutil
+
+
+def get_ffmpeg_exe() -> str:
+    """Return the path to an ffmpeg executable.
+
+    Resolution order:
+    1. System ``ffmpeg`` on ``$PATH``
+    2. Static binary from ``imageio-ffmpeg``
+
+    Raises ``FileNotFoundError`` if neither is available.
+    """
+    system = shutil.which("ffmpeg")
+    if system:
+        return system
+
+    try:
+        import imageio_ffmpeg  # noqa: PLC0415
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except ImportError:
+        pass
+
+    raise FileNotFoundError(
+        "ffmpeg not found. Install it via your OS package manager "
+        "or 'pip install imageio-ffmpeg'."
+    )


### PR DESCRIPTION
## Summary
This PR improves ffmpeg availability handling by implementing a fallback mechanism that uses the `imageio-ffmpeg` package's bundled static binary when the system ffmpeg is not available on `$PATH`.

## Key Changes
- **New utility module** (`vtsearch/utils/ffmpeg.py`): Added `get_ffmpeg_exe()` function that resolves ffmpeg executable with a two-tier approach:
  1. First checks for system `ffmpeg` on `$PATH`
  2. Falls back to the static binary from `imageio-ffmpeg` package
  3. Raises `FileNotFoundError` with helpful installation instructions if neither is available

- **Updated video2audio converter** (`vtsearch/converters/video2audio.py`):
  - Now uses `get_ffmpeg_exe()` instead of hardcoded `"ffmpeg"` command
  - Improved error message to guide users toward the `imageio-ffmpeg` package

- **Updated media transcoding** (`vtsearch/routes/medias.py`):
  - Now uses `get_ffmpeg_exe()` for mp4 transcoding operations

- **Updated dependencies** (`vtsearch/media/video/requirements.txt`):
  - Added `imageio-ffmpeg` as a dependency for the video media type

## Implementation Details
The solution gracefully handles missing ffmpeg by attempting system resolution first (preferred for performance and user control) before falling back to the bundled binary. This ensures video processing works out-of-the-box without requiring separate system-level ffmpeg installation, while still respecting user-installed versions when available.

https://claude.ai/code/session_014bmnBXoDmFtgUiNJHsAE3R