### PR TITLE
Add tooltips to New Model dialog tabs and remaining bare controls

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -4,11 +4,13 @@
       <button type="button" class="tab-btn" role="tab"
         [class.active]="tab === 'blank'"
         [attr.aria-selected]="tab === 'blank'"
-        (click)="setTab('blank')">Blank</button>
+        (click)="setTab('blank')"
+        title="Start a fresh model from a single text description or media example. The model learns from your votes as you label.">Blank</button>
       <button type="button" class="tab-btn" role="tab"
         [class.active]="tab === 'trained'"
         [attr.aria-selected]="tab === 'trained'"
-        (click)="onSelectTrainedTab()">Trained</button>
+        (click)="onSelectTrainedTab()"
+        title="Create a model pre-trained on labels imported from an external source (file, URL, or service).">Trained</button>
     </div>
 
     <form class="new-model-form" (ngSubmit)="submit()">
@@ -128,7 +130,8 @@
             @if (selectedLabelImporter.fields && selectedLabelImporter.fields.length > 0) {
               @for (field of selectedLabelImporter.fields; track field.key) {
                 <div class="form-group">
-                  <label class="form-label" [for]="'nmm-' + field.key">
+                  <label class="form-label" [for]="'nmm-' + field.key"
+                    [title]="field.description || field.label || field.key">
                     {{ field.label || field.key }}
                     @if (field.required) {
                       <span class="required">*</span>
@@ -148,6 +151,7 @@
                       type="file"
                       class="form-input"
                       [accept]="field.accept || ''"
+                      [title]="field.description || field.label || field.key"
                       (change)="onLabelImporterFileSelected($event, field.key)"
                     />
                   } @else if (field.field_type === 'password') {
@@ -158,6 +162,7 @@
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
                       [placeholder]="field.placeholder || field.description || field.label || field.key"
+                      [title]="field.description || field.label || field.key"
                     />
                   } @else if (field.field_type === 'email') {
                     <input
@@ -167,6 +172,7 @@
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
                       [placeholder]="field.placeholder || field.description || field.label || field.key"
+                      [title]="field.description || field.label || field.key"
                     />
                   } @else if (field.field_type === 'url') {
                     <input
@@ -176,6 +182,7 @@
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
                       [placeholder]="field.placeholder || field.description || field.label || field.key"
+                      [title]="field.description || field.label || field.key"
                     />
                   } @else if (field.field_type === 'select') {
                     <select
@@ -183,6 +190,7 @@
                       class="form-select"
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
+                      [title]="field.description || field.label || field.key"
                     >
                       @for (opt of field.options || []; track opt) {
                         <option [value]="opt">{{ opt }}</option>
@@ -196,6 +204,7 @@
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
                       [placeholder]="field.placeholder || field.description || field.label || field.key"
+                      [title]="field.description || field.label || field.key"
                     />
                   }
                 </div>
@@ -215,13 +224,15 @@
 
   @if (view === 'main') {
     <div modal-footer>
-      <button class="btn btn--secondary" (click)="close()">Cancel</button>
+      <button class="btn btn--secondary" (click)="close()" title="Discard this model and close the dialog">Cancel</button>
       @if (tab === 'blank') {
-        <button class="btn btn--primary" [disabled]="!canSubmitBlank" (click)="submit()">
+        <button class="btn btn--primary" [disabled]="!canSubmitBlank" (click)="submit()"
+          title="Create the model with the example you provided">
           {{ submitting ? 'Creating...' : 'Create' }}
         </button>
       } @else {
-        <button class="btn btn--primary" [disabled]="!canSubmitTrained" (click)="submit()">
+        <button class="btn btn--primary" [disabled]="!canSubmitTrained" (click)="submit()"
+          title="Create the model and import labels from the selected source">
           {{ submitting ? 'Importing...' : 'Create & Import' }}
         </button>
       }


### PR DESCRIPTION
## Summary
- Adds `title` tooltips to the **Blank** and **Trained** tabs in the New Model dialog (the tabs were the only controls in the modal with no hover text).
- Fills in tooltips on the remaining bare controls in the same dialog: the **Cancel** button, the **Create** / **Create & Import** submit buttons, and the dynamically generated **Label Importer** form fields (label + input/select/file inputs use `field.description` with sensible fallbacks).
- All additions follow the existing native `title=`/`[title]=` pattern already used elsewhere in this component and in the left-panel tabs.

## Test plan
- [ ] Open the New Model dialog and hover the **Blank** and **Trained** tabs — verify a tooltip appears.
- [ ] Hover **Cancel** and **Create** / **Create & Import** in the footer — verify tooltips.
- [ ] Switch to the **Trained** tab, pick a label importer with declared fields, and hover its labels and inputs — verify tooltips reflect each field's description.

https://claude.ai/code/session_01UgmwdQTbJxHBXFXpaz6mn5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgmwdQTbJxHBXFXpaz6mn5)_