### PR TITLE
Fix symlinked package/module loading in PluginRegistry

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1388,6 +1388,104 @@ class TestSymlinkedImporterDiscovery:
                     del sys.modules[key]
 
 
+    def test_symlinked_package_sets_module_attributes(self, tmp_path):
+        """A symlinked package should have correct __name__, __package__,
+        and __path__ attributes after being loaded via spec_from_file_location."""
+        import os
+        import sys
+
+        from vtsearch.utils.registry import PluginRegistry
+
+        ext_pkg = tmp_path / "attr_check_importer"
+        ext_pkg.mkdir()
+        (ext_pkg / "__init__.py").write_text(
+            "from vtsearch.datasets.importers.base import DatasetImporter\n"
+            "from vtsearch.utils.registry import PluginField\n"
+            "\n"
+            "class _Imp(DatasetImporter):\n"
+            '    name = "attr_check_imp"\n'
+            '    display_name = "Attr Check"\n'
+            '    description = "Test module attributes"\n'
+            "    fields = [PluginField(key='path', label='Path', field_type='folder')]\n"
+            "    def run(self, field_values, medias): return []\n"
+            "\n"
+            "IMPORTER = _Imp()\n"
+        )
+
+        import importlib
+
+        parent = importlib.import_module("vtsearch.datasets.importers")
+        pkg_dir = os.path.dirname(parent.__file__)
+        link = os.path.join(pkg_dir, "attr_check_pkg")
+        os.symlink(str(ext_pkg), link)
+
+        try:
+            reg = PluginRegistry(
+                package="vtsearch.datasets.importers",
+                sentinel="IMPORTER",
+                label="dataset importer",
+            )
+            names = [p.name for p in reg.list()]
+            assert "attr_check_imp" in names
+
+            mod = sys.modules["vtsearch.datasets.importers.attr_check_pkg"]
+            assert mod.__name__ == "vtsearch.datasets.importers.attr_check_pkg"
+            # __path__ should be set (it's a package)
+            assert hasattr(mod, "__path__")
+            assert len(mod.__path__) == 1
+        finally:
+            os.unlink(link)
+            for key in list(sys.modules):
+                if "attr_check_pkg" in key:
+                    del sys.modules[key]
+
+    def test_symlinked_flat_module_is_discovered(self, tmp_path):
+        """A symlink to a .py file should be discovered when
+        discover_modules=True."""
+        import os
+        import sys
+
+        from vtsearch.utils.registry import PluginRegistry
+
+        # Create an external .py module with a sentinel.
+        ext_module = tmp_path / "my_flat_source.py"
+        ext_module.write_text(
+            "class _Src:\n"
+            '    name = "symlinked_flat_mod"\n'
+            "\n"
+            "FAKE_SENTINEL = _Src()\n"
+        )
+
+        # We need a real package dir with __init__.py for the registry.
+        pkg_dir = tmp_path / "fake_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+
+        # Symlink the .py file into the package.
+        link = pkg_dir / "linked_source.py"
+        os.symlink(str(ext_module), str(link))
+
+        # Register the fake package so importlib can find it.
+        sys.modules["_test_flat_pkg"] = type(sys)("_test_flat_pkg")
+        sys.modules["_test_flat_pkg"].__file__ = str(pkg_dir / "__init__.py")
+        sys.modules["_test_flat_pkg"].__path__ = [str(pkg_dir)]
+        sys.modules["_test_flat_pkg"].__package__ = "_test_flat_pkg"
+
+        try:
+            reg = PluginRegistry(
+                package="_test_flat_pkg",
+                sentinel="FAKE_SENTINEL",
+                label="test source",
+                discover_modules=True,
+            )
+            names = [p.name for p in reg.list()]
+            assert "symlinked_flat_mod" in names
+        finally:
+            for key in list(sys.modules):
+                if "_test_flat_pkg" in key:
+                    del sys.modules[key]
+
+
 class TestRglobFollowSymlinks:
     """rglob_follow_symlinks should descend into symlinked directories."""
 

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import importlib.util
+import sys
 import threading
 import warnings
 from dataclasses import dataclass, field
