### PR TITLE
Improve Add Dataset picker: rename Demo, reorder, add server_folder importer

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -5,15 +5,17 @@
         <p class="empty-state">Loading importers...</p>
       }
       @for (imp of orderedImporters; track imp.name) {
-        @if (imp.name === '_server_folder') {
-          <button class="importer-card" (click)="openServerFolderBrowser()">
-            <span class="importer-name"><span class="importer-icon"><vt-icon type="server"></vt-icon></span> Import from Server Folder</span>
-            <span class="importer-desc">Browse directories on the server and import media files</span>
-          </button>
-        } @else if (imp.name === '_demo') {
+        @if (imp.name === '_demo') {
           <button class="importer-card demo-card" (click)="openDemoPicker()">
             <span class="importer-name"><span class="importer-icon"><vt-icon type="globe"></vt-icon></span> Download Demo Data</span>
             <span class="importer-desc">Choose from a selection of pre-configured demo datasets</span>
+          </button>
+        } @else if (imp.name === 'server_folder') {
+          <button class="importer-card" (click)="openServerFolderBrowser(imp)">
+            <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
+            @if (imp.description) {
+              <span class="importer-desc">{{ imp.description }}</span>
+            }
           </button>
         } @else {
           <button class="importer-card" [class.disabled]="imp['enabled'] === false" [disabled]="imp['enabled'] === false" (click)="selectImporter(imp)" [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : ''">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -1,17 +1,18 @@
-<vt-modal [title]="view === 'picker' ? 'Add Dataset' : view === 'demo' ? 'Load Demo Dataset' : view === 'server_folder' ? 'Import from Server Folder' : selectedImporter?.display_name || selectedImporter?.name || 'Import'" [open]="true" (closed)="close()">
+<vt-modal [title]="view === 'picker' ? 'Add Dataset' : view === 'demo' ? 'Download Demo Data' : view === 'server_folder' ? 'Import from Server Folder' : selectedImporter?.display_name || selectedImporter?.name || 'Import'" [open]="true" (closed)="close()">
   @if (view === 'picker') {
     <div class="importer-picker">
       @if (importers.length === 0) {
         <p class="empty-state">Loading importers...</p>
       }
-      <button class="importer-card" (click)="openServerFolderBrowser()">
-        <span class="importer-name"><span class="importer-icon"><vt-icon type="server"></vt-icon></span> Import from Server Folder</span>
-        <span class="importer-desc">Browse directories on the server and import media files</span>
-      </button>
       @for (imp of orderedImporters; track imp.name) {
-        @if (imp.name === '_demo') {
+        @if (imp.name === '_server_folder') {
+          <button class="importer-card" (click)="openServerFolderBrowser()">
+            <span class="importer-name"><span class="importer-icon"><vt-icon type="server"></vt-icon></span> Import from Server Folder</span>
+            <span class="importer-desc">Browse directories on the server and import media files</span>
+          </button>
+        } @else if (imp.name === '_demo') {
           <button class="importer-card demo-card" (click)="openDemoPicker()">
-            <span class="importer-name"><span class="importer-icon"><vt-icon type="database"></vt-icon></span> Load Demo Dataset</span>
+            <span class="importer-name"><span class="importer-icon"><vt-icon type="globe"></vt-icon></span> Download Demo Data</span>
             <span class="importer-desc">Choose from a selection of pre-configured demo datasets</span>
           </button>
         } @else {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -129,7 +129,7 @@ describe('DatasetImporterModalComponent', () => {
     // 2 importers + 1 demo card
     expect(cards.length).toBe(3);
     expect(cards[0].textContent).toContain('Load from Folder');
-    expect(cards[2].textContent).toContain('Load Demo Dataset');
+    expect(cards[2].textContent).toContain('Download Demo Data');
   });
 
   it('should switch to form view on importer selection', () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -116,25 +116,31 @@ export class DatasetImporterModalComponent implements OnInit {
     });
   }
 
-  /** Desired picker order: folder, demo placeholder, then remaining importers. */
-  private static readonly PICKER_ORDER = ['folder', '_demo', 'combine_datasets'];
+  /**
+   * Desired picker order after any discovered extensions:
+   * Server Folder, Local Folder, Download Demo, Combine Existing.
+   * Placeholders (`_server_folder`, `_demo`) render hardcoded buttons.
+   */
+  private static readonly PICKER_ORDER = ['_server_folder', 'folder', '_demo', 'combine_datasets'];
+  private static readonly PICKER_PLACEHOLDERS = new Set(['_server_folder', '_demo']);
 
   get orderedImporters(): ImporterInfo[] {
-    const demoPlaceholder = { name: '_demo' } as ImporterInfo;
     const order = DatasetImporterModalComponent.PICKER_ORDER;
+    const placeholders = DatasetImporterModalComponent.PICKER_PLACEHOLDERS;
     const result: ImporterInfo[] = [];
-    for (const name of order) {
-      if (name === '_demo') {
-        result.push(demoPlaceholder);
-      } else {
-        const imp = this.importers.find((i) => i.name === name);
-        if (imp) result.push(imp);
-      }
-    }
-    // Append any importers not in the explicit order
+    // Discovered extensions (importers not in the explicit order) come first
     for (const imp of this.importers) {
       if (!order.includes(imp.name)) {
         result.push(imp);
+      }
+    }
+    // Then the standard picker entries in the prescribed order
+    for (const name of order) {
+      if (placeholders.has(name)) {
+        result.push({ name } as ImporterInfo);
+      } else {
+        const imp = this.importers.find((i) => i.name === name);
+        if (imp) result.push(imp);
       }
     }
     return result;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -119,14 +119,13 @@ export class DatasetImporterModalComponent implements OnInit {
   /**
    * Desired picker order after any discovered extensions:
    * Server Folder, Local Folder, Download Demo, Combine Existing.
-   * Placeholders (`_server_folder`, `_demo`) render hardcoded buttons.
+   * The `_demo` entry is a synthetic card that opens the demo picker rather
+   * than routing through a single backend importer.
    */
-  private static readonly PICKER_ORDER = ['_server_folder', 'folder', '_demo', 'combine_datasets'];
-  private static readonly PICKER_PLACEHOLDERS = new Set(['_server_folder', '_demo']);
+  private static readonly PICKER_ORDER = ['server_folder', 'folder', '_demo', 'combine_datasets'];
 
   get orderedImporters(): ImporterInfo[] {
     const order = DatasetImporterModalComponent.PICKER_ORDER;
-    const placeholders = DatasetImporterModalComponent.PICKER_PLACEHOLDERS;
     const result: ImporterInfo[] = [];
     // Discovered extensions (importers not in the explicit order) come first
     for (const imp of this.importers) {
@@ -136,7 +135,7 @@ export class DatasetImporterModalComponent implements OnInit {
     }
     // Then the standard picker entries in the prescribed order
     for (const name of order) {
-      if (placeholders.has(name)) {
+      if (name === '_demo') {
         result.push({ name } as ImporterInfo);
       } else {
         const imp = this.importers.find((i) => i.name === name);
@@ -616,7 +615,9 @@ export class DatasetImporterModalComponent implements OnInit {
 
   // --- Server folder browser ---
 
-  openServerFolderBrowser(): void {
+  openServerFolderBrowser(importer?: ImporterInfo): void {
+    this.selectedImporter =
+      importer || this.importers.find((imp) => imp.name === 'server_folder') || null;
     this.view = 'server_folder';
     this.sfBrowsePath = '';
     this.sfBrowseRootPath = '';
@@ -624,9 +625,11 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfBrowseError = '';
     this.sfSubmitting = false;
 
-    // Load media type options from the folder importer's fields
-    const folderImporter = this.importers.find((imp) => imp.name === 'folder');
-    const mtField = folderImporter?.fields?.find((f) => f.key === 'media_type');
+    // Load media type options from the server_folder importer's fields
+    // (falling back to the local-folder importer for older backends).
+    const serverImporter =
+      this.selectedImporter || this.importers.find((imp) => imp.name === 'folder');
+    const mtField = serverImporter?.fields?.find((f) => f.key === 'media_type');
     this.sfMediaTypeOptions = mtField?.options || [];
 
     // Prefer guessed media type when available
@@ -827,7 +830,8 @@ export class DatasetImporterModalComponent implements OnInit {
       }
     }
 
-    this.datasetsApi.runImporter('folder', params).subscribe({
+    const importerName = this.selectedImporter?.name || 'server_folder';
+    this.datasetsApi.runImporter(importerName, params).subscribe({
       next: () => {
         this.sfSubmitting = false;
         this.importStarted.emit();

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -1,0 +1,39 @@
+"""Server-folder importer – wraps :class:`FolderDatasetImporter` for the
+"Import from Server Folder" picker entry.
+
+The dataset-importer modal renders this importer with a built-in directory
+browser rooted at ``saved_datasets_dir``, so the user can pick a folder
+visually instead of typing an absolute path.  All import logic is reused
+from :class:`FolderDatasetImporter`.
+"""
+
+from __future__ import annotations
+
+from vtsearch.datasets.importers.base import ImporterField
+from vtsearch.datasets.importers.folder import FolderDatasetImporter
+
+
+class ServerFolderDatasetImporter(FolderDatasetImporter):
+    name = "server_folder"
+    display_name = "Import from Server Folder"
+    description = "Browse directories on the server and import media files"
+    icon = "\U0001f5a5"  # 🖥 desktop computer
+
+    fields = [
+        ImporterField(
+            key="media_type",
+            label="Media Type",
+            field_type="select",
+            description="Type of media files to scan for in the folder.",
+            default="audio",
+        ),
+        ImporterField(
+            key="path",
+            label="Folder",
+            field_type="server_path",
+            description="Path to a folder on the server containing media files.",
+        ),
+    ]
+
+
+IMPORTER = ServerFolderDatasetImporter()


### PR DESCRIPTION
## Summary
- Rename the demo card from "Load Demo Dataset" to "Download Demo Data" and switch its icon from the database icon to the wireframe globe.
- Reorder the Add Dataset picker so any discovered (extension) importers come first, followed by Server Folder, Local Folder, Download Demo, Combine Existing.
- Promote "Import from Server Folder" to a real `DatasetImporter` (`vtsearch/datasets/importers/server_folder/`) that delegates to the local-folder import logic, so it's no longer a hardcoded placeholder card. The modal routes its click into the existing server-side directory browser.

## Notes
- The user listed "Build Synthetic Data" in the desired order, but no Synthetic Dataset feature exists in the codebase today and there's no clear backend for it. I left that slot out — happy to add it once we agree what it should do (e.g., expose the existing `generate_test_medias` synthetic-WAV generator as an importer?).
- Backwards compatibility: existing pickled datasets created via the server-folder UI carry an `origin.importer == "folder"` value, so they continue to resolve via `FolderDatasetImporter`. New imports via the Server Folder card will record `origin.importer == "server_folder"`. Since `ServerFolderDatasetImporter` subclasses `FolderDatasetImporter`, file resolution still works.

## Test plan
- [x] `./run-tests.sh` — 2970 passed, 1 skipped, 2 xpassed
- [ ] Manual: open Add Dataset, confirm order is Server Folder → Local Folder → Download Demo Data (globe icon) → Combine Existing
- [ ] Manual: click Server Folder, browse to a directory, import — verify the dataset loads
- [ ] Manual: click Download Demo Data and pick a demo — verify the demo flow still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01AC5P1HqFPJ2WERcxTKoiWi)_