### PR TITLE
Drag-to-reorder columns in dashboard dataset and model grids

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -27,18 +27,24 @@
           <thead>
             <tr>
               <th (click)="sortDatasets('name')" class="sortable" title="Dataset display name (click to sort)" data-col="name" [style.width.px]="datasetsTableFixed ? datasetColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isDatasetSortActive('name')">{{ datasetSortIndicator('name') }}</span></th>
-              <th (click)="sortDatasets('media_type')" class="sortable" title="Media type: audio, image, text, video, or document (click to sort)" data-col="media_type" [style.width.px]="datasetsTableFixed ? datasetColWidths['media_type'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Type<span class="sort-indicator" [class.active]="isDatasetSortActive('media_type')">{{ datasetSortIndicator('media_type') }}</span></th>
-              <th (click)="sortDatasets('num_items')" class="sortable" title="Number of media items in the dataset (click to sort)" data-col="num_items" [style.width.px]="datasetsTableFixed ? datasetColWidths['num_items'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div># Items<span class="sort-indicator" [class.active]="isDatasetSortActive('num_items')">{{ datasetSortIndicator('num_items') }}</span></th>
-              <th (click)="sortDatasets('num_dupes')" class="sortable" title="Number of duplicate items collapsed (click to sort)" data-col="num_dupes" [style.width.px]="datasetsTableFixed ? datasetColWidths['num_dupes'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div># Dupes<span class="sort-indicator" [class.active]="isDatasetSortActive('num_dupes')">{{ datasetSortIndicator('num_dupes') }}</span></th>
-              <th (click)="sortDatasets('created_at')" class="sortable" title="When the dataset was first imported (click to sort)" data-col="created_at" [style.width.px]="datasetsTableFixed ? datasetColWidths['created_at'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Created<span class="sort-indicator" [class.active]="isDatasetSortActive('created_at')">{{ datasetSortIndicator('created_at') }}</span></th>
-              <th (click)="sortDatasets('clipper')" class="sortable" title="MediaClipper used at creation (click to sort)" data-col="clipper" [style.width.px]="datasetsTableFixed ? datasetColWidths['clipper'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Clipper<span class="sort-indicator" [class.active]="isDatasetSortActive('clipper')">{{ datasetSortIndicator('clipper') }}</span></th>
-              <th (click)="sortDatasets('embedder')" class="sortable" title="MediaEmbedder used for embedding (click to sort)" data-col="embedder" [style.width.px]="datasetsTableFixed ? datasetColWidths['embedder'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Embedder<span class="sort-indicator" [class.active]="isDatasetSortActive('embedder')">{{ datasetSortIndicator('embedder') }}</span></th>
-              @if (!isDefaultLogin) {
-                <th (click)="sortDatasets('created_by')" class="sortable" title="User who created this dataset (click to sort)" data-col="created_by" [style.width.px]="datasetsTableFixed ? datasetColWidths['created_by'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Creator<span class="sort-indicator" [class.active]="isDatasetSortActive('created_by')">{{ datasetSortIndicator('created_by') }}</span></th>
-                <th (click)="sortDatasets('readers')" class="sortable" title="Users with access to this dataset (click to sort)" data-col="readers" [style.width.px]="datasetsTableFixed ? datasetColWidths['readers'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Readers<span class="sort-indicator" [class.active]="isDatasetSortActive('readers')">{{ datasetSortIndicator('readers') }}</span></th>
+              @for (col of visibleDatasetColumns; track col) {
+                <th
+                  [class.sortable]="datasetColMeta(col).sortable"
+                  [class.col-drop-left]="isDropTarget('datasets', col, 'left')"
+                  [class.col-drop-right]="isDropTarget('datasets', col, 'right')"
+                  [class.col-dragging]="isDragging('datasets', col)"
+                  [attr.data-col]="col"
+                  [title]="datasetColMeta(col).title"
+                  [style.width.px]="datasetsTableFixed ? datasetColWidths[col] : null"
+                  draggable="true"
+                  (click)="onDatasetHeaderClick(col)"
+                  (dragstart)="onColDragStart($event, 'datasets', col)"
+                  (dragover)="onColDragOver($event, 'datasets', col)"
+                  (dragleave)="onColDragLeave($event, 'datasets', col)"
+                  (drop)="onColDrop($event, 'datasets', col)"
+                  (dragend)="onColDragEnd($event)"
+                ><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetColMeta(col).label }}@if (datasetColMeta(col).sortable) {<span class="sort-indicator" [class.active]="isDatasetSortActive(col)">{{ datasetSortIndicator(col) }}</span>}</th>
               }