@@ -222,10 +224,9 @@ class PluginRegistry(Generic[T]):
     def _discover(self) -> None:
         """Scan sub-packages (and optionally flat modules) for sentinel objects.
 
-        Uses direct filesystem scanning instead of :func:`pkgutil.iter_modules`
-        so that symlinked directories are reliably discovered.  A symlink to a
-        package directory (containing ``__init__.py``) is treated identically to
-        a regular sub-package.
+        Uses direct filesystem scanning so that symlinked directories are
+        reliably discovered.  A symlink to a package directory (containing
+        ``__init__.py``) is treated identically to a regular sub-package.
 
         When :attr:`_discover_modules` is ``True``, also scans ``.py`` files
         (excluding ``__init__.py`` and ``base.py``) for the sentinel.
@@ -245,23 +246,48 @@ class PluginRegistry(Generic[T]):
                 # symlinks whose names include an extension or suffix.
                 if "." in entry.name:
                     continue
-                if not (entry / "__init__.py").exists():
+                init_path = entry / "__init__.py"
+                if not init_path.exists():
                     continue
-                self._try_load(entry.name)
+                self._try_load(entry.name, file_path=init_path if entry.is_symlink() else None)
             # Flat modules (.py files)
             elif self._discover_modules and entry.is_file() and entry.suffix == ".py":
                 if entry.name in ("__init__.py", "base.py"):
                     continue
-                self._try_load(entry.stem)
+                self._try_load(entry.stem, file_path=entry if entry.is_symlink() else None)
 
-    def _try_load(self, module_name: str) -> None:
-        """Import *module_name* under this registry's package and register its sentinel."""
+    def _try_load(self, module_name: str, *, file_path: Path | None = None) -> None:
+        """Import *module_name* under this registry's package and register its sentinel.
+
+        When *file_path* is given (symlinked entries), uses
+        :func:`importlib.util.spec_from_file_location` to load the module
+        directly from the resolved path.  Python's default ``FileFinder`` can
+        miss symlinked packages on some platforms because its directory cache
+        may not follow symlinks consistently.
+        """
+        full_name = f"{self._package}.{module_name}"
         try:
-            mod = importlib.import_module(f"{self._package}.{module_name}")
+            if file_path is not None:
+                resolved = file_path.resolve()
+                is_package = resolved.name == "__init__.py"
+                spec = importlib.util.spec_from_file_location(
+                    full_name,
+                    str(resolved),
+                    submodule_search_locations=[str(resolved.parent)] if is_package else None,
+                )
+                if spec is None or spec.loader is None:  # pragma: no cover
+                    return
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules[full_name] = mod
+                spec.loader.exec_module(mod)
+            else:
+                mod = importlib.import_module(full_name)
             plugin = getattr(mod, self._sentinel, None)
             if plugin is not None:
                 self._items[plugin.name] = plugin
         except Exception as exc:  # pragma: no cover
+            # Clean up partially-registered module on failure.
+            sys.modules.pop(full_name, None)
             warnings.warn(
                 f"Failed to load {self._label} '{module_name}': {exc}",
                 stacklevel=2,


### PR DESCRIPTION
## Summary
Fixes an issue where symlinked packages and modules were not being reliably discovered and loaded by `PluginRegistry`. The problem occurred because Python's default `FileFinder` can miss symlinked entries on some platforms due to inconsistent directory caching behavior.

## Key Changes
- **Modified `_discover()` method**: Now passes file paths to `_try_load()` for symlinked entries (both packages and flat modules), enabling direct loading via `importlib.util.spec_from_file_location()`
- **Enhanced `_try_load()` method**: 
  - Added optional `file_path` parameter to handle symlinked entries
  - When `file_path` is provided, uses `spec_from_file_location()` to load directly from the resolved path instead of relying on the standard import machinery
  - Properly sets `submodule_search_locations` for symlinked packages to ensure they're recognized as packages
  - Cleans up `sys.modules` on load failure to prevent partial registration
- **Added comprehensive tests**:
  - `test_symlinked_package_sets_module_attributes`: Verifies symlinked packages have correct `__name__`, `__package__`, and `__path__` attributes
  - `test_symlinked_flat_module_is_discovered`: Verifies symlinked `.py` files are discovered when `discover_modules=True`

## Implementation Details
- Symlinked entries are detected using `entry.is_symlink()` during directory scanning
- The resolved path is obtained via `.resolve()` to handle symlink chains
- Package detection is based on whether the resolved path is an `__init__.py` file
- Error handling includes cleanup of partially-registered modules from `sys.modules`

https://claude.ai/code/session_01K22Ys1XkesmJAB7pFqAZX2