### PR TITLE
Support symlinked file/folder entries in Server Files importer

### DIFF
--- a/tests/test_importer_symlinks.py
+++ b/tests/test_importer_symlinks.py
@@ -233,6 +233,46 @@ class TestRglobFollowSymlinks:
         assert rglob_follow_symlinks(root, "*.wav") == []
 
 
+class TestGlobTopLevelSymlinks:
+    """glob_top_level should pick up symlinked files at the top level."""
+
+    def test_finds_symlinked_file_at_top_level(self, tmp_path):
+        from vtsearch.utils.paths import glob_top_level
+
+        external = tmp_path / "external"
+        external.mkdir()
+        real = external / "real.wav"
+        real.write_bytes(b"r")
+
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "linked.wav").symlink_to(real)
+
+        results = glob_top_level(root, "*.wav")
+        names = {p.name for p in results}
+        assert "linked.wav" in names
+
+    def test_skips_symlinked_dir_at_top_level_when_non_recursive(self, tmp_path):
+        """Non-recursive scans deliberately do not descend into folders.
+
+        A symlink that points at a directory therefore stays out of the
+        result set — only top-level *files* (real or symlinked) are
+        returned.
+        """
+        from vtsearch.utils.paths import glob_top_level
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "deep.wav").write_bytes(b"d")
+
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "linked").symlink_to(external)
+
+        results = glob_top_level(root, "*.wav")
+        assert results == []
+
+
 class TestSymlinkedFolderImport:
     """load_dataset_from_folder must discover files inside symlinked subdirs."""
 

--- a/tests/test_server_files_importer.py
+++ b/tests/test_server_files_importer.py
@@ -17,6 +17,7 @@ import numpy as np
 from vtsearch.datasets.importers import get_importer
 from vtsearch.datasets.importers.server_files import (
     ServerFilesDatasetImporter,
+    _expand_paths,
     _read_paths_file,
     _symlink_paths,
 )
@@ -74,6 +75,59 @@ class TestSymlinkPaths:
         src_a.write_bytes(b"A")
         mapping = _symlink_paths([src_a, tmp_path / "missing.wav"], tmp_path / "stage")
         assert list(mapping.keys()) == ["a.wav"]
+
+    def test_follows_symlinked_file_entries(self, tmp_path):
+        real = tmp_path / "real.wav"
+        real.write_bytes(b"R")
+        link = tmp_path / "link.wav"
+        link.symlink_to(real)
+
+        mapping = _symlink_paths([link], tmp_path / "stage")
+        assert "link.wav" in mapping
+        # The staged symlink resolves back to the real source file.
+        assert (tmp_path / "stage" / "link.wav").resolve() == real.resolve()
+
+    def test_expands_directory_entry(self, tmp_path):
+        d = tmp_path / "media"
+        d.mkdir()
+        (d / "a.wav").write_bytes(b"A")
+        (d / "b.wav").write_bytes(b"B")
+        sub = d / "sub"
+        sub.mkdir()
+        (sub / "c.wav").write_bytes(b"C")
+
+        mapping = _symlink_paths([d], tmp_path / "stage")
+        # All three files (including the one in the subdirectory) are
+        # symlinked into the flat staging dir.
+        assert {"a.wav", "b.wav", "c.wav"} <= set(mapping.keys())
+
+    def test_expands_symlinked_directory_entry(self, tmp_path):
+        real = tmp_path / "real_dir"
+        real.mkdir()
+        (real / "x.wav").write_bytes(b"X")
+        sub = real / "nested"
+        sub.mkdir()
+        (sub / "y.wav").write_bytes(b"Y")
+
+        link = tmp_path / "link_dir"
+        link.symlink_to(real)
+
+        mapping = _symlink_paths([link], tmp_path / "stage")
+        assert {"x.wav", "y.wav"} <= set(mapping.keys())
+
+    def test_expand_paths_follows_symlinked_subdirs(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "top.wav").write_bytes(b"T")
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "ext.wav").write_bytes(b"E")
+        (root / "linked").symlink_to(external)
+
+        files = _expand_paths([root])
+        names = {p.name for p in files}
+        assert "top.wav" in names
+        assert "ext.wav" in names
 
     def test_disambiguates_duplicate_basenames(self, tmp_path):
         d1 = tmp_path / "d1"
@@ -173,6 +227,57 @@ class TestRunEndToEnd:
             assert media["origin_name"] in {str(src_a), str(src_b)}
             assert Path(media["origin_name"]).is_file()
             assert isinstance(media["embedding"], np.ndarray)
