### PR TITLE
Make custom embedders discoverable like other extensions

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -32,15 +32,18 @@ time. The `_discover_media_plugins()` function in
 `vtsearch/media/__init__.py` scans sub-packages of `vtsearch/media/` for
 module-level sentinel attributes:
 
-| Sentinel     | Type                  | Description                          |
-|--------------|-----------------------|--------------------------------------|
-| `MEDIA_TYPE` | `MediaType`           | A single media type instance         |
-| `EMBEDDERS`  | `list[MediaEmbedder]` | Embedder instances (may be empty)    |
-| `CLIPPERS`   | `list[MediaClipper]`  | Clipper instances (may be empty)     |
+| Sentinel     | Location                         | Type                 | Description                          |
+|--------------|----------------------------------|----------------------|--------------------------------------|
+| `MEDIA_TYPE` | media-type package `__init__.py` | `MediaType`          | A single media type instance         |
+| `CLIPPERS`   | media-type package `__init__.py` | `list[MediaClipper]` | Clipper instances (may be empty)     |
+| `EMBEDDER`   | an `embedder*.py` file inside the media-type package | `MediaEmbedder` | One embedder per module              |
 
-To add a new built-in media type, create a sub-package under
-`vtsearch/media/` with an `__init__.py` that exposes the relevant
-sentinels. Symlinked directories are supported.
+Embedders use **one module per embedder**: any `embedder*.py` file inside
+a media-type package is auto-loaded and its module-level `EMBEDDER`
+sentinel is registered. Symlinked directories **and** symlinked embedder
+files are both supported, so a custom embedder can live outside the
+VTSearch tree and be wired in by symlinking a single file into the
+appropriate media-type package — no edits to any `__init__.py` required.
 
 Third-party or project-specific types can still be registered manually
 via `register()`, `register_embedder()`, and `register_clipper()`.
@@ -57,8 +60,9 @@ datasets are available, and how to load media-specific fields from files.
 
 ```
 vtsearch/media/<your_type>/
-├── __init__.py       # Must expose MEDIA_TYPE, EMBEDDERS, CLIPPERS sentinels
-└── media_type.py     # Your MediaType subclass (required)
+├── __init__.py       # Must expose MEDIA_TYPE and CLIPPERS sentinels
+├── media_type.py     # Your MediaType subclass (required)
+└── embedder*.py      # Optional — one file per embedder, each exposing EMBEDDER
 ```
 
 ### What to implement
@@ -152,11 +156,20 @@ Expose the sentinels in your sub-package's `__init__.py`:
 # vtsearch/media/code/__init__.py
 
 from vtsearch.media.code.media_type import CodeMediaType
-from vtsearch.media.code.embedder import CodeBertEmbedder
 
 MEDIA_TYPE = CodeMediaType()
-EMBEDDERS = [CodeBertEmbedder()]
 CLIPPERS = []  # No clippers yet — add when needed
+```
+
+Each embedder lives in its own `embedder*.py` file with an `EMBEDDER`
+sentinel at the bottom:
+
+```python
+# vtsearch/media/code/embedder_codebert.py
+
+# ... class definition ...
+
+EMBEDDER = CodeBertEmbedder()
 ```
 
 The auto-discovery system finds these sentinels at import time. No
@@ -362,19 +375,25 @@ For bulk APIs, also override `supports_batch` / `batch_size` and
 
 ### Register the embedder
 
-Add the embedder to the `EMBEDDERS` sentinel list in your media type's
-`__init__.py`:
+Drop the embedder into an `embedder*.py` file inside the media-type
+package and expose an `EMBEDDER` sentinel at the bottom. Discovery is
+automatic — no edits to `__init__.py` are needed:
 
 ```python
-# vtsearch/media/code/__init__.py
+# vtsearch/media/code/embedder_codebert.py
 
