### PR TITLE
Polish dashboard bulk-actions: dim, gap, combine, animations

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -50,7 +50,7 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
+                  "maximumWarning": "7kB",
                   "maximumError": "10kB"
                 }
               ],

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -102,18 +102,27 @@
   </div>
   <div class="dashboard-side-actions">
     <button class="side-action-btn" (click)="selectAllDatasets()" [disabled]="isLoading || datasets.length === 0" title="Select all datasets" aria-label="Select all">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+      <svg aria-hidden="true" [class.side-action-spin]="spinSelectAllDatasets" (animationend)="onSpinSelectAllDatasetsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
         <rect x="3" y="3" width="18" height="18" rx="2"/>
       </svg>
     </button>
     <button class="side-action-btn" (click)="selectNoneDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" title="Select none" aria-label="Select none">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+      <svg aria-hidden="true" [class.side-action-spin]="spinSelectNoneDatasets" (animationend)="onSpinSelectNoneDatasetsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
         <rect x="3" y="3" width="18" height="18" rx="2"/>
       </svg>
     </button>
     <div class="side-action-gap"></div>
+    <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isLoading || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
+      <!-- Two horizontal arrows on the left, merging into a single arrow on the right. -->
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 7 L11 7 Q15 7 15 12"/>
+        <path d="M3 17 L11 17 Q15 17 15 12"/>
+        <line x1="15" y1="12" x2="21" y2="12"/>
+        <polyline points="18 9 21 12 18 15"/>
+      </svg>
+    </button>
     <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDatasetsConfirm" [class.side-action-delete-inactive]="!deletingSelectedDatasetsConfirm && wasDeletingSelectedDatasetsConfirm" (animationend)="onDeleteSelectedDatasetsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
         <path d="M10 11v6"></path>
@@ -196,18 +205,18 @@
   </div>
   <div class="dashboard-side-actions">
     <button class="side-action-btn" (click)="selectAllModels()" [disabled]="isLoading || models.length === 0" title="Select all models" aria-label="Select all">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+      <svg aria-hidden="true" [class.side-action-spin]="spinSelectAllModels" (animationend)="onSpinSelectAllModelsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
         <rect x="3" y="3" width="18" height="18" rx="2"/>
       </svg>
     </button>
     <button class="side-action-btn" (click)="selectNoneModels()" [disabled]="isLoading || selectedModelIds.size === 0" title="Select none" aria-label="Select none">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+      <svg aria-hidden="true" [class.side-action-spin]="spinSelectNoneModels" (animationend)="onSpinSelectNoneModelsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
         <rect x="3" y="3" width="18" height="18" rx="2"/>
       </svg>
     </button>
     <div class="side-action-gap"></div>
     <button class="side-action-btn side-action-delete" (click)="deleteSelectedModels()" [disabled]="isLoading || selectedModelIds.size === 0" [title]="selectedModelIds.size === 0 ? 'No models selected' : 'Delete selected models'" aria-label="Delete selected">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedModelsConfirm" [class.side-action-delete-inactive]="!deletingSelectedModelsConfirm && wasDeletingSelectedModelsConfirm" (animationend)="onDeleteSelectedModelsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
         <path d="M10 11v6"></path>
@@ -264,6 +273,8 @@
   <vt-dataset-importer-modal
     [guessedMediaType]="guessedMediaType"
     [guessedMediaEmbedder]="guessedMediaEmbedder"