-              <th title="Whether the dataset is currently loaded in memory" data-col="loaded" [style.width.px]="datasetsTableFixed ? datasetColWidths['loaded'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Loaded?</th>
-              <th title="Available operations for this dataset" data-col="actions" [style.width.px]="datasetsTableFixed ? datasetColWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()"></div>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -47,7 +53,7 @@
                 <td>
                   <span class="loading-task-name">{{ task.name || 'Loading...' }}</span>
                 </td>
-                <td [attr.colspan]="isDefaultLogin ? 8 : 10">
+                <td [attr.colspan]="visibleDatasetColumns.length">
                   @if (task.error) {
                     <div class="loading-task-progress loading-task-failed">
                       <span class="error-msg">Failed: {{ task.error }}</span>
@@ -72,6 +78,7 @@
                 [dataset]="dataset"
                 [currentUser]="currentUser"
                 [isDefaultLogin]="isDefaultLogin"
+                [columnOrder]="visibleDatasetColumns"
                 [selected]="isDatasetSelected(dataset.id)"
                 [dimmed]="isLoading && !isDatasetSelected(dataset.id)"
                 [loadingTask]="getInlineTask(dataset.id)"
@@ -115,20 +122,31 @@
           <thead>
             <tr>
               <th (click)="sortModels('name')" class="sortable" title="Model display name (click to sort)" data-col="name" [style.width.px]="modelsTableFixed ? modelColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
-              <th (click)="sortModels('media_type')" class="sortable" title="Media type this model operates on (click to sort)" data-col="media_type" [style.width.px]="modelsTableFixed ? modelColWidths['media_type'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Type<span class="sort-indicator" [class.active]="isModelSortActive('media_type')">{{ modelSortIndicator('media_type') }}</span></th>
-              <th (click)="sortModels('num_training')" class="sortable" title="Number of labeled training examples (click to sort)" data-col="num_training" [style.width.px]="modelsTableFixed ? modelColWidths['num_training'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div># Training<span class="sort-indicator" [class.active]="isModelSortActive('num_training')">{{ modelSortIndicator('num_training') }}</span></th>
-              <th title="Is this Model one we can load into Train Mode and improve?" data-col="trainable" [style.width.px]="modelsTableFixed ? modelColWidths['trainable'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Trainable?</th>
-              <th (click)="sortModels('autodetect')" class="sortable" title="Include this model in CLI autorun (click to sort)" data-col="autodetect" [style.width.px]="modelsTableFixed ? modelColWidths['autodetect'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Autorun?<span class="sort-indicator" [class.active]="isModelSortActive('autodetect')">{{ modelSortIndicator('autodetect') }}</span></th>
-              <th (click)="sortModels('last_trained_at')" class="sortable" title="When the model was last trained (click to sort)" data-col="last_trained_at" [style.width.px]="modelsTableFixed ? modelColWidths['last_trained_at'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Last Trained<span class="sort-indicator" [class.active]="isModelSortActive('last_trained_at')">{{ modelSortIndicator('last_trained_at') }}</span></th>
-              <th (click)="sortModels('created_at')" class="sortable" title="When the model was created (click to sort)" data-col="created_at" [style.width.px]="modelsTableFixed ? modelColWidths['created_at'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Created<span class="sort-indicator" [class.active]="isModelSortActive('created_at')">{{ modelSortIndicator('created_at') }}</span></th>
-              <th title="Whether the model's inference data is cached in memory" data-col="detector_loaded" [style.width.px]="modelsTableFixed ? modelColWidths['detector_loaded'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Loaded?</th>
-              <th title="Available operations for this model" data-col="actions" [style.width.px]="modelsTableFixed ? modelColWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()"></div>Actions</th>
+              @for (col of visibleModelColumns; track col) {
+                <th
+                  [class.sortable]="modelColMeta(col).sortable"
+                  [class.col-drop-left]="isDropTarget('models', col, 'left')"
+                  [class.col-drop-right]="isDropTarget('models', col, 'right')"
+                  [class.col-dragging]="isDragging('models', col)"
+                  [attr.data-col]="col"
+                  [title]="modelColMeta(col).title"
+                  [style.width.px]="modelsTableFixed ? modelColWidths[col] : null"
+                  draggable="true"
+                  (click)="onModelHeaderClick(col)"
+                  (dragstart)="onColDragStart($event, 'models', col)"
+                  (dragover)="onColDragOver($event, 'models', col)"
+                  (dragleave)="onColDragLeave($event, 'models', col)"
+                  (drop)="onColDrop($event, 'models', col)"
+                  (dragend)="onColDragEnd($event)"
+                ><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelColMeta(col).label }}@if (modelColMeta(col).sortable) {<span class="sort-indicator" [class.active]="isModelSortActive(col)">{{ modelSortIndicator(col) }}</span>}</th>
+              }
             </tr>
           </thead>
           <tbody>
             @for (model of sortedModels; track model.id) {
               <vt-model-card
                 [model]="model"
+                [columnOrder]="visibleModelColumns"
                 [selected]="isModelSelected(model.id)"
                 [dimmed]="isLoading && !isModelSelected(model.id)"
                 [loadingTask]="getInlineModelTask(model.id)"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -186,12 +186,61 @@
     letter-spacing: 0.03em;
     user-select: none;
 
+    // Headers (other than name) are draggable for reordering. The text itself
+    // is the drag handle; resize-handle children stop their own mousedown so
+    // dragging does not start when grabbing a divider.
+    &[draggable='true'] {
+      cursor: grab;
+    }
+
+    &[draggable='true']:active {
+      cursor: grabbing;
+    }
+
     &.sortable {
       cursor: pointer;
 
       &:hover {
         color: var(--text-primary);
       }
+    }
+
+    // Combine: a sortable header that is also draggable should still show
+    // grab on hover (drag is the dominant interaction; sort fires on click).
+    &[draggable='true'].sortable {
+      cursor: grab;
+
+      &:active {
+        cursor: grabbing;
+      }
+    }
+
+    // Visual drop indicator: a vertical accent line on the side of the cell
+    // where the dragged column will land.
+    &.col-drop-left::before,
+    &.col-drop-right::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background: var(--accent);
+      z-index: 3;
+      pointer-events: none;
+    }
+
+    &.col-drop-left::before {
+      left: 0;
+    }
+
+    &.col-drop-right::after {
+      right: 0;
+    }
+
+    // Dim the cell currently being dragged so the user can tell which column
+    // they grabbed (the browser-rendered ghost is drawn separately).
+    &.col-dragging {
+      opacity: 0.4;
     }
 
     .sort-indicator {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -99,6 +99,80 @@ export class DashboardComponent implements OnInit, OnDestroy {
     tableEl: HTMLTableElement;
   } | null = null;
 
+  // Column order. The "name" column is fixed in position 0 (so the loading-task
+  // colspan that replaces "all columns after name" keeps working); these arrays
+  // hold the columns that follow name and are user-reorderable.
+  static readonly DATASET_COLUMNS_DEFAULT = [
+    'media_type', 'num_items', 'num_dupes', 'created_at', 'clipper', 'embedder',
+    'created_by', 'readers', 'loaded', 'actions',
+  ];
+  static readonly MODEL_COLUMNS_DEFAULT = [
+    'media_type', 'num_training', 'trainable', 'autodetect', 'last_trained_at',
+    'created_at', 'detector_loaded', 'actions',
+  ];
+  private static readonly DATASET_COL_ORDER_KEY = 'vtsearch.dashboard.datasetColumnOrder';
+  private static readonly MODEL_COL_ORDER_KEY = 'vtsearch.dashboard.modelColumnOrder';
+  datasetColumnOrder: string[] = [...DashboardComponent.DATASET_COLUMNS_DEFAULT];
+  modelColumnOrder: string[] = [...DashboardComponent.MODEL_COLUMNS_DEFAULT];
+
+  // Drag-reorder state
+  dragCol: { table: 'datasets' | 'models'; col: string } | null = null;
+  dropTargetCol: { table: 'datasets' | 'models'; col: string; side: 'left' | 'right' } | null = null;
+
+  // Per-column display metadata. Keyed by `data-col` value; used both by the
+  // header template and by card components when rendering body cells in order.
+  static readonly DATASET_COL_META: Record<string, { label: string; title: string; sortable: boolean }> = {
+    name: { label: 'Name', title: 'Dataset display name (click to sort)', sortable: true },
+    media_type: { label: 'Type', title: 'Media type: audio, image, text, video, or document (click to sort)', sortable: true },
+    num_items: { label: '# Items', title: 'Number of media items in the dataset (click to sort)', sortable: true },
+    num_dupes: { label: '# Dupes', title: 'Number of duplicate items collapsed (click to sort)', sortable: true },
+    created_at: { label: 'Created', title: 'When the dataset was first imported (click to sort)', sortable: true },
+    clipper: { label: 'Clipper', title: 'MediaClipper used at creation (click to sort)', sortable: true },
+    embedder: { label: 'Embedder', title: 'MediaEmbedder used for embedding (click to sort)', sortable: true },
+    created_by: { label: 'Creator', title: 'User who created this dataset (click to sort)', sortable: true },
+    readers: { label: 'Readers', title: 'Users with access to this dataset (click to sort)', sortable: true },
+    loaded: { label: 'Loaded?', title: 'Whether the dataset is currently loaded in memory', sortable: false },
+    actions: { label: 'Actions', title: 'Available operations for this dataset', sortable: false },
+  };
+  static readonly MODEL_COL_META: Record<string, { label: string; title: string; sortable: boolean }> = {
+    name: { label: 'Name', title: 'Model display name (click to sort)', sortable: true },
+    media_type: { label: 'Type', title: 'Media type this model operates on (click to sort)', sortable: true },
+    num_training: { label: '# Training', title: 'Number of labeled training examples (click to sort)', sortable: true },
+    trainable: { label: 'Trainable?', title: 'Is this Model one we can load into Train Mode and improve?', sortable: false },
+    autodetect: { label: 'Autorun?', title: 'Include this model in CLI autorun (click to sort)', sortable: true },
+    last_trained_at: { label: 'Last Trained', title: 'When the model was last trained (click to sort)', sortable: true },
+    created_at: { label: 'Created', title: 'When the model was created (click to sort)', sortable: true },
+    detector_loaded: { label: 'Loaded?', title: "Whether the model's inference data is cached in memory", sortable: false },
+    actions: { label: 'Actions', title: 'Available operations for this model', sortable: false },
+  };
+
+  get visibleDatasetColumns(): string[] {
+    if (this.isDefaultLogin) {
+      return this.datasetColumnOrder.filter((c) => c !== 'created_by' && c !== 'readers');
+    }
+    return this.datasetColumnOrder;
+  }
+
+  get visibleModelColumns(): string[] {
+    return this.modelColumnOrder;
+  }
+
+  datasetColMeta(col: string): { label: string; title: string; sortable: boolean } {
+    return DashboardComponent.DATASET_COL_META[col] ?? { label: col, title: '', sortable: false };
+  }
+
+  modelColMeta(col: string): { label: string; title: string; sortable: boolean } {
+    return DashboardComponent.MODEL_COL_META[col] ?? { label: col, title: '', sortable: false };
+  }
+
+  onDatasetHeaderClick(col: string): void {
+    if (this.datasetColMeta(col).sortable) this.sortDatasets(col);
+  }
+
+  onModelHeaderClick(col: string): void {
+    if (this.modelColMeta(col).sortable) this.sortModels(col);
+  }
+
   private destroy$ = new Subject<void>();
   private polling$ = new Subject<void>();
   private modelPolling$ = new Subject<void>();
@@ -179,6 +253,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.knownModelIds = currentIds;
         this.pushTopBarLabels();
       });
