### PR TITLE
Embedder interface: take media dicts instead of paths

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -361,16 +361,25 @@ threshold = find_optimal_threshold(scores, labels, inclusion_value=0)
 
 Each embedder is a self-contained class (separate from the `MediaType`).
 Instantiate it, call `load_models()`, then use `embed_media()` /
-`embed_text()`:
+`embed_text()`.  `embed_media()` takes a **media dict** (the same shape the
+dataset loader builds); for ad-hoc files, use the `media_from_path` helper:
 
 ```python
 from vtsearch.media.audio.embedder import AudioClapEmbedder
+from vtsearch.media.embedder import media_from_path
 
 embedder = AudioClapEmbedder()
-embedder.load_models()                        # loads CLAP (cached)
-embedding = embedder.embed_media(Path("example.wav"))  # → numpy array
-text_vec  = embedder.embed_text("birdsong")            # same space
+embedder.load_models()                                            # loads CLAP (cached)
+embedding = embedder.embed_media(media_from_path("example.wav"))  # → numpy array
+text_vec  = embedder.embed_text("birdsong")                       # same space
 ```
+
+Because the embedder sees the whole media dict (not just a `Path`), a
+service-based embedder can resolve content via `media["origin"]` /
+`media.get("custom_metadata")` without touching local disk — e.g. a
+remote lookup by `origin["params"]["content_id"]`.  Bulk APIs can override
+`supports_batch = True` / `batch_size` and `_embed_media_batch_impl(medias)`
+to flush whole batches through the loader.
 
 No Flask, no global state, no progress dependency (silent no-op by
 default).  To get progress reporting, set a callback before loading:

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -198,7 +198,6 @@ changes to `vtsearch/media/__init__.py` are needed.
 |-------------------------------|------------------------------------|------------------------------------|
 | `display_metadata(media)`     | `(dict) -> dict[str, Any]`         | Metadata for the labeling UI       |
 | `load_models()`               | `() -> None`                       | Load inline embedding models (legacy) |
-| `embed_media(file_path)`      | `(Path) -> Optional[np.ndarray]`   | Inline embedding (legacy, prefer MediaEmbedder) |
 | `embed_text(text)`            | `(str) -> Optional[np.ndarray]`    | Inline text embedding (legacy)     |
 | `load_demo_source(...)`       | See docstring                      | Download and embed a demo dataset  |
 
@@ -253,7 +252,7 @@ Each media type has one default embedder in `embedder.py`. To add an
 
 ### What to implement
 
-Subclass `MediaEmbedder` from `vtsearch.media.base`.
+Subclass `MediaEmbedder` from `vtsearch.media.embedder`.
 
 ```python
 # vtsearch/media/code/embedder.py
@@ -304,20 +303,26 @@ class CodeBertEmbedder(MediaEmbedder):
 
     # --- Embedding (required abstract method) ---
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
-        """Return a fixed-size embedding vector for the file.
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        """Return a fixed-size embedding vector for a media item.
 
-        Override ``_embed_media_impl`` (not ``embed_media``).
-        The public ``embed_media()`` wrapper acquires a global lock
-        so that only one forward pass runs at a time.
+        *media* is a media dict.  File-based embedders read
+        ``Path(media["media_path"])``.  Service-based embedders can instead
+        use ``media["origin"]``, ``media["origin_name"]``, or
+        ``media.get("custom_metadata")`` to look up the content remotely
+        (e.g. by a ``content_id`` stashed in ``origin.params``).
 
-        Returns None if embedding fails. The vector dimensionality
-        must be consistent and must match embed_text().
+        Override ``_embed_media_impl`` (not ``embed_media``).  The public
+        ``embed_media()`` wrapper acquires a global lock so that only one
+        forward pass runs at a time.
+
+        Returns None if embedding fails.  The vector dimensionality must
+        be consistent and must match embed_text().
         """
         if self._model is None:
             self.load_models()
         try:
-            text = file_path.read_text(errors="replace")[:8000]
+            text = Path(media["media_path"]).read_text(errors="replace")[:8000]
             return self._model.encode(text, normalize_embeddings=True)
         except Exception:
             return None
@@ -336,6 +341,24 @@ class CodeBertEmbedder(MediaEmbedder):
         except Exception:
             return None
 ```
+
+### Service-based embedders
+
+Embedders are not required to read a local file.  Because `_embed_media_impl`
+receives the full media dict, a service-based embedder can resolve content
+remotely from whatever identifier its importer stashed in
+`origin["params"]` or `media["custom_metadata"]`:
+
+```python
+def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+    content_id = (media.get("origin") or {}).get("params", {}).get("content_id")
+    if not content_id:
+        return None  # no server identifier → cannot embed
+    return self._client.get_embedding(content_id)
+```
+
+For bulk APIs, also override `supports_batch` / `batch_size` and
+`_embed_media_batch_impl(medias)` to flush a whole list in one request.
 
 ### Register the embedder
 
