### PR TITLE
Add &quot;Include subfolders&quot; option to local/server folder importers

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -265,6 +265,19 @@
         }
       </div>
 
+      @if (lfPickerKind === 'folder') {
+        <div class="form-group">
+          <label class="form-label" for="lf-recursive" title="When enabled, files inside nested subfolders are also uploaded. When disabled, only files directly inside the picked folder are uploaded.">
+            <input
+              id="lf-recursive"
+              type="checkbox"
+              [(ngModel)]="lfRecursive"
+            />
+            Include subfolders
+          </label>
+        </div>
+      }
+
       @if (lfEmbedders.length > 1) {
         <div class="form-group">
           <label class="form-label" for="lf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
@@ -365,6 +378,17 @@
           <span class="form-label">Path:</span>
           <code class="sf-path-display">{{ sfAbsolutePath }}</code>
         </div>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="sf-recursive" title="When enabled, subdirectories of the chosen folder are scanned recursively. When disabled, only files directly inside the chosen folder are imported.">
+          <input
+            id="sf-recursive"
+            type="checkbox"
+            [(ngModel)]="sfRecursive"
+          />
+          Include subfolders
+        </label>
       </div>
 
       @if (sfEmbedders.length > 1) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -87,6 +87,8 @@ export class DatasetImporterModalComponent implements OnInit {
   /** ``"folder"`` opens a directory picker (Local Folder card),
    *  ``"files"`` opens a multi-file picker (Local Files card). */
   lfPickerKind: 'folder' | 'files' = 'folder';
+  /** Whether subfolders inside the picked local folder are included. */
+  lfRecursive = true;
 
   // Server folder browser state
   sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
@@ -103,6 +105,8 @@ export class DatasetImporterModalComponent implements OnInit {
   sfClipperParams: ClipperParameter[] = [];
   sfClipperParamValues: Record<string, number | string> = {};
   sfSubmitting = false;
+  /** Whether subdirectories of the picked server folder are scanned. */
+  sfRecursive = true;
 
   // Clipper chooser modal state
   clipperChooserOpen = false;
@@ -648,6 +652,14 @@ export class DatasetImporterModalComponent implements OnInit {
     this.error = '';
   }
 
+  /** Read the ``recursive`` field's declared default ("true"/"false") from
+   *  the importer metadata; defaults to ``true`` when the field is absent. */
+  private readRecursiveDefault(importer: ImporterInfo | null): boolean {
+    const field = importer?.fields?.find((f) => f.key === 'recursive');
+    if (!field) return true;
+    return String(field.default ?? 'true').toLowerCase() !== 'false';
+  }
+
   // --- Local folder upload (files come from the browser machine) ---
 
   openLocalFolderUploader(importer?: ImporterInfo): void {
@@ -660,6 +672,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.lfFiles = [];
     this.lfError = '';
     this.lfSubmitting = false;
+    this.lfRecursive = this.readRecursiveDefault(resolved);
 
     // Reuse the server_folder importer's media_type options for consistency.
     const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
@@ -753,11 +766,29 @@ export class DatasetImporterModalComponent implements OnInit {
       this.lfError = 'Please select a folder to upload.';
       return;
     }
+
+    // When recursion is disabled in folder mode, drop any files that live
+    // inside subdirectories of the picked folder.  ``webkitRelativePath``
+    // looks like ``"top/file.wav"`` for top-level entries and
+    // ``"top/sub/file.wav"`` for files inside a subdirectory.
+    let filesToUpload = this.lfFiles;
+    if (this.lfPickerKind === 'folder' && !this.lfRecursive) {
+      filesToUpload = this.lfFiles.filter((file) => {
+        const rel = ((file as any).webkitRelativePath as string | undefined) || '';
+        return rel.split('/').length <= 2;
+      });
+      if (filesToUpload.length === 0) {
+        this.lfError = 'No files at the top level of the selected folder. Enable "Include subfolders" to import nested files.';
+        return;
+      }
+    }
+
     this.lfSubmitting = true;
     this.lfError = '';
 
     const formData = new FormData();
     formData.append('media_type', this.lfMediaType);
+    formData.append('recursive', this.lfRecursive ? 'true' : 'false');
     if (this.lfSelectedEmbedder) {
       formData.append('embedder', this.lfSelectedEmbedder);
     }
@@ -767,7 +798,7 @@ export class DatasetImporterModalComponent implements OnInit {
         formData.append('clipper_params', JSON.stringify(this.lfClipperParamValues));
       }
     }
-    for (const file of this.lfFiles) {
+    for (const file of filesToUpload) {
       const rel = (file as any).webkitRelativePath as string | undefined;
       // Browsers only populate webkitRelativePath when the input has the
       // `webkitdirectory` attribute; fall back to the file's own name.
@@ -796,6 +827,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfBrowseDirs = [];
     this.sfBrowseError = '';
     this.sfSubmitting = false;
+    this.sfRecursive = this.readRecursiveDefault(this.selectedImporter);
 
     // Load media type options from the folder importer's fields
     const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
@@ -1000,6 +1032,7 @@ export class DatasetImporterModalComponent implements OnInit {
     const params: Record<string, unknown> = {
       path: this.sfAbsolutePath,
       media_type: this.sfMediaType,
+      recursive: this.sfRecursive,
     };
     if (this.sfSelectedEmbedder) {
       params['embedder'] = this.sfSelectedEmbedder;

--- a/tests/test_importer_loading.py
+++ b/tests/test_importer_loading.py
@@ -865,5 +865,113 @@ class TestImporterResolveFileContract:
 
 
 # ---------------------------------------------------------------------------
+# Recursive vs. top-level folder scanning
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDatasetRecursive:
+    """``load_dataset_from_folder`` honours the ``recursive`` flag."""
+
+    def _write_wav(self, path):
+        path.write_bytes(_make_wav_bytes())
+
+    def _make_fake_media_type(self):
+        import unittest.mock as mock
+
+        import numpy as np
+
+        mt = mock.MagicMock()
+        mt.type_id = "audio"
+        mt.file_extensions = ["*.wav"]
+        mt.load_media_data.return_value = {"duration": 1.0}
+        embedder = mock.MagicMock()
+        embedder.name = "clap"
+        embedder.media_type_id = "audio"
+        embedder._model = True
+        embedder.embed_media.return_value = np.zeros(3)
+        embedder.embed_media_bulk.side_effect = lambda medias: [np.zeros(3) for _ in medias]
+        mt._mock_embedder = embedder
+        return mt
+
+    def _patch_media_registry(self, mt):
+        import unittest.mock as mock
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        stack.enter_context(mock.patch("vtsearch.media.get_by_folder_name", return_value=mt))
+        stack.enter_context(mock.patch("vtsearch.media.embedders_for_type", return_value=[mt._mock_embedder]))
+        return stack
+
+    def _seed_layout(self, tmp_path):
+        """Create ``tmp_path/top.wav`` and ``tmp_path/sub/nested.wav``."""
+        self._write_wav(tmp_path / "top.wav")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        self._write_wav(sub / "nested.wav")
+
+    def test_recursive_default_includes_subfolders(self, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        self._seed_layout(tmp_path)
+        medias: dict = {}
+        with self._patch_media_registry(self._make_fake_media_type()):
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None)
+
+        names = sorted(m["filename"] for m in medias.values())
+        assert names == ["sub/nested.wav", "top.wav"]
+
+    def test_recursive_false_only_top_level(self, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        self._seed_layout(tmp_path)
+        medias: dict = {}
+        with self._patch_media_registry(self._make_fake_media_type()):
+            load_dataset_from_folder(
+                tmp_path, "audio", medias, on_progress=lambda *a: None, recursive=False
+            )
+
+        names = sorted(m["filename"] for m in medias.values())
+        assert names == ["top.wav"]
+
+    def test_chunked_recursive_false_only_top_level(self, tmp_path):
+        from vtsearch.datasets.loader import load_dataset_from_folder_chunked
+
+        self._seed_layout(tmp_path)
+        with self._patch_media_registry(self._make_fake_media_type()):
+            chunks = list(
+                load_dataset_from_folder_chunked(
+                    tmp_path,
+                    "audio",
+                    chunk_size=10,
+                    on_progress=lambda *a: None,
+                    recursive=False,
+                )
+            )
+
+        names = sorted(m["filename"] for chunk in chunks for m in chunk.values())
+        assert names == ["top.wav"]
+
+
+class TestServerFolderImporterRecursive:
+    """The ``server_folder`` importer exposes a ``recursive`` checkbox field."""
+
+    def test_field_present_default_true(self):
+        from vtsearch.datasets.importers.server_folder import IMPORTER
+
+        recursive = next((f for f in IMPORTER.fields if f.key == "recursive"), None)
+        assert recursive is not None
+        assert recursive.field_type == "checkbox"
+        assert str(recursive.default).lower() == "true"
+
+    def test_build_origin_records_recursive(self):
+        from vtsearch.datasets.importers.server_folder import IMPORTER
+
+        origin = IMPORTER.build_origin(
+            {"path": "/tmp/x", "media_type": "audio", "recursive": False}
+        )
+        assert origin["params"]["recursive"] == "false"
+
+
+# ---------------------------------------------------------------------------
 # Symlinked importer discovery
 # ---------------------------------------------------------------------------

--- a/vtsearch/converters/runner.py
+++ b/vtsearch/converters/runner.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from vtsearch.converters import get_converter
-from vtsearch.utils.paths import rglob_follow_symlinks
+from vtsearch.utils.paths import glob_top_level, rglob_follow_symlinks
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -39,6 +39,7 @@ def run_converters_on_folder(
     thin: bool = False,
     on_progress: Optional[ProgressCallback] = None,
     base_origin: dict[str, Any] | None = None,
+    recursive: bool = True,
 ) -> None:
     """Scan *folder_path* for source files, convert them, and add to *medias*.
 
@@ -107,10 +108,14 @@ def run_converters_on_folder(
         except KeyError:
             continue
 
-        # Scan folder for source files.
+        # Scan folder for source files.  When ``recursive=False`` only the
+        # top-level entries are considered.
         source_files: list[Path] = []
         for ext in source_mt.file_extensions:
-            source_files.extend(rglob_follow_symlinks(folder_path, ext))
+            if recursive:
+                source_files.extend(rglob_follow_symlinks(folder_path, ext))
+            else:
+                source_files.extend(glob_top_level(folder_path, ext))
         source_files.sort()
 
         if not source_files:

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -294,9 +294,15 @@ class DatasetImporter(PluginBase):
         for f in self.fields:
             if f.field_type == "file":
                 continue
+            arg_name = f"--{f.key.replace('_', '-')}"
+            if f.field_type == "checkbox":
+                value = field_values.get(f.key, str(f.default).lower() == "true")
+                truthy = value if isinstance(value, bool) else str(value).lower() == "true"
+                no_arg = f"--no-{f.key.replace('_', '-')}"
+                parts.append(arg_name if truthy else no_arg)
+                continue
             value = field_values.get(f.key, "")
             if value:
-                arg_name = f"--{f.key.replace('_', '-')}"
                 parts.append(f"{arg_name} {value}")
         return " ".join(parts)
 
@@ -319,6 +325,11 @@ class DatasetImporter(PluginBase):
         params: dict[str, str] = {}
         for f in self.fields:
             if f.field_type == "file":
+                continue
+            if f.field_type == "checkbox":
+                val = field_values.get(f.key, str(f.default).lower() == "true")
+                truthy = val if isinstance(val, bool) else str(val).lower() == "true"
+                params[f.key] = "true" if truthy else "false"
                 continue
             val = field_values.get(f.key, "")
             if val:

--- a/vtsearch/datasets/importers/local_folder/__init__.py
+++ b/vtsearch/datasets/importers/local_folder/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from vtsearch.datasets.importers.base import DatasetImporter
+from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 
 
 class LocalFolderDatasetImporter(DatasetImporter):
@@ -35,7 +35,20 @@ class LocalFolderDatasetImporter(DatasetImporter):
     icon = "\U0001f4c1"  # 📁 — frontend renders as a folder icon
     ui_mode = "custom"
     picker_view = "local_folder"
-    fields = []
+    fields = [
+        ImporterField(
+            key="recursive",
+            label="Include subfolders",
+            field_type="checkbox",
+            description=(
+                "When enabled, subfolders inside the chosen folder are also "
+                "uploaded and imported.  When disabled, only files directly "
+                "inside the chosen folder are imported."
+            ),
+            default="true",
+            required=False,
+        ),
+    ]
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         raise NotImplementedError(

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -24,7 +24,15 @@ from typing import Any, Iterator
 
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 from vtsearch.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
-from vtsearch.utils.paths import rglob_follow_symlinks
+from vtsearch.utils.paths import glob_top_level, rglob_follow_symlinks
+
+
+def _coerce_recursive(field_values: dict[str, Any]) -> bool:
+    """Parse the ``recursive`` field value as a bool; default ``True``."""
+    val = field_values.get("recursive", True)
+    if isinstance(val, bool):
+        return val
+    return str(val).lower() != "false"
 
 
 def _load_pdf_images(
@@ -32,6 +40,7 @@ def _load_pdf_images(
     medias: dict[int, dict[str, Any]],
     thin: bool = False,
     embedder_name: str = "",
+    recursive: bool = True,
 ) -> None:
     """Expand all PDFs in *folder* into per-page image medias.
 
@@ -40,7 +49,7 @@ def _load_pdf_images(
     maximum.  The ``origin`` is set to ``{"importer": "pdf", "params":
     {"path": ...}}`` so the provenance points back to the source document.
     """
-    pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf"))
+    pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf") if recursive else glob_top_level(folder, "*.pdf"))
     if not pdf_files:
         return
 
@@ -141,6 +150,7 @@ def _run_selected_converters(
         medias=medias,
         thin=thin,
         base_origin=base_origin,
+        recursive=_coerce_recursive(field_values),
     )
 
 
@@ -189,6 +199,17 @@ class ServerFolderDatasetImporter(DatasetImporter):
             field_type="folder",
             description="Absolute path to the directory containing media files.",
         ),
+        ImporterField(
+            key="recursive",
+            label="Include subfolders",
+            field_type="checkbox",
+            description=(
+                "When enabled, scan subdirectories recursively.  When disabled, "
+                "only files directly inside the chosen folder are imported."
+            ),
+            default="true",
+            required=False,
+        ),
     ]
 
     def __init__(self) -> None:
@@ -222,6 +243,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
         media_type = field_values.get("media_type", "audio")
         emb_name = field_values.get("embedder", "")
         skip_emb = bool(field_values.get("skip_embedding"))
+        recursive = _coerce_recursive(field_values)
         has_regular = True
         try:
             load_dataset_from_folder(
@@ -234,6 +256,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
                 skip_embedding=skip_emb,
+                recursive=recursive,
             )
         except ValueError:
             # No regular image files found — PDFs or converters may still produce output.
@@ -241,7 +264,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 raise
             has_regular = False
         if media_type == "image":
-            _load_pdf_images(folder, medias, thin=thin, embedder_name=emb_name)
+            _load_pdf_images(folder, medias, thin=thin, embedder_name=emb_name, recursive=recursive)
 
         # Run any user-selected converters.
         _run_selected_converters(folder, media_type, field_values, medias, thin=thin)
@@ -271,6 +294,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
         media_type = field_values.get("media_type", "audio")
         emb_name = field_values.get("embedder", "")
         skip_emb = bool(field_values.get("skip_embedding"))
+        recursive = _coerce_recursive(field_values)
         try:
             yield from load_dataset_from_folder_chunked(
                 folder,
@@ -282,13 +306,14 @@ class ServerFolderDatasetImporter(DatasetImporter):
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
                 skip_embedding=skip_emb,
+                recursive=recursive,
             )
         except ValueError:
             if media_type != "image" and not field_values.get("converters"):
                 raise
         if media_type == "image":
             chunk: dict[int, dict[str, Any]] = {}
-            _load_pdf_images(folder, chunk, thin=thin)
+            _load_pdf_images(folder, chunk, thin=thin, recursive=recursive)
             if chunk:
                 yield chunk
         # Run converters and yield as a single chunk.

--- a/vtsearch/datasets/loader_folder.py
+++ b/vtsearch/datasets/loader_folder.py
@@ -20,7 +20,14 @@ from vtsearch.datasets.loader import (
     _pop_md5_key,
     _streaming_md5,
 )
-from vtsearch.utils.paths import rglob_follow_symlinks
+from vtsearch.utils.paths import glob_top_level, rglob_follow_symlinks
+
+
+def _scan_files(folder: Path, pattern: str, recursive: bool) -> list[Path]:
+    """Find files in *folder* matching *pattern*, optionally recursing."""
+    if recursive:
+        return rglob_follow_symlinks(folder, pattern)
+    return glob_top_level(folder, pattern)
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +148,7 @@ def load_dataset_from_folder(
     embedder_name: str = "",
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
     skip_embedding: bool = False,
+    recursive: bool = True,
 ) -> None:
     """Generate a dataset in-place from a flat folder of media files.
 
@@ -242,11 +250,12 @@ def load_dataset_from_folder(
             finally:
                 emb._on_progress = original_cb
 
-    # Find all files of the specified media type (recursive so that
-    # subdirectory structures are preserved).
+    # Find all files of the specified media type.  Recursion descends into
+    # subdirectories (default); when disabled, only files directly inside
+    # ``folder_path`` are included.
     media_files = []
     for ext in mt.file_extensions:
-        media_files.extend(rglob_follow_symlinks(folder_path, ext))
+        media_files.extend(_scan_files(folder_path, ext, recursive))
 
     if not media_files:
         raise ValueError(f"No {media_type} files found in folder")
@@ -435,6 +444,7 @@ def load_dataset_from_folder_chunked(
     embedder_name: str = "",
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
     skip_embedding: bool = False,
+    recursive: bool = True,
 ) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield chunks of medias from a folder of media files.
 
@@ -505,11 +515,12 @@ def load_dataset_from_folder_chunked(
             finally:
                 emb._on_progress = original_cb
 
-    # Find all files of the specified media type (recursive so that
-    # subdirectory structures are preserved).
+    # Find all files of the specified media type.  Recursion descends into
+    # subdirectories (default); when disabled, only files directly inside
+    # ``folder_path`` are included.
     media_files: list[Path] = []
     for ext in mt.file_extensions:
-        media_files.extend(rglob_follow_symlinks(folder_path, ext))
+        media_files.extend(_scan_files(folder_path, ext, recursive))
 
     if not media_files:
         raise ValueError(f"No {media_type} files found in folder")

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -533,6 +533,8 @@ def import_local_folder():
     embedder = (request.form.get("embedder") or "").strip()
     clipper = (request.form.get("clipper") or "").strip()
     converters = (request.form.get("converters") or "").strip()
+    recursive_raw = (request.form.get("recursive") or "true").strip().lower()
+    recursive = recursive_raw not in ("false", "0", "no", "off")
     clipper_params_raw = request.form.get("clipper_params") or ""
     clipper_params: dict | None = None
     if clipper_params_raw:
@@ -567,6 +569,7 @@ def import_local_folder():
     field_values: dict = {
         "path": str(upload_dir),
         "media_type": media_type,
+        "recursive": recursive,
     }
     if embedder:
         field_values["embedder"] = embedder

--- a/vtsearch/utils/paths.py
+++ b/vtsearch/utils/paths.py
@@ -89,3 +89,18 @@ def rglob_follow_symlinks(root: Path, pattern: str) -> list[Path]:
             if fnmatch.fnmatch(filename, pattern):
                 results.append(Path(dirpath) / filename)
     return results
+
+
+def glob_top_level(root: Path, pattern: str) -> list[Path]:
+    """Match *pattern* against files directly in *root* (no recursion).
+
+    Mirrors :func:`rglob_follow_symlinks` but limited to the immediate
+    children of *root*.  Subdirectories are not descended into.
+    """
+    results: list[Path] = []
+    if not root.is_dir():
+        return results
+    for entry in os.scandir(root):
+        if entry.is_file(follow_symlinks=True) and fnmatch.fnmatch(entry.name, pattern):
+            results.append(Path(entry.path))
+    return results

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -40,7 +40,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Generic, Literal, TypeVar
 
-FieldType = Literal["file", "folder", "url", "text", "password", "email", "select", "server_path"]
+FieldType = Literal["file", "folder", "url", "text", "password", "email", "select", "server_path", "checkbox"]
 
 __all__ = [
     "FieldType",
@@ -71,6 +71,9 @@ class PluginField:
     - ``"email"``    – Text input pre-validated as an e-mail address.
     - ``"select"``   – Drop-down; ``options`` must be populated.
     - ``"server_path"`` – File-browser picker for server filesystem paths.
+    - ``"checkbox"`` – Boolean tick-box.  ``default`` should be ``"true"`` or
+      ``"false"``; values arrive at :meth:`run` as plain strings (or already
+      coerced bools) and should be parsed via ``str(value).lower() == "true"``.
     """
 
     key: str
@@ -157,6 +160,12 @@ class PluginBase:
                 "dest": f.key,
                 "help": f.description or f.label,
             }
+            if f.field_type == "checkbox":
+                # ``--<key>`` / ``--no-<key>`` boolean flag.
+                kwargs["action"] = argparse.BooleanOptionalAction
+                kwargs["default"] = str(f.default).lower() == "true"
+                parser.add_argument(arg_name, **kwargs)
+                continue
             if f.default:
                 kwargs["default"] = f.default
             if f.field_type == "select" and f.options:
@@ -166,6 +175,9 @@ class PluginBase:
     def validate_cli_field_values(self, field_values: dict[str, Any]) -> None:
         """Raise ``ValueError`` if any required field is missing or empty."""
         for f in self.fields:
+            # Booleans are always populated by argparse (default included).
+            if f.field_type == "checkbox":
+                continue
             if f.required and not field_values.get(f.key):
                 cli_flag = f"--{f.key.replace('_', '-')}"
                 raise ValueError(f"Missing required argument: {cli_flag}")


### PR DESCRIPTION
## Summary
- Adds a user-selectable **Include subfolders** checkbox to both the **Local Folder** and **Server Folder** dataset importers (with matching `--recursive` / `--no-recursive` CLI flags). Default is on, preserving today's behaviour; when unchecked, only files directly inside the chosen folder are imported.
- Introduces a new `"checkbox"` `PluginField` type with full plumbing through `argparse` (`BooleanOptionalAction`), `build_cli_args`, and `build_origin` so the option round-trips through origins/CLI replays.
- Threads `recursive` through `load_dataset_from_folder`, the chunked variant, the PDF page expansion helper, and `run_converters_on_folder`. Adds a `glob_top_level` helper alongside `rglob_follow_symlinks` for the non-recursive case.
- Wires the flag through `/api/dataset/import-local-folder`; the frontend additionally drops files inside subdirectories before upload when the user unchecks the box, so we don't waste bandwidth uploading content that won't be ingested.
- New tests cover both default-recursive behaviour and `recursive=False` for the regular and chunked folder loaders, plus the field metadata and origin serialisation.

## Test plan
- [ ] `./run-tests.sh datasets io` — folder loader, importer metadata, and origin tests
- [ ] Manual: in the modal, pick **Server Folder** with **Include subfolders** unchecked and confirm only top-level files are imported
- [ ] Manual: same for **Local Folder** (browser upload), checking the upload payload skips subdirectory files
- [ ] Manual: CLI `python app.py --autodetect --importer server_folder --path /data/audio --media-type audio --no-recursive --settings settings.json` only ingests top-level files

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaeSEhfm9dKe8zqwGNCQ98)_