+    this.loadColumnOrders();
     this.refresh();
     this.resumeActivePolling();
   }
@@ -362,6 +437,142 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (wasFixed) {
       tableEl.classList.add('table-fixed');
     }
+  }
+
+  // --- Column reorder (drag and drop) ---
+
+  private loadColumnOrders(): void {
+    this.datasetColumnOrder = this.normalizeColumnOrder(
+      DashboardComponent.DATASET_COL_ORDER_KEY,
+      DashboardComponent.DATASET_COLUMNS_DEFAULT,
+    );
+    this.modelColumnOrder = this.normalizeColumnOrder(
+      DashboardComponent.MODEL_COL_ORDER_KEY,
+      DashboardComponent.MODEL_COLUMNS_DEFAULT,
+    );
+  }
+
+  private normalizeColumnOrder(storageKey: string, defaults: readonly string[]): string[] {
+    let stored: unknown = null;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      stored = raw ? JSON.parse(raw) : null;
+    } catch {
+      stored = null;
+    }
+    const known = new Set(defaults);
+    const result: string[] = [];
+    if (Array.isArray(stored)) {
+      for (const c of stored) {
+        if (typeof c === 'string' && known.has(c) && !result.includes(c)) {
+          result.push(c);
+        }
+      }
+    }
+    // Append any defaults missing from the stored order (e.g. new columns
+    // added after the user's order was saved).
+    for (const c of defaults) {
+      if (!result.includes(c)) result.push(c);
+    }
+    return result;
+  }
+
+  private persistColumnOrder(table: 'datasets' | 'models'): void {
+    const key = table === 'datasets'
+      ? DashboardComponent.DATASET_COL_ORDER_KEY
+      : DashboardComponent.MODEL_COL_ORDER_KEY;
+    const order = table === 'datasets' ? this.datasetColumnOrder : this.modelColumnOrder;
+    try {
+      localStorage.setItem(key, JSON.stringify(order));
+    } catch {
+      // Ignore quota / private-mode failures.
+    }
+  }
+
+  onColDragStart(event: DragEvent, table: 'datasets' | 'models', col: string): void {
+    // Don't start a drag if a column resize is in progress.
+    if (this.resizeState) {
+      event.preventDefault();
+      return;
+    }
+    this.dragCol = { table, col };
+    this.dropTargetCol = null;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      // Some browsers refuse to start the drag without setData.
+      event.dataTransfer.setData('text/plain', col);
+    }
+  }
+
+  onColDragOver(event: DragEvent, table: 'datasets' | 'models', col: string): void {
+    if (!this.dragCol || this.dragCol.table !== table || this.dragCol.col === col) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+    const th = event.currentTarget as HTMLElement;
+    const rect = th.getBoundingClientRect();
+    const side: 'left' | 'right' = (event.clientX - rect.left) < rect.width / 2 ? 'left' : 'right';
+    if (
+      !this.dropTargetCol
+      || this.dropTargetCol.col !== col
+      || this.dropTargetCol.side !== side
+      || this.dropTargetCol.table !== table
+    ) {
+      this.dropTargetCol = { table, col, side };
+    }
+  }
+
+  onColDragLeave(_event: DragEvent, table: 'datasets' | 'models', col: string): void {
+    if (this.dropTargetCol && this.dropTargetCol.table === table && this.dropTargetCol.col === col) {
+      this.dropTargetCol = null;
+    }
+  }
+
+  onColDrop(event: DragEvent, table: 'datasets' | 'models', targetCol: string): void {
+    if (!this.dragCol || this.dragCol.table !== table) {
+      this.dragCol = null;
+      this.dropTargetCol = null;
+      return;
+    }
+    event.preventDefault();
+    const sourceCol = this.dragCol.col;
+    const drop = this.dropTargetCol;
+    this.dragCol = null;
+    this.dropTargetCol = null;
+    if (sourceCol === targetCol) return;
+
+    const order = table === 'datasets' ? this.datasetColumnOrder : this.modelColumnOrder;
+    const fromIdx = order.indexOf(sourceCol);
+    const toIdx = order.indexOf(targetCol);
+    if (fromIdx < 0 || toIdx < 0) return;
+
+    const next = [...order];
+    next.splice(fromIdx, 1);
+    let insertIdx = next.indexOf(targetCol);
+    if (drop?.side === 'right') insertIdx += 1;
+    next.splice(insertIdx, 0, sourceCol);
+
+    if (table === 'datasets') {
+      this.datasetColumnOrder = next;
+    } else {
+      this.modelColumnOrder = next;
+    }
+    this.persistColumnOrder(table);
+  }
+
+  onColDragEnd(_event: DragEvent): void {
+    this.dragCol = null;
+    this.dropTargetCol = null;
+  }
+
+  isDropTarget(table: 'datasets' | 'models', col: string, side: 'left' | 'right'): boolean {
+    return !!this.dropTargetCol
+      && this.dropTargetCol.table === table
+      && this.dropTargetCol.col === col
+      && this.dropTargetCol.side === side;
+  }
+
+  isDragging(table: 'datasets' | 'models', col: string): boolean {
+    return !!this.dragCol && this.dragCol.table === table && this.dragCol.col === col;
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -19,7 +19,7 @@
 </td>
 @if (loadingTask && !loadingTask.error) {
   <!-- Inline progress: replace remaining columns with a progress bar -->
-  <td [attr.colspan]="isDefaultLogin ? 8 : 10">
+  <td [attr.colspan]="columnOrder.length">
     <div class="inline-loading-progress">
       <span class="progress-msg">{{ taskProgressMessage }}</span>
       <vt-progress-bar
@@ -32,94 +32,116 @@
   </td>
 } @else if (loadingTask && loadingTask.error) {
   <!-- Inline error: replace remaining columns with error message -->
-  <td [attr.colspan]="isDefaultLogin ? 8 : 10">
+  <td [attr.colspan]="columnOrder.length">
     <div class="inline-loading-progress inline-loading-failed">
       <span class="error-msg">Failed: {{ loadingTask.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss this error">Dismiss</button>
     </div>
   </td>
 } @else {
-  <td>
-    <span class="type-cell">
-      @switch (dataset.media_type) {
-        @case ('audio') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
-        }
-        @case ('image') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-        }
-        @case ('text') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-        }
-        @case ('video') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-        }
-        @case ('document') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-        }
+  @for (col of columnOrder; track col) {
+    @switch (col) {
+      @case ('media_type') {
+        <td>
+          <span class="type-cell">
+            @switch (dataset.media_type) {
+              @case ('audio') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+              }
+              @case ('image') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+              }
+              @case ('text') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+              }
+              @case ('video') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+              }
+              @case ('document') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
+              }
+            }
+            {{ capitalizeType(dataset.media_type) }}
+          </span>
+        </td>
       }