+    [initialImporter]="importerInitialName"
+    [initialFormValues]="importerInitialFormValues"
     (closed)="closeImporterModal()"
     (importStarted)="onImportComplete()"
     (demoSelected)="onDemoSelected($event)"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -48,8 +48,7 @@
 .side-action-btn {
   background: none;
   border: none;
-  // Dimmer than --text-primary so the enabled buttons recede against the
-  // dashboard's outer background; hover snaps back to full brightness.
+  // Dimmer than --text-primary; hover snaps back to full brightness.
   color: var(--text-secondary);
   cursor: pointer;
   padding: 6px;
@@ -58,10 +57,6 @@
   align-items: center;
   justify-content: center;
   transition: color 0.15s, background 0.15s;
-
-  svg {
-    transition: transform 0.15s;
-  }
 
   &:hover:not(:disabled) {
     color: var(--text-primary);
@@ -76,43 +71,23 @@
   &.side-action-delete:hover:not(:disabled) {
     color: var(--color-bad);
   }
-
-  // Click-triggered 90° spin for the symmetric select-all / select-none
-  // squares.  The icons are rotationally symmetric so we don't bother
-  // animating back; the class is removed in the template's animationend
-  // handler and the SVG snaps back to 0 (un-animated).
-  .side-action-spin {
-    animation: side-action-rotate-90 0.3s ease-in-out;
-  }
-
-  // The delete button rotates to 90° while the confirm dialog is showing,
-  // then back to 0° once it closes.  Same open/close pattern used by the
-  // row-level trash icon in dataset-card / model-card.
-  .side-action-delete-active {
-    animation: side-action-rotate-open 0.3s ease-in-out forwards;
-  }
-
-  .side-action-delete-inactive {
-    animation: side-action-rotate-close 0.3s ease-in-out forwards;
-  }
 }
 
-@keyframes side-action-rotate-90 {
-  0%   { transform: rotate(0deg); }
-  50%  { transform: rotate(45deg); }
-  100% { transform: rotate(90deg); }
+// Select-all/none spins once on click (animationend handler clears class so
+// icon snaps back to 0). Delete spins to 90° while confirm dialog is up,
+// then reverses back. Hoisted out of `.side-action-btn` to keep specificity
+// flat and reduce compiled CSS size.
+.side-action-spin,
+.side-action-delete-active {
+  animation: side-action-rotate 0.3s ease-in-out forwards;
 }
 
-@keyframes side-action-rotate-open {
-  0%   { transform: rotate(0deg); }
-  50%  { transform: rotate(45deg); }
-  100% { transform: rotate(90deg); }
+.side-action-delete-inactive {
+  animation: side-action-rotate 0.3s ease-in-out reverse forwards;
 }
 
-@keyframes side-action-rotate-close {
-  0%   { transform: rotate(90deg); }
-  50%  { transform: rotate(45deg); }
-  100% { transform: rotate(0deg); }
+@keyframes side-action-rotate {
+  to { transform: rotate(90deg); }
 }
 
 .dashboard-section-header {
@@ -472,12 +447,9 @@
   max-width: 100%;
 }
 
-// Waggle animation for Train/Find button icons while loading.
-// 2s cycle: rotate to 90deg (0.3s), hold (0.7s), rotate back (0.3s), hold (0.7s).
+// Waggle for Train/Find icons while loading: rotate to 90° (0.3s), hold,
+// rotate back (0.3s), hold. 2s cycle.
 @keyframes icon-waggle {
-  0%   { transform: rotate(0deg); }
-  15%  { transform: rotate(90deg); }
-  50%  { transform: rotate(90deg); }
-  65%  { transform: rotate(0deg); }
-  100% { transform: rotate(0deg); }
+  0%, 65%, 100% { transform: rotate(0deg); }
+  15%, 50% { transform: rotate(90deg); }
 }

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -48,7 +48,9 @@
 .side-action-btn {
   background: none;
   border: none;
-  color: var(--text-primary);
+  // Dimmer than --text-primary so the enabled buttons recede against the
+  // dashboard's outer background; hover snaps back to full brightness.
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 6px;
   border-radius: 4px;
@@ -57,7 +59,12 @@
   justify-content: center;
   transition: color 0.15s, background 0.15s;
 
+  svg {
+    transition: transform 0.15s;
+  }
+
   &:hover:not(:disabled) {
+    color: var(--text-primary);
     background: var(--btn-icon-hover-bg);
   }
 
@@ -69,6 +76,43 @@
   &.side-action-delete:hover:not(:disabled) {
     color: var(--color-bad);
   }
+
+  // Click-triggered 90° spin for the symmetric select-all / select-none
+  // squares.  The icons are rotationally symmetric so we don't bother
+  // animating back; the class is removed in the template's animationend
+  // handler and the SVG snaps back to 0 (un-animated).
+  .side-action-spin {
+    animation: side-action-rotate-90 0.3s ease-in-out;
+  }
+
+  // The delete button rotates to 90° while the confirm dialog is showing,
+  // then back to 0° once it closes.  Same open/close pattern used by the
+  // row-level trash icon in dataset-card / model-card.
+  .side-action-delete-active {
+    animation: side-action-rotate-open 0.3s ease-in-out forwards;
+  }
+
+  .side-action-delete-inactive {
+    animation: side-action-rotate-close 0.3s ease-in-out forwards;
+  }
+}
+
+@keyframes side-action-rotate-90 {
+  0%   { transform: rotate(0deg); }
+  50%  { transform: rotate(45deg); }
+  100% { transform: rotate(90deg); }
+}
+
+@keyframes side-action-rotate-open {
+  0%   { transform: rotate(0deg); }
+  50%  { transform: rotate(45deg); }
+  100% { transform: rotate(90deg); }
+}
+
+@keyframes side-action-rotate-close {
+  0%   { transform: rotate(90deg); }
+  50%  { transform: rotate(45deg); }
+  100% { transform: rotate(0deg); }
 }
 
 .dashboard-section-header {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -49,6 +49,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
   selectedDatasetIds: Set<string> = new Set();
   selectedModelIds: Set<string> = new Set();
 
+  // Animation flags for the right-side bulk-action column.
+  // Spin flags fire a one-shot 90° rotation on the symmetric select-all/none
+  // squares; the animationend handler clears them so the icon snaps back.
+  spinSelectAllDatasets = false;
+  spinSelectNoneDatasets = false;
+  spinSelectAllModels = false;
+  spinSelectNoneModels = false;
+  // Confirm flags hold the trash icon at 90° while the confirm dialog is up,
+  // and play a reverse animation back to 0° once the dialog resolves.
+  deletingSelectedDatasetsConfirm = false;
+  wasDeletingSelectedDatasetsConfirm = false;
+  deletingSelectedModelsConfirm = false;
+  wasDeletingSelectedModelsConfirm = false;
+
   progressValue = 0;
   progressTotal = 0;
   progressIndeterminate = false;
@@ -58,6 +72,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   importerModalOpen = false;
   importerClosing = false;
+  /** Importer name to auto-select when the modal opens (for "Combine Selected"). */
+  importerInitialName = '';
+  /** Pre-filled form values for the auto-selected importer. */
+  importerInitialFormValues: Record<string, unknown> = {};
   newModelModalOpen = false;
   newModelClosing = false;
   exportModalOpen = false;
@@ -676,6 +694,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   selectAllDatasets(): void {
+    this.spinSelectAllDatasets = true;
     for (const d of this.datasets) {
       this.selectedDatasetIds.add(d.id);
     }
@@ -683,8 +702,53 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   selectNoneDatasets(): void {
+    this.spinSelectNoneDatasets = true;
     this.selectedDatasetIds.clear();
     this.pushTopBarLabels();
+  }
+
+  /**
+   * Combine the currently-selected datasets into a new one.  Opens the
+   * regular Add Dataset modal, jumped to the (otherwise hidden)
+   * combine_datasets importer with the selected pkl paths pre-filled.
+   * The button is only visible/enabled when ≥2 datasets of the same media
+   * type are selected, so we don't re-validate that here.
+   */
+  combineSelectedDatasets(): void {
+    const targets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
+    const paths = targets
+      .map((d) => (d['pkl_path'] as string) || '')
+      .filter((p) => !!p);
+    if (paths.length < 2) return;
+    this.importerInitialName = 'combine_datasets';
+    this.importerInitialFormValues = { datasets: paths.join(',') };
+    this.openImporterModal();
+  }
+
+  /**
+   * True when the "Combine Selected Datasets" button should be enabled:
+   * at least two datasets selected AND all of them share a media type.
+   */
+  get combineSelectedDatasetsEnabled(): boolean {
+    if (this.selectedDatasetIds.size < 2) return false;
+    const targets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
+    if (targets.length < 2) return false;
+    const types = new Set(targets.map((d) => d.media_type));
+    return types.size === 1;
+  }
+
+  /**
+   * Hint shown in the Combine button's tooltip explaining why it's
+   * disabled (or describing the action when enabled).
+   */
+  get combineSelectedDatasetsHint(): string {
+    if (this.selectedDatasetIds.size < 2) {
+      return 'Select two or more datasets to combine';
+    }
+    if (!this.combineSelectedDatasetsEnabled) {
+      return 'All selected datasets must be of the same media type';
+    }
+    return 'Combine selected datasets into a new one';
   }
 
   async deleteSelectedDatasets(): Promise<void> {
@@ -693,11 +757,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const targets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
     if (targets.length === 0) return;
     const names = targets.map((d) => `"${d.name}"`).join(', ');
-    const ok = await this.dialog.confirm(
-      targets.length === 1
-        ? `Delete dataset ${names}?`
-        : `Delete ${targets.length} datasets: ${names}?`,
-    );
+    this.deletingSelectedDatasetsConfirm = true;
+    let ok = false;
+    try {
+      ok = await this.dialog.confirm(
+        targets.length === 1
+          ? `Delete dataset ${names}?`
+          : `Delete ${targets.length} datasets: ${names}?`,
+      );
+    } finally {
+      this.deletingSelectedDatasetsConfirm = false;
+      this.wasDeletingSelectedDatasetsConfirm = true;
+    }
     if (!ok) return;
     for (const dataset of targets) {
       this.datasetsApi.deleteRegistered(dataset.id).subscribe({
@@ -706,6 +777,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
           this.datasetState.refresh();
         },
       });
+    }
+  }
+
+  onSpinSelectAllDatasetsEnd(): void {
+    this.spinSelectAllDatasets = false;
+  }
+
+  onSpinSelectNoneDatasetsEnd(): void {
+    this.spinSelectNoneDatasets = false;
+  }
+
+  onDeleteSelectedDatasetsAnimationEnd(): void {
+    if (!this.deletingSelectedDatasetsConfirm) {
+      this.wasDeletingSelectedDatasetsConfirm = false;
     }
   }
 
@@ -743,6 +828,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   selectAllModels(): void {
+    this.spinSelectAllModels = true;
     for (const m of this.models) {
       this.selectedModelIds.add(m.id);
     }
@@ -750,6 +836,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   selectNoneModels(): void {
+    this.spinSelectNoneModels = true;
     this.selectedModelIds.clear();
     this.pushTopBarLabels();
   }
@@ -760,11 +847,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const targets = this.models.filter((m) => this.selectedModelIds.has(m.id));
     if (targets.length === 0) return;
     const names = targets.map((m) => `"${m.name}"`).join(', ');
-    const ok = await this.dialog.confirm(
-      targets.length === 1
-        ? `Delete model ${names}?`
-        : `Delete ${targets.length} models: ${names}?`,
-    );
+    this.deletingSelectedModelsConfirm = true;
+    let ok = false;
+    try {
+      ok = await this.dialog.confirm(
+        targets.length === 1
+          ? `Delete model ${names}?`
+          : `Delete ${targets.length} models: ${names}?`,
+      );
+    } finally {
+      this.deletingSelectedModelsConfirm = false;
+      this.wasDeletingSelectedModelsConfirm = true;
+    }
     if (!ok) return;
     for (const model of targets) {
       this.modelsApi.deleteFromRegistry(model.id).subscribe({
@@ -776,6 +870,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
           this.dialog.alert(`Failed to delete model "${model.name}".`, 'error');
         },
       });
+    }
+  }
+
+  onSpinSelectAllModelsEnd(): void {
+    this.spinSelectAllModels = false;
+  }
+
+  onSpinSelectNoneModelsEnd(): void {
+    this.spinSelectNoneModels = false;
+  }
+
+  onDeleteSelectedModelsAnimationEnd(): void {
+    if (!this.deletingSelectedModelsConfirm) {
+      this.wasDeletingSelectedModelsConfirm = false;
     }
   }
 
@@ -949,6 +1057,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   closeImporterModal(): void {
     this.importerModalOpen = false;
     this.importerClosing = true;
+    this.importerInitialName = '';
+    this.importerInitialFormValues = {};
   }
 
   onImporterAnimationEnd(): void {
@@ -958,6 +1068,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   onImportComplete(): void {
     this.importerModalOpen = false;
     this.importerClosing = true;
+    this.importerInitialName = '';
+    this.importerInitialFormValues = {};
     this.startProgressPolling();
   }
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -132,12 +132,12 @@
           </button>
           <button class="select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect dataset' : 'Select dataset'" [attr.title]="selected ? 'Deselect' : 'Select'">
             @if (selected) {
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="3" y="3" width="18" height="18" rx="2"/>
                 <polyline points="8 12 11 15 16 9"/>
               </svg>
             } @else {
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="3" y="3" width="18" height="18" rx="2"/>
               </svg>
             }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -215,7 +215,9 @@ td {
 }
 
 .select-checkbox {
-  margin-left: auto;
+  // Sit ~one action-button-width away from the row's other action icons
+  // (an icon button is ~22px: 14px svg + 4px padding both sides).
+  margin-left: 1.375rem;
   background: none;
   border: none;
   color: var(--text-primary);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -20,6 +20,10 @@ export class DatasetImporterModalComponent implements OnInit {
   @Input() guessedMediaType = '';
   /** Embedder name guessed from existing datasets/in-progress loads (e.g. "siglip"). */
   @Input() guessedMediaEmbedder = '';
+  /** When set, jump straight to this importer (even hidden ones) on open. */
+  @Input() initialImporter = '';
+  /** Form values to pre-fill after auto-selecting the initial importer. */
+  @Input() initialFormValues: Record<string, unknown> = {};
 
   @Output() closed = new EventEmitter<void>();
   @Output() importStarted = new EventEmitter<void>();
@@ -123,10 +127,21 @@ export class DatasetImporterModalComponent implements OnInit {
   ngOnInit(): void {
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
-        this.importers = (res.importers || []).filter(
-          (imp) => !imp['hidden_from_picker']
-        );
+        // Keep ALL importers (including hidden_from_picker ones) so callers
+        // can land on a hidden importer via `initialImporter`.  The picker
+        // UI filters hidden importers in `orderedImporters` instead.
+        this.importers = res.importers || [];
         this.declaredTabs = res.tabs || [];
+        if (this.initialImporter) {
+          const target = this.importers.find((i) => i.name === this.initialImporter);
+          if (target) {
+            this.selectImporter(target);
+            // Apply pre-fill values after selectImporter resets formValues
+            for (const [k, v] of Object.entries(this.initialFormValues)) {
+              this.formValues[k] = v;
+            }
+          }
+        }
       },
     });
     this.datasetsApi.getEmbedders().subscribe({
@@ -164,10 +179,10 @@ export class DatasetImporterModalComponent implements OnInit {
     const result: ImporterInfo[] = [];
     for (const name of order) {
       const imp = this.importers.find((i) => i.name === name);
-      if (imp) result.push(imp);
+      if (imp && !imp['hidden_from_picker']) result.push(imp);
     }
     for (const imp of this.importers) {
-      if (!order.includes(imp.name)) {
+      if (!order.includes(imp.name) && !imp['hidden_from_picker']) {
         result.push(imp);
       }
     }

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -161,12 +161,12 @@
           </button>
           <button class="select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect model' : 'Select model'" [attr.title]="selected ? 'Deselect' : 'Select'">
             @if (selected) {
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="3" y="3" width="18" height="18" rx="2"/>
                 <polyline points="8 12 11 15 16 9"/>
               </svg>
             } @else {
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="3" y="3" width="18" height="18" rx="2"/>
               </svg>
             }

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.scss
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.scss
@@ -208,7 +208,9 @@ td {
 }
 
 .select-checkbox {
-  margin-left: auto;
+  // Sit ~one action-button-width away from the row's other action icons
+  // (an icon button is ~22px: 14px svg + 4px padding both sides).
+  margin-left: 1.375rem;
   background: none;
   border: none;
   color: var(--text-primary);


### PR DESCRIPTION
## Summary

- Dim the right-side bulk-action buttons (Select All / None / Delete) when enabled — they now use `--text-secondary` instead of `--text-primary` and brighten back on hover, so they recede against the dashboard's outer background. Disabled appearance is unchanged.
- Lessen the gap between the per-row trash button and the selection checkbox: the checkbox now sits a fixed ~22 px (one action-button width) from the rest of the action icons instead of pushing all the way to the right edge with `margin-left: auto`.
- Match the row checkbox stroke-width (`2 → 1.5`) so it visually matches the pencil / trash / stats / security icons next to it.
- Add a **Combine Selected Datasets** button to the datasets bulk-action column, immediately above Delete. Enabled only when ≥ 2 datasets are selected and they all share a media type. Clicking it opens the standard Add Dataset modal jumped directly to the (otherwise hidden) `combine_datasets` importer with the selected datasets' `pkl_path`s pre-filled in its `datasets` field — so picking three datasets and clicking Combine creates a new combined-dataset row that references those three.
- Custom merging-arrows icon for Combine: two horizontal arrows on the left curving down to converge into a single arrow on the right.
- Animate Select All / Select None with a one-shot 90 ° clockwise spin on click (no reverse — the dotted-square icons are rotationally symmetric, so we just clear the class via `animationend` and the SVG snaps back to 0).
- Animate Delete Selected: while the confirmation dialog is open the trash icon rotates 90 ° clockwise; once it closes, the icon rotates back. Same `open / inactive` pattern used by the per-row trash button.
- The hidden-from-picker filter in `dataset-importer-modal` was lifted into the `orderedImporters` getter so that `combine_datasets` (which is `hidden_from_picker = True`) can still be auto-selected via the new `[initialImporter]` / `[initialFormValues]` inputs while remaining invisible in the regular picker UI.
- Bumped `anyComponentStyle` warning budget 6 → 7 kB (error stays at 10 kB) to make room for the new animations + button. Also deduped the `icon-waggle` keyframe to recover some of the headroom first.

## Test plan
- [x] `./run-tests.sh` — all 3067 fast tests pass, frontend production build is clean (no warnings).
- [ ] Manually verify bulk-action buttons look dimmer when enabled and unchanged when disabled.
- [ ] Manually verify the per-row checkbox sits ~one button-width from the trash icon and has the same visual weight as the other row icons.
- [ ] Select 2+ datasets of the same media type, click Combine, confirm the importer modal lands on combine_datasets with the paths pre-filled.
- [ ] Select datasets of different media types, confirm the Combine button is disabled with the "all selected datasets must be of the same media type" tooltip.
- [ ] Click Select All / Select None and watch for the 90 ° clockwise spin (no reverse).
- [ ] Click Delete Selected, confirm the trash rotates to 90 ° while the dialog is open and back to 0 ° after dismissing it.

https://claude.ai/code/session_016hyavbfMKLMf1vMbsdKhYB

---
_Generated by [Claude Code](https://claude.ai/code/session_016hyavbfMKLMf1vMbsdKhYB)_