### PR TITLE
Refactor trainable model utilities into dedicated model layer modules

### DIFF
--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -438,7 +438,7 @@ class TestFindLabel:
         Previously returned 400 because no pre-trained weights existed.
         """
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.datasets.labelset import LabelSet
         from vtsearch.utils import bad_votes, good_votes, snapshot_medias
 
@@ -505,7 +505,7 @@ class TestFindLabel:
         from unittest.mock import patch
 
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import medias
 
@@ -612,7 +612,7 @@ class TestFindLabel:
     def test_find_label_cross_dataset_error_includes_diagnostics(self, client, tmp_path):
         """When origin resolution fails, the error response should include diagnostics."""
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import medias
 
@@ -698,7 +698,8 @@ class TestFindLabel:
         """
         from vtsearch.datasets.labelset import LabelSet
         from vtsearch.models.registry import add_loaded_model_id, register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _read_model, _write_model, sync_labels_to_loaded_model
+        from vtsearch.models.label_sync import sync_labels_to_loaded_model
+        from vtsearch.models.trainable_model_store import _read_model, _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import bad_votes, good_votes, set_thread_detector_context, snapshot_medias
         from vtsearch.utils.state_core import DetectorContext, register_detector_context
@@ -873,7 +874,7 @@ class TestFindLabelDemoOrigin:
         from unittest.mock import patch
 
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import medias
 
@@ -982,7 +983,7 @@ class TestFindLabelDemoOrigin:
         Simulates old pickles that stored demo origins without the dataset name.
         """
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import medias
 

--- a/tests/test_label_import_endpoint.py
+++ b/tests/test_label_import_endpoint.py
@@ -182,7 +182,7 @@ class TestLabelImportEndpoint:
         """Importing labels should update the loaded model's num_training in the registry."""
         from vtsearch.models.registry import add_loaded_model_id, get_model, register_model, reset_for_tests
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
 
         reset_for_tests()
         set_trainable_models_dir(str(tmp_path / "models"))

--- a/tests/test_multi_dataset.py
+++ b/tests/test_multi_dataset.py
@@ -595,7 +595,7 @@ class TestSyncLabelsAcrossDatasets:
         prior training session on a different dataset."""
         from vtsearch.datasets.labelset import LabelSet
         from vtsearch.models.registry import add_loaded_model_id, register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _read_model, _write_model
+        from vtsearch.models.trainable_model_store import _read_model, _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import bad_votes, good_votes, set_thread_detector_context, snapshot_medias
         from vtsearch.utils.state_core import DetectorContext, register_detector_context
@@ -663,7 +663,7 @@ class TestSyncLabelsAcrossDatasets:
         even though Dataset B has no votes."""
         from vtsearch.datasets.labelset import LabelSet
         from vtsearch.models.registry import add_loaded_model_id, register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _read_model, _write_model
+        from vtsearch.models.trainable_model_store import _read_model, _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import bad_votes, good_votes, set_thread_detector_context, snapshot_medias
         from vtsearch.utils.state_core import DetectorContext, register_detector_context

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -499,7 +499,7 @@ class TestMultiFindCrossDatasetFallback:
 
         # Create a trainable model with labels from label_folder
         label_origin = {"importer": "folder", "params": {"path": str(label_folder), "media_type": "audio"}}
-        from vtsearch.routes.trainable_models import _model_path, _write_model
+        from vtsearch.models.trainable_model_store import _model_path, _write_model
 
         tm_name = "test_cross_detector"
         tm_path = _model_path(tm_name)
@@ -608,7 +608,7 @@ class TestMultiFindCrossDatasetFallback:
         (label_folder / "bad.wav").write_bytes(b"bad_content")
 
         label_origin = {"importer": "folder", "params": {"path": str(label_folder)}}