-      {{ capitalizeType(dataset.media_type) }}
-    </span>
-  </td>
-  <td>{{ dataset.num_items != null ? (dataset.num_items | number) : '-' }}</td>
-  <td>{{ (dataset.num_dupes ?? 0) | number }}</td>
-  <td>{{ formatDate(dataset.created_at) }}</td>
-  <td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
-  <td class="embedder-cell">{{ (dataset.embedder | titlecase) || '-' }}</td>
-  @if (!isDefaultLogin) {
-    <td>{{ dataset.created_by || '-' }}</td>
-    <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>
+      @case ('num_items') {
+        <td>{{ dataset.num_items != null ? (dataset.num_items | number) : '-' }}</td>
+      }
+      @case ('num_dupes') {
+        <td>{{ (dataset.num_dupes ?? 0) | number }}</td>
+      }
+      @case ('created_at') {
+        <td>{{ formatDate(dataset.created_at) }}</td>
+      }
+      @case ('clipper') {
+        <td class="clipper-cell">{{ dataset.clipper || '-' }}</td>
+      }
+      @case ('embedder') {
+        <td class="embedder-cell">{{ (dataset.embedder | titlecase) || '-' }}</td>
+      }
+      @case ('created_by') {
+        <td>{{ dataset.created_by || '-' }}</td>
+      }
+      @case ('readers') {
+        <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>
+      }
+      @case ('loaded') {
+        <td>
+          @if (dataset.loaded) {
+            <span class="status-loaded" aria-label="Loaded" title="Dataset is loaded">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </span>
+          } @else {
+            <button class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+          }
+        </td>
+      }
+      @case ('actions') {
+        <td>
+          <div class="actions-cell">
+          @if (!isDefaultLogin) {
+            <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+              </svg>
+            </button>
+          }
+          <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
+            <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
+              <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
+              <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
+            </svg>
+          </button>
+          <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
+            <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M12 2a10 10 0 0 1 0 20"/>
+              <line x1="12" y1="12" x2="12" y2="2"/>
+              <line x1="12" y1="12" x2="20.66" y2="17"/>
+              <line x1="12" y1="12" x2="2" y2="12"/>
+            </svg>
+          </button>
+          <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
+            <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6"></polyline>
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+              <path d="M10 11v6"></path>
+              <path d="M14 11v6"></path>
+              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+            </svg>
+          </button>
+          </div>
+        </td>
+      }
+    }
   }
