### PR TITLE
Sync file-browser input value on parent component changes

### DIFF
--- a/frontend/src/app/components/file-browser/file-browser.component.ts
+++ b/frontend/src/app/components/file-browser/file-browser.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { FileBrowserApiService, BrowseEntry } from '../../services/file-browser-api.service';
@@ -10,7 +10,7 @@ import { FileBrowserApiService, BrowseEntry } from '../../services/file-browser-
   templateUrl: './file-browser.component.html',
   styleUrl: './file-browser.component.scss',
 })
-export class FileBrowserComponent implements OnInit {
+export class FileBrowserComponent implements OnInit, OnChanges {
   /** Comma-separated extensions to filter files, e.g. ".csv,.json" */
   @Input() extensions = '';
 
@@ -38,6 +38,12 @@ export class FileBrowserComponent implements OnInit {
 
   ngOnInit(): void {
     this.inputValue = this.value;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['value']) {
+      this.inputValue = this.value;
+    }
   }
 
   /** Open the file browser panel and load the root directory. */


### PR DESCRIPTION
## Summary
Updated the FileBrowserComponent to properly respond to changes in the `value` input property from parent components by implementing the `OnChanges` lifecycle hook.

## Key Changes
- Added `OnChanges` and `SimpleChanges` to the component's imports
- Implemented the `OnChanges` interface alongside the existing `OnInit`
- Added `ngOnChanges()` lifecycle hook to detect and sync changes to the `value` input property with the internal `inputValue` state

## Implementation Details
The component now listens for changes to the `value` @Input property and automatically updates the internal `inputValue` field. This ensures that when a parent component updates the bound `value` property, the file browser component's internal state stays synchronized. Previously, the `inputValue` was only initialized during component initialization (`ngOnInit`), which meant subsequent changes to the `value` input would not be reflected in the component's UI.

https://claude.ai/code/session_01FeFCvvBDR73UDrenjDtoBE