-        from vtsearch.routes.trainable_models import _model_path, _write_model
+        from vtsearch.models.trainable_model_store import _model_path, _write_model
 
         tm_name = "test_mt_detector"
         tm_data = {
@@ -687,7 +687,7 @@ class TestMultiFindCrossDatasetFallback:
         (label_folder / "bad.jpg").write_bytes(b"bad_content")
 
         label_origin = {"importer": "folder", "params": {"path": str(label_folder)}}
-        from vtsearch.routes.trainable_models import _model_path, _write_model
+        from vtsearch.models.trainable_model_store import _model_path, _write_model
 
         tm_name = "test_nr_detector"
         tm_data = {
@@ -761,7 +761,7 @@ class TestFindCheckLabels:
 
         from vtsearch.datasets.registry import register_dataset
         from vtsearch.models.registry import register_model
-        from vtsearch.routes.trainable_models import _model_path, _write_model
+        from vtsearch.models.trainable_model_store import _model_path, _write_model
 
         # Create a dataset where labels match by md5
         medias = {}
@@ -822,7 +822,7 @@ class TestFindCheckLabels:
 
         from vtsearch.datasets.registry import register_dataset
         from vtsearch.models.registry import register_model
-        from vtsearch.routes.trainable_models import _model_path, _write_model
+        from vtsearch.models.trainable_model_store import _model_path, _write_model
 
         # Create a target dataset (no overlap with labels)
         medias = {}
@@ -892,7 +892,7 @@ class TestFindCheckLabels:
 
         from vtsearch.datasets.registry import register_dataset
         from vtsearch.models.registry import register_model
-        from vtsearch.routes.trainable_models import _model_path, _write_model
+        from vtsearch.models.trainable_model_store import _model_path, _write_model
 
         # Create a target dataset (no overlap with labels)
         medias = {}

--- a/tests/test_trainable_models.py
+++ b/tests/test_trainable_models.py
@@ -1062,7 +1062,7 @@ class TestLoadModelCrossDatasetResolution:
         import numpy as np
 
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import good_votes, bad_votes, medias
 
@@ -1163,7 +1163,7 @@ class TestLoadModelCrossDatasetResolution:
         import numpy as np
 
         from vtsearch.models.registry import register_model, reset_for_tests
-        from vtsearch.routes.trainable_models import _write_model
+        from vtsearch.models.trainable_model_store import _write_model
         from vtsearch.settings import get_trainable_models_dir, set_trainable_models_dir
         from vtsearch.utils import good_votes, medias
 

--- a/vtsearch/models/label_sync.py
+++ b/vtsearch/models/label_sync.py
@@ -1,0 +1,52 @@
+"""Sync current votes into the loaded trainable model's labelset on disk.
+
+Provides :func:`sync_labels_to_loaded_model` which persists the active
+detector's votes into the corresponding trainable-model JSON file so the
+dashboard stays up-to-date without an explicit save.
+"""
+
+from __future__ import annotations
+
+
+def sync_labels_to_loaded_model() -> None:
+    """Persist the current votes into the loaded model's labelset (if any).
+
+    Called automatically after each vote so the dashboard's "# Training"
+    and "Last Trained" columns stay up to date without an explicit save.
+
+    Skipped when the model is in "find mode" (after ``/api/find-label``),
+    because the global votes reflect scoring results on a different dataset,
+    not the model's original training labels.
+    """
+    from vtsearch.models.registry import get_model, is_find_mode, update_model
+    from vtsearch.models.trainable_model_store import _model_path, _read_model, _write_model
+    from vtsearch.utils import get_active_detector_context
+
+    if is_find_mode():
+        return
+
+    det_ctx = get_active_detector_context()
+    loaded_id = det_ctx.detector_id if det_ctx.detector_id else None
+    if not loaded_id:
+        return
+
+    entry = get_model(loaded_id)
+    if not entry or not entry.get("trainable") or not entry.get("trainable_model_name"):
+        return
+
+    tm_name = entry["trainable_model_name"]
+    path = _model_path(tm_name)
+    data = _read_model(path)
+    if data is None:
+        return
+
+    from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+
+    labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bad_votes, expand_dupes=False)
+    data["labelset"] = labelset.to_dict()
+    _write_model(path, data)
+
+    import time as _time
+
+    update_model(entry["id"], num_training=len(labelset), last_trained_at=_time.time())

--- a/vtsearch/models/trainable_model_store.py
+++ b/vtsearch/models/trainable_model_store.py
@@ -1,0 +1,47 @@
+"""Low-level file I/O helpers for trainable model JSON files.
+
+Provides path resolution, read, and write utilities used by the route
+layer (``vtsearch.routes.trainable_models``) and by model-layer modules
+that need to persist or inspect trainable-model data without importing
+the full route blueprint.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from vtsearch.config import DATA_DIR
+
+
+def get_trainable_models_dir() -> Path:
+    """Return the configured trainable-models directory from settings."""
+    from vtsearch.settings import get_trainable_models_dir as _get
+
+    return _get()
+
+
+#: Backward-compat alias -- prefer :func:`get_trainable_models_dir` for live value.
+TRAINABLE_MODELS_DIR = DATA_DIR / "trainable_models"
+
+
+def _slug(name: str) -> str:
+    """Turn a human-readable name into a filesystem-safe slug."""
+    return re.sub(r"[^a-z0-9_-]+", "_", name.lower()).strip("_") or "model"
+
+
+def _model_path(name: str) -> Path:
+    return get_trainable_models_dir() / f"{_slug(name)}.json"
+
+
+def _read_model(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_model(path: Path, data: dict) -> None:
+    get_trainable_models_dir().mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/vtsearch/models/training_workflow.py
+++ b/vtsearch/models/training_workflow.py
@@ -24,7 +24,7 @@ def apply_and_retrain(
     """
     from flask import g
 
-    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+    from vtsearch.models.label_sync import sync_labels_to_loaded_model
     from vtsearch.utils import (
         apply_label,
         build_media_lookup,

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -143,7 +143,7 @@ def add_autorun_detector_route():
         # model file so that labels and examples persist across restarts.
         trainable_model_name = ""
         if not weights:
-            from vtsearch.routes.trainable_models import _model_path, _write_model
+            from vtsearch.models.trainable_model_store import _model_path, _write_model
             import time as _time
 
             trainable_model_name = name

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -108,7 +108,7 @@ def find_label():
     import torch  # noqa: PLC0415
 
     from vtsearch.models.registry import get_model as reg_get_model
-    from vtsearch.routes.trainable_models import _model_path, _read_model
+    from vtsearch.models.trainable_model_store import _model_path, _read_model
     from vtsearch.utils import (
         apply_labels_bulk_with_click_time,
         get_autorun_detectors,

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -423,7 +423,7 @@ def find_check_labels():
     from vtsearch.datasets.loader import safe_pickle_load
     from vtsearch.datasets.registry import get_dataset as reg_get_ds
     from vtsearch.models.registry import get_model as reg_get_model
-    from vtsearch.routes.trainable_models import _model_path, _read_model
+    from vtsearch.models.trainable_model_store import _model_path, _read_model
 
     body = get_json_safe()
     dataset_ids = body.get("dataset_ids", [])
@@ -534,7 +534,7 @@ def multi_find():
     from vtsearch.datasets.loader import safe_pickle_load
     from vtsearch.datasets.registry import get_dataset as reg_get_ds
     from vtsearch.models.registry import get_model as reg_get_model
-    from vtsearch.routes.trainable_models import _model_path, _read_model
+    from vtsearch.models.trainable_model_store import _model_path, _read_model
 
     body = get_json_safe()
     dataset_ids = body.get("dataset_ids", [])

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -163,7 +163,7 @@ def run_label_import(importer_name: str):
     # Sync updated votes into the loaded model so the dashboard reflects
     # the new label count (num_training) immediately.
     if applied > 0:
-        from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+        from vtsearch.models.label_sync import sync_labels_to_loaded_model
 
         sync_labels_to_loaded_model()
 
@@ -227,7 +227,7 @@ def ingest_missing():
     # Sync updated votes into the loaded model so the dashboard reflects
     # the new label count immediately.
     if applied > 0:
-        from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+        from vtsearch.models.label_sync import sync_labels_to_loaded_model
 
         sync_labels_to_loaded_model()
 

--- a/vtsearch/routes/labels.py
+++ b/vtsearch/routes/labels.py
@@ -153,7 +153,7 @@ def import_labels():
             apply_label(cid, label)
         applied += 1
 
-    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+    from vtsearch.models.label_sync import sync_labels_to_loaded_model
 
     sync_labels_to_loaded_model()
 
@@ -269,7 +269,7 @@ def fill_labels_from_sort():
         },
     }
 
-    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+    from vtsearch.models.label_sync import sync_labels_to_loaded_model
 
     sync_labels_to_loaded_model()
 

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -537,7 +537,7 @@ def vote_media(media_id: int) -> tuple[Response, int] | Response:
 
     toggle_vote(media_id, vote)
 
-    from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+    from vtsearch.models.label_sync import sync_labels_to_loaded_model
 
     sync_labels_to_loaded_model()
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -253,7 +253,7 @@ def seed_votes_from_examples():
     skipped = len(examples) - seeded
 
     if seeded > 0:
-        from vtsearch.routes.trainable_models import sync_labels_to_loaded_model
+        from vtsearch.models.label_sync import sync_labels_to_loaded_model
 
         sync_labels_to_loaded_model()
 

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -27,96 +27,24 @@ POST /api/trainable-models/<name>/labels
 
 from __future__ import annotations
 
-import json
 import logging
-import re
 import threading
 import time
-from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 
 from vtsearch.auth import get_current_user
-from vtsearch.config import DATA_DIR
+from vtsearch.models.label_sync import sync_labels_to_loaded_model
+from vtsearch.models.trainable_model_store import (
+    _model_path,
+    _read_model,
+    _write_model,
+    get_trainable_models_dir,
+)
 
 logger = logging.getLogger(__name__)
 
 trainable_models_bp = Blueprint("trainable_models", __name__)
-
-
-def get_trainable_models_dir() -> Path:
-    """Return the configured trainable-models directory from settings."""
-    from vtsearch.settings import get_trainable_models_dir as _get
-
-    return _get()
-
-
-#: Backward-compat alias — prefer :func:`get_trainable_models_dir` for live value.
-TRAINABLE_MODELS_DIR = DATA_DIR / "trainable_models"
-
-
-def _slug(name: str) -> str:
-    """Turn a human-readable name into a filesystem-safe slug."""
-    return re.sub(r"[^a-z0-9_-]+", "_", name.lower()).strip("_") or "model"
-
-
-def _model_path(name: str) -> Path:
-    return get_trainable_models_dir() / f"{_slug(name)}.json"
-
-
-def _read_model(path: Path) -> dict | None:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-
-
-def _write_model(path: Path, data: dict) -> None:
-    get_trainable_models_dir().mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-
-
-def sync_labels_to_loaded_model() -> None:
-    """Persist the current votes into the loaded model's labelset (if any).
-
-    Called automatically after each vote so the dashboard's "# Training"
-    and "Last Trained" columns stay up to date without an explicit save.
-
-    Skipped when the model is in "find mode" (after ``/api/find-label``),
-    because the global votes reflect scoring results on a different dataset,
-    not the model's original training labels.
-    """
-    from vtsearch.models.registry import get_model, is_find_mode, update_model
-    from vtsearch.utils import get_active_detector_context
-
-    if is_find_mode():
-        return
-
-    det_ctx = get_active_detector_context()
-    loaded_id = det_ctx.detector_id if det_ctx.detector_id else None
-    if not loaded_id:
-        return
-
-    entry = get_model(loaded_id)
-    if not entry or not entry.get("trainable") or not entry.get("trainable_model_name"):
-        return
-
-    tm_name = entry["trainable_model_name"]
-    path = _model_path(tm_name)
-    data = _read_model(path)
-    if data is None:
-        return
-
-    from vtsearch.datasets.labelset import LabelSet
-    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
-
-    labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bad_votes, expand_dupes=False)
-    data["labelset"] = labelset.to_dict()
-    _write_model(path, data)
-
-    import time as _time
-
-    update_model(entry["id"], num_training=len(labelset), last_trained_at=_time.time())
 
 
 # Canonical location: vtsearch.models.media_seeding


