### PR TITLE
Add thumbnail error handling and audio thumbnail support

### DIFF
--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -15,7 +15,7 @@
 >
   @if (isGrid) {
     @if (thumbnailUrl) {
-      <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" />
+      <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" (error)="onThumbnailError()" />
     } @else if (placeholderIcon) {
       <span class="media-placeholder">{{ placeholderIcon }}</span>
     }
@@ -24,6 +24,9 @@
     <span class="label-indicator" [class.good]="voteLabel === 'good'" [class.bad]="voteLabel === 'bad'">
       @if (voteLabel === 'good') { &#x2713; } @else if (voteLabel === 'bad') { &#x2717; }
     </span>
+    @if (thumbnailUrl) {
+      <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" (error)="onThumbnailError()" />
+    }
     <span class="media-name">{{ displayName }}</span>
   }
   @if (score !== null) {

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -69,13 +69,34 @@ describe('MediaItemComponent', () => {
     expect(fixture.nativeElement.querySelector('.media-item.labeled-bad')).toBeTruthy();
   });
 
-  it('should not show thumbnail for audio type', () => {
-    expect(component.thumbnailUrl).toBeNull();
+  it('should show thumbnail for audio type', () => {
+    expect(component.thumbnailUrl).toBe('/api/medias/1/image');
   });
 
   it('should show thumbnail for image type', () => {
     component.media = { ...mockMedia, type: 'image' };
     expect(component.thumbnailUrl).toBe('/api/medias/1/image');
+  });
+
+  it('should not show thumbnail for text type', () => {
+    component.media = { ...mockMedia, type: 'text' };
+    expect(component.thumbnailUrl).toBeNull();
+  });
+
+  it('should fall back to placeholder when thumbnail fails to load', () => {
+    component.viewMode = 'grid';
+    expect(component.thumbnailUrl).toBe('/api/medias/1/image');
+    component.onThumbnailError();
+    expect(component.thumbnailUrl).toBeNull();
+    expect(component.placeholderIcon).toBe('\u266B');
+  });
+
+  it('should reset thumbnailFailed when media changes', () => {
+    component.onThumbnailError();
+    expect(component.thumbnailUrl).toBeNull();
+    component.media = { ...mockMedia, id: 2 };
+    component.ngOnChanges({ media: {} as any });
+    expect(component.thumbnailUrl).toBe('/api/medias/2/image');
   });
 
   it('should show score when provided', () => {

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MediaItem } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -10,7 +10,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   templateUrl: './media-item.component.html',
   styleUrl: './media-item.component.scss',
 })
-export class MediaItemComponent {
+export class MediaItemComponent implements OnChanges {
   @Input({ required: true }) media!: MediaItem;
   @Input() active = false;
   @Input() voteLabel: 'good' | 'bad' | null = null;
@@ -21,14 +21,24 @@ export class MediaItemComponent {
   @Output() select = new EventEmitter<number>();
   @Output() vote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
+  thumbnailFailed = false;
+  private lastMediaId: number | null = null;
+
   constructor(private activeContext: ActiveContextService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['media'] && this.media.id !== this.lastMediaId) {
+      this.thumbnailFailed = false;
+      this.lastMediaId = this.media.id;
+    }
+  }
 
   get isGrid(): boolean {
     return this.viewMode === 'grid';
   }
 
   get thumbnailUrl(): string | null {
-    if (!this.isGrid) return null;
+    if (this.thumbnailFailed) return null;
     if (this.media.type === 'image' || this.media.type === 'video' || this.media.type === 'document' || this.media.type === 'audio') {
       return this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
     }
@@ -41,6 +51,10 @@ export class MediaItemComponent {
     if (this.media.type === 'audio') return '\u266B';
     if (this.media.type === 'text') return '\u00B6';
     return '\u25A1';
+  }
+
+  onThumbnailError(): void {
+    this.thumbnailFailed = true;
   }
 
   get displayName(): string {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -20,7 +20,7 @@
             @if (isVideo(entry.id)) {
               <video class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" muted preload="metadata"></video>
             } @else {
-              <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" />
+              <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
             }
           } @else if (placeholderIcon(entry.id)) {
             <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -152,8 +152,8 @@ describe('LabelListComponent', () => {
       expect(component.hasThumbnailUrl(3)).toBeTrue();
     });
 
-    it('should not have thumbnail URL for audio', () => {
-      expect(component.hasThumbnailUrl(1)).toBeFalse();
+    it('should have thumbnail URL for audio', () => {
+      expect(component.hasThumbnailUrl(1)).toBeTrue();
     });
 
     it('should identify video type', () => {
@@ -162,6 +162,7 @@ describe('LabelListComponent', () => {
     });
 
     it('should generate correct thumbnail URLs', () => {
+      expect(component.thumbnailUrl(1)).toBe('/api/medias/1/image');
       expect(component.thumbnailUrl(2)).toBe('/api/medias/2/image');
       expect(component.thumbnailUrl(3)).toBe('/api/medias/3/video');
     });
@@ -176,9 +177,9 @@ describe('LabelListComponent', () => {
       expect(component.isGrid).toBeFalse();
     });
 
-    it('should show placeholder icon for audio in grid mode', () => {
+    it('should not show placeholder icon for audio in grid mode (has thumbnail)', () => {
       component.viewMode = 'grid';
-      expect(component.placeholderIcon(1)).toBe('\u266B');
+      expect(component.placeholderIcon(1)).toBeNull();
     });
 
     it('should not show placeholder icon for image in grid mode', () => {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -118,9 +118,12 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     return this.viewMode === 'grid';
   }
 
+  private thumbnailFailedIds = new Set<number>();
+
   hasThumbnailUrl(id: number): boolean {
+    if (this.thumbnailFailedIds.has(id)) return false;
     const media = this.mediaMap.get(id);
-    return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document');
+    return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document' || media.type === 'audio');
   }
 
   isVideo(id: number): boolean {
@@ -135,11 +138,15 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
   }
 
+  onThumbnailError(id: number): void {
+    this.thumbnailFailedIds.add(id);
+  }
+
   placeholderIcon(id: number): string | null {
     if (!this.isGrid) return null;
+    if (this.hasThumbnailUrl(id)) return null;
     const media = this.mediaMap.get(id);
     if (!media) return null;
-    if (media.type === 'image' || media.type === 'video' || media.type === 'document') return null;
     if (media.type === 'audio') return '\u266B';
     if (media.type === 'text') return '\u00B6';
     return '\u25A1';

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -231,7 +231,7 @@ def _apply_clipper(
     # clippers override to add their current values (duration, threshold,
     # etc.), then strips the base keys that aren't parameter values.
     _clipper_dict = clipper.to_dict()
-    _base_keys = {"name", "display_name", "media_type", "parameters"}
+    _base_keys = {"name", "display_name", "media_type", "parameters", "description", "creation_questions"}
     effective_params = {k: v for k, v in _clipper_dict.items() if k not in _base_keys}
 
     all_clipped: list[dict] = []


### PR DESCRIPTION
## Summary
This PR enhances thumbnail handling in media components by adding error recovery and extending thumbnail support to audio files. When thumbnails fail to load, the UI gracefully falls back to placeholder icons. Audio files now display thumbnails when available, improving the visual presentation across the application.

## Key Changes

### Frontend - Media Item Component
- Implemented `OnChanges` lifecycle hook to reset thumbnail failure state when media changes
- Added `onThumbnailError()` method to handle failed thumbnail loads and fall back to placeholder icons
- Modified `thumbnailUrl` getter to check `thumbnailFailed` flag instead of just `viewMode`
- Updated template to bind error handler to image elements in both grid and list views
- Added audio type to thumbnail-eligible media types

### Frontend - Label List Component
- Extended `hasThumbnailUrl()` to include audio media type and track failed thumbnail IDs
- Added `onThumbnailError()` method to maintain a set of media IDs with failed thumbnails
- Updated `placeholderIcon()` logic to show icons only when thumbnails are unavailable
- Added error handler binding to thumbnail images in the template

### Backend - Datasets Loading
- Updated `_base_keys` in `_apply_clipper()` to include `"description"` and `"creation_questions"` fields, ensuring these clipper properties are properly excluded from effective parameters

## Implementation Details
- Thumbnail failure tracking uses instance-level state (`thumbnailFailed` in MediaItemComponent, `thumbnailFailedIds` Set in LabelListComponent)
- When media changes, the thumbnail failure state is automatically reset, allowing retries for new media items
- Placeholder icons are now only shown when thumbnails are genuinely unavailable (either not applicable or failed to load)
- Audio files are now treated consistently with images, videos, and documents for thumbnail display purposes

https://claude.ai/code/session_012cqV1YtRU3dyPbQRjc4uNL