### PR TITLE
Refactor dataset importer modal to remove auto-selection and simplify view logic

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -1,42 +1,37 @@
 <vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
-  @if (view === 'picker') {
-    <div class="importer-picker">
-      @if (orderedImporters.length === 0) {
-        <p class="empty-state">Loading importers...</p>
-      } @else {
-        <div class="importer-tab-bar">
-          @for (tab of visibleImporterTabs; track tab.id) {
-            <button
-              class="importer-tab"
-              [class.active]="activeImporterTab === tab.id"
-              (click)="selectImporterTab(tab.id)"
-              [title]="'Show ' + tab.label + ' dataset importers'"
-            >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
-          }
-        </div>
+  <div class="importer-picker">
+    <div class="importer-tab-bar">
+      @for (tab of visibleImporterTabs; track tab.id) {
+        <button
+          class="importer-tab"
+          [class.active]="activeImporterTab === tab.id"
+          (click)="selectImporterTab(tab.id)"
+          [title]="'Show ' + tab.label + ' dataset importers'"
+        >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
+      }
+    </div>
+
+    @if (activeImporterTab) {
+      <div class="importer-subtab-bar">
+        @if (importersForActiveTab.length === 0) {
+          <span class="empty-state empty-state--inline">No importers in this category.</span>
+        }
         @for (imp of importersForActiveTab; track imp.name) {
           <button
-            class="importer-card"
-            [class.demo-card]="imp.picker_view === 'demo'"
+            class="importer-subtab"
+            [class.active]="selectedImporter?.name === imp.name"
             [class.disabled]="imp['enabled'] === false"
             [disabled]="imp['enabled'] === false"
             (click)="selectImporter(imp)"
-            [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : ''"
-          >
-            <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
-            @if (imp.description) {
-              <span class="importer-desc">{{ imp.description }}</span>
-            }
-          </button>
+            [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
+          >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
         }
-      }
-    </div>
-  }
+      </div>
+    }
+  </div>
 
-  @if (view === 'demo') {
+  @if (activePickerView === 'demo' && selectedImporter) {
     <div class="demo-picker">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
-
       @if (demoLoading) {
         <p class="empty-state">Loading demo datasets...</p>
       } @else if (demos.length === 0) {
@@ -53,7 +48,7 @@
           }
         </div>
 
-        @if (demoEmbedders.length > 1 || demoClippers.length > 1) {
+        @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
           <div class="demo-embedder-row">
             @if (demoEmbedders.length > 1) {
               <label class="form-label" for="demo-embedder" title="Embedding model used to compute vector representations of each media item">Embedder:</label>
@@ -76,47 +71,47 @@
           </div>
         }
 
-        <div class="demo-content-area">
-          <table class="demo-table" [class.demo-table-fixed]="demoTableFixed" [style.width]="demoTableFixed ? (demoTableWidth + 'px') : '100%'">
-            <thead>
-              <tr>
-                <th (click)="sortDemoBy('label')" class="sortable" title="Demo dataset name (click to sort)" data-col="label" [style.width.px]="demoTableFixed ? demoColWidths['label'] : null">Name<span class="sort-indicator" [class.active]="demoSortKey === 'label'">{{ demoSortIndicator('label') }}</span></th>
-                <th (click)="sortDemoBy('num_files')" class="sortable col-num" title="Number of media files in the demo dataset (click to sort)" data-col="num_files" [style.width.px]="demoTableFixed ? demoColWidths['num_files'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div># Media<span class="sort-indicator" [class.active]="demoSortKey === 'num_files'">{{ demoSortIndicator('num_files') }}</span></th>
-                <th (click)="sortDemoBy('num_categories')" class="sortable col-num" title="Number of distinct categories or classes in the dataset (click to sort)" data-col="num_categories" [style.width.px]="demoTableFixed ? demoColWidths['num_categories'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div># Cat.<span class="sort-indicator" [class.active]="demoSortKey === 'num_categories'">{{ demoSortIndicator('num_categories') }}</span></th>
-                <th (click)="sortDemoBy('description')" class="sortable" title="Short description of the demo dataset contents (click to sort)" data-col="description" [style.width.px]="demoTableFixed ? demoColWidths['description'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div>Description<span class="sort-indicator" [class.active]="demoSortKey === 'description'">{{ demoSortIndicator('description') }}</span></th>
-                <th (click)="sortDemoBy('status')" class="sortable" title="Whether the dataset is pre-downloaded and ready to load immediately, or needs to be fetched first (click to sort)" data-col="status" [style.width.px]="demoTableFixed ? demoColWidths['status'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div>Readiness<span class="sort-indicator" [class.active]="demoSortKey === 'status'">{{ demoSortIndicator('status') }}</span></th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (demo of filteredDemos; track demo.name) {
-                <tr
-                  class="demo-row"
-                  [class.ready]="demo.status === 'ready'"
-                  role="button"
-                  tabindex="0"
-                  [attr.aria-label]="demo.label + ': ' + demo.description"
-                  (click)="selectDemo(demo)"
-                  (keydown.enter)="selectDemo(demo)"
-                  (keydown.space)="$event.preventDefault(); selectDemo(demo)"
-                >
-                  <td class="col-name">{{ demo.label }}</td>
-                  <td class="col-num">{{ demo.num_files | number }}</td>
-                  <td class="col-num">{{ demo.num_categories | number }}</td>
-                  <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
-                  <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+        @if (activeTab) {
+          <div class="demo-content-area">
+            <table class="demo-table" [class.demo-table-fixed]="demoTableFixed" [style.width]="demoTableFixed ? (demoTableWidth + 'px') : '100%'">
+              <thead>
+                <tr>
+                  <th (click)="sortDemoBy('label')" class="sortable" title="Demo dataset name (click to sort)" data-col="label" [style.width.px]="demoTableFixed ? demoColWidths['label'] : null">Name<span class="sort-indicator" [class.active]="demoSortKey === 'label'">{{ demoSortIndicator('label') }}</span></th>
+                  <th (click)="sortDemoBy('num_files')" class="sortable col-num" title="Number of media files in the demo dataset (click to sort)" data-col="num_files" [style.width.px]="demoTableFixed ? demoColWidths['num_files'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div># Media<span class="sort-indicator" [class.active]="demoSortKey === 'num_files'">{{ demoSortIndicator('num_files') }}</span></th>
+                  <th (click)="sortDemoBy('num_categories')" class="sortable col-num" title="Number of distinct categories or classes in the dataset (click to sort)" data-col="num_categories" [style.width.px]="demoTableFixed ? demoColWidths['num_categories'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div># Cat.<span class="sort-indicator" [class.active]="demoSortKey === 'num_categories'">{{ demoSortIndicator('num_categories') }}</span></th>
+                  <th (click)="sortDemoBy('description')" class="sortable" title="Short description of the demo dataset contents (click to sort)" data-col="description" [style.width.px]="demoTableFixed ? demoColWidths['description'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div>Description<span class="sort-indicator" [class.active]="demoSortKey === 'description'">{{ demoSortIndicator('description') }}</span></th>
+                  <th (click)="sortDemoBy('status')" class="sortable" title="Whether the dataset is pre-downloaded and ready to load immediately, or needs to be fetched first (click to sort)" data-col="status" [style.width.px]="demoTableFixed ? demoColWidths['status'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div>Readiness<span class="sort-indicator" [class.active]="demoSortKey === 'status'">{{ demoSortIndicator('status') }}</span></th>
                 </tr>
-              }
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                @for (demo of filteredDemos; track demo.name) {
+                  <tr
+                    class="demo-row"
+                    [class.ready]="demo.status === 'ready'"
+                    role="button"
+                    tabindex="0"
+                    [attr.aria-label]="demo.label + ': ' + demo.description"
+                    (click)="selectDemo(demo)"
+                    (keydown.enter)="selectDemo(demo)"
+                    (keydown.space)="$event.preventDefault(); selectDemo(demo)"
+                  >
+                    <td class="col-name">{{ demo.label }}</td>
+                    <td class="col-num">{{ demo.num_files | number }}</td>
+                    <td class="col-num">{{ demo.num_categories | number }}</td>
+                    <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
+                    <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
       }
     </div>
   }
 
-  @if (view === 'form' && selectedImporter) {
+  @if (activePickerView !== 'demo' && activePickerView !== 'local_folder' && activePickerView !== 'local_files' && activePickerView !== 'server_folder' && selectedImporter) {
     <div class="importer-form">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
-
       @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
         @for (field of selectedImporter.fields; track field.key) {
           <div class="form-group">
@@ -221,9 +216,7 @@
         <p class="error-text">{{ error }}</p>
       }
     </div>
-  }
 
-  @if (view === 'form' && selectedImporter) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
@@ -236,10 +229,8 @@
     </div>
   }
 
-  @if (view === 'local_folder') {
+  @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
     <div class="local-folder-uploader">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
-
       @if (lfPickerKind === 'folder') {
         <p class="info-text">Pick a folder on <strong>this computer</strong> (the machine your browser is running on). Its contents will be uploaded to the server and embedded into a new dataset.</p>
       } @else {
@@ -345,9 +336,7 @@
         <p class="error-text">{{ lfError }}</p>
       }
     </div>
-  }
 
-  @if (view === 'local_folder') {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="lfSubmit()" [disabled]="lfSubmitting || lfFiles.length === 0">
@@ -360,10 +349,8 @@
     </div>
   }
 
-  @if (view === 'server_folder') {
+  @if (activePickerView === 'server_folder' && selectedImporter) {
     <div class="server-folder-browser">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
-
       <div class="form-group">
         <label class="form-label" for="sf-media-type" title="The type of media files in the folder (audio, image, text, video, or document)">Media Type</label>
         <select
@@ -472,9 +459,7 @@
         <p class="error-text">{{ sfBrowseError }}</p>
       }
     </div>
-  }
 
-  @if (view === 'server_folder') {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="sfSubmit()" [disabled]="sfSubmitting || !sfAbsolutePath">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -216,7 +216,9 @@
         <p class="error-text">{{ error }}</p>
       }
     </div>
+  }
 
+  @if (activePickerView !== 'demo' && activePickerView !== 'local_folder' && activePickerView !== 'local_files' && activePickerView !== 'server_folder' && selectedImporter) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="submit()" [disabled]="submitting">
@@ -336,7 +338,9 @@
         <p class="error-text">{{ lfError }}</p>
       }
     </div>
+  }
 
+  @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="lfSubmit()" [disabled]="lfSubmitting || lfFiles.length === 0">
@@ -459,7 +463,9 @@
         <p class="error-text">{{ sfBrowseError }}</p>
       }
     </div>
