### PR TITLE
Reorganize Add Dataset picker into category tabs

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -3,21 +3,32 @@
     <div class="importer-picker">
       @if (orderedImporters.length === 0) {
         <p class="empty-state">Loading importers...</p>
-      }
-      @for (imp of orderedImporters; track imp.name) {
-        <button
-          class="importer-card"
-          [class.demo-card]="imp.picker_view === 'demo'"
-          [class.disabled]="imp['enabled'] === false"
-          [disabled]="imp['enabled'] === false"
-          (click)="selectImporter(imp)"
-          [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : ''"
-        >
-          <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
-          @if (imp.description) {
-            <span class="importer-desc">{{ imp.description }}</span>
+      } @else {
+        <div class="importer-tab-bar">
+          @for (tab of visibleImporterTabs; track tab.id) {
+            <button
+              class="importer-tab"
+              [class.active]="activeImporterTab === tab.id"
+              (click)="selectImporterTab(tab.id)"
+              [title]="'Show ' + tab.label + ' dataset importers'"
+            >{{ tab.label }}</button>
           }
-        </button>
+        </div>
+        @for (imp of importersForActiveTab; track imp.name) {
+          <button
+            class="importer-card"
+            [class.demo-card]="imp.picker_view === 'demo'"
+            [class.disabled]="imp['enabled'] === false"
+            [disabled]="imp['enabled'] === false"
+            (click)="selectImporter(imp)"
+            [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : ''"
+          >
+            <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
+            @if (imp.description) {
+              <span class="importer-desc">{{ imp.description }}</span>
+            }
+          </button>
+        }
       }
     </div>
   }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -11,6 +11,41 @@
   flex-direction: column;
 }
 
+.importer-tab-bar {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+  border-bottom: 2px solid var(--border);
+  margin-bottom: 12px;
+}
+
+.importer-tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 16px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .85rem;
+  cursor: pointer;
+  transition: all .15s;
+  margin-bottom: -2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-subtle);
+  }
+
+  &.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+    font-weight: 600;
+  }
+}
+
 .clipper-params {
   padding-left: 16px;
   border-left: 2px solid var(--border);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -11,26 +11,29 @@ describe('DatasetImporterModalComponent', () => {
   const mockImporters = [
     {
       name: 'local_folder',
-      display_name: 'Local Folder',
+      display_name: 'Folder',
       description: 'Upload from this computer',
       icon: '📁',
       picker_view: 'local_folder',
+      category: 'local',
       fields: [],
     },
     {
       name: 'local_files',
-      display_name: 'Local Files',
+      display_name: 'Files',
       description: 'Upload one or more individual files from this computer',
       icon: '📄',
       picker_view: 'local_files',
+      category: 'local',
       fields: [],
     },
     {
       name: 'server_folder',
-      display_name: 'Server Folder',
+      display_name: 'Folder',
       description: 'Browse the server filesystem',
       icon: '🖥',
       picker_view: 'server_folder',
+      category: 'server',
       fields: [
         { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'images'] },
         { key: 'path', field_type: 'text', label: 'Folder Path', required: true },
@@ -38,10 +41,11 @@ describe('DatasetImporterModalComponent', () => {
     },
     {
       name: 'server_files',
-      display_name: 'Server Files',
+      display_name: 'Files',
       description: 'Read a text file of paths from the server',
       icon: '🗂',
       picker_view: 'form',
+      category: 'server',
       fields: [
         { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'images'] },
         { key: 'paths_file', field_type: 'server_path', label: 'Paths File', required: true },
@@ -54,6 +58,7 @@ describe('DatasetImporterModalComponent', () => {
       icon: '🗄',
       picker_view: 'demo',
       ui_mode: 'custom',
+      category: 'demo',
       fields: [],
     },
     {
@@ -175,21 +180,24 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.view).toBe('picker');
   });
 
-  it('should render one card per registered importer using display_name', () => {
+  it('should render the cards for the active tab using display_name', () => {
     flushImporters();
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
+    // Default active tab is "local" (the first tab populated by the mocks
+    // that has importers).  Two local importers: local_folder, local_files.
     const cards = el.querySelectorAll('.importer-card');
-    // 7 mock importers (local_folder, local_files, server_folder,
-    // server_files, demo, pickle, generic_form); none hidden.
-    expect(cards.length).toBe(7);
-    // PICKER_ORDER: local_folder, local_files, server_folder, server_files,
-    // demo, combine_datasets — so the local cards appear first.
-    expect(cards[0].textContent).toContain('Local Folder');
-    expect(cards[1].textContent).toContain('Local Files');
-    expect(cards[2].textContent).toContain('Server Folder');
-    expect(cards[3].textContent).toContain('Server Files');
-    expect(cards[4].textContent).toContain('Downloaded Demo Media');
+    expect(cards.length).toBe(2);
+    expect(cards[0].textContent).toContain('Folder');
+    expect(cards[1].textContent).toContain('Files');
+
+    // Switching to the Server tab swaps in the server importers.
+    component.selectImporterTab('server');
+    fixture.detectChanges();
+    const serverCards = el.querySelectorAll('.importer-card');
+    expect(serverCards.length).toBe(2);
+    expect(serverCards[0].textContent).toContain('Folder');
+    expect(serverCards[1].textContent).toContain('Files');
   });
 
   it('should hide importers marked hidden_from_picker', () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -129,6 +129,10 @@ export class DatasetImporterModalComponent implements OnInit {
         this.importers = (res.importers || []).filter(
           (imp) => !imp['hidden_from_picker']
         );
+        const visible = this.visibleImporterTabs;
+        if (!visible.some((t) => t.id === this.activeImporterTab)) {
+          this.activeImporterTab = visible[0]?.id || 'local';
+        }
       },
     });
     this.datasetsApi.getEmbedders().subscribe({
@@ -143,16 +147,27 @@ export class DatasetImporterModalComponent implements OnInit {
     });
   }
 
-  /** Front-of-list order for the picker.  Importers not listed here come
-   *  after these in registry order. */
+  /** Front-of-list order for the picker within each tab.  Importers not
+   *  listed here come after these in registry order. */
   private static readonly PICKER_ORDER = [
     'local_folder',
     'local_files',
     'server_folder',
     'server_files',
     'demo',
-    'combine_datasets',
+    'synthetic',
   ];
+
+  /** Tabs shown above the picker, in display order. */
+  private static readonly CATEGORY_TABS: { id: string; label: string }[] = [
+    { id: 'services', label: 'Services' },
+    { id: 'server', label: 'Server' },
+    { id: 'local', label: 'Local' },
+    { id: 'demo', label: 'Demo' },
+  ];
+
+  /** Currently selected picker tab. */
+  activeImporterTab = 'local';
 
   get orderedImporters(): ImporterInfo[] {
     const order = DatasetImporterModalComponent.PICKER_ORDER;
@@ -167,6 +182,25 @@ export class DatasetImporterModalComponent implements OnInit {
       }
     }
     return result;
+  }
+
+  /** Tabs that have at least one visible importer.  An empty Services tab
+   *  is hidden so the user isn't shown an empty section. */
+  get visibleImporterTabs(): { id: string; label: string }[] {
+    return DatasetImporterModalComponent.CATEGORY_TABS.filter((tab) =>
+      this.orderedImporters.some((imp) => (imp.category || '') === tab.id),
+    );
+  }
+
+  /** Importers belonging to the active tab. */
+  get importersForActiveTab(): ImporterInfo[] {
+    return this.orderedImporters.filter(
+      (imp) => (imp.category || '') === this.activeImporterTab,
+    );
+  }
+
+  selectImporterTab(tabId: string): void {
+    this.activeImporterTab = tabId;
   }
 
   /** Title shown at the top of the modal. */

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -188,6 +188,9 @@ export interface ImporterInfo {
    *  ``"form"`` (default), ``"demo"``, ``"server_folder"``, ``"local_folder"``. */
   picker_view?: string;
   hidden_from_picker?: boolean;
+  /** Picker tab this importer belongs to.  One of ``"services"``,
+   *  ``"server"``, ``"local"``, ``"demo"``, or ``""`` (uncategorised). */
+  category?: string;
   [key: string]: unknown;
 }
 

--- a/tests/test_server_files_importer.py
+++ b/tests/test_server_files_importer.py
@@ -96,7 +96,7 @@ class TestImporterMetadata:
         imp = get_importer("server_files")
         assert imp is not None
         assert imp.name == "server_files"
-        assert imp.display_name == "Server Files"
+        assert imp.display_name == "Files"
         assert imp.picker_view == "form"
         assert imp.hidden_from_picker is False
 

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -134,9 +134,16 @@ class DatasetImporter(PluginBase):
     #: - ``"demo"`` — demo-dataset table.
     picker_view: str = "form"
 
+    #: Picker tab this importer belongs to.  One of ``"services"``,
+    #: ``"server"``, ``"local"``, ``"demo"``, or ``""`` (uncategorised).
+    #: Database/API-style importers (extensions that fetch from a remote
+    #: service) should use ``"services"``.
+    category: str = ""
+
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         d["picker_view"] = self.picker_view
+        d["category"] = self.category
         return d
 
     def __init__(self) -> None:

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -45,6 +45,7 @@ class CombineDatasetsImporter(DatasetImporter):
     description = "Merge multiple saved datasets into one, automatically removing duplicates"
     icon = "\U0001f500"  # twisted rightwards arrows
     ui_mode = "custom"
+    hidden_from_picker = True
     fields = [
         ImporterField(
             key="datasets",

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -34,6 +34,7 @@ class DemoDatasetImporter(DatasetImporter):
     icon = "\U0001f5c4"  # 🗄 — frontend renders as a database icon
     ui_mode = "custom"
     picker_view = "demo"
+    category = "demo"
 
     fields = [
         ImporterField(

--- a/vtsearch/datasets/importers/local_files/__init__.py
+++ b/vtsearch/datasets/importers/local_files/__init__.py
@@ -33,11 +33,12 @@ class LocalFilesDatasetImporter(DatasetImporter):
     """
 
     name = "local_files"
-    display_name = "Local Files"
+    display_name = "Files"
     description = "Upload one or more individual media files from this computer (your browser machine) to the server"
     icon = "\U0001f4c4"  # 📄 — falls back to a generic file icon
     ui_mode = "custom"
     picker_view = "local_files"
+    category = "local"
     fields = []
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:

--- a/vtsearch/datasets/importers/local_folder/__init__.py
+++ b/vtsearch/datasets/importers/local_folder/__init__.py
@@ -30,11 +30,12 @@ class LocalFolderDatasetImporter(DatasetImporter):
     """
 
     name = "local_folder"
-    display_name = "Local Folder"
+    display_name = "Folder"
     description = "Upload a folder of media files from this computer (your browser machine) to the server"
     icon = "\U0001f4c1"  # 📁 — frontend renders as a folder icon
     ui_mode = "custom"
     picker_view = "local_folder"
+    category = "local"
     fields = [
         ImporterField(
             key="recursive",

--- a/vtsearch/datasets/importers/recaller/__init__.py
+++ b/vtsearch/datasets/importers/recaller/__init__.py
@@ -97,6 +97,7 @@ class ReCallerDatasetImporter(DatasetImporter):
     description = "Import media from a ReCaller browsing session."
     icon = "\U0001f50d"  # magnifying glass
     hidden_from_picker = True  # flip to False once API clients are implemented
+    category = "services"
     fields = [
         ImporterField(
             key="query_id",

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -82,12 +82,13 @@ class ServerFilesDatasetImporter(DatasetImporter):
     """
 
     name = "server_files"
-    display_name = "Server Files"
+    display_name = "Files"
     description = (
         "Read a text file on the server containing media-file paths (one per line) and embed every listed file"
     )
     icon = "\U0001f5c2"  # 🗂 — falls back to a generic file icon
     picker_view = "form"
+    category = "server"
     fields = [
         ImporterField(
             key="media_type",

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -181,10 +181,11 @@ class ServerFolderDatasetImporter(DatasetImporter):
     """
 
     name = "server_folder"
-    display_name = "Server Folder"
+    display_name = "Folder"
     description = "Browse the server's filesystem and import media files from a directory"
     icon = "\U0001f5a5"  # 🖥 — frontend renders as a server icon
     picker_view = "server_folder"
+    category = "server"
     fields = [
         ImporterField(
             key="media_type",

--- a/vtsearch/datasets/importers/synthetic/__init__.py
+++ b/vtsearch/datasets/importers/synthetic/__init__.py
@@ -39,6 +39,7 @@ class SyntheticDatasetImporter(DatasetImporter):
     # 🏭 — frontend renders this as a line-drawing factory icon (see
     # frontend/src/app/components/icon/icon.component.ts).
     icon = "\U0001f3ed"
+    category = "demo"
 
     fields = [
         ImporterField(


### PR DESCRIPTION
## Summary
- Group built-in dataset importers into Services / Server / Local / Demo tabs in the dataset-importer modal so the picker is no longer one long flat list
- Hide the "Combined Datasets" card from the picker (the importer itself stays available for combine flows that hit it directly)
- Rename `Server Folder`/`Local Folder` → `Folder` and `Server Files`/`Local Files` → `Files` since the active tab makes the context obvious
- Tag the `recaller` extension scaffold with `category = "services"` so future Services-style importers land in the right tab; the Services tab is hidden when no visible importer claims it

## Implementation
- Adds a `category: str` attribute to `DatasetImporter` (serialised through `to_dict()`); `ImporterInfo` on the frontend gains a matching `category?: string`
- The Angular picker now renders a tab bar above the cards, filters cards by `activeImporterTab`, and only shows tabs whose category contains at least one visible importer

## Backwards compatibility
Breaking change: the importer `display_name` strings for `server_folder`, `server_files`, `local_folder`, and `local_files` are now `"Folder"` / `"Files"`. Anything that displays an importer name outside the picker (e.g. modal titles when one of these importers is selected) will show the shortened name.

## Test plan
- [x] `./run-tests.sh` (3050 passed, 1 skipped, 1 xfailed, 1 xpassed)
- [x] `npm run build:prod` succeeds
- [ ] Manually verify the picker tabs render and switch correctly, and that the Services tab stays hidden by default

https://claude.ai/code/session_01Hz15fi3j4TxvyKp85mNGY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hz15fi3j4TxvyKp85mNGY8)_