### PR TITLE
Dev → main: gunicorn/Docker + autorun fixes + embedder discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 
 After pushing code changes and successfully running tests, **automatically create a PR targeting `dev`**. Do not ask — just create it. This applies whenever Claude both pushes and verifies tests pass in the same session.
 
+## PR Activity Subscription (do not ask)
+
+Never ask the user whether to subscribe to PR activity, and never call `subscribe_pr_activity`. The user does not want Claude to watch PRs or respond to review comments / CI. This overrides the default GitHub Integration instruction to offer PR subscription after creating a PR.
+
 ## Backwards Compatibility
 
 Breaking backwards compatibility is acceptable — do not add shims, feature flags, legacy re-exports, or other compatibility layers to preserve old behavior. Just make the clean change. When a change does break backwards compatibility, mention it to the user so they're aware.

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,12 @@ EXPOSE 5000
 
 # OMP/MKL thread limits are already set in app.py; repeating here
 # ensures they apply even if someone imports vtsearch as a library.
+# VTSEARCH_SERVER_INIT=1 runs the model-load / preload / settings-sync
+# sequence when gunicorn imports app.py (since the __main__ block is
+# skipped under a WSGI server).
 ENV OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    VTSEARCH_SERVER_INIT=1
 
-CMD ["python", "app.py"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -57,6 +57,7 @@ ENV OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
     PYTHONUNBUFFERED=1 \
     NVIDIA_VISIBLE_DEVICES=all \
-    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    VTSEARCH_SERVER_INIT=1
 
-CMD ["python", "app.py"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]

--- a/app.py
+++ b/app.py
@@ -331,9 +331,6 @@ if __name__ == "__main__":
         if imported is not None:
             print(f"\U0001f504 Synced {len(imported)} setting(s) from settings source", flush=True)
 
-        if args.local:
-            app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)
-        else:
-            print("\u2705 VTSearch is ready!", flush=True)
-            print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)
-            app.run(host="127.0.0.1", port=5000, debug=False, threaded=True)
+        print("\u2705 VTSearch is ready!", flush=True)
+        print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)
+        app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)

--- a/app.py
+++ b/app.py
@@ -182,6 +182,41 @@ app.register_blueprint(trainable_models_bp)
 
 
 # ---------------------------------------------------------------------------
+# Server startup
+# ---------------------------------------------------------------------------
+
+
+def initialize_server(mode_label: str = "PRODUCTION") -> None:
+    """Load models, preload media types, and sync from settings source.
+
+    Called from ``__main__`` (when running ``python app.py``) and from
+    gunicorn via ``VTSEARCH_SERVER_INIT=1`` at import time. Idempotent: safe
+    to call multiple times; individual steps handle their own caching.
+    """
+    print(f"\U0001f680 Running in {mode_label} mode", flush=True)
+    initialize_models()
+    preloaded = preload_autoload_media_types()
+    if preloaded:
+        print(f"✅ Preloaded autoload media types: {', '.join(preloaded)}", flush=True)
+
+    from vtsearch.settings import sync_from_settings_source
+
+    imported = sync_from_settings_source()
+    if imported is not None:
+        print(f"\U0001f504 Synced {len(imported)} setting(s) from settings source", flush=True)
+
+    print("✅ VTSearch is ready!", flush=True)
+
+
+# When running under gunicorn (or any other WSGI server), ``app.py`` is
+# imported rather than executed, so the ``__main__`` block below never
+# runs. The Dockerfile sets ``VTSEARCH_SERVER_INIT=1`` to trigger the
+# same startup sequence at import time.
+if os.environ.get("VTSEARCH_SERVER_INIT") == "1":
+    initialize_server()
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -316,21 +351,6 @@ if __name__ == "__main__":
             set_login_provider(TrivialLoginProvider())
             print("\U0001f511 Trivial login enabled \u2014 users will be prompted for a username", flush=True)
 
-        # Common startup: models, autoload, settings source sync
-        mode_label = "LOCAL" if args.local else "PRODUCTION"
-        print(f"\U0001f680 Running in {mode_label} mode" + (" (accessible from other devices)" if args.local else ""), flush=True)
-        initialize_models()
-        preloaded = preload_autoload_media_types()
-        if preloaded:
-            print(f"\u2705 Preloaded autoload media types: {', '.join(preloaded)}", flush=True)
-
-        # Auto-import from settings source (if configured)
-        from vtsearch.settings import sync_from_settings_source
-
-        imported = sync_from_settings_source()
-        if imported is not None:
-            print(f"\U0001f504 Synced {len(imported)} setting(s) from settings source", flush=True)
-
-        print("\u2705 VTSearch is ready!", flush=True)
+        initialize_server(mode_label="LOCAL" if args.local else "PRODUCTION")
         print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)
         app.run(host="0.0.0.0", port=5000, debug=False, threaded=True)

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -32,15 +32,18 @@ time. The `_discover_media_plugins()` function in
 `vtsearch/media/__init__.py` scans sub-packages of `vtsearch/media/` for
 module-level sentinel attributes:
 
-| Sentinel     | Type                  | Description                          |
-|--------------|-----------------------|--------------------------------------|
-| `MEDIA_TYPE` | `MediaType`           | A single media type instance         |
-| `EMBEDDERS`  | `list[MediaEmbedder]` | Embedder instances (may be empty)    |
-| `CLIPPERS`   | `list[MediaClipper]`  | Clipper instances (may be empty)     |
+| Sentinel     | Location                         | Type                 | Description                          |
+|--------------|----------------------------------|----------------------|--------------------------------------|
+| `MEDIA_TYPE` | media-type package `__init__.py` | `MediaType`          | A single media type instance         |
+| `CLIPPERS`   | media-type package `__init__.py` | `list[MediaClipper]` | Clipper instances (may be empty)     |
+| `EMBEDDER`   | an `embedder*.py` file inside the media-type package | `MediaEmbedder` | One embedder per module              |
 
