### PR TITLE
Add row checkboxes and bulk-select side actions to Datasets/Models grids

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -1,5 +1,6 @@
 <div class="dashboard-view">
   <!-- Dataset Section -->
+  <div class="dashboard-section-wrap">
   <div class="dashboard-section">
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</span>
@@ -84,6 +85,7 @@
                 [statsOpen]="statsModalOpen && statsDatasetId === dataset.id"
                 [deleteConfirmOpen]="deletingDatasetId === dataset.id"
                 (rowClick)="!isLoading && toggleDatasetSelection(dataset.id, $event)"
+                (checkboxToggle)="!isLoading && toggleDatasetCheckbox(dataset.id)"
                 (rename)="renameDataset(dataset, $event)"
                 (stats)="showDatasetStats(dataset)"
                 (delete)="deleteDataset(dataset)"
@@ -98,8 +100,32 @@
       </div>
     }
   </div>
+  <div class="dashboard-side-actions">
+    <button class="side-action-btn" (click)="selectAllDatasets()" [disabled]="isLoading || datasets.length === 0" title="Select all datasets" aria-label="Select all">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+        <rect x="3" y="3" width="18" height="18" rx="2"/>
+      </svg>
+    </button>
+    <button class="side-action-btn" (click)="selectNoneDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" title="Select none" aria-label="Select none">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+        <rect x="3" y="3" width="18" height="18" rx="2"/>
+      </svg>
+    </button>
+    <div class="side-action-gap"></div>
+    <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+        <path d="M10 11v6"></path>
+        <path d="M14 11v6"></path>
+        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+      </svg>
+    </button>
+  </div>
+  </div>
 
   <!-- Model Section -->
+  <div class="dashboard-section-wrap">
   <div class="dashboard-section">
     <div class="dashboard-section-header">
       <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="lightbulb" [size]="18"></vt-icon> Models</span>
@@ -151,6 +177,7 @@
                 [deleteConfirmOpen]="deletingModelId === model.id"
                 [addLabelsOpen]="addLabelsModalOpen && addLabelsModelId === model.id"
                 (rowClick)="!isLoading && toggleModelSelection(model.id, $event)"
+                (checkboxToggle)="!isLoading && toggleModelCheckbox(model.id)"
                 (rename)="renameModel(model, $event)"
                 (delete)="deleteModel(model)"
                 (load)="loadModel(model)"
@@ -166,6 +193,29 @@
         </table>
       </div>
     }
+  </div>
+  <div class="dashboard-side-actions">
+    <button class="side-action-btn" (click)="selectAllModels()" [disabled]="isLoading || models.length === 0" title="Select all models" aria-label="Select all">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+        <rect x="3" y="3" width="18" height="18" rx="2"/>
+      </svg>
+    </button>
+    <button class="side-action-btn" (click)="selectNoneModels()" [disabled]="isLoading || selectedModelIds.size === 0" title="Select none" aria-label="Select none">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+        <rect x="3" y="3" width="18" height="18" rx="2"/>
+      </svg>
+    </button>
+    <div class="side-action-gap"></div>
+    <button class="side-action-btn side-action-delete" (click)="deleteSelectedModels()" [disabled]="isLoading || selectedModelIds.size === 0" [title]="selectedModelIds.size === 0 ? 'No models selected' : 'Delete selected models'" aria-label="Delete selected">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+        <path d="M10 11v6"></path>
+        <path d="M14 11v6"></path>
+        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+      </svg>
+    </button>
+  </div>
   </div>
 
   <!-- Action Buttons — STABLE POSITIONING (read before changing!)

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -11,8 +11,18 @@
   overflow: hidden;
 }
 
