### PR TITLE
Fix dashboard SCSS budget warning

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -178,7 +178,7 @@
     }
 
     &.plus-close {
-      animation: plus-spin-close 0.3s ease-in-out forwards;
+      animation: plus-spin-open 0.3s ease-in-out reverse forwards;
     }
   }
 }
@@ -187,12 +187,6 @@
   0% { transform: rotate(0deg); }
   50% { transform: rotate(22.5deg); }
   100% { transform: rotate(45deg); }
-}
-
-@keyframes plus-spin-close {
-  0% { transform: rotate(45deg); }
-  50% { transform: rotate(22.5deg); }
-  100% { transform: rotate(0deg); }
 }
 
 .dashboard-grid {
@@ -216,10 +210,6 @@
     vertical-align: middle;
     border-bottom: 1px solid var(--border-subtle);
     white-space: nowrap;
-  }
-
-  td {
-    padding: 6px 10px;
   }
 
   th {


### PR DESCRIPTION
## Summary
- Reuse `plus-spin-open` keyframes for the close transition via `animation-direction: reverse`, eliminating the duplicate `plus-spin-close` keyframes.
- Drop the duplicate `td { padding: 6px 10px; }` rule that was already covered by the `th, td` selector above it.

This brings `dashboard.component.scss` back under the 6 kB `anyComponentStyle` budget (previously over by 121 bytes).

## Test plan
- [x] `npm run build:prod` completes with no SCSS budget warning.

https://claude.ai/code/session_013HjvmfUTBD3iDv3P3KugJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013HjvmfUTBD3iDv3P3KugJp)_