### PR TITLE
Unify header styling in New Model modal

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -13,7 +13,7 @@
 
     <form class="new-model-form" (ngSubmit)="submit()">
       <div class="form-group">
-        <label for="model-name" title="A short name to identify this model">Model Name <span class="required">*</span></label>
+        <label class="col-label" for="model-name" title="A short name to identify this model">Model Name <span class="required">*</span></label>
         <input
           id="model-name"
           class="form-input"
@@ -27,7 +27,7 @@
 
       @if (tab === 'blank') {
         <div class="form-group">
-          <label title="The type of media this model will process">Media Type</label>
+          <label class="col-label" title="The type of media this model will process">Media Type</label>
           <div class="custom-select" [class.open]="mediaTypeDropdownOpen" title="The type of media this model will process">
             <button type="button" class="custom-select-trigger form-input" (click)="mediaTypeDropdownOpen = !mediaTypeDropdownOpen" title="Select the media type for this model">
               <span class="select-option-content">
@@ -128,7 +128,7 @@
             @if (selectedLabelImporter.fields && selectedLabelImporter.fields.length > 0) {
               @for (field of selectedLabelImporter.fields; track field.key) {
                 <div class="form-group">
-                  <label class="form-label" [for]="'nmm-' + field.key">
+                  <label class="col-label" [for]="'nmm-' + field.key">
                     {{ field.label || field.key }}
                     @if (field.required) {
                       <span class="required">*</span>


### PR DESCRIPTION
## Summary
- Apply the `col-label` class to "Model Name" and "Media Type" in the Blank tab so they match "Text Example" and "Media Example"
- Apply the same `col-label` class to the dynamic label-importer field labels in the Trained tab (e.g. "Server File Path") so they match "Model Name" and "Label Importer"
- Net effect: all section headers in the New Model dialog share the same font weight (600), size (0.85rem), and muted secondary color

## Test plan
- [ ] Open the New Model modal, Blank tab — "Model Name", "Media Type", "Text Example", "Media Example" all render with the same header style
- [ ] Switch to the Trained tab, pick a label importer (e.g. Server CSV File) — "Model Name", "Label Importer", and the importer's dynamic fields (e.g. "Server File Path") all match

https://claude.ai/code/session_01VtC5dtj2FVxKMpgxfV9BG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtC5dtj2FVxKMpgxfV9BG5)_