### PR TITLE
Pin Name and Actions columns; fit grid to container width

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -23,10 +23,10 @@
       <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
-        <table class="dash-table" [class.table-fixed]="datasetsTableFixed" [style.width]="datasetsTableFixed ? (datasetsTableWidth + 'px') : '100%'">
+        <table class="dash-table" [class.table-fixed]="datasetsTableFixed">
           <thead>
             <tr>
-              <th (click)="sortDatasets('name')" class="sortable" title="Dataset display name (click to sort)" data-col="name" [style.width.px]="datasetsTableFixed ? datasetColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isDatasetSortActive('name')">{{ datasetSortIndicator('name') }}</span></th>
+              <th (click)="sortDatasets('name')" class="sortable name-col" title="Dataset display name (click to sort)" data-col="name" [style.width.%]="datasetsTableFixed ? datasetColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isDatasetSortActive('name')">{{ datasetSortIndicator('name') }}</span></th>
               @for (col of visibleDatasetColumns; track col) {
                 <th
                   [class.sortable]="datasetColMeta(col).sortable"
@@ -34,7 +34,7 @@
                   [class.col-dragging]="isDragging('datasets', col)"
                   [attr.data-col]="col"
                   [title]="datasetColMeta(col).title"
-                  [style.width.px]="datasetsTableFixed ? datasetColWidths[col] : null"
+                  [style.width.%]="datasetsTableFixed ? datasetColWidths[col] : null"
                   draggable="true"
                   (click)="onDatasetHeaderClick(col)"
                   (dragstart)="onColDragStart($event, 'datasets', col)"
@@ -44,6 +44,7 @@
                   (dragend)="onColDragEnd($event)"
                 ><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetColMeta(col).label }}@if (datasetColMeta(col).sortable) {<span class="sort-indicator" [class.active]="isDatasetSortActive(col)">{{ datasetSortIndicator(col) }}</span>}</th>
               }
+              <th class="actions-col" data-col="actions" [title]="datasetColMeta('actions').title" [style.width.%]="datasetsTableFixed ? datasetColWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetColMeta('actions').label }}</th>
             </tr>
           </thead>
           <tbody>
@@ -52,7 +53,7 @@
                 <td>
                   <span class="loading-task-name">{{ task.name || 'Loading...' }}</span>
                 </td>
-                <td [attr.colspan]="visibleDatasetColumns.length">
+                <td [attr.colspan]="visibleDatasetColumns.length + 1">
                   @if (task.error) {
                     <div class="loading-task-progress loading-task-failed">
                       <span class="error-msg">Failed: {{ task.error }}</span>
@@ -117,10 +118,10 @@
       <p class="empty-state">No models yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
-        <table class="dash-table" [class.table-fixed]="modelsTableFixed" [style.width]="modelsTableFixed ? (modelsTableWidth + 'px') : '100%'">
+        <table class="dash-table" [class.table-fixed]="modelsTableFixed">
           <thead>
             <tr>
-              <th (click)="sortModels('name')" class="sortable" title="Model display name (click to sort)" data-col="name" [style.width.px]="modelsTableFixed ? modelColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
+              <th (click)="sortModels('name')" class="sortable name-col" title="Model display name (click to sort)" data-col="name" [style.width.%]="modelsTableFixed ? modelColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
               @for (col of visibleModelColumns; track col) {
                 <th
                   [class.sortable]="modelColMeta(col).sortable"
@@ -128,7 +129,7 @@
                   [class.col-dragging]="isDragging('models', col)"
                   [attr.data-col]="col"
                   [title]="modelColMeta(col).title"
-                  [style.width.px]="modelsTableFixed ? modelColWidths[col] : null"
+                  [style.width.%]="modelsTableFixed ? modelColWidths[col] : null"
                   draggable="true"
                   (click)="onModelHeaderClick(col)"
                   (dragstart)="onColDragStart($event, 'models', col)"
@@ -138,6 +139,7 @@
                   (dragend)="onColDragEnd($event)"
                 ><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelColMeta(col).label }}@if (modelColMeta(col).sortable) {<span class="sort-indicator" [class.active]="isModelSortActive(col)">{{ modelSortIndicator(col) }}</span>}</th>
               }