-  <td>
-    @if (dataset.loaded) {
-      <span class="status-loaded" aria-label="Loaded" title="Dataset is loaded">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </span>
-    } @else {
-      <button class="load-action" (click)="onLoad($event)" title="Click to load this dataset" aria-label="Load dataset">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
-    }
-  </td>
-  <td>
-    <div class="actions-cell">
-    @if (!isDefaultLogin) {
-      <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-        </svg>
-      </button>
-    }
-    <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
-        <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
-        <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
-      </svg>
-    </button>
-    <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
-      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="10"/>
-        <path d="M12 2a10 10 0 0 1 0 20"/>
-        <line x1="12" y1="12" x2="12" y2="2"/>
-        <line x1="12" y1="12" x2="20.66" y2="17"/>
-        <line x1="12" y1="12" x2="2" y2="12"/>
-      </svg>
-    </button>
-    <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
-      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="3 6 5 6 21 6"></polyline>
-        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-        <path d="M10 11v6"></path>
-        <path d="M14 11v6"></path>
-        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-      </svg>
-    </button>
-    </div>
-  </td>
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -16,6 +16,7 @@ export class DatasetCardComponent implements OnChanges {
   @Input() dataset: any;
   @Input() currentUser = '';
   @Input() isDefaultLogin = true;
+  @Input() columnOrder: string[] = [];
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -17,7 +17,7 @@
   }
 </td>
 @if (loadingTask && !loadingTask.error) {
-  <td colspan="7">
+  <td [attr.colspan]="columnOrder.length">
     <div class="loading-task-progress">
       <span class="progress-msg">
         @if (loadingTask.step && loadingTask.total_steps) {
@@ -37,111 +37,131 @@
     </div>
   </td>
 } @else if (loadingTask?.error) {
-  <td colspan="7">
+  <td [attr.colspan]="columnOrder.length">
     <div class="loading-task-progress loading-task-failed">
       <span class="error-msg">Failed: {{ loadingTask?.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss error">Dismiss</button>
     </div>
   </td>
 } @else {
-  <td>
-    <span class="type-cell">
-      @switch (model.media_type) {
-        @case ('audio') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
-        }
-        @case ('image') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-        }
-        @case ('text') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-        }
-        @case ('video') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-        }
-        @case ('document') {
-          <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
-        }
+  @for (col of columnOrder; track col) {
+    @switch (col) {
+      @case ('media_type') {
+        <td>
+          <span class="type-cell">
+            @switch (model.media_type) {
+              @case ('audio') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+              }
+              @case ('image') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+              }
+              @case ('text') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+              }
+              @case ('video') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+              }
+              @case ('document') {
+                <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
+              }
+            }
+            {{ capitalizeType(model.media_type) }}
+          </span>
+        </td>
       }
