### PR TITLE
Run server via gunicorn in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,12 @@ EXPOSE 5000
 
 # OMP/MKL thread limits are already set in app.py; repeating here
 # ensures they apply even if someone imports vtsearch as a library.
+# VTSEARCH_SERVER_INIT=1 runs the model-load / preload / settings-sync
+# sequence when gunicorn imports app.py (since the __main__ block is
+# skipped under a WSGI server).
 ENV OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    VTSEARCH_SERVER_INIT=1
 
-CMD ["python", "app.py"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -57,6 +57,7 @@ ENV OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
     PYTHONUNBUFFERED=1 \
     NVIDIA_VISIBLE_DEVICES=all \
-    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    VTSEARCH_SERVER_INIT=1
 
-CMD ["python", "app.py"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]

--- a/app.py
+++ b/app.py
@@ -182,6 +182,41 @@ app.register_blueprint(trainable_models_bp)
 
 
 # ---------------------------------------------------------------------------
+# Server startup
+# ---------------------------------------------------------------------------
+
+
+def initialize_server(mode_label: str = "PRODUCTION") -> None:
+    """Load models, preload media types, and sync from settings source.
+
+    Called from ``__main__`` (when running ``python app.py``) and from
+    gunicorn via ``VTSEARCH_SERVER_INIT=1`` at import time. Idempotent: safe
+    to call multiple times; individual steps handle their own caching.
+    """
+    print(f"\U0001f680 Running in {mode_label} mode", flush=True)
+    initialize_models()
+    preloaded = preload_autoload_media_types()
+    if preloaded:
+        print(f"✅ Preloaded autoload media types: {', '.join(preloaded)}", flush=True)
+
+    from vtsearch.settings import sync_from_settings_source
+
+    imported = sync_from_settings_source()
+    if imported is not None:
+        print(f"\U0001f504 Synced {len(imported)} setting(s) from settings source", flush=True)
+
+    print("✅ VTSearch is ready!", flush=True)
+
+
+# When running under gunicorn (or any other WSGI server), ``app.py`` is
+# imported rather than executed, so the ``__main__`` block below never
+# runs. The Dockerfile sets ``VTSEARCH_SERVER_INIT=1`` to trigger the
+# same startup sequence at import time.
+if os.environ.get("VTSEARCH_SERVER_INIT") == "1":
+    initialize_server()
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -316,21 +351,6 @@ if __name__ == "__main__":
             set_login_provider(TrivialLoginProvider())
             print("\U0001f511 Trivial login enabled \u2014 users will be prompted for a username", flush=True)
 
-        # Common startup: models, autoload, settings source sync
-        mode_label = "LOCAL" if args.local else "PRODUCTION"
-        print(f"\U0001f680 Running in {mode_label} mode" + (" (accessible from other devices)" if args.local else ""), flush=True)
-        initialize_models()
-        preloaded = preload_autoload_media_types()
-        if preloaded:
-            print(f"\u2705 Preloaded autoload media types: {', '.join(preloaded)}", flush=True)
-
-        # Auto-import from settings source (if configured)
-        from vtsearch.settings import sync_from_settings_source
-
-        imported = sync_from_settings_source()
-        if imported is not None:
-            print(f"\U0001f504 Synced {len(imported)} setting(s) from settings source", flush=True)
-
-        print("\u2705 VTSearch is ready!", flush=True)
+        initialize_server(mode_label="LOCAL" if args.local else "PRODUCTION")
         print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,31 @@
+"""Gunicorn configuration for VTSearch.
+
+VTSearch keeps all dataset/model state in-process (see CLAUDE.md: multi-dataset
+context, global registries, RLock-protected mutable state). Multiple worker
+processes would each hold their own independent copy, so we run a single
+worker and rely on threads for concurrency — matching the Flask dev server's
+``threaded=True`` behaviour.
+
+Environment overrides:
+  VTSEARCH_BIND          — host:port (default 0.0.0.0:5000)
+  VTSEARCH_THREADS       — threads per worker (default 8)
+  VTSEARCH_TIMEOUT       — worker timeout in seconds, 0 disables (default 120)
+"""
+
+import os
+
+bind = os.environ.get("VTSEARCH_BIND", "0.0.0.0:5000")
+
+workers = 1
+worker_class = "gthread"
+threads = int(os.environ.get("VTSEARCH_THREADS", "8"))
+
+timeout = int(os.environ.get("VTSEARCH_TIMEOUT", "120"))
+graceful_timeout = 30
+keepalive = 5
+
+accesslog = None
+errorlog = "-"
+loglevel = os.environ.get("VTSEARCH_LOG_LEVEL", "warning").lower()
+
+proc_name = "vtsearch"

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -6,6 +6,7 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+gunicorn
 numpy
 requests
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+gunicorn
 numpy
 requests
 tqdm


### PR DESCRIPTION
## Summary
- Swap both Dockerfiles (CPU + GPU) from `python app.py` (Flask dev server) to `gunicorn -c gunicorn.conf.py app:app`.
- Add `gunicorn.conf.py` pinned to **a single gthread worker** — VTSearch keeps all dataset/model state in-process, so multiple worker processes would each hold independent copies of it. Threads (default 8, via `VTSEARCH_THREADS`) provide the same concurrency model as the dev server's `threaded=True`.
- Extract the model-load / media-preload / settings-sync sequence from the `__main__` block into `initialize_server()` so it runs at module import time when `VTSEARCH_SERVER_INIT=1` (set in both Dockerfiles). `python app.py [--local]` still calls the same function and continues to work for CLI use.
- Add `gunicorn` to `requirements.txt` / `requirements-gpu.txt`.

Tunables via env vars: `VTSEARCH_BIND` (default `0.0.0.0:5000`), `VTSEARCH_THREADS` (8), `VTSEARCH_TIMEOUT` (120).

## Test plan
- [x] `python -m pytest tests/` — 2953 passed, 1 skipped, 1 xfailed (63s)
- [x] `ruff check app.py gunicorn.conf.py` — clean
- [x] Smoke test: `VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app` → `/api/settings` returns 200
- [x] Confirmed module import without `VTSEARCH_SERVER_INIT` does not trigger model load (so tests and CLI autodetect are unaffected)

https://claude.ai/code/session_012EGT7MsjdbCpC9jMbzeJkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012EGT7MsjdbCpC9jMbzeJkQ)_