### PR TITLE
Honor prefers-reduced-motion for thin-client performance

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -12,6 +12,7 @@ import { VideoPlayerComponent } from './video-player/video-player.component';
 import { TextViewerComponent } from './text-viewer/text-viewer.component';
 import { DocumentViewerComponent } from './document-viewer/document-viewer.component';
 import { VotingOverlayComponent } from './voting-overlay/voting-overlay.component';
+import { prefersReducedMotion } from '../../utils/reduced-motion';
 
 @Component({
   selector: 'vt-center-panel',
@@ -153,7 +154,8 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
     this.mediasApi.vote(this.media.id, vote).subscribe({
       next: () => {
-        if (this.swipeAnimation && this.media) {
+        const animate = this.swipeAnimation && !!this.media && !prefersReducedMotion();
+        if (animate) {
           this.swipeClass = vote === 'good' ? 'swipe-right' : 'swipe-left';
           this.spinningVote = vote;
           if (this.spinTimer) clearTimeout(this.spinTimer);

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -18,6 +18,7 @@ import { MediaItemComponent } from '../media-item/media-item.component';
 import { MediaItem } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { SortedItem } from '../left-panel.component';
+import { prefersReducedMotion } from '../../../utils/reduced-motion';
 
 /** Threshold above which we switch from plain DOM to CDK virtual scrolling (list mode only). */
 const VIRTUAL_SCROLL_THRESHOLD = 500;
@@ -152,16 +153,17 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
       scrollEl.scrollTop = pct * maxScroll;
     } else if (this.pendingScrollToSelected) {
       this.pendingScrollToSelected = false;
+      const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
       if (this.useVirtualScroll && this.virtualViewport) {
         // In virtual-scroll mode, find the index and scroll to it.
         const idx = this.cachedOrderedItems.findIndex((i) => i.media.id === this.selectedId);
         if (idx >= 0) {
-          this.virtualViewport.scrollToIndex(idx, 'smooth');
+          this.virtualViewport.scrollToIndex(idx, behavior);
         }
       } else if (this.listContainer) {
         const activeEl = this.listContainer.nativeElement.querySelector('.media-item.active');
         if (activeEl) {
-          activeEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+          activeEl.scrollIntoView({ block: 'nearest', behavior });
         }
       }
     }
@@ -176,8 +178,9 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
   }
 
   scrollToIndex(index: number): void {
+    const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
     if (this.useVirtualScroll && this.virtualViewport) {
-      this.virtualViewport.scrollToIndex(index, 'smooth');
+      this.virtualViewport.scrollToIndex(index, behavior);
       // After scrolling, select the item at this index.
       const item = this.cachedOrderedItems[index];
       if (item) {
@@ -195,7 +198,7 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
     const offset = targetRect.top - containerRect.top + container.scrollTop;
     container.scrollTo({
       top: offset - containerRect.height / 2 + targetRect.height / 2,
-      behavior: 'smooth',
+      behavior,
     });
   }
 

--- a/frontend/src/app/utils/reduced-motion.ts
+++ b/frontend/src/app/utils/reduced-motion.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns true when the user (or OS) has asked for reduced motion.
+ * Falls back to false in non-browser contexts (SSR, tests without matchMedia).
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -16,3 +16,17 @@ html, body {
   background: var(--bg-body);
   color: var(--text-primary);
 }
+
+// Honor OS-level "reduce motion" requests (also a useful escape hatch for
+// thin clients with no GPU compositing — long CSS animations can pin a
+// software-rendered browser).
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

Thin-clients with software-rendered browsers can get pinned by long CSS animations and native smooth-scroll. This PR makes the UI degrade gracefully on those machines by respecting the OS-level `prefers-reduced-motion` setting.

- **Global CSS** in `styles.scss`: under `@media (prefers-reduced-motion: reduce)`, animation/transition durations collapse to 0.01ms, infinite animations stop after one iteration, and CSS smooth-scroll is disabled.
- **Vote casting** (`center-panel.component.ts`): when motion is reduced, skip the 180ms swipe-out timer and emit `mediaVoted` immediately, so cards advance instantly instead of waiting on an animation that's been squashed to nothing.
- **Media list scroll** (`media-list.component.ts`): `scrollToIndex` and scroll-to-selected pass `'auto'` instead of `'smooth'` when motion is reduced, avoiding browser smooth-scroll jank on weak GPUs.
- **Shared util**: `frontend/src/app/utils/reduced-motion.ts` — a small `prefersReducedMotion()` helper wrapping `matchMedia`, safe for SSR/tests.

Users already had the `swipe_animation` setting as an escape hatch; this adds automatic detection so thin-client users don't need to find the toggle.

## Test plan

- [x] `./run-tests.sh core` — 341/341 passed (includes frontend TypeScript build + audit)
- [x] `npm run build:prod` — clean, no TS errors
- [ ] Manual: load the app with DevTools "Emulate CSS prefers-reduced-motion: reduce" and confirm voting advances instantly and list scrolling jumps without animation
- [ ] Manual: with the emulation off, confirm swipe animations and smooth-scroll still work as before