-      {{ capitalizeType(model.media_type) }}
-    </span>
-  </td>
-  <td>{{ (model.num_training ?? 0) | number }}</td>
-  <td>
-    @if (model.trainable) {
-      <span class="status-icon" title="Model supports training" aria-label="Trainable">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </span>
-    } @else {
-      <span class="status-icon" title="Model does not support training" aria-label="Not trainable">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </span>
-    }
-  </td>
-  <td>
-    <button class="autorun-toggle" (click)="onAutorunToggle($event)" aria-label="Autorun" title="Include in CLI autorun">
-      @if (model.autodetect) {
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      } @else {
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
+      @case ('num_training') {
+        <td>{{ (model.num_training ?? 0) | number }}</td>
       }
-    </button>
-  </td>
-  <td>{{ formatDate(model.last_trained_at) }}</td>
-  <td>{{ formatDate(model.created_at) }}</td>
-  <td>
-    @if (model.detector_loaded) {
-      <span class="status-loaded" aria-label="Loaded" title="Model is loaded">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </span>
-    } @else {
-      <button class="load-action" (click)="onLoad($event)" title="Click to load this model" aria-label="Load model">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
+      @case ('trainable') {
+        <td>
+          @if (model.trainable) {
+            <span class="status-icon" title="Model supports training" aria-label="Trainable">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </span>
+          } @else {
+            <span class="status-icon" title="Model does not support training" aria-label="Not trainable">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </span>
+          }
+        </td>
+      }
+      @case ('autodetect') {
+        <td>
+          <button class="autorun-toggle" (click)="onAutorunToggle($event)" aria-label="Autorun" title="Include in CLI autorun">
+            @if (model.autodetect) {
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            } @else {
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            }
+          </button>
+        </td>
+      }
+      @case ('last_trained_at') {
+        <td>{{ formatDate(model.last_trained_at) }}</td>
+      }
+      @case ('created_at') {
+        <td>{{ formatDate(model.created_at) }}</td>
+      }
+      @case ('detector_loaded') {
+        <td>
+          @if (model.detector_loaded) {
+            <span class="status-loaded" aria-label="Loaded" title="Model is loaded">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </span>
+          } @else {
+            <button class="load-action" (click)="onLoad($event)" title="Click to load this model" aria-label="Load model">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+          }
+        </td>
+      }
+      @case ('actions') {
+        <td>
+          <div class="actions-cell">
+          <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
+            <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
+              <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
+              <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
+            </svg>
+          </button>
+          <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
+            <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
+          </button>
+          <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 14 20 9 15 4"></polyline>
+              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+            </svg>
+          </button>
+          <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
+            <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6"></polyline>
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+              <path d="M10 11v6"></path>
+              <path d="M14 11v6"></path>
+              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+            </svg>
+          </button>
+          </div>
+        </td>
+      }
     }
-  </td>
+  }
 }
