### PR TITLE
Print PID in startup banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ warnings.filterwarnings("ignore", message=".*unauthenticated requests.*")
 warnings.filterwarnings("ignore", message=".*HF_TOKEN.*")
 
 # Visual feedback for startup
-print("⏳ Initializing VTSearch...", flush=True)
+print(f"⏳ Initializing VTSearch... (PID {os.getpid()})", flush=True)
 
 from flask import Flask, g
 


### PR DESCRIPTION
## Summary
- Append the process ID to the `⏳ Initializing VTSearch...` startup line so users can identify the VTSearch process from its log output.

## Test plan
- [ ] `python app.py` prints `⏳ Initializing VTSearch... (PID <n>)` where `<n>` matches the running process.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DtTPGU4P6pBpt2URCjPcES)_