### PR TITLE
Add install-cpu.sh convenience script for CPU-only setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Breaking backwards compatibility is acceptable — do not add shims, feature fla
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter server_json_file --filepath results.json`
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer folder --path /data/sounds --media-type audio --settings <settings.json>`
-- **Install deps (CPU)**: `bash install-plugin-deps.sh && pip install -r requirements.txt && pip install --no-deps -e .`
+- **Install deps (CPU)**: `bash install-cpu.sh`
 - **Install deps (GPU)**: `bash install-gpu.sh` (or `bash install-gpu.sh cu121` for CUDA 12.1)
 - **Build frontend**: `cd frontend && npm install && npm run build:prod` (builds Angular app to `static/`)
 - **Frontend dev server**: `cd frontend && npm start` (proxies `/api/*` to Flask at localhost:5000)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -358,7 +358,7 @@ Install commands:
 
 ```bash
 # CPU with all features + dev tools
-bash install-plugin-deps.sh && pip install -r requirements.txt && pip install --no-deps -e .
+bash install-cpu.sh
 
 # GPU
 bash install-gpu.sh
@@ -429,5 +429,5 @@ via the folder or pickle importer instead.
 
 **Fix**: Reinstall to ensure all dependencies are present:
 ```bash
-bash install-plugin-deps.sh && pip install -r requirements.txt && pip install --no-deps -e .
+bash install-cpu.sh
 ```

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -22,7 +22,7 @@ This will:
 Install dependencies (if you haven't already):
 
 ```bash
-bash install-plugin-deps.sh && pip install -r requirements.txt && pip install --no-deps -e .
+bash install-cpu.sh
 ```
 
 Matplotlib and pandas are required for plot generation and are included in the dev dependencies.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -61,7 +61,7 @@ deployments. Runs locally or in Docker.
 
 ```bash
 python3 -m venv venv && source venv/bin/activate
-bash install-plugin-deps.sh && pip install -r requirements.txt && pip install --no-deps -e .
+bash install-cpu.sh
 python app.py --local        # binds to 0.0.0.0 (network-accessible)
 ```
 
@@ -259,7 +259,7 @@ Use this checklist when setting up VTSearch for a new environment.
 
 - [ ] Python 3.10+ available (or Docker installed)
 - [ ] System packages: `libsndfile1`, `ffmpeg`, `libgl1`, `libglib2.0-0`
-- [ ] `bash install-plugin-deps.sh && pip install -r requirements.txt && pip install --no-deps -e .` (or build Docker image)
+- [ ] `bash install-cpu.sh` (or build Docker image)
 - [ ] `data/` directory writable (models, embeddings, settings stored here)
 - [ ] Port 5000 available (or configure as needed)
 - [ ] Run `python app.py` or `docker compose up`

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -151,9 +151,7 @@ All dependencies live in `requirements.txt` files. Core deps are in the top-leve
 **For CPU only** (recommended if you don't have a compatible GPU):
 
 ```bash
-bash install-plugin-deps.sh        # auto-discover plugin deps
-pip install -r requirements.txt    # install everything (core + plugins + CPU PyTorch)
-pip install --no-deps -e .         # editable install for 'import vtsearch'
+bash install-cpu.sh
 ```
 
 **For GPU** (NVIDIA CUDA-compatible systems):
@@ -164,7 +162,7 @@ bash install-gpu.sh cu121    # for CUDA 12.1
 bash install-gpu.sh cu124    # for CUDA 12.4
 ```
 
-`install-gpu.sh` is an all-in-one script — it runs `install-plugin-deps.sh` automatically, installs all dependencies with the correct CUDA PyTorch build, and does the editable install. No extra steps needed.
+Both scripts are all-in-one — they run `install-plugin-deps.sh` automatically, install all dependencies, and do the editable install. No extra steps needed.
 
 The CPU `requirements.txt` includes `--extra-index-url` for the smaller CPU-only PyTorch wheel (~200 MB) instead of the default CUDA build (~2 GB).
 

--- a/install-cpu.sh
+++ b/install-cpu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# CPU dependency installer for VTSearch.
+#
+# Discovers plugin requirements, installs all dependencies with CPU PyTorch,
+# and performs an editable install of the vtsearch package.
+#
+# Usage:
+#   bash install-cpu.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Installing VTSearch CPU dependencies..."
+
+# Step 1: Regenerate requirements-plugins.txt from discovered plugin files.
+bash "$SCRIPT_DIR/install-plugin-deps.sh" --dry-run
+
+# Step 2: Install all dependencies (core + plugins) with CPU PyTorch.
+echo "Installing all dependencies..."
+pip install -r requirements.txt -q
+
+# Step 3: Editable install so 'import vtsearch' works.
+pip install --no-deps -e . -q
+
+echo "CPU dependencies installed successfully."


### PR DESCRIPTION
## Summary
Introduces a new `install-cpu.sh` convenience script that consolidates the CPU installation workflow into a single command, improving the user experience and reducing setup complexity.

## Key Changes
- **New script**: `install-cpu.sh` — an all-in-one installer that:
  - Runs `install-plugin-deps.sh` to auto-discover plugin dependencies
  - Installs all dependencies (core + plugins) with CPU PyTorch
  - Performs an editable install of the vtsearch package
  
- **Documentation updates**: Simplified setup instructions across multiple docs:
  - `docs/SETUP.md` — replaced 3-line manual steps with single `bash install-cpu.sh` command
  - `docs/DEPLOYMENT.md` — updated CPU installation examples
  - `docs/HANDOFF.md` — updated setup checklist and quick-start instructions
  - `CLAUDE.md` — updated development reference commands
  - `docs/EVAL.md` — simplified evaluation setup instructions

## Implementation Details
The script follows the same pattern as the existing `install-gpu.sh`, providing consistency across installation methods. It uses `set -euo pipefail` for safety and includes clear progress messaging. The script is positioned as the recommended CPU installation method, with documentation now treating both CPU and GPU installations as equally streamlined workflows.

https://claude.ai/code/session_01Gxt1dxVRxkX61TTewJJaxq