### PR TITLE
Fix concurrency issues and improve robustness across sync and state management

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,11 +82,20 @@ app.secret_key = os.environ.get("VTSEARCH_SECRET_KEY", "vtsearch-dev-key-change-
 
 @app.before_request
 def _set_user_context():
-    """Populate ``g.user`` from the active LoginProvider on every request."""
+    """Populate ``g.user`` from the active LoginProvider on every request.
+
+    A misbehaving provider must not be able to take down the server by
+    raising from ``get_user``; swallow exceptions and fall back to
+    ``"default"``.
+    """
     from flask import request
 
-    provider = get_login_provider()
-    g.user = provider.get_user(request)
+    try:
+        provider = get_login_provider()
+        g.user = provider.get_user(request)
+    except Exception:
+        logging.getLogger(__name__).exception("Login provider get_user failed")
+        g.user = "default"
 
 
 @app.before_request
@@ -100,6 +109,9 @@ def _set_request_context():
 
     When the headers are absent the proxies fall back to the global
     active pointers, preserving backward compatibility.
+
+    Any failure here must not 500 every subsequent request — fall back
+    to the default (empty) context.
     """
     from flask import request
     from vtsearch.utils.state_core import (
@@ -107,20 +119,23 @@ def _set_request_context():
         get_detector_context,
     )
 
-    # Headers (Angular HttpClient interceptor) take priority, with query
-    # params as fallback for browser-native requests (<img src>, <audio src>,
-    # <video src>, etc.) that bypass Angular's interceptor.
-    ds_id = request.headers.get("X-Dataset-Id") or request.args.get("dataset_id")
-    if ds_id:
-        ctx = get_context(ds_id)
-        if ctx is not None:
-            g._dataset_context = ctx
+    try:
+        # Headers (Angular HttpClient interceptor) take priority, with query
+        # params as fallback for browser-native requests (<img src>,
+        # <audio src>, <video src>) that bypass Angular's interceptor.
+        ds_id = request.headers.get("X-Dataset-Id") or request.args.get("dataset_id")
+        if ds_id:
+            ctx = get_context(ds_id)
+            if ctx is not None:
+                g._dataset_context = ctx
 
-    model_id = request.headers.get("X-Model-Id") or request.args.get("model_id")
-    if model_id:
-        det_ctx = get_detector_context(model_id)
-        if det_ctx is not None:
-            g._detector_context = det_ctx
+        model_id = request.headers.get("X-Model-Id") or request.args.get("model_id")
+        if model_id:
+            det_ctx = get_detector_context(model_id)
+            if det_ctx is not None:
+                g._detector_context = det_ctx
+    except Exception:
+        logging.getLogger(__name__).exception("Request context resolution failed")
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -3,8 +3,15 @@
 import os
 from pathlib import Path
 
-# Dataset paths
-DATA_DIR = Path("data")
+# Data paths are anchored to the repository root, NOT to the current working
+# directory.  Without this, starting the app from a different CWD (systemd,
+# cron, dev shell) would create a fresh empty `data/` and silently lose the
+# user's existing datasets, settings, and embeddings.  Override with the
+# ``VTSEARCH_DATA_DIR`` env var if you need to relocate state outside the repo.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = (
+    Path(os.environ["VTSEARCH_DATA_DIR"]) if "VTSEARCH_DATA_DIR" in os.environ else _REPO_ROOT / "data"
+)
 EMBEDDINGS_DIR = DATA_DIR / "embeddings"
 MODELS_CACHE_DIR = (
     Path(os.environ["VTSEARCH_MODELS_DIR"]) if "VTSEARCH_MODELS_DIR" in os.environ else DATA_DIR / "models"

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -117,7 +117,9 @@ def download_file_with_progress(
     if on_progress is None:
         on_progress = _default_progress()
 
-    response = requests.get(url, stream=True)
+    # (connect_timeout, read_timeout): fail fast on unresponsive hosts
+    # and abort if the server stops streaming bytes for 60s mid-download.
+    response = requests.get(url, stream=True, timeout=(10, 60))
     response.raise_for_status()
     total_size = int(response.headers.get("content-length", 0))
     if total_size == 0:

--- a/vtsearch/datasets/downloader/video.py
+++ b/vtsearch/datasets/downloader/video.py
@@ -13,7 +13,7 @@ def _extract_rar(rar_path: Path, extract_to: Path) -> None:
     """Extract a RAR archive using the system ``unrar`` command.
 
     Raises ``RuntimeError`` with installation instructions when ``unrar``
-    is not found on the system PATH.
+    is not found on the system PATH, or if extraction hangs / fails.
     """
     extract_to.mkdir(parents=True, exist_ok=True)
     try:
@@ -21,12 +21,20 @@ def _extract_rar(rar_path: Path, extract_to: Path) -> None:
             ["unrar", "x", "-o+", "-y", str(rar_path), str(extract_to) + "/"],
             check=True,
             capture_output=True,
+            # Cap at 30 minutes. A malformed RAR could otherwise hang the
+            # loader thread indefinitely.
+            timeout=1800,
         )
     except FileNotFoundError:
         raise RuntimeError(
             "The 'unrar' command is required to extract HMDB51 but was not found. "
             "Install it with: apt-get install unrar (Debian/Ubuntu) or "
             "brew install unrar (macOS)."
+        ) from None
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"unrar timed out after {e.timeout}s while extracting {rar_path.name}. "
+            "The archive may be corrupt."
         ) from None
 
 

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -21,6 +21,7 @@ import json
 from typing import Any, Callable, Optional
 
 from vtsearch.utils.state import next_media_id
+from vtsearch.utils.state_core import _state_lock
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -111,7 +112,6 @@ def _ingest_via_source(
     from vtsearch.models.resolver import embed_file
 
     ingested = 0
-    cid = next_media_id(medias)
 
     try:
         for entry in entries:
@@ -133,19 +133,20 @@ def _ingest_via_source(
             file_bytes = file_path.read_bytes()
             md5 = hashlib.md5(file_bytes).hexdigest()
 
-            media_data: dict[str, Any] = {
-                "id": cid,
-                "filename": origin_name or file_path.name,
-                "origin": origin_dict,
-                "origin_name": origin_name or file_path.name,
-                "md5": md5,
-                "embedding": embedding,
-                "media_bytes": file_bytes,
-                "media_path": str(file_path),
-            }
-
-            medias[cid] = media_data
-            cid += 1
+            # Allocate the ID and insert atomically, so two concurrent
+            # ingests cannot collide on the same next_media_id.
+            with _state_lock:
+                cid = next_media_id(medias)
+                medias[cid] = {
+                    "id": cid,
+                    "filename": origin_name or file_path.name,
+                    "origin": origin_dict,
+                    "origin_name": origin_name or file_path.name,
+                    "md5": md5,
+                    "embedding": embedding,
+                    "media_bytes": file_bytes,
+                    "media_path": str(file_path),
+                }
             ingested += 1
 
             on_progress(
@@ -183,7 +184,6 @@ def _ingest_via_resolver(
     from vtsearch.models.resolver import embed_file, resolve_file_from_origin
 
     ingested = 0
-    cid = next_media_id(medias)
 
     for entry in entries:
         origin_name = entry.get("origin_name", "")
@@ -207,19 +207,19 @@ def _ingest_via_resolver(
         file_bytes = file_path.read_bytes()
         md5 = hashlib.md5(file_bytes).hexdigest()
 
-        media_data: dict[str, Any] = {
-            "id": cid,
-            "filename": origin_name or file_path.name,
-            "origin": origin_dict,
-            "origin_name": origin_name or file_path.name,
-            "md5": md5,
-            "embedding": embedding,
-            "media_bytes": file_bytes,
-            "media_path": str(file_path),
-        }
-
-        medias[cid] = media_data
-        cid += 1
+        # Atomic id allocation + insert, see _ingest_via_source above.
+        with _state_lock:
+            cid = next_media_id(medias)
+            medias[cid] = {
+                "id": cid,
+                "filename": origin_name or file_path.name,
+                "origin": origin_dict,
+                "origin_name": origin_name or file_path.name,
+                "md5": md5,
+                "embedding": embedding,
+                "media_bytes": file_bytes,
+                "media_path": str(file_path),
+            }
         ingested += 1
 
         on_progress(
@@ -326,15 +326,16 @@ def ingest_missing_medias(
             if not media.get("origin_name"):
                 media["origin_name"] = media.get("filename", "")
 
-        # Cherry-pick matching medias
-        cid = next_media_id(medias)
+        # Cherry-pick matching medias.  Allocate IDs and insert atomically
+        # under _state_lock so a concurrent ingest can't reuse the same ID.
         for temp_clip in temp_medias.values():
             clip_origin_name = temp_clip.get("origin_name", "")
             clip_md5 = temp_clip.get("md5", "")
             if clip_origin_name in wanted_names or clip_md5 in wanted_md5s:
-                temp_clip["id"] = cid
-                medias[cid] = temp_clip
-                cid += 1
+                with _state_lock:
+                    cid = next_media_id(medias)
+                    temp_clip["id"] = cid
+                    medias[cid] = temp_clip
                 total_ingested += 1
 
     on_progress("idle", f"Ingested {total_ingested} media(s) from origins.", 0, 0)

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -11,11 +11,29 @@ No additional pip packages are required; uses only Python's ``csv`` and
 from __future__ import annotations
 
 import csv
+import io
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
+
+
+def _atomic_write_csv(path: Path, write_rows) -> None:
+    """Build CSV content in memory then write atomically.
+
+    *write_rows* is invoked with a ``csv.writer`` and is expected to emit
+    every row.  Buffering in memory keeps the destination file untouched
+    until the write succeeds, so a process crash mid-write cannot leave
+    a half-written CSV behind.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    write_rows(writer)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(buf.getvalue(), encoding="utf-8", newline="")
+    os.replace(tmp, path)
 
 # Characters that trigger formula execution in spreadsheet applications.
 _FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
@@ -89,10 +107,10 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         columns.append("origin")
 
         total_rows = 0
-        with open(filepath, "w", newline="", encoding="utf-8") as f:
-            writer = csv.writer(f)
-            writer.writerow(columns)
 
+        def _write(writer: "csv.writer") -> None:  # type: ignore[name-defined]
+            nonlocal total_rows
+            writer.writerow(columns)
             for entry in labels:
                 meta = entry.get("custom_metadata") or {}
                 row = []
@@ -113,6 +131,8 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                         row.append("")
                 writer.writerow(row)
                 total_rows += 1
+
+        _atomic_write_csv(filepath, _write)
 
         return {
             "message": f"Saved {total_rows} label(s) to {filepath.resolve()}.",
@@ -143,10 +163,10 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         base_cols.extend(["origin", "origin_name"])
 
         total_hits = 0
-        with open(filepath, "w", newline="", encoding="utf-8") as f:
-            writer = csv.writer(f)
-            writer.writerow(base_cols)
 
+        def _write(writer: "csv.writer") -> None:  # type: ignore[name-defined]
+            nonlocal total_hits
+            writer.writerow(base_cols)
             for detector_name, threshold, hit in all_hits:
                 origin = hit.get("origin")
                 origin_str = ""
@@ -174,6 +194,8 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
                 ])
                 writer.writerow(row)
                 total_hits += 1
