### PR TITLE
Prevent stale data by canceling in-flight requests and disabling API caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,6 +124,26 @@ def _set_request_context():
 
 
 # ---------------------------------------------------------------------------
+# Prevent browser caching of API responses
+# ---------------------------------------------------------------------------
+
+
+@app.after_request
+def _no_cache_api(response):
+    """Prevent browsers from caching mutable API responses.
+
+    Without this, concurrent or rapid-fire fetches to the same endpoint
+    (e.g. ``/api/datasets/registry``) can receive stale cached data,
+    causing the frontend to miss newly loaded datasets.
+    """
+    from flask import request
+
+    if request.path.startswith("/api/"):
+        response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+# ---------------------------------------------------------------------------
 # Register Blueprints
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/app/services/dataset-state.service.spec.ts
+++ b/frontend/src/app/services/dataset-state.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { DatasetStateService } from './dataset-state.service';
@@ -42,6 +42,31 @@ describe('DatasetStateService', () => {
     expect(service.models.length).toBe(1);
     expect(service.models[0].name).toBe('model1');
   });
+
+  it('rapid refresh should cancel stale in-flight requests', fakeAsync(() => {
+    // First refresh — will be cancelled by the second
+    service.refresh();
+    tick();
+    const staleDs = httpMock.expectOne('/api/datasets/registry');
+    const staleModels = httpMock.expectOne('/api/trainable-models/registry');
+
+    // Second refresh — this one should win
+    service.refresh();
+    tick();
+    const freshDs = httpMock.expectOne('/api/datasets/registry');
+    const freshModels = httpMock.expectOne('/api/trainable-models/registry');
+
+    // The first (stale) requests were cancelled by switchMap
+    expect(staleDs.cancelled).toBeTrue();
+    expect(staleModels.cancelled).toBeTrue();
+
+    // Flush the fresh responses
+    freshDs.flush({ datasets: [{ id: '1', name: 'fresh' }] });
+    freshModels.flush({ models: [] });
+
+    expect(service.datasets.length).toBe(1);
+    expect(service.datasets[0].name).toBe('fresh');
+  }));
 
   it('setLoading and setProgressMessage should update state', () => {
     service.setLoading(true);

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject, forkJoin } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { switchMap, takeUntil } from 'rxjs/operators';
 import { DatasetRegistryEntry, LoadingTask, ModelRegistryEntry } from '../models/api.models';
 import { DatasetsApiService } from './datasets-api.service';
 import { TrainableModelsApiService } from './trainable-models-api.service';
@@ -14,6 +14,8 @@ export class DatasetStateService implements OnDestroy {
   private readonly progressMessageSubject = new BehaviorSubject<string>('');
   private readonly errorMessageSubject = new BehaviorSubject<string>('');
   private readonly destroy$ = new Subject<void>();
+  /** Emits whenever a refresh is requested; switchMap ensures only the latest response is used. */
+  private readonly refreshTrigger$ = new Subject<void>();
 
   readonly datasets$ = this.datasetsSubject.asObservable();
   readonly models$ = this.modelsSubject.asObservable();
@@ -25,7 +27,27 @@ export class DatasetStateService implements OnDestroy {
   constructor(
     private datasetsApi: DatasetsApiService,
     private modelsApi: TrainableModelsApiService,
-  ) {}
+  ) {
+    // Single subscription that uses switchMap to cancel in-flight requests
+    // when a new refresh is triggered, preventing stale responses from
+    // overwriting fresh data.
+    this.refreshTrigger$
+      .pipe(
+        switchMap(() =>
+          forkJoin({
+            datasets: this.datasetsApi.getRegistry(),
+            models: this.modelsApi.getRegistry(),
+          }),
+        ),
+        takeUntil(this.destroy$),
+      )
+      .subscribe({
+        next: ({ datasets, models }) => {
+          this.datasetsSubject.next(datasets.datasets || []);
+          this.modelsSubject.next(models.models || []);
+        },
+      });
+  }
 
   ngOnDestroy(): void {
     this.destroy$.next();
@@ -73,17 +95,7 @@ export class DatasetStateService implements OnDestroy {
   }
 
   refresh(): void {
-    forkJoin({
-      datasets: this.datasetsApi.getRegistry(),
-      models: this.modelsApi.getRegistry(),
-    })
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: ({ datasets, models }) => {
-          this.datasetsSubject.next(datasets.datasets || []);
-          this.modelsSubject.next(models.models || []);
-        },
-      });
+    this.refreshTrigger$.next();
   }
 
   clear(): void {

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -722,3 +722,27 @@ class TestErrorResponseFormat:
         assert resp.status_code == 400
         data = resp.get_json()
         assert "error" in data
+
+
+class TestApiCacheControl:
+    """API responses should prevent browser caching of mutable data."""
+
+    def setup_method(self):
+        app_module.app.config["TESTING"] = True
+        self.client = app_module.app.test_client()
+
+    def test_datasets_registry_no_store(self):
+        resp = self.client.get("/api/datasets/registry")
+        assert resp.headers.get("Cache-Control") == "no-store"
+
+    def test_loading_tasks_no_store(self):
+        resp = self.client.get("/api/dataset/loading-tasks")
+        assert resp.headers.get("Cache-Control") == "no-store"
+
+    def test_dataset_status_no_store(self):
+        resp = self.client.get("/api/dataset/status")
+        assert resp.headers.get("Cache-Control") == "no-store"
+
+    def test_medias_no_store(self):
+        resp = self.client.get("/api/medias")
+        assert resp.headers.get("Cache-Control") == "no-store"

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -134,6 +134,34 @@ class TestLoadingTasksTracker:
         assert len(tasks) == 1
         assert tasks[0]["media_type"] == "image"
 
+    def test_set_dataset_id(self):
+        """set_dataset_id updates the dataset_id on an existing task."""
+        tracker = LoadingTasksTracker()
+        tracker.create_task("t1", "DS")
+        tasks = tracker.list_tasks()
+        assert tasks[0].get("dataset_id") is None or tasks[0].get("dataset_id") == ""
+
+        tracker.set_dataset_id("t1", "real-registry-id")
+        tasks = tracker.list_tasks()
+        assert tasks[0]["dataset_id"] == "real-registry-id"
+
+    def test_set_dataset_id_nonexistent(self):
+        """set_dataset_id on a missing task is a no-op."""
+        tracker = LoadingTasksTracker()
+        tracker.set_dataset_id("nope", "some-id")  # should not raise
+
+    def test_set_dataset_id_visible_after_finish(self):
+        """dataset_id is still visible on recently-finished tasks."""
+        tracker = LoadingTasksTracker()
+        pt = tracker.create_task("t1", "DS")
+        tracker.set_dataset_id("t1", "ds-123")
+        pt.update("idle", "Done")
+        tracker.mark_finished("t1")
+
+        tasks = tracker.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0]["dataset_id"] == "ds-123"
+
 
 # ---------------------------------------------------------------------------
 # Thread-local progress tests

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -608,6 +608,10 @@ def _run_origin_load_in_background(
                 _migrate_context_id(task_id, entry["id"])
                 context_id = entry["id"]
                 ctx.dataset_display_name = entry.get("name", name)
+                # Associate the loading task with the real dataset ID so the
+                # frontend can show the embedder-warmup progress inline on the
+                # dataset row instead of as an orphan loading task.
+                loading_tasks.set_dataset_id(task_id, entry["id"])
 
             # Warm up the embedder.  Use a progress wrapper that updates the
             # task tracker, not the global singleton.

--- a/vtsearch/utils/progress.py
+++ b/vtsearch/utils/progress.py
@@ -205,6 +205,13 @@ class LoadingTasksTracker:
         for entry in tasks:
             entry["tracker"].cancel()
 
+    def set_dataset_id(self, task_id: str, dataset_id: str) -> None:
+        """Associate a loading task with its final registry dataset ID."""
+        with self._lock:
+            entry = self._tasks.get(task_id)
+            if entry:
+                entry["dataset_id"] = dataset_id
+
     def remove_task(self, task_id: str) -> None:
         """Remove a completed/cancelled task from the tracker."""
         with self._lock:


### PR DESCRIPTION
## Summary
This PR fixes a race condition where concurrent or rapid-fire API requests could result in stale data overwriting fresh responses. The fix involves three coordinated changes: (1) using RxJS `switchMap` to cancel in-flight requests when new refreshes are triggered, (2) adding `Cache-Control: no-store` headers to all API responses to prevent browser caching, and (3) associating loading tasks with their final dataset IDs for better UI feedback.

## Key Changes

- **Frontend request cancellation**: Modified `DatasetStateService` to use `switchMap` in a centralized refresh subscription. When `refresh()` is called, any pending API requests are automatically cancelled, ensuring only the latest response updates the state.

- **API cache control headers**: Added an `after_request` hook in `app.py` that sets `Cache-Control: no-store` on all `/api/*` responses, preventing browsers from serving stale cached data on rapid successive requests.

- **Loading task dataset association**: Added `set_dataset_id()` method to `LoadingTasksTracker` to link loading tasks with their final registry dataset IDs. This allows the frontend to display embedder-warmup progress inline on the dataset row rather than as an orphan task.

- **Test coverage**: Added comprehensive tests for the new behavior:
  - Frontend test verifying that rapid refreshes cancel stale requests
  - Backend tests confirming `Cache-Control` headers are set correctly
  - Backend tests validating the `set_dataset_id()` functionality persists through task completion

## Implementation Details

The `switchMap` operator is key to the solution—it automatically unsubscribes from the previous observable when a new refresh is triggered, causing any pending HTTP requests to be cancelled. This is combined with server-side cache prevention to ensure the frontend always receives fresh data.

https://claude.ai/code/session_01DbghD7tL9yoKrUbJSHy1ke