@@ -364,17 +387,25 @@ type's `EMBEDDERS` list (e.g. in `vtsearch/media/image/__init__.py`).
 
 **Required abstract methods:**
 
-| Method                      | Signature                        | Description                    |
-|-----------------------------|----------------------------------|--------------------------------|
-| `_load_models_impl()`       | `() -> None`                     | Load model; must be idempotent. Override this, not `load_models()` |
-| `embed_media(file_path)`    | `(Path) -> Optional[np.ndarray]` | Embed a media file             |
+| Method                      | Signature                              | Description                    |
+|-----------------------------|----------------------------------------|--------------------------------|
+| `_load_models_impl()`       | `() -> None`                           | Load model; must be idempotent. Override this, not `load_models()` |
+| `_embed_media_impl(media)`  | `(dict) -> Optional[np.ndarray]`       | Embed a single media item. Override this, not `embed_media()`      |
 
 **Optional overridable methods:**
 
-| Method                          | Signature                         | Description                          |
-|---------------------------------|-----------------------------------|--------------------------------------|
-| `embed_text(text)`              | `(str) -> Optional[np.ndarray]`   | Embed a text query (default: `None`) |
-| `embed_text_enriched(text)`     | `(str) -> Optional[np.ndarray]`   | Average over `description_wrappers`  |
+| Method                                | Signature                                          | Description                          |
+|---------------------------------------|----------------------------------------------------|--------------------------------------|
+| `embed_text(text)`                    | `(str) -> Optional[np.ndarray]`                    | Embed a text query (default: `None`) |
+| `embed_text_enriched(text)`           | `(str) -> Optional[np.ndarray]`                    | Average over `description_wrappers`  |
+| `_embed_media_batch_impl(medias)`     | `(list[dict]) -> list[Optional[np.ndarray]]`       | Bulk embed; default loops over `_embed_media_impl`. Override with `supports_batch=True` for a remote bulk API |
+
+**Optional overridable properties:**
+
+| Property          | Returns | Description                                                                 |
+|-------------------|---------|-----------------------------------------------------------------------------|
+| `supports_batch`  | `bool`  | Set to `True` to route loader through `embed_media_batch` (default: `False`) |
+| `batch_size`      | `int`   | Max items per batch call when `supports_batch=True` (default: `32`)          |
 
 **Optional overridable properties:**
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,14 +153,17 @@ config.TRAIN_EPOCHS = 30
 _EMBEDDING_DIM = 512
 
 
-def _fake_embed_audio(path):
+def _fake_embed_audio(arg):
     """Deterministic fake audio embedding derived from the file contents.
 
-    Uses the first 1000 bytes of the file as a seed so that different audio
-    files (even when written to the same temp path) produce distinct vectors.
+    Accepts either a path (from the legacy ``embed_audio_file`` wrapper) or a
+    media dict (from ``MediaEmbedder.embed_media``).  Uses the first 1000
+    bytes of the resolved file as a seed so that different audio files
+    (even when written to the same temp path) produce distinct vectors.
     """
     import hashlib
 
+    path = arg["media_path"] if isinstance(arg, dict) else arg
     try:
         with open(path, "rb") as f:
             data = f.read(1000)
@@ -290,7 +293,6 @@ def _stub_embedding_models():
     stack.enter_context(patch("vtsearch.medias.embed_audio_file", side_effect=_fake_embed_audio))
     for mt in _ALL_MEDIA_TYPES:
         stack.enter_context(patch.object(mt, "embed_text", side_effect=_fake_embed_text))
-        stack.enter_context(patch.object(mt, "embed_media", side_effect=_fake_embed_audio))
         stack.enter_context(patch.object(mt, "load_models"))
     for emb in _ALL_EMBEDDERS:
         stack.enter_context(patch.object(emb, "embed_media", side_effect=_fake_embed_audio))

--- a/tests/test_bulk_embedding.py
+++ b/tests/test_bulk_embedding.py
@@ -34,8 +34,8 @@ def _make_batch_embedder(batch_size: int = 32, embed_return_dim: int = 3):
     emb.supports_batch = True
     emb.batch_size = batch_size
 
-    def _batch(paths):
-        return [np.full(embed_return_dim, float(i), dtype=np.float32) for i, _ in enumerate(paths)]
+    def _batch(medias):
+        return [np.full(embed_return_dim, float(i), dtype=np.float32) for i, _ in enumerate(medias)]
 
     emb.embed_media_batch.side_effect = _batch
     return emb
@@ -72,7 +72,7 @@ class TestEmbedderDefaults:
             )
 
     def test_default_batch_impl_loops_over_single(self, tmp_path):
-        """The default _embed_media_batch_impl dispatches to _embed_media_impl per file."""
+        """The default _embed_media_batch_impl dispatches to _embed_media_impl per item."""
         from vtsearch.media.embedder import MediaEmbedder
 
         class _Stub(MediaEmbedder):
