### PR TITLE
Add timed_progress context manager for long-running imports

### DIFF
--- a/tests/test_preload_progress.py
+++ b/tests/test_preload_progress.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch.nn as nn
 
-from vtsearch.media.base import intercept_weight_loading_progress, load_pretrained_local_first
+from vtsearch.media.base import intercept_weight_loading_progress, load_pretrained_local_first, timed_progress
 from vtsearch.models.loader import _make_console_progress, preload_autoload_media_types
 
 
@@ -587,3 +587,111 @@ class TestLoadPretrainedLocalFirst:
         result = load_pretrained_local_first(fake_load, "model-id")
         assert result is sentinel
         assert mock_sleep.call_count == 2
+
+
+class TestTimedProgress:
+    """Unit tests for the timed_progress context manager."""
+
+    def test_sends_initial_progress_immediately(self):
+        """The initial progress message should be sent before the block executes."""
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append((status, message, current, total))
+
+        with timed_progress(cb, "loading", "Importing torch…", 1, 2):
+            pass  # fast — no tick fires
+
+        assert len(calls) >= 1
+        assert calls[0] == ("loading", "Importing torch…", 1, 2)
+
+    def test_no_elapsed_suffix_for_fast_operations(self):
+        """If the block completes in under 1 second, no elapsed suffix should appear."""
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append((status, message, current, total))
+
+        with timed_progress(cb, "loading", "Importing torch…", 1, 2):
+            pass  # completes instantly
+
+        # Only the initial call (no time suffix)
+        assert all("(" not in c[1] for c in calls)
+
+    def test_elapsed_time_updates_during_slow_operation(self):
+        """A slow block should produce elapsed-time suffixed messages."""
+        import time
+
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append((status, message, current, total))
+
+        with timed_progress(cb, "loading", "Importing torch…", 1, 2):
+            # Sleep long enough for at least one tick (~1s interval)
+            time.sleep(2.5)
+
+        # Should have the initial message plus at least one timed update
+        timed_calls = [c for c in calls if "(" in c[1]]
+        assert len(timed_calls) >= 1
+        # Check format: "Importing torch… (1s)" or "Importing torch… (2s)"
+        assert any("(1s)" in c[1] or "(2s)" in c[1] for c in timed_calls)
+        # All calls should preserve status, current, total
+        for c in calls:
+            assert c[0] == "loading"
+            assert c[2] == 1
+            assert c[3] == 2
+
+    def test_ticker_stops_after_block_exits(self):
+        """The background ticker thread should stop once the with block exits."""
+        import time
+
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append(time.monotonic())
+
+        with timed_progress(cb, "loading", "test", 0, 1):
+            time.sleep(1.5)
+
+        count_during = len(calls)
+        time.sleep(1.5)
+        count_after = len(calls)
+
+        # No new calls should arrive after the block exits
+        assert count_after == count_during
+
+    def test_exception_in_block_still_stops_ticker(self):
+        """The ticker should be cleaned up even if the block raises."""
+        import time
+
+        calls = []
+
+        def cb(status, message, current, total):
+            calls.append(message)
+
+        try:
+            with timed_progress(cb, "loading", "test", 0, 0):
+                time.sleep(1.5)
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+        count_during = len(calls)
+        time.sleep(1.5)
+        count_after = len(calls)
+
+        assert count_after == count_during
+
+    def test_works_with_console_progress_wrapper(self, capsys):
+        """timed_progress should integrate with _make_console_progress."""
+        import time
+
+        cb = _make_console_progress(lambda *a, **kw: None)
+
+        with timed_progress(cb, "loading", "Importing torch…", 1, 2):
+            time.sleep(1.5)
+
+        captured = capsys.readouterr()
+        # Should see the initial message and at least one elapsed update
+        assert "Importing torch…" in captured.out

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MODEL_ID, CLAP_SAMPLE_RATE
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, load_pretrained_local_first
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, load_pretrained_local_first, timed_progress
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -47,17 +47,17 @@ class AudioClapEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 4)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 4):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 4)
-        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 4):
+            from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
 
-        self._on_progress("loading", "Importing librosa…", 3, 4)
-        import librosa  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 4):
+            import librosa  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing soundfile…", 4, 4)
-        import soundfile  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing soundfile…", 4, 4):
+            import soundfile  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP model weights…")
         with intercept_tqdm_progress(self._on_progress):

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import CLAP_MUSIC_MODEL_ID, CLAP_SAMPLE_RATE
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, load_pretrained_local_first
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, load_pretrained_local_first, timed_progress
 
 if TYPE_CHECKING:
     from transformers import ClapModel, ClapProcessor
@@ -51,14 +51,14 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 3)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 3)
-        from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+            from transformers import ClapModel, ClapProcessor  # noqa: PLC0415
 
-        self._on_progress("loading", "Importing librosa…", 3, 3)
-        import librosa  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing librosa…", 3, 3):
+            import librosa  # noqa: F401, PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLAP Music model weights…")
         with intercept_tqdm_progress(self._on_progress):

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -51,6 +51,7 @@ __all__ = [
     "intercept_tqdm_progress",
     "intercept_weight_loading_progress",
     "load_pretrained_local_first",
+    "timed_progress",
 ]
 
 
@@ -101,6 +102,44 @@ def extract_tensor(output: object):
             return val
     # Final fallback: treat as tuple-like and return first element
     return output[0]  # type: ignore[index]