-<td>
-  <div class="actions-cell">
-  <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
-    <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
-      <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
-      <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
-    </svg>
-  </button>
-  <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
-    <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
-  </button>
-  <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
-    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="15 14 20 9 15 4"></polyline>
-      <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
-    </svg>
-  </button>
-  <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
-    <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="3 6 5 6 21 6"></polyline>
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-      <path d="M10 11v6"></path>
-      <path d="M14 11v6"></path>
-      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-    </svg>
-  </button>
-  </div>
-</td>

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -14,6 +14,7 @@ import { formatProgressFraction } from '../../../utils/format-progress';
 })
 export class ModelCardComponent implements OnChanges {
   @Input() model: any;
+  @Input() columnOrder: string[] = [];
   @Input() @HostBinding('class.selected') selected = false;
   @Input() @HostBinding('class.dimmed') dimmed = false;
   @Input() loadingTask?: LoadingTask;


### PR DESCRIPTION
## Summary
- Each column header in the Dashboard's Datasets and Models grids is now a drag handle: grab a header and drop it on another header to reorder. The existing column-resize divider handles are preserved (their `mousedown` calls `preventDefault()`, so grabbing a divider does not start a drag).
- A vertical accent line at the left/right edge of the hover-target column shows where the dragged column will land. The dragged column is dimmed.
- The `Name` column is pinned at position 0 so the existing loading-task colspan (which replaces "all columns after Name" with a progress bar) keeps working unchanged. Every other column is reorderable.
- Order persists per browser via `localStorage` (`vtsearch.dashboard.datasetColumnOrder` / `…modelColumnOrder`). Stored orders are filtered against the current default columns on load, so unknown entries are dropped and newly-added columns are appended.

## Implementation
- `dashboard.component.ts`: column-order arrays, per-column metadata (label/title/sortable), drag-and-drop handlers (`onColDragStart`/`onColDragOver`/`onColDragLeave`/`onColDrop`/`onColDragEnd`), drop-target tracking, and localStorage round-trip.
- `dashboard.component.html`: the `<thead>` for both grids now renders Name as a fixed first cell, then `@for (col of visibleDatasetColumns/visibleModelColumns)` to render the rest; each draggable `<th>` gets `draggable="true"`, drag/drop bindings, and conditional `col-drop-left`/`col-drop-right`/`col-dragging` classes.
- `dataset-card.component` and `model-card.component`: now accept a `columnOrder: string[]` Input and render their body `<td>`s via `@for`/`@switch` over that order, instead of a fixed sequence. Loading-task colspan is bound to `columnOrder.length`.
- `dashboard.component.scss`: grab/grabbing cursors on draggable headers, accent-colored drop indicator (`::before`/`::after` at z-index 3 so it paints over the resize divider), opacity dim on the dragged column.

## Behavior preserved
- Column resize via the divider handles (existing `test_resize_handle_centering.py` continues to pass).
- Sortable click-to-sort on header click (drag uses `dragstart`, not `click`, so a pure click still sorts).
- Loading-task inline progress and error rows.
- `created_by` / `readers` columns hidden when `isDefaultLogin` is true.

## Test plan
- [x] `./run-tests.sh core` (345 passed) — includes frontend `npm run build:prod` type-check and the resize-handle centering test.
- [ ] Manually drag a header in the Datasets grid; verify the drop indicator follows the pointer and the column lands on the correct side.
- [ ] Drag in the Models grid; verify the same.
- [ ] Resize via a divider while drag-reorder is wired up; verify resize still works and does not initiate a drag.
- [ ] Reload the page after reordering; verify the order is preserved.
- [ ] With a non-default login, verify Creator/Readers columns appear and can be reordered.

https://claude.ai/code/session_01WwfndQpqMwQZyb1Tg2gdZB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwfndQpqMwQZyb1Tg2gdZB)_