### PR TITLE
Plumb chunk_size through web import flow + local-folder upload

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -192,6 +192,20 @@
         </div>
       }
 
+      <div class="form-group">
+        <label class="form-label" for="field-chunk-size" title="Embed at most this many medias at once to bound peak memory. 0 means load everything in one pass.">
+          Chunk size (advanced — 0 = no chunking)
+        </label>
+        <input
+          id="field-chunk-size"
+          type="number"
+          min="0"
+          step="1"
+          class="form-input"
+          [(ngModel)]="chunkSize"
+        />
+      </div>
+
       @if (error) {
         <p class="error-text">{{ error }}</p>
       }
@@ -277,6 +291,20 @@
           </label>
         </div>
       }
+
+      <div class="form-group">
+        <label class="form-label" for="lf-chunk-size" title="Embed at most this many medias at once to bound peak memory. 0 means load everything in one pass.">
+          Chunk size (advanced — 0 = no chunking)
+        </label>
+        <input
+          id="lf-chunk-size"
+          type="number"
+          min="0"
+          step="1"
+          class="form-input"
+          [(ngModel)]="lfChunkSize"
+        />
+      </div>
 
       @if (lfEmbedders.length > 1) {
         <div class="form-group">
@@ -389,6 +417,20 @@
           />
           Include subfolders
         </label>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="sf-chunk-size" title="Embed at most this many medias at once to bound peak memory. 0 means load everything in one pass.">
+          Chunk size (advanced — 0 = no chunking)
+        </label>
+        <input
+          id="sf-chunk-size"
+          type="number"
+          min="0"
+          step="1"
+          class="form-input"
+          [(ngModel)]="sfChunkSize"
+        />
       </div>
 
       @if (sfEmbedders.length > 1) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -89,6 +89,8 @@ export class DatasetImporterModalComponent implements OnInit {
   lfPickerKind: 'folder' | 'files' = 'folder';
   /** Whether subfolders inside the picked local folder are included. */
   lfRecursive = true;
+  /** Maximum medias per chunk during embedding; 0 means "no chunking". */
+  lfChunkSize = 0;
 
   // Server folder browser state
   sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
@@ -107,6 +109,11 @@ export class DatasetImporterModalComponent implements OnInit {
   sfSubmitting = false;
   /** Whether subdirectories of the picked server folder are scanned. */
   sfRecursive = true;
+  /** Maximum medias per chunk during embedding; 0 means "no chunking". */
+  sfChunkSize = 0;
+
+  /** Maximum medias per chunk during embedding for the generic form view; 0 means "no chunking". */
+  chunkSize = 0;
 
   // Clipper chooser modal state
   clipperChooserOpen = false;
@@ -789,6 +796,9 @@ export class DatasetImporterModalComponent implements OnInit {
     const formData = new FormData();
     formData.append('media_type', this.lfMediaType);
     formData.append('recursive', this.lfRecursive ? 'true' : 'false');
+    if (this.lfChunkSize && this.lfChunkSize > 0) {
+      formData.append('chunk_size', String(Math.floor(this.lfChunkSize)));
+    }
     if (this.lfSelectedEmbedder) {
       formData.append('embedder', this.lfSelectedEmbedder);
     }
@@ -1034,6 +1044,9 @@ export class DatasetImporterModalComponent implements OnInit {
       media_type: this.sfMediaType,
       recursive: this.sfRecursive,
     };
+    if (this.sfChunkSize && this.sfChunkSize > 0) {
+      params['chunk_size'] = Math.floor(this.sfChunkSize);
+    }
     if (this.sfSelectedEmbedder) {
       params['embedder'] = this.sfSelectedEmbedder;
     }
@@ -1079,6 +1092,9 @@ export class DatasetImporterModalComponent implements OnInit {
     }
     if (this.selectedEmbedder) {
       submitValues['embedder'] = this.selectedEmbedder;
+    }
+    if (this.chunkSize && this.chunkSize > 0) {
+      submitValues['chunk_size'] = Math.floor(this.chunkSize);
     }
 
     // If there's a file field, use loadFile; otherwise runImporter

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -5,9 +5,9 @@
 # 'pip install -r requirements.txt' cascades through the entire tree.
 
 -r vtsearch/datasets/importers/combine_datasets/requirements.txt
--r vtsearch/datasets/importers/folder/requirements.txt
 -r vtsearch/datasets/importers/http_archive/requirements.txt
 -r vtsearch/datasets/importers/pickle/requirements.txt
+-r vtsearch/datasets/importers/server_folder/requirements.txt
 -r vtsearch/datasets/importers/synthetic/requirements.txt
 -r vtsearch/exporters/email_smtp/requirements.txt
 -r vtsearch/exporters/gui/requirements.txt

--- a/tests/test_chunked_web_flow.py
+++ b/tests/test_chunked_web_flow.py
@@ -1,0 +1,333 @@
+"""Tests for chunked dataset loading via the web (modal) flow.
+
+Two pieces:
+
+1. ``consume_chunks_into`` — the helper that drains an importer's
+   ``run_chunked()`` iterator into a target medias dict, renumbering IDs
+   so chunks (which each restart at 1) don't collide.
+2. The two web import routes —
+   ``POST /api/dataset/import/<importer_name>`` and
+   ``POST /api/dataset/import-local-folder`` — must pass an optional
+   ``chunk_size`` form/JSON value through to the load pipeline, and the
+   pipeline must use ``run_chunked`` over ``run`` when chunked is
+   supported and the value is positive.
+"""
+
+import io
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import numpy as np
+
+from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+from vtsearch.datasets.load_pipeline import consume_chunks_into
+
+
+# ===========================================================================
+# consume_chunks_into
+# ===========================================================================
+
+
+class TestConsumeChunksInto:
+    def test_renumbers_into_empty_target(self):
+        target: dict[int, dict[str, Any]] = {}
+        chunks = [{1: {"id": 1, "x": "a"}, 2: {"id": 2, "x": "b"}}, {1: {"id": 1, "x": "c"}}]
+        consume_chunks_into(target, iter(chunks))
+        assert sorted(target.keys()) == [1, 2, 3]
+        assert target[1]["x"] == "a"
+        assert target[2]["x"] == "b"
+        assert target[3]["x"] == "c"
+        # IDs on the media dicts themselves are rewritten to match.
+        assert target[1]["id"] == 1
+        assert target[2]["id"] == 2
+        assert target[3]["id"] == 3
+
+    def test_continues_from_existing_ids(self):
+        target: dict[int, dict[str, Any]] = {5: {"id": 5, "x": "pre"}}
+        chunks = [{1: {"id": 1, "x": "a"}}]
+        consume_chunks_into(target, iter(chunks))
+        assert sorted(target.keys()) == [5, 6]
+        assert target[5]["x"] == "pre"
+        assert target[6]["x"] == "a"
+        assert target[6]["id"] == 6
+
+    def test_empty_iterator_no_ops(self):
+        target: dict[int, dict[str, Any]] = {}
+        consume_chunks_into(target, iter([]))
+        assert target == {}
+
+
+# ===========================================================================
+# _DummyChunkedImporter — supports_chunked=True, no real I/O
+# ===========================================================================
+
+
+class _DummyChunkedImporter(DatasetImporter):
+    name = "_dummy_chunked"
+    display_name = "Dummy Chunked"
+    description = "Test importer"
+    icon = ""
+    fields: list[ImporterField] = []
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_called = False
+        self.run_chunked_called = False
+        self.last_chunk_size: int | None = None
+
+    @property
+    def supports_chunked(self) -> bool:
+        return True
+
+    def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+        self.run_called = True
+        medias[1] = {"id": 1, "type": "audio", "embedding": np.zeros(4)}
+        medias[2] = {"id": 2, "type": "audio", "embedding": np.ones(4)}
+
+    def run_chunked(
+        self,
+        field_values: dict[str, Any],
+        chunk_size: int,
+        thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        self.run_chunked_called = True
+        self.last_chunk_size = chunk_size
+        yield {1: {"id": 1, "type": "audio", "embedding": np.zeros(4)}}
+        yield {1: {"id": 1, "type": "audio", "embedding": np.ones(4)}}
+
+
+class _DummyNonChunkedImporter(DatasetImporter):
+    name = "_dummy_nonchunked"
+    display_name = "Dummy Non-Chunked"
+    description = "Test importer (no chunked support)"
+    icon = ""
+    fields: list[ImporterField] = []
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_called = False
+        self.run_chunked_called = False
+
+    def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+        self.run_called = True
+        medias[1] = {"id": 1, "type": "audio", "embedding": np.zeros(4)}
+
+    def run_chunked(
+        self,
+        field_values: dict[str, Any],
+        chunk_size: int,
+        thin: bool = False,
+    ) -> Iterator[dict[int, dict[str, Any]]]:
+        # The base class default delegates to run().  Track whether we
+        # were called so the test can assert the pipeline did *not* call
+        # us when chunk_size was supplied for an unsupporting importer.
+        self.run_chunked_called = True
+        yield from super().run_chunked(field_values, chunk_size, thin=thin)
+
+
+# ===========================================================================
+# _run_importer_in_background — chunked-vs-whole dispatch
+# ===========================================================================
+
+
+class TestRunImporterChunkedDispatch:
+    """Verify the load_fn produced by ``_run_importer_in_background``
+    routes to ``run_chunked`` only when chunk_size > 0 and the importer
+    supports it.
+
+    We patch ``_run_origin_load_in_background`` so the load_fn is invoked
+    synchronously against a throwaway dict instead of being scheduled on
+    a background thread.
+    """
+
+    def _invoke(self, importer, *, chunk_size: int) -> dict[int, dict[str, Any]]:
+        from vtsearch.datasets import load_pipeline
+
+        captured: dict[str, Any] = {}
+
+        def _fake_origin_load(load_fn, origin, **kwargs):
+            target: dict[int, dict[str, Any]] = {}
+            load_fn(target)
+            captured["target"] = target
+            return "task-fake"
+
+        with patch.object(
+            load_pipeline,
+            "_run_origin_load_in_background",
+            side_effect=_fake_origin_load,
+        ):
+            load_pipeline._run_importer_in_background(importer, {}, chunk_size=chunk_size)
+
+        return captured["target"]
+
+    def test_uses_run_chunked_when_supported_and_positive(self):
+        imp = _DummyChunkedImporter()
+        target = self._invoke(imp, chunk_size=1)
+        assert imp.run_chunked_called is True
+        assert imp.run_called is False
+        assert imp.last_chunk_size == 1
+        # Two single-media chunks (each with id=1) renumbered to 1,2.
+        assert sorted(target.keys()) == [1, 2]
+
+    def test_falls_back_to_run_when_chunk_size_zero(self):
+        imp = _DummyChunkedImporter()
+        target = self._invoke(imp, chunk_size=0)
+        assert imp.run_chunked_called is False
+        assert imp.run_called is True
+        assert sorted(target.keys()) == [1, 2]
+
+    def test_falls_back_to_run_when_importer_unsupported(self):
+        imp = _DummyNonChunkedImporter()
+        target = self._invoke(imp, chunk_size=10)
+        assert imp.run_chunked_called is False
+        assert imp.run_called is True
+        assert sorted(target.keys()) == [1]
+
+
+# ===========================================================================
+# Route plumbing — POST /api/dataset/import/<importer_name>
+# ===========================================================================
+
+
+class TestImportRouteChunkSize:
+    def test_chunk_size_passed_via_json_body(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={"path": "/tmp/test", "media_type": "image", "chunk_size": 25},
+            )
+            assert resp.status_code == 200
+            assert mock_run.call_args.kwargs["chunk_size"] == 25
+
+    def test_missing_chunk_size_defaults_to_zero(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={"path": "/tmp/test", "media_type": "image"},
+            )
+            assert resp.status_code == 200
+            assert mock_run.call_args.kwargs["chunk_size"] == 0
+
+    def test_invalid_chunk_size_treated_as_zero(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={"path": "/tmp/test", "media_type": "image", "chunk_size": "not-a-number"},
+            )
+            assert resp.status_code == 200
+            assert mock_run.call_args.kwargs["chunk_size"] == 0
+
+    def test_negative_chunk_size_clamped_to_zero(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={"path": "/tmp/test", "media_type": "image", "chunk_size": -10},
+            )
+            assert resp.status_code == 200
+            assert mock_run.call_args.kwargs["chunk_size"] == 0
+
+
+# ===========================================================================
+# Route plumbing — POST /api/dataset/import-local-folder
+# ===========================================================================
+
+
+class TestLocalFolderRouteChunked:
+    """The browser-upload route must accept ``chunk_size`` as a form field
+    and route through ``run_chunked`` when set."""
+
+    def test_chunk_size_form_field_routes_to_run_chunked(self, client, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads"
+        )
+
+        captured: dict[str, Any] = {}
+
+        # Patch the server_folder importer registered globally so we
+        # observe whether run_chunked was invoked, without doing any
+        # real audio embedding.
+        from vtsearch.datasets.importers import get_importer
+
+        real_importer = get_importer("server_folder")
+        assert real_importer is not None
+
+        chunked_calls: list[int] = []
+
+        def _stub_run_chunked(field_values, chunk_size, thin=False):
+            chunked_calls.append(chunk_size)
+            yield {1: {"id": 1, "type": "audio", "embedding": np.zeros(4), "filename": "a.wav"}}
+
+        def _stub_run(field_values, medias, thin=False):
+            captured["run_called"] = True
+
+        monkeypatch.setattr(real_importer, "run_chunked", _stub_run_chunked)
+        monkeypatch.setattr(real_importer, "run", _stub_run)
+
+        def _fake_origin_load(load_fn, origin, **kwargs):
+            target: dict[int, dict[str, Any]] = {}
+            load_fn(target)
+            captured["target"] = target
+            return "task-fake-chunked"
+
+        with patch(
+            "vtsearch.routes.datasets._run_origin_load_in_background",
+            side_effect=_fake_origin_load,
+        ):
+            resp = client.post(
+                "/api/dataset/import-local-folder",
+                data={
+                    "media_type": "audio",
+                    "chunk_size": "7",
+                    "files": [(io.BytesIO(b"AAA"), "myfolder/one.wav")],
+                },
+                content_type="multipart/form-data",
+            )
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert chunked_calls == [7]
+        assert "run_called" not in captured
+        assert sorted(captured["target"].keys()) == [1]
+
+    def test_no_chunk_size_uses_run(self, client, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads"
+        )
+
+        from vtsearch.datasets.importers import get_importer
+
+        real_importer = get_importer("server_folder")
+        assert real_importer is not None
+
+        chunked_calls: list[int] = []
+        run_calls: list[None] = []
+
+        def _stub_run_chunked(field_values, chunk_size, thin=False):
+            chunked_calls.append(chunk_size)
+            yield {}
+
+        def _stub_run(field_values, medias, thin=False):
+            run_calls.append(None)
+
+        monkeypatch.setattr(real_importer, "run_chunked", _stub_run_chunked)
+        monkeypatch.setattr(real_importer, "run", _stub_run)
+
+        def _fake_origin_load(load_fn, origin, **kwargs):
+            load_fn({})
+            return "task-fake-whole"
+
+        with patch(
+            "vtsearch.routes.datasets._run_origin_load_in_background",
+            side_effect=_fake_origin_load,
+        ):
+            resp = client.post(
+                "/api/dataset/import-local-folder",
+                data={
+                    "media_type": "audio",
+                    "files": [(io.BytesIO(b"AAA"), "myfolder/one.wav")],
+                },
+                content_type="multipart/form-data",
+            )
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert chunked_calls == []
+        assert len(run_calls) == 1

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -6,8 +6,9 @@ import gc
 import time
 import traceback
 import threading
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 from uuid import uuid4
 
 from vtsearch.settings import (
@@ -787,8 +788,32 @@ def _migrate_context_id(old_id: str, new_id: str) -> None:
             _contexts.pop(old_id, None)
 
 
-def _run_importer_in_background(importer, field_values: dict) -> str:
+def consume_chunks_into(
+    target: dict[int, dict[str, Any]],
+    chunks: Iterable[dict[int, dict[str, Any]]],
+) -> None:
+    """Drain *chunks* into *target* with sequential IDs.
+
+    Each chunk yielded by an importer's ``run_chunked()`` re-uses IDs
+    starting at 1, so naive ``target.update(chunk)`` would overwrite
+    earlier chunks.  Renumber every media to a unique ID continuing from
+    whatever IDs are already present in *target*.
+    """
+    next_id = max(target.keys(), default=0) + 1
+    for chunk in chunks:
+        for media in chunk.values():
+            media["id"] = next_id
+            target[next_id] = media
+            next_id += 1
+
+
+def _run_importer_in_background(importer, field_values: dict, *, chunk_size: int = 0) -> str:
     """Start *importer*.run() in a daemon thread.
+
+    When *chunk_size* is positive and the importer reports
+    ``supports_chunked``, ``run_chunked`` is used instead and the yielded
+    chunks are merged into the target medias dict.  This bounds peak
+    memory during the import/embedding phase for large datasets.
 
     Returns the task_id for progress tracking.
     """
@@ -813,8 +838,13 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # to the frontend (used for guessing the type in subsequent add dialogs).
     media_type_hint = _normalize_media_type(field_values.get("media_type", ""))
 
+    use_chunked = chunk_size > 0 and getattr(importer, "supports_chunked", False)
+
     def _load(target_medias):
-        importer.run(field_values, target_medias)
+        if use_chunked:
+            consume_chunks_into(target_medias, importer.run_chunked(field_values, chunk_size))
+        else:
+            importer.run(field_values, target_medias)
 
     return _run_origin_load_in_background(
         _load,

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -13,6 +13,7 @@ import json
 import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
+from typing import Any
 from uuid import uuid4
 
 from flask import Blueprint, jsonify, request, send_file
@@ -469,7 +470,9 @@ def import_dataset(importer_name: str):
         if val:
             field_values[key] = val
 
-    task_id = _run_importer_in_background(importer, field_values)
+    chunk_size = _parse_chunk_size(get_request_field("chunk_size", bool(file_keys)))
+
+    task_id = _run_importer_in_background(importer, field_values, chunk_size=chunk_size)
     return jsonify({"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""})
 
 
@@ -478,6 +481,21 @@ def import_dataset(importer_name: str):
 # ---------------------------------------------------------------------------
 
 LOCAL_UPLOADS_DIR = DATA_DIR / "local_uploads"
+
+
+def _parse_chunk_size(value: Any) -> int:
+    """Parse an optional ``chunk_size`` form/JSON value into a non-negative int.
+
+    Returns ``0`` when the value is missing, blank, or non-numeric — which
+    means "no chunking, load everything in one pass".
+    """
+    if value is None or value == "":
+        return 0
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, n)
 
 
 def _safe_relative_upload_path(filename: str) -> PurePosixPath | None:
@@ -535,6 +553,7 @@ def import_local_folder():
     converters = (request.form.get("converters") or "").strip()
     recursive_raw = (request.form.get("recursive") or "true").strip().lower()
     recursive = recursive_raw not in ("false", "0", "no", "off")
+    chunk_size = _parse_chunk_size(request.form.get("chunk_size"))
     clipper_params_raw = request.form.get("clipper_params") or ""
     clipper_params: dict | None = None
     if clipper_params_raw:
@@ -594,14 +613,19 @@ def import_local_folder():
     if clipper_name and not clipper_name.endswith("_default"):
         field_values["skip_embedding"] = True
 
+    from vtsearch.auth import get_current_user
+    from vtsearch.datasets.load_pipeline import _normalize_media_type, consume_chunks_into
+
+    use_chunked = chunk_size > 0 and getattr(importer, "supports_chunked", False)
+
     def _load(target_medias):
         try:
-            importer.run(field_values, target_medias)
+            if use_chunked:
+                consume_chunks_into(target_medias, importer.run_chunked(field_values, chunk_size))
+            else:
+                importer.run(field_values, target_medias)
         finally:
             shutil.rmtree(upload_dir, ignore_errors=True)
-
-    from vtsearch.auth import get_current_user
-    from vtsearch.datasets.load_pipeline import _normalize_media_type
 
     task_id = _run_origin_load_in_background(
         _load,


### PR DESCRIPTION
## Summary

The CLI's `--chunk-size` flag streams imports through `run_chunked()` to bound peak memory; the web import flow (importer modal) ran the non-chunked `run()` instead, so big browser uploads or server-folder imports could OOM during embedding regardless of dataset shape. This wires `chunk_size` through both web entry points.

## Backend

- `vtsearch/datasets/load_pipeline.py`: new `consume_chunks_into(target, chunks)` helper that renumbers per-chunk IDs (each chunk restarts at 1) and appends into a shared medias dict. `_run_importer_in_background` gains a `chunk_size` kwarg — when positive and the importer reports `supports_chunked`, the load callback drains `run_chunked()` instead of calling `run()`.
- `POST /api/dataset/import/<name>`: reads optional `chunk_size` from the JSON body / form and forwards it.
- `POST /api/dataset/import-local-folder`: accepts a `chunk_size` form field and routes the post-upload load through `run_chunked` when the underlying `server_folder` importer supports it. The upload itself remains a single multipart POST — that's bounded at the HTTP layer, not here.

## Frontend

- Importer modal exposes a single "Chunk size (advanced — 0 = no chunking)" number input on the **Local Folder**, **Server Folder**, and **generic-form** views. The value is appended to the request only when > 0.

## Other

- Fixes a stale `requirements-plugins.txt` entry that pointed at the old `folder` importer path (renamed to `server_folder` in 8641cc5).
- New `tests/test_chunked_web_flow.py` covers `consume_chunks_into`, the run/run_chunked dispatch, route plumbing for both endpoints (json body, missing/invalid/negative chunk_size), and end-to-end routing of chunk_size through the local-folder upload.

## Test plan

- [x] `./run-tests.sh` — 3050 passed, 1 skipped
- [x] Frontend build OK; npm audit 0 vulnerabilities
- [ ] Manual: load a folder via the modal with `chunk_size=10` and confirm progress shows "(chunk N)" messages

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ubm59aKac7q1mgumUyrJ5C)_