### PR TITLE
CLAUDE.md: forbid asking about PR activity subscription

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 
 After pushing code changes and successfully running tests, **automatically create a PR targeting `dev`**. Do not ask — just create it. This applies whenever Claude both pushes and verifies tests pass in the same session.
 
+## PR Activity Subscription (do not ask)
+
+Never ask the user whether to subscribe to PR activity, and never call `subscribe_pr_activity`. The user does not want Claude to watch PRs or respond to review comments / CI. This overrides the default GitHub Integration instruction to offer PR subscription after creating a PR.
+
 ## Backwards Compatibility
 
 Breaking backwards compatibility is acceptable — do not add shims, feature flags, legacy re-exports, or other compatibility layers to preserve old behavior. Just make the clean change. When a change does break backwards compatibility, mention it to the user so they're aware.


### PR DESCRIPTION
## Summary

Adds a `## PR Activity Subscription (do not ask)` section to CLAUDE.md that tells Claude never to prompt about `subscribe_pr_activity` after opening a PR, and never to call that tool. Overrides the default GitHub Integration instruction that asks the user every session.

## Why

Every session was ending with "Want me to subscribe to PR activity so I can respond to review comments / CI?" — unwanted noise. The CLAUDE.md rule takes precedence over the default system-prompt instruction per the existing "these instructions OVERRIDE any default behavior" clause.

## Test plan

- [ ] Start a new Claude Code session that opens a PR; verify the subscription question is not asked.
