### PR TITLE
Add bulk embedding support via embed_media_batch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ _TEST_GROUPS = {
         "test_corrections_export",
         "test_settings_io",
         "test_sync_sources",
+        "test_bulk_embedding",
     ],
     "models": [
         "test_detectors",

--- a/tests/test_bulk_embedding.py
+++ b/tests/test_bulk_embedding.py
@@ -1,0 +1,338 @@
+"""Bulk (batch) embedding support tests.
+
+Verifies that :class:`~vtsearch.media.embedder.MediaEmbedder` exposes an
+opt-in batch API and that :func:`~vtsearch.datasets.loader.load_dataset_from_folder`
+(and its chunked sibling) route through it when an embedder advertises
+``supports_batch=True``.
+
+The goal is to support embedders backed by a remote bulk API (e.g. Datawave)
+without forcing every existing embedder to implement batching.
+"""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from helpers import make_raw_wav_bytes as _make_wav_bytes
+
+
+# ---------------------------------------------------------------------------
+# Fake batch-capable embedder used across the loader tests.
+# ---------------------------------------------------------------------------
+
+
+def _make_batch_embedder(batch_size: int = 32, embed_return_dim: int = 3):
+    """Return a MagicMock that mimics a batch-capable MediaEmbedder."""
+    emb = mock.MagicMock()
+    emb.name = "fake_batch"
+    emb.media_type_id = "audio"
+    emb._model = True  # skip eager model-load path
+    emb.supports_batch = True
+    emb.batch_size = batch_size
+
+    def _batch(paths):
+        return [np.full(embed_return_dim, float(i), dtype=np.float32) for i, _ in enumerate(paths)]
+
+    emb.embed_media_batch.side_effect = _batch
+    return emb
+
+
+def _make_media_type_for_audio():
+    mt = mock.MagicMock()
+    mt.type_id = "audio"
+    mt.file_extensions = ["*.wav"]
+    mt.load_media_data.return_value = {"duration": 1.0}
+    return mt
+
+
+def _write_wav(path: Path) -> None:
+    path.write_bytes(_make_wav_bytes())
+
+
+# ---------------------------------------------------------------------------
+# MediaEmbedder.embed_media_batch defaults
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedderDefaults:
+    """The ABC's defaults should preserve existing per-file behaviour."""
+
+    def test_supports_batch_defaults_false(self):
+        """Concrete embedders that don't override stay one-by-one."""
+        from vtsearch.media import all_embedders
+
+        for emb in all_embedders():
+            assert emb.supports_batch is False, (
+                f"{type(emb).__name__} reports supports_batch=True but has no overridden "
+                "_embed_media_batch_impl"
+            )
+
+    def test_default_batch_impl_loops_over_single(self, tmp_path):
+        """The default _embed_media_batch_impl dispatches to _embed_media_impl per file."""
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, file_path):
+                return np.array([float(file_path.stat().st_size)], dtype=np.float32)
+
+        emb = _Stub()
+        emb._model = True
+        files = []
+        for i, name in enumerate(["a.bin", "b.bin", "c.bin"]):
+            p = tmp_path / name
+            p.write_bytes(b"x" * (i + 1))
+            files.append(p)
+
+        vecs = emb.embed_media_batch(files)
+        assert len(vecs) == 3
+        assert vecs[0][0] == 1.0
+        assert vecs[1][0] == 2.0
+        assert vecs[2][0] == 3.0
+
+    def test_empty_batch_returns_empty(self):
+        """Passing an empty list must not acquire the lock or call the hook."""
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, file_path):
+                raise AssertionError("should not be called for empty batch")
+
+        emb = _Stub()
+        assert emb.embed_media_batch([]) == []
+
+
+# ---------------------------------------------------------------------------
+# load_dataset_from_folder routes through embed_media_batch when opted in
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderRoutesToBatch:
+    """load_dataset_from_folder must call embed_media_batch when supports_batch=True."""
+
+    def test_single_batch_for_small_folder(self, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        for name in ("a.wav", "b.wav", "c.wav"):
+            _write_wav(tmp_path / name)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_batch_embedder(batch_size=32)
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+
+        assert len(medias) == 3
+        # Exactly one batch call — all three files in one request.
+        assert emb.embed_media_batch.call_count == 1
+        sent_paths = emb.embed_media_batch.call_args.args[0]
+        assert sorted(p.name for p in sent_paths) == ["a.wav", "b.wav", "c.wav"]
+        # Per-file embed_media must NOT have been called.
+        emb.embed_media.assert_not_called()
+
+    def test_splits_into_multiple_batches_by_batch_size(self, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        # 5 files, batch_size=2 → 3 batches of sizes 2, 2, 1
+        for i in range(5):
+            _write_wav(tmp_path / f"f{i}.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = _make_batch_embedder(batch_size=2)
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+
+        assert len(medias) == 5
+        assert emb.embed_media_batch.call_count == 3
+        sizes = [len(call.args[0]) for call in emb.embed_media_batch.call_args_list]
+        assert sizes == [2, 2, 1]
+
+    def test_overrides_skip_batch_call(self, tmp_path):
+        """Files with content_vectors or custom_metadata embedding aren't sent to batch."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        for name in ("keep.wav", "pre1.wav", "pre2.wav"):
+            _write_wav(tmp_path / name)
+
+        mt = _make_media_type_for_audio()
+        emb = _make_batch_embedder(batch_size=32)
+
+        pre_vec = np.array([99.0, 99.0, 99.0], dtype=np.float32)
+        cm_vec = np.array([42.0, 42.0, 42.0], dtype=np.float32)
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            load_dataset_from_folder(
+                tmp_path,
+                "audio",
+                medias,
+                content_vectors={"pre1.wav": pre_vec},
+                custom_metadata_map={"pre2.wav": {"embedding": cm_vec}},
+                on_progress=lambda *a: None,
+            )
+
+        assert len(medias) == 3
+        # Only the non-overridden file should have been batched.
+        assert emb.embed_media_batch.call_count == 1
+        sent = emb.embed_media_batch.call_args.args[0]
+        assert [p.name for p in sent] == ["keep.wav"]
+
+        # Verify overrides won
+        by_name = {m["filename"]: m["embedding"] for m in medias.values()}
+        np.testing.assert_array_equal(by_name["pre1.wav"], pre_vec)
+        np.testing.assert_array_equal(by_name["pre2.wav"], cm_vec)
+
+    def test_skip_embedding_does_not_trigger_batch(self, tmp_path):
+        """skip_embedding=True must bypass the batch API entirely."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "a.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = _make_batch_embedder(batch_size=32)
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            load_dataset_from_folder(
+                tmp_path, "audio", medias, on_progress=lambda *a: None, skip_embedding=True
+            )
+
+        emb.embed_media_batch.assert_not_called()
+        emb.embed_media.assert_not_called()
+        assert medias[1]["embedding"] is None
+
+    def test_batch_returning_none_skips_file(self, tmp_path):
+        """A None entry in the batch response should skip that file, matching per-file semantics."""
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        _write_wav(tmp_path / "good.wav")
+        _write_wav(tmp_path / "bad.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = mock.MagicMock()
+        emb.name = "fake_batch"
+        emb.media_type_id = "audio"
+        emb._model = True
+        emb.supports_batch = True
+        emb.batch_size = 32
+
+        def _batch(paths):
+            return [None if p.name == "bad.wav" else np.array([1.0, 2.0]) for p in paths]
+
+        emb.embed_media_batch.side_effect = _batch
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+
+        assert len(medias) == 1
+        assert list(medias.values())[0]["filename"] == "good.wav"
+
+
+# ---------------------------------------------------------------------------
+# Non-batch embedders keep the old per-file path
+# ---------------------------------------------------------------------------
+
+
+class TestNonBatchEmbedderUnchanged:
+    """Embedders with supports_batch=False must still use embed_media per file."""
+
+    def test_per_file_path_still_used(self, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        for name in ("a.wav", "b.wav"):
+            _write_wav(tmp_path / name)
+
+        mt = _make_media_type_for_audio()
+        emb = mock.MagicMock()
+        emb.name = "single"
+        emb.media_type_id = "audio"
+        emb._model = True
+        emb.supports_batch = False
+        emb.embed_media.return_value = np.array([1.0, 2.0])
+
+        medias: dict = {}
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+
+        assert emb.embed_media.call_count == 2
+        emb.embed_media_batch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Chunked loader batches within each chunk
+# ---------------------------------------------------------------------------
+
+
+class TestChunkedLoaderBatches:
+    """load_dataset_from_folder_chunked must batch within each chunk."""
+
+    def test_batches_scoped_to_chunk(self, tmp_path):
+        """Four files with chunk_size=2 and batch_size=10 → 2 batch calls, one per chunk.
+
+        Ensures the batch is flushed per chunk (to preserve chunked loading's
+        memory story) rather than across the whole folder.
+        """
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        for i in range(4):
+            _write_wav(tmp_path / f"f{i}.wav")
+
+        mt = _make_media_type_for_audio()
+        emb = _make_batch_embedder(batch_size=10)
+
+        with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt), mock.patch(
+            "vtsearch.media.embedders_for_type", return_value=[emb]
+        ):
+            chunks = list(
+                load_dataset_from_folder_chunked(
+                    tmp_path, "audio", chunk_size=2, on_progress=lambda *a: None
+                )
+            )
+
+        assert len(chunks) == 2
+        assert all(len(c) == 2 for c in chunks)
+        # One batch call per chunk, each receiving exactly 2 files.
+        assert emb.embed_media_batch.call_count == 2
+        for call in emb.embed_media_batch.call_args_list:
+            assert len(call.args[0]) == 2

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -106,6 +106,76 @@ def _streaming_md5(file_path: Path) -> str:
     return h.hexdigest()
 
 
+def _has_override(
+    rel_path: str,
+    file_name: str,
+    content_vectors: dict[str, Any] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> bool:
+    """Return True if the file's embedding is already resolved by overrides.
+
+    An override is either a ``custom_metadata`` entry with an ``"embedding"``
+    key or a ``content_vectors`` entry.  Files with overrides do not need to
+    be sent to the embedding model.
+    """
+    if custom_metadata_map:
+        cm = custom_metadata_map.get(rel_path) or custom_metadata_map.get(file_name)
+        if cm and _get_embedding_value(cm) is not None:
+            return True
+    if content_vectors and (rel_path in content_vectors or file_name in content_vectors):
+        return True
+    return False
+
+
+def _batch_embed_files(
+    emb: Any,
+    media_files: list[Path],
+    folder_path: Path,
+    content_vectors: dict[str, Any] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+    on_progress: ProgressCallback,
+    media_type: str,
+) -> dict[Path, Any]:
+    """Pre-compute embeddings for *media_files* via :meth:`embed_media_batch`.
+
+    Files whose embedding is already resolved by ``custom_metadata`` or
+    ``content_vectors`` are skipped (they don't need to be sent to the
+    model).  Remaining files are grouped into batches of ``emb.batch_size``
+    and flushed via :meth:`MediaEmbedder.embed_media_batch`.
+
+    Returns a dict mapping ``Path`` → embedding vector.  Paths whose
+    batch call returned ``None`` are omitted, matching the per-file
+    behaviour of skipping files that fail to embed.
+    """
+    pending: list[Path] = []
+    for file_path in media_files:
+        rel_path = file_path.relative_to(folder_path).as_posix()
+        if _has_override(rel_path, file_path.name, content_vectors, custom_metadata_map):
+            continue
+        pending.append(file_path)
+
+    results: dict[Path, Any] = {}
+    if not pending:
+        return results
+
+    bsize = max(1, emb.batch_size)
+    total = len(pending)
+    for start in range(0, total, bsize):
+        batch = pending[start : start + bsize]
+        batch_idx = start // bsize + 1
+        on_progress(
+            "embedding",
+            f"Embedding {media_type} batch {batch_idx} ({len(batch)} files)...",
+            min(start + len(batch), total),
+            total,
+        )
+        vectors = emb.embed_media_batch(batch)
+        for fp, vec in zip(batch, vectors):
+            if vec is not None:
+                results[fp] = vec
+    return results
+
+
 def load_dataset_from_folder(
     folder_path: Path,
     media_type: str,
@@ -232,6 +302,19 @@ def load_dataset_from_folder(
     media_id = 1
     total_files = len(media_files)
 
+    # Batch-capable embedders get all their files flushed through
+    # ``embed_media_batch`` up front; the per-file loop then just looks
+    # up the pre-computed vector.  Non-batch embedders fall through to
+    # the per-file ``embed_media`` call below.  ``is True`` (not truthy)
+    # is deliberate so that test mocks without an explicit override stay
+    # on the per-file path.
+    use_batch = emb is not None and not skip_embedding and getattr(emb, "supports_batch", False) is True
+    batch_embeddings: dict[Path, Any] = {}
+    if use_batch:
+        batch_embeddings = _batch_embed_files(
+            emb, media_files, folder_path, content_vectors, custom_metadata_map, on_progress, media_type
+        )
+
     try:
         for i, file_path in enumerate(media_files):
             # Preserve relative path from the import root so that files in
@@ -268,7 +351,10 @@ def load_dataset_from_folder(
             else:
                 if emb is None:
                     continue
-                embedding = emb.embed_media(file_path)
+                if use_batch:
+                    embedding = batch_embeddings.get(file_path)
+                else:
+                    embedding = emb.embed_media(file_path)
                 if embedding is None:
                     continue
 
@@ -476,11 +562,23 @@ def load_dataset_from_folder_chunked(
     total_files = len(media_files)
     embedder_id = emb.name if emb else ""
 
+    use_batch = emb is not None and not skip_embedding and getattr(emb, "supports_batch", False) is True
+
     # Process in groups of chunk_size
     for start in range(0, total_files, chunk_size):
         batch = media_files[start : start + chunk_size]
         chunk_medias: dict[int, dict[str, Any]] = {}
         media_id = 1
+
+        # Batch-capable embedders embed the whole chunk up front, then the
+        # per-file loop below just looks up the pre-computed vector.  This
+        # keeps chunked loading's memory story intact — only one chunk's
+        # worth of embeddings lives in memory at a time.
+        chunk_batch_embeddings: dict[Path, Any] = {}
+        if use_batch:
+            chunk_batch_embeddings = _batch_embed_files(
+                emb, batch, folder_path, content_vectors, custom_metadata_map, on_progress, media_type
+            )
 
         for i, file_path in enumerate(batch):
             global_idx = start + i
@@ -515,7 +613,10 @@ def load_dataset_from_folder_chunked(
             else:
                 if emb is None:
                     continue
-                embedding = emb.embed_media(file_path)
+                if use_batch:
+                    embedding = chunk_batch_embeddings.get(file_path)
+                else:
+                    embedding = emb.embed_media(file_path)
                 if embedding is None:
                     continue
 

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -458,6 +458,59 @@ class MediaEmbedder(ABC):
         Override this instead of :meth:`embed_media`.
         """
 
+    # ------------------------------------------------------------------
+    # Bulk embedding
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_batch(self) -> bool:
+        """Whether this embedder has a native bulk-embedding path.
+
+        Defaults to ``False``.  Subclasses backed by a remote bulk API (or
+        any backend where a single request amortises setup cost across many
+        inputs) should override this to return ``True`` **and** override
+        :meth:`_embed_media_batch_impl`.
+
+        When ``True``, :func:`~vtsearch.datasets.loader.load_dataset_from_folder`
+        and its chunked sibling collect files into groups of :attr:`batch_size`
+        and flush them through :meth:`embed_media_batch` instead of calling
+        :meth:`embed_media` per file.
+        """
+        return False
+
+    @property
+    def batch_size(self) -> int:
+        """Maximum number of files per call to :meth:`embed_media_batch`.
+
+        Only consulted when :attr:`supports_batch` is ``True``.  Override in
+        subclasses to match the remote API's preferred request size.
+        """
+        return 32
+
+    def embed_media_batch(self, file_paths: list[Path]) -> list[Optional[np.ndarray]]:
+        """Return embeddings for a batch of media files.
+
+        Must return a list the same length as *file_paths*, with ``None`` at
+        positions where a file could not be embedded.
+
+        Acquires :attr:`_embed_lock` once per batch (not per file) so that
+        bulk API calls don't serialise at per-file granularity.  Subclasses
+        must override :meth:`_embed_media_batch_impl` (not this method).
+        """
+        if not file_paths:
+            return []
+        with self._embed_lock:
+            return self._embed_media_batch_impl(file_paths)
+
+    def _embed_media_batch_impl(self, file_paths: list[Path]) -> list[Optional[np.ndarray]]:
+        """Subclass hook: embed a batch of media files.
+
+        The default implementation simply loops over :meth:`_embed_media_impl`,
+        which is correct for embedders that have no native bulk path.
+        Override this in subclasses that back onto a remote bulk API.
+        """
+        return [self._embed_media_impl(fp) for fp in file_paths]
+
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.
 


### PR DESCRIPTION
## Summary

- Add an opt-in batch API on `MediaEmbedder` (`supports_batch`, `batch_size`, `embed_media_batch`, `_embed_media_batch_impl`) so embedders backed by a remote bulk service (e.g. Datawave) can amortise per-file setup cost across many inputs.
- Teach `load_dataset_from_folder` and `load_dataset_from_folder_chunked` to pre-compute embeddings via `embed_media_batch` when the embedder opts in, honouring `content_vectors` / `custom_metadata` overrides so override files don't hit the remote API.
- Default `_embed_media_batch_impl` just loops over `_embed_media_impl`, so every existing embedder (CLAP / CLIP / SigLIP / X-CLIP / E5 / BGE) is unchanged. The chunked loader batches per-chunk to preserve its memory story.

## Design notes

- The loader uses `getattr(emb, "supports_batch", False) is True` (identity check, not truthy) so MagicMock-based test embedders without an explicit override stay on the per-file path — no existing tests needed to change.
- `embed_media_batch` acquires `_embed_lock` once per batch (not per file), so bulk API calls no longer serialise at per-file granularity.
- Progress reporting becomes per-batch during the embedding phase, then per-file during the record-building phase.

## Test plan

- [x] New `tests/test_bulk_embedding.py` covers: default ABC behaviour preserves one-by-one, default `_embed_media_batch_impl` loops, empty batch is a no-op, single batch for small folder, splits into multiple batches by `batch_size`, overrides skip the batch call, `skip_embedding=True` bypasses batch, `None` in batch response skips that file, non-batch embedders still use per-file path, chunked loader batches scoped to the chunk.
- [x] Full suite green: 2945 passed, 1 skipped, 1 xfailed, 1 xpassed.

https://claude.ai/code/session_01KWiEqEvvRGSitrZuXnnrxA