### PR TITLE
Normalize SVG stroke widths in dashboard card components

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -80,7 +80,7 @@
       </span>
     } @else {
       <button class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -91,20 +91,20 @@
     <div class="actions-cell">
     @if (!isDefaultLogin) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
         </svg>
       </button>
     }
     <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
         <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
         <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
       </svg>
     </button>
     <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
-      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
         <path d="M12 2a10 10 0 0 1 0 20"/>
         <line x1="12" y1="12" x2="12" y2="2"/>
@@ -113,7 +113,7 @@
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
-      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
         <path d="M10 11v6"></path>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -86,11 +86,11 @@
   <td>
     <button class="autorun-toggle" (click)="onAutorunToggle($event)" aria-label="Autorun" title="Include in CLI autorun">
       @if (model.autodetect) {
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="20 6 9 17 4 12"></polyline>
         </svg>
       } @else {
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -108,7 +108,7 @@
       </span>
     } @else {
       <button class="load-action" (click)="onLoad($event)" title="Click to load this model" aria-label="Load model">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -119,23 +119,23 @@
 <td>
   <div class="actions-cell">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
-    <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
       <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
       <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
     </svg>
   </button>
   <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
-    <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
+    <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
   </button>
   <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
-    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="15 14 20 9 15 4"></polyline>
       <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
     </svg>
   </button>
   <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
-    <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="3 6 5 6 21 6"></polyline>
       <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
       <path d="M10 11v6"></path>


### PR DESCRIPTION
## Summary
Standardized SVG icon stroke widths across the model-card and dataset-card components for visual consistency.

## Changes
- **model-card.component.html**: Updated stroke-width values from `2.5` to `2` for autorun toggle icons and load action icon; changed from `2` to `1.5` for edit (pencil), add labels (cap), export, and delete (trash) action buttons
- **dataset-card.component.html**: Updated stroke-width values from `2.5` to `2` for load action icon; changed from `2` to `1.5` for security, edit (pencil), stats (pie), and delete (trash) action buttons

## Details
This change establishes a consistent stroke-width hierarchy:
- **Stroke-width 2**: Primary action icons (load/unload)
- **Stroke-width 1.5**: Secondary action icons (edit, delete, export, stats, security, add labels)

This improves visual hierarchy and ensures all SVG icons render with consistent line weights across the dashboard interface.

https://claude.ai/code/session_019QfamzfHnG2z5iaRQd8u7E