### PR TITLE
Merge dev into main

### DIFF
--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -221,9 +221,8 @@ def _resolve_browse_root(source: str) -> Path | None:
         from vtsearch.settings import get_saved_datasets_dir
 
         ds_dir = get_saved_datasets_dir()
-        if ds_dir.is_dir():
-            return ds_dir.resolve()
-        return None
+        ds_dir.mkdir(parents=True, exist_ok=True)
+        return ds_dir.resolve()
 
     return None
 


### PR DESCRIPTION
## Summary of changes since the last dev→main merge

Dev is 2 commits ahead of main, consisting of a single merged PR (#1160).

### #1160 — Auto-create `saved_datasets_dir` when browsing from server

**Problem:** The "Import from Server" → "folder" browse flow returned 404 if the saved-datasets directory had not yet been created. The directory was previously only created as a side effect of finishing a dataset load, so offline users hitting the folder import path on a fresh install had no way to make it appear.

**Fix:** `_resolve_browse_root("folder")` in `vtsearch/routes/datasets_ui.py` now creates the directory on demand (`mkdir(parents=True, exist_ok=True)`) instead of returning `None` when it doesn't exist. The default load-from-folder workflow now works on first try.

**Diff:** 1 file changed, 2 insertions, 3 deletions in `vtsearch/routes/datasets_ui.py`.

No backwards-compatibility breaks. No schema, API, or settings changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014kKtNhJc41PeDy61fwxv3q)_