+
+
+@contextlib.contextmanager
+def timed_progress(
+    on_progress: ProgressCallback,
+    status: str,
+    message: str,
+    current: int = 0,
+    total: int = 0,
+) -> Any:
+    """Show elapsed time in the progress message while a block executes.
+
+    Wraps a long-running blocking operation (typically a heavy ``import``)
+    so that the progress callback is updated every second with an elapsed-
+    time suffix, e.g. ``"Importing torch… (3s)"``.  This prevents the UI
+    from appearing frozen during operations that cannot report incremental
+    progress themselves.
+
+    The initial progress update is sent immediately (without a time suffix).
+    After the first second the background ticker appends ``(1s)``, ``(2s)``,
+    etc. until the ``with`` block exits.
+    """
+    stop = threading.Event()
+
+    def _ticker() -> None:
+        start = time.monotonic()
+        while not stop.wait(timeout=1.0):
+            elapsed = int(time.monotonic() - start)
+            on_progress(status, f"{message} ({elapsed}s)", current, total)
+
+    on_progress(status, message, current, total)
+    t = threading.Thread(target=_ticker, daemon=True)
+    t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        t.join(timeout=2)
 
 
 def embedder_load_setup(on_progress: ProgressCallback, message: str) -> str:

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -16,6 +16,7 @@ from vtsearch.media.base import (
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
+    timed_progress,
 )
 
 if TYPE_CHECKING:
@@ -57,11 +58,11 @@ class ImageClipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 2)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 2)
-        from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+            from transformers import CLIPModel, CLIPProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading CLIP model weights…")
         CLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -16,6 +16,7 @@ from vtsearch.media.base import (
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
+    timed_progress,
 )
 
 if TYPE_CHECKING:
@@ -57,11 +58,11 @@ class ImageSiglipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 2)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 2)
-        from transformers import SiglipModel, SiglipProcessor  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+            from transformers import SiglipModel, SiglipProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading SigLIP model weights…")
         with intercept_tqdm_progress(self._on_progress), intercept_weight_loading_progress(

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import E5_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress, load_pretrained_local_first
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress, load_pretrained_local_first, timed_progress
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -47,14 +47,14 @@ class TextE5Embedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 3)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 3)
-        from transformers import BertModel  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+            from transformers import BertModel  # noqa: PLC0415
 
-        self._on_progress("loading", "Importing sentence_transformers…", 3, 3)
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing sentence_transformers…", 3, 3):
+            from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading E5 model…")
         BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from vtsearch.config import BGE_MODEL_ID
-from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress, load_pretrained_local_first
+from vtsearch.media.base import MediaEmbedder, embedder_load_setup, intercept_tqdm_progress, intercept_weight_loading_progress, load_pretrained_local_first, timed_progress
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -47,14 +47,14 @@ class TextBGEEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 3)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 3):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 3)
-        from transformers import BertModel  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 3):
+            from transformers import BertModel  # noqa: PLC0415
 
-        self._on_progress("loading", "Importing sentence_transformers…", 3, 3)
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing sentence_transformers…", 3, 3):
+            from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading BGE model…")
         BertModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -16,6 +16,7 @@ from vtsearch.media.base import (
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
     load_pretrained_local_first,
+    timed_progress,
 )
 
 if TYPE_CHECKING:
@@ -54,11 +55,11 @@ class VideoXClipEmbedder(MediaEmbedder):
         if self._model is not None:
             return
 
-        self._on_progress("loading", "Importing torch…", 1, 2)
-        import torch  # noqa: F401, PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing torch…", 1, 2):
+            import torch  # noqa: F401, PLC0415
 
-        self._on_progress("loading", "Importing transformers…", 2, 2)
-        from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
+        with timed_progress(self._on_progress, "loading", "Importing transformers…", 2, 2):
+            from transformers import XCLIPModel, XCLIPProcessor  # noqa: PLC0415
 
         cache_dir = embedder_load_setup(self._on_progress, "Loading X-CLIP model weights…")
         XCLIPModel._keys_to_ignore_on_load_unexpected = [r".*position_ids.*"]


### PR DESCRIPTION
## Summary
Introduces a new `timed_progress` context manager that displays elapsed time in progress messages during long-running blocking operations (like heavy imports). This prevents the UI from appearing frozen when operations cannot report incremental progress themselves.

## Key Changes
- **New `timed_progress` context manager** in `vtsearch/media/base.py`:
  - Wraps blocking operations to show elapsed time with a background ticker thread
  - Sends initial progress update immediately (without time suffix)
  - After 1 second, appends elapsed time suffix (e.g., `"Importing torch… (3s)"`) every second
  - Properly cleans up the ticker thread on block exit or exception
  - Exported in the module's `__all__` list

- **Updated all embedder modules** to use `timed_progress` for import statements:
  - `vtsearch/media/audio/embedder.py`
  - `vtsearch/media/audio/embedder_clap_music.py`
  - `vtsearch/media/text/embedder.py`
  - `vtsearch/media/text/embedder_bge.py`
  - `vtsearch/media/image/embedder.py`
  - `vtsearch/media/image/embedder_siglip.py`
  - `vtsearch/media/video/embedder.py`

- **Comprehensive test suite** in `tests/test_preload_progress.py`:
  - Tests for immediate initial progress delivery
  - Verification that fast operations don't show elapsed time
  - Validation of elapsed time updates during slow operations
  - Confirmation that ticker stops after block exit
  - Exception handling and cleanup verification
  - Integration test with `_make_console_progress`

## Implementation Details
- Uses `threading.Event` and a daemon thread for the background ticker
- Ticker updates every 1 second with `time.monotonic()` for accurate elapsed time tracking
- Thread is properly joined with a 2-second timeout on exit to ensure cleanup
- Preserves all progress callback parameters (status, current, total) across updates

https://claude.ai/code/session_01YAL4iqQDdv7ENZaniu2ofo