### PR TITLE
Add descriptive tooltips to buttons, headers, and controls

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -5,6 +5,7 @@
   <nav class="burger-menu" aria-label="Main menu">
     <button
       class="burger-btn"
+      title="Open main menu"
       aria-label="Menu"
       [attr.aria-expanded]="menuOpen"
       aria-haspopup="true"

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.html
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.html
@@ -12,6 +12,6 @@
   (error)="onError()"
 ></video>
 <div *ngIf="videoError" class="video-error">
-  <span class="error-icon">&#9888;</span>
+  <span class="error-icon" title="Video format error">&#9888;</span>
   <span>Video cannot be played. The format may require transcoding — install ffmpeg on the server.</span>
 </div>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -8,6 +8,7 @@
       (keydown)="onRenameKeydown($event)"
       (blur)="confirmRename()"
       (click)="$event.stopPropagation()"
+      title="Enter a new name for the dataset"
       aria-label="Dataset name"
     />
   } @else {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -28,7 +28,7 @@
 
   @if (view === 'demo') {
     <div class="demo-picker">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
       @if (demoLoading) {
         <p class="empty-state">Loading demo datasets...</p>
@@ -41,6 +41,7 @@
               class="demo-tab"
               [class.active]="activeTab === tab"
               (click)="selectDemoTabWithEmbedder(tab)"
+              [title]="'Filter demos by media type: ' + getTabText(tab)"
             >@if (getTabIcon(tab)) {<vt-icon [icon]="getTabIcon(tab)" [size]="14"></vt-icon>}{{ getTabText(tab) }}</button>
           }
         </div>
@@ -107,7 +108,7 @@
 
   @if (view === 'form' && selectedImporter) {
     <div class="importer-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
         @for (field of selectedImporter.fields; track field.key) {
@@ -216,7 +217,7 @@
 
   @if (view === 'server_folder') {
     <div class="server-folder-browser">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
       <div class="form-group">
         <label class="form-label" for="sf-media-type" title="The type of media files in the folder (audio, image, text, video, or document)">Media Type</label>
@@ -251,13 +252,13 @@
             <p class="sf-empty-dir">No subdirectories. This folder will be imported.</p>
           }
           @if (sfBrowsePath) {
-            <button class="sf-dir-item" (click)="sfGoUp()">
+            <button class="sf-dir-item" (click)="sfGoUp()" title="Go to parent directory">
               <span class="sf-dir-icon"><vt-icon type="arrow-up"></vt-icon></span>
               <span class="sf-dir-name">..</span>
             </button>
           }
           @for (dir of sfBrowseDirs; track dir.path) {
-            <button class="sf-dir-item" (click)="sfEnterDirectory(dir)">
+            <button class="sf-dir-item" (click)="sfEnterDirectory(dir)" [title]="dir.path">
               <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
               <span class="sf-dir-name">{{ dir.name }}</span>
               @if (dir.modified_at) {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -7,6 +7,7 @@
       (keydown)="onRenameKeydown($event)"
       (blur)="confirmRename()"
       (click)="$event.stopPropagation()"
+      title="Enter a new name for the model"
       aria-label="Model name"
     />
   } @else {
@@ -68,13 +69,13 @@
   <td>{{ (model.num_training ?? 0) | number }}</td>
   <td>
     @if (model.trainable) {
-      <span class="status-icon" aria-label="Trainable">
+      <span class="status-icon" title="Model supports training" aria-label="Trainable">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="20 6 9 17 4 12"></polyline>
         </svg>
       </span>
     } @else {
-      <span class="status-icon" aria-label="Not trainable">
+      <span class="status-icon" title="Model does not support training" aria-label="Not trainable">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -17,7 +17,7 @@
       <div class="form-group">
         <label title="The type of media this model will process">Media Type</label>
         <div class="custom-select" [class.open]="mediaTypeDropdownOpen" title="The type of media this model will process">
-          <button type="button" class="custom-select-trigger form-input" (click)="mediaTypeDropdownOpen = !mediaTypeDropdownOpen">
+          <button type="button" class="custom-select-trigger form-input" (click)="mediaTypeDropdownOpen = !mediaTypeDropdownOpen" title="Select the media type for this model">
             <span class="select-option-content">
               @if (getMediaTypeIcon(mediaType)) {
                 <vt-icon [type]="getMediaTypeIcon(mediaType)" [size]="14"></vt-icon>
@@ -47,7 +47,7 @@
           <div class="example-row">
             <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
             <span class="example-label" [title]="exampleDisplay">{{ exampleDisplay }}</span>
-            <button type="button" class="btn btn--secondary btn--sm" (click)="clearExample()">Change</button>
+            <button type="button" class="btn btn--secondary btn--sm" (click)="clearExample()" title="Remove this example and choose a different one">Change</button>
           </div>
         </div>
       } @else {
@@ -67,14 +67,14 @@
           </div>
           <div class="example-col">
             <label class="col-label">Media Example</label>
-            <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText">Browse Media...</button>
+            <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse loaded media to pick an example">Browse Media...</button>
             <input
               #fileInput
               type="file"
               class="hidden-file-input"
               (change)="onLocalFileSelected($event)"
             />
-            <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()" [disabled]="hasPendingText">Upload File...</button>
+            <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()" [disabled]="hasPendingText" title="Upload a media file from your computer">Upload File...</button>
           </div>
         </div>
       }
@@ -96,7 +96,7 @@
 
   @if (view === 'media-picker') {
     <div class="media-picker">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()" title="Return to the model creation form">&larr; Back</button>
 
       <!-- Source selection (top level) -->
       @if (!selectedSource) {

--- a/frontend/src/app/components/file-browser/file-browser.component.html
+++ b/frontend/src/app/components/file-browser/file-browser.component.html
@@ -41,20 +41,20 @@
           <div class="file-browser-error">{{ error }}</div>
         } @else {
           @if (currentPath) {
-            <button class="file-browser-item file-browser-dir" (click)="goUp()">
+            <button class="file-browser-item file-browser-dir" (click)="goUp()" title="Go to parent directory">
               <span class="file-browser-icon"><svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 2l5 6H9v6H7V8H3z"/></svg></span>
               <span class="file-browser-name">..</span>
             </button>
           }
           @for (dir of directories; track dir.path) {
-            <button class="file-browser-item file-browser-dir" (click)="enterDirectory(dir)">
+            <button class="file-browser-item file-browser-dir" (click)="enterDirectory(dir)" [title]="dir.path">
               <span class="file-browser-icon"><svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M1 3h5l1.5 1.5H15v9.5H1V3zm1 1v8.5h12V5.5H7.1L5.6 4H2z"/></svg></span>
               <span class="file-browser-name">{{ dir.name }}</span>
               <span class="file-browser-date">{{ dir.modified_at }}</span>
             </button>
           }
           @for (file of files; track file.path) {
-            <button class="file-browser-item file-browser-file" (click)="selectFile(file)">
+            <button class="file-browser-item file-browser-file" (click)="selectFile(file)" [title]="file.path">
               <span class="file-browser-icon"><svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M3 1h7l4 4v10H3V1zm1 1v12h9V5.5L9.5 2H4zm6 0v3.5h3.5"/></svg></span>
               <span class="file-browser-name">{{ file.name }}</span>
               <span class="file-browser-date">{{ file.modified_at }}</span>

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -37,11 +37,11 @@
           >
             <div class="ap-step-marker">
               @if (step.state === 'done') {
-                <span class="ap-check" aria-label="Complete">&#10003;</span>
+                <span class="ap-check" title="Complete" aria-label="Complete">&#10003;</span>
               } @else if (step.state === 'active') {
-                <span class="ap-dot active-dot" aria-label="Current step"></span>
+                <span class="ap-dot active-dot" title="Current step" aria-label="Current step"></span>
               } @else {
-                <span class="ap-dot" aria-label="Upcoming step"></span>
+                <span class="ap-dot" title="Upcoming step" aria-label="Upcoming step"></span>
               }
             </div>
             <div class="ap-step-content">
@@ -56,6 +56,7 @@
                       class="ap-status-icon"
                       [attr.data-color]="icon.color"
                       [attr.aria-label]="icon.ariaLabel"
+                      [title]="icon.ariaLabel"
                       role="img"
                     ></span>
                   }

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.html
@@ -10,6 +10,7 @@
     step="1"
     [value]="value"
     (input)="onInput($event)"
+    title="Adjust inclusion bias. Positive favors recall, negative favors precision."
     aria-label="Inclusion"
   />
 </div>

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -21,7 +21,7 @@
     }
     <span class="media-name-grid">{{ displayName }}</span>
   } @else {
-    <span class="label-indicator" [class.good]="voteLabel === 'good'" [class.bad]="voteLabel === 'bad'">
+    <span class="label-indicator" [class.good]="voteLabel === 'good'" [class.bad]="voteLabel === 'bad'" [title]="voteLabel === 'good' ? 'Labeled good' : voteLabel === 'bad' ? 'Labeled bad' : ''">
       @if (voteLabel === 'good') { &#x2713; } @else if (voteLabel === 'bad') { &#x2717; }
     </span>
     @if (thumbnailUrl) {
@@ -30,6 +30,6 @@
     <span class="media-name">{{ displayName }}</span>
   }
   @if (score !== null) {
-    <span class="media-score">{{ score | number:'1.2-2' }}</span>
+    <span class="media-score" title="Model confidence score">{{ score | number:'1.2-2' }}</span>
   }
 </div>

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -3,7 +3,7 @@
   <cdk-virtual-scroll-viewport [itemSize]="listItemHeight" class="media-list virtual-scroll-viewport">
     <ng-container *cdkVirtualFor="let item of cachedOrderedItems; trackBy: trackByMediaId">
       @if (item.showThreshold) {
-        <div class="media-threshold-line" aria-label="Good/Bad threshold">
+        <div class="media-threshold-line" title="Decision boundary between predicted good and bad items" aria-label="Good/Bad threshold">
           <span class="threshold-label">threshold</span>
         </div>
       }
@@ -24,7 +24,7 @@
   <div class="media-list" [class.grid-layout]="viewMode === 'grid'" [style.--grid-goal-width]="gridGoalWidth + 'px'" role="listbox" aria-label="Media items" #listContainer>
     @for (item of cachedOrderedItems; track trackByMediaId($index, item)) {
       @if (item.showThreshold) {
-        <div class="media-threshold-line" aria-label="Good/Bad threshold">
+        <div class="media-threshold-line" title="Decision boundary between predicted good and bad items" aria-label="Good/Bad threshold">
           <span class="threshold-label">threshold</span>
         </div>
       }

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -43,6 +43,7 @@
           placeholder="Describe what you're looking for..."
           [value]="textQuery"
           (input)="onTextInput($any($event.target).value)"
+          title="Enter a text description to rank items by semantic similarity"
           aria-label="Text sort query"
         />
       </div>

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -11,6 +11,7 @@
         [(ngModel)]="username"
         name="username"
         placeholder="Username"
+        title="Enter your username to log in"
         aria-label="Username"
         autofocus
         autocomplete="username"
@@ -20,7 +21,7 @@
       @if (error) {
         <p class="login-error">{{ error }}</p>
       }
-      <button type="submit" [disabled]="busy">
+      <button type="submit" [disabled]="busy" title="Log in to VTSearch">
         {{ busy ? 'Logging in...' : 'Log in' }}
       </button>
     </form>

--- a/frontend/src/app/components/modal/modal.component.html
+++ b/frontend/src/app/components/modal/modal.component.html
@@ -12,7 +12,7 @@
     <div class="modal-header">
       <h2>{{ title }}</h2>
       @if (showCloseButton) {
-        <button class="modal-close" (click)="close()" aria-label="Close">&times;</button>
+        <button class="modal-close" (click)="close()" title="Close" aria-label="Close">&times;</button>
       }
     </div>
     <div class="modal-body">

--- a/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-progress-modal/autodetect-progress-modal.component.html
@@ -3,6 +3,6 @@
     <p aria-live="polite">{{ statusText }}</p>
     <vt-progress-bar [value]="progress" [max]="100"></vt-progress-bar>
     <p class="progress-pct">{{ progress }}%</p>
-    <button class="btn btn--secondary" (click)="onCancel()">Cancel</button>
+    <button class="btn btn--secondary" (click)="onCancel()" title="Cancel the auto-detect process">Cancel</button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -20,10 +20,10 @@
       <table class="results-table">
         <thead>
           <tr>
-            <th>Origin</th>
-            <th>Name</th>
-            <th>MD5</th>
-            <th>Filename</th>
+            <th title="Source origin of the media item">Origin</th>
+            <th title="Display name of the media item">Name</th>
+            <th title="MD5 content hash of the media file">MD5</th>
+            <th title="Original filename on disk">Filename</th>
           </tr>
         </thead>
         <tbody>
@@ -43,13 +43,13 @@
   <!-- Export controls -->
   <div class="export-controls">
     <div class="export-sides">
-      <label><input type="radio" name="sides" value="good" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Good</label>
-      <label><input type="radio" name="sides" value="bad" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Bad</label>
-      <label><input type="radio" name="sides" value="both" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Both</label>
+      <label title="Show only items predicted as good"><input type="radio" name="sides" value="good" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Good</label>
+      <label title="Show only items predicted as bad"><input type="radio" name="sides" value="bad" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Bad</label>
+      <label title="Show both good and bad predictions"><input type="radio" name="sides" value="both" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Both</label>
     </div>
 
     <div class="export-row">
-      <select class="form-select" [(ngModel)]="selectedExporter" (ngModelChange)="onExporterChange()">
+      <select class="form-select" [(ngModel)]="selectedExporter" (ngModelChange)="onExporterChange()" title="Choose export destination">
         @for (exp of exporters; track exp.name) {
           <option [value]="exp.name">{{ exp['label'] || exp.name }}</option>
         }
@@ -72,20 +72,20 @@
     }
 
     <div class="copy-row">
-      <select class="form-select" [(ngModel)]="copyColumn">
+      <select class="form-select" [(ngModel)]="copyColumn" title="Column to copy to clipboard">
         <option value="origin+name">Origin + Name</option>
         <option value="name">Name</option>
         <option value="md5">MD5</option>
         <option value="filename">Filename</option>
         <option value="origin">Origin</option>
       </select>
-      <select class="form-select" [(ngModel)]="copySeparator">
+      <select class="form-select" [(ngModel)]="copySeparator" title="Separator between copied values">
         <option value="newline">Newline</option>
         <option value=",">Comma</option>
         <option value="tab">Tab</option>
         <option value="space">Space</option>
       </select>
-      <button class="btn btn--secondary" (click)="copyToClipboard()">{{ copyButtonText }}</button>
+      <button class="btn btn--secondary" (click)="copyToClipboard()" title="Copy selected column values to clipboard">{{ copyButtonText }}</button>
     </div>
   </div>
 

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
@@ -10,7 +10,7 @@
             @if (ex.type === 'good') {
               <div class="example-card">
                 <span class="example-label">{{ ex.label || 'Example ' + (i + 1) }}</span>
-                <button class="remove-btn" (click)="removeExample(i)" aria-label="Remove">&times;</button>
+                <button class="remove-btn" (click)="removeExample(i)" title="Remove this example" aria-label="Remove">&times;</button>
               </div>
             }
           }
@@ -28,7 +28,7 @@
             @if (ex.type === 'bad') {
               <div class="example-card">
                 <span class="example-label">{{ ex.label || 'Example ' + (i + 1) }}</span>
-                <button class="remove-btn" (click)="removeExample(i)" aria-label="Remove">&times;</button>
+                <button class="remove-btn" (click)="removeExample(i)" title="Remove this example" aria-label="Remove">&times;</button>
               </div>
             }
           }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -53,7 +53,7 @@
           <thead>
             <tr>
               @for (col of enabledColumns; track col.key) {
-                <th>{{ col.label }}</th>
+                <th [title]="col.label">{{ col.label }}</th>
               }
             </tr>
           </thead>
@@ -113,6 +113,7 @@
           class="export-tab"
           [class.active]="activeTab === exp.name"
           (click)="selectExporterTab(exp)"
+          [title]="exp.description || exp.display_name || exp.name"
         >
           <svg class="tab-icon-svg" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             @switch (getExporterIconType(exp)) {
@@ -142,6 +143,7 @@
             class="btn btn--primary"
             (click)="copyToClipboard()"
             [disabled]="!hasLabels || enabledColumns.length === 0"
+            title="Copy exported data to clipboard"
           >
             @if (copySuccess) {
               <vt-icon type="check"></vt-icon> Copied!
@@ -220,6 +222,7 @@
             class="btn btn--primary"
             (click)="submitExporterTab()"
             [disabled]="!hasLabels || submitting"
+            title="Send exported data to the selected destination"
           >
             @if (submitting) {
               Exporting...

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -63,7 +63,7 @@
 
   @if (view === 'form' && selectedImporter) {
     <div class="importer-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
         @for (field of selectedImporter.fields; track field.key) {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -3,7 +3,7 @@
     <p class="empty-state">Loading...</p>
   } @else if (showMediaPicker) {
     <div class="media-picker">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="closeMediaPicker()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="closeMediaPicker()" title="Return to sort options">&larr; Back</button>
 
       <!-- Source selection -->
       @if (mediaPickerView === 'sources') {
@@ -98,7 +98,7 @@
         @if (serverDetectors.length > 0) {
           <div class="file-list">
             @for (det of serverDetectors; track det.name) {
-              <button class="file-item" (click)="loadServerDetector(det.name)">{{ det.name }}</button>
+              <button class="file-item" (click)="loadServerDetector(det.name)" [title]="'Load detector: ' + det.name">{{ det.name }}</button>
             }
           </div>
         } @else {
@@ -108,7 +108,7 @@
         @if (registryModels.length > 0) {
           <div class="file-list">
             @for (model of registryModels; track model.id) {
-              <button class="file-item" (click)="loadRegistryModel(model)">
+              <button class="file-item" (click)="loadRegistryModel(model)" [title]="'Load model: ' + model.name">
                 {{ model.name }}
                 @if (model.num_training) {
                   <span class="item-meta">{{ model.num_training }} labels</span>
@@ -133,7 +133,7 @@
           <h4 title="Example media files available on the server">Server Example Media</h4>
           <div class="file-list">
             @for (file of serverMediaFiles; track file.name) {
-              <button class="file-item" (click)="loadServerMedia(file.filename || file.name)">{{ file.filename || file.name }}</button>
+              <button class="file-item" (click)="loadServerMedia(file.filename || file.name)" [title]="'Sort by example: ' + (file.filename || file.name)">{{ file.filename || file.name }}</button>
             }
           </div>
         }

--- a/frontend/src/app/components/modals/processor-importer-modal/processor-importer-modal.component.html
+++ b/frontend/src/app/components/modals/processor-importer-modal/processor-importer-modal.component.html
@@ -20,7 +20,7 @@
 
   @if (view === 'form' && selectedImporter) {
     <div class="importer-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
         @for (field of selectedImporter.fields; track field.key) {

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
@@ -15,21 +15,22 @@
               class="form-input"
               [(ngModel)]="pendingText"
               placeholder="e.g. dog barking sounds"
+              title="Enter a text description to sort by"
               (keydown.enter)="$event.preventDefault(); submitText()"
             />
-            <button type="button" class="btn btn--primary btn--sm" (click)="submitText()" [disabled]="!pendingText.trim()">Use</button>
+            <button type="button" class="btn btn--primary btn--sm" (click)="submitText()" [disabled]="!pendingText.trim()" title="Use this text as the new sort example">Use</button>
           </div>
         </div>
         <div class="example-col">
           <label class="col-label">New Media Example</label>
-          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()">Browse Media...</button>
+          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" title="Browse loaded media to pick a new example">Browse Media...</button>
           <input
             #fileInput
             type="file"
             class="hidden-file-input"
             (change)="onLocalFileSelected($event)"
           />
-          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()">Upload File...</button>
+          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()" title="Upload a media file from your computer">Upload File...</button>
         </div>
       </div>
 
@@ -41,13 +42,13 @@
 
   @if (view === 'prompt') {
     <div modal-footer>
-      <button class="btn btn--secondary" (click)="onKeep()">Keep Current{{ keepLabelsCount ? ' for ' + keepLabelsCount + ' more labels' : '' }}</button>
+      <button class="btn btn--secondary" (click)="onKeep()" title="Continue sorting with the current example">Keep Current{{ keepLabelsCount ? ' for ' + keepLabelsCount + ' more labels' : '' }}</button>
     </div>
   }
 
   @if (view === 'media-picker') {
     <div class="media-picker">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="backToPrompt()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="backToPrompt()" title="Return to the example prompt">&larr; Back</button>
 
       @if (!selectedSource) {
         <p class="picker-instructions">Choose a source to browse media from:</p>

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -27,7 +27,7 @@
 
   @if (view === 'form' && selectedExporter) {
     <div class="exporter-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to exporter list">&larr; Back</button>
 
       @if (selectedExporter.fields && selectedExporter.fields.length > 0) {
         @for (field of selectedExporter.fields; track field.key) {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -27,7 +27,7 @@
 
   @if (view === 'form' && selectedImporter) {
     <div class="importer-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
         @for (field of selectedImporter.fields; track field.key) {

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
@@ -19,6 +19,7 @@
             [(ngModel)]="editValue"
             (blur)="finishRename()"
             (keydown)="onKeydown($event)"
+            title="Enter a new name for the detector"
           />
         }
       </div>


### PR DESCRIPTION
## Summary
- Adds `title` attributes across 25 component templates so that buttons, column headers, status indicators, inputs, and navigation elements show descriptive mouse-over tips
- Covers modal close buttons, back/browse/upload buttons, autopilot status icons, label indicators, media scores, sort/select inputs, file browser navigation, export table headers, autodetect results controls, login form, inline-rename inputs, trainable status icons, load-sort file items, and the burger menu
- No logic changes — HTML-only additions

## Test plan
- [x] Frontend builds successfully (`npm run build:prod`)
- [x] Core test group passes (`./run-tests.sh core` — 341 passed)
- [ ] Hover over buttons/headers throughout the app and verify tooltips appear

https://claude.ai/code/session_01R4hRCto3ThPWK96tuHeW3i