### PR TITLE
Blur active element on keyboard navigation actions

### DIFF
--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -52,10 +52,12 @@ export class KeyboardService implements OnDestroy {
     switch (e.key) {
       case 'ArrowRight':
         e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
         this.zone.run(() => this.action$.next({ type: 'vote', direction: 'good' }));
         break;
       case 'ArrowLeft':
         e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
         this.zone.run(() => this.action$.next({ type: 'vote', direction: 'bad' }));
         break;
       case 'ArrowUp':
@@ -70,6 +72,7 @@ export class KeyboardService implements OnDestroy {
         break;
       case ' ':
         e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
         this.zone.run(() => this.action$.next({ type: 'playback' }));
         break;
     }


### PR DESCRIPTION
## Summary
This change ensures that keyboard navigation actions (arrow keys and spacebar) blur the currently focused element before triggering their respective actions. This prevents unintended interactions with focused UI elements when using keyboard shortcuts.

## Key Changes
- Added `blur()` call on `ArrowRight` key press (vote good action)
- Added `blur()` call on `ArrowLeft` key press (vote bad action)
- Added `blur()` call on `Space` key press (playback action)

## Implementation Details
The blur is applied to the active element using `(document.activeElement as HTMLElement)?.blur()` with optional chaining to safely handle cases where `activeElement` might not be an HTMLElement. This ensures that any focused form inputs, buttons, or other interactive elements lose focus before the keyboard action is processed, preventing conflicting behavior between the keyboard shortcut handler and the focused element's default behavior.

https://claude.ai/code/session_01RdKgXSkaknTuB7679yVPCf