### PR TITLE
Lock New Model and Add Labels modals to a single fixed width

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -43,6 +43,8 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 480px;
+  max-width: 100%;
 }
 
 .form-group {
@@ -140,6 +142,8 @@
 // Media picker view
 .media-picker {
   min-height: 200px;
+  width: 480px;
+  max-width: 100%;
 }
 
 .back-btn {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 480px;
+  max-width: 100%;
 }
 
 .importer-card {
@@ -42,6 +44,8 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 480px;
+  max-width: 100%;
 }
 
 .back-btn {
@@ -91,6 +95,8 @@
   margin-top: 16px;
   padding-top: 16px;
   border-top: 1px solid var(--border);
+  width: 480px;
+  max-width: 100%;
 }
 
 .add-media-heading {


### PR DESCRIPTION
## Summary

Both the **New Model** dialog and the **Add Labels to Model** dialog reflowed as the user navigated between tabs and views — Blank vs. Trained, picker vs. form, with vs. without a selected label importer. The width jumped at every transition, which felt jarring.

`vt-modal`'s `.modal-content` sizes naturally to its inner content (clamped between `min-width: 320px` and `max-width: 90vw`), so the dialog tracks whatever the active sub-view happens to need. Now the top-level containers inside each dialog are pinned to a single width, so the modal box stays put across every state.

### Changes

- `new-model-modal.component.scss`: `width: 480px; max-width: 100%` on `.new-model-form` and `.media-picker`.
- `label-importer-modal.component.scss`: same on `.importer-picker`, `.importer-form`, and `.add-media-section` (all three are top-level siblings inside the modal body, so each needs the lock for the picker view to stay the same width as the form view).

`max-width: 100%` keeps the modal usable on narrow viewports — the existing `max-width: 90vw` on `.modal-content` continues to clamp the outer box, and the inner containers shrink with it.

## Test plan
- [ ] Open the New Model dialog, click between **Blank** and **Trained** tabs — modal width does not change.
- [ ] On the **Trained** tab, select a label importer (e.g. server JSON file) and confirm the modal stays the same width as the picker.
- [ ] Click **Back** in the importer form — width still unchanged.
- [ ] Open the Add Labels to Model dialog, switch between the importer picker and a selected importer's form — same width throughout.
- [ ] Resize the browser narrow (≤ ~530px) and confirm both dialogs shrink rather than overflow.

https://claude.ai/code/session_01A2yTu51tcXYZkrjYjAMjZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2yTu51tcXYZkrjYjAMjZb)_