+
+        _atomic_write_csv(filepath, _write)
 
         return {
             "message": (

--- a/vtsearch/exporters/server_json_file/__init__.py
+++ b/vtsearch/exporters/server_json_file/__init__.py
@@ -11,10 +11,22 @@ No additional pip packages are required; uses only Python's ``json`` and
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically (tmp file + rename).
+
+    A direct ``write_text`` call leaves the destination truncated if the
+    process is killed mid-write.
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
 
 
 class ServerJsonLabelsetExporter(LabelsetExporter):
@@ -57,7 +69,7 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
             return self._export_labels(results, filepath)
 
         # Autodetect results format (from CLI / fill-from-sort)
-        filepath.write_text(json.dumps(results, indent=2), encoding="utf-8")
+        _atomic_write_text(filepath, json.dumps(results, indent=2))
 
         total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
         return {
@@ -89,7 +101,7 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
         else:
             output = {"labels": labels}
 
-        filepath.write_text(json.dumps(output, indent=2), encoding="utf-8")
+        _atomic_write_text(filepath, json.dumps(output, indent=2))
         return {
             "message": f"Saved {len(labels)} label(s) to {filepath.resolve()}.",
             "filepath": str(filepath.resolve()),

--- a/vtsearch/labels/sync.py
+++ b/vtsearch/labels/sync.py
@@ -4,7 +4,9 @@ Provides :func:`sync_to_labelset_source` which exports the current
 detector's labels to its linked labelset source (if any), and
 :func:`sync_from_labelset_source` which imports labels from the source.
 
-A thread-local guard prevents re-exporting during an import pass.
+A module-level (NOT thread-local) flag, coordinated by ``_sync_lock``,
+prevents re-exporting during an import pass — including from concurrent
+``sync_to`` calls running on other threads.
 """
 
 from __future__ import annotations
@@ -15,9 +17,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Thread-local guard to prevent re-exporting to the source during an
-# import-from-source pass.
-_syncing = threading.local()
+# Serializes label sync operations and protects ``_syncing``.  A
+# thread-local guard cannot stop a parallel ``sync_to`` on another
+# thread from racing with a ``sync_from`` import.
+_sync_lock = threading.RLock()
+_syncing: bool = False
 
 
 def sync_to_labelset_source() -> None:
@@ -27,9 +31,6 @@ def sync_to_labelset_source() -> None:
     a labelset source attached.  Skips silently if no source is configured
     or if we are already inside a sync-from-source import.
     """
-    if getattr(_syncing, "active", False):
-        return
-
     from vtsearch.utils.state_core import get_active_detector_context
 
     ctx = get_active_detector_context()
@@ -53,11 +54,17 @@ def sync_to_labelset_source() -> None:
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.utils.state_core import good_votes, bad_votes, medias
 
-    try:
-        labelset = LabelSet.from_clips_and_votes(dict(medias), dict(good_votes), dict(bad_votes))
-        source.save(labelset, field_values)
-    except Exception as exc:
-        logger.exception("Failed to sync labels to source: %s", exc)
+    # Serialize against any in-progress sync_from on another thread.
+    # Re-check the flag inside the lock so we never push partial state
+    # back to the source during an import.
+    with _sync_lock:
+        if _syncing:
+            return
+        try:
+            labelset = LabelSet.from_clips_and_votes(dict(medias), dict(good_votes), dict(bad_votes))
+            source.save(labelset, field_values)
+        except Exception as exc:
+            logger.exception("Failed to sync labels to source: %s", exc)
 
 
 def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, str]] | None:
@@ -103,25 +110,30 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
     if not labels:
         return None
 
-    # Apply under sync guard to prevent re-exporting back to source.
-    _syncing.active = True
-    try:
-        from vtsearch.utils.state_votes import apply_label
+    # Hold _sync_lock for the entire apply pass so that any concurrent
+    # sync_to_labelset_source() on another thread blocks (or skips, on
+    # re-entry from this same thread) instead of pushing the pre-import
+    # state back to the source.
+    global _syncing
+    with _sync_lock:
+        _syncing = True
+        try:
+            from vtsearch.utils.state_votes import apply_label
 
-        for entry in labels:
-            label = entry.get("label")
-            md5 = entry.get("md5")
-            if label not in ("good", "bad") or not md5:
-                continue
+            for entry in labels:
+                label = entry.get("label")
+                md5 = entry.get("md5")
+                if label not in ("good", "bad") or not md5:
+                    continue
 
-            # Find media by md5
-            from vtsearch.utils.state_core import medias
+                # Find media by md5
+                from vtsearch.utils.state_core import medias
 
-            for mid, media in medias.items():
-                if media.get("md5") == md5:
-                    apply_label(mid, label)
-                    break
-    finally:
-        _syncing.active = False
+                for mid, media in medias.items():
+                    if media.get("md5") == md5:
+                        apply_label(mid, label)
+                        break
+        finally:
+            _syncing = False
 
     return labels

--- a/vtsearch/routes/datasets_loading.py
+++ b/vtsearch/routes/datasets_loading.py
@@ -684,13 +684,18 @@ def _run_origin_load_in_background(
 
 def _migrate_context_id(old_id: str, new_id: str) -> None:
     """Re-key a context from *old_id* to *new_id* in the store."""
-    from vtsearch.utils.state_core import _contexts
+    from vtsearch.utils.state_core import _contexts, _state_lock
 
-    ctx = _contexts.pop(old_id, None)
-    if ctx is None:
-        return
-    ctx.dataset_id = new_id
-    _contexts[new_id] = ctx
+    with _state_lock:
+        ctx = _contexts.get(old_id)
+        if ctx is None:
+            return
+        ctx.dataset_id = new_id
+        # Insert under the new key before removing the old, so the context
+        # is never briefly invisible to concurrent lookups.
+        _contexts[new_id] = ctx
+        if old_id != new_id:
+            _contexts.pop(old_id, None)
 
 
 def _run_importer_in_background(importer, field_values: dict) -> str:

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -146,6 +146,18 @@ def _send_video_bytes(data: bytes, mimetype: str, download_name: str) -> Respons
             start, end = 0, total - 1
 
         end = min(end, total - 1)
+
+        # Reject unsatisfiable ranges (start past EOF, negative, or
+        # inverted). RFC 7233 requires 416 with Content-Range: bytes */N.
+        if start < 0 or start >= total or start > end:
+            resp = make_response(b"")
+            resp.status_code = 416
+            resp.headers["Content-Range"] = f"bytes */{total}"
+            resp.headers["Content-Length"] = "0"
+            resp.headers["Content-Type"] = mimetype
+            resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+
         length = end - start + 1
 
         resp = make_response(data[start : end + 1])

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -93,9 +93,13 @@ _settings: dict[str, Any] | None = None
 # public functions that also acquire the lock.
 _settings_lock = threading.RLock()
 
-# Thread-local guard to prevent re-exporting to the source during an
-# import-from-source pass.
-_syncing = threading.local()
+# Module-level (NOT thread-local) guard that prevents re-exporting to the
+# source during an import-from-source pass.  A thread-local flag would not
+# block a concurrent ``set_*()`` call running on a different thread from
+# triggering a ``_sync_to_source(...)`` while we are mid-import — racing
+# with and potentially overwriting the data we just imported.  Always
+# read/written while holding ``_settings_lock``.
+_syncing: bool = False
 
 
 def _load() -> dict[str, Any]:
@@ -127,7 +131,9 @@ def _save(data: dict[str, Any]) -> None:
     os.replace(tmp, SETTINGS_PATH)
 
     # Auto-export to active settings source (skip during import-from-source).
-    if not getattr(_syncing, "active", False):
+    # ``_syncing`` is process-wide, so a parallel set_*() on another thread
+    # correctly skips the export while sync_from_settings_source() is running.
+    if not _syncing:
         _sync_to_source(data)
 
 
@@ -804,12 +810,18 @@ def sync_from_settings_source() -> dict[str, Any] | None:
     if not imported:
         return None
 
-    # Apply under sync guard to prevent re-exporting back to source.
-    _syncing.active = True
-    try:
-        _apply_settings(imported)
-    finally:
-        _syncing.active = False
+    # Hold _settings_lock for the entire apply pass so that:
+    #   * concurrent set_*() calls on other threads block until we finish,
+    #     instead of racing and re-exporting partially-imported state
+    #   * the _syncing flag (also guarded by _settings_lock) is observed
+    #     consistently by every _save() that runs during the import
+    global _syncing
+    with _settings_lock:
+        _syncing = True
+        try:
+            _apply_settings(imported)
+        finally:
+            _syncing = False
 
     return imported
 

--- a/vtsearch/settings_io/exporters/server_json_file/__init__.py
+++ b/vtsearch/settings_io/exporters/server_json_file/__init__.py
@@ -7,6 +7,7 @@ filesystem.  The user supplies a destination path via the file browser.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -43,7 +44,12 @@ class ServerFileSettingsExporter(SettingsExporter):
 
         filepath = Path(filepath_str)
         filepath.parent.mkdir(parents=True, exist_ok=True)
-        filepath.write_text(json.dumps(settings_data, indent=2), encoding="utf-8")
+
+        # Atomic write: tmp + rename. A direct write_text leaves the file
+        # truncated if the process is killed mid-write.
+        tmp = filepath.with_name(filepath.name + ".tmp")
+        tmp.write_text(json.dumps(settings_data, indent=2), encoding="utf-8")
+        os.replace(tmp, filepath)
 
         return {
             "message": f"Settings saved to {filepath.resolve()}.",

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -207,35 +207,40 @@ def get_thread_dataset_context() -> DatasetContext | None:
 
 def register_context(ctx: DatasetContext) -> None:
     """Add *ctx* to the context store, keyed by its ``dataset_id``."""
-    _contexts[ctx.dataset_id] = ctx
+    with _state_lock:
+        _contexts[ctx.dataset_id] = ctx
 
 
 def unregister_context(dataset_id: str) -> DatasetContext | None:
     """Remove and return the context for *dataset_id*, or ``None``."""
-    ctx = _contexts.pop(dataset_id, None)
-    # Clear thread-local if it was pointing to the removed context.
-    tl_ctx = getattr(_thread_local, "dataset_context", None)
-    if tl_ctx is not None and tl_ctx.dataset_id == dataset_id:
-        _thread_local.dataset_context = None
-    return ctx
+    with _state_lock:
+        ctx = _contexts.pop(dataset_id, None)
+        # Clear thread-local if it was pointing to the removed context.
+        tl_ctx = getattr(_thread_local, "dataset_context", None)
+        if tl_ctx is not None and tl_ctx.dataset_id == dataset_id:
+            _thread_local.dataset_context = None
+        return ctx
 
 
 def get_context(dataset_id: str) -> DatasetContext | None:
     """Return the context for *dataset_id*, or ``None`` if not loaded."""
-    return _contexts.get(dataset_id)
+    with _state_lock:
+        return _contexts.get(dataset_id)
 
 
 def list_loaded_dataset_ids() -> list[str]:
     """Return all dataset IDs that have an in-memory context."""
-    return list(_contexts.keys())
+    with _state_lock:
+        return list(_contexts.keys())
 
 
 def clear_all_contexts() -> None:
     """Remove all dataset contexts and clear the thread-local.  For tests."""
-    _contexts.clear()
-    _thread_local.dataset_context = None
-    # Also reset the empty context's state
-    _empty_dataset_context.__init__("")  # type: ignore[misc]
+    with _state_lock:
+        _contexts.clear()
+        _thread_local.dataset_context = None
+        # Also reset the empty context's state
+        _empty_dataset_context.__init__("")  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +293,10 @@ def register_detector_context(ctx: DetectorContext) -> None:
     """
     from vtsearch.models.progress import clear_progress_cache
 
-    _detector_contexts[ctx.detector_id] = ctx
+    with _state_lock:
+        _detector_contexts[ctx.detector_id] = ctx
+    # clear_progress_cache acquires its own lock; call outside _state_lock
+    # to avoid lock-ordering concerns.
     clear_progress_cache()
 
 
@@ -300,29 +308,33 @@ def unregister_detector_context(detector_id: str) -> DetectorContext | None:
     """
     from vtsearch.models.progress import clear_progress_cache
 
-    ctx = _detector_contexts.pop(detector_id, None)
-    tl_ctx = getattr(_thread_local, "detector_context", None)
-    if tl_ctx is not None and tl_ctx.detector_id == detector_id:
-        _thread_local.detector_context = None
+    with _state_lock:
+        ctx = _detector_contexts.pop(detector_id, None)
+        tl_ctx = getattr(_thread_local, "detector_context", None)
+        if tl_ctx is not None and tl_ctx.detector_id == detector_id:
+            _thread_local.detector_context = None
     clear_progress_cache()
     return ctx
 
 
 def get_detector_context(detector_id: str) -> DetectorContext | None:
     """Return the detector context for *detector_id*, or ``None`` if not loaded."""
-    return _detector_contexts.get(detector_id)
+    with _state_lock:
+        return _detector_contexts.get(detector_id)
 
 
 def list_loaded_detector_ids() -> list[str]:
     """Return all detector IDs that have an in-memory context."""
-    return list(_detector_contexts.keys())
+    with _state_lock:
+        return list(_detector_contexts.keys())
 
 
 def clear_all_detector_contexts() -> None:
     """Remove all detector contexts and clear the thread-local.  For tests."""
-    _detector_contexts.clear()
-    _thread_local.detector_context = None
-    _empty_detector_context.__init__("")  # type: ignore[misc]
+    with _state_lock:
+        _detector_contexts.clear()
+        _thread_local.detector_context = None
+        _empty_detector_context.__init__("")  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -368,7 +380,9 @@ class _ProxyDict(dict):
         return self._target().__contains__(key)
 
     def __iter__(self):
-        return self._target().__iter__()
+        # Snapshot keys so `for k in proxy` is safe against concurrent
+        # mutation of the underlying dict by another thread.
+        return iter(list(self._target()))
 
     def __len__(self):
         return self._target().__len__()
@@ -421,7 +435,8 @@ class _ProxyDict(dict):
         return self
 
     def __reversed__(self):
-        return self._target().__reversed__()
+        # Snapshot to avoid RuntimeError under concurrent mutation.
+        return reversed(list(self._target()))
 
 
 class _ProxyList(list):
@@ -449,7 +464,8 @@ class _ProxyList(list):
         return self._target().__contains__(item)
 
     def __iter__(self):
-        return self._target().__iter__()
+        # Snapshot elements so iteration is safe against concurrent mutation.
+        return iter(list(self._target()))
 
     def __len__(self):
         return self._target().__len__()


### PR DESCRIPTION
This PR addresses multiple concurrency bugs and improves error handling and atomicity throughout the codebase.

## Summary
The changes fix race conditions in label syncing, settings management, and media ingestion by replacing thread-local guards with proper locking mechanisms. Additionally, several robustness improvements are made to file I/O, error handling, and request validation.

## Key Changes

**Concurrency & Synchronization:**
- Replace thread-local `_syncing` flag with module-level boolean protected by `_sync_lock` (RLock) in `vtsearch/labels/sync.py`. Thread-local guards cannot prevent concurrent operations on other threads from racing with imports.
- Apply same fix to `vtsearch/settings.py` — replace thread-local `_syncing` with module-level boolean guarded by `_settings_lock`.
- Add `_state_lock` protection to all context management operations in `vtsearch/utils/state_core.py` (register/unregister/get/list/clear for both dataset and detector contexts).
- Make proxy dict/list iteration safe against concurrent mutation by snapshotting to lists in `_ProxyDict.__iter__()`, `_ProxyDict.__reversed__()`, and `_ProxyList.__iter__()`.
- Fix media ingestion in `vtsearch/datasets/ingest.py` to allocate IDs and insert atomically under `_state_lock` to prevent concurrent ingests from colliding on the same ID.
- Fix context migration in `vtsearch/routes/datasets_loading.py` to insert under new key before removing old key, keeping context visible during the transition.

**File I/O Atomicity:**
- Implement `_atomic_write_csv()` in `vtsearch/exporters/server_csv_file/__init__.py` to buffer CSV content in memory and write via temp file + rename, preventing half-written files on crash.
- Implement `_atomic_write_text()` in `vtsearch/exporters/server_json_file/__init__.py` for atomic JSON writes.
- Apply atomic writes to settings export in `vtsearch/settings_io/exporters/server_json_file/__init__.py`.

**Error Handling & Robustness:**
- Add exception handling in `app.py` `_set_user_context()` to prevent misbehaving login providers from crashing the server.
- Add exception handling in `app.py` `_set_request_context()` to gracefully fall back to default context on resolution failures.
- Add timeout (30 minutes) and exception handling to RAR extraction in `vtsearch/datasets/downloader/video.py` to prevent hangs on malformed archives.
- Add timeout to HTTP requests in `vtsearch/datasets/downloader/core.py` (10s connect, 60s read) to fail fast on unresponsive hosts.
- Add validation for HTTP range requests in `vtsearch/routes/medias.py` to reject unsatisfiable ranges with proper 416 responses per RFC 7233.

**Configuration:**
- Fix `vtsearch/config.py` to anchor data paths to repository root instead of current working directory, preventing silent data loss when app is started from different CWD (systemd, cron, etc.). Add `VTSEARCH_DATA_DIR` env var override.

## Implementation Details
- All lock acquisitions use context managers (`with _sync_lock:`) to ensure proper cleanup.
- The `_syncing` flag is now checked inside the lock in `sync_to_labelset_source()` to prevent pushing partial state during concurrent imports.
- Proxy iteration snapshots avoid holding locks during iteration, reducing contention while remaining safe against concurrent mutation.
- Atomic file writes use a `.tmp` suffix and `os.replace()` for atomic rename on all platforms.

https://claude.ai/code/session_01H4DQBm1ir1eENpKipWFMgQ