### PR TITLE
Default custom DatasetImporter category to "services"

### DIFF
--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -135,10 +135,12 @@ class DatasetImporter(PluginBase):
     picker_view: str = "form"
 
     #: Picker tab this importer belongs to.  One of ``"services"``,
-    #: ``"server"``, ``"local"``, ``"demo"``, or ``""`` (uncategorised).
-    #: Database/API-style importers (extensions that fetch from a remote
-    #: service) should use ``"services"``.
-    category: str = ""
+    #: ``"server"``, ``"local"``, ``"demo"``, or ``""`` (uncategorised —
+    #: hidden from the tabbed picker entirely).  Database/API-style
+    #: importers (extensions that fetch from a remote service) belong on
+    #: the ``"services"`` tab, which is the default for any custom importer
+    #: that doesn't override this attribute.
+    category: str = "services"
 
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()


### PR DESCRIPTION
## Summary
- Change `DatasetImporter.category` default from `""` to `"services"` so custom/extension importers show up under the Services tab in the Add Dataset modal instead of being hidden entirely.
- Built-in importers without an explicit category are all `hidden_from_picker=True`, so this only affects third-party/extension importers.

## Test plan
- [x] `./run-tests.sh datasets io` (1017 passed)
- [ ] Manually verify a custom importer with no `category` declaration appears under the Services tab.

https://claude.ai/code/session_01C3qXd7N91U6Nz5KCto4DyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3qXd7N91U6Nz5KCto4DyH)_