### PR TITLE
Move Add Dataset hints under tabs and unify demo grid with dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -24,28 +24,28 @@
       <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
-        <table class="dash-table" [class.table-fixed]="datasetsTableFixed">
+        <table class="dash-table" [class.table-fixed]="datasetCols.tableFixed">
           <thead>
             <tr>
-              <th (click)="sortDatasets('name')" class="sortable name-col" title="Dataset display name (click to sort)" data-col="name" [style.width.%]="datasetsTableFixed ? datasetColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isDatasetSortActive('name')">{{ datasetSortIndicator('name') }}</span></th>
+              <th (click)="datasetCols.sortBy('name')" class="sortable name-col" title="Dataset display name (click to sort)" data-col="name" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['name'] : null">Name<span class="sort-indicator" [class.active]="datasetCols.isSortActive('name')">{{ datasetCols.sortIndicator('name') }}</span></th>
               @for (col of visibleDatasetColumns; track col) {
                 <th
-                  [class.sortable]="datasetColMeta(col).sortable"
-                  [class.col-drop-target]="isDropTarget('datasets', col)"
-                  [class.col-dragging]="isDragging('datasets', col)"
+                  [class.sortable]="datasetCols.meta(col).sortable"
+                  [class.col-drop-target]="datasetCols.isDropTarget(col)"
+                  [class.col-dragging]="datasetCols.isDragging(col)"
                   [attr.data-col]="col"
-                  [title]="datasetColMeta(col).title"
-                  [style.width.%]="datasetsTableFixed ? datasetColWidths[col] : null"
+                  [title]="datasetCols.meta(col).title"
+                  [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths[col] : null"
                   draggable="true"
                   (click)="onDatasetHeaderClick(col)"
-                  (dragstart)="onColDragStart($event, 'datasets', col)"
-                  (dragover)="onColDragOver($event, 'datasets', col)"
-                  (dragleave)="onColDragLeave($event, 'datasets', col)"
-                  (drop)="onColDrop($event, 'datasets', col)"
-                  (dragend)="onColDragEnd($event)"
-                ><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetColMeta(col).label }}@if (datasetColMeta(col).sortable) {<span class="sort-indicator" [class.active]="isDatasetSortActive(col)">{{ datasetSortIndicator(col) }}</span>}</th>
+                  (dragstart)="datasetCols.onColDragStart($event, col)"
+                  (dragover)="datasetCols.onColDragOver($event, col)"
+                  (dragleave)="datasetCols.onColDragLeave($event, col)"
+                  (drop)="datasetCols.onColDrop($event, col)"
+                  (dragend)="datasetCols.onColDragEnd($event)"
+                ><div class="col-resize-handle" (mousedown)="datasetCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetCols.meta(col).label }}@if (datasetCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="datasetCols.isSortActive(col)">{{ datasetCols.sortIndicator(col) }}</span>}</th>
               }
-              <th class="actions-col" data-col="actions" [title]="datasetColMeta('actions').title" [style.width.%]="datasetsTableFixed ? datasetColWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'datasets')" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetColMeta('actions').label }}</th>
+              <th class="actions-col" data-col="actions" [title]="datasetCols.meta('actions').title" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="datasetCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>{{ datasetCols.meta('actions').label }}</th>
             </tr>
           </thead>
           <tbody>
@@ -152,28 +152,28 @@
       <p class="empty-state">No models yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
-        <table class="dash-table" [class.table-fixed]="modelsTableFixed">
+        <table class="dash-table" [class.table-fixed]="modelCols.tableFixed">
           <thead>
             <tr>
-              <th (click)="sortModels('name')" class="sortable name-col" title="Model display name (click to sort)" data-col="name" [style.width.%]="modelsTableFixed ? modelColWidths['name'] : null">Name<span class="sort-indicator" [class.active]="isModelSortActive('name')">{{ modelSortIndicator('name') }}</span></th>
+              <th (click)="modelCols.sortBy('name')" class="sortable name-col" title="Model display name (click to sort)" data-col="name" [style.width.%]="modelCols.tableFixed ? modelCols.colWidths['name'] : null">Name<span class="sort-indicator" [class.active]="modelCols.isSortActive('name')">{{ modelCols.sortIndicator('name') }}</span></th>
               @for (col of visibleModelColumns; track col) {
                 <th
-                  [class.sortable]="modelColMeta(col).sortable"
-                  [class.col-drop-target]="isDropTarget('models', col)"
-                  [class.col-dragging]="isDragging('models', col)"
+                  [class.sortable]="modelCols.meta(col).sortable"
+                  [class.col-drop-target]="modelCols.isDropTarget(col)"
+                  [class.col-dragging]="modelCols.isDragging(col)"
                   [attr.data-col]="col"
-                  [title]="modelColMeta(col).title"
-                  [style.width.%]="modelsTableFixed ? modelColWidths[col] : null"
+                  [title]="modelCols.meta(col).title"
+                  [style.width.%]="modelCols.tableFixed ? modelCols.colWidths[col] : null"
                   draggable="true"
                   (click)="onModelHeaderClick(col)"
-                  (dragstart)="onColDragStart($event, 'models', col)"
-                  (dragover)="onColDragOver($event, 'models', col)"
-                  (dragleave)="onColDragLeave($event, 'models', col)"
-                  (drop)="onColDrop($event, 'models', col)"
-                  (dragend)="onColDragEnd($event)"
-                ><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelColMeta(col).label }}@if (modelColMeta(col).sortable) {<span class="sort-indicator" [class.active]="isModelSortActive(col)">{{ modelSortIndicator(col) }}</span>}</th>
+                  (dragstart)="modelCols.onColDragStart($event, col)"
+                  (dragover)="modelCols.onColDragOver($event, col)"
+                  (dragleave)="modelCols.onColDragLeave($event, col)"
+                  (drop)="modelCols.onColDrop($event, col)"
+                  (dragend)="modelCols.onColDragEnd($event)"
+                ><div class="col-resize-handle" (mousedown)="modelCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelCols.meta(col).label }}@if (modelCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="modelCols.isSortActive(col)">{{ modelCols.sortIndicator(col) }}</span>}</th>
               }
-              <th class="actions-col" data-col="actions" [title]="modelColMeta('actions').title" [style.width.%]="modelsTableFixed ? modelColWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="startResize($event, 'models')" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelColMeta('actions').label }}</th>
+              <th class="actions-col" data-col="actions" [title]="modelCols.meta('actions').title" [style.width.%]="modelCols.tableFixed ? modelCols.colWidths['actions'] : null"><div class="col-resize-handle" (mousedown)="modelCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>{{ modelCols.meta('actions').label }}</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -139,10 +139,10 @@ describe('DashboardComponent', () => {
     ];
     flushInitialRequests(datasets);
 
-    component.sortDatasets('name');
+    component.datasetCols.sortBy('name');
     expect(component.sortedDatasets[0].name).toBe('Alpha');
 
-    component.sortDatasets('name');
+    component.datasetCols.sortBy('name');
     expect(component.sortedDatasets[0].name).toBe('Bravo');
   });
 
