### PR TITLE
Standardize icon button styling across dashboard cards

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -48,7 +48,7 @@ td {
 .edit-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -152,7 +152,7 @@ td {
 .security-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -175,7 +175,7 @@ td {
 .stats-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -201,7 +201,7 @@ td {
 .delete-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -58,8 +58,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 
   .pencil-active {
@@ -129,7 +128,7 @@ td {
 .load-action {
   background: none;
   border: none;
-  color: inherit;
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -139,8 +138,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 }
 
@@ -162,8 +160,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover:not(.disabled) {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 
   &.disabled {
@@ -185,8 +182,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 
   .pie-active {
@@ -212,7 +208,7 @@ td {
 
   &:hover {
     color: var(--color-bad);
-    background: var(--bad-bg);
+    background: var(--btn-icon-hover-bg);
   }
 
   .trash-active {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -54,8 +54,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 
   .pencil-active {
@@ -121,7 +120,7 @@ td {
 .autorun-toggle {
   background: none;
   border: none;
-  color: inherit;
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -131,8 +130,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 }
 
@@ -154,8 +152,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 
   .cap-active {
@@ -180,8 +177,7 @@ td {
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
+    background: var(--btn-icon-hover-bg);
   }
 }
 
@@ -199,7 +195,7 @@ td {
 
   &:hover {
     color: var(--color-bad);
-    background: var(--bad-bg);
+    background: var(--btn-icon-hover-bg);
   }
 
   .trash-active {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -44,7 +44,7 @@ td {
 .edit-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -144,7 +144,7 @@ td {
 .add-labels-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -170,7 +170,7 @@ td {
 .export-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -188,7 +188,7 @@ td {
 .delete-btn {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -46,6 +46,7 @@
   --scrollbar-thumb: #3a3d52;
   --scrollbar-thumb-hover: #7c8aff;
   --badge-embedding: #e0a020;
+  --btn-icon-hover-bg: rgba(255, 255, 255, 0.08);
 
   // Aliases used by component SCSS files
   --border-color: var(--border);
@@ -115,6 +116,7 @@
   --scrollbar-thumb: #c0c3cc;
   --scrollbar-thumb-hover: #5a68d8;
   --badge-embedding: #c99000;
+  --btn-icon-hover-bg: rgba(0, 0, 0, 0.07);
 
   // Aliases
   --border-color: var(--border);
@@ -184,6 +186,7 @@
   --scrollbar-thumb: #888888;
   --scrollbar-thumb-hover: #ffff00;
   --badge-embedding: #ffff00;
+  --btn-icon-hover-bg: rgba(255, 255, 255, 0.15);
 
   // Aliases
   --border-color: var(--border);


### PR DESCRIPTION
## Summary
This PR standardizes the styling of icon buttons across the dashboard dataset and model card components by introducing a new CSS variable for hover backgrounds and updating button color defaults for consistency.

## Key Changes
- **New CSS Variable**: Added `--btn-icon-hover-bg` to `_variables.scss` with theme-specific values:
  - Dark theme: `rgba(255, 255, 255, 0.08)`
  - Light theme: `rgba(0, 0, 0, 0.07)`
  - High contrast theme: `rgba(255, 255, 255, 0.15)`

- **Dataset Card Component**: Updated all icon buttons (edit, load-action, security, stats, delete) to:
  - Use `var(--text-primary)` as default color instead of `var(--text-muted)` or `inherit`
  - Replace individual hover states with unified `--btn-icon-hover-bg` background
  - Remove redundant color changes on hover (color now consistent in default and hover states)

- **Model Card Component**: Applied the same standardization to icon buttons (edit, autorun-toggle, add-labels, export, delete)

## Implementation Details
- The delete button hover state maintains the `var(--color-bad)` text color while using the new `--btn-icon-hover-bg` for background consistency
- This change improves visual consistency and reduces CSS duplication across components
- The new variable approach makes it easier to maintain theme-specific hover effects in one place

https://claude.ai/code/session_01Egn7xvbGKgccKtNRupm9qV