+
+
+class TestRunWithSymlinkEntries:
+    """End-to-end: list entries that are symlinks (file or folder) work."""
+
+    def test_run_imports_through_symlinked_directory_entry(self, tmp_path):
+        from helpers import make_raw_wav_bytes
+
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir()
+        a = real_dir / "a.wav"
+        b = real_dir / "b.wav"
+        a.write_bytes(make_raw_wav_bytes())
+        # Make b structurally distinct so dedup doesn't collapse it.
+        b.write_bytes(make_raw_wav_bytes() + b"\x00\x00")
+
+        link_dir = tmp_path / "link_dir"
+        link_dir.symlink_to(real_dir)
+
+        listing = tmp_path / "list.txt"
+        listing.write_text(f"{link_dir}\n")
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        imp.run({"paths_file": str(listing), "media_type": "audio"}, medias)
+
+        assert len(medias) == 2
+        origin_names = {m["origin_name"] for m in medias.values()}
+        # origin_name is the resolved absolute path of the real source file,
+        # so resolve_file works regardless of whether the symlinked dir
+        # later disappears.
+        assert origin_names == {str(a.resolve()), str(b.resolve())}
+
+    def test_run_imports_through_symlinked_file_entry(self, tmp_path):
+        from helpers import make_raw_wav_bytes
+
+        real = tmp_path / "real.wav"
+        real.write_bytes(make_raw_wav_bytes())
+        link = tmp_path / "link.wav"
+        link.symlink_to(real)
+
+        listing = tmp_path / "list.txt"
+        listing.write_text(f"{link}\n")
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        imp.run({"paths_file": str(listing), "media_type": "audio"}, medias)
+
+        assert len(medias) == 1
+        media = next(iter(medias.values()))
+        assert media["origin_name"] == str(real.resolve())
 
 
 class TestRunChunked:

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -3,7 +3,9 @@
 The user supplies the absolute path of a UTF-8 text file on the server.
 Each non-empty, non-comment line of that file is treated as the
 absolute path (or path relative to the text file's directory) of a
-media file to embed.  The importer symlinks each listed file into a
+media file or directory to embed.  Symlinks (to either files or
+directories) are followed, and directory entries are walked recursively
+for media files.  The importer symlinks every resulting file into a
 temporary directory and then delegates to :mod:`server_folder` for the
 actual scanning/embedding.  After the import each media's origin is
 rewritten to point at this importer so that
@@ -14,6 +16,7 @@ Lines beginning with ``#`` are treated as comments and skipped.
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 from collections.abc import Iterator
@@ -42,11 +45,36 @@ def _read_paths_file(paths_file: Path) -> list[Path]:
     return paths
 
 
+def _expand_paths(paths: list[Path]) -> list[Path]:
+    """Expand any directory entries in *paths* into the files they contain.
+
+    Both ``Path.is_file`` and ``Path.is_dir`` follow symlinks by default, so
+    a list entry that's a symlink to a file or to a directory is treated
+    just like the underlying target.  Directory entries are walked
+    recursively with ``followlinks=True`` so symlinked sub-directories are
+    also descended.
+    """
+    expanded: list[Path] = []
+    for src in paths:
+        if src.is_file():
+            expanded.append(src)
+        elif src.is_dir():
+            for dirpath, _dirnames, filenames in os.walk(src, followlinks=True):
+                for name in filenames:
+                    expanded.append(Path(dirpath) / name)
+    return expanded
+
+
 def _symlink_paths(paths: list[Path], target_dir: Path) -> dict[str, Path]:
-    """Symlink each *paths* entry into *target_dir*; return name→source map."""
+    """Symlink each *paths* entry into *target_dir*; return name→source map.
+
+    Entries that are directories (or symlinks to directories) are walked
+    recursively for files; every regular file found inside is symlinked
+    into the staging directory with a disambiguated basename.
+    """
     target_dir.mkdir(parents=True, exist_ok=True)
     name_to_source: dict[str, Path] = {}
-    for src in paths:
+    for src in _expand_paths(paths):
         if not src.is_file():
             continue
         # Disambiguate identical basenames by appending an index.
@@ -100,7 +128,11 @@ class ServerFilesDatasetImporter(DatasetImporter):
             key="paths_file",
             label="Paths File",
             field_type="server_path",
-            description="Absolute server path to a text file containing one media-file path per line.",
+            description=(
+                "Absolute server path to a text file containing one media-file or "
+                "directory path per line.  Symlinks are followed; directory entries "
+                "are scanned recursively for media files."
+            ),
             accept=".txt,.list",
         ),
     ]


### PR DESCRIPTION
## Summary

The folder-based importers (Server Folder, Local Folder, Local Files) already follow symlinks via `rglob_follow_symlinks` (recursive) and `glob_top_level` (non-recursive, top-level files via `is_file(follow_symlinks=True)`). The Server Files importer accepted symlinked **file** entries — `Path.is_file()` follows symlinks by default — but silently skipped any list entry that pointed at a directory (whether the directory itself or a symlink to one).

This PR rounds out the support so that all four importers handle symlinked files **and** folders in their list/folder source:

- Add `_expand_paths` in `server_files` to walk directory entries with `followlinks=True`, then feed the flattened result through `_symlink_paths` so each file is staged into the temp dir as before.
- Update the Paths File field description and the module docstring to document the new behavior.
- Add tests covering: symlinked-file list entry, plain-directory list entry, symlinked-directory list entry, symlinked sub-dir inside a directory entry, top-level symlinked file glob, and end-to-end `run()` with a symlinked-directory entry.

No behavior change for the Folder importers (they already worked); the change is additive for the Files importer.

## Test plan
- [x] `./run-tests.sh` — 3058 passed
- [x] New unit tests for `_expand_paths`, `_symlink_paths`, top-level symlink glob, and end-to-end `run()` with symlinked file/folder entries

https://claude.ai/code/session_01EkkYSzpojYMmmTM1jX86ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkkYSzpojYMmmTM1jX86ry)_