### PR TITLE
Add embed_medias() dict-wrapper for id-keyed bulk embedding

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -377,6 +377,21 @@ pending file; the default implementation loops over `embed_media`
 per item and emits progress via `self._on_progress`, so custom
 overrides that batch internally should emit their own progress too.
 
+Importer code that has already built a `dict[int, dict]` of medias
+(keyed by media ID) can call the dict-shaped sugar wrapper directly:
+
+```python
+# medias: dict[int, dict] keyed by 1-based media ID
+vectors = emb.embed_medias(medias)  # -> dict[int, Optional[np.ndarray]]
+for media_id, vec in vectors.items():
+    if vec is not None:
+        medias[media_id]["embedding"] = vec
+```
+
+`embed_medias` delegates to `embed_media_bulk` internally — subclasses
+only need to override `_embed_media_bulk_impl` to gain a native bulk
+path; the dict wrapper picks it up automatically.
+
 ### Register the embedder
 
 Drop the embedder into an `embedder*.py` file inside the media-type
@@ -422,6 +437,13 @@ loaded via `spec_from_file_location` so discovery still works.
 | `embed_text(text)`                    | `(str) -> Optional[np.ndarray]`                    | Embed a text query (default: `None`) |
 | `embed_text_enriched(text)`           | `(str) -> Optional[np.ndarray]`                    | Average over `description_wrappers`  |
 | `_embed_media_bulk_impl(medias)`      | `(list[dict]) -> list[Optional[np.ndarray]]`       | Embed a list of medias. Default loops over `embed_media` with per-item progress. Override for a native bulk path (e.g. a remote API that accepts many items per request); overrides that batch internally must emit their own progress through `self._on_progress`. |
