### PR TITLE
Polish Add Dataset modal: hints, hierarchy, consistent tab styling

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -9,6 +9,9 @@
           [title]="'Show ' + tab.label + ' dataset importers'"
         >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
       }
+      @if (!activeImporterTab) {
+        <span class="tab-bar-hint">Select what type of dataset to add.</span>
+      }
     </div>
 
     @if (activeImporterTab) {
@@ -25,6 +28,9 @@
             (click)="selectImporter(imp)"
             [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
           >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
+        }
+        @if (!selectedImporter && importersForActiveTab.length > 0) {
+          <span class="tab-bar-hint">Select how to add a {{ activeImporterTabLabel }} dataset.</span>
         }
       </div>
     }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -2,10 +2,12 @@
 // tabs (Services / Server / Local / Demo) and inner widgets doesn't reflow
 // the dialog.  680px (matching the Settings modal) was too narrow for the
 // demo table; 900px gives the table room without overflowing typical
-// laptop displays.
+// laptop displays.  min-height keeps the dialog from collapsing to a thin
+// strip in the no-selection state and then jumping to fit the demo table.
 :host {
   ::ng-deep .modal-content {
     width: 900px;
+    min-height: 480px;
   }
 }
 
@@ -19,8 +21,18 @@
 
 .importer-picker { gap: 0; margin-bottom: 12px; }
 
+// Indent the Importer's content area inward from the tabs above so the
+// hierarchy reads top-down: category tabs → importer tabs → controls.
+.importer-form,
+.demo-picker,
+.local-folder-uploader,
+.server-folder-browser {
+  padding-left: 20px;
+}
+
 .importer-tab-bar {
   display: flex;
+  align-items: center;
   gap: 4px;
   width: 100%;
   border-bottom: 2px solid var(--border);
@@ -53,53 +65,30 @@
   }
 }
 
-// Inner row of importer "tabs" within the active category.  Renders
-// underneath the top tab bar; selecting one swaps in that importer's
-// widgets in the area below.
+// Inner row of importer "tabs" within the active category.  Uses the same
+// underline-tab styling as the top-level category tabs so all three tab
+// levels (category, importer, demo media-type) feel like one consistent
+// system.
 .importer-subtab-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  width: 100%;
-  border-bottom: 1px solid var(--border-subtle, var(--border));
-  padding: 6px 4px 0;
-  background: var(--bg-subtle);
-  margin-bottom: 12px;
+  @extend .importer-tab-bar;
 }
 
 .importer-subtab {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 14px;
-  border: 1px solid transparent;
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
-  background: none;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .82rem;
-  cursor: pointer;
-  transition: all .15s;
-  white-space: nowrap;
-  margin-bottom: -1px;
-
-  &:hover:not(:disabled) {
-    color: var(--text-primary);
-    background: var(--bg-surface);
-  }
-
-  &.active {
-    color: var(--text-primary);
-    background: var(--bg-surface);
-    border-color: var(--border-subtle, var(--border));
-    border-bottom-color: var(--bg-surface);
-    font-weight: 600;
-  }
+  @extend .importer-tab;
 
   &.disabled, &:disabled {
     opacity: 0.45;
     cursor: not-allowed;
   }
+}
+
+.tab-bar-hint {
+  margin-left: auto;
+  padding: 0 12px;
+  color: var(--text-muted);
+  font-size: .8rem;
+  font-style: italic;
+  white-space: nowrap;
 }
 
 .importer-subtab-icon {
@@ -120,7 +109,7 @@
   gap: 8px;
 }
 
-.demo-picker { gap: 8px; }
+.demo-picker { gap: 12px; }
 
 // .demo-tab-bar / .demo-tab share the visual styling of the top
 // .importer-tab-bar / .importer-tab.  Define the chrome once via @extend
@@ -132,8 +121,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
-  padding-left: 10px;
 
   .form-label { margin: 0; font-size: .85rem; white-space: nowrap; }
   .form-select--inline { width: auto; min-width: 140px; }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -218,6 +218,12 @@ export class DatasetImporterModalComponent implements OnInit {
     );
   }
 
+  /** Display label of the currently selected category tab, or empty when none. */
+  get activeImporterTabLabel(): string {
+    const tab = this.visibleImporterTabs.find((t) => t.id === this.activeImporterTab);
+    return tab?.label || '';
+  }
+
   selectImporterTab(tabId: string): void {
     this.activeImporterTab = tabId;
     // Clearing the selected importer keeps the inner sub-tab row blank


### PR DESCRIPTION
## Summary

Cleans up the Add Dataset modal so it's clearer what to do, sits at a stable size, and reads as a coherent hierarchy.

- **Hints when nothing is selected.** "Select what type of dataset to add." appears on the empty category tab row; "Select how to add a `<Category>` dataset." appears on the empty importer subtab row. Both disappear once the user clicks a tab.
- **Stable dialog height.** Pinned the modal to `min-height: 480px` so it no longer starts as a thin strip and then jumps to fit the demo table when an importer is picked. The empty state now hints there's content coming below.
- **Consistent tab styling at all three levels.** Category, importer, and demo media-type tabs now share the same underline-tab look. The importer subtabs no longer render as rounded boxes on a `bg-subtle` strip while the other two levels use a flat underline — they all match.
- **Top-down indentation hierarchy.** The importer's content area (`importer-form`, `demo-picker`, `local-folder-uploader`, `server-folder-browser`) is indented 20px in from the tabs above. Previously the controls sat ~10px to the *left* of the tabs above them; now they're inside.
- **Reduced double gap** between the importer subtab row and the demo media-type tab row by dropping the redundant `margin-bottom` on the subtab bar.

## Test plan

- [ ] Open Add Dataset — empty modal shows category-row hint and is at full height.
- [ ] Click a category — hint disappears; subtab-row hint appears with correct category label.
- [ ] Click an importer — subtab hint disappears; importer content appears indented inward from the tabs.
- [ ] Pick Demo → mediaType tabs render in the same underline style as the category tabs, with no awkward extra gap above.
- [ ] All three tab rows visually align (no rogue background colors / rounded boxes on a single level).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MBMgeL4qnMEpcUAYDw6eNF)_