### PR TITLE
CLAUDE.md: always open a PR targeting dev when changes are done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 
 Before comparing branches (`git log a..b`, `git diff a...b`, etc.), always run `git fetch origin --prune` first. Do **not** trust `origin/<branch>` refs after a partial fetch like `git fetch origin main` — that only updates the branch you named, leaving other remote-tracking refs stale and producing misleading diffs.
 
-## Auto-PR After Successful Tests
+## Auto-PR
 
-After pushing code changes and successfully running tests, **automatically create a PR targeting `dev`**. Do not ask — just create it. This applies whenever Claude both pushes and verifies tests pass in the same session.
+When you're done with your changes, open a PR targeting `dev`. Do not ask — just create it. Always pass `base=dev` explicitly (the GitHub PR-creation URL printed by `git push` defaults to `main`).
 
 ## PR Activity Subscription (do not ask)
 


### PR DESCRIPTION
## Summary

- Replace the "Auto-PR After Successful Tests" rule with a simpler "Auto-PR" rule: when changes are done, open a PR targeting `dev`.
- Drop the test-pass gate from the rule — tests-before-done is already covered by the Test Workflow section, and the gate caused docs-only pushes to be skipped (which left a branch pushed without a PR earlier this session).
- Note the GitHub PR-creation URL trap: the link printed by `git push` defaults to the repo's default branch (`main`), so always pass `base=dev` explicitly via the GitHub MCP tools.

## Test plan

- [ ] No code changes — CLAUDE.md only

https://claude.ai/code/session_016kVXkcnCFMtcfBhJQXkkuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Um763BcTZ9dPXMWaBp7cec)_