### PR TITLE
Auto-create saved_datasets_dir when browsing from server

### DIFF
--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -221,9 +221,8 @@ def _resolve_browse_root(source: str) -> Path | None:
         from vtsearch.settings import get_saved_datasets_dir
 
         ds_dir = get_saved_datasets_dir()
-        if ds_dir.is_dir():
-            return ds_dir.resolve()
-        return None
+        ds_dir.mkdir(parents=True, exist_ok=True)
+        return ds_dir.resolve()
 
     return None
 


### PR DESCRIPTION
## Summary
- The "Import from Server" → "folder" browse flow used to return 404 if the saved-datasets directory had not yet been created. Today the directory is only created as a side effect of `_auto_register_dataset()` after a dataset finishes loading (`vtsearch/datasets/load_pipeline.py:467`), which means a fresh offline install has no way to reach the folder-import path — the very first try fails.
- Fix: create the directory on demand inside `_resolve_browse_root("folder")` so the default load-from-folder workflow works on first try, with no demo dataset required.

## Test plan
- [ ] Fresh offline launch → `/api/browse-media-files?source=folder` returns the (empty) directory listing instead of 404.
- [ ] Existing tests still pass: `./run-tests.sh datasets api`.
- [ ] Changing `saved_datasets_dir` at runtime to a missing path and immediately browsing it works (the new path is auto-created).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VuQcNCYkm5WJzgtBrcL93Q)_