### PR TITLE
Fix cubes icon getting clipped at the bottom

### DIFF
--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -177,7 +177,7 @@ function emojiToType(icon: string): string {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v7.5a2 2 0 0 1-.3 1L4 20a1.5 1.5 0 0 0 1.3 2.2h13.4A1.5 1.5 0 0 0 20 20l-4.7-9.5a2 2 0 0 1-.3-1V2"/><line x1="8" y1="2" x2="16" y2="2"/><line x1="7" y1="15" x2="17" y2="15"/></svg>
       }
       @case ('cubes') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 6h18v18H2z"/><path d="M2 6l2-2h18v18l-2 2"/><path d="M20 6l2-2"/><path d="M11 6v18M2 15h18"/><path d="M11 6l2-2"/><path d="M20 15l2-2"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h18v18H2z"/><path d="M2 4l2-2h18v18l-2 2"/><path d="M20 4l2-2"/><path d="M11 4v18M2 13h18"/><path d="M11 4l2-2"/><path d="M20 13l2-2"/></svg>
       }
     } }
   `,


### PR DESCRIPTION
## Summary
- The cubes icon next to "Datasets" in the dashboard was missing its bottom edge — the front face extended to `y=24` (the viewBox edge), so the bottom stroke fell outside the viewBox and got clipped.
- Shifted the cubes figure up by 2 units so all strokes fit inside the `0 0 24 24` viewBox.

## Test plan
- [x] `npm run build:prod` succeeds
- [ ] Visually verify the Datasets icon now shows a complete bottom edge

https://claude.ai/code/session_01NzNUav9f2Vbvha5csgNR4r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzNUav9f2Vbvha5csgNR4r)_