### PR TITLE
Refactor plugin registry boilerplate with make_plugin_registry factory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7857,9 +7857,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -370,16 +370,17 @@ class TestDynamicImporterDispatch:
         custom = CustomImporter()
 
         # Temporarily register it in the importer registry
-        from vtsearch.datasets.importers import _registry
+        from vtsearch.datasets.importers import get_importer
 
-        _registry._ensure_discovered()
-        _registry._items[custom.name] = custom
+        registry = get_importer.__self__
+        registry._ensure_discovered()
+        registry._items[custom.name] = custom
         try:
             origin = {"importer": "test_custom", "params": {"path": str(tmp_path)}}
             result = resolve_file_from_origin(origin, origin_name="custom_media.wav")
             assert result == marker_file
         finally:
-            _registry._items.pop(custom.name, None)
+            registry._items.pop(custom.name, None)
 
 
 class TestResolveLabelEmbeddings:

--- a/vtsearch/datasets/importers/__init__.py
+++ b/vtsearch/datasets/importers/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(imp.name, imp.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.datasets.importers.base import DatasetImporter
-
-_registry: PluginRegistry[DatasetImporter] = PluginRegistry(
-    package="vtsearch.datasets.importers",
+get_importer, list_importers = make_plugin_registry(
+    package=__name__,
     sentinel="IMPORTER",
     label="dataset importer",
 )
 
-get_importer = _registry.get
-list_importers = _registry.list
-
-__all__ = [
-    "get_importer",
-    "list_importers",
-]
+__all__ = ["get_importer", "list_importers"]

--- a/vtsearch/exporters/__init__.py
+++ b/vtsearch/exporters/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(exp.name, exp.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.exporters.base import LabelsetExporter
-
-_registry: PluginRegistry[LabelsetExporter] = PluginRegistry(
-    package="vtsearch.exporters",
+get_exporter, list_exporters = make_plugin_registry(
+    package=__name__,
     sentinel="EXPORTER",
     label="labelset exporter",
 )
 
-get_exporter = _registry.get
-list_exporters = _registry.list
-
-__all__ = [
-    "get_exporter",
-    "list_exporters",
-]
+__all__ = ["get_exporter", "list_exporters"]

--- a/vtsearch/labels/importers/__init__.py
+++ b/vtsearch/labels/importers/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(imp.name, imp.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.labels.importers.base import LabelImporter
-
-_registry: PluginRegistry[LabelImporter] = PluginRegistry(
-    package="vtsearch.labels.importers",
+get_label_importer, list_label_importers = make_plugin_registry(
+    package=__name__,
     sentinel="LABEL_IMPORTER",
     label="label importer",
 )
 
-get_label_importer = _registry.get
-list_label_importers = _registry.list
-
-__all__ = [
-    "get_label_importer",
-    "list_label_importers",
-]
+__all__ = ["get_label_importer", "list_label_importers"]

--- a/vtsearch/labels/sources/__init__.py
+++ b/vtsearch/labels/sources/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(src.name, src.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.labels.sources.base import LabelsetSource
-
-_registry: PluginRegistry[LabelsetSource] = PluginRegistry(
-    package="vtsearch.labels.sources",
+get_labelset_source, list_labelset_sources = make_plugin_registry(
+    package=__name__,
     sentinel="LABELSET_SOURCE",
     label="labelset source",
 )
 
-get_labelset_source = _registry.get
-list_labelset_sources = _registry.list
-
-__all__ = [
-    "get_labelset_source",
-    "list_labelset_sources",
-]
+__all__ = ["get_labelset_source", "list_labelset_sources"]

--- a/vtsearch/processors/importers/__init__.py
+++ b/vtsearch/processors/importers/__init__.py
@@ -13,20 +13,12 @@ Usage::
         print(imp.name, imp.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.processors.importers.base import ProcessorImporter
-
-_registry: PluginRegistry[ProcessorImporter] = PluginRegistry(
-    package="vtsearch.processors.importers",
+get_processor_importer, list_processor_importers = make_plugin_registry(
+    package=__name__,
     sentinel="PROCESSOR_IMPORTER",
     label="processor importer",
 )
 
-get_processor_importer = _registry.get
-list_processor_importers = _registry.list
+__all__ = ["get_processor_importer", "list_processor_importers"]

--- a/vtsearch/settings_io/exporters/__init__.py
+++ b/vtsearch/settings_io/exporters/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(exp.name, exp.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.settings_io.exporters.base import SettingsExporter
-
-_registry: PluginRegistry[SettingsExporter] = PluginRegistry(
-    package="vtsearch.settings_io.exporters",
+get_settings_exporter, list_settings_exporters = make_plugin_registry(
+    package=__name__,
     sentinel="SETTINGS_EXPORTER",
     label="settings exporter",
 )
 
-get_settings_exporter = _registry.get
-list_settings_exporters = _registry.list
-
-__all__ = [
-    "get_settings_exporter",
-    "list_settings_exporters",
-]
+__all__ = ["get_settings_exporter", "list_settings_exporters"]

--- a/vtsearch/settings_io/importers/__init__.py
+++ b/vtsearch/settings_io/importers/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(imp.name, imp.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.settings_io.importers.base import SettingsImporter
-
-_registry: PluginRegistry[SettingsImporter] = PluginRegistry(
-    package="vtsearch.settings_io.importers",
+get_settings_importer, list_settings_importers = make_plugin_registry(
+    package=__name__,
     sentinel="SETTINGS_IMPORTER",
     label="settings importer",
 )
 
-get_settings_importer = _registry.get
-list_settings_importers = _registry.list
-
-__all__ = [
-    "get_settings_importer",
-    "list_settings_importers",
-]
+__all__ = ["get_settings_importer", "list_settings_importers"]

--- a/vtsearch/settings_io/sources/__init__.py
+++ b/vtsearch/settings_io/sources/__init__.py
@@ -13,25 +13,12 @@ Usage::
         print(src.name, src.display_name)
 """
 
-from __future__ import annotations
+from vtsearch.utils.registry import make_plugin_registry
 
-from typing import TYPE_CHECKING
-
-from vtsearch.utils.registry import PluginRegistry
-
-if TYPE_CHECKING:
-    from vtsearch.settings_io.sources.base import SettingsSource
-
-_registry: PluginRegistry[SettingsSource] = PluginRegistry(
-    package="vtsearch.settings_io.sources",
+get_settings_source, list_settings_sources = make_plugin_registry(
+    package=__name__,
     sentinel="SETTINGS_SOURCE",
     label="settings source",
 )
 
-get_settings_source = _registry.get
-list_settings_sources = _registry.list
-
-__all__ = [
-    "get_settings_source",
-    "list_settings_sources",
-]
+__all__ = ["get_settings_source", "list_settings_sources"]

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -38,7 +38,7 @@ import threading
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Callable, Generic, Literal, TypeVar
 
 FieldType = Literal["file", "folder", "url", "text", "password", "email", "select", "server_path"]
 
@@ -47,6 +47,7 @@ __all__ = [
     "PluginBase",
     "PluginField",
     "PluginRegistry",
+    "make_plugin_registry",
 ]
 
 
@@ -324,3 +325,38 @@ class PluginRegistry(Generic[T]):
         """Return all registered plugins in discovery order."""
         self._ensure_discovered()
         return list(self._items.values())
+
+
+# ---------------------------------------------------------------------------
+# Factory helper — collapses the per-package boilerplate into one call
+# ---------------------------------------------------------------------------
+
+
+def make_plugin_registry(
+    package: str,
+    sentinel: str,
+    label: str,
+    *,
+    discover_modules: bool = False,
+) -> tuple[Callable[[str], Any], Callable[[], list[Any]]]:
+    """Create a :class:`PluginRegistry` and return its ``(get, list)`` accessors.
+
+    Shorthand for the boilerplate repeated across every plugin ``__init__.py``::
+
+        from vtsearch.utils.registry import make_plugin_registry
+
+        get_importer, list_importers = make_plugin_registry(
+            package=__name__,
+            sentinel="IMPORTER",
+            label="dataset importer",
+        )
+
+    Parameters are forwarded to :class:`PluginRegistry`.
+    """
+    registry: PluginRegistry = PluginRegistry(
+        package=package,
+        sentinel=sentinel,
+        label=label,
+        discover_modules=discover_modules,
+    )
+    return registry.get, registry.list


### PR DESCRIPTION
## Summary
This PR introduces a factory function `make_plugin_registry()` to eliminate repetitive boilerplate code across all plugin `__init__.py` modules. The factory collapses the common pattern of creating a `PluginRegistry` instance and extracting its `get` and `list` methods into a single function call.

## Key Changes
- **New factory function**: Added `make_plugin_registry()` to `vtsearch/utils/registry.py` that creates a `PluginRegistry` and returns a tuple of `(get, list)` accessor functions
- **Simplified plugin modules**: Refactored 8 plugin `__init__.py` files to use the new factory:
  - `vtsearch/datasets/importers/__init__.py`
  - `vtsearch/exporters/__init__.py`
  - `vtsearch/labels/importers/__init__.py`
  - `vtsearch/labels/sources/__init__.py`
  - `vtsearch/settings_io/exporters/__init__.py`
  - `vtsearch/settings_io/importers/__init__.py`
  - `vtsearch/settings_io/sources/__init__.py`
  - `vtsearch/processors/importers/__init__.py`
- **Removed boilerplate**: Eliminated redundant imports (`from __future__ import annotations`, `TYPE_CHECKING` blocks) and intermediate `_registry` variables from all plugin modules
- **Updated test**: Modified `tests/test_resolver.py` to access the registry via `get_importer.__self__` instead of importing the private `_registry` variable

## Implementation Details
- The factory function accepts `package`, `sentinel`, `label`, and optional `discover_modules` parameters, all forwarded to `PluginRegistry`
- Each plugin module now uses a single line to initialize both accessors: `get_*, list_* = make_plugin_registry(...)`
- The `Callable` type was added to imports in `registry.py` to support the return type annotation
- The factory is exported in `__all__` for public API access

https://claude.ai/code/session_01PuLtxgJd4A7mHZKVPA7GkB