+
+**Convenience wrappers (don't override these):**
+
+| Method                                | Signature                                                       | Description                          |
+|---------------------------------------|-----------------------------------------------------------------|--------------------------------------|
+| `embed_media_bulk(medias)`            | `(list[dict]) -> list[Optional[np.ndarray]]`                    | List-shaped public entrypoint. Calls `_embed_media_bulk_impl` and short-circuits empty input. |
+| `embed_medias(medias)`                | `(dict[int, dict]) -> dict[int, Optional[np.ndarray]]`          | Sugar for callers with id-keyed medias (e.g. importers). Delegates to `embed_media_bulk`, pairs vectors back to input keys. |
 
 **Optional overridable properties:**
 

--- a/tests/test_bulk_embedding.py
+++ b/tests/test_bulk_embedding.py
@@ -343,3 +343,134 @@ class TestChunkedLoaderBulkPerChunk:
         assert emb.embed_media_bulk.call_count == 2
         for call in emb.embed_media_bulk.call_args_list:
             assert len(call.args[0]) == 2
+
+
+# ---------------------------------------------------------------------------
+# embed_medias: dict-keyed convenience wrapper around embed_media_bulk
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedMediasDictWrapper:
+    """``embed_medias`` is a sugar wrapper for callers that already have
+    medias keyed by ID (e.g. importers building the medias dict before
+    embedding).  It delegates to ``embed_media_bulk`` and pairs vectors
+    back to the original IDs."""
+
+    def test_returns_dict_keyed_by_input_ids(self):
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                return np.array([float(media["tag"])], dtype=np.float32)
+
+        emb = _Stub()
+        emb._model = True
+
+        medias = {1: {"tag": 10}, 2: {"tag": 20}, 7: {"tag": 70}}
+        out = emb.embed_medias(medias)
+
+        assert set(out.keys()) == {1, 2, 7}
+        assert out[1][0] == 10.0
+        assert out[2][0] == 20.0
+        assert out[7][0] == 70.0
+
+    def test_handles_sparse_keys(self):
+        """Non-contiguous keys (e.g. post-collapse_duplicates) round-trip."""
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                return np.array([float(media["tag"])], dtype=np.float32)
+
+        emb = _Stub()
+        emb._model = True
+
+        medias = {1: {"tag": 1}, 3: {"tag": 3}, 5: {"tag": 5}}
+        out = emb.embed_medias(medias)
+        assert list(out.keys()) == [1, 3, 5]
+        assert out[3][0] == 3.0
+
+    def test_propagates_none_for_failed_embeddings(self):
+        """A None vector from the underlying bulk call surfaces as None
+        at the matching key — no silent dropping like the loader does."""
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                if media["tag"] == "skip":
+                    return None
+                return np.array([1.0], dtype=np.float32)
+
+        emb = _Stub()
+        emb._model = True
+
+        out = emb.embed_medias({1: {"tag": "ok"}, 2: {"tag": "skip"}, 3: {"tag": "ok"}})
+        assert out[1] is not None
+        assert out[2] is None
+        assert out[3] is not None
+
+    def test_empty_dict_returns_empty_dict(self):
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                raise AssertionError("should not be called for empty dict")
+
+        emb = _Stub()
+        assert emb.embed_medias({}) == {}
+
+    def test_delegates_to_embed_media_bulk(self):
+        """The wrapper calls embed_media_bulk once with values in key order."""
+        emb = _make_bulk_embedder()
+        medias = {10: {"x": 1}, 20: {"x": 2}, 30: {"x": 3}}
+
+        out = emb.embed_medias(medias)
+
+        assert emb.embed_media_bulk.call_count == 1
+        sent = emb.embed_media_bulk.call_args.args[0]
+        assert sent == [{"x": 1}, {"x": 2}, {"x": 3}]
+        assert set(out.keys()) == {10, 20, 30}

--- a/tests/test_bulk_embedding.py
+++ b/tests/test_bulk_embedding.py
@@ -465,12 +465,38 @@ class TestEmbedMediasDictWrapper:
 
     def test_delegates_to_embed_media_bulk(self):
         """The wrapper calls embed_media_bulk once with values in key order."""
-        emb = _make_bulk_embedder()
-        medias = {10: {"x": 1}, 20: {"x": 2}, 30: {"x": 3}}
+        from vtsearch.media.embedder import MediaEmbedder
 
+        captured: list[list[dict]] = []
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "audio"
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                return np.array([float(media["x"])], dtype=np.float32)
+
+            def _embed_media_bulk_impl(self, medias):
+                captured.append(list(medias))
+                return [np.array([float(m["x"])], dtype=np.float32) for m in medias]
+
+        emb = _Stub()
+        emb._model = True
+
+        medias = {10: {"x": 1}, 20: {"x": 2}, 30: {"x": 3}}
         out = emb.embed_medias(medias)
 
-        assert emb.embed_media_bulk.call_count == 1
-        sent = emb.embed_media_bulk.call_args.args[0]
-        assert sent == [{"x": 1}, {"x": 2}, {"x": 3}]
+        assert len(captured) == 1
+        assert captured[0] == [{"x": 1}, {"x": 2}, {"x": 3}]
         assert set(out.keys()) == {10, 20, 30}
+        assert out[10][0] == 1.0
+        assert out[20][0] == 2.0
+        assert out[30][0] == 3.0

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -520,6 +520,22 @@ class MediaEmbedder(ABC):
             results.append(self.embed_media(m))
         return results
 
+    def embed_medias(self, medias: dict[int, dict]) -> dict[int, Optional[np.ndarray]]:
+        """Bulk-embed an id→media dict; return id→vector (or ``None``) dict.
+
+        Convenience wrapper around :meth:`embed_media_bulk` for callers that
+        already have medias keyed by ID — typically dataset importers that
+        have built the medias dict before embedding.  IDs whose embedding
+        failed map to ``None`` in the returned dict, mirroring the position-
+        based ``None`` contract of :meth:`embed_media_bulk`.
+        """
+        if not medias:
+            return {}
+        keys = list(medias.keys())
+        values = [medias[k] for k in keys]
+        vectors = self.embed_media_bulk(values)
+        return dict(zip(keys, vectors))
+
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         """Return an embedding of *text* in the **same vector space** as :meth:`embed_media`.
 


### PR DESCRIPTION
## Summary

- Adds `MediaEmbedder.embed_medias(dict[int, dict]) -> dict[int, Optional[np.ndarray]]` as a thin sugar wrapper around `embed_media_bulk` for callers that already have medias keyed by ID (e.g. dataset importers that build the medias dict before embedding).
- Subclass contract is unchanged — `_embed_media_bulk_impl` still takes `list[dict]`. Subclasses that override the bulk hook automatically pick up the dict-shaped wrapper.
- Failed embeds map to `None` at their key, mirroring the position-based `None` contract of `embed_media_bulk`.

## Why a wrapper instead of changing the bulk signature

PR #1145 just consolidated the embedder ABC around a single list-shaped `embed_media_bulk` entrypoint and pushed batching responsibility into subclasses. Switching that to a dict would force every subclass that builds a tensor / request body to call `list(medias.values())` first, and would force `_bulk_embed_files` (the pre-registration loader path, where items don't have IDs yet) to invent synthetic keys. The wrapper gives importer code dict-in/dict-out ergonomics without touching the contract that other call sites rely on.

## Test plan

- [x] `tests/test_bulk_embedding.py` — added `TestEmbedMediasDictWrapper` (5 tests: id-keyed return, sparse keys, None propagation, empty dict, delegates to `embed_media_bulk`)
- [x] Full fast CPU suite: 2966 passed, 1 skipped, 75 deselected (gpu/slow), 2 xpassed
- [x] `docs/EXTENDING-media.md` updated with usage example and reference table entry

https://claude.ai/code/session_01SSHRimQMXVoAtWfe64QDBV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSHRimQMXVoAtWfe64QDBV)_