### PR TITLE
CLAUDE.md: require full fetch before branch comparison

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 - When creating a PR, always use `--base dev` (e.g., `gh pr create --base dev ...` or the equivalent MCP tool parameter).
 - If your feature branch was forked from `main` instead of `dev`, rebase or merge onto `dev` before opening a PR.
 
+## Git Fetch Hygiene
+
+Before comparing branches (`git log a..b`, `git diff a...b`, etc.), always run `git fetch origin --prune` first. Do **not** trust `origin/<branch>` refs after a partial fetch like `git fetch origin main` — that only updates the branch you named, leaving other remote-tracking refs stale and producing misleading diffs.
+
 ## Auto-PR After Successful Tests
 
 After pushing code changes and successfully running tests, **automatically create a PR targeting `dev`**. Do not ask — just create it. This applies whenever Claude both pushes and verifies tests pass in the same session.


### PR DESCRIPTION
## Summary
- Add a "Git Fetch Hygiene" section to `CLAUDE.md` requiring a full `git fetch origin --prune` before comparing branches.
- Motivated by a misread earlier in this session: a partial `git fetch origin main` left `origin/dev` stale at a pre-#1131 SHA, so an eight-PR gap between dev and main looked like zero commits.

## Test plan
- No code changed — docs only; no tests needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EANrtYbswvq4vvfCXBysz1)_