-To add a new built-in media type, create a sub-package under
-`vtsearch/media/` with an `__init__.py` that exposes the relevant
-sentinels. Symlinked directories are supported.
+Embedders use **one module per embedder**: any `embedder*.py` file inside
+a media-type package is auto-loaded and its module-level `EMBEDDER`
+sentinel is registered. Symlinked directories **and** symlinked embedder
+files are both supported, so a custom embedder can live outside the
+VTSearch tree and be wired in by symlinking a single file into the
+appropriate media-type package — no edits to any `__init__.py` required.
 
 Third-party or project-specific types can still be registered manually
 via `register()`, `register_embedder()`, and `register_clipper()`.
@@ -57,8 +60,9 @@ datasets are available, and how to load media-specific fields from files.
 
 ```
 vtsearch/media/<your_type>/
-├── __init__.py       # Must expose MEDIA_TYPE, EMBEDDERS, CLIPPERS sentinels
-└── media_type.py     # Your MediaType subclass (required)
+├── __init__.py       # Must expose MEDIA_TYPE and CLIPPERS sentinels
+├── media_type.py     # Your MediaType subclass (required)
+└── embedder*.py      # Optional — one file per embedder, each exposing EMBEDDER
 ```
 
 ### What to implement
@@ -152,11 +156,20 @@ Expose the sentinels in your sub-package's `__init__.py`:
 # vtsearch/media/code/__init__.py
 
 from vtsearch.media.code.media_type import CodeMediaType
-from vtsearch.media.code.embedder import CodeBertEmbedder
 
 MEDIA_TYPE = CodeMediaType()
-EMBEDDERS = [CodeBertEmbedder()]
 CLIPPERS = []  # No clippers yet — add when needed
+```
+
+Each embedder lives in its own `embedder*.py` file with an `EMBEDDER`
+sentinel at the bottom:
+
+```python
+# vtsearch/media/code/embedder_codebert.py
+
+# ... class definition ...
+
+EMBEDDER = CodeBertEmbedder()
 ```
 
 The auto-discovery system finds these sentinels at import time. No
@@ -362,19 +375,25 @@ For bulk APIs, also override `supports_batch` / `batch_size` and
 
 ### Register the embedder
 
-Add the embedder to the `EMBEDDERS` sentinel list in your media type's
-`__init__.py`:
+Drop the embedder into an `embedder*.py` file inside the media-type
+package and expose an `EMBEDDER` sentinel at the bottom. Discovery is
+automatic — no edits to `__init__.py` are needed:
 
 ```python
-# vtsearch/media/code/__init__.py
+# vtsearch/media/code/embedder_codebert.py
 
