### PR TITLE
CLAUDE.md: require full fetch before branch comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ See [docs/SETUP.md](docs/SETUP.md) for prerequisites, getting the code, virtual 
 
 ## Running the app
 
+For development, start the Flask dev server:
+
 ```bash
 python app.py
 ```
@@ -15,12 +17,20 @@ python app.py
 You should see output like:
 
 ```
- * Running on http://127.0.0.1:5000
+ * Running on http://0.0.0.0:5000
 ```
 
-Open that URL in your browser. The app starts with no clips loaded — use the menu to load a demo dataset (see below).
+Open `http://localhost:5000` in your browser. The app starts with no clips loaded — use the menu to load a demo dataset (see below).
 
 Press **Ctrl+C** in the terminal to stop the server.
+
+For production, run under gunicorn (the Docker images do this automatically):
+
+```bash
+VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
+```
+
+See [docs/SETUP.md](docs/SETUP.md#running-the-app) and [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for details.
 
 > **New to VTSearch?** Read **[docs/USER_GUIDE.md](docs/USER_GUIDE.md)** — a walkthrough of loading a dataset, using Autopilot to label, and exporting results. Most users never need anything else.
 
@@ -40,6 +50,7 @@ You can also load your own data from pickle files or folders via the same menu.
 
 ```
 ├── app.py                          # Flask entry point, registers blueprints, CLI arg parsing
+├── gunicorn.conf.py                # Gunicorn WSGI config (single worker + threads)
 ├── vtsearch/                       # Main application package
 │   ├── config.py                   # Constants (CLAP_SAMPLE_RATE, paths, model IDs)
 │   ├── medias.py                   # Test media generation & embedding cache
@@ -57,7 +68,7 @@ You can also load your own data from pickle files or folders via the same menu.
 │   ├── processors/importers/       # Processor importer plugins
 │   ├── settings_io/                # Settings importers, exporters & sync sources
 │   ├── audio/                      # Audio generation utility
-│   └── utils/                      # Global state (medias, votes) & progress helpers
+│   └── utils/                      # State proxies (per-dataset/per-detector contexts) & progress helpers
 ├── static/                         # Angular build output (HTML, JS, CSS, assets)
 ├── tests/                          # Test suite (pytest)
 ├── docs/                           # Extended documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,9 +25,9 @@ VTSearch is a media-explorer web app for browsing, voting on, and
 semantically sorting collections of audio, images, text, video, or
 documents.  It combines:
 
-- **Semantic sorting** — LAION-CLAP (audio), CLIP (images), X-CLIP
+- **Semantic sorting** — LAION-CLAP (audio), SigLIP (images), X-CLIP
   (video), E5-base-v2 (text) for embedding-based similarity search,
-  with alternative embedders available (CLAP Music, SigLIP, BGE).
+  with alternative embedders available (CLAP Music, OpenAI CLIP, BGE).
 - **Learned sorting** — a small MLP trained on user votes to predict
   good/bad labels.
 - **Flask web UI** — Angular SPA frontend with a REST API.
@@ -127,7 +127,8 @@ VTSearch/
 │   │       ├── pickle/             .pkl file importer
 │   │       ├── http_zip/           HTTP archive importer (API name: http_archive)
 │   │       ├── combine_datasets/   Merge multiple pickle datasets
-│   │       └── demo/              Demo dataset importer (pre-configured catalogues)
+│   │       ├── demo/               Demo dataset importer (pre-configured catalogues)
+│   │       └── recaller/           ReCaller importer (scaffold — hidden from picker)
 │   │
 │   ├── exporters/                  Plugin system for output destinations
 │   │   ├── base.py                 LabelsetExporter ABC + ExporterField
@@ -135,7 +136,8 @@ VTSearch/
 │   │   ├── server_csv_file/        CSV file on server
 │   │   ├── email_smtp/             SMTP email sender
 │   │   ├── webhook/                HTTP POST webhook
-│   │   └── gui/                    In-browser / console display
+│   │   ├── gui/                    In-browser / console display
+│   │   └── holder/                 Holder labelset exporter (scaffold — hidden from picker)
 │   │
 │   ├── settings_io/                Settings import/export/sync plugins
 │   │   ├── importers/              One-shot settings importers
@@ -154,7 +156,8 @@ VTSearch/
 │   │   ├── importers/              Plugin system for one-shot label import
 │   │   │   ├── base.py             LabelImporter ABC + LabelImporterField
 │   │   │   ├── server_json_file/   JSON label file on server
-│   │   │   └── server_csv_file/    CSV label file on server
+│   │   │   ├── server_csv_file/    CSV label file on server
+│   │   │   └── holder/             Holder label importer (scaffold — hidden from picker)
 │   │   ├── sources/                Bidirectional label sync sources
 │   │   │   ├── base.py             LabelsetSource ABC + LabelsetSourceField
 │   │   │   └── server_json_file/   Sync labels with server JSON file
@@ -492,8 +495,12 @@ register function.  See `EXTENDING.md` (in this directory) for full examples.
 
 ## State management
 
-Application state lives in `vtsearch/utils/state.py` as module-level
-dicts, all protected by `_state_lock` (a `threading.RLock`):
+Application state is exposed through `vtsearch/utils/state.py` (a
+re-export facade over the `state_*.py` submodules). The module-level
+names below are **proxy objects** that delegate to a per-request
+`DatasetContext` or `DetectorContext` — see
+[Multi-dataset support](#multi-dataset-support). All mutable access is
+protected by `_state_lock` (a `threading.RLock`):
 
 | Variable | Type | Purpose |
 |----------|------|---------|
@@ -510,6 +517,13 @@ dicts, all protected by `_state_lock` (a `threading.RLock`):
 | `autorun_localizers` | `dict` | Saved localizer configurations |
 | `_diversity_tree` | `DiversityTree \| None` | Hierarchical k-means tree for diverse sampling |
 | `_dataset_display_name` | `str \| None` | Custom display name for the loaded dataset |
+
+Of these, only `autorun_detectors`, `autorun_extractors`, and
+`autorun_localizers` are truly global (shared across all loaded
+datasets). The rest are per-dataset (`medias`, `_diversity_tree`,
+`_dataset_display_name`) or per-detector (votes, label history, click
+times, learned scores, inclusion, textsort suggestions) and resolve via
+the active `DatasetContext` / `DetectorContext`.
 
 Persistent settings live separately in `vtsearch/settings.py` and are
 auto-saved to `data/settings.json`.  Keys include: `volume`, `theme`,
@@ -528,10 +542,12 @@ Trainable models are persisted as JSON files in `data/trainable_models/`
 via the `trainable_models_bp` route blueprint.  Each stores a name,
 text query, media type, examples list, and labelset.
 
-**Only Flask routes mutate this state.**  All ML and dataset functions
-accept state as parameters — they never import it directly.  This means
-you can use the ML code in a script or notebook by passing your own
-dicts.
+**Primarily Flask routes mutate this state.**  Most ML and dataset
+functions accept state as parameters — so you can use the ML code in a
+script or notebook by passing your own dicts. A few modules (notably
+`training_workflow.py` and `labels/sync.py`) import specific helpers
+and resolve the active context via Flask's `g` or thread-local storage,
+but these are the exceptions rather than the rule.
 
 ### State submodule organisation
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -76,24 +76,32 @@ Items with origin information include the origin display string before the filen
 
 ## Web server modes
 
-**Default (production) mode** — binds to `127.0.0.1:5000` (localhost only):
+**Development (Flask dev server)** — bind to `0.0.0.0:5000`:
 
 ```bash
 python app.py
 ```
 
-**Local mode** (`--local`) — binds to `0.0.0.0:5000` (accessible from other
-devices on the network):
+A `--local` flag is accepted for historical reasons and only changes the
+banner text (`LOCAL` vs. `PRODUCTION`); the bind address is the same either
+way. This entry point uses Flask's built-in dev server and is not
+recommended for production.
+
+**Production (gunicorn)** — run the WSGI app under the bundled config:
 
 ```bash
-python app.py --local
+VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
 ```
 
-Both modes run the same startup sequence (model initialization, autoload
-preloading, settings source sync). The only difference is the network bind
-address.
+`VTSEARCH_SERVER_INIT=1` runs the same startup sequence (model
+initialization, autoload preloading, settings-source sync) that `python
+app.py` runs — gunicorn imports `app.py` rather than executing its
+`__main__` block, so the env var is what triggers initialization. The
+bundled Docker images already run gunicorn this way. See
+[DEPLOYMENT.md](DEPLOYMENT.md#gunicorn-tuning) for tuning.
 
-**Authentication mode** (`--login`) — select the login provider:
+**Authentication mode** (`--login`) — select the login provider (dev
+server only; set up the provider in code when running under gunicorn):
 
 ```bash
 python app.py --login trivial    # multi-user mode with simple username auth

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,27 +7,115 @@ installation and getting started, see [SETUP.md](SETUP.md).
 ## Table of Contents
 
 1. [Environment variables](#environment-variables)
-2. [Network dependencies](#network-dependencies)
-3. [Offline deployment](#offline-deployment)
-4. [Data directory layout](#data-directory-layout)
-5. [Docker production notes](#docker-production-notes)
-6. [Requirements file structure](#requirements-file-structure)
-7. [Troubleshooting](#troubleshooting)
+2. [Running under gunicorn](#running-under-gunicorn)
+3. [Network dependencies](#network-dependencies)
+4. [Offline deployment](#offline-deployment)
+5. [Data directory layout](#data-directory-layout)
+6. [Docker production notes](#docker-production-notes)
+7. [Requirements file structure](#requirements-file-structure)
+8. [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Environment variables
 
+### Application
+
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `VTSEARCH_SECRET_KEY` | `vtsearch-dev-key-change-in-production` | Flask session secret key — **set this to a random value in production** |
+| `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
+
+### Gunicorn / WSGI (production)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn — triggers model init / autoload / settings-source sync at import time (the Flask `__main__` block is skipped under WSGI). Set automatically in the Dockerfiles. |
+| `VTSEARCH_BIND` | `0.0.0.0:5000` | Gunicorn bind address (`host:port`) |
+| `VTSEARCH_THREADS` | `8` | Threads per gunicorn worker |
+| `VTSEARCH_TIMEOUT` | `120` | Worker request timeout in seconds; `0` disables |
+
+### HuggingFace / PyTorch
+
+| Variable | Default | Description |
+|----------|---------|-------------|
 | `HF_HUB_OFFLINE` | unset | Set to `1` to prevent any HuggingFace Hub downloads |
 | `HF_HUB_DISABLE_IMPLICIT_TOKEN` | `1` (set by app) | Disables HuggingFace auth tokens (all models are public) |
+| `TRANSFORMERS_NO_ADVISORY_WARNINGS` | `1` (set by app) | Suppresses advisory warnings from `transformers` |
 | `OMP_NUM_THREADS` | `1` (set by app) | OpenMP thread count; kept at 1 for memory optimization |
 | `MKL_NUM_THREADS` | `1` (set by app) | Intel MKL thread count; kept at 1 for memory optimization |
+
+### Docker / GPU
+
+| Variable | Default | Description |
+|----------|---------|-------------|
 | `PYTHONUNBUFFERED` | `1` (set in Dockerfiles) | Disables Python output buffering for real-time logs |
 | `NVIDIA_VISIBLE_DEVICES` | `all` (GPU Dockerfile) | GPU visibility for NVIDIA Container Toolkit |
 | `NVIDIA_DRIVER_CAPABILITIES` | `compute,utility` (GPU Dockerfile) | GPU driver capabilities |
+
+---
+
+## Running under gunicorn
+
+For production, run the app under [gunicorn](https://gunicorn.org/) using
+the bundled config:
+
+```bash
+VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
+```
+
+`python app.py` runs Flask's built-in dev server and is intended for
+development only. The Docker images already use gunicorn via the CMD in
+`Dockerfile` and `Dockerfile.gpu`, so this only applies if you are
+running outside Docker.
+
+### Why `VTSEARCH_SERVER_INIT=1`?
+
+`app.py` runs its startup sequence (model init, embedder preload,
+settings-source sync) from its `if __name__ == "__main__":` block.
+Gunicorn **imports** `app.py` rather than executing it, so that block
+never runs. Setting `VTSEARCH_SERVER_INIT=1` tells `app.py` to also run
+`initialize_server()` at import time. The Dockerfiles set this env var
+automatically.
+
+### `gunicorn.conf.py`
+
+The bundled config pins a single worker with 8 gthread threads:
+
+```python
+workers = 1
+worker_class = "gthread"
+threads = 8
+timeout = 120
+```
+
+**Why one worker?** VTSearch keeps all dataset/model state in-process
+(multi-dataset context, global registries, RLock-protected mutable
+state). Multiple worker processes would each hold their own independent
+copy — which wastes memory and breaks cross-request state continuity.
+Concurrency comes from threads within the single worker, matching the
+Flask dev server's `threaded=True` behaviour.
+
+### Tuning
+
+Override the relevant config via environment variables:
+
+| Env var | Default | Notes |
+|---------|---------|-------|
+| `VTSEARCH_BIND` | `0.0.0.0:5000` | `host:port` |
+| `VTSEARCH_THREADS` | `8` | Threads per worker — raise for more concurrent requests |
+| `VTSEARCH_TIMEOUT` | `120` | Worker timeout in seconds; `0` disables |
+| `VTSEARCH_LOG_LEVEL` | `warning` | Gunicorn log level |
+
+For larger tuning changes, edit `gunicorn.conf.py` directly.
+
+### Reverse proxy
+
+For public deployments, put nginx / Caddy / Traefik in front of gunicorn
+to handle TLS, gzip, and static-asset caching. Flask serves the Angular
+build from `static/` directly, but a dedicated reverse proxy is much
+more efficient for that traffic.
 
 ---
 
@@ -187,9 +275,9 @@ It is created automatically on first startup.
 
 ```
 data/
-├── models/                           # HuggingFace model cache (~3.1 GB total)
+├── models/                           # HuggingFace model cache (~3.2 GB total)
 │   ├── models--laion--clap-htsat-unfused/
-│   ├── models--openai--clip-vit-base-patch32/
+│   ├── models--google--siglip-base-patch16-224/
 │   ├── models--microsoft--xclip-base-patch32/
 │   └── models--intfloat--e5-base-v2/
 ├── embeddings/                       # Cached dataset embeddings (.pkl files)
@@ -206,7 +294,7 @@ data/
 
 | Path | Preserve? | Why |
 |------|-----------|-----|
-| `data/models/` | **Yes** | Re-downloading is slow (~3.1 GB) |
+| `data/models/` | **Yes** | Re-downloading is slow (~3.2 GB) |
 | `data/embeddings/` | **Yes** | Contains cached embeddings; losing them means recomputing |
 | `data/settings.json` | **Yes** | User preferences, trained detectors, autorun processors |
 | `data/trainable_models/` | **Yes** | Persistent trainable model definitions with labelsets |
@@ -250,7 +338,9 @@ and auto-saved on every change. Schema:
   "autorun_detector_names": [],
   "saved_datasets_dir": "data/saved_datasets",
   "detectors_dir": "data/detectors",
-  "trainable_models_dir": "data/trainable_models"
+  "trainable_models_dir": "data/trainable_models",
+  "max_concurrent_dataset_downloads": 1,
+  "max_concurrent_dataset_embeddings": 1
 }
 ```
 
@@ -263,6 +353,16 @@ Notable fields:
   importer name, processor name, and field values
 - `saved_datasets_dir`, `detectors_dir`, `trainable_models_dir` —
   infrastructure directories (overridable for custom data layouts)
+- `max_concurrent_dataset_downloads` /
+  `max_concurrent_dataset_embeddings` — concurrency gates for dataset
+  loading. The download gate covers the bandwidth/disk-bound import
+  phase; the embed gate covers CPU/GPU-bound embedding plus post-load
+  clipping, dedup, and diversity-tree construction. Changes take
+  effect on queued and future loads (running tasks are never
+  preempted). Defaults are `1/1` (serialised).
+- `settings_source` (not shown above; excluded from defaults) — opt-in
+  bidirectional sync. Set to a plugin name + field values to auto-export
+  every settings change and auto-import at startup. See `settings_io/sources/`.
 - `theme` — `"dark"`, `"light"`, or `"highviz"`
 - `view_mode_*`, `grid_icon_size_*`, `focus_mode_*`, `panel_pct_*` —
   per-media-type UI layout preferences (keyed by media type ID)
@@ -271,6 +371,11 @@ Notable fields:
 ---
 
 ## Docker production notes
+
+Both images run the app under gunicorn with the bundled `gunicorn.conf.py`
+(single worker + gthread threads) — not Flask's dev server — and set
+`VTSEARCH_SERVER_INIT=1` so the startup sequence runs at WSGI import
+time. See [Running under gunicorn](#running-under-gunicorn) for tuning.
 
 ### CPU deployment
 
@@ -308,7 +413,7 @@ docker run -p 5000:5000 -v /path/on/host:/app/data vtsearch
   With all four loaded simultaneously, expect ~4–6 GB total application
   memory. Models are loaded lazily — only the media types actually used are
   loaded.
-- **Disk**: The `data/models/` directory uses ~3.1 GB. Dataset embeddings
+- **Disk**: The `data/models/` directory uses ~3.2 GB. Dataset embeddings
   and media files vary by dataset size.
 - **CPU**: `OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1` are set to reduce
   per-operation memory. This trades single-operation throughput for lower

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -85,11 +85,17 @@ serialisation. All plugin base classes inherit from it.
 ### PluginRegistry (Auto-Discovery)
 
 All plugin families use `PluginRegistry` for auto-discovery. The
-registry uses direct filesystem scanning (`Path.iterdir()`) to find
-**sub-packages** (directories with `__init__.py`) under the plugin
-directory. For each sub-package, it imports the module and looks for a
-module-level sentinel attribute. If found, the plugin is registered by
-its `name`.
+registry uses direct filesystem scanning (`Path.iterdir()`) under the
+plugin package directory. It discovers both **sub-packages**
+(directories with `__init__.py`) and, for registries created with
+`discover_modules=True`, **flat `.py` modules** (excluding `__init__.py`
+and `base.py`). In each module it looks for a module-level sentinel
+attribute; if found, the plugin is registered by its `name`.
+
+Most plugin families use sub-packages, which pair well with per-plugin
+`requirements.txt` files. The exception is **media sources**
+(`vtsearch.datasets.sources`), which use flat `.py` modules
+(`local_folder.py`, `http_archive.py`, `pullwrest.py`).
 
 | Plugin Family       | Package                            | Sentinel              | Base Class          |
 |---------------------|------------------------------------|-----------------------|---------------------|

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -70,13 +70,21 @@ class MyProvider(LoginProvider):
 `DefaultLoginProvider` (the default) returns `"default"` for every request,
 is always authenticated, and uses the shared `data/` directory.
 
-### Current limitations
+### Current scope
 
-In-memory state (votes, medias, labels, settings) is globally shared.
-The auth infrastructure supports ownership tracking (`created_by`) and
-per-user data directories, but full runtime state isolation is not yet
-implemented. Custom providers should be aware that votes and loaded
-datasets are shared across all users.
+Per-dataset runtime state (`medias`, diversity tree, display name) is
+isolated in `DatasetContext` objects, and per-detector state (votes,
+label history, click times, learned scores, inclusion, labelset source)
+is isolated in `DetectorContext` objects. The frontend sends
+`X-Dataset-Id` / `X-Model-Id` headers, and a `before_request`
+middleware resolves the active contexts per request — so multiple users
+can work with different datasets/models simultaneously.
+
+The auth infrastructure supports ownership tracking (`created_by` on
+detectors, datasets, and trainable models) and per-user data
+directories via `get_user_data_dir(username, base)`. **Settings remain
+globally shared** across all users — there is no per-user settings
+isolation yet.
 
 ---
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -63,8 +63,11 @@ deployments. Runs locally or in Docker.
 ```bash
 python3 -m venv venv && source venv/bin/activate
 bash install-cpu.sh
-python app.py --local        # binds to 0.0.0.0 (network-accessible)
+python app.py                # Flask dev server on 0.0.0.0:5000
 ```
+
+For production, run under gunicorn instead:
+`VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app`.
 
 ### Docker (recommended for deployment)
 

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -1,6 +1,6 @@
 # Machine Learning Details
 
-VTSearch uses a small MLP (multi-layer perceptron) neural network to learn a binary classifier from user votes ("good" vs "bad"). The model operates on embeddings produced by pretrained feature extractors and outputs a score in [0, 1] for each item in the dataset.
+VTSearch uses a small MLP (multi-layer perceptron) neural network to learn a binary classifier from user votes ("good" vs "bad"). The model operates on embeddings produced by pretrained feature extractors (LAION-CLAP for audio, SigLIP for images, X-CLIP for video, E5-base-v2 for text) and outputs a score in [0, 1] for each item in the dataset.
 
 ## Architecture
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -209,7 +209,7 @@ npm start
 
 ## Running the app
 
-Start the server:
+For local development, start the Flask dev server:
 
 ```bash
 python app.py
@@ -218,14 +218,20 @@ python app.py
 You should see output like:
 
 ```
- * Running on http://127.0.0.1:5000
+ * Running on http://0.0.0.0:5000
 ```
 
-Open that URL in your browser. Use `--local` mode to bind to `0.0.0.0:5000` (accessible from other devices on the network) instead of localhost only:
+Open `http://localhost:5000` in your browser. The server binds to `0.0.0.0:5000`, so it is also reachable from other devices on the network.
+
+`python app.py` uses Flask's built-in dev server — fine for development but **not recommended for production**. For production, run under gunicorn using the bundled config:
 
 ```bash
-python app.py --local
+VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
 ```
+
+`VTSEARCH_SERVER_INIT=1` triggers the same startup sequence (model init, autoload preloading, settings-source sync) that `python app.py` runs, since gunicorn imports `app.py` rather than executing its `__main__` block. `gunicorn.conf.py` pins a single worker with 8 threads — VTSearch keeps all dataset/model state in-process, so multiple workers would each hold their own copy. See [DEPLOYMENT.md](DEPLOYMENT.md#gunicorn-tuning) for tuning.
+
+The Docker images already use this configuration (see [Docker](#docker) below).
 
 ## Docker
 
@@ -347,8 +353,12 @@ VTSearch reads several optional environment variables:
 | `VTSEARCH_SECRET_KEY` | `vtsearch-dev-key-change-in-production` | Flask session secret key (set this in production) |
 | `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
+| `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn — triggers model init / settings sync at import time |
+| `VTSEARCH_BIND` | `0.0.0.0:5000` | Gunicorn bind address (`host:port`) |
+| `VTSEARCH_THREADS` | `8` | Threads per gunicorn worker |
+| `VTSEARCH_TIMEOUT` | `120` | Gunicorn worker timeout in seconds |
 
-See [DEPLOYMENT.md](DEPLOYMENT.md) for additional deployment-specific configuration.
+See [DEPLOYMENT.md](DEPLOYMENT.md) for additional deployment-specific configuration, including the full env-var reference and gunicorn tuning.
 
 ## Next steps
 


### PR DESCRIPTION
Partial fetches (e.g. 'git fetch origin main') leave other
remote-tracking refs stale, which caused a misread of dev vs main
state earlier in this session.