### PR TITLE
Add enabled flag to combine_datasets importer

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -15,7 +15,7 @@
             <span class="importer-desc">Choose from a selection of pre-configured demo datasets</span>
           </button>
         } @else {
-          <button class="importer-card" (click)="selectImporter(imp)">
+          <button class="importer-card" [class.disabled]="imp['enabled'] === false" [disabled]="imp['enabled'] === false" (click)="selectImporter(imp)" [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : ''">
             <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
             @if (imp.description) {
               <span class="importer-desc">{{ imp.description }}</span>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,4 +1,8 @@
 .importer-card { padding: 12px 16px; }
+.importer-card.disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 .btn--sm { padding: 2px 10px; font-size: .85rem; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
 

--- a/tests/test_combine_datasets.py
+++ b/tests/test_combine_datasets.py
@@ -148,6 +148,77 @@ class TestCombineDatasetsBuiltinExclusion:
 
 
 # ---------------------------------------------------------------------------
+# Enabled flag in all-importers endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestCombineDatasetsEnabledFlag:
+    def _find_combine(self, client):
+        resp = client.get("/api/dataset/all-importers")
+        data = resp.get_json()
+        for imp in data["importers"]:
+            if imp["name"] == "combine_datasets":
+                return imp
+        return None
+
+    def test_disabled_with_no_saved_datasets(self, client):
+        """combine_datasets is disabled when the registry is empty."""
+        imp = self._find_combine(client)
+        assert imp is not None
+        assert imp["enabled"] is False
+
+    def test_disabled_with_one_dataset(self, client):
+        """combine_datasets is disabled with only one saved dataset."""
+        from vtsearch.datasets import registry
+
+        registry.register_dataset(
+            name="solo", media_type="audio", num_items=10, pkl_path="/tmp/solo.pkl"
+        )
+        try:
+            imp = self._find_combine(client)
+            assert imp["enabled"] is False
+        finally:
+            entries = registry.list_datasets()
+            for e in entries:
+                if e["name"] == "solo":
+                    registry.unregister_dataset(e["id"])
+
+    def test_disabled_with_two_different_media_types(self, client):
+        """combine_datasets is disabled when two datasets have different media types."""
+        from vtsearch.datasets import registry
+
+        e1 = registry.register_dataset(
+            name="audio_ds", media_type="audio", num_items=10, pkl_path="/tmp/a.pkl"
+        )
+        e2 = registry.register_dataset(
+            name="image_ds", media_type="image", num_items=10, pkl_path="/tmp/b.pkl"
+        )
+        try:
+            imp = self._find_combine(client)
+            assert imp["enabled"] is False
+        finally:
+            registry.unregister_dataset(e1["id"])
+            registry.unregister_dataset(e2["id"])
+
+    def test_enabled_with_two_same_media_type(self, client):
+        """combine_datasets is enabled when two datasets share a media type."""
+        from vtsearch.datasets import registry
+
+        e1 = registry.register_dataset(
+            name="audio_a", media_type="audio", num_items=10, pkl_path="/tmp/a.pkl"
+        )
+        e2 = registry.register_dataset(
+            name="audio_b", media_type="audio", num_items=5, pkl_path="/tmp/b.pkl"
+        )
+        try:
+            imp = self._find_combine(client)
+            assert imp["enabled"] is True
+        finally:
+            registry.unregister_dataset(e1["id"])
+            registry.unregister_dataset(e2["id"])
+
+
+# ---------------------------------------------------------------------------
 # Core combining logic
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -26,6 +26,7 @@ from vtsearch.datasets.registry import (
     get_loaded_ids as _reg_loaded_ids,
     is_loaded as _reg_is_loaded,
     is_owner as _reg_is_owner,
+    list_datasets as _reg_list_all,
     list_datasets_for_user as _reg_list_for_user,
     remove_loaded_id as _reg_remove_loaded,
     rename_dataset as _reg_rename,
@@ -262,6 +263,18 @@ def dataset_importers():
 def dataset_all_importers():
     """List all registered importers (including built-in ones)."""
     all_importers = [imp.to_dict() for imp in list_importers()]
+
+    # Annotate combine_datasets with an enabled flag: requires 2+ saved
+    # datasets sharing the same media type.
+    from collections import Counter
+
+    type_counts = Counter(e.get("media_type") for e in _reg_list_all())
+    can_combine = any(c >= 2 for c in type_counts.values())
+    for imp_dict in all_importers:
+        if imp_dict["name"] == "combine_datasets":
+            imp_dict["enabled"] = can_combine
+            break
+
     return jsonify({"importers": all_importers})
 
 


### PR DESCRIPTION
## Summary
This PR adds an `enabled` flag to the `combine_datasets` importer in the all-importers endpoint. The importer is only enabled when there are two or more saved datasets sharing the same media type, and the frontend UI reflects this state by disabling and visually dimming the importer card.

## Key Changes
- **Backend**: Modified `/api/dataset/all-importers` endpoint to compute and annotate the `combine_datasets` importer with an `enabled` flag based on registry state
  - Counts datasets by media type
  - Sets `enabled=true` only when at least one media type has 2+ datasets
  - Uses existing `list_datasets()` registry function to inspect saved datasets

- **Frontend**: Updated the importer card UI to respect the enabled flag
  - Disabled button state when `enabled === false`
  - Added visual styling (reduced opacity, not-allowed cursor) for disabled cards
  - Added tooltip explaining the requirement for combining datasets

- **Tests**: Added comprehensive test suite (`TestCombineDatasetsEnabledFlag`) covering:
  - Disabled state with empty registry
  - Disabled state with single dataset
  - Disabled state with multiple datasets of different media types
  - Enabled state with multiple datasets of same media type

## Implementation Details
- The enabled flag is computed dynamically on each request using a `Counter` to efficiently check media type distribution
- No database schema changes required; the flag is computed from existing dataset metadata
- Backward compatible: the flag is only added to the `combine_datasets` importer entry

https://claude.ai/code/session_01V3yeUHYJS97pjb4G7PYYh5