@@ -87,18 +87,18 @@ class TestEmbedderDefaults:
             def _load_models_impl(self):
                 self._model = True
 
-            def _embed_media_impl(self, file_path):
-                return np.array([float(file_path.stat().st_size)], dtype=np.float32)
+            def _embed_media_impl(self, media):
+                return np.array([float(Path(media["media_path"]).stat().st_size)], dtype=np.float32)
 
         emb = _Stub()
         emb._model = True
-        files = []
+        medias = []
         for i, name in enumerate(["a.bin", "b.bin", "c.bin"]):
             p = tmp_path / name
             p.write_bytes(b"x" * (i + 1))
-            files.append(p)
+            medias.append({"media_path": str(p)})
 
-        vecs = emb.embed_media_batch(files)
+        vecs = emb.embed_media_batch(medias)
         assert len(vecs) == 3
         assert vecs[0][0] == 1.0
         assert vecs[1][0] == 2.0
@@ -120,7 +120,7 @@ class TestEmbedderDefaults:
             def _load_models_impl(self):
                 self._model = True
 
-            def _embed_media_impl(self, file_path):
+            def _embed_media_impl(self, media):
                 raise AssertionError("should not be called for empty batch")
 
         emb = _Stub()
@@ -153,8 +153,8 @@ class TestLoaderRoutesToBatch:
         assert len(medias) == 3
         # Exactly one batch call — all three files in one request.
         assert emb.embed_media_batch.call_count == 1
-        sent_paths = emb.embed_media_batch.call_args.args[0]
-        assert sorted(p.name for p in sent_paths) == ["a.wav", "b.wav", "c.wav"]
+        sent_medias = emb.embed_media_batch.call_args.args[0]
+        assert sorted(Path(m["media_path"]).name for m in sent_medias) == ["a.wav", "b.wav", "c.wav"]
         # Per-file embed_media must NOT have been called.
         emb.embed_media.assert_not_called()
 
@@ -209,7 +209,7 @@ class TestLoaderRoutesToBatch:
         # Only the non-overridden file should have been batched.
         assert emb.embed_media_batch.call_count == 1
         sent = emb.embed_media_batch.call_args.args[0]
-        assert [p.name for p in sent] == ["keep.wav"]
+        assert [Path(m["media_path"]).name for m in sent] == ["keep.wav"]
 
         # Verify overrides won
         by_name = {m["filename"]: m["embedding"] for m in medias.values()}
@@ -252,8 +252,11 @@ class TestLoaderRoutesToBatch:
         emb.supports_batch = True
         emb.batch_size = 32
 
-        def _batch(paths):
-            return [None if p.name == "bad.wav" else np.array([1.0, 2.0]) for p in paths]
+        def _batch(medias_in):
+            return [
+                None if Path(m["media_path"]).name == "bad.wav" else np.array([1.0, 2.0])
+                for m in medias_in
+            ]
 
         emb.embed_media_batch.side_effect = _batch
 

--- a/tests/test_document_and_converters.py
+++ b/tests/test_document_and_converters.py
@@ -124,12 +124,6 @@ class TestDocumentMediaType:
         mt = DocumentMediaType()
         assert mt.demo_datasets == []
 
-    def test_embed_media_returns_none(self, tmp_path):
-        mt = DocumentMediaType()
-        pdf_path = tmp_path / "test.pdf"
-        pdf_path.write_bytes(_make_minimal_pdf())
-        assert mt.embed_media(pdf_path) is None
-
     def test_embed_text_returns_none(self):
         mt = DocumentMediaType()
         assert mt.embed_text("hello") is None

--- a/tests/test_enrich_descriptions.py
+++ b/tests/test_enrich_descriptions.py
@@ -96,7 +96,7 @@ class TestEmbedTextEnriched:
             def _load_models_impl(self):
                 pass
 
-            def _embed_media_impl(self, file_path):
+            def _embed_media_impl(self, media):
                 return None
 
             def embed_text(self, text):