+  }
 
+  @if (activePickerView === 'server_folder' && selectedImporter) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="sfSubmit()" [disabled]="sfSubmitting || !sfAbsolutePath">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -122,40 +122,11 @@
 
 .demo-picker { gap: 8px; }
 
-.demo-tab-bar {
-  display: flex;
-  gap: 4px;
-  width: 100%;
-  border-bottom: 2px solid var(--border);
-  margin-bottom: 12px;
-}
-
-.demo-tab {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 8px 16px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  background: none;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .85rem;
-  cursor: pointer;
-  transition: all .15s;
-  margin-bottom: -2px;
-  white-space: nowrap;
-
-  &:hover {
-    color: var(--text-primary);
-    background: var(--bg-subtle);
-  }
-
-  &.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-    font-weight: 600;
-  }
-}
+// .demo-tab-bar / .demo-tab share the visual styling of the top
+// .importer-tab-bar / .importer-tab.  Define the chrome once via @extend
+// so the compiled output stays under the per-component CSS budget.
+.demo-tab-bar { @extend .importer-tab-bar; }
+.demo-tab { @extend .importer-tab; }
 
 .demo-embedder-row {
   display: flex;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,22 +1,29 @@
-.importer-card { padding: 12px 16px; }
-.importer-card.disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
+// Pin the Add Dataset modal to a single large width so flipping between
+// tabs (Services / Server / Local / Demo) and inner widgets doesn't reflow
+// the dialog.  680px (matching the Settings modal) was too narrow for the
+// demo table; 900px gives the table room without overflowing typical
+// laptop displays.
+:host {
+  ::ng-deep .modal-content {
+    width: 900px;
+  }
 }
+
 .btn--sm { padding: 2px 10px; font-size: .85rem; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
 
-.importer-picker, .clipper-params, .demo-picker, .server-folder-browser, .sf-browse-section {
+.importer-picker, .clipper-params, .demo-picker, .server-folder-browser, .sf-browse-section, .importer-form, .local-folder-uploader {
   display: flex;
   flex-direction: column;
 }
+
+.importer-picker { gap: 0; margin-bottom: 12px; }
 
 .importer-tab-bar {
   display: flex;
   gap: 4px;
   width: 100%;
   border-bottom: 2px solid var(--border);
-  margin-bottom: 12px;
 }
 
 .importer-tab {
@@ -44,6 +51,67 @@
     border-bottom-color: var(--accent);
     font-weight: 600;
   }
+}
+
+// Inner row of importer "tabs" within the active category.  Renders
+// underneath the top tab bar; selecting one swaps in that importer's
+// widgets in the area below.
+.importer-subtab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  width: 100%;
+  border-bottom: 1px solid var(--border-subtle, var(--border));
+  padding: 6px 4px 0;
+  background: var(--bg-subtle);
+  margin-bottom: 12px;
+}
+
+.importer-subtab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 14px;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  background: none;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .82rem;
+  cursor: pointer;
+  transition: all .15s;
+  white-space: nowrap;
+  margin-bottom: -1px;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    background: var(--bg-surface);
+  }
+
+  &.active {
+    color: var(--text-primary);
+    background: var(--bg-surface);
+    border-color: var(--border-subtle, var(--border));
+    border-bottom-color: var(--bg-surface);
+    font-weight: 600;
+  }
+
+  &.disabled, &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.importer-subtab-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.empty-state--inline {
+  padding: 6px 10px;
+  font-size: .8rem;
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .clipper-params {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -153,18 +153,28 @@ describe('DatasetImporterModalComponent', () => {
     httpMock.expectOne('/api/dataset/all-importers').flush({ importers: mockImporters, tabs: mockTabs });
   }
 
-  /** Open the demo picker and flush all resulting HTTP requests. */
-  function openAndFlushDemoPicker(embedders = mockEmbedders): void {
+  /** Open the demo picker and flush the always-issued requests.  Unlike
+   *  the previous behavior, opening the picker no longer auto-selects a
+   *  media-type tab, so no per-tab embedder/clipper requests fire here.
+   *  Tests that need a tab selected should call ``selectDemoTab`` (or
+   *  ``selectDemoTabWithEmbedder``) explicitly and flush the resulting
+   *  requests themselves. */
+  function openAndFlushDemoPicker(): void {
     component.openDemoPicker();
 
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
-    // Initial demo list fetch (no embedder param)
     httpMock.expectOne('/api/dataset/demo-list').flush({ datasets: mockDemos });
-    // loadDemoEmbedders fires for the first tab
+  }
+
+  /** Helper: select a demo media-type tab and flush the embedder + clipper
+   *  fetches plus the embedder-aware refetch.  Returns the flushed
+   *  embedders for convenience. */
+  function selectDemoTabAndFlush(tab: string, embedders: typeof mockEmbedders): void {
+    component.selectDemoTabWithEmbedder(tab);
     httpMock.expectOne(req =>
-      req.url === '/api/embedders' && req.params.get('media_type') === 'audio',
+      req.url === '/api/embedders' && req.params.get('media_type') === tab,
     ).flush({ embedders });
-    // refetchDemoStatuses fires after embedders are loaded (if embedder is set)
+    httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
     if (embedders.length > 0) {
       httpMock.expectOne(req =>
         req.url === '/api/dataset/demo-list' && req.params.get('embedder') === embedders[0].name,
@@ -182,29 +192,48 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.importers.length).toBe(7);
   });
 
-  it('should start in picker view', () => {
+  it('should start with no top-level tab selected and a blank content area', () => {
     flushImporters();
-    expect(component.view).toBe('picker');
+    fixture.detectChanges();
+    expect(component.activeImporterTab).toBe('');
+    expect(component.selectedImporter).toBeNull();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelectorAll('.importer-subtab').length).toBe(0);
   });
 
-  it('should render the cards for the active tab using display_name', () => {
+  it('should always render the Services tab even when no importers populate it', () => {
     flushImporters();
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
-    // Default active tab is "local" (the first tab populated by the mocks
-    // that has importers).  Two local importers: local_folder, local_files.
-    const cards = el.querySelectorAll('.importer-card');
-    expect(cards.length).toBe(2);
-    expect(cards[0].textContent).toContain('Folder');
-    expect(cards[1].textContent).toContain('Files');
+    const tabLabels = Array.from(el.querySelectorAll('.importer-tab')).map(
+      (b) => (b.textContent || '').trim(),
+    );
+    expect(tabLabels.some((l) => l.includes('Services'))).toBeTrue();
+    // No importer is wired to category="services" in the mocks, so the
+    // tab renders but importersForActiveTab is empty when selected.
+    component.selectImporterTab('services');
+    expect(component.importersForActiveTab.length).toBe(0);
+  });
 
-    // Switching to the Server tab swaps in the server importers.
-    component.selectImporterTab('server');
+  it('should render inner importer sub-tabs for the active category', () => {
+    flushImporters();
+    component.selectImporterTab('local');
     fixture.detectChanges();
-    const serverCards = el.querySelectorAll('.importer-card');
-    expect(serverCards.length).toBe(2);
-    expect(serverCards[0].textContent).toContain('Folder');
-    expect(serverCards[1].textContent).toContain('Files');
+    const el = fixture.nativeElement as HTMLElement;
+    const subtabs = el.querySelectorAll('.importer-subtab');
+    expect(subtabs.length).toBe(2);
+    expect(subtabs[0].textContent).toContain('Folder');
+    expect(subtabs[1].textContent).toContain('Files');
+
+    // Switching to the Server tab swaps in the server importers and
+    // clears the prior importer selection so the user must click again.
+    component.selectImporterTab('server');
+    expect(component.selectedImporter).toBeNull();
+    fixture.detectChanges();
+    const serverSubtabs = el.querySelectorAll('.importer-subtab');
+    expect(serverSubtabs.length).toBe(2);
+    expect(serverSubtabs[0].textContent).toContain('Folder');
+    expect(serverSubtabs[1].textContent).toContain('Files');
   });
 
   it('should hide importers marked hidden_from_picker', () => {
@@ -217,52 +246,48 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.importers.find((i) => i.name === 'recaller')).toBeUndefined();
   });
 
-  it('should switch to local_folder view when the Local Folder card is clicked', () => {
+  it('should set activePickerView=local_folder when the Local Folder sub-tab is clicked', () => {
     flushImporters();
     const localFolder = component.importers.find((i) => i.name === 'local_folder')!;
     component.selectImporter(localFolder);
-    expect(component.view).toBe('local_folder');
+    expect(component.activePickerView).toBe('local_folder');
     expect(component.selectedImporter?.name).toBe('local_folder');
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
   });
 
-  it('should switch to server_folder view when the Server Folder card is clicked', () => {
+  it('should set activePickerView=server_folder when the Server Folder sub-tab is clicked', () => {
     flushImporters();
     const folder = component.importers.find((i) => i.name === 'server_folder')!;
     component.selectImporter(folder);
-    expect(component.view).toBe('server_folder');
+    expect(component.activePickerView).toBe('server_folder');
     expect(component.selectedImporter?.name).toBe('server_folder');
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
     httpMock.expectOne(req => req.url === '/api/browse-media-files').flush({ directories: [], files: [], root_path: '' });
   });
 
-  it('should switch to local_files view (multi-file picker) when the Local Files card is clicked', () => {
+  it('should set activePickerView=local_files (multi-file picker) when the Local Files sub-tab is clicked', () => {
     flushImporters();
     const localFiles = component.importers.find((i) => i.name === 'local_files')!;
     component.selectImporter(localFiles);
-    expect(component.view).toBe('local_folder'); // shared view
+    expect(component.activePickerView).toBe('local_files');
     expect(component.lfPickerKind).toBe('files');
     expect(component.selectedImporter?.name).toBe('local_files');
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
   });
 
-  it('should switch to demo view when the Demo card is clicked', () => {
+  it('should set activePickerView=demo when the Demo sub-tab is clicked', () => {
     flushImporters();
     const demo = component.importers.find((i) => i.name === 'demo')!;
     component.selectImporter(demo);
-    expect(component.view).toBe('demo');
+    expect(component.activePickerView).toBe('demo');
     expect(component.selectedImporter?.name).toBe('demo');
+    // Opening the demo picker no longer auto-selects a media-type tab,
+    // so only the always-issued media-types + demo-list calls fire.
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
     httpMock.expectOne('/api/dataset/demo-list').flush({ datasets: mockDemos });
-    httpMock.expectOne(req =>
-      req.url === '/api/embedders' && req.params.get('media_type') === 'audio',
-    ).flush({ embedders: mockEmbedders });
-    httpMock.expectOne(req =>
-      req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'clap',
-    ).flush({ datasets: mockDemos });
   });
 
   it('should POST uploaded folder via importLocalFolder', () => {
@@ -291,11 +316,11 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.importStarted.emit).toHaveBeenCalled();
   });
 
-  it('should switch to form view on importer selection', () => {
+  it('should set activePickerView=form on generic importer selection', () => {
     flushImporters();
     const imp = genericForm();
     component.selectImporter(imp);
-    expect(component.view).toBe('form');
+    expect(component.activePickerView).toBe('form');
     expect(component.selectedImporter).toBe(imp);
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
@@ -309,14 +334,16 @@ describe('DatasetImporterModalComponent', () => {
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
   });
 
-  it('should go back to picker view', () => {
+  it('should clear the selected importer when the active top-level tab changes', () => {
     flushImporters();
+    component.selectImporterTab('local');
     component.selectImporter(genericForm());
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
-    component.back();
-    expect(component.view).toBe('picker');
+    expect(component.selectedImporter).not.toBeNull();
+    component.selectImporterTab('demo');
     expect(component.selectedImporter).toBeNull();
+    expect(component.activePickerView).toBe('');
   });
 
   it('should submit form values via runImporter', () => {
@@ -379,56 +406,45 @@ describe('DatasetImporterModalComponent', () => {
 
   // --- Demo picker tests ---
 
-  it('should switch to demo view when openDemoPicker is called', () => {
+  it('should activate the demo view when openDemoPicker is called', () => {
     flushImporters();
 
-    expect(component.view).toBe('picker');
+    expect(component.activePickerView).toBe('');
     component.openDemoPicker();
-    expect(component.view).toBe('demo');
+    expect(component.activePickerView).toBe('demo');
     expect(component.demoLoading).toBeTrue();
 
     // Flush media types and demo list requests
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
     httpMock.expectOne('/api/dataset/demo-list').flush({ datasets: mockDemos });
 
-    // Flush embedder fetch + refetch triggered by loadDemoEmbedders
-    httpMock.expectOne(req =>
-      req.url === '/api/embedders' && req.params.get('media_type') === 'audio',
-    ).flush({ embedders: mockEmbedders });
-    httpMock.expectOne(req =>
-      req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'clap',
-    ).flush({ datasets: mockDemos });
-
+    // No media-type tab is auto-selected anymore, so no embedder/clipper
+    // fetches fire automatically.
     expect(component.demoLoading).toBeFalse();
     expect(component.demos.length).toBe(2);
+    expect(component.activeTab).toBe('');
   });
 
-  it('should build tabs from media types in demo data', () => {
+  it('should build tabs from media types in demo data without auto-selecting one', () => {
     flushImporters();
     openAndFlushDemoPicker();
 
     expect(component.demoTabs).toEqual(['audio', 'image']);
-    expect(component.activeTab).toBe('audio');
+    // No media-type tab is auto-selected — the demo table area stays
+    // blank until the user clicks one.
+    expect(component.activeTab).toBe('');
+    expect(component.filteredDemos.length).toBe(0);
   });
 
-  it('should filter demos by active tab', () => {
+  it('should filter demos by the explicitly selected media-type tab', () => {
     flushImporters();
     openAndFlushDemoPicker();
 
+    selectDemoTabAndFlush('audio', mockEmbedders);
     expect(component.filteredDemos.length).toBe(1);
     expect(component.filteredDemos[0].name).toBe('gtzan');
 
-    component.selectDemoTab('image');
-
-    // selectDemoTab triggers loadDemoEmbedders for the new tab
-    httpMock.expectOne(req =>
-      req.url === '/api/embedders' && req.params.get('media_type') === 'image',
-    ).flush({ embedders: mockImageEmbedders });
-    // refetchDemoStatuses fires
-    httpMock.expectOne(req =>
-      req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'clip',
-    ).flush({ datasets: mockDemos });
-
+    selectDemoTabAndFlush('image', mockImageEmbedders);
     expect(component.filteredDemos.length).toBe(1);
     expect(component.filteredDemos[0].name).toBe('flowers102');
   });
@@ -463,16 +479,7 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should go back from demo to picker view', () => {
-    flushImporters();
-    openAndFlushDemoPicker();
-
-    expect(component.view).toBe('demo');
-    component.back();
-    expect(component.view).toBe('picker');
-  });
-
-  it('should render demo tab bar and table in template', () => {
+  it('should render the demo tab bar but no rows until a media-type tab is clicked', () => {
     flushImporters();
     openAndFlushDemoPicker();
 
@@ -482,8 +489,12 @@ describe('DatasetImporterModalComponent', () => {
     const tabs = el.querySelectorAll('.demo-tab');
     expect(tabs.length).toBe(2);
 
-    const rows = el.querySelectorAll('.demo-row');
-    expect(rows.length).toBe(1); // Only audio tab active, one audio demo
+    // No tab auto-selected → no rows rendered yet.
+    expect(el.querySelectorAll('.demo-row').length).toBe(0);
+
+    selectDemoTabAndFlush('audio', mockEmbedders);
+    fixture.detectChanges();
+    expect(el.querySelectorAll('.demo-row').length).toBe(1);
   });
 
   it('should get correct tab label from media types', () => {
@@ -519,7 +530,8 @@ describe('DatasetImporterModalComponent', () => {
 
   it('should re-fetch demos from server when embedder changes', () => {
     flushImporters();
-    openAndFlushDemoPicker(mockImageEmbedders);
+    openAndFlushDemoPicker();
+    selectDemoTabAndFlush('image', mockImageEmbedders);
 
     // Changing embedder triggers a re-fetch with the new embedder param
     component.onDemoEmbedderChange('siglip');
@@ -688,19 +700,25 @@ describe('DatasetImporterModalComponent', () => {
     expect(downloadDemos[0].status).toBe('needs_download');
   });
 
-  it('should re-fetch demos with default embedder on initial load', () => {
+  it('should re-fetch demos with the tab embedder once the user picks a media-type tab', () => {
     flushImporters();
     component.openDemoPicker();
 
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
     httpMock.expectOne('/api/dataset/demo-list').flush({ datasets: mockDemos });
 
-    // loadDemoEmbedders fires for the first tab
+    // No requests fire yet — the user hasn't picked a media-type tab.
+    httpMock.expectNone(req => req.url === '/api/embedders');
+
+    // Picking a media-type tab loads its embedders + clippers and then
+    // re-fetches the demo list with the now-known default embedder.
+    component.selectDemoTabWithEmbedder('audio');
+
     httpMock.expectOne(req =>
       req.url === '/api/embedders' && req.params.get('media_type') === 'audio',
     ).flush({ embedders: mockEmbedders });
+    httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
 
-    // After embedders load, refetchDemoStatuses fires with the default embedder
     const refetchReq = httpMock.expectOne(req =>
       req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'clap',
     );

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -8,8 +8,6 @@ import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/cl
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { ImporterInfo, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 
-type ModalView = 'picker' | 'form' | 'demo' | 'server_folder' | 'local_folder';
-
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
@@ -27,7 +25,6 @@ export class DatasetImporterModalComponent implements OnInit {
   @Output() importStarted = new EventEmitter<void>();
   @Output() demoSelected = new EventEmitter<DemoDataset>();
 
-  view: ModalView = 'picker';
   importers: ImporterInfo[] = [];
   selectedImporter: ImporterInfo | null = null;
   formValues: Record<string, any> = {};
@@ -130,10 +127,6 @@ export class DatasetImporterModalComponent implements OnInit {
           (imp) => !imp['hidden_from_picker']
         );
         this.declaredTabs = res.tabs || [];
-        const visible = this.visibleImporterTabs;
-        if (!visible.some((t) => t.id === this.activeImporterTab)) {
-          this.activeImporterTab = visible[0]?.id || 'local';
-        }
       },
     });
     this.datasetsApi.getEmbedders().subscribe({
@@ -162,8 +155,9 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Tab declarations supplied by the backend (``/api/dataset/all-importers``). */
   declaredTabs: ImporterPickerTab[] = [];
 
-  /** Currently selected picker tab. */
-  activeImporterTab = 'local';
+  /** Currently selected picker tab.  Empty string means no tab is selected
+   *  yet, so the content area below the tab bars stays blank. */
+  activeImporterTab = '';
 
   get orderedImporters(): ImporterInfo[] {
     const order = DatasetImporterModalComponent.PICKER_ORDER;
@@ -190,26 +184,25 @@ export class DatasetImporterModalComponent implements OnInit {
       .join(' ');
   }
 
-  /** Tabs that have at least one visible importer.  Tabs declared by the
-   *  backend render in their declared order; categories used by importers
-   *  but never declared get appended at the end with a title-cased label
-   *  and no icon.  An empty tab (no importers) is hidden so the user
-   *  isn't shown an empty section. */
+  /** Picker tabs to display.  All tabs declared by the backend render in
+   *  their declared order, regardless of whether any importers populate
+   *  them — so categories like "Services" remain visible even when no
+   *  extension importers are installed.  Categories used by importers but
+   *  never declared get appended at the end with a title-cased label and
+   *  no icon. */
   get visibleImporterTabs(): ImporterPickerTab[] {
-    const usedCategories = new Set(
-      this.orderedImporters.map((imp) => imp.category || '').filter(Boolean),
-    );
     const visible: ImporterPickerTab[] = [];
     const seen = new Set<string>();
     const declared = [...this.declaredTabs].sort(
       (a, b) => (a.order ?? 100) - (b.order ?? 100),
     );
     for (const tab of declared) {
-      if (usedCategories.has(tab.id)) {
-        visible.push(tab);
-        seen.add(tab.id);
-      }
+      visible.push(tab);
+      seen.add(tab.id);
     }
+    const usedCategories = new Set(
+      this.orderedImporters.map((imp) => imp.category || '').filter(Boolean),
+    );
     for (const id of usedCategories) {
       if (!seen.has(id)) {
         visible.push({ id, label: this.fallbackTabLabel(id) });
@@ -227,16 +220,28 @@ export class DatasetImporterModalComponent implements OnInit {
 
   selectImporterTab(tabId: string): void {
     this.activeImporterTab = tabId;
+    // Clearing the selected importer keeps the inner sub-tab row blank
+    // until the user explicitly clicks one — matching the "no auto-select"
+    // policy that applies at every tab level.
+    this.selectedImporter = null;
   }
 
   /** Title shown at the top of the modal. */
   get modalTitle(): string {
-    if (this.view === 'picker') return 'Add Dataset';
-    return this.selectedImporter?.display_name || this.selectedImporter?.name || 'Import';
+    return 'Add Dataset';
+  }
+
+  /** ``picker_view`` of the currently selected importer, or empty when
+   *  nothing is selected.  Drives which inline widget set is rendered
+   *  below the inner tab row. */
+  get activePickerView(): string {
+    return this.selectedImporter?.picker_view || '';
   }
 
   selectImporter(importer: ImporterInfo): void {
-    // Dispatch to the dedicated view for importers that aren't a generic form.
+    // Dispatch to the importer-specific setup logic.  Each helper
+    // populates its own state slice but no longer changes a global
+    // ``view`` because the modal renders all tab levels together.
     const pickerView = importer.picker_view || 'form';
     if (pickerView === 'local_folder' || pickerView === 'local_files') {
       this.openLocalFolderUploader(importer);
@@ -284,8 +289,6 @@ export class DatasetImporterModalComponent implements OnInit {
       this.loadClippers(defaultType);
       this.loadEmbedders(defaultType);
     }
-
-    this.view = 'form';
   }
 
   onMediaTypeChange(mediaType: string): void {
@@ -347,7 +350,6 @@ export class DatasetImporterModalComponent implements OnInit {
 
   openDemoPicker(importer?: ImporterInfo): void {
     this.selectedImporter = importer || this.importers.find((i) => i.name === 'demo') || null;
-    this.view = 'demo';
     this.demoLoading = true;
     this.demos = [];
     this.demoTabs = [];
@@ -388,15 +390,9 @@ export class DatasetImporterModalComponent implements OnInit {
         this.demoTabs.push(mt);
       }
     }
-    if (this.demoTabs.length > 0 && !this.activeTab) {
-      // Prefer guessed media type if it has demos
-      if (this.guessedMediaType && this.demoTabs.includes(this.guessedMediaType)) {
-        this.activeTab = this.guessedMediaType;
-      } else {
-        this.activeTab = this.demoTabs[0];
-      }
-      this.loadDemoEmbedders(this.activeTab);
-    }
+    // Intentionally leave ``activeTab`` blank — no media-type tab is
+    // auto-selected.  The demo table stays empty until the user clicks
+    // one of the inner tabs.
   }
 
   private loadDemoEmbedders(mediaType: string): void {
@@ -713,12 +709,6 @@ export class DatasetImporterModalComponent implements OnInit {
     // Clipper is reset by loadDemoEmbedders (called from selectDemoTab)
   }
 
-  back(): void {
-    this.view = 'picker';
-    this.selectedImporter = null;
-    this.error = '';
-  }
-
   /** Read the ``recursive`` field's declared default ("true"/"false") from
    *  the importer metadata; defaults to ``true`` when the field is absent. */
   private readRecursiveDefault(importer: ImporterInfo | null): boolean {
@@ -735,7 +725,6 @@ export class DatasetImporterModalComponent implements OnInit {
       || null;
     this.selectedImporter = resolved;
     this.lfPickerKind = resolved?.name === 'local_files' ? 'files' : 'folder';
-    this.view = 'local_folder';
     this.lfFiles = [];
     this.lfError = '';
     this.lfSubmitting = false;
@@ -891,7 +880,6 @@ export class DatasetImporterModalComponent implements OnInit {
 
   openServerFolderBrowser(importer?: ImporterInfo): void {
     this.selectedImporter = importer || this.importers.find((i) => i.name === 'server_folder') || null;
-    this.view = 'server_folder';
     this.sfBrowsePath = '';
     this.sfBrowseRootPath = '';
     this.sfBrowseDirs = [];


### PR DESCRIPTION
## Summary
This PR refactors the dataset importer modal to eliminate automatic tab selection at all levels and simplifies the view management by removing the global `view` state variable. The modal now renders all tab levels together, with content areas conditionally displayed based on the current selection state.

## Key Changes

- **Removed global `view` state**: Replaced the `view: ModalView` property with `activePickerView` getter that derives the current view from `selectedImporter.picker_view`. This eliminates the need to manually synchronize view state across multiple methods.

- **Eliminated auto-selection behavior**: 
  - Top-level importer tabs no longer auto-select the first tab; `activeImporterTab` now defaults to empty string
  - Demo media-type tabs no longer auto-select the first tab; `activeTab` remains empty until explicitly selected
  - This requires users to explicitly click tabs at each level, providing clearer intent

- **Removed `back()` method**: Navigation now happens through explicit tab selection rather than a back button. Selecting a different top-level tab clears the selected importer.

- **Restructured template layout**: 
  - All tab levels and content areas now render together in the template with conditional visibility
  - Removed back buttons from individual views
  - Inner importer "sub-tabs" now display in a dedicated `.importer-subtab-bar` below the main tab bar
  - Demo table only renders when a media-type tab is explicitly selected

- **Updated test helpers and assertions**:
  - `openAndFlushDemoPicker()` no longer auto-selects a tab or flushes embedder requests
  - New `selectDemoTabAndFlush()` helper encapsulates tab selection and request flushing
  - Tests updated to reflect no auto-selection at any level
  - Assertions now verify empty states when no tab is selected

- **Styling improvements**:
  - Fixed modal width to 900px to prevent reflow when switching between tabs
  - Redesigned inner sub-tabs with subtle background and border styling
  - Added empty state message for categories with no importers

## Implementation Details

The refactoring maintains all existing functionality while improving the UX by making tab selection explicit. The template now uses a single conditional structure based on `activePickerView` rather than multiple view-specific sections, reducing complexity and making the state flow more predictable.

https://claude.ai/code/session_01KKFwPt1Wa1K8hzBJgpfXSC