### PR TITLE
Fix column drag-reorder dead zones with shift semantics

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -30,8 +30,7 @@
               @for (col of visibleDatasetColumns; track col) {
                 <th
                   [class.sortable]="datasetColMeta(col).sortable"
-                  [class.col-drop-left]="isDropTarget('datasets', col, 'left')"
-                  [class.col-drop-right]="isDropTarget('datasets', col, 'right')"
+                  [class.col-drop-target]="isDropTarget('datasets', col)"
                   [class.col-dragging]="isDragging('datasets', col)"
                   [attr.data-col]="col"
                   [title]="datasetColMeta(col).title"
@@ -125,8 +124,7 @@
               @for (col of visibleModelColumns; track col) {
                 <th
                   [class.sortable]="modelColMeta(col).sortable"
-                  [class.col-drop-left]="isDropTarget('models', col, 'left')"
-                  [class.col-drop-right]="isDropTarget('models', col, 'right')"
+                  [class.col-drop-target]="isDropTarget('models', col)"
                   [class.col-dragging]="isDragging('models', col)"
                   [attr.data-col]="col"
                   [title]="modelColMeta(col).title"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -215,26 +215,11 @@
       }
     }
 
-    // Visual drop indicator: a vertical accent line on the side of the cell
-    // where the dragged column will land.
-    &.col-drop-left::before,
-    &.col-drop-right::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 3px;
-      background: var(--accent);
-      z-index: 3;
-      pointer-events: none;
-    }
-
-    &.col-drop-left::before {
-      left: 0;
-    }
-
-    &.col-drop-right::after {
-      right: 0;
+    // Visual drop indicator: highlight the target cell — the dragged column
+    // will land in this slot, displacing the target toward the dragged
+    // column's original position.
+    &.col-drop-target {
+      box-shadow: inset 0 0 0 2px var(--accent);
     }
 
     // Dim the cell currently being dragged so the user can tell which column

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -116,7 +116,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // Drag-reorder state
   dragCol: { table: 'datasets' | 'models'; col: string } | null = null;
-  dropTargetCol: { table: 'datasets' | 'models'; col: string; side: 'left' | 'right' } | null = null;
+  dropTargetCol: { table: 'datasets' | 'models'; col: string } | null = null;
 
   // Per-column display metadata. Keyed by `data-col` value; used both by the
   // header template and by card components when rendering body cells in order.
@@ -504,16 +504,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (!this.dragCol || this.dragCol.table !== table || this.dragCol.col === col) return;
     event.preventDefault();
     if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
-    const th = event.currentTarget as HTMLElement;
-    const rect = th.getBoundingClientRect();
-    const side: 'left' | 'right' = (event.clientX - rect.left) < rect.width / 2 ? 'left' : 'right';
     if (
       !this.dropTargetCol
       || this.dropTargetCol.col !== col
-      || this.dropTargetCol.side !== side
       || this.dropTargetCol.table !== table
     ) {
-      this.dropTargetCol = { table, col, side };
+      this.dropTargetCol = { table, col };
     }
   }
 
@@ -531,7 +527,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
     event.preventDefault();
     const sourceCol = this.dragCol.col;
-    const drop = this.dropTargetCol;
     this.dragCol = null;
     this.dropTargetCol = null;
     if (sourceCol === targetCol) return;
@@ -541,11 +536,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const toIdx = order.indexOf(targetCol);
     if (fromIdx < 0 || toIdx < 0) return;
 
+    // Shift semantics: source lands at target's slot; intermediate columns shift
+    // by one toward source's old slot. Splicing in at the target's *original*
+    // index achieves this for both directions: when fromIdx < toIdx, removing
+    // source first shifts target down by one, so inserting at the original
+    // toIdx places source just past target; when fromIdx > toIdx, target's
+    // index is unchanged, so inserting at toIdx places source just before it.
     const next = [...order];
     next.splice(fromIdx, 1);
-    let insertIdx = next.indexOf(targetCol);
-    if (drop?.side === 'right') insertIdx += 1;
-    next.splice(insertIdx, 0, sourceCol);
+    next.splice(toIdx, 0, sourceCol);
 
     if (table === 'datasets') {
       this.datasetColumnOrder = next;
@@ -560,11 +559,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.dropTargetCol = null;
   }
 
-  isDropTarget(table: 'datasets' | 'models', col: string, side: 'left' | 'right'): boolean {
+  isDropTarget(table: 'datasets' | 'models', col: string): boolean {
     return !!this.dropTargetCol
       && this.dropTargetCol.table === table
-      && this.dropTargetCol.col === col
-      && this.dropTargetCol.side === side;
+      && this.dropTargetCol.col === col;
   }
 
   isDragging(table: 'datasets' | 'models', col: string): boolean {


### PR DESCRIPTION
## Summary

The dashboard column drag-reorder used a left/right-half insert model that produced two confusing behaviors:

- **Dead-zone no-op**: dragging C one slot right and dropping on D's *left* half computed "insert before D" — exactly where C already was — so the column appeared to "pop back."
- **Off-by-one displacement**: dragging C two slots right onto E's *left* half landed C between D and E (`A B D C E`), which looked like C trading with D rather than landing at E.

Replaced with **shift semantics**: dropping X onto Y places X at Y's slot; intermediate columns shift one position toward X's old slot. The whole `<th>` is now a single drop target (no left/right halves), highlighted with an inset border.

Examples on `A B C D E`:
- Drag C → D: `A B D C E`
- Drag C → E: `A B D E C`
- Drag D → B: `A D B C E`

Implementation is one line: after removing source from `fromIdx`, splice it back in at the target's *original* `toIdx`. This works for both directions because removing source first only shifts target when `fromIdx < toIdx`, and that shift is exactly what we want for "land just past target."

## Test plan
- [x] Frontend `npm run build:prod` succeeds
- [ ] Manually drag dataset/model columns one slot right, one slot left, several slots right, several slots left — verify result matches the shift-semantics rules above
- [ ] Verify drop-target highlight (inset accent border) appears on the hovered column header during drag
- [ ] Verify dragged column stays dimmed (`col-dragging`) during drag
- [ ] Verify column order persists across reload (localStorage)

https://claude.ai/code/session_01YKAp4x8RynZhFxPdpGQEvX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKAp4x8RynZhFxPdpGQEvX)_