### PR TITLE
Recognize folder-based embedders in auto-discovery

### DIFF
--- a/tests/test_new_embedders.py
+++ b/tests/test_new_embedders.py
@@ -518,6 +518,72 @@ class TestEmbedderSentinelDiscovery:
                 "embedders should be discovered via per-module EMBEDDER sentinels"
             )
 
+    def test_folder_embedder_auto_discovered(self, tmp_path):
+        """A new ``embedder_*/`` sub-package (directory with ``__init__.py``)
+        dropped into a media-type package should be auto-discovered, just
+        like a flat ``embedder_*.py`` module.
+        """
+        import importlib
+        import sys
+        from pathlib import Path
+
+        from vtsearch.media import _discover_embedders_in
+        from vtsearch.media.embedder import MediaEmbedder
+
+        # Fake media-type package containing an embedder *sub-package*
+        # (not a flat module) exposing the EMBEDDER sentinel from its
+        # __init__.py.
+        fake_pkg = tmp_path / "fakemedia_folder"
+        fake_pkg.mkdir()
+        (fake_pkg / "__init__.py").write_text("")
+
+        embedder_pkg = fake_pkg / "embedder_folder"
+        embedder_pkg.mkdir()
+        (embedder_pkg / "__init__.py").write_text(
+            "from vtsearch.media.embedder import MediaEmbedder\n"
+            "\n"
+            "class _FolderEmbedder(MediaEmbedder):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            "        return 'folder_discoverable'\n"
+            "    @property\n"
+            "    def media_type_id(self):\n"
+            "        return 'fake'\n"
+            "    def _load_models_impl(self):\n"
+            "        pass\n"
+            "    def _embed_media_impl(self, media):\n"
+            "        return None\n"
+            "\n"
+            "EMBEDDER = _FolderEmbedder()\n"
+        )
+
+        package_name = "vtsearch.media._fakemedia_folder_test"
+        spec = importlib.util.spec_from_file_location(
+            package_name,
+            str(fake_pkg / "__init__.py"),
+            submodule_search_locations=[str(fake_pkg)],
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[package_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+            from vtsearch.media import _embedder_registry
+
+            saved = dict(_embedder_registry)
+            try:
+                _discover_embedders_in(Path(fake_pkg), package_name)
+                assert "folder_discoverable" in _embedder_registry
+                discovered = _embedder_registry["folder_discoverable"]
+                assert isinstance(discovered, MediaEmbedder)
+                assert discovered.media_type_id == "fake"
+            finally:
+                _embedder_registry.clear()
+                _embedder_registry.update(saved)
+        finally:
+            for key in list(sys.modules):
+                if key == package_name or key.startswith(package_name + "."):
+                    sys.modules.pop(key, None)
+
     def test_custom_embedder_auto_discovered(self, tmp_path, monkeypatch):
         """A new ``embedder_*.py`` file dropped into a media-type package
         should be auto-discovered with no ``__init__.py`` edits.

--- a/vtsearch/media/__init__.py
+++ b/vtsearch/media/__init__.py
@@ -5,16 +5,20 @@ import time by scanning sub-packages of ``vtsearch.media``:
 
 - Each media-type sub-package (``audio/``, ``image/``, ...) exposes a
   ``MEDIA_TYPE`` sentinel in its ``__init__.py`` (plus a ``CLIPPERS`` list).
-- Each embedder lives in its own module under the media-type package
-  (e.g. ``vtsearch/media/audio/embedder_clap_music.py``) and exposes a
-  module-level ``EMBEDDER`` sentinel — one embedder per module.  Any
-  ``embedder*.py`` file found inside a media-type package is auto-loaded.
+- Each embedder lives under the media-type package as either a flat
+  module (e.g. ``vtsearch/media/audio/embedder_clap_music.py``) or a
+  sub-package (e.g. ``vtsearch/media/image/embedder_fancy/__init__.py``)
+  and exposes a module-level ``EMBEDDER`` sentinel — one embedder per
+  module or sub-package.  Any ``embedder*.py`` file or ``embedder*/``
+  directory with an ``__init__.py`` found inside a media-type package
+  is auto-loaded.
 
-To add a new embedder, drop an ``embedder_<name>.py`` file into the
-appropriate media-type package with an ``EMBEDDER`` sentinel at the bottom.
-Symlinked directories and symlinked embedder files are both supported, so
-custom embedders living outside the VTSearch tree can be wired in without
-editing any package ``__init__.py``.
+To add a new embedder, drop an ``embedder_<name>.py`` file — or an
+``embedder_<name>/`` sub-package containing an ``__init__.py`` — into
+the appropriate media-type package with an ``EMBEDDER`` sentinel at the
+module/package top level.  Symlinked directories and symlinked embedder
+files are both supported, so custom embedders living outside the
+VTSearch tree can be wired in without editing any package ``__init__.py``.
 
 Third-party or project-specific types can still be registered manually::
 
@@ -247,26 +251,46 @@ def all_embedders_dict() -> list[dict]:
 
 
 def _discover_embedders_in(media_type_dir: Path, package_name: str) -> None:
-    """Scan a media-type sub-package for modules exposing an ``EMBEDDER`` sentinel.
+    """Scan a media-type sub-package for modules or sub-packages exposing an ``EMBEDDER``.
 
-    Any ``embedder*.py`` file (excluding ``__init__.py``) is imported, and its
-    module-level ``EMBEDDER`` attribute is registered if present.  Symlinked
-    files are loaded via :func:`importlib.util.spec_from_file_location` so
-    that symlinks pointing outside the package are handled reliably (mirrors
-    the same approach used by :class:`vtsearch.utils.registry.PluginRegistry`).
+    Any ``embedder*.py`` file **or** ``embedder*/`` sub-package (directory
+    containing an ``__init__.py``) is imported, and its module-level
+    ``EMBEDDER`` attribute is registered if present.  Symlinked files and
+    symlinked directories are both loaded via
+    :func:`importlib.util.spec_from_file_location` so that symlinks
+    pointing outside the package are handled reliably (mirrors the same
+    approach used by :class:`vtsearch.utils.registry.PluginRegistry`).
     """
     for entry in sorted(media_type_dir.iterdir()):
         if entry.name.startswith((".", "_")):
             continue
-        if not entry.is_file() or entry.suffix != ".py":
-            continue
         if not entry.name.startswith("embedder"):
             continue
-        full_name = f"{package_name}.{entry.stem}"
+
+        # Flat module: embedder_<name>.py
+        if entry.is_file() and entry.suffix == ".py":
+            module_stem = entry.stem
+            load_path = entry
+            is_package = False
+        # Sub-package: embedder_<name>/__init__.py.  Skip names containing
+        # dots — they aren't valid Python identifiers and would be
+        # misinterpreted as nested module paths by importlib.
+        elif entry.is_dir() and "." not in entry.name and (entry / "__init__.py").exists():
+            module_stem = entry.name
+            load_path = entry / "__init__.py"
+            is_package = True
+        else:
+            continue
+
+        full_name = f"{package_name}.{module_stem}"
         try:
             if entry.is_symlink():
-                resolved = entry.resolve()
-                spec = importlib.util.spec_from_file_location(full_name, str(resolved))
+                resolved = load_path.resolve()
+                spec = importlib.util.spec_from_file_location(
+                    full_name,
+                    str(resolved),
+                    submodule_search_locations=[str(resolved.parent)] if is_package else None,
+                )
                 if spec is None or spec.loader is None:
                     continue
                 mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary

- Embedder auto-discovery in `vtsearch/media/__init__.py` previously scanned only flat `embedder*.py` files inside a media-type package. A custom embedder packaged as a sub-directory (e.g. `embedder_fancy/__init__.py` with an `EMBEDDER` sentinel) was silently skipped — diverging from every other plugin family (importers, exporters, settings importers/exporters, sync sources, label importers, processor importers), which all support sub-packages via `PluginRegistry`.
- `_discover_embedders_in` now also picks up `embedder*/` directories with an `__init__.py`, mirroring `PluginRegistry._discover`: dotted dir names are skipped, and symlinked packages load via `spec_from_file_location` with `submodule_search_locations` so symlinked external embedder packages work identically to symlinked flat files.
- Docstring updated to document both module- and package-style embedders.

## Test plan

- [x] `./run-tests.sh models` — 553 passed (includes `test_new_embedders.py`)
- [x] `python -m pytest tests/ -m 'not gpu'` — 2999 passed, 1 skipped, 1 xfailed, 1 xpassed
- [x] New test `TestEmbedderSentinelDiscovery::test_folder_embedder_auto_discovered` asserts a directory-based embedder sub-package is registered by `_discover_embedders_in`
- [x] Existing flat-file discovery test still passes unchanged

https://claude.ai/code/session_01TYyUuDA1rrcG9gxWsoZe7k

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYyUuDA1rrcG9gxWsoZe7k)_