### PR TITLE
Add video thumbnail generation and display support

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -17,11 +17,7 @@
       >
         @if (isGrid) {
           @if (hasThumbnailUrl(entry.id)) {
-            @if (isVideo(entry.id)) {
-              <video class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" muted preload="metadata"></video>
-            } @else {
-              <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
-            }
+            <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
           } @else if (placeholderIcon(entry.id)) {
             <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>
           }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -126,15 +126,9 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document' || media.type === 'audio');
   }
 
-  isVideo(id: number): boolean {
-    const media = this.mediaMap.get(id);
-    return !!media && media.type === 'video';
-  }
-
   thumbnailUrl(id: number): string {
     const media = this.mediaMap.get(id);
     if (!media) return '';
-    if (media.type === 'video') return this.activeContext.mediaUrl(`/api/medias/${id}/video`);
     return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
   }
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import tempfile
 from pathlib import Path
 
 from vtsearch.media.base import (
@@ -11,6 +13,88 @@ from vtsearch.media.base import (
     ProgressCallback,
     _noop_progress,
 )
+
+_THUMB_SIZE = 128
+
+
+def generate_video_thumbnail(video_bytes: bytes, *, size: int = _THUMB_SIZE) -> bytes | None:
+    """Extract the middle frame of a video and return it as a PNG thumbnail.
+
+    Uses OpenCV to decode the video and PIL to produce the PNG.  Returns
+    ``None`` if the video cannot be decoded or has no frames.
+    """
+    try:
+        import cv2  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+    except Exception:
+        return None
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    try:
+        tmp.write(video_bytes)
+        tmp.close()
+
+        cap = cv2.VideoCapture(tmp.name)
+        try:
+            if not cap.isOpened():
+                return None
+            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            if frame_count <= 0:
+                return None
+            mid = frame_count // 2
+            cap.set(cv2.CAP_PROP_POS_FRAMES, mid)
+            ret, frame = cap.read()
+            if not ret:
+                return None
+        finally:
+            cap.release()
+    finally:
+        import os  # noqa: PLC0415
+
+        os.unlink(tmp.name)
+
+    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(frame_rgb)
+    img.thumbnail((size, size))
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+def generate_video_thumbnail_from_file(file_path: Path, *, size: int = _THUMB_SIZE) -> bytes | None:
+    """Extract the middle frame of a video file and return it as a PNG thumbnail."""
+    try:
+        import cv2  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+    except Exception:
+        return None
+
+    try:
+        cap = cv2.VideoCapture(str(file_path))
+        try:
+            if not cap.isOpened():
+                return None
+            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            if frame_count <= 0:
+                return None
+            mid = frame_count // 2
+            cap.set(cv2.CAP_PROP_POS_FRAMES, mid)
+            ret, frame = cap.read()
+            if not ret:
+                return None
+        finally:
+            cap.release()
+    except Exception:
+        return None
+
+    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(frame_rgb)
+    img.thumbnail((size, size))
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
 
 
 _VIDEO_MIME_TYPES: dict[str, str] = {
@@ -198,6 +282,7 @@ class VideoMediaType(MediaType):
                 "md5": hashlib.md5(video_bytes).hexdigest(),
                 "embedding": embedding,
                 "media_bytes": video_bytes,
+                "thumbnail_bytes": media_fields.get("thumbnail_bytes"),
                 "filename": rel_name,
                 "category": meta["category"],
                 "origin": {**demo_origin_template},
@@ -210,6 +295,10 @@ class VideoMediaType(MediaType):
     # ------------------------------------------------------------------
     # Clip data
     # ------------------------------------------------------------------
+
+    @property
+    def pickle_extra_fields(self) -> list[str]:
+        return ["thumbnail_bytes"]
 
     def load_media_data(self, file_path: Path) -> dict:
         with open(file_path, "rb") as f:
@@ -226,11 +315,34 @@ class VideoMediaType(MediaType):
                 cap.release()
         except Exception:
             duration = 0.0
-        return {"media_bytes": media_bytes, "duration": duration}
+        thumbnail = generate_video_thumbnail_from_file(file_path)
+        return {"media_bytes": media_bytes, "duration": duration, "thumbnail_bytes": thumbnail}
 
     # ------------------------------------------------------------------
     # HTTP serving
     # ------------------------------------------------------------------
+
+    def image_response(self, media: dict) -> MediaResponse | None:
+        """Return the video thumbnail as a PNG image, or *None*."""
+        thumb = media.get("thumbnail_bytes")
+        if thumb:
+            return MediaResponse(
+                data=thumb,
+                mimetype="image/png",
+                download_name=f"media_{media['id']}_thumb.png",
+            )
+        # Fallback: generate on the fly from media bytes
+        raw = self._resolve_media_bytes(media)
+        if raw:
+            thumb = generate_video_thumbnail(raw)
+            if thumb:
+                media["thumbnail_bytes"] = thumb
+                return MediaResponse(
+                    data=thumb,
+                    mimetype="image/png",
+                    download_name=f"media_{media['id']}_thumb.png",
+                )
+        return None
 
     def media_response(self, media: dict) -> MediaResponse:
         filename = media.get("filename", "")

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -631,12 +631,16 @@ def add_media_to_pile() -> tuple[Response, int] | Response:
     if embedding is None:
         return jsonify({"error": "Failed to embed the uploaded file."}), 400
 
-    # Generate thumbnail for audio media
+    # Generate thumbnail for non-image media
     thumb = None
     if dataset_media_type == "audio":
         from vtsearch.media.audio.media_type import generate_waveform_thumbnail  # noqa: PLC0415
 
         thumb = generate_waveform_thumbnail(file_bytes)
+    elif dataset_media_type == "video":
+        from vtsearch.media.video.media_type import generate_video_thumbnail  # noqa: PLC0415
+
+        thumb = generate_video_thumbnail(file_bytes)
 
     with _state_lock:
         new_id = next_media_id(medias)


### PR DESCRIPTION
## Summary
This PR adds automatic thumbnail generation for video media and updates the UI to display video thumbnails as PNG images instead of embedded video players.

## Key Changes

**Backend (Python)**
- Added `generate_video_thumbnail()` function to extract the middle frame from video bytes and return it as a PNG thumbnail
- Added `generate_video_thumbnail_from_file()` function to generate thumbnails directly from video files on disk
- Updated `VideoMedia.load_media_data()` to automatically generate and store video thumbnails when loading media
- Added `pickle_extra_fields` property to persist thumbnail data
- Implemented `image_response()` method to serve video thumbnails as PNG images with fallback generation from media bytes
- Updated media upload endpoint to generate video thumbnails for newly uploaded video files
- Updated demo source loading to include thumbnail data

**Frontend (Angular)**
- Simplified thumbnail display in label list to always use `<img>` tags instead of conditional `<video>` tags
- Removed `isVideo()` method from component logic
- Updated `thumbnailUrl()` to always return the image endpoint (`/api/medias/{id}/image`) for all media types

## Implementation Details
- Thumbnails are generated using OpenCV (cv2) to decode video frames and PIL to produce PNG output
- The middle frame of the video is selected for the thumbnail
- Thumbnails are resized to 128x128 pixels by default with optimized PNG compression
- Graceful fallback: if thumbnail generation fails, the system returns `None` rather than crashing
- Thumbnails are cached in the media object to avoid regeneration on subsequent requests

https://claude.ai/code/session_01WRtpyxxpmozPEKQGuZhPV9