@@ -153,18 +153,18 @@ describe('DashboardComponent', () => {
     ];
     flushInitialRequests([], models);
 
-    component.sortModels('name');
+    component.modelCols.sortBy('name');
     expect(component.sortedModels[0].name).toBe('Alpha');
   });
 
   it('should show sort indicators', () => {
     flushInitialRequests();
-    component.sortDatasets('name');
-    expect(component.datasetSortIndicator('name')).toContain('\u25B2');
-    expect(component.isDatasetSortActive('name')).toBeTrue();
-    component.sortDatasets('name');
-    expect(component.datasetSortIndicator('name')).toContain('\u25BC');
-    expect(component.isDatasetSortActive('other')).toBeFalse();
+    component.datasetCols.sortBy('name');
+    expect(component.datasetCols.sortIndicator('name')).toContain('\u25B2');
+    expect(component.datasetCols.isSortActive('name')).toBeTrue();
+    component.datasetCols.sortBy('name');
+    expect(component.datasetCols.sortIndicator('name')).toContain('\u25BC');
+    expect(component.datasetCols.isSortActive('other')).toBeFalse();
   });
 
   describe('button state', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -15,6 +15,7 @@ import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
 import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, LoadingTasksResponse, ModelRegistryEntry } from '../../models/api.models';
 import { formatProgressFraction } from '../../utils/format-progress';
+import { ColMeta, ManagedColumns } from '../../utils/managed-columns';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
@@ -94,33 +95,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   findLoading = false;
   trainAfterModelCreation = false;
 
-  datasetSortColumn = 'name';
-  datasetSortAsc = true;
-  modelSortColumn = 'name';
-  modelSortAsc = true;
-
-  // Column resize state. Widths are stored as percentages summing to ~100;
-  // the table is always 100% wide so columns fit the container without
-  // horizontal scrolling. Resizing one column shifts width to/from its
-  // right-hand neighbour (the cell that hosts the resize handle).
-  datasetColWidths: Record<string, number> = {};
-  modelColWidths: Record<string, number> = {};
-  datasetsTableFixed = false;
-  modelsTableFixed = false;
-  private datasetsResizeInit = false;
-  private modelsResizeInit = false;
-  private resizeState: {
-    startX: number;
-    startGrowPct: number;
-    startShrinkPct: number;
-    growCol: string;
-    shrinkCol: string;
-    table: 'datasets' | 'models';
-    dragged: boolean;
-    tableEl: HTMLTableElement;
-  } | null = null;
-  private static readonly MIN_COL_PCT = 3;
-
   // Column order. "name" is pinned at position 0 and "actions" is pinned at
   // the far right; these arrays hold only the user-reorderable middle columns.
   static readonly DATASET_COLUMNS_DEFAULT = [
@@ -132,16 +106,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ];
   private static readonly DATASET_COL_ORDER_KEY = 'vtsearch.dashboard.datasetColumnOrder';
   private static readonly MODEL_COL_ORDER_KEY = 'vtsearch.dashboard.modelColumnOrder';
-  datasetColumnOrder: string[] = [...DashboardComponent.DATASET_COLUMNS_DEFAULT];
-  modelColumnOrder: string[] = [...DashboardComponent.MODEL_COLUMNS_DEFAULT];
-
-  // Drag-reorder state
-  dragCol: { table: 'datasets' | 'models'; col: string } | null = null;
-  dropTargetCol: { table: 'datasets' | 'models'; col: string } | null = null;
 
   // Per-column display metadata. Keyed by `data-col` value; used both by the
   // header template and by card components when rendering body cells in order.
-  static readonly DATASET_COL_META: Record<string, { label: string; title: string; sortable: boolean }> = {
+  static readonly DATASET_COL_META: Record<string, ColMeta> = {
     name: { label: 'Name', title: 'Dataset display name (click to sort)', sortable: true },
     media_type: { label: 'Type', title: 'Media type: audio, image, text, video, or document (click to sort)', sortable: true },
     num_items: { label: '# Items', title: 'Number of media items in the dataset (click to sort)', sortable: true },
@@ -151,7 +119,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     loaded: { label: 'Loaded?', title: 'Whether the dataset is currently loaded in memory', sortable: false },
     actions: { label: 'Actions', title: 'Available operations for this dataset', sortable: false },
   };
-  static readonly MODEL_COL_META: Record<string, { label: string; title: string; sortable: boolean }> = {
+  static readonly MODEL_COL_META: Record<string, ColMeta> = {
     name: { label: 'Name', title: 'Model display name (click to sort)', sortable: true },
     media_type: { label: 'Type', title: 'Media type this model operates on (click to sort)', sortable: true },
     num_training: { label: '# Training', title: 'Number of labeled training examples (click to sort)', sortable: true },
@@ -163,31 +131,34 @@ export class DashboardComponent implements OnInit, OnDestroy {
     actions: { label: 'Actions', title: 'Available operations for this model', sortable: false },
   };
 
+  datasetCols = new ManagedColumns(
+    DashboardComponent.DATASET_COLUMNS_DEFAULT,
+    DashboardComponent.DATASET_COL_META,
+    { initialSort: 'name', storageKey: DashboardComponent.DATASET_COL_ORDER_KEY },
+  );
+  modelCols = new ManagedColumns(
+    DashboardComponent.MODEL_COLUMNS_DEFAULT,
+    DashboardComponent.MODEL_COL_META,
+    { initialSort: 'name', storageKey: DashboardComponent.MODEL_COL_ORDER_KEY },
+  );
+
   get visibleDatasetColumns(): string[] {
     if (this.isDefaultLogin) {
-      return this.datasetColumnOrder.filter((c) => c !== 'created_by' && c !== 'readers');
+      return this.datasetCols.columnOrder.filter((c) => c !== 'created_by' && c !== 'readers');
     }
-    return this.datasetColumnOrder;
+    return this.datasetCols.columnOrder;
   }
 
   get visibleModelColumns(): string[] {
-    return this.modelColumnOrder;
-  }
-
-  datasetColMeta(col: string): { label: string; title: string; sortable: boolean } {
-    return DashboardComponent.DATASET_COL_META[col] ?? { label: col, title: '', sortable: false };
-  }
-
-  modelColMeta(col: string): { label: string; title: string; sortable: boolean } {
-    return DashboardComponent.MODEL_COL_META[col] ?? { label: col, title: '', sortable: false };
+    return this.modelCols.columnOrder;
   }
 
   onDatasetHeaderClick(col: string): void {
-    if (this.datasetColMeta(col).sortable) this.sortDatasets(col);
+    if (this.datasetCols.meta(col).sortable) this.datasetCols.sortBy(col);
   }
 
   onModelHeaderClick(col: string): void {
-    if (this.modelColMeta(col).sortable) this.sortModels(col);
+    if (this.modelCols.meta(col).sortable) this.modelCols.sortBy(col);
   }
 
   private destroy$ = new Subject<void>();
@@ -270,7 +241,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.knownModelIds = currentIds;
         this.pushTopBarLabels();
       });
-    this.loadColumnOrders();
     this.refresh();
     this.resumeActivePolling();
   }
@@ -289,290 +259,23 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  // --- Column resize ---
+  // --- Column resize / drag-reorder ---
   //
