### PR TITLE
Optimize tar extraction with lazy iteration to avoid double decompression

### DIFF
--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -226,32 +226,37 @@ def _download_and_extract(
         # error page (e.g. 404/503) which gets saved with a .tar.gz extension.
         _validate_archive(temp_archive, archive_name, dataset_name)
 
-        on_progress("downloading", f"Extracting {dataset_name}...", 0, 0)
+        total_bytes = temp_archive.stat().st_size
+        on_progress("downloading", f"Extracting {dataset_name}...", 0, total_bytes)
         temp_extract.mkdir(parents=True, exist_ok=True)
 
         suffix = archive_name.lower()
         if suffix.endswith((".tar.gz", ".tgz")):
+            # Iterate lazily instead of calling getmembers() — the latter must
+            # decompress the entire gzip stream just to read tar headers, then
+            # extraction decompresses it *again*.  Lazy iteration decompresses
+            # once and avoids a minutes-long stall on multi-GB archives.
             # Use "r:*" to auto-detect compression — some CDNs (e.g. HuggingFace
             # Xet) transparently decompress .tar.gz files during transfer.
-            with tarfile.open(temp_archive, "r:*") as tar_ref:
-                members = tar_ref.getmembers()
-                total = len(members)
-                for i, member in enumerate(members):
-                    if i % 100 == 0 or i == total - 1:
-                        on_progress(
-                            "downloading", f"Extracting {dataset_name} ({i + 1}/{total})...", i + 1, total
-                        )
-                    tar_ref.extract(member, temp_extract, filter="data")
+            with open(temp_archive, "rb") as raw_f:
+                with tarfile.open(fileobj=raw_f, mode="r:*") as tar_ref:
+                    for i, member in enumerate(tar_ref):
+                        if i % 100 == 0:
+                            on_progress(
+                                "downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes
+                            )
+                        tar_ref.extract(member, temp_extract, filter="data")
+            on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
         elif suffix.endswith(".tar"):
-            with tarfile.open(temp_archive, "r:") as tar_ref:
-                members = tar_ref.getmembers()
-                total = len(members)
-                for i, member in enumerate(members):
-                    if i % 100 == 0 or i == total - 1:
-                        on_progress(
-                            "downloading", f"Extracting {dataset_name} ({i + 1}/{total})...", i + 1, total
-                        )
-                    tar_ref.extract(member, temp_extract, filter="data")
+            with open(temp_archive, "rb") as raw_f:
+                with tarfile.open(fileobj=raw_f, mode="r:") as tar_ref:
+                    for i, member in enumerate(tar_ref):
+                        if i % 100 == 0:
+                            on_progress(
+                                "downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes
+                            )
+                        tar_ref.extract(member, temp_extract, filter="data")
+            on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
         elif suffix.endswith(".zip"):
             with zipfile.ZipFile(temp_archive, "r") as zip_ref:
                 members = zip_ref.namelist()

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -226,8 +226,7 @@ def _download_and_extract(
         # error page (e.g. 404/503) which gets saved with a .tar.gz extension.
         _validate_archive(temp_archive, archive_name, dataset_name)
 
-        total_bytes = temp_archive.stat().st_size
-        on_progress("downloading", f"Extracting {dataset_name}...", 0, total_bytes)
+        on_progress("downloading", f"Extracting {dataset_name}...", 0, 0)
         temp_extract.mkdir(parents=True, exist_ok=True)
 
         suffix = archive_name.lower()
@@ -238,6 +237,7 @@ def _download_and_extract(
             # once and avoids a minutes-long stall on multi-GB archives.
             # Use "r:*" to auto-detect compression — some CDNs (e.g. HuggingFace
             # Xet) transparently decompress .tar.gz files during transfer.
+            total_bytes = temp_archive.stat().st_size
             with open(temp_archive, "rb") as raw_f:
                 with tarfile.open(fileobj=raw_f, mode="r:*") as tar_ref:
                     for i, member in enumerate(tar_ref):
@@ -248,6 +248,7 @@ def _download_and_extract(
                         tar_ref.extract(member, temp_extract, filter="data")
             on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
         elif suffix.endswith(".tar"):
+            total_bytes = temp_archive.stat().st_size
             with open(temp_archive, "rb") as raw_f:
                 with tarfile.open(fileobj=raw_f, mode="r:") as tar_ref:
                     for i, member in enumerate(tar_ref):


### PR DESCRIPTION
## Summary
Optimize tar archive extraction by using lazy iteration instead of loading all members upfront, eliminating redundant decompression of large archives.

## Key Changes
- **Lazy tar member iteration**: Changed from `tar_ref.getmembers()` to iterating directly over `tar_ref`, which decompresses the archive only once instead of twice
- **Progress tracking by bytes**: Switched from counting extracted members to tracking bytes read via `raw_f.tell()`, providing more accurate progress for large files
- **File handle management**: Open tar archives with explicit file handles (`open()` + `fileobj=`) to enable byte position tracking
- **Applied to both .tar.gz and .tar formats**: Updated extraction logic for both compressed and uncompressed tar archives
- **Simplified progress reporting**: Removed member count from progress messages and added final completion callback

## Implementation Details
- Progress updates now occur every 100 members (unchanged frequency) but report bytes processed instead of member count
- Uses file size (`temp_archive.stat().st_size`) as the total for progress calculation
- Maintains the same extraction filter (`filter="data"`) for security
- Eliminates the "stall" on multi-GB archives caused by double decompression during header reading

https://claude.ai/code/session_015yVaZfeuE2qvDewRJnjptn