### PR TITLE
Rename embedder batch→bulk; push batching to subclasses

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -377,9 +377,11 @@ text_vec  = embedder.embed_text("birdsong")                       # same space
 Because the embedder sees the whole media dict (not just a `Path`), a
 service-based embedder can resolve content via `media["origin"]` /
 `media.get("custom_metadata")` without touching local disk — e.g. a
-remote lookup by `origin["params"]["content_id"]`.  Bulk APIs can override
-`supports_batch = True` / `batch_size` and `_embed_media_batch_impl(medias)`
-to flush whole batches through the loader.
+remote lookup by `origin["params"]["content_id"]`.  The loader always
+routes every pending file through `embed_media_bulk(medias)`; the ABC's
+default implementation loops per item (with progress).  Services that
+natively accept many items per request override `_embed_media_bulk_impl`
+and batch internally.
 
 No Flask, no global state, no progress dependency (silent no-op by
 default).  To get progress reporting, set a callback before loading:

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -370,8 +370,12 @@ def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
     return self._client.get_embedding(content_id)
 ```
 
-For bulk APIs, also override `supports_batch` / `batch_size` and
-`_embed_media_batch_impl(medias)` to flush a whole list in one request.
+For services that natively accept many items per request, override
+`_embed_media_bulk_impl(medias)` to send one request (or do internal
+batching). The loader always calls `embed_media_bulk` with every
+pending file; the default implementation loops over `embed_media`
+per item and emits progress via `self._on_progress`, so custom
+overrides that batch internally should emit their own progress too.
 
 ### Register the embedder
 
@@ -417,14 +421,7 @@ loaded via `spec_from_file_location` so discovery still works.
 |---------------------------------------|----------------------------------------------------|--------------------------------------|
 | `embed_text(text)`                    | `(str) -> Optional[np.ndarray]`                    | Embed a text query (default: `None`) |
 | `embed_text_enriched(text)`           | `(str) -> Optional[np.ndarray]`                    | Average over `description_wrappers`  |
-| `_embed_media_batch_impl(medias)`     | `(list[dict]) -> list[Optional[np.ndarray]]`       | Bulk embed; default loops over `_embed_media_impl`. Override with `supports_batch=True` for a remote bulk API |
-
-**Optional overridable properties:**
-
-| Property          | Returns | Description                                                                 |
-|-------------------|---------|-----------------------------------------------------------------------------|
-| `supports_batch`  | `bool`  | Set to `True` to route loader through `embed_media_batch` (default: `False`) |
-| `batch_size`      | `int`   | Max items per batch call when `supports_batch=True` (default: `32`)          |
+| `_embed_media_bulk_impl(medias)`      | `(list[dict]) -> list[Optional[np.ndarray]]`       | Embed a list of medias. Default loops over `embed_media` with per-item progress. Override for a native bulk path (e.g. a remote API that accepts many items per request); overrides that batch internally must emit their own progress through `self._on_progress`. |
 
 **Optional overridable properties:**
 

--- a/tests/test_bulk_embedding.py
+++ b/tests/test_bulk_embedding.py
@@ -1,12 +1,12 @@
-"""Bulk (batch) embedding support tests.
+"""Bulk embedding support tests.
 
-Verifies that :class:`~vtsearch.media.embedder.MediaEmbedder` exposes an
-opt-in batch API and that :func:`~vtsearch.datasets.loader.load_dataset_from_folder`
-(and its chunked sibling) route through it when an embedder advertises
-``supports_batch=True``.
-
-The goal is to support embedders backed by a remote bulk API (e.g. Datawave)
-without forcing every existing embedder to implement batching.
+The :class:`~vtsearch.media.embedder.MediaEmbedder` ABC exposes a single
+bulk entrypoint (:meth:`embed_media_bulk`) that the dataset loader
+always routes through.  The default implementation loops per item and
+emits progress via ``_on_progress`` so long embeds stay responsive;
+subclasses backed by a service that natively accepts many items can
+override :meth:`_embed_media_bulk_impl` and do their own internal
+batching (emitting their own progress).
 """
 
 from __future__ import annotations
@@ -20,23 +20,22 @@ from helpers import make_raw_wav_bytes as _make_wav_bytes
 
 
 # ---------------------------------------------------------------------------
-# Fake batch-capable embedder used across the loader tests.
+# Fake embedders used across the loader tests.
 # ---------------------------------------------------------------------------
 
 
-def _make_batch_embedder(batch_size: int = 32, embed_return_dim: int = 3):
-    """Return a MagicMock that mimics a batch-capable MediaEmbedder."""
+def _make_bulk_embedder(embed_return_dim: int = 3):
+    """Return a MagicMock that mimics an embedder with a native bulk path."""
     emb = mock.MagicMock()
-    emb.name = "fake_batch"
+    emb.name = "fake_bulk"
     emb.media_type_id = "audio"
     emb._model = True  # skip eager model-load path
-    emb.supports_batch = True
-    emb.batch_size = batch_size
+    emb._on_progress = lambda *a, **kw: None
 
-    def _batch(medias):
+    def _bulk(medias):
         return [np.full(embed_return_dim, float(i), dtype=np.float32) for i, _ in enumerate(medias)]
 
-    emb.embed_media_batch.side_effect = _batch
+    emb.embed_media_bulk.side_effect = _bulk
     return emb
 
 
@@ -53,24 +52,15 @@ def _write_wav(path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# MediaEmbedder.embed_media_batch defaults
+# MediaEmbedder.embed_media_bulk defaults
 # ---------------------------------------------------------------------------
 
 
 class TestEmbedderDefaults:
-    """The ABC's defaults should preserve existing per-file behaviour."""
+    """The ABC's default bulk impl loops per item and emits progress."""
 
-    def test_supports_batch_defaults_false(self):
-        """Concrete embedders that don't override stay one-by-one."""
-        from vtsearch.media import all_embedders
-
-        for emb in all_embedders():
-            assert emb.supports_batch is False, (
-                f"{type(emb).__name__} reports supports_batch=True but has no overridden _embed_media_batch_impl"
-            )
-
-    def test_default_batch_impl_loops_over_single(self, tmp_path):
-        """The default _embed_media_batch_impl dispatches to _embed_media_impl per item."""
+    def test_default_bulk_impl_loops_over_single(self, tmp_path):
+        """The default _embed_media_bulk_impl dispatches to embed_media per item."""
         from vtsearch.media.embedder import MediaEmbedder
 
         class _Stub(MediaEmbedder):
@@ -96,14 +86,15 @@ class TestEmbedderDefaults:
             p.write_bytes(b"x" * (i + 1))
             medias.append({"media_path": str(p)})
 
-        vecs = emb.embed_media_batch(medias)
+        vecs = emb.embed_media_bulk(medias)
         assert len(vecs) == 3
         assert vecs[0][0] == 1.0
         assert vecs[1][0] == 2.0
         assert vecs[2][0] == 3.0
 
-    def test_empty_batch_returns_empty(self):
-        """Passing an empty list must not acquire the lock or call the hook."""
+    def test_default_bulk_impl_emits_per_item_progress(self, tmp_path):
+        """The default bulk loop must call _on_progress on each iteration
+        so the progress bar keeps moving for slow local embedders."""
         from vtsearch.media.embedder import MediaEmbedder
 
         class _Stub(MediaEmbedder):
@@ -119,28 +110,68 @@ class TestEmbedderDefaults:
                 self._model = True
 
             def _embed_media_impl(self, media):
-                raise AssertionError("should not be called for empty batch")
+                return np.array([1.0], dtype=np.float32)
 
         emb = _Stub()
-        assert emb.embed_media_batch([]) == []
+        emb._model = True
+
+        events: list[tuple[str, str, int, int]] = []
+        emb._on_progress = lambda status, msg, cur, tot: events.append((status, msg, cur, tot))
+
+        medias = []
+        for name in ["a.bin", "b.bin", "c.bin"]:
+            p = tmp_path / name
+            p.write_bytes(b"x")
+            medias.append({"media_path": str(p)})
+
+        emb.embed_media_bulk(medias)
+
+        # One progress event per item, each reporting (i+1)/3 with status "embedding".
+        assert len(events) == 3
+        for i, (status, _msg, cur, tot) in enumerate(events):
+            assert status == "embedding"
+            assert cur == i + 1
+            assert tot == 3
+
+    def test_empty_bulk_returns_empty(self):
+        """Passing an empty list must not invoke the hook."""
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                raise AssertionError("should not be called for empty bulk")
+
+        emb = _Stub()
+        assert emb.embed_media_bulk([]) == []
 
 
 # ---------------------------------------------------------------------------
-# load_dataset_from_folder routes through embed_media_batch when opted in
+# load_dataset_from_folder always routes through embed_media_bulk
 # ---------------------------------------------------------------------------
 
 
-class TestLoaderRoutesToBatch:
-    """load_dataset_from_folder must call embed_media_batch when supports_batch=True."""
+class TestLoaderRoutesToBulk:
+    """The loader hands pending files to embed_media_bulk in a single call."""
 
-    def test_single_batch_for_small_folder(self, tmp_path):
+    def test_single_bulk_call_for_folder(self, tmp_path):
         from vtsearch.datasets.loader import load_dataset_from_folder
 
         for name in ("a.wav", "b.wav", "c.wav"):
             _write_wav(tmp_path / name)
 
         mt = _make_media_type_for_audio()
-        emb = _make_batch_embedder(batch_size=32)
+        emb = _make_bulk_embedder()
 
         medias: dict = {}
         with (
@@ -150,44 +181,60 @@ class TestLoaderRoutesToBatch:
             load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
 
         assert len(medias) == 3
-        # Exactly one batch call — all three files in one request.
-        assert emb.embed_media_batch.call_count == 1
-        sent_medias = emb.embed_media_batch.call_args.args[0]
+        # Exactly one bulk call — all three files in one request.
+        assert emb.embed_media_bulk.call_count == 1
+        sent_medias = emb.embed_media_bulk.call_args.args[0]
         assert sorted(Path(m["media_path"]).name for m in sent_medias) == ["a.wav", "b.wav", "c.wav"]
-        # Per-file embed_media must NOT have been called.
-        emb.embed_media.assert_not_called()
 
-    def test_splits_into_multiple_batches_by_batch_size(self, tmp_path):
+    def test_loader_routes_embedder_progress_to_caller(self, tmp_path):
+        """The loader sets emb._on_progress to its own on_progress for the
+        duration of the bulk call, so progress emitted by the embedder (or
+        its default per-item loop) reaches the UI."""
         from vtsearch.datasets.loader import load_dataset_from_folder
 
-        # 5 files, batch_size=2 → 3 batches of sizes 2, 2, 1
-        for i in range(5):
-            _write_wav(tmp_path / f"f{i}.wav")
+        for name in ("a.wav", "b.wav"):
+            _write_wav(tmp_path / name)
 
         mt = _make_media_type_for_audio()
-        emb = _make_batch_embedder(batch_size=2)
+
+        captured_cb: list = []
+
+        def _bulk_that_pings_progress(medias_in):
+            # Whatever _on_progress is set to *at the moment of the bulk call*
+            # is what the loader routed through.
+            captured_cb.append(emb._on_progress)
+            emb._on_progress("embedding", "halfway", 1, 2)
+            return [np.array([1.0], dtype=np.float32) for _ in medias_in]
+
+        emb = _make_bulk_embedder()
+        emb.embed_media_bulk.side_effect = _bulk_that_pings_progress
+
+        events: list[tuple] = []
+
+        def loader_progress(status, msg, cur, tot):
+            events.append((status, msg, cur, tot))
 
         medias: dict = {}
         with (
             mock.patch("vtsearch.media.get_by_folder_name", return_value=mt),
             mock.patch("vtsearch.media.embedders_for_type", return_value=[emb]),
         ):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=loader_progress)
 
-        assert len(medias) == 5
-        assert emb.embed_media_batch.call_count == 3
-        sizes = [len(call.args[0]) for call in emb.embed_media_batch.call_args_list]
-        assert sizes == [2, 2, 1]
+        # The embedder's _on_progress during the call is the loader's callback.
+        assert captured_cb and captured_cb[0] is loader_progress
+        # The "halfway" event from inside the bulk call reached the loader's callback.
+        assert ("embedding", "halfway", 1, 2) in events
 
-    def test_overrides_skip_batch_call(self, tmp_path):
-        """Files with content_vectors or custom_metadata embedding aren't sent to batch."""
+    def test_overrides_skip_bulk_call(self, tmp_path):
+        """Files with content_vectors or custom_metadata embedding aren't sent to bulk."""
         from vtsearch.datasets.loader import load_dataset_from_folder
 
         for name in ("keep.wav", "pre1.wav", "pre2.wav"):
             _write_wav(tmp_path / name)
 
         mt = _make_media_type_for_audio()
-        emb = _make_batch_embedder(batch_size=32)
+        emb = _make_bulk_embedder()
 
         pre_vec = np.array([99.0, 99.0, 99.0], dtype=np.float32)
         cm_vec = np.array([42.0, 42.0, 42.0], dtype=np.float32)
@@ -207,24 +254,22 @@ class TestLoaderRoutesToBatch:
             )
 
         assert len(medias) == 3
-        # Only the non-overridden file should have been batched.
-        assert emb.embed_media_batch.call_count == 1
-        sent = emb.embed_media_batch.call_args.args[0]
+        assert emb.embed_media_bulk.call_count == 1
+        sent = emb.embed_media_bulk.call_args.args[0]
         assert [Path(m["media_path"]).name for m in sent] == ["keep.wav"]
 
-        # Verify overrides won
         by_name = {m["filename"]: m["embedding"] for m in medias.values()}
         np.testing.assert_array_equal(by_name["pre1.wav"], pre_vec)
         np.testing.assert_array_equal(by_name["pre2.wav"], cm_vec)
 
-    def test_skip_embedding_does_not_trigger_batch(self, tmp_path):
-        """skip_embedding=True must bypass the batch API entirely."""
+    def test_skip_embedding_does_not_trigger_bulk(self, tmp_path):
+        """skip_embedding=True must bypass the bulk API entirely."""
         from vtsearch.datasets.loader import load_dataset_from_folder
 
         _write_wav(tmp_path / "a.wav")
 
         mt = _make_media_type_for_audio()
-        emb = _make_batch_embedder(batch_size=32)
+        emb = _make_bulk_embedder()
 
         medias: dict = {}
         with (
@@ -233,12 +278,11 @@ class TestLoaderRoutesToBatch:
         ):
             load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None, skip_embedding=True)
 
-        emb.embed_media_batch.assert_not_called()
-        emb.embed_media.assert_not_called()
+        emb.embed_media_bulk.assert_not_called()
         assert medias[1]["embedding"] is None
 
-    def test_batch_returning_none_skips_file(self, tmp_path):
-        """A None entry in the batch response should skip that file, matching per-file semantics."""
+    def test_bulk_returning_none_skips_file(self, tmp_path):
+        """A None entry in the bulk response should skip that file."""
         from vtsearch.datasets.loader import load_dataset_from_folder
 
         _write_wav(tmp_path / "good.wav")
@@ -246,16 +290,15 @@ class TestLoaderRoutesToBatch:
 
         mt = _make_media_type_for_audio()
         emb = mock.MagicMock()
-        emb.name = "fake_batch"
+        emb.name = "fake_bulk"
         emb.media_type_id = "audio"
         emb._model = True
-        emb.supports_batch = True
-        emb.batch_size = 32
+        emb._on_progress = lambda *a, **kw: None
 
-        def _batch(medias_in):
+        def _bulk(medias_in):
             return [None if Path(m["media_path"]).name == "bad.wav" else np.array([1.0, 2.0]) for m in medias_in]
 
-        emb.embed_media_batch.side_effect = _batch
+        emb.embed_media_bulk.side_effect = _bulk
 
         medias: dict = {}
         with (
@@ -269,59 +312,22 @@ class TestLoaderRoutesToBatch:
 
 
 # ---------------------------------------------------------------------------
-# Non-batch embedders keep the old per-file path
+# Chunked loader bulk-embeds per chunk
 # ---------------------------------------------------------------------------
 
 
-class TestNonBatchEmbedderUnchanged:
-    """Embedders with supports_batch=False must still use embed_media per file."""
+class TestChunkedLoaderBulkPerChunk:
+    """The chunked loader issues one bulk call per chunk — preserving the
+    memory story where only one chunk's worth of embeddings is in RAM at a time."""
 
-    def test_per_file_path_still_used(self, tmp_path):
-        from vtsearch.datasets.loader import load_dataset_from_folder
-
-        for name in ("a.wav", "b.wav"):
-            _write_wav(tmp_path / name)
-
-        mt = _make_media_type_for_audio()
-        emb = mock.MagicMock()
-        emb.name = "single"
-        emb.media_type_id = "audio"
-        emb._model = True
-        emb.supports_batch = False
-        emb.embed_media.return_value = np.array([1.0, 2.0])
-
-        medias: dict = {}
-        with (
-            mock.patch("vtsearch.media.get_by_folder_name", return_value=mt),
-            mock.patch("vtsearch.media.embedders_for_type", return_value=[emb]),
-        ):
-            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
-
-        assert emb.embed_media.call_count == 2
-        emb.embed_media_batch.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Chunked loader batches within each chunk
-# ---------------------------------------------------------------------------
-
-
-class TestChunkedLoaderBatches:
-    """load_dataset_from_folder_chunked must batch within each chunk."""
-
-    def test_batches_scoped_to_chunk(self, tmp_path):
-        """Four files with chunk_size=2 and batch_size=10 → 2 batch calls, one per chunk.
-
-        Ensures the batch is flushed per chunk (to preserve chunked loading's
-        memory story) rather than across the whole folder.
-        """
+    def test_bulk_call_scoped_to_chunk(self, tmp_path):
         from vtsearch.datasets.loader import load_dataset_from_folder_chunked
 
         for i in range(4):
             _write_wav(tmp_path / f"f{i}.wav")
 
         mt = _make_media_type_for_audio()
-        emb = _make_batch_embedder(batch_size=10)
+        emb = _make_bulk_embedder()
 
         with (
             mock.patch("vtsearch.media.get_by_folder_name", return_value=mt),
@@ -333,7 +339,7 @@ class TestChunkedLoaderBatches:
 
         assert len(chunks) == 2
         assert all(len(c) == 2 for c in chunks)
-        # One batch call per chunk, each receiving exactly 2 files.
-        assert emb.embed_media_batch.call_count == 2
-        for call in emb.embed_media_batch.call_args_list:
+        # One bulk call per chunk, each receiving exactly 2 files.
+        assert emb.embed_media_bulk.call_count == 2
+        for call in emb.embed_media_bulk.call_args_list:
             assert len(call.args[0]) == 2

--- a/tests/test_bulk_embedding.py
+++ b/tests/test_bulk_embedding.py
@@ -211,7 +211,7 @@ class TestLoaderRoutesToBulk:
 
         events: list[tuple] = []
 
-        def loader_progress(status, msg, cur, tot):
+        def loader_progress(status, msg="", cur=0, tot=0):
             events.append((status, msg, cur, tot))
 
         medias: dict = {}

--- a/tests/test_dataset_importer_media.py
+++ b/tests/test_dataset_importer_media.py
@@ -35,6 +35,8 @@ def _make_mock_media_type():
     emb.media_type_id = "audio"
     emb._model = True  # already loaded
     emb.embed_media.return_value = np.zeros(8)
+    # Route the loader's bulk dispatch through the per-file mock.
+    emb.embed_media_bulk.side_effect = lambda medias: [emb.embed_media(m) for m in medias]
     return mt, emb
 
 

--- a/tests/test_importer_loading.py
+++ b/tests/test_importer_loading.py
@@ -39,6 +39,11 @@ class TestLoadDatasetContentVectors:
         mt._mock_embedder.media_type_id = "audio"
         mt._mock_embedder._model = True
         mt._mock_embedder.embed_media.return_value = embed_return
+        # Route the bulk entrypoint through the per-file mock so tests that
+        # configured embed_media keep working under the loader's bulk dispatch.
+        mt._mock_embedder.embed_media_bulk.side_effect = lambda medias: [
+            mt._mock_embedder.embed_media(m) for m in medias
+        ]
         return mt
 
     def _patch_media_registry(self, mt):

--- a/tests/test_importer_symlinks.py
+++ b/tests/test_importer_symlinks.py
@@ -254,6 +254,9 @@ class TestSymlinkedFolderImport:
         mt._mock_embedder.media_type_id = "audio"
         mt._mock_embedder._model = True
         mt._mock_embedder.embed_media.return_value = np.zeros(3)
+        mt._mock_embedder.embed_media_bulk.side_effect = lambda medias: [
+            mt._mock_embedder.embed_media(m) for m in medias
+        ]
         return mt
 
     def _patch_media_registry(self, mt):

--- a/tests/test_memory_errors.py
+++ b/tests/test_memory_errors.py
@@ -142,6 +142,9 @@ class TestFolderMemoryError:
             return np.zeros(10)
 
         mock_emb.embed_media.side_effect = embed_then_oom
+        # Route the bulk entrypoint through embed_media so the per-file OOM
+        # simulator still fires under the loader's bulk dispatch.
+        mock_emb.embed_media_bulk.side_effect = lambda medias: [mock_emb.embed_media(m) for m in medias]
         mock_mt.load_media_data.return_value = {"media_bytes": b"\x00", "duration": 1}
 
         with (

--- a/tests/test_pdf_import.py
+++ b/tests/test_pdf_import.py
@@ -119,6 +119,7 @@ class TestFolderImporterPdf:
         emb._model = True
         emb.embed_media.return_value = np.zeros(768)
         emb.embed_pil_image.return_value = np.zeros(768)
+        emb.embed_media_bulk.side_effect = lambda medias: [emb.embed_media(m) for m in medias]
         return emb
 
     def _patch_media_registry(self, mt, emb):
@@ -367,6 +368,7 @@ class TestPdfSymlinkDiscovery:
         emb._model = True
         emb.embed_media.return_value = np.zeros(768)
         emb.embed_pil_image.return_value = np.zeros(768)
+        emb.embed_media_bulk.side_effect = lambda medias: [emb.embed_media(m) for m in medias]
         return emb
 
     def test_pdfs_in_symlinked_subdir_are_discovered(self, tmp_path):

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -333,20 +333,20 @@ def load_dataset_from_folder(
     # pre-computed vector.  Subclasses that override ``_embed_media_bulk_impl``
     # can batch internally; the default impl loops per item and emits
     # per-item progress so the UI stays responsive.
-    bulk_embeddings: dict[Path, Any] = {}
-    if emb is not None and not skip_embedding:
-        bulk_embeddings = _bulk_embed_files(
-            emb,
-            media_files,
-            folder_path,
-            content_vectors,
-            custom_metadata_map,
-            on_progress,
-            media_type,
-            origin=origin,
-        )
-
     try:
+        bulk_embeddings: dict[Path, Any] = {}
+        if emb is not None and not skip_embedding:
+            bulk_embeddings = _bulk_embed_files(
+                emb,
+                media_files,
+                folder_path,
+                content_vectors,
+                custom_metadata_map,
+                on_progress,
+                media_type,
+                origin=origin,
+            )
+
         for i, file_path in enumerate(media_files):
             # Preserve relative path from the import root so that files in
             # different subdirectories with the same basename stay distinct.

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -154,7 +154,7 @@ def _make_embed_input(
     }
 
 
-def _batch_embed_files(
+def _bulk_embed_files(
     emb: Any,
     media_files: list[Path],
     folder_path: Path,
@@ -164,16 +164,18 @@ def _batch_embed_files(
     media_type: str,
     origin: dict[str, Any] | None = None,
 ) -> dict[Path, Any]:
-    """Pre-compute embeddings for *media_files* via :meth:`embed_media_batch`.
+    """Pre-compute embeddings for *media_files* via :meth:`embed_media_bulk`.
 
-    Files whose embedding is already resolved by ``custom_metadata`` or
-    ``content_vectors`` are skipped (they don't need to be sent to the
-    model).  Remaining files are packaged into minimal media dicts (via
-    :func:`_make_embed_input`), grouped into batches of ``emb.batch_size``,
-    and flushed via :meth:`MediaEmbedder.embed_media_batch`.
+    Files already resolved by ``custom_metadata`` or ``content_vectors``
+    are skipped; the rest are packaged into minimal media dicts (via
+    :func:`_make_embed_input`) and handed to the embedder in a single
+    call.  The embedder's ``_on_progress`` callback is routed through
+    *on_progress* for the duration of the call so progress updates
+    (whether from the default per-item loop or a subclass's custom
+    batching) reach the UI.
 
     Returns a dict mapping ``Path`` → embedding vector.  Paths whose
-    batch call returned ``None`` are omitted, matching the per-file
+    bulk call returned ``None`` are omitted, matching the per-file
     behaviour of skipping files that fail to embed.
     """
     pending_paths: list[Path] = []
@@ -185,27 +187,19 @@ def _batch_embed_files(
         pending_paths.append(file_path)
         pending_medias.append(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
 
-    results: dict[Path, Any] = {}
     if not pending_paths:
-        return results
+        return {}
 
-    bsize = max(1, emb.batch_size)
-    total = len(pending_paths)
-    for start in range(0, total, bsize):
-        batch_paths = pending_paths[start : start + bsize]
-        batch_medias = pending_medias[start : start + bsize]
-        batch_idx = start // bsize + 1
-        on_progress(
-            "embedding",
-            f"Embedding {media_type} batch {batch_idx} ({len(batch_paths)} files)...",
-            min(start + len(batch_paths), total),
-            total,
-        )
-        vectors = emb.embed_media_batch(batch_medias)
-        for fp, vec in zip(batch_paths, vectors):
-            if vec is not None:
-                results[fp] = vec
-    return results
+    on_progress("embedding", f"Embedding {len(pending_paths)} {media_type} files...", 0, len(pending_paths))
+
+    original_cb = emb._on_progress
+    emb._on_progress = on_progress
+    try:
+        vectors = emb.embed_media_bulk(pending_medias)
+    finally:
+        emb._on_progress = original_cb
+
+    return {fp: vec for fp, vec in zip(pending_paths, vectors) if vec is not None}
 
 
 def load_dataset_from_folder(
@@ -334,16 +328,14 @@ def load_dataset_from_folder(
     media_id = 1
     total_files = len(media_files)
 
-    # Batch-capable embedders get all their files flushed through
-    # ``embed_media_batch`` up front; the per-file loop then just looks
-    # up the pre-computed vector.  Non-batch embedders fall through to
-    # the per-file ``embed_media`` call below.  ``is True`` (not truthy)
-    # is deliberate so that test mocks without an explicit override stay
-    # on the per-file path.
-    use_batch = emb is not None and not skip_embedding and getattr(emb, "supports_batch", False) is True
-    batch_embeddings: dict[Path, Any] = {}
-    if use_batch:
-        batch_embeddings = _batch_embed_files(
+    # Flush everything that still needs embedding through the embedder's
+    # bulk entrypoint up front; the per-file loop below just looks up the
+    # pre-computed vector.  Subclasses that override ``_embed_media_bulk_impl``
+    # can batch internally; the default impl loops per item and emits
+    # per-item progress so the UI stays responsive.
+    bulk_embeddings: dict[Path, Any] = {}
+    if emb is not None and not skip_embedding:
+        bulk_embeddings = _bulk_embed_files(
             emb,
             media_files,
             folder_path,
@@ -390,10 +382,7 @@ def load_dataset_from_folder(
             else:
                 if emb is None:
                     continue
-                if use_batch:
-                    embedding = batch_embeddings.get(file_path)
-                else:
-                    embedding = emb.embed_media(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
+                embedding = bulk_embeddings.get(file_path)
                 if embedding is None:
                     continue
 
@@ -601,21 +590,20 @@ def load_dataset_from_folder_chunked(
     total_files = len(media_files)
     embedder_id = emb.name if emb else ""
 
-    use_batch = emb is not None and not skip_embedding and getattr(emb, "supports_batch", False) is True
-
     # Process in groups of chunk_size
     for start in range(0, total_files, chunk_size):
         batch = media_files[start : start + chunk_size]
         chunk_medias: dict[int, dict[str, Any]] = {}
         media_id = 1
 
-        # Batch-capable embedders embed the whole chunk up front, then the
-        # per-file loop below just looks up the pre-computed vector.  This
-        # keeps chunked loading's memory story intact — only one chunk's
-        # worth of embeddings lives in memory at a time.
-        chunk_batch_embeddings: dict[Path, Any] = {}
-        if use_batch:
-            chunk_batch_embeddings = _batch_embed_files(
+        # Flush the whole chunk through ``embed_media_bulk`` up front, then
+        # the per-file loop below just looks up the pre-computed vector.
+        # Scoping the bulk call to a single chunk preserves chunked loading's
+        # memory story — only one chunk's worth of embeddings lives in
+        # memory at a time.
+        chunk_bulk_embeddings: dict[Path, Any] = {}
+        if emb is not None and not skip_embedding:
+            chunk_bulk_embeddings = _bulk_embed_files(
                 emb,
                 batch,
                 folder_path,
@@ -659,10 +647,7 @@ def load_dataset_from_folder_chunked(
             else:
                 if emb is None:
                     continue
-                if use_batch:
-                    embedding = chunk_batch_embeddings.get(file_path)
-                else:
-                    embedding = emb.embed_media(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
+                embedding = chunk_bulk_embeddings.get(file_path)
                 if embedding is None:
                     continue
 

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -487,54 +487,38 @@ class MediaEmbedder(ABC):
     # Bulk embedding
     # ------------------------------------------------------------------
 
-    @property
-    def supports_batch(self) -> bool:
-        """Whether this embedder has a native bulk-embedding path.
+    def embed_media_bulk(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        """Embed every item in *medias* and return a same-length list of vectors.
 
-        Defaults to ``False``.  Subclasses backed by a remote bulk API (or
-        any backend where a single request amortises setup cost across many
-        inputs) should override this to return ``True`` **and** override
-        :meth:`_embed_media_batch_impl`.
+        Positions where an item could not be embedded contain ``None``.
 
-        When ``True``, :func:`~vtsearch.datasets.loader.load_dataset_from_folder`
-        and its chunked sibling collect medias into groups of :attr:`batch_size`
-        and flush them through :meth:`embed_media_batch` instead of calling
-        :meth:`embed_media` per item.
-        """
-        return False
+        The default implementation dispatches to :meth:`embed_media` per
+        item — each call acquires :attr:`_embed_lock` individually so
+        concurrent callers can interleave — and emits per-item progress
+        via :attr:`_on_progress` so long runs stay visible in the UI.
 
-    @property
-    def batch_size(self) -> int:
-        """Maximum number of items per call to :meth:`embed_media_batch`.
-
-        Only consulted when :attr:`supports_batch` is ``True``.  Override in
-        subclasses to match the remote API's preferred request size.
-        """
-        return 32
-
-    def embed_media_batch(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
-        """Return embeddings for a batch of media items.
-
-        Must return a list the same length as *medias*, with ``None`` at
-        positions where an item could not be embedded.
-
-        Acquires :attr:`_embed_lock` once per batch (not per item) so that
-        bulk API calls don't serialise at per-item granularity.  Subclasses
-        must override :meth:`_embed_media_batch_impl` (not this method).
+        Subclasses backed by a service that natively accepts many items
+        per request should override :meth:`_embed_media_bulk_impl`.  If
+        they chunk internally (batching), they are responsible for
+        emitting their own progress updates through :attr:`_on_progress`.
         """
         if not medias:
             return []
-        with self._embed_lock:
-            return self._embed_media_batch_impl(medias)
+        return self._embed_media_bulk_impl(medias)
 
-    def _embed_media_batch_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
-        """Subclass hook: embed a batch of media items.
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        """Subclass hook: embed a list of media items.
 
-        The default implementation simply loops over :meth:`_embed_media_impl`,
-        which is correct for embedders that have no native bulk path.
-        Override this in subclasses that back onto a remote bulk API.
+        Default: loop over :meth:`embed_media`, emitting per-item progress.
+        Override to replace the per-item loop with a single bulk request,
+        or to batch internally in chunks sized for a remote API.
         """
-        return [self._embed_media_impl(m) for m in medias]
+        total = len(medias)
+        results: list[Optional[np.ndarray]] = []
+        for i, m in enumerate(medias):
+            self._on_progress("embedding", f"Embedding {i + 1}/{total}...", i + 1, total)
+            results.append(self.embed_media(m))
+        return results
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.


### PR DESCRIPTION
## Summary

Clarifies the batch/bulk terminology in the embedder API per the convention: **bulk** = send a plural in one call, **batch** = split a plural into chunks. The ABC was doing both at different layers; subclasses now own batching entirely.

- ABC (`vtsearch/media/embedder.py`) now exposes a single bulk entrypoint: `embed_media_bulk` / `_embed_media_bulk_impl`. `supports_batch`, `batch_size`, and the `embed_media_batch` names are gone.
- Loader (`vtsearch/datasets/loader.py`) unconditionally routes every pending file through `embed_media_bulk` — no chunk loop, no capability check. Chunked loading keeps the one-bulk-call-per-chunk memory story.
- Default `_embed_media_bulk_impl` loops over `embed_media` per item and emits per-item progress via `self._on_progress`, so slow local embedders keep the progress bar moving. The loader routes the embedder's `_on_progress` through its own `on_progress` callback during the bulk call.
- Subclasses backed by a service that natively accepts many items per request override `_embed_media_bulk_impl` and batch internally however they want (emitting their own progress).
- Bulk call is inside the loader's `MemoryError` handler so OOM during embedding still surfaces the "Out of memory after loading N of M files" message.
- Docs (`EXTENDING-media.md`, `ARCHITECTURE.md`) updated; `test_bulk_embedding.py` rewritten with a dedicated progress-responsiveness test; existing per-file mock helpers wire `embed_media_bulk.side_effect` through their `embed_media` mock so they keep working under the bulk dispatch.

**Breaking change:** `supports_batch`, `batch_size`, `embed_media_batch`, and `_embed_media_batch_impl` are removed from the `MediaEmbedder` ABC. No in-tree subclasses overrode any of these, so nothing downstream breaks in this repo.

## Test plan

- [x] `./run-tests.sh datasets io models` — 1505 passed, 1 skipped
- [x] `./run-tests.sh sorting api integration cli converters` — 975 passed, 2 xfailed
- [x] `ruff check` on changed files — clean
- [ ] Manually exercise a folder import to confirm progress bar stays responsive during a long embed (not testable in this environment — no GPU, no large datasets)

https://claude.ai/code/session_01GN95NAwzDf91a4vKArkTWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN95NAwzDf91a4vKArkTWm)_