-from vtsearch.media.code.embedder import CodeBertEmbedder
-# ...
-EMBEDDERS = [CodeBertEmbedder()]
+class CodeBertEmbedder(MediaEmbedder):
+    ...
+
+EMBEDDER = CodeBertEmbedder()
 ```
 
-For an alternative embedder on an **existing** media type, add it to that
-type's `EMBEDDERS` list (e.g. in `vtsearch/media/image/__init__.py`).
+For an alternative embedder on an **existing** media type, drop a new
+`embedder_<name>.py` file into that type's package (e.g.
+`vtsearch/media/image/embedder_myclip.py`) with its own `EMBEDDER`
+sentinel. To wire in a custom embedder living outside the VTSearch
+source tree, symlink the file in — symlinked embedder modules are
+loaded via `spec_from_file_location` so discovery still works.
 
 ### MediaEmbedder abstract interface reference
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -218,7 +218,7 @@ See [EXTENDING-media.md § Adding a Media Type](EXTENDING-media.md#adding-a-medi
 
 - [ ] Create `vtsearch/media/<type>/` directory with `__init__.py`, `media_type.py`
 - [ ] Subclass `MediaType` and implement all abstract properties and methods
-- [ ] Expose `MEDIA_TYPE`, `EMBEDDERS`, and `CLIPPERS` sentinels in `__init__.py`
+- [ ] Expose `MEDIA_TYPE` and `CLIPPERS` sentinels in `__init__.py` (embedders are discovered per-module — see the embedder checklist below)
 - [ ] Add a `requirements.txt` in the plugin directory and run `bash install-plugin-deps.sh`
 - [ ] Override `pickle_extra_fields` if you use custom clip keys
 - [ ] Test: import a folder of your media type, verify clips appear and are sortable
@@ -231,7 +231,7 @@ See [EXTENDING-media.md § Adding a Media Embedder](EXTENDING-media.md#adding-a-
 - [ ] Subclass `MediaEmbedder`, implement `name`, `media_type_id`, `_load_models_impl()`, `embed_media()`
 - [ ] Optionally implement `embed_text()` for text-query sorting
 - [ ] Optionally set `description_wrappers` for enriched text embedding
-- [ ] Add to the `EMBEDDERS` list in the media type's `__init__.py`
+- [ ] Expose `EMBEDDER = YourEmbedder()` at module level — auto-discovery picks it up, no `__init__.py` edits needed (symlinked files are supported)
 - [ ] Test: load a dataset and verify embeddings are generated
 
 ### New Media Clipper Checklist

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -82,7 +82,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Text (`text`) | `bge` | BGE (`BAAI/bge-base-en-v1.5`) | 768 |
 | Document (`document`) | — | None (no embedder) | N/A |
 
-Audio, image, and text media types each have an **alternative embedder** in addition to the default. The first entry in each media type's `EMBEDDERS` list in `vtsearch/media/<type>/__init__.py` is the default; subsequent entries are alternatives.
+Audio, image, and text media types each have an **alternative embedder** in addition to the default. Each embedder lives in its own `embedder*.py` file inside the media-type package and exposes a module-level `EMBEDDER` sentinel; the default for a given media type is the one whose file sorts first (plain `embedder.py` ahead of `embedder_<variant>.py`).
 
 The **document** media type has no embedding model of its own. Documents (PDF, DOC, PPT) are intended to be converted to other media types (images or text) via media converters in `vtsearch/converters/` before embedding.
 

--- a/tests/test_new_embedders.py
+++ b/tests/test_new_embedders.py
@@ -458,6 +458,133 @@ class TestAllEmbeddersRegistration:
             assert "media_type_id" in d
 
 
+class TestEmbedderSentinelDiscovery:
+    """Verify built-in embedder modules expose the ``EMBEDDER`` sentinel
+    so that auto-discovery picks them up with no edits to any
+    ``__init__.py`` — the same pattern used by exporters, dataset
+    importers, label importers, processor importers, settings importers /
+    exporters, and sync sources.
+    """
+
+    def test_every_builtin_embedder_module_has_sentinel(self):
+        from vtsearch.media.audio import embedder as audio_clap
+        from vtsearch.media.audio import embedder_clap_music
+        from vtsearch.media.image import embedder as image_clip
+        from vtsearch.media.image import embedder_siglip
+        from vtsearch.media.text import embedder as text_e5
+        from vtsearch.media.text import embedder_bge
+        from vtsearch.media.video import embedder as video_xclip
+        from vtsearch.media.video import embedder_languagebind
+
+        from vtsearch.media.embedder import MediaEmbedder
+
+        modules = [
+            audio_clap,
+            embedder_clap_music,
+            image_clip,
+            embedder_siglip,
+            text_e5,
+            embedder_bge,
+            video_xclip,
+            embedder_languagebind,
+        ]
+        for mod in modules:
+            sentinel = getattr(mod, "EMBEDDER", None)
+            assert sentinel is not None, f"{mod.__name__} is missing an EMBEDDER sentinel"
+            assert isinstance(sentinel, MediaEmbedder), (
+                f"{mod.__name__}.EMBEDDER must be a MediaEmbedder instance"
+            )
+
+    def test_sentinel_identity_matches_registry(self):
+        """The registered embedder for each name should be the module's EMBEDDER sentinel."""
+        from vtsearch.media import get_embedder
+        from vtsearch.media.audio.embedder import EMBEDDER as clap_sentinel
+        from vtsearch.media.text.embedder_bge import EMBEDDER as bge_sentinel
+        from vtsearch.media.video.embedder_languagebind import EMBEDDER as lb_sentinel
+
+        assert get_embedder("clap") is clap_sentinel
+        assert get_embedder("bge") is bge_sentinel
+        assert get_embedder("languagebind") is lb_sentinel
+
+    def test_media_type_init_no_longer_lists_embedders(self):
+        """Media-type package ``__init__.py`` files should not expose an
+        ``EMBEDDERS`` attribute — embedders are discovered per-module.
+        """
+        from vtsearch.media import audio, document, image, text, video
+
+        for pkg in (audio, image, text, video, document):
+            assert not hasattr(pkg, "EMBEDDERS"), (
+                f"{pkg.__name__} still exposes an EMBEDDERS list — "
+                "embedders should be discovered via per-module EMBEDDER sentinels"
+            )
+
+    def test_custom_embedder_auto_discovered(self, tmp_path, monkeypatch):
+        """A new ``embedder_*.py`` file dropped into a media-type package
+        should be auto-discovered with no ``__init__.py`` edits.
+        """
+        import importlib
+        import sys
+        from pathlib import Path
+
+        import vtsearch.media as media_pkg
+        from vtsearch.media import _discover_embedders_in, register_embedder
+        from vtsearch.media.embedder import MediaEmbedder
+
+        # Create a throwaway media-type package under tmp_path with a single
+        # embedder module exposing the EMBEDDER sentinel.
+        fake_pkg = tmp_path / "fakemedia"
+        fake_pkg.mkdir()
+        (fake_pkg / "__init__.py").write_text("")
+        embedder_src = (
+            "from vtsearch.media.embedder import MediaEmbedder\n"
+            "\n"
+            "class _FakeEmbedder(MediaEmbedder):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            "        return 'fake_discoverable'\n"
+            "    @property\n"
+            "    def media_type_id(self):\n"
+            "        return 'fake'\n"
+            "    def _load_models_impl(self):\n"
+            "        pass\n"
+            "    def _embed_media_impl(self, media):\n"
+            "        return None\n"
+            "\n"
+            "EMBEDDER = _FakeEmbedder()\n"
+        )
+        (fake_pkg / "embedder_fake.py").write_text(embedder_src)
+
+        # Make the fake package importable as if it lived under vtsearch.media.
+        package_name = "vtsearch.media._fakemedia_test"
+        spec = importlib.util.spec_from_file_location(
+            package_name,
+            str(fake_pkg / "__init__.py"),
+            submodule_search_locations=[str(fake_pkg)],
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[package_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+            # Snapshot the registry so we can restore it after the test.
+            from vtsearch.media import _embedder_registry
+
+            saved = dict(_embedder_registry)
+            try:
+                _discover_embedders_in(Path(fake_pkg), package_name)
+                assert "fake_discoverable" in _embedder_registry
+                discovered = _embedder_registry["fake_discoverable"]
+                assert isinstance(discovered, MediaEmbedder)
+                assert discovered.media_type_id == "fake"
+            finally:
+                _embedder_registry.clear()
+                _embedder_registry.update(saved)
+        finally:
+            # Remove the fake package and its submodule from sys.modules.
+            for key in list(sys.modules):
+                if key == package_name or key.startswith(package_name + "."):
+                    sys.modules.pop(key, None)
+
+
 class TestNewEmbeddersInheritance:
     """Verify new embedders correctly extend MediaEmbedder."""
 

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -1,16 +1,20 @@
 """Media type, embedder, and clipper registries.
 
 Built-in media types, embedders, and clippers are **auto-discovered** at
-import time by scanning sub-packages of ``vtsearch.media`` for sentinel
-attributes:
+import time by scanning sub-packages of ``vtsearch.media``:
 
-- ``MEDIA_TYPE`` — a single :class:`MediaType` instance.
-- ``EMBEDDERS`` — a list of :class:`MediaEmbedder` instances (may be empty).
-- ``CLIPPERS``  — a list of :class:`MediaClipper` instances (may be empty).
+- Each media-type sub-package (``audio/``, ``image/``, ...) exposes a
+  ``MEDIA_TYPE`` sentinel in its ``__init__.py`` (plus a ``CLIPPERS`` list).
+- Each embedder lives in its own module under the media-type package
+  (e.g. ``vtsearch/media/audio/embedder_clap_music.py``) and exposes a
+  module-level ``EMBEDDER`` sentinel — one embedder per module.  Any
+  ``embedder*.py`` file found inside a media-type package is auto-loaded.
 
-To add a new media type (or embedder / clipper), create a sub-package under
-``vtsearch/media/`` with an ``__init__.py`` that exposes the relevant
-sentinels.  Symlinked directories are supported.
+To add a new embedder, drop an ``embedder_<name>.py`` file into the
+appropriate media-type package with an ``EMBEDDER`` sentinel at the bottom.
+Symlinked directories and symlinked embedder files are both supported, so
+custom embedders living outside the VTSearch tree can be wired in without
+editing any package ``__init__.py``.
 
 Third-party or project-specific types can still be registered manually::
 
@@ -22,6 +26,8 @@ Third-party or project-specific types can still be registered manually::
 from __future__ import annotations
 
 import importlib
+import importlib.util
+import sys
 import warnings
 from pathlib import Path
 
@@ -240,14 +246,57 @@ def all_embedders_dict() -> list[dict]:
 # ------------------------------------------------------------------
 
 
+def _discover_embedders_in(media_type_dir: Path, package_name: str) -> None:
+    """Scan a media-type sub-package for modules exposing an ``EMBEDDER`` sentinel.
+
+    Any ``embedder*.py`` file (excluding ``__init__.py``) is imported, and its
+    module-level ``EMBEDDER`` attribute is registered if present.  Symlinked
+    files are loaded via :func:`importlib.util.spec_from_file_location` so
+    that symlinks pointing outside the package are handled reliably (mirrors
+    the same approach used by :class:`vtsearch.utils.registry.PluginRegistry`).
+    """
+    for entry in sorted(media_type_dir.iterdir()):
+        if entry.name.startswith((".", "_")):
+            continue
+        if not entry.is_file() or entry.suffix != ".py":
+            continue
+        if not entry.name.startswith("embedder"):
+            continue
+        full_name = f"{package_name}.{entry.stem}"
+        try:
+            if entry.is_symlink():
+                resolved = entry.resolve()
+                spec = importlib.util.spec_from_file_location(full_name, str(resolved))
+                if spec is None or spec.loader is None:
+                    continue
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules[full_name] = mod
+                spec.loader.exec_module(mod)
+            else:
+                mod = importlib.import_module(full_name)
+        except Exception as exc:  # pragma: no cover
+            sys.modules.pop(full_name, None)
+            warnings.warn(
+                f"Failed to load embedder module '{full_name}': {exc}",
+                stacklevel=2,
+            )
+            continue
+        emb = getattr(mod, "EMBEDDER", None)
+        if emb is not None:
+            register_embedder(emb)
+
+
 def _discover_media_plugins() -> None:
     """Scan sub-packages of ``vtsearch.media`` for sentinel attributes.
 
-    Each sub-package (directory with ``__init__.py``) may expose:
+    Each media-type sub-package (directory with ``__init__.py``) may expose:
 
     - ``MEDIA_TYPE`` — a single :class:`MediaType` instance.
-    - ``EMBEDDERS`` — a list of :class:`MediaEmbedder` instances.
     - ``CLIPPERS``  — a list of :class:`MediaClipper` instances.
+
+    Embedders are auto-discovered per module: every ``embedder*.py`` file
+    inside a media-type sub-package is scanned for an ``EMBEDDER`` sentinel
+    (see :func:`_discover_embedders_in`).
 
     Symlinked directories are followed (``entry.is_dir()`` resolves
     symlinks), so an external media-type package can be symlinked into
@@ -259,8 +308,9 @@ def _discover_media_plugins() -> None:
             continue
         if not entry.is_dir() or "." in entry.name or not (entry / "__init__.py").exists():
             continue
+        package_name = f"vtsearch.media.{entry.name}"
         try:
-            mod = importlib.import_module(f"vtsearch.media.{entry.name}")
+            mod = importlib.import_module(package_name)
         except Exception as exc:  # pragma: no cover
             warnings.warn(
                 f"Failed to load media sub-package '{entry.name}': {exc}",
@@ -271,10 +321,9 @@ def _discover_media_plugins() -> None:
         mt = getattr(mod, "MEDIA_TYPE", None)
         if mt is not None:
             register(mt)
-        for emb in getattr(mod, "EMBEDDERS", []):
-            register_embedder(emb)
         for clip in getattr(mod, "CLIPPERS", []):
             register_clipper(clip)
+        _discover_embedders_in(entry, package_name)
 
 
 _discover_media_plugins()

--- a/vtsearch/media/audio/__init__.py
+++ b/vtsearch/media/audio/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.audio.clipper import SoundDefaultClipper, SoundTilingClipper
-from vtsearch.media.audio.embedder import AudioClapEmbedder
-from vtsearch.media.audio.embedder_clap_music import AudioClapMusicEmbedder
 from vtsearch.media.audio.media_type import AudioMediaType
 
 MEDIA_TYPE = AudioMediaType()
-EMBEDDERS = [AudioClapEmbedder(), AudioClapMusicEmbedder()]
 CLIPPERS = [SoundDefaultClipper(), SoundTilingClipper(2.0)]

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -175,3 +175,6 @@ class AudioClapEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = AudioClapEmbedder()

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -157,3 +157,6 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = AudioClapMusicEmbedder()

--- a/vtsearch/media/document/__init__.py
+++ b/vtsearch/media/document/__init__.py
@@ -2,5 +2,4 @@ from vtsearch.media.document.clipper import DocumentDefaultClipper
 from vtsearch.media.document.media_type import DocumentMediaType
 
 MEDIA_TYPE = DocumentMediaType()
-EMBEDDERS = []
 CLIPPERS = [DocumentDefaultClipper()]

--- a/vtsearch/media/image/__init__.py
+++ b/vtsearch/media/image/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.image.clipper import ImageDefaultClipper, ImageTilingClipper
-from vtsearch.media.image.embedder import ImageClipEmbedder
-from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
 from vtsearch.media.image.media_type import ImageMediaType
 
 MEDIA_TYPE = ImageMediaType()
-EMBEDDERS = [ImageSiglipEmbedder(), ImageClipEmbedder()]
 CLIPPERS = [ImageDefaultClipper(), ImageTilingClipper()]

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -152,3 +152,6 @@ class ImageClipEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = ImageClipEmbedder()

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -157,3 +157,6 @@ class ImageSiglipEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = ImageSiglipEmbedder()

--- a/vtsearch/media/text/__init__.py
+++ b/vtsearch/media/text/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.text.clipper import TextDefaultClipper, TextSentenceClipper
-from vtsearch.media.text.embedder import TextE5Embedder
-from vtsearch.media.text.embedder_bge import TextBGEEmbedder
 from vtsearch.media.text.media_type import TextMediaType
 
 MEDIA_TYPE = TextMediaType()
-EMBEDDERS = [TextE5Embedder(), TextBGEEmbedder()]
 CLIPPERS = [TextDefaultClipper(), TextSentenceClipper()]

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -122,3 +122,6 @@ class TextE5Embedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model
+
+
+EMBEDDER = TextE5Embedder()

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -122,3 +122,6 @@ class TextBGEEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model
+
+
+EMBEDDER = TextBGEEmbedder()

--- a/vtsearch/media/video/__init__.py
+++ b/vtsearch/media/video/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.video.clipper import VideoDefaultClipper, VideoSceneClipper, VideoTilingClipper
-from vtsearch.media.video.embedder import VideoXClipEmbedder
-from vtsearch.media.video.embedder_languagebind import VideoLanguageBindEmbedder
 from vtsearch.media.video.media_type import VideoMediaType
 
 MEDIA_TYPE = VideoMediaType()
-EMBEDDERS = [VideoXClipEmbedder(), VideoLanguageBindEmbedder()]
 CLIPPERS = [VideoDefaultClipper(), VideoTilingClipper(2.0), VideoSceneClipper()]

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -166,3 +166,6 @@ class VideoXClipEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = VideoXClipEmbedder()

--- a/vtsearch/media/video/embedder_languagebind.py
+++ b/vtsearch/media/video/embedder_languagebind.py
@@ -228,3 +228,6 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._tokenizer
+
+
+EMBEDDER = VideoLanguageBindEmbedder()


### PR DESCRIPTION
## Summary

Brings embedders in line with the plugin-discovery pattern already used by exporters, dataset/label/processor/settings importers, and sync sources. Adding a custom embedder — including one that lives outside the VTSearch source tree, symlinked in — no longer requires editing any `__init__.py`.

## What changed

- Each embedder module now exposes a module-level `EMBEDDER` sentinel (one embedder per module).
- `_discover_media_plugins()` in `vtsearch/media/__init__.py` scans every `embedder*.py` file inside each media-type package for the `EMBEDDER` sentinel. Symlinked files are loaded via `importlib.util.spec_from_file_location`, mirroring the approach in `PluginRegistry`.
- The `EMBEDDERS = [...]` lists have been removed from each media-type package's `__init__.py`. The `MEDIA_TYPE` and `CLIPPERS` sentinels remain.
- Docs (`EXTENDING.md`, `EXTENDING-media.md`, `ML.md`) updated to describe the new per-module sentinel.
- New tests in `tests/test_new_embedders.py::TestEmbedderSentinelDiscovery` verify that every built-in embedder exposes the sentinel, that the sentinel object *is* the registered instance, and that dropping a new `embedder_*.py` file into a media-type package is automatically picked up.

## Backwards compatibility

Breaking: the `EMBEDDERS` list attribute is no longer exposed by `vtsearch.media.<type>` packages. Any external code that relied on introspecting `vtsearch.media.audio.EMBEDDERS` (etc.) should switch to `vtsearch.media.embedders_for_type("audio")` or `vtsearch.media.all_embedders()`. All public registry APIs (`get_embedder`, `register_embedder`, `all_embedders`, `embedders_for_type`) are unchanged, as are the class import paths (`from vtsearch.media.audio.embedder import AudioClapEmbedder`).

## Test plan

- [x] `./run-tests.sh` — 2948 passed, 1 skipped, 1 xfailed, 1 xpassed
- [x] `./run-tests.sh core models` — 889 passed
- [x] New `TestEmbedderSentinelDiscovery` covers sentinel presence, identity with registry, absence of legacy `EMBEDDERS` attribute, and auto-discovery of a newly dropped-in embedder module