### PR TITLE
Switch default image embedder from CLIP to SigLIP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-Media explorer web app for browsing/voting on audio, images, text, video, or documents. Semantic sorting (LAION-CLAP, CLIP, X-CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + Angular + PyTorch.
+Media explorer web app for browsing/voting on audio, images, text, video, or documents. Semantic sorting (LAION-CLAP, SigLIP, X-CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + Angular + PyTorch.
 
 ## Branch Policy (CRITICAL)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ VTSearch/
 │   │   ├── audio/speech_extractor.py  SpeechExtractor processor
 │   │   ├── image/media_type.py     Image media type (JPEG/PNG serving)
 │   │   ├── image/embedder.py       ImageClipEmbedder (OpenAI CLIP, 768-d)
-│   │   ├── image/embedder_siglip.py  ImageSiglipEmbedder (SigLIP, 768-d)
+│   │   ├── image/embedder_siglip.py  ImageSiglipEmbedder (SigLIP, 768-d, default)
 │   │   ├── image/clipper.py        ImageDefaultClipper, ImageTilingClipper
 │   │   ├── image/extractor.py      ImageClassExtractor (YOLO-based)
 │   │   ├── image/face_localizer.py FaceLocalizer (MediaPipe-based)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,11 +43,11 @@ settings).
 | Model | Media type | HuggingFace ID | Approx. size |
 |-------|-----------|----------------|-------------|
 | CLAP | Audio (default) | `laion/clap-htsat-unfused` | ~1.1 GB |
-| CLIP | Image (default) | `openai/clip-vit-base-patch32` | ~350 MB |
+| SigLIP | Image (default) | `google/siglip-base-patch16-224` | ~400 MB |
 | X-CLIP | Video (default) | `microsoft/xclip-base-patch32` | ~1.2 GB |
 | E5 | Text (default) | `intfloat/e5-base-v2` | ~440 MB |
 
-**Total: ~3.1 GB** for the four default models.
+**Total: ~3.2 GB** for the four default models.
 
 #### Alternative embedders
 
@@ -57,7 +57,7 @@ These are only downloaded if explicitly selected:
 | Model | Media type | HuggingFace ID | Approx. size |
 |-------|-----------|----------------|-------------|
 | CLAP Music & Speech | Audio | `laion/larger_clap_music_and_speech` | ~1.3 GB |
-| SigLIP | Image | `google/siglip-base-patch16-224` | ~400 MB |
+| CLIP | Image | `openai/clip-vit-base-patch32` | ~350 MB |
 | BGE | Text | `BAAI/bge-base-en-v1.5` | ~440 MB |
 
 All model downloads use `token=False` — no HuggingFace account or API

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1426,8 +1426,8 @@ type's `EMBEDDERS` list (e.g. in `vtsearch/media/image/__init__.py`).
 |----------|------|------------|-------|------------|
 | `AudioClapEmbedder` | `clap` | `audio` | LAION CLAP (laion/clap-htsat-unfused) | 512 |
 | `AudioClapMusicEmbedder` | `clap_music` | `audio` | CLAP Music & Speech (laion/larger_clap_music_and_speech) | 512 |
-| `ImageClipEmbedder` | `clip` | `image` | OpenAI CLIP (openai/clip-vit-base-patch32) | 768 |
 | `ImageSiglipEmbedder` | `siglip` | `image` | SigLIP (google/siglip-base-patch16-224) | 768 |
+| `ImageClipEmbedder` | `clip` | `image` | OpenAI CLIP (openai/clip-vit-base-patch32) | 768 |
 | `TextE5Embedder` | `e5` | `text` | E5-base-v2 (intfloat/e5-base-v2) | 768 |
 | `TextBGEEmbedder` | `bge` | `text` | BGE-base-en-v1.5 (BAAI/bge-base-en-v1.5) | 768 |
 | `VideoXClipEmbedder` | `xclip` | `video` | X-CLIP (microsoft/xclip-base-patch32) | 768 |

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -75,14 +75,14 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 |------------------------|----------|-------|--------------|
 | Audio (`audio`) | `clap` (default) | LAION CLAP (`laion/clap-htsat-unfused`) | 512 |
 | Audio (`audio`) | `clap_music` | CLAP Music & Speech (`laion/larger_clap_music_and_speech`) | 512 |
-| Image (`image`) | `clip` (default) | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 768 |
-| Image (`image`) | `siglip` | SigLIP (`google/siglip-base-patch16-224`) | 768 |
+| Image (`image`) | `siglip` (default) | SigLIP (`google/siglip-base-patch16-224`) | 768 |
+| Image (`image`) | `clip` | OpenAI CLIP (`openai/clip-vit-base-patch32`) | 768 |
 | Video (`video`) | `xclip` (default) | Microsoft X-CLIP (`microsoft/xclip-base-patch32`) | 768 |
 | Text (`text`) | `e5` (default) | E5 (`intfloat/e5-base-v2`) | 768 |
 | Text (`text`) | `bge` | BGE (`BAAI/bge-base-en-v1.5`) | 768 |
 | Document (`document`) | — | None (no embedder) | N/A |
 
-Audio, image, and text media types each have an **alternative embedder** in addition to the default. Alternative embedders are registered in `vtsearch/media/__init__.py` and live in files like `embedder_clap_music.py`, `embedder_siglip.py`, and `embedder_bge.py` alongside the primary `embedder.py` in each media type directory.
+Audio, image, and text media types each have an **alternative embedder** in addition to the default. The first entry in each media type's `EMBEDDERS` list in `vtsearch/media/<type>/__init__.py` is the default; subsequent entries are alternatives.
 
 The **document** media type has no embedding model of its own. Documents (PDF, DOC, PPT) are intended to be converted to other media types (images or text) via media converters in `vtsearch/converters/` before embedding.
 

--- a/download_models.sh
+++ b/download_models.sh
@@ -28,7 +28,7 @@ cache_dir = sys.argv[1]
 # ------------------------------------------------------------------
 # 1. CLAP  (audio)  —  laion/clap-htsat-unfused
 # ------------------------------------------------------------------
-print("\n[1/4] Downloading CLAP model (laion/clap-htsat-unfused) ...")
+print("\n[1/5] Downloading CLAP model (laion/clap-htsat-unfused) ...")
 from transformers import ClapModel, ClapProcessor
 
 ClapModel.from_pretrained("laion/clap-htsat-unfused", cache_dir=cache_dir)
@@ -36,9 +36,20 @@ ClapProcessor.from_pretrained("laion/clap-htsat-unfused", cache_dir=cache_dir)
 print("  CLAP done.")
 
 # ------------------------------------------------------------------
-# 2. CLIP  (image)  —  openai/clip-vit-base-patch32
+# 2. SigLIP  (image, default)  —  google/siglip-base-patch16-224
 # ------------------------------------------------------------------
-print("\n[2/4] Downloading CLIP model (openai/clip-vit-base-patch32) ...")
+print("\n[2/5] Downloading SigLIP model (google/siglip-base-patch16-224) ...")
+from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer
+
+SiglipModel.from_pretrained("google/siglip-base-patch16-224", cache_dir=cache_dir)
+SiglipImageProcessor.from_pretrained("google/siglip-base-patch16-224", cache_dir=cache_dir)
+SiglipTokenizer.from_pretrained("google/siglip-base-patch16-224", cache_dir=cache_dir)
+print("  SigLIP done.")
+
+# ------------------------------------------------------------------
+# 3. CLIP  (image, alternative)  —  openai/clip-vit-base-patch32
+# ------------------------------------------------------------------
+print("\n[3/5] Downloading CLIP model (openai/clip-vit-base-patch32) ...")
 from transformers import CLIPModel, CLIPProcessor
 
 CLIPModel.from_pretrained("openai/clip-vit-base-patch32", cache_dir=cache_dir)
@@ -46,9 +57,9 @@ CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32", cache_dir=cache_di
 print("  CLIP done.")
 
 # ------------------------------------------------------------------
-# 3. X-CLIP  (video)  —  microsoft/xclip-base-patch32
+# 4. X-CLIP  (video)  —  microsoft/xclip-base-patch32
 # ------------------------------------------------------------------
-print("\n[3/4] Downloading X-CLIP model (microsoft/xclip-base-patch32) ...")
+print("\n[4/5] Downloading X-CLIP model (microsoft/xclip-base-patch32) ...")
 from transformers import XCLIPModel, XCLIPProcessor
 
 XCLIPModel.from_pretrained("microsoft/xclip-base-patch32", cache_dir=cache_dir)
@@ -56,9 +67,9 @@ XCLIPProcessor.from_pretrained("microsoft/xclip-base-patch32", cache_dir=cache_d
 print("  X-CLIP done.")
 
 # ------------------------------------------------------------------
-# 4. E5  (text)  —  intfloat/e5-base-v2
+# 5. E5  (text)  —  intfloat/e5-base-v2
 # ------------------------------------------------------------------
-print("\n[4/4] Downloading E5 model (intfloat/e5-base-v2) ...")
+print("\n[5/5] Downloading E5 model (intfloat/e5-base-v2) ...")
 from sentence_transformers import SentenceTransformer
 
 SentenceTransformer("intfloat/e5-base-v2", cache_folder=cache_dir)

--- a/vtsearch/media/image/__init__.py
+++ b/vtsearch/media/image/__init__.py
@@ -4,5 +4,5 @@ from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
 from vtsearch.media.image.media_type import ImageMediaType
 
 MEDIA_TYPE = ImageMediaType()
-EMBEDDERS = [ImageClipEmbedder(), ImageSiglipEmbedder()]
+EMBEDDERS = [ImageSiglipEmbedder(), ImageClipEmbedder()]
 CLIPPERS = [ImageDefaultClipper(), ImageTilingClipper()]


### PR DESCRIPTION
## Summary
This PR makes SigLIP the default image embedder for VTSearch, replacing OpenAI CLIP as the primary model while keeping CLIP available as an alternative.

## Key Changes
- **Model ordering**: Reordered `EMBEDDERS` list in `vtsearch/media/image/__init__.py` to make SigLIP the default (first) and CLIP the alternative (second)
- **Download script**: Updated `download_models.sh` to download SigLIP before CLIP and adjusted step numbering from [1-4] to [1-5]
- **Documentation updates**:
  - Updated `docs/DEPLOYMENT.md` to reflect SigLIP as the default image model (~400 MB) and CLIP as an alternative
  - Updated `docs/ML.md` to show SigLIP as default with `(default)` marker and CLIP as alternative
  - Updated `docs/ARCHITECTURE.md` to note SigLIP as the default in the embedder description
  - Updated `docs/EXTENDING.md` embedder table to list SigLIP before CLIP
  - Updated `CLAUDE.md` project description to mention SigLIP instead of CLIP
- **Total model size**: Updated from ~3.1 GB to ~3.2 GB (reflecting SigLIP's slightly larger footprint)

## Implementation Details
- SigLIP model (`google/siglip-base-patch16-224`) is downloaded with its associated `SiglipModel`, `SiglipImageProcessor`, and `SiglipTokenizer` components
- CLIP remains fully functional as an alternative embedder with no code removal
- All documentation consistently reflects the new default while maintaining clarity about alternatives

https://claude.ai/code/session_01TmHTNAv9d2PtannxWBt31L