### PR TITLE
Add HMDB51, UCF-101 Full, and KTH Actions video dataset downloaders

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ _TEST_GROUPS = {
         "test_imdb_download",
         "test_ucsf_documents_download",
         "test_download_and_extract",
+        "test_video_datasets_download",
     ],
     "integration": [
         "test_integration",

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1033,36 +1033,22 @@ class TestUCF101SubsetDownload:
 
     def test_demo_list_shows_video_download_size(self, client):
         """Video demo datasets should report a non-zero download size."""
-        from vtsearch.datasets.downloader import UCF101_SUBSET_DOWNLOAD_SIZE_MB
-
         resp = client.get("/api/dataset/demo-list")
         data = resp.get_json()
         video_ds = [d for d in data["datasets"] if d["media_type"] == "video"]
         assert len(video_ds) > 0, "Should have at least one video demo dataset"
         for ds in video_ds:
             if ds["status"] == "needs_download":
-                assert ds["download_size_mb"] == UCF101_SUBSET_DOWNLOAD_SIZE_MB
+                assert ds["download_size_mb"] > 0, f"Video demo '{ds['name']}' should have a positive download size"
 
-    def test_video_demo_categories_match_subset(self, client):
-        """Video demo datasets should only use categories from the UCF-101 subset."""
+    def test_video_demo_categories_match_source(self, client):
+        """Video demo datasets should only use categories defined for their source."""
         from vtsearch.datasets.config import DEMO_DATASETS
 
-        subset_categories = {
-            "ApplyEyeMakeup",
-            "ApplyLipstick",
-            "Archery",
-            "BabyCrawling",
-            "BalanceBeam",
-            "BandMarching",
-            "BaseballPitch",
-            "Basketball",
-            "BasketballDunk",
-            "BenchPress",
-        }
         for name, info in DEMO_DATASETS.items():
             if info.get("media_type") == "video":
-                for cat in info["categories"]:
-                    assert cat in subset_categories, f"Video demo '{name}' uses category '{cat}' not in UCF-101 subset"
+                cats = info.get("categories", [])
+                assert len(cats) > 0, f"Video demo '{name}' should have at least one category"
 
 
 class TestLoadProgressRaceCondition:

--- a/tests/test_video_datasets_download.py
+++ b/tests/test_video_datasets_download.py
@@ -31,7 +31,7 @@ class TestDownloadHmdb51:
 
         def fake_extract_rar(rar_path, extract_to):
             call_log.append(rar_path.name)
-            if rar_path.name == "hmdb51_org.rar":
+            if "hmdb51_org" in rar_path.name:
                 # Outer RAR: create inner .rar stubs
                 extract_to.mkdir(parents=True, exist_ok=True)
                 for cat in ("brush_hair", "cartwheel", "catch"):
@@ -294,14 +294,19 @@ class TestDownloadKth:
             assert len(avi_files) == 6, f"Expected 6 .avi files for {action}, got {len(avi_files)}"
 
     def test_skips_if_already_present(self, tmp_path):
-        """If kth/ already has videos, skip download entirely."""
+        """If kth/ already has all action videos, skip download entirely."""
         from vtsearch.datasets.downloader import video as vid_module
 
         data_dir = tmp_path / "data"
         video_dir = data_dir / "video"
-        kth_dir = video_dir / "kth" / "walking"
-        kth_dir.mkdir(parents=True)
-        (kth_dir / "person01_walking_d1_uncomp.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+        # Populate ALL 6 actions so the early-exit check passes.
+        for action in ("walking", "jogging", "running", "boxing", "handwaving", "handclapping"):
+            cat_dir = video_dir / "kth" / action
+            cat_dir.mkdir(parents=True)
+            (cat_dir / f"person01_{action}_d1_uncomp.avi").write_bytes(
+                b"RIFF" + b"\x00" * 20 + b"AVI "
+            )
 
         download_called = []
 
@@ -442,14 +447,14 @@ class TestVideoDemoDatasetRegistration:
 
     def test_source_dirs_registered(self):
         """New video sources should appear in the demo importer source dirs."""
-        from vtsearch.datasets.importers.demo import _source_directory, _SOURCE_DIRS
+        from vtsearch.datasets.importers import demo as demo_module
 
         # Force lazy init
-        _source_directory("hmdb51")
+        demo_module._source_directory("hmdb51")
 
-        assert "hmdb51" in _SOURCE_DIRS
-        assert "ucf101_full" in _SOURCE_DIRS
-        assert "kth" in _SOURCE_DIRS
+        assert "hmdb51" in demo_module._SOURCE_DIRS
+        assert "ucf101_full" in demo_module._SOURCE_DIRS
+        assert "kth" in demo_module._SOURCE_DIRS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_video_datasets_download.py
+++ b/tests/test_video_datasets_download.py
@@ -1,0 +1,636 @@
+"""Tests for video dataset downloaders: HMDB51, UCF-101 full, and KTH Actions."""
+
+import io
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# HMDB51
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadHmdb51:
+    """Verify download_hmdb51 downloads, extracts nested RARs, and organises."""
+
+    def test_extracts_into_category_dirs(self, tmp_path):
+        """download_hmdb51 should create per-category dirs with .avi files."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+
+        # Simulate what _extract_rar does: create category dirs with .avi files.
+        call_log = []
+
+        def fake_extract_rar(rar_path, extract_to):
+            call_log.append(rar_path.name)
+            if rar_path.name == "hmdb51_org.rar":
+                # Outer RAR: create inner .rar stubs
+                extract_to.mkdir(parents=True, exist_ok=True)
+                for cat in ("brush_hair", "cartwheel", "catch"):
+                    (extract_to / f"{cat}.rar").write_bytes(b"Rar!")
+            else:
+                # Inner RAR: create .avi files in the target dir
+                extract_to.mkdir(parents=True, exist_ok=True)
+                cat = rar_path.stem
+                for i in range(3):
+                    (extract_to / f"{cat}_video_{i}.avi").write_bytes(
+                        b"RIFF" + b"\x00" * 20 + b"AVI "
+                    )
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(
+                vid_module._core,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: dest.write_bytes(b"Rar!"),
+            ),
+            patch.object(vid_module, "_extract_rar", fake_extract_rar),
+        ):
+            result = vid_module.download_hmdb51(on_progress=lambda *a: None)
+
+        assert result.exists()
+        assert result.name == "hmdb51"
+        assert (result / "brush_hair").is_dir()
+        assert (result / "cartwheel").is_dir()
+        assert (result / "catch").is_dir()
+        assert len(list((result / "brush_hair").glob("*.avi"))) == 3
+
+    def test_skips_if_already_present(self, tmp_path):
+        """If hmdb51/ already has videos, skip download entirely."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        video_dir = data_dir / "video"
+        hmdb_dir = video_dir / "hmdb51" / "brush_hair"
+        hmdb_dir.mkdir(parents=True)
+        (hmdb_dir / "brush_hair_video_0.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+        download_called = []
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(
+                vid_module._core,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = vid_module.download_hmdb51(on_progress=lambda *a: None)
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert result.exists()
+
+    def test_temp_files_cleaned_up(self, tmp_path):
+        """Temp archive and staging dir should be removed after extraction."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+
+        def fake_extract_rar(rar_path, extract_to):
+            extract_to.mkdir(parents=True, exist_ok=True)
+            if rar_path.name.startswith(".dl_"):
+                # Treat as outer
+                for cat in ("run",):
+                    (extract_to / f"{cat}.rar").write_bytes(b"Rar!")
+            elif rar_path.suffix == ".rar" and not rar_path.name.startswith(".dl_"):
+                # Treat as outer if in staging, inner otherwise
+                if "hmdb51_org" in rar_path.name:
+                    for cat in ("run",):
+                        (extract_to / f"{cat}.rar").write_bytes(b"Rar!")
+                else:
+                    cat = rar_path.stem
+                    (extract_to / f"{cat}_v1.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(
+                vid_module._core,
+                "download_file_with_progress",
+                lambda url, dest, size, cb: dest.write_bytes(b"Rar!"),
+            ),
+            patch.object(vid_module, "_extract_rar", fake_extract_rar),
+        ):
+            vid_module.download_hmdb51(on_progress=lambda *a: None)
+
+        # No temp download files should remain in data_dir.
+        leftover_dl = [p for p in data_dir.iterdir() if p.name.startswith(".dl_")]
+        assert not leftover_dl, f"Temp archive files should be cleaned up: {leftover_dl}"
+        leftover_ex = [p for p in data_dir.iterdir() if p.name.startswith(".extract_")]
+        assert not leftover_ex, f"Temp staging dirs should be cleaned up: {leftover_ex}"
+
+
+class TestExtractRar:
+    """Unit tests for the _extract_rar helper."""
+
+    def test_raises_when_unrar_missing(self, tmp_path):
+        """_extract_rar raises RuntimeError with install instructions when unrar is absent."""
+        import pytest
+
+        from vtsearch.datasets.downloader.video import _extract_rar
+
+        rar_file = tmp_path / "test.rar"
+        rar_file.write_bytes(b"Rar!")
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("unrar")):
+            with pytest.raises(RuntimeError, match="unrar"):
+                _extract_rar(rar_file, tmp_path / "out")
+
+
+# ---------------------------------------------------------------------------
+# UCF-101 Full
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadUcf101Full:
+    """Verify download_ucf101_full downloads, extracts, and moves to VIDEO_DIR."""
+
+    def _make_ucf101_zip(self, zip_path: Path) -> None:
+        """Create a minimal UCF-101.zip with category subdirectories."""
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for cat in ("Archery", "Basketball", "Diving"):
+                for i in range(3):
+                    fname = f"UCF-101/{cat}/v_{cat}_g{i:02d}_c01.avi"
+                    zf.writestr(fname, b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+    def test_extracts_into_category_dirs(self, tmp_path):
+        """download_ucf101_full should create per-category dirs with .avi files."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+        zip_path = tmp_path / "UCF-101.zip"
+        self._make_ucf101_zip(zip_path)
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch(
+                "vtsearch.datasets.downloader.core.download_file_with_progress",
+                lambda url, dest, size, cb: shutil.copy(str(zip_path), str(dest)),
+            ),
+        ):
+            result = vid_module.download_ucf101_full(on_progress=lambda *a: None)
+
+        assert result.exists()
+        assert result.name == "ucf101_full"
+        assert (result / "Archery").is_dir()
+        assert (result / "Basketball").is_dir()
+        assert (result / "Diving").is_dir()
+        assert len(list((result / "Archery").glob("*.avi"))) == 3
+
+    def test_staging_dir_cleaned_up(self, tmp_path):
+        """The UCF-101 staging directory should be removed after moving."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+        zip_path = tmp_path / "UCF-101.zip"
+        self._make_ucf101_zip(zip_path)
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch(
+                "vtsearch.datasets.downloader.core.download_file_with_progress",
+                lambda url, dest, size, cb: shutil.copy(str(zip_path), str(dest)),
+            ),
+        ):
+            vid_module.download_ucf101_full(on_progress=lambda *a: None)
+
+        staging = data_dir / "UCF-101"
+        assert not staging.exists(), "Staging directory should be removed after moving"
+
+    def test_skips_if_already_present(self, tmp_path):
+        """If ucf101_full/ already has videos, skip download entirely."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        video_dir = data_dir / "video"
+        ucf_dir = video_dir / "ucf101_full" / "Archery"
+        ucf_dir.mkdir(parents=True)
+        (ucf_dir / "v_Archery_g01_c01.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+        download_called = []
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch(
+                "vtsearch.datasets.downloader.core.download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = vid_module.download_ucf101_full(on_progress=lambda *a: None)
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert result.exists()
+
+
+# ---------------------------------------------------------------------------
+# KTH Actions
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadKth:
+    """Verify download_kth downloads and extracts per-action zips."""
+
+    def _make_kth_zip(self, zip_path: Path, action: str) -> None:
+        """Create a minimal KTH action zip with .avi files."""
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for person in range(1, 4):
+                for scenario in range(1, 3):
+                    fname = f"person{person:02d}_{action}_d{scenario}_uncomp.avi"
+                    zf.writestr(fname, b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+    def test_extracts_into_category_dirs(self, tmp_path):
+        """download_kth should create per-action dirs with .avi files."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+
+        # Pre-create zip fixtures for each action.
+        action_zips = {}
+        for action in ("walking", "jogging", "running", "boxing", "handwaving", "handclapping"):
+            zp = tmp_path / f"{action}.zip"
+            self._make_kth_zip(zp, action)
+            action_zips[action] = zp
+
+        def fake_download(url, dest, size, cb):
+            # Extract the action name from the URL.
+            action = Path(url).stem
+            shutil.copy(str(action_zips[action]), str(dest))
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(vid_module._core, "download_file_with_progress", fake_download),
+        ):
+            result = vid_module.download_kth(on_progress=lambda *a: None)
+
+        assert result.exists()
+        assert result.name == "kth"
+        for action in ("walking", "jogging", "running", "boxing", "handwaving", "handclapping"):
+            cat_dir = result / action
+            assert cat_dir.is_dir(), f"Missing category dir: {action}"
+            avi_files = list(cat_dir.glob("*.avi"))
+            # 3 persons × 2 scenarios = 6 files per action
+            assert len(avi_files) == 6, f"Expected 6 .avi files for {action}, got {len(avi_files)}"
+
+    def test_skips_if_already_present(self, tmp_path):
+        """If kth/ already has videos, skip download entirely."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        video_dir = data_dir / "video"
+        kth_dir = video_dir / "kth" / "walking"
+        kth_dir.mkdir(parents=True)
+        (kth_dir / "person01_walking_d1_uncomp.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+
+        download_called = []
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(
+                vid_module._core,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = vid_module.download_kth(on_progress=lambda *a: None)
+
+        assert not download_called, "download should be skipped when cache exists"
+        assert result.exists()
+
+    def test_skips_already_extracted_actions(self, tmp_path):
+        """Actions already extracted should not be re-downloaded."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+
+        # Pre-populate one action
+        walking_dir = video_dir / "kth" / "walking"
+        walking_dir.mkdir(parents=True)
+        (walking_dir / "person01_walking_d1_uncomp.avi").write_bytes(
+            b"RIFF" + b"\x00" * 20 + b"AVI "
+        )
+
+        downloaded_urls = []
+
+        def fake_download(url, dest, size, cb):
+            downloaded_urls.append(url)
+            action = Path(url).stem
+            zp = tmp_path / f"{action}.zip"
+            self._make_kth_zip(zp, action)
+            shutil.copy(str(zp), str(dest))
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(vid_module._core, "download_file_with_progress", fake_download),
+        ):
+            vid_module.download_kth(on_progress=lambda *a: None)
+
+        # walking should NOT have been downloaded (already present)
+        walking_urls = [u for u in downloaded_urls if "walking" in u]
+        assert not walking_urls, "walking action should be skipped"
+        # Other actions SHOULD have been downloaded
+        assert len(downloaded_urls) == 5  # all except walking
+
+    def test_temp_zips_cleaned_up(self, tmp_path):
+        """Temp zip files should be removed after extraction."""
+        from vtsearch.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+
+        def fake_download(url, dest, size, cb):
+            action = Path(url).stem
+            zp = tmp_path / f"{action}.zip"
+            self._make_kth_zip(zp, action)
+            shutil.copy(str(zp), str(dest))
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch.object(vid_module._core, "download_file_with_progress", fake_download),
+        ):
+            vid_module.download_kth(on_progress=lambda *a: None)
+
+        leftover = [p for p in data_dir.iterdir() if p.name.startswith(".dl_")]
+        assert not leftover, f"Temp zip files should be cleaned up: {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# Demo dataset registration
+# ---------------------------------------------------------------------------
+
+
+class TestVideoDemoDatasetRegistration:
+    """Verify new video demo datasets appear in the registry."""
+
+    def test_hmdb51_variants_registered(self):
+        """HMDB51 S/M/L/A variants should appear in demo_datasets."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        ids = [d.id for d in mt.demo_datasets]
+        for variant in ("hmdb51_s", "hmdb51_m", "hmdb51_l", "hmdb51_a"):
+            assert variant in ids, f"{variant} not found in demo_datasets"
+
+    def test_ucf101_full_variants_registered(self):
+        """UCF-101 Full S/M/L/A variants should appear in demo_datasets."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        ids = [d.id for d in mt.demo_datasets]
+        for variant in ("ucf101_full_s", "ucf101_full_m", "ucf101_full_l", "ucf101_full_a"):
+            assert variant in ids, f"{variant} not found in demo_datasets"
+
+    def test_kth_variants_registered(self):
+        """KTH Actions S/M/L/A variants should appear in demo_datasets."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        ids = [d.id for d in mt.demo_datasets]
+        for variant in ("kth_s", "kth_m", "kth_l", "kth_a"):
+            assert variant in ids, f"{variant} not found in demo_datasets"
+
+    def test_hmdb51_has_51_categories(self):
+        """HMDB51 demo datasets should reference all 51 action categories."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        hmdb = next(d for d in mt.demo_datasets if d.id == "hmdb51_a")
+        assert len(hmdb.categories) == 51
+
+    def test_ucf101_full_has_101_categories(self):
+        """UCF-101 Full demo datasets should reference all 101 action categories."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        ucf = next(d for d in mt.demo_datasets if d.id == "ucf101_full_a")
+        assert len(ucf.categories) == 101
+
+    def test_kth_has_6_categories(self):
+        """KTH Actions demo datasets should reference all 6 action categories."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        kth = next(d for d in mt.demo_datasets if d.id == "kth_a")
+        assert len(kth.categories) == 6
+
+    def test_source_dirs_registered(self):
+        """New video sources should appear in the demo importer source dirs."""
+        from vtsearch.datasets.importers.demo import _source_directory, _SOURCE_DIRS
+
+        # Force lazy init
+        _source_directory("hmdb51")
+
+        assert "hmdb51" in _SOURCE_DIRS
+        assert "ucf101_full" in _SOURCE_DIRS
+        assert "kth" in _SOURCE_DIRS
+
+
+# ---------------------------------------------------------------------------
+# load_demo_source — video (hmdb51, ucf101_full, kth)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDemoSourceHmdb51:
+    """VideoMediaType.load_demo_source with source='hmdb51'."""
+
+    def _make_mock_embedder(self):
+        mock_emb = MagicMock()
+        mock_emb.name = "xclip"
+        mock_emb.media_type_id = "video"
+        mock_emb._model = True
+        mock_emb.embed_media = MagicMock(return_value=np.zeros(512))
+        return mock_emb
+
+    def test_hmdb51_source_populates_clips(self, tmp_path):
+        """load_demo_source with source='hmdb51' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import loader as loader_module
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        fake_metadata = {
+            "brush_hair/brush_hair_video_0.avi": {
+                "category": "brush_hair",
+                "path": tmp_path / "brush_hair_video_0.avi",
+            },
+            "cartwheel/cartwheel_video_0.avi": {
+                "category": "cartwheel",
+                "path": tmp_path / "cartwheel_video_0.avi",
+            },
+        }
+        for meta in fake_metadata.values():
+            meta["path"].write_bytes(b"RIFF" + b"\x00" * 40)
+
+        mt = VideoMediaType()
+        mt.load_media_data = MagicMock(return_value={"media_bytes": b"", "duration": 2.5})
+        mock_emb = self._make_mock_embedder()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_hmdb51", return_value=tmp_path),
+            patch.object(loader_module, "load_video_metadata_from_folders", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="hmdb51",
+                categories=["brush_hair", "cartwheel"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+            )
+
+        assert len(clips) == 2
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"brush_hair", "cartwheel"}
+
+
+class TestLoadDemoSourceUcf101Full:
+    """VideoMediaType.load_demo_source with source='ucf101_full'."""
+
+    def _make_mock_embedder(self):
+        mock_emb = MagicMock()
+        mock_emb.name = "xclip"
+        mock_emb.media_type_id = "video"
+        mock_emb._model = True
+        mock_emb.embed_media = MagicMock(return_value=np.zeros(512))
+        return mock_emb
+
+    def test_ucf101_full_source_populates_clips(self, tmp_path):
+        """load_demo_source with source='ucf101_full' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import loader as loader_module
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        fake_metadata = {
+            "Archery/v_Archery_g01_c01.avi": {
+                "category": "Archery",
+                "path": tmp_path / "v_Archery_g01_c01.avi",
+            },
+            "Diving/v_Diving_g01_c01.avi": {
+                "category": "Diving",
+                "path": tmp_path / "v_Diving_g01_c01.avi",
+            },
+        }
+        for meta in fake_metadata.values():
+            meta["path"].write_bytes(b"RIFF" + b"\x00" * 40)
+
+        mt = VideoMediaType()
+        mt.load_media_data = MagicMock(return_value={"media_bytes": b"", "duration": 7.0})
+        mock_emb = self._make_mock_embedder()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_ucf101_full", return_value=tmp_path),
+            patch.object(loader_module, "load_video_metadata_from_folders", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="ucf101_full",
+                categories=["Archery", "Diving"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+            )
+
+        assert len(clips) == 2
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"Archery", "Diving"}
+
+
+class TestLoadDemoSourceKth:
+    """VideoMediaType.load_demo_source with source='kth'."""
+
+    def _make_mock_embedder(self):
+        mock_emb = MagicMock()
+        mock_emb.name = "xclip"
+        mock_emb.media_type_id = "video"
+        mock_emb._model = True
+        mock_emb.embed_media = MagicMock(return_value=np.zeros(512))
+        return mock_emb
+
+    def test_kth_source_populates_clips(self, tmp_path):
+        """load_demo_source with source='kth' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import loader as loader_module
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        fake_metadata = {
+            "walking/person01_walking_d1_uncomp.avi": {
+                "category": "walking",
+                "path": tmp_path / "person01_walking_d1_uncomp.avi",
+            },
+            "boxing/person01_boxing_d1_uncomp.avi": {
+                "category": "boxing",
+                "path": tmp_path / "person01_boxing_d1_uncomp.avi",
+            },
+        }
+        for meta in fake_metadata.values():
+            meta["path"].write_bytes(b"RIFF" + b"\x00" * 40)
+
+        mt = VideoMediaType()
+        mt.load_media_data = MagicMock(return_value={"media_bytes": b"", "duration": 12.0})
+        mock_emb = self._make_mock_embedder()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_kth", return_value=tmp_path),
+            patch.object(loader_module, "load_video_metadata_from_folders", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="kth",
+                categories=["walking", "boxing"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+            )
+
+        assert len(clips) == 2
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"walking", "boxing"}
+
+    def test_unsupported_source_raises(self):
+        """Non-existent sources still raise ValueError."""
+        from vtsearch.media.video.media_type import VideoMediaType
+
+        mt = VideoMediaType()
+        import pytest
+
+        with pytest.raises(ValueError, match="Unsupported video source"):
+            mt.load_demo_source(
+                source="unknown_source",
+                categories=[],
+                slice_start=0,
+                slice_end=10,
+                clips={},
+                on_progress=lambda *a: None,
+            )

--- a/vtsearch/datasets/downloader/__init__.py
+++ b/vtsearch/datasets/downloader/__init__.py
@@ -36,9 +36,14 @@ from vtsearch.datasets.downloader.core import (
     FOOD101_URL,
     GTZAN_DOWNLOAD_SIZE_MB,
     GTZAN_URL,
+    HMDB51_DOWNLOAD_SIZE_MB,
+    HMDB51_URL,
     IMAGE_DIR,
     IMDB_DOWNLOAD_SIZE_MB,
     IMDB_URL,
+    KTH_ACTIONS,
+    KTH_BASE_URL,
+    KTH_DOWNLOAD_SIZE_MB,
     OXFORD_FLOWERS_DOWNLOAD_SIZE_MB,
     OXFORD_FLOWERS_LABELS_URL,
     OXFORD_FLOWERS_URL,
@@ -47,6 +52,8 @@ from vtsearch.datasets.downloader.core import (
     SPEECH_COMMANDS_V2_URL,
     STANFORD_DOGS_DOWNLOAD_SIZE_MB,
     STANFORD_DOGS_URL,
+    UCF101_FULL_DOWNLOAD_SIZE_MB,
+    UCF101_FULL_URL,
     UCF101_SUBSET_DOWNLOAD_SIZE_MB,
     UCF101_SUBSET_URL,
     UCSF_IDL_API_URL,
@@ -83,7 +90,12 @@ from vtsearch.datasets.downloader.images import (
 )
 
 # Video downloaders
-from vtsearch.datasets.downloader.video import download_ucf101_subset
+from vtsearch.datasets.downloader.video import (
+    download_hmdb51,
+    download_kth,
+    download_ucf101_full,
+    download_ucf101_subset,
+)
 
 # Text downloaders
 from vtsearch.datasets.downloader.text import (
@@ -122,9 +134,14 @@ __all__ = [
     "FOOD101_URL",
     "GTZAN_DOWNLOAD_SIZE_MB",
     "GTZAN_URL",
+    "HMDB51_DOWNLOAD_SIZE_MB",
+    "HMDB51_URL",
     "IMAGE_DIR",
     "IMDB_DOWNLOAD_SIZE_MB",
     "IMDB_URL",
+    "KTH_ACTIONS",
+    "KTH_BASE_URL",
+    "KTH_DOWNLOAD_SIZE_MB",
     "OXFORD_FLOWERS_DOWNLOAD_SIZE_MB",
     "OXFORD_FLOWERS_LABELS_URL",
     "OXFORD_FLOWERS_URL",
@@ -134,6 +151,8 @@ __all__ = [
     "SPEECH_COMMANDS_V2_URL",
     "STANFORD_DOGS_DOWNLOAD_SIZE_MB",
     "STANFORD_DOGS_URL",
+    "UCF101_FULL_DOWNLOAD_SIZE_MB",
+    "UCF101_FULL_URL",
     "UCF101_SUBSET_DOWNLOAD_SIZE_MB",
     "UCF101_SUBSET_URL",
     "UCSF_IDL_API_URL",
@@ -157,6 +176,9 @@ __all__ = [
     "download_oxford_flowers",
     "download_stanford_dogs",
     # Video
+    "download_hmdb51",
+    "download_kth",
+    "download_ucf101_full",
     "download_ucf101_subset",
     # Text
     "download_20newsgroups",

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -44,6 +44,16 @@ STANFORD_DOGS_URL = "https://huggingface.co/datasets/Alanox/stanford-dogs/resolv
 UCSF_IDL_API_URL = "https://metadata.idl.ucsf.edu/solr/ltdl3/query"
 UCSF_IDL_DOWNLOAD_URL = "https://download.industrydocuments.ucsf.edu"
 
+# HMDB51
+HMDB51_URL = "http://serre-lab.clps.brown.edu/wp-content/uploads/2013/10/hmdb51_org.rar"
+
+# UCF101 full (ZIP mirror on HuggingFace — no auth required)
+UCF101_FULL_URL = "https://huggingface.co/datasets/quchenyuan/UCF101-ZIP/resolve/main/UCF-101.zip"
+
+# KTH Actions
+KTH_BASE_URL = "https://www.csc.kth.se/cvap/actions/"
+KTH_ACTIONS = ("walking", "jogging", "running", "boxing", "handwaving", "handclapping")
+
 # Demo dataset download size estimates (MB)
 ESC50_DOWNLOAD_SIZE_MB = 600
 SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB = 150
@@ -62,6 +72,9 @@ FOOD101_DOWNLOAD_SIZE_MB = 5000
 EUROSAT_DOWNLOAD_SIZE_MB = 90
 STANFORD_DOGS_DOWNLOAD_SIZE_MB = 750
 UCSF_IDL_DOWNLOAD_SIZE_MB = 50
+HMDB51_DOWNLOAD_SIZE_MB = 2000
+UCF101_FULL_DOWNLOAD_SIZE_MB = 6960
+KTH_DOWNLOAD_SIZE_MB = 1150
 
 ProgressCallback = Callable[[str, str, int, int], None]
 

--- a/vtsearch/datasets/downloader/video.py
+++ b/vtsearch/datasets/downloader/video.py
@@ -1,10 +1,33 @@
-"""Video dataset downloaders: UCF-101 subset."""
+"""Video dataset downloaders: UCF-101 subset, UCF-101 full, HMDB51, KTH Actions."""
 
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional
 
 from vtsearch.datasets.downloader import core as _core
 from vtsearch.datasets.downloader.core import ProgressCallback
+
+
+def _extract_rar(rar_path: Path, extract_to: Path) -> None:
+    """Extract a RAR archive using the system ``unrar`` command.
+
+    Raises ``RuntimeError`` with installation instructions when ``unrar``
+    is not found on the system PATH.
+    """
+    extract_to.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["unrar", "x", "-o+", "-y", str(rar_path), str(extract_to) + "/"],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "The 'unrar' command is required to extract HMDB51 but was not found. "
+            "Install it with: apt-get install unrar (Debian/Ubuntu) or "
+            "brew install unrar (macOS)."
+        ) from None
 
 
 def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Path:
@@ -72,5 +95,179 @@ def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Pa
 
     # Clean up the extracted staging directory.
     shutil.rmtree(extract_dir, ignore_errors=True)
+
+    return video_dir
+
+
+def download_hmdb51(on_progress: Optional[ProgressCallback] = None) -> Path:
+    """Download and extract the HMDB51 dataset.
+
+    Downloads the ~2 GB ``hmdb51_org.rar`` archive from the Serre Lab,
+    extracts the outer RAR (which contains 51 per-category ``.rar`` files),
+    then extracts each inner RAR into its own category subdirectory under
+    ``VIDEO_DIR / "hmdb51"``.
+
+    Requires the ``unrar`` command to be installed on the system.
+
+    Args:
+        on_progress: Optional progress callback.
+
+    Returns:
+        Path to the ``hmdb51/`` directory inside ``VIDEO_DIR``, containing
+        one subdirectory per action category with ``.avi`` files.
+    """
+    if on_progress is None:
+        on_progress = _core._default_progress()
+
+    video_dir = _core.VIDEO_DIR / "hmdb51"
+    _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
+
+    # Already downloaded and extracted.
+    if video_dir.exists() and any(video_dir.glob("*/*.avi")):
+        return video_dir
+
+    import uuid
+
+    unique_id = uuid.uuid4().hex[:8]
+    archive_path = _core.DATA_DIR / f".dl_{unique_id}_hmdb51_org.rar"
+    staging_dir = _core.DATA_DIR / f".extract_{unique_id}_hmdb51"
+    _core.DATA_DIR.mkdir(exist_ok=True, parents=True)
+
+    try:
+        on_progress("downloading", "Starting HMDB51 download...", 0, 0)
+        _core.download_file_with_progress(
+            _core.HMDB51_URL,
+            archive_path,
+            _core.HMDB51_DOWNLOAD_SIZE_MB * 1024 * 1024,
+            on_progress,
+        )
+
+        if video_dir.exists() and any(video_dir.glob("*/*.avi")):
+            return video_dir
+
+        # Extract outer RAR → 51 per-category .rar files.
+        on_progress("downloading", "Extracting HMDB51 (outer archive)...", 0, 0)
+        _extract_rar(archive_path, staging_dir)
+
+        # Extract each inner .rar into a category subdirectory.
+        inner_rars = sorted(staging_dir.glob("*.rar"))
+        total_rars = len(inner_rars)
+        video_dir.mkdir(parents=True, exist_ok=True)
+
+        for i, rar_file in enumerate(inner_rars):
+            cat_name = rar_file.stem  # e.g. "brush_hair"
+            on_progress("downloading", f"Extracting HMDB51 ({cat_name})...", i + 1, total_rars)
+            cat_dir = video_dir / cat_name
+            _extract_rar(rar_file, cat_dir)
+    finally:
+        archive_path.unlink(missing_ok=True)
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+    return video_dir
+
+
+def download_ucf101_full(on_progress: Optional[ProgressCallback] = None) -> Path:
+    """Download and extract the full UCF-101 dataset (101 action classes).
+
+    Downloads the ~7 GB ``UCF-101.zip`` from a HuggingFace mirror and
+    extracts it into ``VIDEO_DIR / "ucf101_full"`` with one subdirectory
+    per action class.
+
+    Args:
+        on_progress: Optional progress callback.
+
+    Returns:
+        Path to the ``ucf101_full/`` directory inside ``VIDEO_DIR``,
+        containing 101 category subdirectories with ``.avi`` files.
+    """
+    if on_progress is None:
+        on_progress = _core._default_progress()
+
+    video_dir = _core.VIDEO_DIR / "ucf101_full"
+    _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
+
+    # Already downloaded and extracted.
+    if video_dir.exists() and any(video_dir.glob("*/*.avi")):
+        return video_dir
+
+    extract_dir = _core.DATA_DIR / "UCF-101"
+    _core._download_and_extract(
+        url=_core.UCF101_FULL_URL,
+        archive_name="UCF-101.zip",
+        extract_to=_core.DATA_DIR,
+        check_path=extract_dir,
+        download_size_mb=_core.UCF101_FULL_DOWNLOAD_SIZE_MB,
+        dataset_name="UCF-101 (full)",
+        on_progress=on_progress,
+    )
+
+    # Move extracted UCF-101/ to VIDEO_DIR/ucf101_full/.
+    video_dir.mkdir(parents=True, exist_ok=True)
+    _core._move_tree_contents(extract_dir, video_dir)
+    shutil.rmtree(extract_dir, ignore_errors=True)
+
+    return video_dir
+
+
+def download_kth(on_progress: Optional[ProgressCallback] = None) -> Path:
+    """Download and extract the KTH Actions dataset (6 action classes).
+
+    Downloads six individual ZIP files (one per action, ~1.1 GB total)
+    from the KTH website and extracts each into its own category
+    subdirectory under ``VIDEO_DIR / "kth"``.
+
+    Args:
+        on_progress: Optional progress callback.
+
+    Returns:
+        Path to the ``kth/`` directory inside ``VIDEO_DIR``, containing
+        six category subdirectories (boxing, handclapping, handwaving,
+        jogging, running, walking) with ``.avi`` files.
+    """
+    if on_progress is None:
+        on_progress = _core._default_progress()
+
+    video_dir = _core.VIDEO_DIR / "kth"
+    _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
+
+    # Already downloaded and extracted.
+    if video_dir.exists() and any(video_dir.glob("*/*.avi")):
+        return video_dir
+
+    video_dir.mkdir(parents=True, exist_ok=True)
+    actions = _core.KTH_ACTIONS
+    total = len(actions)
+
+    for i, action in enumerate(actions):
+        cat_dir = video_dir / action
+        if cat_dir.exists() and any(cat_dir.glob("*.avi")):
+            continue  # This action already extracted.
+
+        import uuid
+        import zipfile
+
+        unique_id = uuid.uuid4().hex[:8]
+        zip_name = f"{action}.zip"
+        zip_path = _core.DATA_DIR / f".dl_{unique_id}_{zip_name}"
+
+        try:
+            url = f"{_core.KTH_BASE_URL}{zip_name}"
+            on_progress("downloading", f"Downloading KTH {action} ({i + 1}/{total})...", i, total)
+            _core.download_file_with_progress(url, zip_path, 0, on_progress)
+
+            on_progress("downloading", f"Extracting KTH {action}...", i + 1, total)
+            cat_dir.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                for member in zf.namelist():
+                    # Extract only .avi files, into the category directory.
+                    if member.lower().endswith(".avi"):
+                        basename = Path(member).name
+                        dest = cat_dir / basename
+                        if not dest.exists():
+                            with zf.open(member) as src, open(dest, "wb") as dst:
+                                shutil.copyfileobj(src, dst)
+        finally:
+            zip_path.unlink(missing_ok=True)
 
     return video_dir

--- a/vtsearch/datasets/downloader/video.py
+++ b/vtsearch/datasets/downloader/video.py
@@ -231,12 +231,15 @@ def download_kth(on_progress: Optional[ProgressCallback] = None) -> Path:
     video_dir = _core.VIDEO_DIR / "kth"
     _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
 
-    # Already downloaded and extracted.
-    if video_dir.exists() and any(video_dir.glob("*/*.avi")):
+    # Already downloaded and extracted (all actions present).
+    actions = _core.KTH_ACTIONS
+    if video_dir.exists() and all(
+        (video_dir / action).exists() and any((video_dir / action).glob("*.avi"))
+        for action in actions
+    ):
         return video_dir
 
     video_dir.mkdir(parents=True, exist_ok=True)
-    actions = _core.KTH_ACTIONS
     total = len(actions)
 
     for i, action in enumerate(actions):

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -206,6 +206,9 @@ def _source_directory(source: str) -> Path | None:
             "urbansound8k": DATA_DIR / "UrbanSound8K" / "audio",
             # Video sources
             "ucf101": video_dir / "ucf101",
+            "hmdb51": video_dir / "hmdb51",
+            "ucf101_full": video_dir / "ucf101_full",
+            "kth": video_dir / "kth",
         }
     return _SOURCE_DIRS.get(source)
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -185,13 +185,69 @@ class VideoMediaType(MediaType):
         "BandMarching", "BaseballPitch", "Basketball", "BasketballDunk", "BenchPress",
     ]
 
+    _HMDB51_CATEGORIES = [
+        "brush_hair", "cartwheel", "catch", "chew", "clap", "climb", "climb_stairs",
+        "dive", "draw_sword", "dribble", "drink", "eat", "fall_floor", "fencing",
+        "flic_flac", "golf", "handstand", "hit", "hug", "jump", "kick", "kick_ball",
+        "kiss", "laugh", "pick", "pour", "pullup", "punch", "push", "pushup",
+        "ride_bike", "ride_horse", "run", "shake_hands", "shoot_ball", "shoot_bow",
+        "shoot_gun", "sit", "situp", "smile", "smoke", "somersault", "stand",
+        "swing_baseball", "sword", "sword_exercise", "talk", "throw", "turn", "walk",
+        "wave",
+    ]
+
+    _UCF101_FULL_CATEGORIES = [
+        "ApplyEyeMakeup", "ApplyLipstick", "Archery", "BabyCrawling", "BalanceBeam",
+        "BandMarching", "BaseballPitch", "Basketball", "BasketballDunk", "BenchPress",
+        "Biking", "Billiards", "BlowDryHair", "BlowingCandles", "BodyWeightSquats",
+        "Bowling", "BoxingPunchingBag", "BoxingSpeedBag", "BreastStroke", "BrushingTeeth",
+        "CleanAndJerk", "CliffDiving", "CricketBowling", "CricketShot", "CuttingInKitchen",
+        "Diving", "Drumming", "Fencing", "FieldHockeyPenalty", "FloorGymnastics",
+        "FrisbeeCatch", "FrontCrawl", "GolfSwing", "Haircut", "Hammering",
+        "HammerThrow", "HandstandPushups", "HandstandWalking", "HeadMassage", "HighJump",
+        "HorseRace", "HorseRiding", "HulaHoop", "IceDancing", "JavelinThrow",
+        "JugglingBalls", "JumpingJack", "JumpRope", "Kayaking", "Knitting",
+        "LongJump", "Lunges", "MilitaryParade", "Mixing", "MoppingFloor",
+        "Nunchucks", "ParallelBars", "PizzaTossing", "PlayingCello", "PlayingDaf",
+        "PlayingDhol", "PlayingFlute", "PlayingGuitar", "PlayingPiano", "PlayingSitar",
+        "PlayingTabla", "PlayingViolin", "PoleVault", "PommelHorse", "PullUps",
+        "Punch", "PushUps", "Rafting", "RockClimbingIndoor", "RopeClimbing",
+        "Rowing", "SalsaSpin", "ShavingBeard", "Shotput", "SkateBoarding",
+        "Skiing", "Skijet", "SkyDiving", "SoccerJuggling", "SoccerPenalty",
+        "StillRings", "SumoWrestling", "Surfing", "Swing", "TableTennisShot",
+        "TaiChi", "TennisSwing", "ThrowDiscus", "TrampolineJumping", "Typing",
+        "UnevenBars", "VolleyballSpiking", "WalkingWithDog", "WallPushups",
+        "WritingOnBoard", "YoYo",
+    ]
+
+    _KTH_CATEGORIES = [
+        "boxing", "handclapping", "handwaving", "jogging", "running", "walking",
+    ]
+
     @property
     def demo_datasets(self) -> list:
-        from vtsearch.datasets.downloader import UCF101_SUBSET_DOWNLOAD_SIZE_MB, VIDEO_DIR  # noqa: PLC0415
+        from vtsearch.datasets.downloader import (  # noqa: PLC0415
+            HMDB51_DOWNLOAD_SIZE_MB,
+            KTH_DOWNLOAD_SIZE_MB,
+            UCF101_FULL_DOWNLOAD_SIZE_MB,
+            UCF101_SUBSET_DOWNLOAD_SIZE_MB,
+            VIDEO_DIR,
+        )
 
         cats = self._DEMO_CATEGORIES
         folder = VIDEO_DIR / "ucf101"
+
+        hmdb_cats = self._HMDB51_CATEGORIES
+        hmdb_folder = VIDEO_DIR / "hmdb51"
+
+        ucf_full_cats = self._UCF101_FULL_CATEGORIES
+        ucf_full_folder = VIDEO_DIR / "ucf101_full"
+
+        kth_cats = self._KTH_CATEGORIES
+        kth_folder = VIDEO_DIR / "kth"
+
         return [
+            # UCF-101 subset (10 classes, 171 MB download)
             DemoDataset(
                 id="ucf101_s", label="UCF-101 (S)",
                 description="Action recognition videos sourced from YouTube, covering sports and everyday activities.",
@@ -210,11 +266,93 @@ class VideoMediaType(MediaType):
                 categories=cats, source="ucf101", required_folder=folder,
                 slice_start=40, slice_end=150, download_size_mb=UCF101_SUBSET_DOWNLOAD_SIZE_MB,
             ),
+            # HMDB51 (51 action classes, ~2 GB download)
+            DemoDataset(
+                id="hmdb51_s", label="HMDB51 (S)",
+                description="Human motion clips from movies and web videos, covering 51 diverse action categories.",
+                categories=hmdb_cats, source="hmdb51", required_folder=hmdb_folder,
+                slice_start=0, slice_end=5, download_size_mb=HMDB51_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="hmdb51_m", label="HMDB51 (M)",
+                description="Human motion clips from movies and web videos, covering 51 diverse action categories.",
+                categories=hmdb_cats, source="hmdb51", required_folder=hmdb_folder,
+                slice_start=5, slice_end=15, download_size_mb=HMDB51_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="hmdb51_l", label="HMDB51 (L)",
+                description="Human motion clips from movies and web videos, covering 51 diverse action categories.",
+                categories=hmdb_cats, source="hmdb51", required_folder=hmdb_folder,
+                slice_start=15, slice_end=50, download_size_mb=HMDB51_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="hmdb51_a", label="HMDB51 (A)",
+                description="Human motion clips from movies and web videos, covering 51 diverse action categories.",
+                categories=hmdb_cats, source="hmdb51", required_folder=hmdb_folder,
+                slice_start=0, slice_end=None, download_size_mb=HMDB51_DOWNLOAD_SIZE_MB,
+            ),
+            # UCF-101 full (101 action classes, ~7 GB download)
+            DemoDataset(
+                id="ucf101_full_s", label="UCF-101 Full (S)",
+                description="Full UCF-101 with all 101 action classes — sports, instruments, daily activities.",
+                categories=ucf_full_cats, source="ucf101_full", required_folder=ucf_full_folder,
+                slice_start=0, slice_end=5, download_size_mb=UCF101_FULL_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="ucf101_full_m", label="UCF-101 Full (M)",
+                description="Full UCF-101 with all 101 action classes — sports, instruments, daily activities.",
+                categories=ucf_full_cats, source="ucf101_full", required_folder=ucf_full_folder,
+                slice_start=5, slice_end=15, download_size_mb=UCF101_FULL_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="ucf101_full_l", label="UCF-101 Full (L)",
+                description="Full UCF-101 with all 101 action classes — sports, instruments, daily activities.",
+                categories=ucf_full_cats, source="ucf101_full", required_folder=ucf_full_folder,
+                slice_start=15, slice_end=50, download_size_mb=UCF101_FULL_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="ucf101_full_a", label="UCF-101 Full (A)",
+                description="Full UCF-101 with all 101 action classes — sports, instruments, daily activities.",
+                categories=ucf_full_cats, source="ucf101_full", required_folder=ucf_full_folder,
+                slice_start=0, slice_end=None, download_size_mb=UCF101_FULL_DOWNLOAD_SIZE_MB,
+            ),
+            # KTH Actions (6 action classes, ~1.1 GB download)
+            DemoDataset(
+                id="kth_s", label="KTH Actions (S)",
+                description="Simple human actions in controlled settings — a classic action recognition benchmark.",
+                categories=kth_cats, source="kth", required_folder=kth_folder,
+                slice_start=0, slice_end=10, download_size_mb=KTH_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="kth_m", label="KTH Actions (M)",
+                description="Simple human actions in controlled settings — a classic action recognition benchmark.",
+                categories=kth_cats, source="kth", required_folder=kth_folder,
+                slice_start=10, slice_end=30, download_size_mb=KTH_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="kth_l", label="KTH Actions (L)",
+                description="Simple human actions in controlled settings — a classic action recognition benchmark.",
+                categories=kth_cats, source="kth", required_folder=kth_folder,
+                slice_start=30, slice_end=70, download_size_mb=KTH_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="kth_a", label="KTH Actions (A)",
+                description="Simple human actions in controlled settings — a classic action recognition benchmark.",
+                categories=kth_cats, source="kth", required_folder=kth_folder,
+                slice_start=0, slice_end=None, download_size_mb=KTH_DOWNLOAD_SIZE_MB,
+            ),
         ]
 
     # ------------------------------------------------------------------
     # Demo dataset loading
     # ------------------------------------------------------------------
+
+    _VIDEO_SOURCE_DOWNLOADERS = {
+        "ucf101": "download_ucf101_subset",
+        "hmdb51": "download_hmdb51",
+        "ucf101_full": "download_ucf101_full",
+        "kth": "download_kth",
+    }
 
     def load_demo_source(self, source, categories, slice_start, slice_end, clips, on_progress=None, embedder=None):
         import hashlib  # noqa: PLC0415
@@ -232,13 +370,15 @@ class VideoMediaType(MediaType):
                 raise ValueError(f"No embedders registered for media type {self.type_id!r}")
             embedder = avail[0]
 
-        if source != "ucf101":
+        downloader_name = self._VIDEO_SOURCE_DOWNLOADERS.get(source)
+        if downloader_name is None:
             raise ValueError(f"Unsupported video source: {source!r}")
 
-        from vtsearch.datasets.downloader import download_ucf101_subset  # noqa: PLC0415
+        import vtsearch.datasets.downloader as dl_module  # noqa: PLC0415
         from vtsearch.datasets.loader import load_video_metadata_from_folders  # noqa: PLC0415
 
-        video_dir = download_ucf101_subset(on_progress=on_progress)
+        download_fn = getattr(dl_module, downloader_name)
+        video_dir = download_fn(on_progress=on_progress)
         metadata = load_video_metadata_from_folders(video_dir, categories)
 
         by_cat: dict[str, list] = {}
@@ -251,7 +391,7 @@ class VideoMediaType(MediaType):
             video_files.extend(by_cat.get(cat, [])[slice_start:slice_end])
 
         if getattr(embedder, "_model", None) is None:
-            on_progress("loading", "Loading video embedding model…", 0, 0)
+            on_progress("loading", "Loading video embedding model\u2026", 0, 0)
             original_cb = embedder._on_progress
             embedder._on_progress = on_progress
             try:


### PR DESCRIPTION
## Summary
This PR adds support for downloading and managing three major video action recognition datasets: HMDB51 (51 action classes), UCF-101 Full (101 action classes), and KTH Actions (6 action classes). These datasets complement the existing UCF-101 subset downloader and are registered as demo datasets with S/M/L/A size variants.

## Key Changes

### New Video Dataset Downloaders
- **`download_hmdb51()`**: Downloads the ~2 GB `hmdb51_org.rar` archive from Serre Lab, extracts nested RAR files (outer RAR contains 51 per-category RARs), and organizes videos into category subdirectories. Requires system `unrar` command.
- **`download_ucf101_full()`**: Downloads the full ~7 GB UCF-101 dataset (101 classes) from a HuggingFace mirror and extracts into category subdirectories.
- **`download_kth()`**: Downloads six individual ZIP files (one per action) from the KTH website (~1.1 GB total) and extracts each into its own category subdirectory.
- **`_extract_rar()`**: Helper function to extract RAR archives using the system `unrar` command with proper error handling and installation instructions.

### Demo Dataset Registration
- Added HMDB51 category list (51 actions) and registered 4 variants: `hmdb51_s`, `hmdb51_m`, `hmdb51_l`, `hmdb51_a`
- Added UCF-101 Full category list (101 actions) and registered 4 variants: `ucf101_full_s`, `ucf101_full_m`, `ucf101_full_l`, `ucf101_full_a`
- Added KTH Actions category list (6 actions) and registered 4 variants: `kth_s`, `kth_m`, `kth_l`, `kth_a`
- Updated `VideoMediaType.demo_datasets` property to include all new datasets with appropriate download sizes and slice ranges

### Core Infrastructure Updates
- Added download URLs and size constants to `core.py`: `HMDB51_URL`, `UCF101_FULL_URL`, `KTH_BASE_URL`, `KTH_ACTIONS`, and corresponding download size constants
- Updated demo importer source directory mapping to recognize `hmdb51`, `ucf101_full`, and `kth` sources
- Exported new downloaders and constants from `vtsearch.datasets.downloader` package

### Implementation Details
- **Caching**: All downloaders check for existing extracted videos and skip download if already present
- **Cleanup**: Temporary archive and staging files are properly cleaned up after extraction using try/finally blocks
- **Progress Tracking**: All downloaders support optional progress callbacks for user feedback
- **Incremental Extraction**: KTH downloader skips re-downloading actions that are already extracted
- **Error Handling**: RAR extraction includes helpful error messages with installation instructions when `unrar` is unavailable

### Testing
- Comprehensive test suite covering download, extraction, caching, and cleanup for all three datasets
- Tests for demo dataset registration and category counts
- Tests for `load_demo_source()` integration with each dataset
- Tests for unsupported source error handling
- Updated existing tests to be dataset-agnostic rather than hardcoded to UCF-101 subset

https://claude.ai/code/session_01CDwE1qsagJ4ug9kYuvcYHu