### PR TITLE
Backend-declared picker tabs + folder/file/cubes icons

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
   <!-- Dataset Section -->
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="database" [size]="18"></vt-icon> Datasets</span>
+      <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</span>
       @if (errorMessage) {
         <div class="dashboard-error">
           <span class="error-msg">{{ errorMessage }}</span>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -11,7 +11,7 @@
               [class.active]="activeImporterTab === tab.id"
               (click)="selectImporterTab(tab.id)"
               [title]="'Show ' + tab.label + ' dataset importers'"
-            >{{ tab.label }}</button>
+            >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
           }
         </div>
         @for (imp of importersForActiveTab; track imp.name) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -141,9 +141,16 @@ describe('DatasetImporterModalComponent', () => {
     httpMock.verify();
   });
 
+  const mockTabs = [
+    { id: 'services', label: 'Services', icon: 'lightning', order: 10 },
+    { id: 'server', label: 'Server', icon: 'server', order: 20 },
+    { id: 'local', label: 'Local', icon: 'house', order: 30 },
+    { id: 'demo', label: 'Demo', icon: 'flask', order: 40 },
+  ];
+
   function flushImporters(): void {
     fixture.detectChanges();
-    httpMock.expectOne('/api/dataset/all-importers').flush({ importers: mockImporters });
+    httpMock.expectOne('/api/dataset/all-importers').flush({ importers: mockImporters, tabs: mockTabs });
   }
 
   /** Open the demo picker and flush all resulting HTTP requests. */
