### PR TITLE
Add embedder selection support for media ingestion

### DIFF
--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -89,6 +89,21 @@ def _media_type_from_origin(origin_dict: dict[str, Any]) -> str:
     return ""
 
 
+def _embedder_name_for_type(medias: dict[int, dict[str, Any]], media_type_id: str) -> str:
+    """Return the embedder name used by existing medias of the given type.
+
+    Scans the live dataset for the first media whose ``type`` matches
+    *media_type_id* and returns its ``embedder`` field.  Returns an empty
+    string when no matching media is found (caller falls back to the default).
+    """
+    for m in medias.values():
+        if m.get("type") == media_type_id:
+            name = m.get("embedder", "")
+            if name:
+                return name
+    return ""
+
+
 def _build_media_data(
     *,
     origin_dict: dict[str, Any],
@@ -99,6 +114,7 @@ def _build_media_data(
     file_bytes: bytes,
     md5: str,
     embedding: Any,
+    embedder_name: str = "",
 ) -> dict[str, Any]:
     """Build a media dict matching the shape produced by folder loading.
 
@@ -113,6 +129,7 @@ def _build_media_data(
         "file_size": len(file_bytes),
         "md5": md5,
         "embedding": embedding,
+        "embedder": embedder_name,
         "filename": entry.get("filename") or name,
         "category": entry.get("category", ""),
         "origin": origin_dict,
@@ -147,6 +164,7 @@ def _ingest_via_source(
         return -1
 
     media_type_id = _media_type_from_origin(origin_dict)
+    embedder_name = _embedder_name_for_type(medias, media_type_id) if media_type_id else ""
 
     from vtsearch.models.resolver import embed_file
 
@@ -163,7 +181,7 @@ def _ingest_via_source(
 
             # Embed the file — if embedding fails, fall back to legacy path
             # so we don't produce medias without embeddings.
-            embedding = embed_file(file_path, media_type_id) if media_type_id else None
+            embedding = embed_file(file_path, media_type_id, embedder_name) if media_type_id else None
             if embedding is None:
                 source.cleanup()
                 return -1  # Signal caller to use legacy full-import path
@@ -181,6 +199,7 @@ def _ingest_via_source(
                 file_bytes=file_bytes,
                 md5=md5,
                 embedding=embedding,
+                embedder_name=embedder_name,
             )
 
             # Allocate the ID and insert atomically, so two concurrent
@@ -223,6 +242,8 @@ def _ingest_via_resolver(
     if not media_type_id:
         return -1
 
+    embedder_name = _embedder_name_for_type(medias, media_type_id)
+
     from vtsearch.models.resolver import embed_file, resolve_file_from_origin
 
     ingested = 0
@@ -240,9 +261,9 @@ def _ingest_via_resolver(
         if origin_dict.get("params", {}).get("clipper"):
             from vtsearch.models.resolver import _apply_clip_and_embed
 
-            embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict)
+            embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict, embedder_name)
         else:
-            embedding = embed_file(file_path, media_type_id)
+            embedding = embed_file(file_path, media_type_id, embedder_name)
         if embedding is None:
             continue
 
@@ -258,6 +279,7 @@ def _ingest_via_resolver(
             file_bytes=file_bytes,
             md5=md5,
             embedding=embedding,
+            embedder_name=embedder_name,
         )
 
         # Atomic id allocation + insert, see _ingest_via_source above.

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -281,19 +281,37 @@ def _resolve_converter(params: dict[str, str]) -> Path | None:
     return resolve_file_from_origin(parent_origin, origin_name=source_file)
 
 
-def embed_file(file_path: Path, media_type: str) -> np.ndarray | None:
-    """Embed a media file using the appropriate embedder for the media type."""
-    from vtsearch.media import embedders_for_type
+def embed_file(file_path: Path, media_type: str, embedder_name: str = "") -> np.ndarray | None:
+    """Embed a media file using the appropriate embedder for the media type.
 
-    avail = embedders_for_type(media_type)
-    if not avail:
-        log.warning(
-            "embed_file: no embedders registered for media_type=%r — "
-            "cannot embed %s",
-            media_type, file_path,
-        )
-        return None
-    embedder = avail[0]
+    If *embedder_name* is given, that specific embedder is used (matching by
+    name); if it is not found or not given, the first registered embedder for
+    the media type is used as a fallback.
+    """
+    from vtsearch.media import embedders_for_type, get_embedder
+
+    if embedder_name:
+        try:
+            embedder = get_embedder(embedder_name)
+        except (KeyError, ValueError):
+            log.warning(
+                "embed_file: embedder %r not found, falling back to default for media_type=%r",
+                embedder_name, media_type,
+            )
+            embedder = None
+    else:
+        embedder = None
+
+    if embedder is None:
+        avail = embedders_for_type(media_type)
+        if not avail:
+            log.warning(
+                "embed_file: no embedders registered for media_type=%r — "
+                "cannot embed %s",
+                media_type, file_path,
+            )
+            return None
+        embedder = avail[0]
     from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
 
     try:
@@ -322,6 +340,7 @@ def _apply_clip_and_embed(
     file_path: Path,
     media_type: str,
     origin: dict[str, Any],
+    embedder_name: str = "",
 ) -> np.ndarray | None:
     """Apply clip params from *origin* to a resolved file and embed the result.
 
@@ -337,7 +356,7 @@ def _apply_clip_and_embed(
     clipper_name = params.get("clipper", "")
 
     if not clipper_name:
-        return embed_file(file_path, media_type)
+        return embed_file(file_path, media_type, embedder_name)
 
     clip_start = params.get("clip_start")
     clip_end = params.get("clip_end")
@@ -354,7 +373,7 @@ def _apply_clip_and_embed(
             try:
                 os.write(fd, sliced)
                 os.close(fd)
-                return embed_file(Path(tmp), media_type)
+                return embed_file(Path(tmp), media_type, embedder_name)
             finally:
                 try:
                     os.unlink(tmp)
@@ -362,7 +381,7 @@ def _apply_clip_and_embed(
                     pass
         except Exception:
             log.debug("_apply_clip_and_embed: audio clip failed, falling back", exc_info=True)
-            return embed_file(file_path, media_type)
+            return embed_file(file_path, media_type, embedder_name)
 
     # --- Image clips: crop to clip_box ---
     if clip_box is not None and media_type == "image":
@@ -381,7 +400,7 @@ def _apply_clip_and_embed(
             try:
                 os.write(fd, crop_bytes)
                 os.close(fd)
-                return embed_file(Path(tmp), media_type)
+                return embed_file(Path(tmp), media_type, embedder_name)
             finally:
                 try:
                     os.unlink(tmp)
@@ -389,7 +408,7 @@ def _apply_clip_and_embed(
                     pass
         except Exception:
             log.debug("_apply_clip_and_embed: image clip failed, falling back", exc_info=True)
-            return embed_file(file_path, media_type)
+            return embed_file(file_path, media_type, embedder_name)
 
     # --- Text clips: extract the sentence by clip_index ---
     if media_type == "text":
@@ -407,7 +426,7 @@ def _apply_clip_and_embed(
                     try:
                         os.write(fd, sentences[idx].encode("utf-8"))
                         os.close(fd)
-                        return embed_file(Path(tmp), media_type)
+                        return embed_file(Path(tmp), media_type, embedder_name)
                     finally:
                         try:
                             os.unlink(tmp)
@@ -415,10 +434,10 @@ def _apply_clip_and_embed(
                             pass
         except Exception:
             log.debug("_apply_clip_and_embed: text clip failed, falling back", exc_info=True)
-            return embed_file(file_path, media_type)
+            return embed_file(file_path, media_type, embedder_name)
 
     # Video clips and unrecognised clippers: embed the full file.
-    return embed_file(file_path, media_type)
+    return embed_file(file_path, media_type, embedder_name)
 
 
 def resolve_label_embeddings(


### PR DESCRIPTION
## Summary
This PR adds support for specifying which embedder to use when ingesting media files, with automatic fallback to the default embedder for each media type. When ingesting new media, the system now detects and reuses the embedder from existing media of the same type to maintain consistency.

## Key Changes

- **Enhanced `embed_file()` function**: Added optional `embedder_name` parameter to allow explicit embedder selection. If specified, the named embedder is used; if not found or not provided, falls back to the first registered embedder for the media type.

- **Updated `_apply_clip_and_embed()` function**: Added `embedder_name` parameter and propagates it through all `embed_file()` calls for clipped audio, images, and text media.

- **New `_embedder_name_for_type()` helper**: Scans existing media in the dataset to find and return the embedder name used by media of a given type, enabling consistency across ingestion operations.

- **Enhanced `_build_media_data()` function**: Now includes the `embedder` field in the media dictionary to track which embedder was used for each media item.

- **Updated ingestion paths**: Both `_ingest_via_source()` and `_ingest_via_resolver()` now:
  - Detect the embedder used by existing media of the same type
  - Pass the embedder name through the embedding pipeline
  - Store the embedder name in the resulting media metadata

## Implementation Details

The embedder selection follows a priority order:
1. If an explicit embedder name is provided, attempt to use it
2. If that fails or no name is provided, use the first registered embedder for the media type
3. The system logs warnings when a specified embedder is not found but continues with the fallback

This ensures backward compatibility while allowing fine-grained control over embedder selection during media ingestion.

https://claude.ai/code/session_012m3jDofePUhyM6VGVc5ZUZ