-  // The handle sits on the LEFT edge of its host <th> and represents the
-  // boundary between the previous column ("grow" target) and the host column
-  // ("shrink" target). Dragging the handle right grows the previous column
-  // and shrinks the host by the same amount, keeping the table at 100%.
-
-  private captureColumnPercentages(tableEl: HTMLTableElement, colWidths: Record<string, number>): void {
-    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
-    const tableWidth = tableEl.offsetWidth || 1;
-    ths.forEach((t) => {
-      const colKey = t.getAttribute('data-col');
-      if (colKey) colWidths[colKey] = (t.offsetWidth / tableWidth) * 100;
-    });
-  }
-
-  startResize(event: MouseEvent, table: 'datasets' | 'models'): void {
-    event.stopPropagation();
-    event.preventDefault();
-
-    const th = (event.target as HTMLElement).closest('th') as HTMLElement;
-    const prevTh = th.previousElementSibling as HTMLElement | null;
-    const growCol = prevTh?.getAttribute('data-col');
-    const shrinkCol = th.getAttribute('data-col');
-    if (!growCol || !shrinkCol) return;
-    const tableEl = th.closest('table') as HTMLTableElement;
-    const colWidths = table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
-    const initialized = table === 'datasets' ? this.datasetsResizeInit : this.modelsResizeInit;
-
-    if (!initialized) {
-      this.captureColumnPercentages(tableEl, colWidths);
-      if (table === 'datasets') {
-        this.datasetsResizeInit = true;
-        this.datasetsTableFixed = true;
-      } else {
-        this.modelsResizeInit = true;
-        this.modelsTableFixed = true;
-      }
-    }
-
-    this.resizeState = {
-      startX: event.clientX,
-      startGrowPct: colWidths[growCol] ?? 10,
-      startShrinkPct: colWidths[shrinkCol] ?? 10,
-      growCol,
-      shrinkCol,
-      table,
-      dragged: false,
-      tableEl,
-    };
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  }
+  // The actual logic lives in `ManagedColumns`. We just forward document-level
+  // mouse events to both managers so resize tracking works regardless of which
+  // table the user grabbed. Drag-reorder uses native HTML5 drag events and is
+  // dispatched directly from the template.
 
   @HostListener('document:mousemove', ['$event'])
   onColResizeMove(event: MouseEvent): void {
-    if (!this.resizeState) return;
-    const dx = event.clientX - this.resizeState.startX;
-    if (Math.abs(dx) > 3) this.resizeState.dragged = true;
-    if (!this.resizeState.dragged) return;
-
-    const tableWidth = this.resizeState.tableEl.offsetWidth || 1;
-    const dPct = (dx / tableWidth) * 100;
-    const min = DashboardComponent.MIN_COL_PCT;
-    const sum = this.resizeState.startGrowPct + this.resizeState.startShrinkPct;
-
-    let newGrow = this.resizeState.startGrowPct + dPct;
-    let newShrink = this.resizeState.startShrinkPct - dPct;
-    if (newShrink < min) {
-      newShrink = min;
-      newGrow = sum - min;
-    } else if (newGrow < min) {
-      newGrow = min;
-      newShrink = sum - min;
-    }
-
-    const colWidths = this.resizeState.table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
-    colWidths[this.resizeState.growCol] = newGrow;
-    colWidths[this.resizeState.shrinkCol] = newShrink;
+    this.datasetCols.onResizeMove(event);
+    this.modelCols.onResizeMove(event);
   }
 
   @HostListener('document:mouseup')
   onColResizeEnd(): void {
-    if (!this.resizeState) return;
-    const state = this.resizeState;
-    this.resizeState = null;
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-
-    if (!state.dragged) {
-      this.autoSizeColumn(state.tableEl, state.table, state.growCol, state.shrinkCol);
-    }
-  }
-
-  /** Auto-fit the grow column to its natural content width; take/return the
-   *  delta from the shrink column so total stays at 100%. */
-  private autoSizeColumn(
-    tableEl: HTMLTableElement,
-    table: 'datasets' | 'models',
-    growCol: string,
-    shrinkCol: string,
-  ): void {
-    const colWidths = table === 'datasets' ? this.datasetColWidths : this.modelColWidths;
-
-    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
-    let colIndex = -1;
-    for (let i = 0; i < ths.length; i++) {
-      if (ths[i].getAttribute('data-col') === growCol) {
-        colIndex = i;
-        break;
-      }
-    }
-    if (colIndex < 0) return;
-
-    // Temporarily release fixed layout for this column so we can measure
-    // its natural width from the body cells.
-    const wasFixed = tableEl.classList.contains('table-fixed');
-    const prevColWidth = ths[colIndex].style.width;
-    tableEl.classList.remove('table-fixed');
-    ths[colIndex].style.width = '';
-
-    let maxPx = 0;
-    const rows = tableEl.querySelectorAll('tbody tr');
-    rows.forEach((row) => {
-      const cell = row.children[colIndex] as HTMLElement | undefined;
-      if (!cell || cell.hasAttribute('colspan')) return;
-      maxPx = Math.max(maxPx, cell.scrollWidth);
-    });
-    if (maxPx === 0) maxPx = ths[colIndex].offsetWidth;
-    maxPx = Math.max(30, maxPx + 2);
-
-    if (wasFixed) tableEl.classList.add('table-fixed');
-    ths[colIndex].style.width = prevColWidth;
-
-    const tableWidth = tableEl.offsetWidth || 1;
-    const min = DashboardComponent.MIN_COL_PCT;
-    const sum = (colWidths[growCol] ?? 0) + (colWidths[shrinkCol] ?? 0);
-    let targetGrow = (maxPx / tableWidth) * 100;
-    if (targetGrow > sum - min) targetGrow = sum - min;
-    if (targetGrow < min) targetGrow = min;
-    colWidths[growCol] = targetGrow;
-    colWidths[shrinkCol] = sum - targetGrow;
-
-    if (table === 'datasets') {
-      this.datasetsTableFixed = true;
-      this.datasetsResizeInit = true;
-    } else {
-      this.modelsTableFixed = true;
-      this.modelsResizeInit = true;
-    }
-  }
-
-  // --- Column reorder (drag and drop) ---
-
-  private loadColumnOrders(): void {
-    this.datasetColumnOrder = this.normalizeColumnOrder(
-      DashboardComponent.DATASET_COL_ORDER_KEY,
-      DashboardComponent.DATASET_COLUMNS_DEFAULT,
-    );
-    this.modelColumnOrder = this.normalizeColumnOrder(
-      DashboardComponent.MODEL_COL_ORDER_KEY,
-      DashboardComponent.MODEL_COLUMNS_DEFAULT,
-    );
-  }
-
-  private normalizeColumnOrder(storageKey: string, defaults: readonly string[]): string[] {
-    let stored: unknown = null;
-    try {
-      const raw = localStorage.getItem(storageKey);
-      stored = raw ? JSON.parse(raw) : null;
-    } catch {
-      stored = null;
-    }
-    const known = new Set(defaults);
-    const result: string[] = [];
-    if (Array.isArray(stored)) {
-      for (const c of stored) {
-        if (typeof c === 'string' && known.has(c) && !result.includes(c)) {
-          result.push(c);
-        }
-      }
-    }
-    // Append any defaults missing from the stored order (e.g. new columns
-    // added after the user's order was saved).
-    for (const c of defaults) {
-      if (!result.includes(c)) result.push(c);
-    }
-    return result;
-  }
-
-  private persistColumnOrder(table: 'datasets' | 'models'): void {
-    const key = table === 'datasets'
-      ? DashboardComponent.DATASET_COL_ORDER_KEY
-      : DashboardComponent.MODEL_COL_ORDER_KEY;
-    const order = table === 'datasets' ? this.datasetColumnOrder : this.modelColumnOrder;
-    try {
-      localStorage.setItem(key, JSON.stringify(order));
-    } catch {
-      // Ignore quota / private-mode failures.
-    }
-  }
-
-  onColDragStart(event: DragEvent, table: 'datasets' | 'models', col: string): void {
-    // Don't start a drag if a column resize is in progress.
-    if (this.resizeState) {
-      event.preventDefault();
-      return;
-    }
-    this.dragCol = { table, col };
-    this.dropTargetCol = null;
-    if (event.dataTransfer) {
-      event.dataTransfer.effectAllowed = 'move';
-      // Some browsers refuse to start the drag without setData.
-      event.dataTransfer.setData('text/plain', col);
-    }
-  }
-
-  onColDragOver(event: DragEvent, table: 'datasets' | 'models', col: string): void {
-    if (!this.dragCol || this.dragCol.table !== table || this.dragCol.col === col) return;
-    event.preventDefault();
-    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
-    if (
-      !this.dropTargetCol
-      || this.dropTargetCol.col !== col
-      || this.dropTargetCol.table !== table
-    ) {
-      this.dropTargetCol = { table, col };
-    }
-  }
-
-  onColDragLeave(_event: DragEvent, table: 'datasets' | 'models', col: string): void {
-    if (this.dropTargetCol && this.dropTargetCol.table === table && this.dropTargetCol.col === col) {
-      this.dropTargetCol = null;
-    }
-  }
-
-  onColDrop(event: DragEvent, table: 'datasets' | 'models', targetCol: string): void {
-    if (!this.dragCol || this.dragCol.table !== table) {
-      this.dragCol = null;
-      this.dropTargetCol = null;
-      return;
-    }
-    event.preventDefault();
-    const sourceCol = this.dragCol.col;
-    this.dragCol = null;
-    this.dropTargetCol = null;
-    if (sourceCol === targetCol) return;
-
-    const order = table === 'datasets' ? this.datasetColumnOrder : this.modelColumnOrder;
-    const fromIdx = order.indexOf(sourceCol);
-    const toIdx = order.indexOf(targetCol);
-    if (fromIdx < 0 || toIdx < 0) return;
-
-    // Shift semantics: source lands at target's slot; intermediate columns shift
-    // by one toward source's old slot. Splicing in at the target's *original*
-    // index achieves this for both directions: when fromIdx < toIdx, removing
-    // source first shifts target down by one, so inserting at the original
-    // toIdx places source just past target; when fromIdx > toIdx, target's
-    // index is unchanged, so inserting at toIdx places source just before it.
-    const next = [...order];
-    next.splice(fromIdx, 1);
-    next.splice(toIdx, 0, sourceCol);
-
-    if (table === 'datasets') {
-      this.datasetColumnOrder = next;
-    } else {
-      this.modelColumnOrder = next;
-    }
-    this.persistColumnOrder(table);
-  }
-
-  onColDragEnd(_event: DragEvent): void {
-    this.dragCol = null;
-    this.dropTargetCol = null;
-  }
-
-  isDropTarget(table: 'datasets' | 'models', col: string): boolean {
-    return !!this.dropTargetCol
-      && this.dropTargetCol.table === table
-      && this.dropTargetCol.col === col;
-  }
-
-  isDragging(table: 'datasets' | 'models', col: string): boolean {
-    return !!this.dragCol && this.dragCol.table === table && this.dragCol.col === col;
+    this.datasetCols.onResizeEnd();
+    this.modelCols.onResizeEnd();
   }
 
   ngOnDestroy(): void {
@@ -1278,18 +981,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Sorting ---
 
-  sortDatasets(column: string): void {
-    if (this.datasetSortColumn === column) {
-      this.datasetSortAsc = !this.datasetSortAsc;
-    } else {
-      this.datasetSortColumn = column;
-      this.datasetSortAsc = true;
-    }
-  }
-
   get sortedDatasets(): DatasetRegistryEntry[] {
-    const col = this.datasetSortColumn;
-    const asc = this.datasetSortAsc ? 1 : -1;
+    const col = this.datasetCols.sortColumn;
+    const asc = this.datasetCols.sortAsc ? 1 : -1;
     return [...this.datasets].sort((a, b) => {
       const va = a[col] ?? '';
       const vb = b[col] ?? '';
@@ -1298,42 +992,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  sortModels(column: string): void {
-    if (this.modelSortColumn === column) {
-      this.modelSortAsc = !this.modelSortAsc;
-    } else {
-      this.modelSortColumn = column;
-      this.modelSortAsc = true;
-    }
-  }
-
   get sortedModels(): ModelRegistryEntry[] {
-    const col = this.modelSortColumn;
-    const asc = this.modelSortAsc ? 1 : -1;
+    const col = this.modelCols.sortColumn;
+    const asc = this.modelCols.sortAsc ? 1 : -1;
     return [...this.models].sort((a, b) => {
       const va = a[col] ?? '';
       const vb = b[col] ?? '';
       if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * asc;
       return String(va).localeCompare(String(vb)) * asc;
     });
-  }
-
-  datasetSortIndicator(column: string): string {
-    if (this.datasetSortColumn !== column) return '\u25B2';
-    return this.datasetSortAsc ? '\u25B2' : '\u25BC';
-  }
-
-  isDatasetSortActive(column: string): boolean {
-    return this.datasetSortColumn === column;
-  }
-
-  modelSortIndicator(column: string): string {
-    if (this.modelSortColumn !== column) return '\u25B2';
-    return this.modelSortAsc ? '\u25B2' : '\u25BC';
-  }
-
-  isModelSortActive(column: string): boolean {
-    return this.modelSortColumn === column;
   }
 
   // --- Button state ---

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -9,10 +9,10 @@
           [title]="'Show ' + tab.label + ' dataset importers'"
         >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
       }
-      @if (!activeImporterTab) {
-        <span class="tab-bar-hint">Select what type of dataset to add.</span>
-      }
     </div>
+    @if (!activeImporterTab) {
+      <p class="tab-bar-hint">Select what type of dataset to add.</p>
+    }
 
     @if (activeImporterTab) {
       <div class="importer-subtab-bar">
@@ -29,10 +29,10 @@
             [title]="imp['enabled'] === false ? 'Requires two or more saved datasets of the same media type' : (imp.description || '')"
           >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
         }
-        @if (!selectedImporter && importersForActiveTab.length > 0) {
-          <span class="tab-bar-hint">Select how to add a {{ activeImporterTabLabel }} dataset.</span>
-        }
       </div>
+      @if (!selectedImporter && importersForActiveTab.length > 0) {
+        <p class="tab-bar-hint">Select how to add a {{ activeImporterTabLabel }} dataset.</p>
+      }
     }
   </div>
 
@@ -53,6 +53,9 @@
             >@if (getTabIcon(tab)) {<vt-icon [icon]="getTabIcon(tab)" [size]="14"></vt-icon>}{{ getTabText(tab) }}</button>
           }
         </div>
+        @if (!activeTab) {
+          <p class="tab-bar-hint">Select the media type to demonstrate.</p>
+        }
 
         @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
           <div class="demo-embedder-row">
@@ -79,14 +82,27 @@
 
         @if (activeTab) {
           <div class="demo-content-area">
-            <table class="demo-table" [class.demo-table-fixed]="demoTableFixed" [style.width]="demoTableFixed ? (demoTableWidth + 'px') : '100%'">
+            <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
               <thead>
                 <tr>
-                  <th (click)="sortDemoBy('label')" class="sortable" title="Demo dataset name (click to sort)" data-col="label" [style.width.px]="demoTableFixed ? demoColWidths['label'] : null">Name<span class="sort-indicator" [class.active]="demoSortKey === 'label'">{{ demoSortIndicator('label') }}</span></th>
-                  <th (click)="sortDemoBy('num_files')" class="sortable col-num" title="Number of media files in the demo dataset (click to sort)" data-col="num_files" [style.width.px]="demoTableFixed ? demoColWidths['num_files'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div># Media<span class="sort-indicator" [class.active]="demoSortKey === 'num_files'">{{ demoSortIndicator('num_files') }}</span></th>
-                  <th (click)="sortDemoBy('num_categories')" class="sortable col-num" title="Number of distinct categories or classes in the dataset (click to sort)" data-col="num_categories" [style.width.px]="demoTableFixed ? demoColWidths['num_categories'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div># Cat.<span class="sort-indicator" [class.active]="demoSortKey === 'num_categories'">{{ demoSortIndicator('num_categories') }}</span></th>
-                  <th (click)="sortDemoBy('description')" class="sortable" title="Short description of the demo dataset contents (click to sort)" data-col="description" [style.width.px]="demoTableFixed ? demoColWidths['description'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div>Description<span class="sort-indicator" [class.active]="demoSortKey === 'description'">{{ demoSortIndicator('description') }}</span></th>
-                  <th (click)="sortDemoBy('status')" class="sortable" title="Whether the dataset is pre-downloaded and ready to load immediately, or needs to be fetched first (click to sort)" data-col="status" [style.width.px]="demoTableFixed ? demoColWidths['status'] : null"><div class="col-resize-handle" (mousedown)="startDemoResize($event)" (click)="$event.stopPropagation()"></div>Readiness<span class="sort-indicator" [class.active]="demoSortKey === 'status'">{{ demoSortIndicator('status') }}</span></th>
+                  @for (col of demoCols.columnOrder; track col; let first = $first) {
+                    <th
+                      [class.sortable]="demoCols.meta(col).sortable"
+                      [class.col-drop-target]="demoCols.isDropTarget(col)"
+                      [class.col-dragging]="demoCols.isDragging(col)"
+                      [class.col-num]="col === 'num_files' || col === 'num_categories'"
+                      [attr.data-col]="col"
+                      [title]="demoCols.meta(col).title"
+                      [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
+                      draggable="true"
+                      (click)="onDemoHeaderClick(col)"
+                      (dragstart)="demoCols.onColDragStart($event, col)"
+                      (dragover)="demoCols.onColDragOver($event, col)"
+                      (dragleave)="demoCols.onColDragLeave($event, col)"
+                      (drop)="demoCols.onColDrop($event, col)"
+                      (dragend)="demoCols.onColDragEnd($event)"
+                    >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
+                  }
                 </tr>
               </thead>
               <tbody>
@@ -101,11 +117,25 @@
                     (keydown.enter)="selectDemo(demo)"
                     (keydown.space)="$event.preventDefault(); selectDemo(demo)"
                   >
-                    <td class="col-name">{{ demo.label }}</td>
-                    <td class="col-num">{{ demo.num_files | number }}</td>
-                    <td class="col-num">{{ demo.num_categories | number }}</td>
-                    <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
-                    <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+                    @for (col of demoCols.columnOrder; track col) {
+                      @switch (col) {
+                        @case ('label') {
+                          <td class="col-name">{{ demo.label }}</td>
+                        }
+                        @case ('num_files') {
+                          <td class="col-num">{{ demo.num_files | number }}</td>
+                        }
+                        @case ('num_categories') {
+                          <td class="col-num">{{ demo.num_categories | number }}</td>
+                        }
+                        @case ('description') {
+                          <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
+                        }
+                        @case ('status') {
+                          <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+                        }
+                      }
+                    }
                   </tr>
                 }
               </tbody>
@@ -123,7 +153,7 @@
           <div class="form-group">
             <label class="form-label" [for]="'field-' + field.key">
               {{ field.label || field.key }}
-              @if (field.required) {
+              @if (field.required && !(field.field_type === 'select' && field.key === 'media_type')) {
                 <span class="required">*</span>
               }
             </label>
@@ -259,9 +289,9 @@
         </select>
       </div>
 
-      <div class="form-group">
+      <div class="form-group form-group--section">
         @if (lfPickerKind === 'folder') {
-          <label class="form-label" for="lf-folder-input" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder</label>
+          <label class="form-label" for="lf-folder-input" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
           <input
             id="lf-folder-input"
             type="file"
@@ -272,7 +302,7 @@
             (change)="lfOnFolderSelected($event)"
           />
         } @else {
-          <label class="form-label" for="lf-files-input" title="Choose one or more files on your local machine. Each selected file will be uploaded.">Files</label>
+          <label class="form-label" for="lf-files-input" title="Choose one or more files on your local machine. Each selected file will be uploaded.">Files<span class="required">*</span></label>
           <input
             id="lf-files-input"
             type="file"
@@ -302,7 +332,7 @@
         </div>
       }
 
-      <div class="form-group">
+      <div class="form-group form-group--section">
         <label class="form-label" for="lf-chunk-size" title="Embed at most this many medias at once to bound peak memory. 0 means load everything in one pass.">
           Chunk size (advanced — 0 = no chunking)
         </label>
@@ -317,7 +347,7 @@
       </div>
 
       @if (lfEmbedders.length > 1) {
-        <div class="form-group">
+        <div class="form-group form-group--section">
           <label class="form-label" for="lf-embedder" title="Embedding model used to compute vector representations of each media item">Embedder</label>
           <select
             id="lf-embedder"
@@ -332,7 +362,7 @@
       }
 
       @if (lfClippers.length > 1) {
-        <div class="form-group">
+        <div class="form-group form-group--section">
           <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
           <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('lf')" title="Choose a MediaClipper to segment or trim media before embedding">
             Use MediaClipper: {{ clipperDisplayName('lf') }}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -23,8 +23,9 @@
 
 // Indent the Importer's content area inward from the tabs above so the
 // hierarchy reads top-down: category tabs → importer tabs → controls.
+// .demo-picker is intentionally NOT indented — its inner tab bar must
+// line up with the category and importer tabs above it.
 .importer-form,
-.demo-picker,
 .local-folder-uploader,
 .server-folder-browser {
   padding-left: 20px;
@@ -82,13 +83,22 @@
   }
 }
 
+// Hint shown directly below the tab row when no tab/importer/media-type is
+// selected yet — placed where the next-step content will appear so the user's
+// eye lands on it naturally.
 .tab-bar-hint {
-  margin-left: auto;
-  padding: 0 12px;
+  margin: 8px 0 0 0;
   color: var(--text-muted);
-  font-size: .8rem;
+  font-size: .85rem;
   font-style: italic;
-  white-space: nowrap;
+}
+
+// Extra vertical breathing room above grouped sections inside the Local /
+// Folder uploader (Folder picker, Chunk size, Embedder, Clipper). The
+// Recursive checkbox intentionally does NOT get this class — it is a
+// sub-option of the Folder picker above it.
+.form-group--section {
+  margin-top: 16px;
 }
 
 .importer-subtab-icon {
@@ -130,10 +140,11 @@
 .demo-content-area {
   min-height: 200px;
   max-height: 50vh;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
-.demo-table-fixed {
+.table-fixed {
   table-layout: fixed;
 }
 
@@ -149,8 +160,13 @@
     white-space: nowrap;
   }
 
+  // Body cells truncate with ellipsis when the column is narrower than
+  // their content. Header cells must NOT clip — they host the resize handle
+  // which pokes 6px to the left of the cell's edge.
   td {
     padding: 6px 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   th {
@@ -166,12 +182,37 @@
     letter-spacing: 0.03em;
     user-select: none;
 
+    // Headers are draggable for reordering (matches the Dashboard tables).
+    &[draggable='true'] {
+      cursor: grab;
+
+      &:active {
+        cursor: grabbing;
+      }
+    }
+
     &.sortable {
       cursor: pointer;
 
       &:hover {
         color: var(--text-primary);
       }
+    }
+
+    &[draggable='true'].sortable {
+      cursor: grab;
+
+      &:active {
+        cursor: grabbing;
+      }
+    }
+
+    &.col-drop-target {
+      box-shadow: inset 0 0 0 2px var(--accent);
+    }
+
+    &.col-dragging {
+      opacity: 0.4;
     }
 
     .sort-indicator {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -7,6 +7,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { ImporterInfo, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
+import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 @Component({
   selector: 'vt-dataset-importer-modal',
@@ -51,8 +52,6 @@ export class DatasetImporterModalComponent implements OnInit {
   mediaTypes: MediaTypeInfo[] = [];
   demoTabs: string[] = [];
   activeTab = '';
-  demoSortKey = 'num_files';
-  demoSortAsc = true;
   demoLoading = false;
   demoEmbedders: EmbedderInfo[] = [];
   selectedDemoEmbedder = '';
@@ -60,18 +59,24 @@ export class DatasetImporterModalComponent implements OnInit {
   demoClippers: ClipperInfo[] = [];
   selectedDemoClipper = '';
 
-  // Demo table column resize state
-  demoColWidths: Record<string, number> = {};
-  demoTableFixed = false;
-  demoTableWidth = 0;
-  private demoResizeInit = false;
-  private demoResizeState: {
-    startX: number;
-    startWidth: number;
-    col: string;
-    dragged: boolean;
-    tableEl: HTMLTableElement;
-  } | null = null;
+  // Demo table column metadata + controller. Mirrors the Dashboard datagrid:
+  // percentage widths summing to 100, draggable column reorder, click-to-sort
+  // headers, and column-resize handles between cells.
+  static readonly DEMO_COL_META: Record<string, ColMeta> = {
+    label: { label: 'Name', title: 'Demo dataset name (click to sort)', sortable: true },
+    num_files: { label: '# Media', title: 'Number of media files in the demo dataset (click to sort)', sortable: true },
+    num_categories: { label: '# Cat.', title: 'Number of distinct categories or classes in the dataset (click to sort)', sortable: true },
+    description: { label: 'Description', title: 'Short description of the demo dataset contents (click to sort)', sortable: true },
+    status: { label: 'Readiness', title: 'Whether the dataset is pre-downloaded and ready to load immediately, or needs to be fetched first (click to sort)', sortable: true },
+  };
+  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'num_categories', 'description', 'status'];
+  private static readonly DEMO_COL_ORDER_KEY = 'vtsearch.dashboard.demoColumnOrder';
+
+  demoCols = new ManagedColumns(
+    DatasetImporterModalComponent.DEMO_COLUMNS_DEFAULT,
+    DatasetImporterModalComponent.DEMO_COL_META,
+    { initialSort: 'num_files', storageKey: DatasetImporterModalComponent.DEMO_COL_ORDER_KEY },
+  );
 
   // Local folder upload state — files come from the browser machine
   lfFiles: File[] = [];
@@ -514,8 +519,10 @@ export class DatasetImporterModalComponent implements OnInit {
   get filteredDemos(): DemoDataset[] {
     const items = this.demos.filter((d) => d.media_type === this.activeTab);
     const statusOrder: Record<string, number> = { ready: 0, needs_embedding: 1, needs_download: 2 };
+    const sortKey = this.demoCols.sortColumn;
+    const asc = this.demoCols.sortAsc;
     return items.sort((a, b) => {
-      const key = this.demoSortKey as keyof DemoDataset;
+      const key = sortKey as keyof DemoDataset;
       let va: any = a[key];
       let vb: any = b[key];
       if (key === 'status') {
@@ -523,11 +530,11 @@ export class DatasetImporterModalComponent implements OnInit {
         vb = statusOrder[vb as string] ?? 3;
       }
       if (typeof va === 'number' && typeof vb === 'number') {
-        return this.demoSortAsc ? va - vb : vb - va;
+        return asc ? va - vb : vb - va;
       }
       va = String(va || '').toLowerCase();
       vb = String(vb || '').toLowerCase();
-      return this.demoSortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
     });
   }
 
@@ -536,132 +543,20 @@ export class DatasetImporterModalComponent implements OnInit {
     this.loadDemoEmbedders(tab);
   }
 
-  sortDemoBy(key: string): void {
-    if (this.demoSortKey === key) {
-      this.demoSortAsc = !this.demoSortAsc;
-    } else {
-      this.demoSortKey = key;
-      this.demoSortAsc = true;
-    }
+  onDemoHeaderClick(col: string): void {
+    if (this.demoCols.meta(col).sortable) this.demoCols.sortBy(col);
   }
 
-  demoSortIndicator(key: string): string {
-    if (this.demoSortKey !== key) return '';
-    return this.demoSortAsc ? ' \u25B2' : ' \u25BC';
-  }
-
-  // --- Demo table column resize ---
-
-  startDemoResize(event: MouseEvent): void {
-    event.stopPropagation();
-    event.preventDefault();
-
-    // The handle sits on the LEFT edge of its host <th> and resizes the
-    // column to its left (see dashboard.component.scss for why).
-    const th = (event.target as HTMLElement).closest('th') as HTMLElement;
-    const prevTh = th.previousElementSibling as HTMLElement | null;
-    const col = prevTh?.getAttribute('data-col');
-    if (!col) return;
-    const tableEl = th.closest('table') as HTMLTableElement;
-
-    if (!this.demoResizeInit) {
-      const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
-      let totalWidth = 0;
-      ths.forEach((t) => {
-        const colKey = t.getAttribute('data-col');
-        const w = t.offsetWidth;
-        if (colKey) this.demoColWidths[colKey] = w;
-        totalWidth += w;
-      });
-      this.demoTableWidth = totalWidth;
-      this.demoResizeInit = true;
-      this.demoTableFixed = true;
-    }
-
-    this.demoResizeState = {
-      startX: event.clientX,
-      startWidth: this.demoColWidths[col] ?? 100,
-      col,
-      dragged: false,
-      tableEl,
-    };
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  }
+  // --- Document-level resize tracking ---
 
   @HostListener('document:mousemove', ['$event'])
-  onDemoResizeMove(event: MouseEvent): void {
-    if (!this.demoResizeState) return;
-    const delta = event.clientX - this.demoResizeState.startX;
-    if (Math.abs(delta) > 3) this.demoResizeState.dragged = true;
-    if (!this.demoResizeState.dragged) return;
-    const newWidth = Math.max(30, this.demoResizeState.startWidth + delta);
-    const prevWidth = this.demoColWidths[this.demoResizeState.col] ?? this.demoResizeState.startWidth;
-    this.demoColWidths[this.demoResizeState.col] = newWidth;
-    this.demoTableWidth = Math.max(100, this.demoTableWidth + (newWidth - prevWidth));
+  onDocResizeMove(event: MouseEvent): void {
+    this.demoCols.onResizeMove(event);
   }
 
   @HostListener('document:mouseup')
-  onDemoResizeEnd(): void {
-    if (!this.demoResizeState) return;
-    const state = this.demoResizeState;
-    this.demoResizeState = null;
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-
-    if (!state.dragged) {
-      this.autoSizeDemoColumn(state.tableEl, state.col);
-    }
-  }
-
-  private autoSizeDemoColumn(tableEl: HTMLTableElement, col: string): void {
-    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
-    let colIndex = -1;
-    for (let i = 0; i < ths.length; i++) {
-      if (ths[i].getAttribute('data-col') === col) {
-        colIndex = i;
-        break;
-      }
-    }
-    if (colIndex < 0) return;
-
-    const prevTableWidth = tableEl.style.width;
-    tableEl.classList.remove('demo-table-fixed');
-    tableEl.style.width = 'auto';
-    ths[colIndex].style.width = '';
-
-    let maxWidth = 0;
-    const rows = tableEl.querySelectorAll('tbody tr');
-    rows.forEach((row) => {
-      const cell = row.children[colIndex] as HTMLElement | undefined;
-      if (cell) {
-        if (cell.hasAttribute('colspan')) return;
-        maxWidth = Math.max(maxWidth, cell.scrollWidth);
-      }
-    });
-    if (maxWidth === 0) {
-      maxWidth = ths[colIndex].offsetWidth;
-    }
-    maxWidth = Math.max(30, maxWidth + 2);
-
-    this.demoColWidths[col] = maxWidth;
-    this.demoTableFixed = true;
-    this.demoResizeInit = true;
-
-    let total = 0;
-    ths.forEach((t) => {
-      const key = t.getAttribute('data-col');
-      if (key && key !== col) {
-        if (!this.demoColWidths[key]) this.demoColWidths[key] = t.offsetWidth;
-        total += this.demoColWidths[key];
-      } else if (key === col) {
-        total += maxWidth;
-      }
-    });
-    this.demoTableWidth = total;
-
-    tableEl.style.width = prevTableWidth;
-    tableEl.classList.add('demo-table-fixed');
+  onDocResizeEnd(): void {
+    this.demoCols.onResizeEnd();
   }
 
   /** Convert a type_id (e.g. "image") to the corresponding folder_import_name (e.g. "images"). */

--- a/frontend/src/app/utils/managed-columns.ts
+++ b/frontend/src/app/utils/managed-columns.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared controller for tables whose columns can be sorted, resized, and
+ * drag-reordered.  Holds all the mutable state plus the event handlers; a
+ * component creates one instance per table and forwards `mousemove`/`mouseup`
+ * from its HostListener so resize tracking works document-wide.
+ *
+ * Resize model: column widths are stored as percentages summing to ~100, so
+ * the table always fills its container without horizontal scroll.  Dragging
+ * a divider grows the column to its left and shrinks the host column by the
+ * same amount; clicking (no drag) auto-fits the left column to its content.
+ */
+export interface ColMeta {
+  label: string;
+  title: string;
+  sortable: boolean;
+}
+
+export interface ManagedColumnsOptions<TCol extends string> {
+  /** Column id whose values the table is initially sorted by. */
+  initialSort: TCol;
+  /** Initial sort direction; defaults to ascending. */
+  initialSortAsc?: boolean;
+  /** localStorage key for persisting reorder state. Pass `null` to disable. */
+  storageKey?: string | null;
+}
+
+interface ResizeState {
+  startX: number;
+  startGrowPct: number;
+  startShrinkPct: number;
+  growCol: string;
+  shrinkCol: string;
+  dragged: boolean;
+  tableEl: HTMLTableElement;
+}
+
+export class ManagedColumns<TCol extends string = string> {
+  static readonly MIN_COL_PCT = 3;
+
+  columnOrder: TCol[];
+  colWidths: Record<string, number> = {};
+  tableFixed = false;
+  sortColumn: TCol;
+  sortAsc: boolean;
+
+  dragCol: TCol | null = null;
+  dropTargetCol: TCol | null = null;
+
+  private readonly metaMap: Record<string, ColMeta>;
+  private readonly storageKey: string | null;
+  private readonly defaults: readonly TCol[];
+  private resizeInit = false;
+  private resizeState: ResizeState | null = null;
+
+  constructor(
+    defaults: readonly TCol[],
+    meta: Record<string, ColMeta>,
+    options: ManagedColumnsOptions<TCol>,
+  ) {
+    this.defaults = defaults;
+    this.metaMap = meta;
+    this.storageKey = options.storageKey ?? null;
+    this.sortColumn = options.initialSort;
+    this.sortAsc = options.initialSortAsc ?? true;
+    this.columnOrder = this.loadColumnOrder();
+  }
+
+  meta(col: string): ColMeta {
+    return this.metaMap[col] ?? { label: col, title: '', sortable: false };
+  }
+
+  // --- Sort ---
+
+  sortBy(col: TCol): void {
+    if (this.sortColumn === col) {
+      this.sortAsc = !this.sortAsc;
+    } else {
+      this.sortColumn = col;
+      this.sortAsc = true;
+    }
+  }
+
+  sortIndicator(col: string): string {
+    if (this.sortColumn !== col) return '▲';
+    return this.sortAsc ? '▲' : '▼';
+  }
+
+  isSortActive(col: string): boolean {
+    return this.sortColumn === col;
+  }
+
+  // --- Resize ---
+
+  private captureColumnPercentages(tableEl: HTMLTableElement): void {
+    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
+    const tableWidth = tableEl.offsetWidth || 1;
+    ths.forEach((t) => {
+      const colKey = t.getAttribute('data-col');
+      if (colKey) this.colWidths[colKey] = (t.offsetWidth / tableWidth) * 100;
+    });
+  }
+
+  startResize(event: MouseEvent): void {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const th = (event.target as HTMLElement).closest('th') as HTMLElement;
+    const prevTh = th.previousElementSibling as HTMLElement | null;
+    const growCol = prevTh?.getAttribute('data-col');
+    const shrinkCol = th.getAttribute('data-col');
+    if (!growCol || !shrinkCol) return;
+    const tableEl = th.closest('table') as HTMLTableElement;
+
+    if (!this.resizeInit) {
+      this.captureColumnPercentages(tableEl);
+      this.resizeInit = true;
+      this.tableFixed = true;
+    }
+
+    this.resizeState = {
+      startX: event.clientX,
+      startGrowPct: this.colWidths[growCol] ?? 10,
+      startShrinkPct: this.colWidths[shrinkCol] ?? 10,
+      growCol,
+      shrinkCol,
+      dragged: false,
+      tableEl,
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }
+
+  onResizeMove(event: MouseEvent): void {
+    if (!this.resizeState) return;
+    const dx = event.clientX - this.resizeState.startX;
+    if (Math.abs(dx) > 3) this.resizeState.dragged = true;
+    if (!this.resizeState.dragged) return;
+
+    const tableWidth = this.resizeState.tableEl.offsetWidth || 1;
+    const dPct = (dx / tableWidth) * 100;
+    const min = ManagedColumns.MIN_COL_PCT;
+    const sum = this.resizeState.startGrowPct + this.resizeState.startShrinkPct;
+
+    let newGrow = this.resizeState.startGrowPct + dPct;
+    let newShrink = this.resizeState.startShrinkPct - dPct;
+    if (newShrink < min) {
+      newShrink = min;
+      newGrow = sum - min;
+    } else if (newGrow < min) {
+      newGrow = min;
+      newShrink = sum - min;
+    }
+
+    this.colWidths[this.resizeState.growCol] = newGrow;
+    this.colWidths[this.resizeState.shrinkCol] = newShrink;
+  }
+
+  onResizeEnd(): void {
+    if (!this.resizeState) return;
+    const state = this.resizeState;
+    this.resizeState = null;
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+
+    if (!state.dragged) {
+      this.autoSizeColumn(state.tableEl, state.growCol, state.shrinkCol);
+    }
+  }
+
+  /** Auto-fit the grow column to its natural content width; take/return the
+   *  delta from the shrink column so total stays at 100%. */
+  private autoSizeColumn(
+    tableEl: HTMLTableElement,
+    growCol: string,
+    shrinkCol: string,
+  ): void {
+    const ths = tableEl.querySelectorAll('thead tr th') as NodeListOf<HTMLElement>;
+    let colIndex = -1;
+    for (let i = 0; i < ths.length; i++) {
+      if (ths[i].getAttribute('data-col') === growCol) {
+        colIndex = i;
+        break;
+      }
+    }
+    if (colIndex < 0) return;
+
+    const wasFixed = tableEl.classList.contains('table-fixed');
+    const prevColWidth = ths[colIndex].style.width;
+    tableEl.classList.remove('table-fixed');
+    ths[colIndex].style.width = '';
+
+    let maxPx = 0;
+    const rows = tableEl.querySelectorAll('tbody tr');
+    rows.forEach((row) => {
+      const cell = row.children[colIndex] as HTMLElement | undefined;
+      if (!cell || cell.hasAttribute('colspan')) return;
+      maxPx = Math.max(maxPx, cell.scrollWidth);
+    });
+    if (maxPx === 0) maxPx = ths[colIndex].offsetWidth;
+    maxPx = Math.max(30, maxPx + 2);
+
+    if (wasFixed) tableEl.classList.add('table-fixed');
+    ths[colIndex].style.width = prevColWidth;
+
+    const tableWidth = tableEl.offsetWidth || 1;
+    const min = ManagedColumns.MIN_COL_PCT;
+    const sum = (this.colWidths[growCol] ?? 0) + (this.colWidths[shrinkCol] ?? 0);
+    let targetGrow = (maxPx / tableWidth) * 100;
+    if (targetGrow > sum - min) targetGrow = sum - min;
+    if (targetGrow < min) targetGrow = min;
+    this.colWidths[growCol] = targetGrow;
+    this.colWidths[shrinkCol] = sum - targetGrow;
+
+    this.tableFixed = true;
+    this.resizeInit = true;
+  }
+
+  // --- Drag-reorder ---
+
+  private loadColumnOrder(): TCol[] {
+    return this.normalizeColumnOrder(this.readStoredOrder());
+  }
+
+  private readStoredOrder(): unknown {
+    if (!this.storageKey) return null;
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizeColumnOrder(stored: unknown): TCol[] {
+    const known = new Set(this.defaults);
+    const result: TCol[] = [];
+    if (Array.isArray(stored)) {
+      for (const c of stored) {
+        if (typeof c === 'string' && known.has(c as TCol) && !result.includes(c as TCol)) {
+          result.push(c as TCol);
+        }
+      }
+    }
+    // Append any defaults missing from the stored order (e.g. new columns
+    // added after the user's order was saved).
+    for (const c of this.defaults) {
+      if (!result.includes(c)) result.push(c);
+    }
+    return result;
+  }
+
+  private persistColumnOrder(): void {
+    if (!this.storageKey) return;
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.columnOrder));
+    } catch {
+      // Ignore quota / private-mode failures.
+    }
+  }
+
+  onColDragStart(event: DragEvent, col: TCol): void {
+    if (this.resizeState) {
+      event.preventDefault();
+      return;
+    }
+    this.dragCol = col;
+    this.dropTargetCol = null;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', col);
+    }
+  }
+
+  onColDragOver(event: DragEvent, col: TCol): void {
+    if (!this.dragCol || this.dragCol === col) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+    if (this.dropTargetCol !== col) {
+      this.dropTargetCol = col;
+    }
+  }
+
+  onColDragLeave(_event: DragEvent, col: TCol): void {
+    if (this.dropTargetCol === col) {
+      this.dropTargetCol = null;
+    }
+  }
+
+  onColDrop(event: DragEvent, targetCol: TCol): void {
+    if (!this.dragCol) {
+      this.dragCol = null;
+      this.dropTargetCol = null;
+      return;
+    }
+    event.preventDefault();
+    const sourceCol = this.dragCol;
+    this.dragCol = null;
+    this.dropTargetCol = null;
+    if (sourceCol === targetCol) return;
+
+    const fromIdx = this.columnOrder.indexOf(sourceCol);
+    const toIdx = this.columnOrder.indexOf(targetCol);
+    if (fromIdx < 0 || toIdx < 0) return;
+
+    // Shift semantics: source lands at target's slot; intermediate columns
+    // shift by one toward source's old slot. Splicing in at the target's
+    // original index achieves this for both directions.
+    const next = [...this.columnOrder];
+    next.splice(fromIdx, 1);
+    next.splice(toIdx, 0, sourceCol);
+    this.columnOrder = next;
+    this.persistColumnOrder();
+  }
+
+  onColDragEnd(_event: DragEvent): void {
+    this.dragCol = null;
+    this.dropTargetCol = null;
+  }
+
+  isDropTarget(col: TCol): boolean {
+    return this.dropTargetCol === col;
+  }
+
+  isDragging(col: TCol): boolean {
+    return this.dragCol === col;
+  }
+}


### PR DESCRIPTION
## Summary
- Hints (`Select what type of dataset to add.`, `Select how to add a … dataset.`, and a new `Select the media type to demonstrate.`) now sit directly below their tab row instead of floating to the right of it, so the user's eye lands where the next-step content will render.
- Demo media-type tabs no longer have a left indent — they line up with the category and importer tabs above them.
- Demo datagrid now matches the Dashboard tables: percentage column widths summing to 100, draggable column reorder (persisted to `localStorage`), resize-handle behavior, and consistent sort indicators.
- Extracted the shared column logic into `frontend/src/app/utils/managed-columns.ts` so the three tables (Datasets, Models, Demos) cannot drift.
- **Local / Folder**: the Folder/Files picker is now marked required with an asterisk, and there is more vertical breathing room above the Folder, Chunk size, Embedder, and Clipper sections.
- **Server / Files**: dropped the asterisk from the Media Type dropdown; a select with no blank option is always populated, so the required marker was misleading.

## Test plan
- [x] `./run-tests.sh core` passes (345 tests)
- [x] `npm run build:prod` builds cleanly
- [ ] Manual: open Add Dataset → confirm category-tab hint sits directly below the tabs and disappears when a tab is picked
- [ ] Manual: pick a category → confirm importer-tab hint sits directly below the importer tabs
- [ ] Manual: open Demo → confirm media-type tabs line up with category/importer tabs above and the new hint appears below them
- [ ] Manual: in Demo → confirm columns are draggable, sortable, and resize percentages stay summed to 100
- [ ] Manual: open Local/Folder → confirm Folder/Files label has an asterisk and there is extra space above Folder, Chunk size, Embedder, Clipper
- [ ] Manual: open Server/Files → confirm Media Type dropdown has no asterisk

https://claude.ai/code/session_011kNdbjnyke3kN2JSeCNUxg

---
_Generated by [Claude Code](https://claude.ai/code/session_011kNdbjnyke3kN2JSeCNUxg)_