-from vtsearch.media.code.embedder import CodeBertEmbedder
-# ...
-EMBEDDERS = [CodeBertEmbedder()]
+class CodeBertEmbedder(MediaEmbedder):
+    ...
+
+EMBEDDER = CodeBertEmbedder()
 ```
 
-For an alternative embedder on an **existing** media type, add it to that
-type's `EMBEDDERS` list (e.g. in `vtsearch/media/image/__init__.py`).
+For an alternative embedder on an **existing** media type, drop a new
+`embedder_<name>.py` file into that type's package (e.g.
+`vtsearch/media/image/embedder_myclip.py`) with its own `EMBEDDER`
+sentinel. To wire in a custom embedder living outside the VTSearch
+source tree, symlink the file in — symlinked embedder modules are
+loaded via `spec_from_file_location` so discovery still works.
 
 ### MediaEmbedder abstract interface reference
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -218,7 +218,7 @@ See [EXTENDING-media.md § Adding a Media Type](EXTENDING-media.md#adding-a-medi
 
 - [ ] Create `vtsearch/media/<type>/` directory with `__init__.py`, `media_type.py`
 - [ ] Subclass `MediaType` and implement all abstract properties and methods
-- [ ] Expose `MEDIA_TYPE`, `EMBEDDERS`, and `CLIPPERS` sentinels in `__init__.py`
+- [ ] Expose `MEDIA_TYPE` and `CLIPPERS` sentinels in `__init__.py` (embedders are discovered per-module — see the embedder checklist below)
 - [ ] Add a `requirements.txt` in the plugin directory and run `bash install-plugin-deps.sh`
 - [ ] Override `pickle_extra_fields` if you use custom clip keys
 - [ ] Test: import a folder of your media type, verify clips appear and are sortable
@@ -231,7 +231,7 @@ See [EXTENDING-media.md § Adding a Media Embedder](EXTENDING-media.md#adding-a-
 - [ ] Subclass `MediaEmbedder`, implement `name`, `media_type_id`, `_load_models_impl()`, `embed_media()`
 - [ ] Optionally implement `embed_text()` for text-query sorting
 - [ ] Optionally set `description_wrappers` for enriched text embedding
-- [ ] Add to the `EMBEDDERS` list in the media type's `__init__.py`
+- [ ] Expose `EMBEDDER = YourEmbedder()` at module level — auto-discovery picks it up, no `__init__.py` edits needed (symlinked files are supported)
 - [ ] Test: load a dataset and verify embeddings are generated
 
 ### New Media Clipper Checklist

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -82,7 +82,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Text (`text`) | `bge` | BGE (`BAAI/bge-base-en-v1.5`) | 768 |
 | Document (`document`) | — | None (no embedder) | N/A |
 
-Audio, image, and text media types each have an **alternative embedder** in addition to the default. The first entry in each media type's `EMBEDDERS` list in `vtsearch/media/<type>/__init__.py` is the default; subsequent entries are alternatives.
+Audio, image, and text media types each have an **alternative embedder** in addition to the default. Each embedder lives in its own `embedder*.py` file inside the media-type package and exposes a module-level `EMBEDDER` sentinel; the default for a given media type is the one whose file sorts first (plain `embedder.py` ahead of `embedder_<variant>.py`).
 
 The **document** media type has no embedding model of its own. Documents (PDF, DOC, PPT) are intended to be converted to other media types (images or text) via media converters in `vtsearch/converters/` before embedding.
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -80,7 +80,7 @@
       </span>
     } @else {
       <button class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -91,20 +91,20 @@
     <div class="actions-cell">
     @if (!isDefaultLogin) {
       <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
         </svg>
       </button>
     }
     <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
         <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
         <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
       </svg>
     </button>
     <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
-      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
         <path d="M12 2a10 10 0 0 1 0 20"/>
         <line x1="12" y1="12" x2="12" y2="2"/>
@@ -113,7 +113,7 @@
       </svg>
     </button>
     <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
-      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
         <path d="M10 11v6"></path>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -86,11 +86,11 @@
   <td>
     <button class="autorun-toggle" (click)="onAutorunToggle($event)" aria-label="Autorun" title="Include in CLI autorun">
       @if (model.autodetect) {
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="20 6 9 17 4 12"></polyline>
         </svg>
       } @else {
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -108,7 +108,7 @@
       </span>
     } @else {
       <button class="load-action" (click)="onLoad($event)" title="Click to load this model" aria-label="Load model">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -119,23 +119,23 @@
 <td>
   <div class="actions-cell">
   <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
-    <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
       <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
       <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
     </svg>
   </button>
   <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
-    <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
+    <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
   </button>
   <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
-    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="15 14 20 9 15 4"></polyline>
       <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
     </svg>
   </button>
   <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
-    <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="3 6 5 6 21 6"></polyline>
       <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
       <path d="M10 11v6"></path>

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,31 @@
+"""Gunicorn configuration for VTSearch.
+
+VTSearch keeps all dataset/model state in-process (see CLAUDE.md: multi-dataset
+context, global registries, RLock-protected mutable state). Multiple worker
+processes would each hold their own independent copy, so we run a single
+worker and rely on threads for concurrency — matching the Flask dev server's
+``threaded=True`` behaviour.
+
+Environment overrides:
+  VTSEARCH_BIND          — host:port (default 0.0.0.0:5000)
+  VTSEARCH_THREADS       — threads per worker (default 8)
+  VTSEARCH_TIMEOUT       — worker timeout in seconds, 0 disables (default 120)
+"""
+
+import os
+
+bind = os.environ.get("VTSEARCH_BIND", "0.0.0.0:5000")
+
+workers = 1
+worker_class = "gthread"
+threads = int(os.environ.get("VTSEARCH_THREADS", "8"))
+
+timeout = int(os.environ.get("VTSEARCH_TIMEOUT", "120"))
+graceful_timeout = 30
+keepalive = 5
+
+accesslog = None
+errorlog = "-"
+loglevel = os.environ.get("VTSEARCH_LOG_LEVEL", "warning").lower()
+
+proc_name = "vtsearch"

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -6,6 +6,7 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+gunicorn
 numpy
 requests
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 
 # ── Core framework ───────────────────────────────────────────────────
 flask
+gunicorn
 numpy
 requests
 tqdm

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -688,6 +688,25 @@ class TestAutorunCheckboxPersistence:
         m = resp.get_json()["models"][0]
         assert m["autodetect"] is False
 
+    def test_autodetect_toggle_reflects_in_registry_for_trainable_model(self, client):
+        """Trainable models created via the UI have detector_name="".
+
+        Toggling autorun uses the display name, and the registry response must
+        reflect the toggle state by falling back to the name when detector_name
+        is empty — otherwise the Autorun button in the Models grid appears dead.
+        """
+        register_model(name="Dog Barks", media_type="audio", trainable=True)
+
+        resp = client.put(
+            "/api/autorun-detectors/Dog Barks/autodetect",
+            json={"autodetect": True},
+        )
+        assert resp.status_code == 200
+
+        resp = client.get("/api/models/registry")
+        m = next(m for m in resp.get_json()["models"] if m["name"] == "Dog Barks")
+        assert m["autodetect"] is True
+
     def test_autorun_not_in_settings_window(self, client):
         """autorun_detector_names should not appear in the defaults endpoint."""
         resp = client.get("/api/settings/defaults")

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -228,6 +228,37 @@ class TestAutorunDetectors:
         )
         assert resp.status_code == 400
 
+    # -- autodetect toggle --
+
+    def test_set_autodetect_on_existing_detector(self, client):
+        det = self._export_detector(client)
+        self._post_autorun(client, "tog-det", det)
+
+        resp = client.put("/api/autorun-detectors/tog-det/autodetect", json={"autodetect": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["autodetect"] is True
+
+        detectors = client.get("/api/autorun-detectors").get_json()["detectors"]
+        d = next(d for d in detectors if d["name"] == "tog-det")
+        assert d["autodetect"] is True
+
+    def test_set_autodetect_true_on_nonexistent_detector_persists_to_settings(self, client, isolated_settings):
+        """Enabling autorun for a model-registry entry not yet in autorun_detectors must succeed."""
+        from vtsearch.settings import get_autorun_detector_names
+
+        resp = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["autodetect"] is True
+        assert "ghost-model" in get_autorun_detector_names()
+
+    def test_set_autodetect_false_on_nonexistent_detector_returns_404(self, client):
+        resp = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": False})
+        assert resp.status_code == 404
+
+    def test_set_autodetect_missing_field_returns_400(self, client):
+        resp = client.put("/api/autorun-detectors/any/autodetect", json={})
+        assert resp.status_code == 400
+
     # -- import-pkl (detector JSON file) --
 
     def test_import_pkl_from_detector_json(self, client):

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -307,10 +307,13 @@ class TestNonexistentResources:
         assert resp.status_code == 400  # "not found or new name already exists"
 
     def test_autodetect_nonexistent_detector(self, client):
+        # autodetect=True on a name without an in-memory detector persists to
+        # settings (for model-registry entries that haven't been trained yet)
+        # and returns 200; disabling on a missing detector still returns 404.
         resp = client.put(
             "/api/autorun-detectors/does_not_exist/autodetect",
             json={
-                "autodetect": True,
+                "autodetect": False,
             },
         )
         assert resp.status_code == 404

--- a/tests/test_new_embedders.py
+++ b/tests/test_new_embedders.py
@@ -458,6 +458,133 @@ class TestAllEmbeddersRegistration:
             assert "media_type_id" in d
 
 
+class TestEmbedderSentinelDiscovery:
+    """Verify built-in embedder modules expose the ``EMBEDDER`` sentinel
+    so that auto-discovery picks them up with no edits to any
+    ``__init__.py`` — the same pattern used by exporters, dataset
+    importers, label importers, processor importers, settings importers /
+    exporters, and sync sources.
+    """
+
+    def test_every_builtin_embedder_module_has_sentinel(self):
+        from vtsearch.media.audio import embedder as audio_clap
+        from vtsearch.media.audio import embedder_clap_music
+        from vtsearch.media.image import embedder as image_clip
+        from vtsearch.media.image import embedder_siglip
+        from vtsearch.media.text import embedder as text_e5
+        from vtsearch.media.text import embedder_bge
+        from vtsearch.media.video import embedder as video_xclip
+        from vtsearch.media.video import embedder_languagebind
+
+        from vtsearch.media.embedder import MediaEmbedder
+
+        modules = [
+            audio_clap,
+            embedder_clap_music,
+            image_clip,
+            embedder_siglip,
+            text_e5,
+            embedder_bge,
+            video_xclip,
+            embedder_languagebind,
+        ]
+        for mod in modules:
+            sentinel = getattr(mod, "EMBEDDER", None)
+            assert sentinel is not None, f"{mod.__name__} is missing an EMBEDDER sentinel"
+            assert isinstance(sentinel, MediaEmbedder), (
+                f"{mod.__name__}.EMBEDDER must be a MediaEmbedder instance"
+            )
+
+    def test_sentinel_identity_matches_registry(self):
+        """The registered embedder for each name should be the module's EMBEDDER sentinel."""
+        from vtsearch.media import get_embedder
+        from vtsearch.media.audio.embedder import EMBEDDER as clap_sentinel
+        from vtsearch.media.text.embedder_bge import EMBEDDER as bge_sentinel
+        from vtsearch.media.video.embedder_languagebind import EMBEDDER as lb_sentinel
+
+        assert get_embedder("clap") is clap_sentinel
+        assert get_embedder("bge") is bge_sentinel
+        assert get_embedder("languagebind") is lb_sentinel
+
+    def test_media_type_init_no_longer_lists_embedders(self):
+        """Media-type package ``__init__.py`` files should not expose an
+        ``EMBEDDERS`` attribute — embedders are discovered per-module.
+        """
+        from vtsearch.media import audio, document, image, text, video
+
+        for pkg in (audio, image, text, video, document):
+            assert not hasattr(pkg, "EMBEDDERS"), (
+                f"{pkg.__name__} still exposes an EMBEDDERS list — "
+                "embedders should be discovered via per-module EMBEDDER sentinels"
+            )
+
+    def test_custom_embedder_auto_discovered(self, tmp_path, monkeypatch):
+        """A new ``embedder_*.py`` file dropped into a media-type package
+        should be auto-discovered with no ``__init__.py`` edits.
+        """
+        import importlib
+        import sys
+        from pathlib import Path
+
+        import vtsearch.media as media_pkg
+        from vtsearch.media import _discover_embedders_in, register_embedder
+        from vtsearch.media.embedder import MediaEmbedder
+
+        # Create a throwaway media-type package under tmp_path with a single
+        # embedder module exposing the EMBEDDER sentinel.
+        fake_pkg = tmp_path / "fakemedia"
+        fake_pkg.mkdir()
+        (fake_pkg / "__init__.py").write_text("")
+        embedder_src = (
+            "from vtsearch.media.embedder import MediaEmbedder\n"
+            "\n"
+            "class _FakeEmbedder(MediaEmbedder):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            "        return 'fake_discoverable'\n"
+            "    @property\n"
+            "    def media_type_id(self):\n"
+            "        return 'fake'\n"
+            "    def _load_models_impl(self):\n"
+            "        pass\n"
+            "    def _embed_media_impl(self, media):\n"
+            "        return None\n"
+            "\n"
+            "EMBEDDER = _FakeEmbedder()\n"
+        )
+        (fake_pkg / "embedder_fake.py").write_text(embedder_src)
+
+        # Make the fake package importable as if it lived under vtsearch.media.
+        package_name = "vtsearch.media._fakemedia_test"
+        spec = importlib.util.spec_from_file_location(
+            package_name,
+            str(fake_pkg / "__init__.py"),
+            submodule_search_locations=[str(fake_pkg)],
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[package_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+            # Snapshot the registry so we can restore it after the test.
+            from vtsearch.media import _embedder_registry
+
+            saved = dict(_embedder_registry)
+            try:
+                _discover_embedders_in(Path(fake_pkg), package_name)
+                assert "fake_discoverable" in _embedder_registry
+                discovered = _embedder_registry["fake_discoverable"]
+                assert isinstance(discovered, MediaEmbedder)
+                assert discovered.media_type_id == "fake"
+            finally:
+                _embedder_registry.clear()
+                _embedder_registry.update(saved)
+        finally:
+            # Remove the fake package and its submodule from sys.modules.
+            for key in list(sys.modules):
+                if key == package_name or key.startswith(package_name + "."):
+                    sys.modules.pop(key, None)
+
+
 class TestNewEmbeddersInheritance:
     """Verify new embedders correctly extend MediaEmbedder."""
 

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -89,6 +89,21 @@ def _media_type_from_origin(origin_dict: dict[str, Any]) -> str:
     return ""
 
 
+def _embedder_name_for_type(medias: dict[int, dict[str, Any]], media_type_id: str) -> str:
+    """Return the embedder name used by existing medias of the given type.
+
+    Scans the live dataset for the first media whose ``type`` matches
+    *media_type_id* and returns its ``embedder`` field.  Returns an empty
+    string when no matching media is found (caller falls back to the default).
+    """
+    for m in medias.values():
+        if m.get("type") == media_type_id:
+            name = m.get("embedder", "")
+            if name:
+                return name
+    return ""
+
+
 def _build_media_data(
     *,
     origin_dict: dict[str, Any],
@@ -99,6 +114,7 @@ def _build_media_data(
     file_bytes: bytes,
     md5: str,
     embedding: Any,
+    embedder_name: str = "",
 ) -> dict[str, Any]:
     """Build a media dict matching the shape produced by folder loading.
 
@@ -113,6 +129,7 @@ def _build_media_data(
         "file_size": len(file_bytes),
         "md5": md5,
         "embedding": embedding,
+        "embedder": embedder_name,
         "filename": entry.get("filename") or name,
         "category": entry.get("category", ""),
         "origin": origin_dict,
@@ -147,6 +164,7 @@ def _ingest_via_source(
         return -1
 
     media_type_id = _media_type_from_origin(origin_dict)
+    embedder_name = _embedder_name_for_type(medias, media_type_id) if media_type_id else ""
 
     from vtsearch.models.resolver import embed_file
 
@@ -163,7 +181,7 @@ def _ingest_via_source(
 
             # Embed the file — if embedding fails, fall back to legacy path
             # so we don't produce medias without embeddings.
-            embedding = embed_file(file_path, media_type_id) if media_type_id else None
+            embedding = embed_file(file_path, media_type_id, embedder_name) if media_type_id else None
             if embedding is None:
                 source.cleanup()
                 return -1  # Signal caller to use legacy full-import path
@@ -181,6 +199,7 @@ def _ingest_via_source(
                 file_bytes=file_bytes,
                 md5=md5,
                 embedding=embedding,
+                embedder_name=embedder_name,
             )
 
             # Allocate the ID and insert atomically, so two concurrent
@@ -223,6 +242,8 @@ def _ingest_via_resolver(
     if not media_type_id:
         return -1
 
+    embedder_name = _embedder_name_for_type(medias, media_type_id)
+
     from vtsearch.models.resolver import embed_file, resolve_file_from_origin
 
     ingested = 0
@@ -240,9 +261,9 @@ def _ingest_via_resolver(
         if origin_dict.get("params", {}).get("clipper"):
             from vtsearch.models.resolver import _apply_clip_and_embed
 
-            embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict)
+            embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict, embedder_name)
         else:
-            embedding = embed_file(file_path, media_type_id)
+            embedding = embed_file(file_path, media_type_id, embedder_name)
         if embedding is None:
             continue
 
@@ -258,6 +279,7 @@ def _ingest_via_resolver(
             file_bytes=file_bytes,
             md5=md5,
             embedding=embedding,
+            embedder_name=embedder_name,
         )
 
         # Atomic id allocation + insert, see _ingest_via_source above.

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -1,16 +1,20 @@
 """Media type, embedder, and clipper registries.
 
 Built-in media types, embedders, and clippers are **auto-discovered** at
-import time by scanning sub-packages of ``vtsearch.media`` for sentinel
-attributes:
+import time by scanning sub-packages of ``vtsearch.media``:
 
-- ``MEDIA_TYPE`` — a single :class:`MediaType` instance.
-- ``EMBEDDERS`` — a list of :class:`MediaEmbedder` instances (may be empty).
-- ``CLIPPERS``  — a list of :class:`MediaClipper` instances (may be empty).
+- Each media-type sub-package (``audio/``, ``image/``, ...) exposes a
+  ``MEDIA_TYPE`` sentinel in its ``__init__.py`` (plus a ``CLIPPERS`` list).
+- Each embedder lives in its own module under the media-type package
+  (e.g. ``vtsearch/media/audio/embedder_clap_music.py``) and exposes a
+  module-level ``EMBEDDER`` sentinel — one embedder per module.  Any
+  ``embedder*.py`` file found inside a media-type package is auto-loaded.
 
-To add a new media type (or embedder / clipper), create a sub-package under
-``vtsearch/media/`` with an ``__init__.py`` that exposes the relevant
-sentinels.  Symlinked directories are supported.
+To add a new embedder, drop an ``embedder_<name>.py`` file into the
+appropriate media-type package with an ``EMBEDDER`` sentinel at the bottom.
+Symlinked directories and symlinked embedder files are both supported, so
+custom embedders living outside the VTSearch tree can be wired in without
+editing any package ``__init__.py``.
 
 Third-party or project-specific types can still be registered manually::
 
@@ -22,6 +26,8 @@ Third-party or project-specific types can still be registered manually::
 from __future__ import annotations
 
 import importlib
+import importlib.util
+import sys
 import warnings
 from pathlib import Path
 
@@ -240,14 +246,57 @@ def all_embedders_dict() -> list[dict]:
 # ------------------------------------------------------------------
 
 
+def _discover_embedders_in(media_type_dir: Path, package_name: str) -> None:
+    """Scan a media-type sub-package for modules exposing an ``EMBEDDER`` sentinel.
+
+    Any ``embedder*.py`` file (excluding ``__init__.py``) is imported, and its
+    module-level ``EMBEDDER`` attribute is registered if present.  Symlinked
+    files are loaded via :func:`importlib.util.spec_from_file_location` so
+    that symlinks pointing outside the package are handled reliably (mirrors
+    the same approach used by :class:`vtsearch.utils.registry.PluginRegistry`).
+    """
+    for entry in sorted(media_type_dir.iterdir()):
+        if entry.name.startswith((".", "_")):
+            continue
+        if not entry.is_file() or entry.suffix != ".py":
+            continue
+        if not entry.name.startswith("embedder"):
+            continue
+        full_name = f"{package_name}.{entry.stem}"
+        try:
+            if entry.is_symlink():
+                resolved = entry.resolve()
+                spec = importlib.util.spec_from_file_location(full_name, str(resolved))
+                if spec is None or spec.loader is None:
+                    continue
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules[full_name] = mod
+                spec.loader.exec_module(mod)
+            else:
+                mod = importlib.import_module(full_name)
+        except Exception as exc:  # pragma: no cover
+            sys.modules.pop(full_name, None)
+            warnings.warn(
+                f"Failed to load embedder module '{full_name}': {exc}",
+                stacklevel=2,
+            )
+            continue
+        emb = getattr(mod, "EMBEDDER", None)
+        if emb is not None:
+            register_embedder(emb)
+
+
 def _discover_media_plugins() -> None:
     """Scan sub-packages of ``vtsearch.media`` for sentinel attributes.
 
-    Each sub-package (directory with ``__init__.py``) may expose:
+    Each media-type sub-package (directory with ``__init__.py``) may expose:
 
     - ``MEDIA_TYPE`` — a single :class:`MediaType` instance.
-    - ``EMBEDDERS`` — a list of :class:`MediaEmbedder` instances.
     - ``CLIPPERS``  — a list of :class:`MediaClipper` instances.
+
+    Embedders are auto-discovered per module: every ``embedder*.py`` file
+    inside a media-type sub-package is scanned for an ``EMBEDDER`` sentinel
+    (see :func:`_discover_embedders_in`).
 
     Symlinked directories are followed (``entry.is_dir()`` resolves
     symlinks), so an external media-type package can be symlinked into
@@ -259,8 +308,9 @@ def _discover_media_plugins() -> None:
             continue
         if not entry.is_dir() or "." in entry.name or not (entry / "__init__.py").exists():
             continue
+        package_name = f"vtsearch.media.{entry.name}"
         try:
-            mod = importlib.import_module(f"vtsearch.media.{entry.name}")
+            mod = importlib.import_module(package_name)
         except Exception as exc:  # pragma: no cover
             warnings.warn(
                 f"Failed to load media sub-package '{entry.name}': {exc}",
@@ -271,10 +321,9 @@ def _discover_media_plugins() -> None:
         mt = getattr(mod, "MEDIA_TYPE", None)
         if mt is not None:
             register(mt)
-        for emb in getattr(mod, "EMBEDDERS", []):
-            register_embedder(emb)
         for clip in getattr(mod, "CLIPPERS", []):
             register_clipper(clip)
+        _discover_embedders_in(entry, package_name)
 
 
 _discover_media_plugins()

--- a/vtsearch/media/audio/__init__.py
+++ b/vtsearch/media/audio/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.audio.clipper import SoundDefaultClipper, SoundTilingClipper
-from vtsearch.media.audio.embedder import AudioClapEmbedder
-from vtsearch.media.audio.embedder_clap_music import AudioClapMusicEmbedder
 from vtsearch.media.audio.media_type import AudioMediaType
 
 MEDIA_TYPE = AudioMediaType()
-EMBEDDERS = [AudioClapEmbedder(), AudioClapMusicEmbedder()]
 CLIPPERS = [SoundDefaultClipper(), SoundTilingClipper(2.0)]

--- a/vtsearch/media/audio/embedder.py
+++ b/vtsearch/media/audio/embedder.py
@@ -175,3 +175,6 @@ class AudioClapEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = AudioClapEmbedder()

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -157,3 +157,6 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = AudioClapMusicEmbedder()

--- a/vtsearch/media/document/__init__.py
+++ b/vtsearch/media/document/__init__.py
@@ -2,5 +2,4 @@ from vtsearch.media.document.clipper import DocumentDefaultClipper
 from vtsearch.media.document.media_type import DocumentMediaType
 
 MEDIA_TYPE = DocumentMediaType()
-EMBEDDERS = []
 CLIPPERS = [DocumentDefaultClipper()]

--- a/vtsearch/media/image/__init__.py
+++ b/vtsearch/media/image/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.image.clipper import ImageDefaultClipper, ImageTilingClipper
-from vtsearch.media.image.embedder import ImageClipEmbedder
-from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
 from vtsearch.media.image.media_type import ImageMediaType
 
 MEDIA_TYPE = ImageMediaType()
-EMBEDDERS = [ImageSiglipEmbedder(), ImageClipEmbedder()]
 CLIPPERS = [ImageDefaultClipper(), ImageTilingClipper()]

--- a/vtsearch/media/image/embedder.py
+++ b/vtsearch/media/image/embedder.py
@@ -152,3 +152,6 @@ class ImageClipEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = ImageClipEmbedder()

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -157,3 +157,6 @@ class ImageSiglipEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = ImageSiglipEmbedder()

--- a/vtsearch/media/text/__init__.py
+++ b/vtsearch/media/text/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.text.clipper import TextDefaultClipper, TextSentenceClipper
-from vtsearch.media.text.embedder import TextE5Embedder
-from vtsearch.media.text.embedder_bge import TextBGEEmbedder
 from vtsearch.media.text.media_type import TextMediaType
 
 MEDIA_TYPE = TextMediaType()
-EMBEDDERS = [TextE5Embedder(), TextBGEEmbedder()]
 CLIPPERS = [TextDefaultClipper(), TextSentenceClipper()]

--- a/vtsearch/media/text/embedder.py
+++ b/vtsearch/media/text/embedder.py
@@ -122,3 +122,6 @@ class TextE5Embedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model
+
+
+EMBEDDER = TextE5Embedder()

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -122,3 +122,6 @@ class TextBGEEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model
+
+
+EMBEDDER = TextBGEEmbedder()

--- a/vtsearch/media/video/__init__.py
+++ b/vtsearch/media/video/__init__.py
@@ -1,8 +1,5 @@
 from vtsearch.media.video.clipper import VideoDefaultClipper, VideoSceneClipper, VideoTilingClipper
-from vtsearch.media.video.embedder import VideoXClipEmbedder
-from vtsearch.media.video.embedder_languagebind import VideoLanguageBindEmbedder
 from vtsearch.media.video.media_type import VideoMediaType
 
 MEDIA_TYPE = VideoMediaType()
-EMBEDDERS = [VideoXClipEmbedder(), VideoLanguageBindEmbedder()]
 CLIPPERS = [VideoDefaultClipper(), VideoTilingClipper(2.0), VideoSceneClipper()]

--- a/vtsearch/media/video/embedder.py
+++ b/vtsearch/media/video/embedder.py
@@ -166,3 +166,6 @@ class VideoXClipEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._processor
+
+
+EMBEDDER = VideoXClipEmbedder()

--- a/vtsearch/media/video/embedder_languagebind.py
+++ b/vtsearch/media/video/embedder_languagebind.py
@@ -228,3 +228,6 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
         if self._model is None:
             self.load_models()
         return self._model, self._tokenizer
+
+
+EMBEDDER = VideoLanguageBindEmbedder()

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -281,19 +281,37 @@ def _resolve_converter(params: dict[str, str]) -> Path | None:
     return resolve_file_from_origin(parent_origin, origin_name=source_file)
 
 
-def embed_file(file_path: Path, media_type: str) -> np.ndarray | None:
-    """Embed a media file using the appropriate embedder for the media type."""
-    from vtsearch.media import embedders_for_type
+def embed_file(file_path: Path, media_type: str, embedder_name: str = "") -> np.ndarray | None:
+    """Embed a media file using the appropriate embedder for the media type.
 
-    avail = embedders_for_type(media_type)
-    if not avail:
-        log.warning(
-            "embed_file: no embedders registered for media_type=%r — "
-            "cannot embed %s",
-            media_type, file_path,
-        )
-        return None
-    embedder = avail[0]
+    If *embedder_name* is given, that specific embedder is used (matching by
+    name); if it is not found or not given, the first registered embedder for
+    the media type is used as a fallback.
+    """
+    from vtsearch.media import embedders_for_type, get_embedder
+
+    if embedder_name:
+        try:
+            embedder = get_embedder(embedder_name)
+        except (KeyError, ValueError):
+            log.warning(
+                "embed_file: embedder %r not found, falling back to default for media_type=%r",
+                embedder_name, media_type,
+            )
+            embedder = None
+    else:
+        embedder = None
+
+    if embedder is None:
+        avail = embedders_for_type(media_type)
+        if not avail:
+            log.warning(
+                "embed_file: no embedders registered for media_type=%r — "
+                "cannot embed %s",
+                media_type, file_path,
+            )
+            return None
+        embedder = avail[0]
     from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
 
     try:
@@ -322,6 +340,7 @@ def _apply_clip_and_embed(
     file_path: Path,
     media_type: str,
     origin: dict[str, Any],
+    embedder_name: str = "",
 ) -> np.ndarray | None:
     """Apply clip params from *origin* to a resolved file and embed the result.
 
@@ -337,7 +356,7 @@ def _apply_clip_and_embed(
     clipper_name = params.get("clipper", "")
 
     if not clipper_name:
-        return embed_file(file_path, media_type)
+        return embed_file(file_path, media_type, embedder_name)
 
     clip_start = params.get("clip_start")
     clip_end = params.get("clip_end")
@@ -354,7 +373,7 @@ def _apply_clip_and_embed(
             try:
                 os.write(fd, sliced)
                 os.close(fd)
-                return embed_file(Path(tmp), media_type)
+                return embed_file(Path(tmp), media_type, embedder_name)
             finally:
                 try:
                     os.unlink(tmp)
@@ -362,7 +381,7 @@ def _apply_clip_and_embed(
                     pass
         except Exception:
             log.debug("_apply_clip_and_embed: audio clip failed, falling back", exc_info=True)
-            return embed_file(file_path, media_type)
+            return embed_file(file_path, media_type, embedder_name)
 
     # --- Image clips: crop to clip_box ---
     if clip_box is not None and media_type == "image":
@@ -381,7 +400,7 @@ def _apply_clip_and_embed(
             try:
                 os.write(fd, crop_bytes)
                 os.close(fd)
-                return embed_file(Path(tmp), media_type)
+                return embed_file(Path(tmp), media_type, embedder_name)
             finally:
                 try:
                     os.unlink(tmp)
@@ -389,7 +408,7 @@ def _apply_clip_and_embed(
                     pass
         except Exception:
             log.debug("_apply_clip_and_embed: image clip failed, falling back", exc_info=True)
-            return embed_file(file_path, media_type)
+            return embed_file(file_path, media_type, embedder_name)
 
     # --- Text clips: extract the sentence by clip_index ---
     if media_type == "text":
@@ -407,7 +426,7 @@ def _apply_clip_and_embed(
                     try:
                         os.write(fd, sentences[idx].encode("utf-8"))
                         os.close(fd)
-                        return embed_file(Path(tmp), media_type)
+                        return embed_file(Path(tmp), media_type, embedder_name)
                     finally:
                         try:
                             os.unlink(tmp)
@@ -415,10 +434,10 @@ def _apply_clip_and_embed(
                             pass
         except Exception:
             log.debug("_apply_clip_and_embed: text clip failed, falling back", exc_info=True)
-            return embed_file(file_path, media_type)
+            return embed_file(file_path, media_type, embedder_name)
 
     # Video clips and unrecognised clippers: embed the full file.
-    return embed_file(file_path, media_type)
+    return embed_file(file_path, media_type, embedder_name)
 
 
 def resolve_label_embeddings(

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -220,16 +220,18 @@ def set_autorun_detector_autodetect_route(name):
     if autodetect is None:
         return jsonify({"error": "autodetect is required"}), 400
 
-    if set_autorun_detector_autodetect(name, bool(autodetect)):
-        # Persist in settings so the flag survives restarts
-        from vtsearch.settings import add_autorun_detector_name, remove_autorun_detector_name
+    from vtsearch.settings import add_autorun_detector_name, remove_autorun_detector_name
 
-        if autodetect:
-            add_autorun_detector_name(name)
-        else:
-            remove_autorun_detector_name(name)
-        return jsonify({"success": True, "autodetect": bool(autodetect)})
-    return jsonify({"error": "Detector not found"}), 404
+    found_in_memory = set_autorun_detector_autodetect(name, bool(autodetect))
+    # Even if the detector isn't loaded in memory, persist the setting so it
+    # takes effect on next load / CLI autorun.
+    if autodetect:
+        add_autorun_detector_name(name)
+    else:
+        remove_autorun_detector_name(name)
+        if not found_in_memory:
+            return jsonify({"error": "Detector not found"}), 404
+    return jsonify({"success": True, "autodetect": bool(autodetect)})
 
 
 @detectors_crud_bp.route("/api/autorun-detectors/<name>/export", methods=["GET"])

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -444,19 +444,20 @@ def list_registered_models():
     for entry in entries:
         mid = entry["id"]
         entry["loaded"] = mid in loaded_ids
-        det_name = entry.get("detector_name", "")
+        # Trainable models created through the UI have detector_name="", but their
+        # autorun key is the display name (matches the frontend's toggleAutorun fallback).
+        det_name = entry.get("detector_name", "") or entry.get("name", "")
         det = detectors.get(det_name) if det_name else None
         if det:
             entry["autodetect"] = bool(det.get("autodetect"))
         else:
-            # Fall back to the persisted settings list
             entry["autodetect"] = det_name in autorun_names if det_name else False
         entry.setdefault("last_trained_at", None)
         # detector_loaded: True when the model has inference data in RAM.
         # Either via a DetectorContext (multi-loaded) or via autorun_detectors weights.
         if mid in loaded_ids:
             entry["detector_loaded"] = True
-        elif det_name and det:
+        elif det:
             entry["detector_loaded"] = det.get("weights") is not None
         else:
             entry["detector_loaded"] = False


### PR DESCRIPTION
## Summary

Eight PRs since main's last dev-merge (#1130):

**Infra / deploy**
- #1138 — Run server via gunicorn in Docker (single gthread worker; `initialize_server()` runs under `VTSEARCH_SERVER_INIT=1`). Added `gunicorn` to CPU + GPU requirements.
- #1137 — Always bind to `0.0.0.0` so Docker port-forwarding works; removed `--local` branch.

**Fixes**
- #1136 — Label ingestion reuses the dataset's existing embedder.
- #1135 — Autorun toggle works for trainable models with empty `detector_name`; fixed stale `test_autodetect_nonexistent_detector`.
- #1133 — Autorun toggle no longer silently fails for models not yet in `autorun_detectors`.

**UI / plugins / meta**
- #1134 — Thinner action-button icon strokes to match font weight.
- #1131 — Custom embedders discoverable via per-module `EMBEDDER` sentinel.
- #1132 — CLAUDE.md: forbid asking about PR-activity subscription.

Content diff: +486 / −124 across 34 files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EANrtYbswvq4vvfCXBysz1)_