@@ -206,7 +213,7 @@ describe('DatasetImporterModalComponent', () => {
       ...mockImporters,
       { name: 'recaller', display_name: 'ReCaller', hidden_from_picker: true, fields: [] },
     ];
-    httpMock.expectOne('/api/dataset/all-importers').flush({ importers: importersWithHidden });
+    httpMock.expectOne('/api/dataset/all-importers').flush({ importers: importersWithHidden, tabs: mockTabs });
     expect(component.importers.find((i) => i.name === 'recaller')).toBeUndefined();
   });
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -6,7 +6,7 @@ import { FileBrowserComponent } from '../../file-browser/file-browser.component'
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
-import { ImporterInfo, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
+import { ImporterInfo, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 
 type ModalView = 'picker' | 'form' | 'demo' | 'server_folder' | 'local_folder';
 
@@ -129,6 +129,7 @@ export class DatasetImporterModalComponent implements OnInit {
         this.importers = (res.importers || []).filter(
           (imp) => !imp['hidden_from_picker']
         );
+        this.declaredTabs = res.tabs || [];
         const visible = this.visibleImporterTabs;
         if (!visible.some((t) => t.id === this.activeImporterTab)) {
           this.activeImporterTab = visible[0]?.id || 'local';
@@ -158,13 +159,8 @@ export class DatasetImporterModalComponent implements OnInit {
     'synthetic',
   ];
 
-  /** Tabs shown above the picker, in display order. */
-  private static readonly CATEGORY_TABS: { id: string; label: string }[] = [
-    { id: 'services', label: 'Services' },
-    { id: 'server', label: 'Server' },
-    { id: 'local', label: 'Local' },
-    { id: 'demo', label: 'Demo' },
-  ];
+  /** Tab declarations supplied by the backend (``/api/dataset/all-importers``). */
+  declaredTabs: ImporterPickerTab[] = [];
 
   /** Currently selected picker tab. */
   activeImporterTab = 'local';
@@ -184,12 +180,42 @@ export class DatasetImporterModalComponent implements OnInit {
     return result;
   }
 
-  /** Tabs that have at least one visible importer.  An empty Services tab
-   *  is hidden so the user isn't shown an empty section. */
-  get visibleImporterTabs(): { id: string; label: string }[] {
-    return DatasetImporterModalComponent.CATEGORY_TABS.filter((tab) =>
-      this.orderedImporters.some((imp) => (imp.category || '') === tab.id),
+  /** Title-case an importer category id when no backend declaration exists.
+   *  ``"my_cloud"`` → ``"My Cloud"``. */
+  private fallbackTabLabel(id: string): string {
+    return id
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+      .map((part) => part[0].toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  /** Tabs that have at least one visible importer.  Tabs declared by the
+   *  backend render in their declared order; categories used by importers
+   *  but never declared get appended at the end with a title-cased label
+   *  and no icon.  An empty tab (no importers) is hidden so the user
+   *  isn't shown an empty section. */
+  get visibleImporterTabs(): ImporterPickerTab[] {
+    const usedCategories = new Set(
+      this.orderedImporters.map((imp) => imp.category || '').filter(Boolean),
     );
+    const visible: ImporterPickerTab[] = [];
+    const seen = new Set<string>();
+    const declared = [...this.declaredTabs].sort(
+      (a, b) => (a.order ?? 100) - (b.order ?? 100),
+    );
+    for (const tab of declared) {
+      if (usedCategories.has(tab.id)) {
+        visible.push(tab);
+        seen.add(tab.id);
+      }
+    }
+    for (const id of usedCategories) {
+      if (!seen.has(id)) {
+        visible.push({ id, label: this.fallbackTabLabel(id) });
+      }
+    }
+    return visible;
   }
 
   /** Importers belonging to the active tab. */

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -14,7 +14,7 @@ const KNOWN_TYPES = new Set([
   'list', 'grid', 'cursor-click', 'cursor-hover',
   'palette', 'sort-descending', 'steering-wheel', 'cloud-upload',
   'thumbs-up', 'thumbs-down', 'factory',
-  'house', 'lightning', 'flask',
+  'house', 'lightning', 'flask', 'cubes',
 ]);
 
 function emojiToType(icon: string): string {
@@ -175,6 +175,9 @@ function emojiToType(icon: string): string {
       }
       @case ('flask') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v7.5a2 2 0 0 1-.3 1L4 20a1.5 1.5 0 0 0 1.3 2.2h13.4A1.5 1.5 0 0 0 20 20l-4.7-9.5a2 2 0 0 1-.3-1V2"/><line x1="8" y1="2" x2="16" y2="2"/><line x1="7" y1="15" x2="17" y2="15"/></svg>
+      }
+      @case ('cubes') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 6h18v18H2z"/><path d="M2 6l2-2h18v18l-2 2"/><path d="M20 6l2-2"/><path d="M8 6v18M14 6v18M2 12h18M2 18h18"/><path d="M8 6l2-2M14 6l2-2"/><path d="M20 12l2-2M20 18l2-2"/></svg>
       }
     } }
   `,

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -14,6 +14,7 @@ const KNOWN_TYPES = new Set([
   'list', 'grid', 'cursor-click', 'cursor-hover',
   'palette', 'sort-descending', 'steering-wheel', 'cloud-upload',
   'thumbs-up', 'thumbs-down', 'factory',
+  'house', 'lightning', 'flask',
 ]);
 
 function emojiToType(icon: string): string {
@@ -165,6 +166,15 @@ function emojiToType(icon: string): string {
       }
       @case ('factory') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8l-7 5V8l-7 5V4a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"/><path d="M17 18h1"/><path d="M12 18h1"/><path d="M7 18h1"/></svg>
+      }
+      @case ('house') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      }
+      @case ('lightning') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+      }
+      @case ('flask') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v7.5a2 2 0 0 1-.3 1L4 20a1.5 1.5 0 0 0 1.3 2.2h13.4A1.5 1.5 0 0 0 20 20l-4.7-9.5a2 2 0 0 1-.3-1V2"/><line x1="8" y1="2" x2="16" y2="2"/><line x1="7" y1="15" x2="17" y2="15"/></svg>
       }
     } }
   `,

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -206,8 +206,19 @@ export interface ImporterField {
   placeholder?: string;
 }
 
+export interface ImporterPickerTab {
+  id: string;
+  label: string;
+  icon?: string;
+  order?: number;
+}
+
 export interface ImportersResponse {
   importers: ImporterInfo[];
+  /** Picker tab declarations.  When present, the frontend renders one tab
+   *  per entry; when absent (older backends) the frontend falls back to
+   *  inferring tabs from importer ``category`` values. */
+  tabs?: ImporterPickerTab[];
 }
 
 export interface DemoDataset {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -581,8 +581,8 @@ class TestImporterMetadata:
         data = resp.get_json()
         folder_imp = next((i for i in data["importers"] if i["name"] == "server_folder"), None)
         assert folder_imp is not None
-        # 🖥 — frontend renders this as a "server" icon (see icon.component.ts).
-        assert folder_imp["icon"] == "\U0001f5a5"
+        # 📁 — frontend renders this as a "folder" icon (see icon.component.ts).
+        assert folder_imp["icon"] == "\U0001f4c1"
 
     def test_folder_importer_description(self, client):
         resp = client.get("/api/dataset/importers")

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -301,10 +301,11 @@ class TestFolderImporterMetadata:
     def test_name_is_folder(self):
         assert self._get_importer().name == "server_folder"
 
-    def test_icon_is_server_emoji(self):
-        # 🖥 — frontend renders this as a "server" icon, distinguishing
-        # the server-side card from the browser-side Local Folder card.
-        assert self._get_importer().icon == "🖥"
+    def test_icon_is_folder_emoji(self):
+        # 📁 — frontend renders this as a "folder" icon, matching the
+        # browser-side Local Folder card.  The Server tab makes the
+        # server-vs-local distinction.
+        assert self._get_importer().icon == "📁"
 
     def test_description_says_media_files_from_a_folder(self):
         desc = self._get_importer().description.lower()
@@ -325,7 +326,7 @@ class TestFolderImporterMetadata:
 
     def test_to_dict_includes_icon(self):
         d = self._get_importer().to_dict()
-        assert d["icon"] == "🖥"
+        assert d["icon"] == "📁"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_picker_tabs.py
+++ b/tests/test_picker_tabs.py
@@ -1,0 +1,75 @@
+"""Tests for the dataset-importer picker-tab registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch.datasets.importers.tabs import (
+    _PICKER_TABS,
+    list_picker_tabs,
+    register_picker_tab,
+)
+
+
+@pytest.fixture
+def restore_tabs():
+    """Snapshot/restore the picker-tab registry around tests that mutate it."""
+    snapshot = [dict(t) for t in _PICKER_TABS]
+    yield
+    _PICKER_TABS.clear()
+    _PICKER_TABS.extend(snapshot)
+
+
+class TestBuiltinTabs:
+    def test_built_in_tabs_present(self):
+        ids = {t["id"] for t in list_picker_tabs()}
+        assert {"services", "server", "local", "demo"} <= ids
+
+    def test_built_in_tabs_have_labels_and_icons(self):
+        for tab in list_picker_tabs():
+            assert tab.get("label")
+            assert tab.get("icon")
+
+    def test_tabs_are_sorted_by_order(self):
+        tabs = list_picker_tabs()
+        orders = [t.get("order", 100) for t in tabs]
+        assert orders == sorted(orders)
+
+
+class TestRegisterPickerTab:
+    def test_register_appends_new_tab(self, restore_tabs):
+        register_picker_tab({"id": "cloud", "label": "Cloud", "icon": "cloud", "order": 25})
+        ids = [t["id"] for t in list_picker_tabs()]
+        assert "cloud" in ids
+
+    def test_register_replaces_existing_tab(self, restore_tabs):
+        register_picker_tab({"id": "server", "label": "Servers", "icon": "server", "order": 5})
+        tabs = list_picker_tabs()
+        server = next(t for t in tabs if t["id"] == "server")
+        assert server["label"] == "Servers"
+        assert server["order"] == 5
+
+    def test_register_requires_id(self):
+        with pytest.raises(ValueError):
+            register_picker_tab({"label": "Bad"})
+
+    def test_register_requires_label(self):
+        with pytest.raises(ValueError):
+            register_picker_tab({"id": "bad"})
+
+
+class TestApiResponse:
+    def test_all_importers_includes_tabs(self, client):
+        resp = client.get("/api/dataset/all-importers")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "tabs" in data
+        assert isinstance(data["tabs"], list)
+        ids = {t["id"] for t in data["tabs"]}
+        assert {"services", "server", "local", "demo"} <= ids
+
+    def test_tab_entries_have_id_and_label(self, client):
+        resp = client.get("/api/dataset/all-importers")
+        for tab in resp.get_json()["tabs"]:
+            assert tab.get("id")
+            assert tab.get("label")

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -183,7 +183,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
     name = "server_folder"
     display_name = "Folder"
     description = "Browse the server's filesystem and import media files from a directory"
-    icon = "\U0001f5a5"  # 🖥 — frontend renders as a server icon
+    icon = "\U0001f4c1"  # 📁 — frontend renders as a folder icon
     picker_view = "server_folder"
     category = "server"
     fields = [

--- a/vtsearch/datasets/importers/tabs.py
+++ b/vtsearch/datasets/importers/tabs.py
@@ -1,0 +1,50 @@
+"""Picker tab definitions for the dataset-importer modal.
+
+Each importer's ``category`` field references a tab id declared here.  The
+frontend renders one tab per declaration, in :attr:`order`, and only shows
+tabs that have at least one visible importer.
+
+Extensions that introduce new categories can call :func:`register_picker_tab`
+to give the new tab a pretty label and icon.  The frontend falls back to a
+title-cased version of the id if no declaration exists, but registering one
+yields a nicer result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Built-in picker tabs.  ``order`` is ascending (smaller comes first).  The
+#: ``icon`` field references a type understood by ``vt-icon`` (see
+#: ``frontend/src/app/components/icon/icon.component.ts``).
+_PICKER_TABS: list[dict[str, Any]] = [
+    {"id": "services", "label": "Services", "icon": "lightning", "order": 10},
+    {"id": "server", "label": "Server", "icon": "server", "order": 20},
+    {"id": "local", "label": "Local", "icon": "house", "order": 30},
+    {"id": "demo", "label": "Demo", "icon": "flask", "order": 40},
+]
+
+
+def list_picker_tabs() -> list[dict[str, Any]]:
+    """Return the registered picker tabs sorted by ``order``."""
+    return [dict(t) for t in sorted(_PICKER_TABS, key=lambda t: t.get("order", 100))]
+
+
+def register_picker_tab(tab: dict[str, Any]) -> None:
+    """Add or replace a picker tab definition.
+
+    Args:
+        tab: A dict with at least ``id`` (matching importer ``category``
+            values) and ``label``.  Optional fields: ``icon`` (vt-icon type
+            name), ``order`` (int — lower values render first).
+    """
+    tab_id = tab.get("id")
+    if not tab_id:
+        raise ValueError("picker tab requires an 'id' field")
+    if not tab.get("label"):
+        raise ValueError("picker tab requires a 'label' field")
+    for i, existing in enumerate(_PICKER_TABS):
+        if existing["id"] == tab_id:
+            _PICKER_TABS[i] = dict(tab)
+            return
+    _PICKER_TABS.append(dict(tab))

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -253,6 +253,8 @@ def dataset_importers():
 @datasets_bp.route("/api/dataset/all-importers")
 def dataset_all_importers():
     """List all registered importers (including built-in ones)."""
+    from vtsearch.datasets.importers.tabs import list_picker_tabs
+
     all_importers = [imp.to_dict() for imp in list_importers()]
 
     # Annotate combine_datasets with an enabled flag: requires 2+ saved
@@ -266,7 +268,7 @@ def dataset_all_importers():
             imp_dict["enabled"] = can_combine
             break
 
-    return jsonify({"importers": all_importers})
+    return jsonify({"importers": all_importers, "tabs": list_picker_tabs()})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #1170 (already merged). This PR covers everything that landed on the same branch after the merge.

## Summary
- **Backend-declared picker tabs.** New `vtsearch/datasets/importers/tabs.py` with `list_picker_tabs()` and `register_picker_tab(tab)`. The `/api/dataset/all-importers` response now includes a `tabs` array (`{ id, label, icon, order }`); extensions can register their own tab id with a pretty label and icon. Frontend renders one tab per declaration, sorted by `order`, hiding any tab whose category has no visible importers, and falling back to a title-cased label for any importer category that's used but never declared.
- **New SVG icons.** `house` (Local tab), `lightning` (Services tab), `flask` (Demo tab), and `cubes` — a 3×3 grid of cube outlines drawn as a single front face gridded into thirds with isometric depth lines projecting to the top and right faces, so each cell reads as a separate cube.
- **Icon cleanup on the importer cards.** `server_folder` now uses 📁 (folder) instead of 🖥, matching `local_folder`; both `*_files` importers continue to render the file icon. The Server tab makes the server-vs-local distinction at the tab level.
- **Dashboard Datasets section** uses the new `cubes` icon instead of `database`, freeing the cylinder/disk look from collision with the server icon.

## Test plan
- [x] `./run-tests.sh` (3059 passed, 1 skipped, 2 xpassed)
- [x] New `tests/test_picker_tabs.py` covers built-in tabs, `register_picker_tab` validation/replacement, the `tabs` field in the API response
- [x] `npm run build:prod` succeeds
- [ ] Manually verify the four tab icons render at 14px next to their labels, and that the Datasets dashboard shows the new cubes icon

https://claude.ai/code/session_01Hz15fi3j4TxvyKp85mNGY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hz15fi3j4TxvyKp85mNGY8)_