+.dashboard-section-wrap {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: stretch;
+}
+
 .dashboard-section {
   flex: 1 1 0;
+  min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -20,6 +30,45 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
+}
+
+.dashboard-side-actions {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.side-action-gap {
+  height: 12px;
+}
+
+.side-action-btn {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover:not(:disabled) {
+    background: var(--btn-icon-hover-bg);
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  &.side-action-delete:hover:not(:disabled) {
+    color: var(--color-bad);
+  }
 }
 
 .dashboard-section-header {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -666,6 +666,49 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.selectedDatasetIds.has(id);
   }
 
+  toggleDatasetCheckbox(id: string): void {
+    if (this.selectedDatasetIds.has(id)) {
+      this.selectedDatasetIds.delete(id);
+    } else {
+      this.selectedDatasetIds.add(id);
+    }
+    this.pushTopBarLabels();
+  }
+
+  selectAllDatasets(): void {
+    for (const d of this.datasets) {
+      this.selectedDatasetIds.add(d.id);
+    }
+    this.pushTopBarLabels();
+  }
+
+  selectNoneDatasets(): void {
+    this.selectedDatasetIds.clear();
+    this.pushTopBarLabels();
+  }
+
+  async deleteSelectedDatasets(): Promise<void> {
+    const ids = [...this.selectedDatasetIds];
+    if (ids.length === 0) return;
+    const targets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
+    if (targets.length === 0) return;
+    const names = targets.map((d) => `"${d.name}"`).join(', ');
+    const ok = await this.dialog.confirm(
+      targets.length === 1
+        ? `Delete dataset ${names}?`
+        : `Delete ${targets.length} datasets: ${names}?`,
+    );
+    if (!ok) return;
+    for (const dataset of targets) {
+      this.datasetsApi.deleteRegistered(dataset.id).subscribe({
+        next: () => {
+          this.selectedDatasetIds.delete(dataset.id);
+          this.datasetState.refresh();
+        },
+      });
+    }
+  }
+
   // --- Model selection ---
 
   toggleModelSelection(id: string, event: MouseEvent): void {
@@ -688,6 +731,52 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   isModelSelected(id: string): boolean {
     return this.selectedModelIds.has(id);
+  }
+
+  toggleModelCheckbox(id: string): void {
+    if (this.selectedModelIds.has(id)) {
+      this.selectedModelIds.delete(id);
+    } else {
+      this.selectedModelIds.add(id);
+    }
+    this.pushTopBarLabels();
+  }
+
+  selectAllModels(): void {
+    for (const m of this.models) {
+      this.selectedModelIds.add(m.id);
+    }
+    this.pushTopBarLabels();
+  }
+
+  selectNoneModels(): void {
+    this.selectedModelIds.clear();
+    this.pushTopBarLabels();
+  }
+
+  async deleteSelectedModels(): Promise<void> {
+    const ids = [...this.selectedModelIds];
+    if (ids.length === 0) return;
+    const targets = this.models.filter((m) => this.selectedModelIds.has(m.id));
+    if (targets.length === 0) return;
+    const names = targets.map((m) => `"${m.name}"`).join(', ');
+    const ok = await this.dialog.confirm(
+      targets.length === 1
+        ? `Delete model ${names}?`
+        : `Delete ${targets.length} models: ${names}?`,
+    );
+    if (!ok) return;
+    for (const model of targets) {
+      this.modelsApi.deleteFromRegistry(model.id).subscribe({
+        next: () => {
+          this.selectedModelIds.delete(model.id);
+          this.datasetState.refresh();
+        },
+        error: () => {
+          this.dialog.alert(`Failed to delete model "${model.name}".`, 'error');
+        },
+      });
+    }
   }
 
   // --- Dataset actions ---

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -130,6 +130,18 @@
               <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
             </svg>
           </button>
+          <button class="select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect dataset' : 'Select dataset'" [attr.title]="selected ? 'Deselect' : 'Select'">
+            @if (selected) {
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+                <polyline points="8 12 11 15 16 9"/>
+              </svg>
+            } @else {
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+              </svg>
+            }
+          </button>
           </div>
         </td>
       }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -214,6 +214,24 @@ td {
   }
 }
 
+.select-checkbox {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+  }
+}
+
 // Inline loading progress (replaces data columns while loading)
 .inline-loading-progress {
   display: flex;

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -38,6 +38,7 @@ export class DatasetCardComponent implements OnChanges {
   @Output() security = new EventEmitter<void>();
   @Output() cancelTask = new EventEmitter<string>();
   @Output() dismissTask = new EventEmitter<string>();
+  @Output() checkboxToggle = new EventEmitter<void>();
 
   get isOwner(): boolean {
     return this.dataset?.created_by === this.currentUser;
@@ -127,6 +128,11 @@ export class DatasetCardComponent implements OnChanges {
   onDelete(event: MouseEvent): void {
     event.stopPropagation();
     this.delete.emit();
+  }
+
+  onCheckboxClick(event: MouseEvent): void {
+    event.stopPropagation();
+    this.checkboxToggle.emit();
   }
 
   formatDate(timestamp: number | null): string {

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -159,6 +159,18 @@
               <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
             </svg>
           </button>
+          <button class="select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect model' : 'Select model'" [attr.title]="selected ? 'Deselect' : 'Select'">
+            @if (selected) {
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+                <polyline points="8 12 11 15 16 9"/>
+              </svg>
+            } @else {
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+              </svg>
+            }
+          </button>
           </div>
         </td>
       }

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -206,3 +206,21 @@ td {
     animation: icon-rotate-close 0.3s ease-in-out forwards;
   }
 }
+
+.select-checkbox {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+  }
+}

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.ts
@@ -39,6 +39,7 @@ export class ModelCardComponent implements OnChanges {
   @Output() cancelTask = new EventEmitter<string>();
   @Output() dismissTask = new EventEmitter<string>();
   @Output() autorunToggle = new EventEmitter<boolean>();
+  @Output() checkboxToggle = new EventEmitter<void>();
 
   @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
 
@@ -129,6 +130,11 @@ export class ModelCardComponent implements OnChanges {
   onAutorunToggle(event: MouseEvent): void {
     event.stopPropagation();
     this.autorunToggle.emit(!this.model.autodetect);
+  }
+
+  onCheckboxClick(event: MouseEvent): void {
+    event.stopPropagation();
+    this.checkboxToggle.emit();
   }
 
   formatDate(timestamp: number | null): string {


### PR DESCRIPTION
## Summary
- Each Datasets/Models row's Actions cell now ends with a far-right selection checkbox that mirrors the row's selected state. Clicking the checkbox toggles set membership without clearing other selections; clicking the row still uses the existing single-select behavior.
- Added a bulk-action side column outside each grid (on the dashboard's base background): Select All (dotted-line filled square), Select None (dotted-line empty square), small gap, and Delete (same trash icon as per-row delete, with confirmation).

## Test plan
- [ ] Datasets grid: clicking a row checks/unchecks its box; clicking the box adds/removes from selection without affecting other rows.
- [ ] Models grid: same checkbox behavior.
- [ ] "Select All" selects every visible dataset/model.
- [ ] "Select None" clears the selection.
- [ ] "Delete" prompts and deletes every selected row (1 vs N wording).
- [ ] Side-action column visibly sits on the page's base background, outside the grid's surface.

https://claude.ai/code/session_01D7LjTv7nSTXjRXpEa2BGpV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7LjTv7nSTXjRXpEa2BGpV)_