--- a/tests/test_new_embedders.py
+++ b/tests/test_new_embedders.py
@@ -5,7 +5,6 @@ without downloading model weights.
 """
 
 import threading
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -68,14 +67,12 @@ class TestImageSiglipEmbedderProperties:
         assert isinstance(emb._model, MagicMock)
 
     def test_embed_media_returns_none_when_not_loaded(self):
-        from pathlib import Path
-
         from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
 
         emb = ImageSiglipEmbedder()
         # Patch load_models to not actually load anything
         with patch.object(emb, "load_models"):
-            result = emb.embed_media(Path("/nonexistent.jpg"))
+            result = emb.embed_media({"media_path": "/nonexistent.jpg"})
         assert result is None
 
     def test_embed_text_returns_none_when_not_loaded(self):
@@ -155,13 +152,11 @@ class TestAudioClapMusicEmbedderProperties:
         assert isinstance(emb._model, MagicMock)
 
     def test_embed_media_returns_none_when_not_loaded(self):
-        from pathlib import Path
-
         from vtsearch.media.audio.embedder_clap_music import AudioClapMusicEmbedder
 
         emb = AudioClapMusicEmbedder()
         with patch.object(emb, "load_models"):
-            result = emb.embed_media(Path("/nonexistent.wav"))
+            result = emb.embed_media({"media_path": "/nonexistent.wav"})
         assert result is None
 
     def test_embed_text_returns_none_when_not_loaded(self):
@@ -231,13 +226,11 @@ class TestTextBGEEmbedderProperties:
         assert isinstance(emb._model, MagicMock)
 
     def test_embed_media_returns_none_when_not_loaded(self):
-        from pathlib import Path
-
         from vtsearch.media.text.embedder_bge import TextBGEEmbedder
 
         emb = TextBGEEmbedder()
         with patch.object(emb, "load_models"):
-            result = emb.embed_media(Path("/nonexistent.txt"))
+            result = emb.embed_media({"media_path": "/nonexistent.txt"})
         assert result is None
 
     def test_embed_text_returns_none_when_not_loaded(self):
@@ -285,7 +278,7 @@ class TestTextBGEEmbedderProperties:
         text_file = tmp_path / "test.txt"
         text_file.write_text("Hello world", encoding="utf-8")
 
-        result = emb.embed_media(text_file)
+        result = emb.embed_media({"media_path": str(text_file)})
         assert result is not None
         mock_model.encode.assert_called_once_with("Hello world", normalize_embeddings=True)
 
@@ -363,7 +356,7 @@ class TestVideoLanguageBindEmbedderProperties:
 
         emb = VideoLanguageBindEmbedder()
         with patch.object(emb, "load_models"):
-            result = emb.embed_media(Path("/nonexistent.mp4"))
+            result = emb.embed_media({"media_path": "/nonexistent.mp4"})
         assert result is None
 
     def test_embed_text_returns_none_when_not_loaded(self):
@@ -527,7 +520,7 @@ class TestEmbedMediaLock:
             def _load_models_impl(self):
                 pass
 
-            def _embed_media_impl(self, file_path):
+            def _embed_media_impl(self, media):
                 nonlocal overlap_detected
                 if inside.is_set():
                     overlap_detected = True
@@ -543,7 +536,7 @@ class TestEmbedMediaLock:
         results = [None, None]
 
         def call_embed(idx):
-            results[idx] = emb.embed_media(Path("/fake"))
+            results[idx] = emb.embed_media({"media_path": "/fake"})
 
         t1 = threading.Thread(target=call_embed, args=(0,))
         t2 = threading.Thread(target=call_embed, args=(1,))
@@ -592,13 +585,13 @@ class TestEmbedMediaLock:
             def _load_models_impl(self):
                 pass
 
-            def _embed_media_impl(self, file_path):
+            def _embed_media_impl(self, media):
                 return np.ones(4, dtype=np.float32)
 
             def embed_text(self, text):
                 return None
 
         emb = SimpleEmbedder()
-        result = emb.embed_media(Path("/fake"))
+        result = emb.embed_media({"media_path": "/fake"})
         assert result is not None
         np.testing.assert_array_equal(result, np.ones(4, dtype=np.float32))

--- a/tests/test_parallel_loading.py
+++ b/tests/test_parallel_loading.py
@@ -567,7 +567,7 @@ class TestConcurrentModelLoading:
                 call_count += 1
                 self._model = "loaded"
 
-            def _embed_media_impl(self, file_path):
+            def _embed_media_impl(self, media):
                 return None
 
             def embed_text(self, text):

--- a/vtsearch/converters/runner.py
+++ b/vtsearch/converters/runner.py
@@ -232,6 +232,8 @@ def _embed_converted_output(target_emb, output: dict[str, Any]):
     media_bytes = output.get("media_bytes")
     media_string = output.get("media_string")
 
+    from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
     if media_bytes:
         # Binary media (image, audio, video) — write to temp file.
         suffix = Path(output.get("filename", "output")).suffix or ".bin"
@@ -239,7 +241,7 @@ def _embed_converted_output(target_emb, output: dict[str, Any]):
             tmp.write(media_bytes)
             tmp_path = Path(tmp.name)
         try:
-            embedding = target_emb.embed_media(tmp_path)
+            embedding = target_emb.embed_media(media_from_path(tmp_path))
         finally:
             tmp_path.unlink(missing_ok=True)
         return embedding
@@ -250,7 +252,7 @@ def _embed_converted_output(target_emb, output: dict[str, Any]):
             tmp.write(media_string)
             tmp_path = Path(tmp.name)
         try:
-            embedding = target_emb.embed_media(tmp_path)
+            embedding = target_emb.embed_media(media_from_path(tmp_path))
         finally:
             tmp_path.unlink(missing_ok=True)
         return embedding

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -127,6 +127,33 @@ def _has_override(
     return False
 
 
+def _make_embed_input(
+    file_path: Path,
+    folder_path: Path,
+    origin: dict[str, Any] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Build a minimal media dict suitable for :meth:`MediaEmbedder.embed_media`.
+
+    File-based embedders pull ``media["media_path"]`` from this dict;
+    service-based embedders can use ``media["origin"]``, ``media["origin_name"]``,
+    and ``media.get("custom_metadata")`` to resolve the content without
+    touching local disk.  The full media dict (with bytes, md5, duration,
+    type-specific fields) is constructed after the embedding succeeds.
+    """
+    rel_path = file_path.relative_to(folder_path).as_posix()
+    file_cm: dict[str, Any] | None = None
+    if custom_metadata_map:
+        file_cm = custom_metadata_map.get(rel_path) or custom_metadata_map.get(file_path.name)
+    return {
+        "media_path": str(file_path.resolve()),
+        "origin": origin,
+        "origin_name": rel_path,
+        "filename": rel_path,
+        "custom_metadata": file_cm,
+    }
+
+
 def _batch_embed_files(
     emb: Any,
     media_files: list[Path],
@@ -135,42 +162,47 @@ def _batch_embed_files(
     custom_metadata_map: dict[str, dict[str, Any]] | None,
     on_progress: ProgressCallback,
     media_type: str,
+    origin: dict[str, Any] | None = None,
 ) -> dict[Path, Any]:
     """Pre-compute embeddings for *media_files* via :meth:`embed_media_batch`.
 
     Files whose embedding is already resolved by ``custom_metadata`` or
     ``content_vectors`` are skipped (they don't need to be sent to the
-    model).  Remaining files are grouped into batches of ``emb.batch_size``
+    model).  Remaining files are packaged into minimal media dicts (via
+    :func:`_make_embed_input`), grouped into batches of ``emb.batch_size``,
     and flushed via :meth:`MediaEmbedder.embed_media_batch`.
 
     Returns a dict mapping ``Path`` → embedding vector.  Paths whose
     batch call returned ``None`` are omitted, matching the per-file
     behaviour of skipping files that fail to embed.
     """
-    pending: list[Path] = []
+    pending_paths: list[Path] = []
+    pending_medias: list[dict[str, Any]] = []
     for file_path in media_files:
         rel_path = file_path.relative_to(folder_path).as_posix()
         if _has_override(rel_path, file_path.name, content_vectors, custom_metadata_map):
             continue
-        pending.append(file_path)
+        pending_paths.append(file_path)
+        pending_medias.append(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
 
     results: dict[Path, Any] = {}
-    if not pending:
+    if not pending_paths:
         return results
 
     bsize = max(1, emb.batch_size)
-    total = len(pending)
+    total = len(pending_paths)
     for start in range(0, total, bsize):
-        batch = pending[start : start + bsize]
+        batch_paths = pending_paths[start : start + bsize]
+        batch_medias = pending_medias[start : start + bsize]
         batch_idx = start // bsize + 1
         on_progress(
             "embedding",
-            f"Embedding {media_type} batch {batch_idx} ({len(batch)} files)...",
-            min(start + len(batch), total),
+            f"Embedding {media_type} batch {batch_idx} ({len(batch_paths)} files)...",
+            min(start + len(batch_paths), total),
             total,
         )
-        vectors = emb.embed_media_batch(batch)
-        for fp, vec in zip(batch, vectors):
+        vectors = emb.embed_media_batch(batch_medias)
+        for fp, vec in zip(batch_paths, vectors):
             if vec is not None:
                 results[fp] = vec
     return results
@@ -312,7 +344,8 @@ def load_dataset_from_folder(
     batch_embeddings: dict[Path, Any] = {}
     if use_batch:
         batch_embeddings = _batch_embed_files(
-            emb, media_files, folder_path, content_vectors, custom_metadata_map, on_progress, media_type
+            emb, media_files, folder_path, content_vectors, custom_metadata_map, on_progress, media_type,
+            origin=origin,
         )
 
     try:
@@ -354,7 +387,9 @@ def load_dataset_from_folder(
                 if use_batch:
                     embedding = batch_embeddings.get(file_path)
                 else:
-                    embedding = emb.embed_media(file_path)
+                    embedding = emb.embed_media(
+                        _make_embed_input(file_path, folder_path, origin, custom_metadata_map)
+                    )
                 if embedding is None:
                     continue
 
@@ -577,7 +612,8 @@ def load_dataset_from_folder_chunked(
         chunk_batch_embeddings: dict[Path, Any] = {}
         if use_batch:
             chunk_batch_embeddings = _batch_embed_files(
-                emb, batch, folder_path, content_vectors, custom_metadata_map, on_progress, media_type
+                emb, batch, folder_path, content_vectors, custom_metadata_map, on_progress, media_type,
+                origin=origin,
             )
 
         for i, file_path in enumerate(batch):
@@ -616,7 +652,9 @@ def load_dataset_from_folder_chunked(
                 if use_batch:
                     embedding = chunk_batch_embeddings.get(file_path)
                 else:
-                    embedding = emb.embed_media(file_path)
+                    embedding = emb.embed_media(
+                        _make_embed_input(file_path, folder_path, origin, custom_metadata_map)
+                    )
                 if embedding is None:
                     continue
 

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -122,11 +122,12 @@ class AudioClapEmbedder(MediaEmbedder):
             "the noise of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -104,11 +104,12 @@ class AudioClapMusicEmbedder(MediaEmbedder):
             "the noise of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             import librosa  # noqa: PLC0415
             import torch  # noqa: PLC0415

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -428,10 +428,12 @@ class AudioMediaType(MediaType):
         on_progress("embedding", f"Starting embedding for {total} audio files...", 0, total)
         demo_origin: dict = {"importer": "demo", "params": {}}
 
+        from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
         for i, (audio_path, meta) in enumerate(audio_files):
             rel_name = f"{meta['category']}/{audio_path.name}"
             on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
-            embedding = embedder.embed_media(audio_path)
+            embedding = embedder.embed_media(media_from_path(audio_path))
             if embedding is None:
                 continue
 

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -332,16 +332,8 @@ class MediaType(ABC):
         their own model logic (legacy) can override this.
         """
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
-        """Return a fixed-size embedding vector for the media file at *file_path*.
-
-        Returns ``None`` by default.  Overridden by media types that have
-        inline embedding logic (legacy) or that delegate to an embedder.
-        """
-        return None
-
     def embed_text(self, text: str) -> Optional[np.ndarray]:
-        """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.
+        """Return an embedding of *text* in the same vector space as the embedder.
 
         Returns ``None`` by default.
         """

--- a/vtsearch/media/document/media_type.py
+++ b/vtsearch/media/document/media_type.py
@@ -96,9 +96,6 @@ class DocumentMediaType(MediaType):
     def load_models(self) -> None:
         pass
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
-        return None
-
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         return None
 

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -8,7 +8,6 @@ import logging
 import threading
 import time
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Any, Callable, Optional
 
 import numpy as np
@@ -22,8 +21,29 @@ __all__ = [
     "intercept_tqdm_progress",
     "intercept_weight_loading_progress",
     "load_pretrained_local_first",
+    "media_from_path",
     "timed_progress",
 ]
+
+
+def media_from_path(file_path: Any, origin: dict | None = None) -> dict:
+    """Build a minimal media dict suitable for :meth:`MediaEmbedder.embed_media`.
+
+    Convenience helper for callers that only have a local file path (uploaded
+    files, converter outputs, seed data, CLI utilities).  File-based embedders
+    read ``media["media_path"]``; service-based embedders can also inspect
+    *origin* when supplied.
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    p = Path(file_path)
+    return {
+        "media_path": str(p.resolve()),
+        "origin": origin,
+        "origin_name": p.name,
+        "filename": p.name,
+        "custom_metadata": None,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -439,21 +459,27 @@ class MediaEmbedder(ABC):
     # Embedding
     # ------------------------------------------------------------------
 
-    def embed_media(self, file_path: Path) -> Optional[np.ndarray]:
-        """Return a fixed-size embedding vector for the media file at *file_path*.
+    def embed_media(self, media: dict) -> Optional[np.ndarray]:
+        """Return a fixed-size embedding vector for *media*.
+
+        *media* is a media dict (the same shape produced by the dataset
+        loader).  File-based embedders pull ``Path(media["media_path"])``;
+        service-based embedders can use ``media["origin"]``,
+        ``media["origin_name"]``, ``media.get("custom_metadata")`` etc. to
+        look the content up remotely without touching disk.
 
         Acquires :attr:`_embed_lock` so that only one forward pass runs at a
         time across all embedder types.  Subclasses must override
         :meth:`_embed_media_impl` (not this method).
 
-        Returns ``None`` if the file cannot be embedded.
+        Returns ``None`` if the media cannot be embedded.
         """
         with self._embed_lock:
-            return self._embed_media_impl(file_path)
+            return self._embed_media_impl(media)
 
     @abstractmethod
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
-        """Subclass hook: embed a single media file.
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        """Subclass hook: embed a single media item.
 
         Override this instead of :meth:`embed_media`.
         """
@@ -472,44 +498,44 @@ class MediaEmbedder(ABC):
         :meth:`_embed_media_batch_impl`.
 
         When ``True``, :func:`~vtsearch.datasets.loader.load_dataset_from_folder`
-        and its chunked sibling collect files into groups of :attr:`batch_size`
+        and its chunked sibling collect medias into groups of :attr:`batch_size`
         and flush them through :meth:`embed_media_batch` instead of calling
-        :meth:`embed_media` per file.
+        :meth:`embed_media` per item.
         """
         return False
 
     @property
     def batch_size(self) -> int:
-        """Maximum number of files per call to :meth:`embed_media_batch`.
+        """Maximum number of items per call to :meth:`embed_media_batch`.
 
         Only consulted when :attr:`supports_batch` is ``True``.  Override in
         subclasses to match the remote API's preferred request size.
         """
         return 32
 
-    def embed_media_batch(self, file_paths: list[Path]) -> list[Optional[np.ndarray]]:
-        """Return embeddings for a batch of media files.
+    def embed_media_batch(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        """Return embeddings for a batch of media items.
 
-        Must return a list the same length as *file_paths*, with ``None`` at
-        positions where a file could not be embedded.
+        Must return a list the same length as *medias*, with ``None`` at
+        positions where an item could not be embedded.
 
-        Acquires :attr:`_embed_lock` once per batch (not per file) so that
-        bulk API calls don't serialise at per-file granularity.  Subclasses
+        Acquires :attr:`_embed_lock` once per batch (not per item) so that
+        bulk API calls don't serialise at per-item granularity.  Subclasses
         must override :meth:`_embed_media_batch_impl` (not this method).
         """
-        if not file_paths:
+        if not medias:
             return []
         with self._embed_lock:
-            return self._embed_media_batch_impl(file_paths)
+            return self._embed_media_batch_impl(medias)
 
-    def _embed_media_batch_impl(self, file_paths: list[Path]) -> list[Optional[np.ndarray]]:
-        """Subclass hook: embed a batch of media files.
+    def _embed_media_batch_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        """Subclass hook: embed a batch of media items.
 
         The default implementation simply loops over :meth:`_embed_media_impl`,
         which is correct for embedders that have no native bulk path.
         Override this in subclasses that back onto a remote bulk API.
         """
-        return [self._embed_media_impl(fp) for fp in file_paths]
+        return [self._embed_media_impl(m) for m in medias]
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -93,11 +93,12 @@ class ImageClipEmbedder(MediaEmbedder):
             "a picture of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             from PIL import Image  # noqa: PLC0415
 

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -98,11 +98,12 @@ class ImageSiglipEmbedder(MediaEmbedder):
             "a picture of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             from PIL import Image  # noqa: PLC0415
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -411,9 +411,11 @@ class ImageMediaType(MediaType):
             total = len(selected)
             on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
 
+            from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
             for i, (img_path, category) in enumerate(selected):
                 on_progress("embedding", f"Embedding {category}/{img_path.name}", i + 1, total)
-                embedding = embedder.embed_media(img_path)
+                embedding = embedder.embed_media(media_from_path(img_path))
                 if embedding is None:
                     continue
                 with open(img_path, "rb") as f:

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -77,11 +77,12 @@ class TextE5Embedder(MediaEmbedder):
             "writing on the topic of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 text_content = f.read().strip()

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -77,11 +77,12 @@ class TextBGEEmbedder(MediaEmbedder):
             "writing on the topic of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 text_content = f.read().strip()

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -90,11 +90,12 @@ class VideoXClipEmbedder(MediaEmbedder):
             "a video media of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             import cv2  # noqa: PLC0415
             import torch  # noqa: PLC0415

--- a/vtsearch/media/video/embedder_languagebind.py
+++ b/vtsearch/media/video/embedder_languagebind.py
@@ -137,11 +137,12 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
             "a video media of {text}",
         ]
 
-    def _embed_media_impl(self, file_path: Path) -> Optional[np.ndarray]:
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._tokenizer is None:
             return None
+        file_path = Path(media["media_path"])
         try:
             import cv2  # noqa: PLC0415
             import torch  # noqa: PLC0415

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -436,10 +436,12 @@ class VideoMediaType(MediaType):
         on_progress("embedding", f"Starting embedding for {total} video files...", 0, total)
         demo_origin_template: dict = {"importer": "demo", "params": {}}
 
+        from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
         for i, (video_path, meta) in enumerate(video_files):
             rel_name = f"{meta['category']}/{video_path.name}"
             on_progress("embedding", f"Embedding {rel_name}", i + 1, total)
-            embedding = embedder.embed_media(video_path)
+            embedding = embedder.embed_media(media_from_path(video_path))
             if embedding is None:
                 continue
             with open(video_path, "rb") as f:

--- a/vtsearch/models/embeddings.py
+++ b/vtsearch/models/embeddings.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 import numpy as np
 
+from vtsearch.media.embedder import media_from_path
+
 
 def _get_embedder_for_media_type(media_type: str):
     """Return the first registered embedder for *media_type*, or None."""
@@ -24,25 +26,25 @@ def _get_embedder_for_media_type(media_type: str):
 def embed_audio_file(audio_path: Path) -> Optional[np.ndarray]:
     """Generate a CLAP audio embedding for *audio_path*."""
     emb = _get_embedder_for_media_type("audio")
-    return emb.embed_media(audio_path) if emb else None
+    return emb.embed_media(media_from_path(audio_path)) if emb else None
 
 
 def embed_video_file(video_path: Path) -> Optional[np.ndarray]:
     """Generate an X-CLIP video embedding for *video_path*."""
     emb = _get_embedder_for_media_type("video")
-    return emb.embed_media(video_path) if emb else None
+    return emb.embed_media(media_from_path(video_path)) if emb else None
 
 
 def embed_image_file(image_path: Path) -> Optional[np.ndarray]:
     """Generate a CLIP image embedding for *image_path*."""
     emb = _get_embedder_for_media_type("image")
-    return emb.embed_media(image_path) if emb else None
+    return emb.embed_media(media_from_path(image_path)) if emb else None
 
 
 def embed_paragraph_file(text_path: Path) -> Optional[np.ndarray]:
     """Generate an E5-base-v2 embedding for *text_path*."""
     emb = _get_embedder_for_media_type("text")
-    return emb.embed_media(text_path) if emb else None
+    return emb.embed_media(media_from_path(text_path)) if emb else None
 
 
 def embed_text_query(text: str, media_type: str, enrich: bool = False, embedder_name: str = "") -> Optional[np.ndarray]:

--- a/vtsearch/models/media_seeding.py
+++ b/vtsearch/models/media_seeding.py
@@ -95,7 +95,9 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
                     # No embedder available; skip remaining examples.
                     continue
 
-            embedding = embedder.embed_media(file_path)
+            from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
+            embedding = embedder.embed_media(media_from_path(file_path))
             if embedding is None:
                 continue
 

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -294,8 +294,10 @@ def embed_file(file_path: Path, media_type: str) -> np.ndarray | None:
         )
         return None
     embedder = avail[0]
+    from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
     try:
-        result = embedder.embed_media(file_path)
+        result = embedder.embed_media(media_from_path(file_path))
     except Exception:
         log.warning(
             "embed_file: %s.embed_media(%s) raised an exception",

--- a/vtsearch/routes/detectors_training.py
+++ b/vtsearch/routes/detectors_training.py
@@ -158,7 +158,9 @@ def import_detector_labels():
         avail = embedders_for_type(media_type)
         if not avail:
             return None
-        return avail[0].embed_media(p)
+        from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
+        return avail[0].embed_media(media_from_path(p))
 
     try:
         text = file.read().decode("utf-8")

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -635,8 +635,10 @@ def add_media_to_pile() -> tuple[Response, int] | Response:
         tmp.write(file_bytes)
         tmp_path = Path(tmp.name)
 
+    from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
     try:
-        embedding = embedder.embed_media(tmp_path)
+        embedding = embedder.embed_media(media_from_path(tmp_path))
     finally:
         tmp_path.unlink(missing_ok=True)
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -343,7 +343,9 @@ def _example_sort_from_path(file_path: Path) -> tuple:
     emb = _get_embedder_for_loaded_data()
     if emb is None:
         raise ValueError("No embedder available for loaded dataset")
-    example_embedding = emb.embed_media(file_path)
+    from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
+    example_embedding = emb.embed_media(media_from_path(file_path))
 
     if example_embedding is None:
         raise ValueError("Failed to embed media file")
@@ -450,7 +452,9 @@ def label_file_sort():
                 continue
 
             # Embed the media file using the dataset's embedder
-            embedding = emb.embed_media(media_path)
+            from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
+            embedding = emb.embed_media(media_from_path(media_path))
             if embedding is None:
                 skipped_count += 1
                 continue


### PR DESCRIPTION
## Summary
- `MediaEmbedder.embed_media` / `embed_media_batch` (and their `_impl` hooks) now receive **media dicts** instead of bare `Path`s, unlocking service-based embedders that resolve content remotely via `media["origin"]` / `media.get("custom_metadata")` (e.g. a lookup by `origin.params.content_id`).
- File-based embedders pull `Path(media["media_path"])` at the top of `_embed_media_impl`. Added `vtsearch.media.embedder.media_from_path()` for callers that only have a local file (uploads, converter output, seed data, CLI utilities).
- Dropped the unused `MediaType.embed_media` default (and the `DocumentMediaType` override that matched it) — only the `MediaEmbedder` API is in use. Tests, EXTENDING-media.md, and ARCHITECTURE.md updated accordingly.

**Backwards compatibility:** this is a breaking change to the `MediaEmbedder` subclass contract (third-party embedders that override `_embed_media_impl(self, file_path)` must switch to `_embed_media_impl(self, media)`).

## Test plan
- [x] `./run-tests.sh` — `ALL 2944 TESTS PASSED (1 skipped, total: 2945)`

https://claude.ai/code/session_01Kd3dzWKBgrR1ZyjGnYFAHL