### PR TITLE
Fix autorun toggle silently failing for models not in autorun_detectors

### DIFF
--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -228,6 +228,37 @@ class TestAutorunDetectors:
         )
         assert resp.status_code == 400
 
+    # -- autodetect toggle --
+
+    def test_set_autodetect_on_existing_detector(self, client):
+        det = self._export_detector(client)
+        self._post_autorun(client, "tog-det", det)
+
+        resp = client.put("/api/autorun-detectors/tog-det/autodetect", json={"autodetect": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["autodetect"] is True
+
+        detectors = client.get("/api/autorun-detectors").get_json()["detectors"]
+        d = next(d for d in detectors if d["name"] == "tog-det")
+        assert d["autodetect"] is True
+
+    def test_set_autodetect_true_on_nonexistent_detector_persists_to_settings(self, client, isolated_settings):
+        """Enabling autorun for a model-registry entry not yet in autorun_detectors must succeed."""
+        from vtsearch.settings import get_autorun_detector_names
+
+        resp = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["autodetect"] is True
+        assert "ghost-model" in get_autorun_detector_names()
+
+    def test_set_autodetect_false_on_nonexistent_detector_returns_404(self, client):
+        resp = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": False})
+        assert resp.status_code == 404
+
+    def test_set_autodetect_missing_field_returns_400(self, client):
+        resp = client.put("/api/autorun-detectors/any/autodetect", json={})
+        assert resp.status_code == 400
+
     # -- import-pkl (detector JSON file) --
 
     def test_import_pkl_from_detector_json(self, client):

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -220,16 +220,18 @@ def set_autorun_detector_autodetect_route(name):
     if autodetect is None:
         return jsonify({"error": "autodetect is required"}), 400
 
-    if set_autorun_detector_autodetect(name, bool(autodetect)):
-        # Persist in settings so the flag survives restarts
-        from vtsearch.settings import add_autorun_detector_name, remove_autorun_detector_name
+    from vtsearch.settings import add_autorun_detector_name, remove_autorun_detector_name
 
-        if autodetect:
-            add_autorun_detector_name(name)
-        else:
-            remove_autorun_detector_name(name)
-        return jsonify({"success": True, "autodetect": bool(autodetect)})
-    return jsonify({"error": "Detector not found"}), 404
+    found_in_memory = set_autorun_detector_autodetect(name, bool(autodetect))
+    # Even if the detector isn't loaded in memory, persist the setting so it
+    # takes effect on next load / CLI autorun.
+    if autodetect:
+        add_autorun_detector_name(name)
+    else:
+        remove_autorun_detector_name(name)
+        if not found_in_memory:
+            return jsonify({"error": "Detector not found"}), 404
+    return jsonify({"success": True, "autodetect": bool(autodetect)})
 
 
 @detectors_crud_bp.route("/api/autorun-detectors/<name>/export", methods=["GET"])


### PR DESCRIPTION
## Summary

- Clicking the Autorun X on a model-registry entry that has no in-memory `autorun_detectors` slot returned 404; the frontend's `subscribe({next})` never fired, so the UI appeared frozen
- Fix: when `autodetect=true`, always persist the name to settings and return 200, even if the detector isn't loaded in memory — it will be picked up on next CLI autorun / detector load
- Disabling autorun (`autodetect=false`) on a detector not in memory still returns 404 (it was already off)

## Test plan

- [ ] New tests cover: toggle on existing detector, enable on ghost (not-in-memory) model persists to settings, disable on ghost returns 404, missing field returns 400
- [ ] `./run-tests.sh models` — 552 passed

https://claude.ai/code/session_01R1giWV5zewzmMPXaBjGq68