### PR TITLE
Prevent body overflow in app container

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  overflow: hidden;
 }
 
 header {


### PR DESCRIPTION
## Summary
Added `overflow: hidden` to the app container to prevent scrollbars from appearing when content exceeds the viewport height.

## Changes
- Added `overflow: hidden` CSS property to the app component's root container that uses `height: 100vh`

## Details
The app container is set to fill the full viewport height (`height: 100vh`) with a flex column layout. Without the overflow constraint, any content that exceeds the viewport dimensions would cause unwanted scrollbars. This change ensures the container respects its viewport-bound dimensions and clips any overflowing content, maintaining a clean full-screen layout.

https://claude.ai/code/session_01VZyRbg7GbLNJbXosRuV6Fh