### PR DESCRIPTION
## Summary
Extracted low-level trainable model file I/O utilities and label synchronization logic from the routes layer into dedicated model layer modules to improve code organization and reduce circular dependencies.

## Key Changes

- **New module `vtsearch/models/trainable_model_store.py`**: Contains all file I/O helpers for trainable model JSON files:
  - `get_trainable_models_dir()` - directory path resolution
  - `_slug()` - filename slug generation
  - `_model_path()` - model file path resolution
  - `_read_model()` - JSON deserialization with error handling
  - `_write_model()` - JSON serialization with directory creation
  - `TRAINABLE_MODELS_DIR` - backward-compatibility constant

- **New module `vtsearch/models/label_sync.py`**: Contains label synchronization logic:
  - `sync_labels_to_loaded_model()` - persists current votes into the loaded model's labelset on disk, called automatically after each vote to keep the dashboard up-to-date

- **Updated `vtsearch/routes/trainable_models.py`**: Removed extracted utilities and functions, now imports them from the new model layer modules

- **Updated all imports across the codebase**: 
  - Routes and other modules now import `_model_path`, `_read_model`, `_write_model` from `vtsearch.models.trainable_model_store`
  - Routes and other modules now import `sync_labels_to_loaded_model` from `vtsearch.models.label_sync`
  - Updated imports in: `detectors_training.py`, `label_importers.py`, `labels.py`, `detectors_crud.py`, `detectors_scoring.py`, `medias.py`, `sorting.py`, `training_workflow.py`
  - Updated test imports in: `test_detectors.py`, `test_resolver.py`, `test_multi_dataset.py`, `test_trainable_models.py`, `test_label_import_endpoint.py`

## Implementation Details

- The extracted utilities are now part of the model layer (`vtsearch.models`), making them available to other model-layer modules without importing from routes
- This eliminates potential circular import issues and provides a cleaner separation of concerns
- All functionality remains unchanged; this is purely a refactoring for better code organization
- The `sync_labels_to_loaded_model()` function includes comprehensive docstrings explaining its behavior and when it's skipped (find mode)

https://claude.ai/code/session_01K8PKLsMHJXvZAYbMroSvrH