### PR TITLE
Fix Autorun toggle in Models grid for trainable models

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -688,6 +688,25 @@ class TestAutorunCheckboxPersistence:
         m = resp.get_json()["models"][0]
         assert m["autodetect"] is False
 
+    def test_autodetect_toggle_reflects_in_registry_for_trainable_model(self, client):
+        """Trainable models created via the UI have detector_name="".
+
+        Toggling autorun uses the display name, and the registry response must
+        reflect the toggle state by falling back to the name when detector_name
+        is empty — otherwise the Autorun button in the Models grid appears dead.
+        """
+        register_model(name="Dog Barks", media_type="audio", trainable=True)
+
+        resp = client.put(
+            "/api/autorun-detectors/Dog Barks/autodetect",
+            json={"autodetect": True},
+        )
+        assert resp.status_code == 200
+
+        resp = client.get("/api/models/registry")
+        m = next(m for m in resp.get_json()["models"] if m["name"] == "Dog Barks")
+        assert m["autodetect"] is True
+
     def test_autorun_not_in_settings_window(self, client):
         """autorun_detector_names should not appear in the defaults endpoint."""
         resp = client.get("/api/settings/defaults")

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -307,10 +307,13 @@ class TestNonexistentResources:
         assert resp.status_code == 400  # "not found or new name already exists"
 
     def test_autodetect_nonexistent_detector(self, client):
+        # autodetect=True on a name without an in-memory detector persists to
+        # settings (for model-registry entries that haven't been trained yet)
+        # and returns 200; disabling on a missing detector still returns 404.
         resp = client.put(
             "/api/autorun-detectors/does_not_exist/autodetect",
             json={
-                "autodetect": True,
+                "autodetect": False,
             },
         )
         assert resp.status_code == 404

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -444,19 +444,20 @@ def list_registered_models():
     for entry in entries:
         mid = entry["id"]
         entry["loaded"] = mid in loaded_ids
-        det_name = entry.get("detector_name", "")
+        # Trainable models created through the UI have detector_name="", but their
+        # autorun key is the display name (matches the frontend's toggleAutorun fallback).
+        det_name = entry.get("detector_name", "") or entry.get("name", "")
         det = detectors.get(det_name) if det_name else None
         if det:
             entry["autodetect"] = bool(det.get("autodetect"))
         else:
-            # Fall back to the persisted settings list
             entry["autodetect"] = det_name in autorun_names if det_name else False
         entry.setdefault("last_trained_at", None)
         # detector_loaded: True when the model has inference data in RAM.
         # Either via a DetectorContext (multi-loaded) or via autorun_detectors weights.
         if mid in loaded_ids:
             entry["detector_loaded"] = True
-        elif det_name and det:
+        elif det:
             entry["detector_loaded"] = det.get("weights") is not None
         else:
             entry["detector_loaded"] = False


### PR DESCRIPTION
## Summary

- Clicking the X in the Models-grid "Autorun?" column appeared dead for trainable models created through the UI. The PUT succeeded and the name was persisted to `autorun_detector_names`, but the subsequent `GET /api/models/registry` always reported `autodetect: false` because it skipped the lookup whenever `detector_name` was empty — which is the case for every trainable model created via the new-model modal.
- Aligned the backend registry response with the frontend's existing fallback: when `detector_name` is empty, fall back to `name`. Also simplified the redundant `det_name and det` check on `detector_loaded` (`det` is already `None` when `det_name` is empty).
- Fixed a stale test in `test_error_recovery.py` that still asserted the pre-cb14dd5 404 behavior for `autodetect=True` on a nonexistent detector; flipped it to exercise the still-404 `autodetect=False` branch.

## Test plan

- [x] `./run-tests.sh` — 2953 passed, 1 skipped (0 failures)
- [x] New regression test `test_autodetect_toggle_reflects_in_registry_for_trainable_model` in `test_dashboard.py` covering the trainable-model path (empty `detector_name`).

https://claude.ai/code/session_01NBEEvJ1bwjazP4YDXVFpp8