+              <th class="actions-col" data-col="actions" [title]="modelColMeta('actions').title" [style.width.%]="modelsTableFixed ? modelColWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelColMeta('actions').label }}</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -149,7 +149,11 @@
 .dashboard-grid {
   flex: 1 1 0;
   min-height: 0;
-  overflow: auto;
+  // Vertical scroll only — Name is pinned left, Actions is pinned right, and
+  // the middle columns share the remaining width so the table always fills
+  // the container without horizontal overflow.
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .table-fixed {
@@ -169,8 +173,19 @@
     white-space: nowrap;
   }
 
+  // Body cells truncate with ellipsis when the column is narrower than
+  // their content. Header cells must NOT clip — they host the resize
+  // handle which pokes 6px to the left of the cell's edge.
   td {
     padding: 6px 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Pinned columns: Name on the left, Actions on the right.
+  th.actions-col,
+  td.actions-col {
+    text-align: right;
   }
 
   th {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -81,33 +81,36 @@ export class DashboardComponent implements OnInit, OnDestroy {
   modelSortColumn = 'name';
   modelSortAsc = true;
 
-  // Column resize state
+  // Column resize state. Widths are stored as percentages summing to ~100;
+  // the table is always 100% wide so columns fit the container without
+  // horizontal scrolling. Resizing one column shifts width to/from its
+  // right-hand neighbour (the cell that hosts the resize handle).
   datasetColWidths: Record<string, number> = {};
   modelColWidths: Record<string, number> = {};
   datasetsTableFixed = false;
   modelsTableFixed = false;
-  datasetsTableWidth = 0;
-  modelsTableWidth = 0;
   private datasetsResizeInit = false;
   private modelsResizeInit = false;
   private resizeState: {
     startX: number;
-    startWidth: number;
+    startGrowPct: number;
+    startShrinkPct: number;
+    growCol: string;
+    shrinkCol: string;
     table: 'datasets' | 'models';
-    col: string;
     dragged: boolean;
     tableEl: HTMLTableElement;
   } | null = null;
+  private static readonly MIN_COL_PCT = 3;
 
-  // Column order. The "name" column is fixed in position 0 (so the loading-task
-  // colspan that replaces "all columns after name" keeps working); these arrays
-  // hold the columns that follow name and are user-reorderable.
+  // Column order. "name" is pinned at position 0 and "actions" is pinned at
+  // the far right; these arrays hold only the user-reorderable middle columns.
   static readonly DATASET_COLUMNS_DEFAULT = [
-    'media_type', 'num_items', 'created_at', 'created_by', 'readers', 'loaded', 'actions',
+    'media_type', 'num_items', 'created_at', 'created_by', 'readers', 'loaded',
   ];
   static readonly MODEL_COLUMNS_DEFAULT = [
     'media_type', 'num_training', 'trainable', 'autodetect', 'last_trained_at',
-    'created_at', 'detector_loaded', 'actions',
+    'created_at', 'detector_loaded',
   ];
   private static readonly DATASET_COL_ORDER_KEY = 'vtsearch.dashboard.datasetColumnOrder';
   private static readonly MODEL_COL_ORDER_KEY = 'vtsearch.dashboard.modelColumnOrder';
@@ -269,36 +272,40 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   // --- Column resize ---
+  //
+  // The handle sits on the LEFT edge of its host <th> and represents the
+  // boundary between the previous column ("grow" target) and the host column
+  // ("shrink" target). Dragging the handle right grows the previous column
+  // and shrinks the host by the same amount, keeping the table at 100%.
+
+  private captureColumnPercentages(tableEl: HTMLTableElement, colWidths: Record<string, number>): void {
+    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
+    const tableWidth = tableEl.offsetWidth || 1;
+    ths.forEach((t) => {
+      const colKey = t.getAttribute('data-col');
+      if (colKey) colWidths[colKey] = (t.offsetWidth / tableWidth) * 100;
+    });
+  }
 
   startResize(event: MouseEvent, table: 'datasets' | 'models'): void {
     event.stopPropagation();
     event.preventDefault();
 
-    // The handle sits on the LEFT edge of its host <th> and resizes the
-    // column to its left (see dashboard.component.scss for why).
     const th = (event.target as HTMLElement).closest('th') as HTMLElement;
     const prevTh = th.previousElementSibling as HTMLElement | null;
-    const col = prevTh?.getAttribute('data-col');
-    if (!col) return;
+    const growCol = prevTh?.getAttribute('data-col');
+    const shrinkCol = th.getAttribute('data-col');
+    if (!growCol || !shrinkCol) return;
     const tableEl = th.closest('table') as HTMLTableElement;
     const colWidths = table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
     const initialized = table === 'datasets' ? this.datasetsResizeInit : this.modelsResizeInit;
 
     if (!initialized) {
-      const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
-      let totalWidth = 0;
-      ths.forEach((t) => {
-        const colKey = t.getAttribute('data-col');
-        const w = t.offsetWidth;
-        if (colKey) colWidths[colKey] = w;
-        totalWidth += w;
-      });
+      this.captureColumnPercentages(tableEl, colWidths);
       if (table === 'datasets') {
-        this.datasetsTableWidth = totalWidth;
         this.datasetsResizeInit = true;
         this.datasetsTableFixed = true;
       } else {
-        this.modelsTableWidth = totalWidth;
         this.modelsResizeInit = true;
         this.modelsTableFixed = true;
       }
@@ -306,9 +313,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     this.resizeState = {
       startX: event.clientX,
-      startWidth: colWidths[col] ?? 100,
+      startGrowPct: colWidths[growCol] ?? 10,
+      startShrinkPct: colWidths[shrinkCol] ?? 10,
+      growCol,
+      shrinkCol,
       table,
-      col,
       dragged: false,
       tableEl,
     };
@@ -319,19 +328,28 @@ export class DashboardComponent implements OnInit, OnDestroy {
   @HostListener('document:mousemove', ['$event'])
   onColResizeMove(event: MouseEvent): void {
     if (!this.resizeState) return;
-    const delta = event.clientX - this.resizeState.startX;
-    if (Math.abs(delta) > 3) this.resizeState.dragged = true;
+    const dx = event.clientX - this.resizeState.startX;
+    if (Math.abs(dx) > 3) this.resizeState.dragged = true;
     if (!this.resizeState.dragged) return;
-    const colWidths = this.resizeState.table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
-    const newWidth = Math.max(30, this.resizeState.startWidth + delta);
-    const prevWidth = colWidths[this.resizeState.col] ?? this.resizeState.startWidth;
-    colWidths[this.resizeState.col] = newWidth;
-    const widthChange = newWidth - prevWidth;
-    if (this.resizeState.table === 'datasets') {
-      this.datasetsTableWidth = Math.max(100, this.datasetsTableWidth + widthChange);
-    } else {
-      this.modelsTableWidth = Math.max(100, this.modelsTableWidth + widthChange);
+
+    const tableWidth = this.resizeState.tableEl.offsetWidth || 1;
+    const dPct = (dx / tableWidth) * 100;
+    const min = DashboardComponent.MIN_COL_PCT;
+    const sum = this.resizeState.startGrowPct + this.resizeState.startShrinkPct;
+
+    let newGrow = this.resizeState.startGrowPct + dPct;
+    let newShrink = this.resizeState.startShrinkPct - dPct;
+    if (newShrink < min) {
+      newShrink = min;
+      newGrow = sum - min;
+    } else if (newGrow < min) {
+      newGrow = min;
+      newShrink = sum - min;
     }
+
+    const colWidths = this.resizeState.table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
+    colWidths[this.resizeState.growCol] = newGrow;
+    colWidths[this.resizeState.shrinkCol] = newShrink;
   }
 
   @HostListener('document:mouseup')
@@ -343,95 +361,65 @@ export class DashboardComponent implements OnInit, OnDestroy {
     document.body.style.userSelect = '';
 
     if (!state.dragged) {
-      this.autoSizeColumn(state.tableEl, state.table, state.col);
+      this.autoSizeColumn(state.tableEl, state.table, state.growCol, state.shrinkCol);
     }
   }
 
-  private autoSizeColumn(tableEl: HTMLTableElement, table: 'datasets' | 'models', col: string): void {
+  /** Auto-fit the grow column to its natural content width; take/return the
+   *  delta from the shrink column so total stays at 100%. */
+  private autoSizeColumn(
+    tableEl: HTMLTableElement,
+    table: 'datasets' | 'models',
+    growCol: string,
+    shrinkCol: string,
+  ): void {
     const colWidths = table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
 
-    // Find the column index from the header
     const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
     let colIndex = -1;
     for (let i = 0; i < ths.length; i++) {
-      if (ths[i].getAttribute('data-col') === col) {
+      if (ths[i].getAttribute('data-col') === growCol) {
         colIndex = i;
         break;
       }
     }
     if (colIndex < 0) return;
 
-    // Temporarily switch to auto layout so content determines width
+    // Temporarily release fixed layout for this column so we can measure
+    // its natural width from the body cells.
     const wasFixed = tableEl.classList.contains('table-fixed');
-    const prevTableWidth = tableEl.style.width;
     const prevColWidth = ths[colIndex].style.width;
-
     tableEl.classList.remove('table-fixed');
-    // Force width:auto so the table shrinks to content instead of stretching
-    // to 100% (the CSS class default).  Without this, the browser distributes
-    // extra container space across columns, inflating every measurement.
-    tableEl.style.width = 'auto';
     ths[colIndex].style.width = '';
 
-    // Measure the natural width of the column from body cells.
-    let maxWidth = 0;
+    let maxPx = 0;
     const rows = tableEl.querySelectorAll('tbody tr');
     rows.forEach((row) => {
       const cell = row.children[colIndex] as HTMLElement | undefined;
-      if (cell) {
-        // For cells with colspan, skip (loading task rows)
-        if (cell.hasAttribute('colspan')) return;
-        maxWidth = Math.max(maxWidth, cell.scrollWidth);
-      }
+      if (!cell || cell.hasAttribute('colspan')) return;
+      maxPx = Math.max(maxPx, cell.scrollWidth);
     });
-    // Fall back to header width only when the table has no body rows
-    if (maxWidth === 0) {
-      maxWidth = ths[colIndex].offsetWidth;
-    }
+    if (maxPx === 0) maxPx = ths[colIndex].offsetWidth;
+    maxPx = Math.max(30, maxPx + 2);
 
-    // Add a small buffer for padding
-    maxWidth = Math.max(30, maxWidth + 2);
+    if (wasFixed) tableEl.classList.add('table-fixed');
+    ths[colIndex].style.width = prevColWidth;
 
-    // Apply the measured width and restore fixed layout
-    const prevWidth = colWidths[col] ?? 0;
-    colWidths[col] = maxWidth;
+    const tableWidth = tableEl.offsetWidth || 1;
+    const min = DashboardComponent.MIN_COL_PCT;
+    const sum = (colWidths[growCol] ?? 0) + (colWidths[shrinkCol] ?? 0);
+    let targetGrow = (maxPx / tableWidth) * 100;
+    if (targetGrow > sum - min) targetGrow = sum - min;
+    if (targetGrow < min) targetGrow = min;
+    colWidths[growCol] = targetGrow;
+    colWidths[shrinkCol] = sum - targetGrow;
 
     if (table === 'datasets') {
       this.datasetsTableFixed = true;
       this.datasetsResizeInit = true;
-      // Recalculate total table width
-      let total = 0;
-      ths.forEach((t) => {
-        const key = t.getAttribute('data-col');
-        if (key && key !== col) {
-          if (!colWidths[key]) colWidths[key] = t.offsetWidth;
-          total += colWidths[key];
-        } else if (key === col) {
-          total += maxWidth;
-        }
-      });
-      this.datasetsTableWidth = total;
     } else {
       this.modelsTableFixed = true;
       this.modelsResizeInit = true;
-      let total = 0;
-      ths.forEach((t) => {
-        const key = t.getAttribute('data-col');
-        if (key && key !== col) {
-          if (!colWidths[key]) colWidths[key] = t.offsetWidth;
-          total += colWidths[key];
-        } else if (key === col) {
-          total += maxWidth;
-        }
-      });
-      this.modelsTableWidth = total;
-    }
-
-    // Restore layout (Angular binding will apply on next change detection).
-    // Clear the temporary 'auto' override so Angular bindings take over.
-    tableEl.style.width = prevTableWidth;
-    if (wasFixed) {
-      tableEl.classList.add('table-fixed');
     }
   }
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -18,8 +18,8 @@
   }
 </td>
 @if (loadingTask && !loadingTask.error) {
-  <!-- Inline progress: replace remaining columns with a progress bar -->
-  <td [attr.colspan]="columnOrder.length">
+  <!-- Inline progress: replace remaining columns (middle + actions) with a progress bar -->
+  <td [attr.colspan]="columnOrder.length + 1">
     <div class="inline-loading-progress">
       <span class="progress-msg">{{ taskProgressMessage }}</span>
       <vt-progress-bar
@@ -31,8 +31,8 @@
     </div>
   </td>
 } @else if (loadingTask && loadingTask.error) {
-  <!-- Inline error: replace remaining columns with error message -->
-  <td [attr.colspan]="columnOrder.length">
+  <!-- Inline error: replace remaining columns (middle + actions) with error message -->
+  <td [attr.colspan]="columnOrder.length + 1">
     <div class="inline-loading-progress inline-loading-failed">
       <span class="error-msg">Failed: {{ loadingTask.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss this error">Dismiss</button>
@@ -95,44 +95,42 @@
           }
         </td>
       }
-      @case ('actions') {
-        <td>
-          <div class="actions-cell">
-          @if (!isDefaultLogin) {
-            <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-              </svg>
-            </button>
-          }
-          <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
-            <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
-              <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
-              <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
-            </svg>
-          </button>
-          <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
-            <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 2a10 10 0 0 1 0 20"/>
-              <line x1="12" y1="12" x2="12" y2="2"/>
-              <line x1="12" y1="12" x2="20.66" y2="17"/>
-              <line x1="12" y1="12" x2="2" y2="12"/>
-            </svg>
-          </button>
-          <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
-            <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="3 6 5 6 21 6"></polyline>
-              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-              <path d="M10 11v6"></path>
-              <path d="M14 11v6"></path>
-              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-            </svg>
-          </button>
-          </div>
-        </td>
-      }
     }
   }
+  <td class="actions-col">
+    <div class="actions-cell">
+    @if (!isDefaultLogin) {
+      <button class="security-btn" [class.disabled]="!isOwner" [disabled]="!isOwner" (click)="onSecurity($event)" [attr.aria-label]="isOwner ? 'Edit access list' : 'Only the creator can edit access'" [title]="isOwner ? 'Edit access list' : 'Only the creator can edit access'">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+        </svg>
+      </button>
+    }
+    <button class="edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
+      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
+        <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
+        <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
+      </svg>
+    </button>
+    <button class="stats-btn" (click)="onStats($event)" aria-label="Dataset stats" title="Stats">
+      <svg aria-hidden="true" [class.pie-active]="statsOpen" [class.pie-inactive]="!statsOpen && wasStatsOpen" (animationend)="onPieAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M12 2a10 10 0 0 1 0 20"/>
+        <line x1="12" y1="12" x2="12" y2="2"/>
+        <line x1="12" y1="12" x2="20.66" y2="17"/>
+        <line x1="12" y1="12" x2="2" y2="12"/>
+      </svg>
+    </button>
+    <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete">
+      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+        <path d="M10 11v6"></path>
+        <path d="M14 11v6"></path>
+        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+      </svg>
+    </button>
+    </div>
+  </td>
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -31,6 +31,13 @@ td {
   white-space: nowrap;
   vertical-align: middle;
   border-bottom: 1px solid var(--border-subtle);
+  // Truncate with ellipsis if the column is narrower than the content.
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+td.actions-col {
+  text-align: right;
 }
 
 .name-cell {
@@ -42,6 +49,7 @@ td {
 .actions-cell {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: var(--space-xs);
 }
 

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -17,7 +17,7 @@
   }
 </td>
 @if (loadingTask && !loadingTask.error) {
-  <td [attr.colspan]="columnOrder.length">
+  <td [attr.colspan]="columnOrder.length + 1">
     <div class="loading-task-progress">
       <span class="progress-msg">
         @if (loadingTask.step && loadingTask.total_steps) {
@@ -37,7 +37,7 @@
     </div>
   </td>
 } @else if (loadingTask?.error) {
-  <td [attr.colspan]="columnOrder.length">
+  <td [attr.colspan]="columnOrder.length + 1">
     <div class="loading-task-progress loading-task-failed">
       <span class="error-msg">Failed: {{ loadingTask?.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss error">Dismiss</button>
@@ -131,37 +131,35 @@
           }
         </td>
       }
-      @case ('actions') {
-        <td>
-          <div class="actions-cell">
-          <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
-            <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
-              <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
-              <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
-            </svg>
-          </button>
-          <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
-            <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
-          </button>
-          <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="15 14 20 9 15 4"></polyline>
-              <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
-            </svg>
-          </button>
-          <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
-            <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="3 6 5 6 21 6"></polyline>
-              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-              <path d="M10 11v6"></path>
-              <path d="M14 11v6"></path>
-              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-            </svg>
-          </button>
-          </div>
-        </td>
-      }
     }
   }
+  <td class="actions-col">
+    <div class="actions-cell">
+    <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
+      <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
+        <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
+        <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
+      </svg>
+    </button>
+    <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
+      <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
+    </button>
+    <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="15 14 20 9 15 4"></polyline>
+        <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
+      </svg>
+    </button>
+    <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
+      <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+        <path d="M10 11v6"></path>
+        <path d="M14 11v6"></path>
+        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
+      </svg>
+    </button>
+    </div>
+  </td>
 }

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -27,6 +27,13 @@ td {
   white-space: nowrap;
   vertical-align: middle;
   border-bottom: 1px solid var(--border-subtle);
+  // Truncate with ellipsis if the column is narrower than the content.
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+td.actions-col {
+  text-align: right;
 }
 
 .name-cell {
@@ -38,6 +45,7 @@ td {
 .actions-cell {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 4px;
 }
 


### PR DESCRIPTION
## Summary

Reworks the dashboard grids so the columns can never be reordered out of position or scrolled horizontally:

- **Name** is always the leftmost column, left-justified.
- **Actions** is always the rightmost column, right-justified.
- The middle columns can be reordered (drag/drop) and resized (drag handles) as before, but only between Name and Actions.
- Column widths are stored as percentages summing to ~100, so the table always fits the container. Resizing one column shifts width to/from its right-hand neighbour rather than growing the table — the grid never overflows horizontally.

## Implementation notes

- `actions` removed from the user-reorderable column-order arrays in `dashboard.component.ts`. The header `<th>` and the per-row `<td>` are rendered explicitly at the end of each grid, after the `@for` loop.
- Column widths in `datasetColWidths` / `modelColWidths` are now percentages instead of pixels. `startResize` records both the grow and shrink columns, and `onColResizeMove` redistributes width with a 3% minimum on each side.
- `autoSizeColumn` (single-click on a handle) measures the natural content width, converts to a percentage, and takes the delta from the neighbour.
- `.dashboard-grid` now uses `overflow-y: auto; overflow-x: hidden;`. `<td>` cells truncate with ellipsis when narrower than their content; `<th>` cells do not (the resize handle pokes 6px outside the cell and would be clipped by `overflow: hidden`).
- Stored column orders from localStorage that include the old `'actions'` entry are silently filtered out by `normalizeColumnOrder`, since `actions` is no longer in the defaults set. No migration needed.

## Test plan

- [x] `./run-tests.sh` — 3067 passed, 1 skipped, 2 xpassed
- [x] `npm run build:prod` — clean build, no template/TS errors
- [ ] Manual: load dashboard, verify Name pins left, Actions pins right, middle columns drag-reorder and resize, table never scrolls horizontally
- [ ] Manual: drag a handle past the neighbour's minimum — confirm clamp at 3%
- [ ] Manual: resize browser window — confirm columns scale with container

https://claude.ai/code/session_01DyBpaMnsmVF2jBsWZxWCjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyBpaMnsmVF2jBsWZxWCjU)_