### PR TITLE
Replace checkboxes with SVG icons in model and dataset cards

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -119,16 +119,17 @@ td {
 }
 
 .status-loaded {
-  color: var(--color-good);
+  color: inherit;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding: 4px;
 }
 
 .load-action {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: inherit;
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -68,20 +68,33 @@
   <td>{{ (model.num_training ?? 0) | number }}</td>
   <td>
     @if (model.trainable) {
-      <span class="check" aria-label="Trainable">&#10003;</span>
+      <span class="status-icon" aria-label="Trainable">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="20 6 9 17 4 12"></polyline>
+        </svg>
+      </span>
     } @else {
-      <span class="dim">-</span>
+      <span class="status-icon" aria-label="Not trainable">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </span>
     }
   </td>
   <td>
-    <input
-      type="checkbox"
-      [checked]="model.autodetect"
-      (change)="onAutorunToggle($event)"
-      (click)="$event.stopPropagation()"
-      aria-label="Autorun"
-      title="Include in CLI autorun"
-    />
+    <button class="autorun-toggle" (click)="onAutorunToggle($event)" aria-label="Autorun" title="Include in CLI autorun">
+      @if (model.autodetect) {
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="20 6 9 17 4 12"></polyline>
+        </svg>
+      } @else {
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      }
+    </button>
   </td>
   <td>{{ formatDate(model.last_trained_at) }}</td>
   <td>{{ formatDate(model.created_at) }}</td>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -108,22 +108,20 @@ td {
   opacity: 0.7;
 }
 
-.check,
+.status-icon,
 .status-loaded {
-  color: var(--color-good);
+  color: inherit;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding: 4px;
 }
 
-.dim {
-  color: var(--text-dim);
-}
-
-.load-action {
+.load-action,
+.autorun-toggle {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: inherit;
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -125,10 +125,9 @@ export class ModelCardComponent implements OnChanges {
     this.export.emit();
   }
 
-  onAutorunToggle(event: Event): void {
+  onAutorunToggle(event: MouseEvent): void {
     event.stopPropagation();
-    const checked = (event.target as HTMLInputElement).checked;
-    this.autorunToggle.emit(checked);
+    this.autorunToggle.emit(!this.model.autodetect);
   }
 
   formatDate(timestamp: number | null): string {


### PR DESCRIPTION
## Summary
Replaced HTML checkbox and text-based status indicators with SVG icons for a more modern and consistent UI in the model and dataset card components.

## Key Changes
- **Model Card Component**:
  - Replaced checkmark text (`&#10003;`) with SVG checkmark icon for trainable status
  - Replaced dash text (`-`) with SVG X icon for non-trainable status
  - Converted autorun checkbox input to a button with conditional SVG icons (checkmark when enabled, X when disabled)
  - Updated `onAutorunToggle()` method to work with button click events instead of checkbox change events

- **Styling Updates**:
  - Unified `.status-icon` and `.status-loaded` classes to use `color: inherit` instead of hardcoded color variables
  - Removed `.dim` class (no longer needed)
  - Added `padding: 4px` to status icon containers for consistent spacing
  - Updated `.autorun-toggle` button styling to match `.load-action` patterns
  - Applied same styling changes to dataset card component for consistency

## Implementation Details
- SVG icons use consistent sizing (14x14) and stroke properties (width: 2.5, rounded caps/joins)
- Icons inherit color from parent context, allowing for theme flexibility
- Improved accessibility with proper `aria-label` and `aria-hidden` attributes
- Button-based autorun toggle maintains event handling while providing better visual feedback

https://claude.ai/code/session_01SoL2yn64ZJCsCgjZ7ZQviG