### PR TITLE
Fix dashboard column divider drifting right on each click

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -403,12 +403,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
     if (colIndex < 0) return;
 
-    // Temporarily release fixed layout for this column so we can measure
-    // its natural width from the body cells.
-    const wasFixed = tableEl.classList.contains('table-fixed');
+    // Collapse the host column to 0px under table-layout: fixed so body cells
+    // (which have overflow: hidden) overflow with their content. scrollWidth
+    // then reports the content's natural width rather than the cell's current
+    // client width — without this, repeated auto-fits drift right by the +2px
+    // padding on every click because scrollWidth == clientWidth when the cell
+    // has slack.
     const prevColWidth = ths[colIndex].style.width;
-    tableEl.classList.remove('table-fixed');
-    ths[colIndex].style.width = '';
+    ths[colIndex].style.width = '0px';
 
     let maxPx = 0;
     const rows = tableEl.querySelectorAll('tbody tr');
@@ -417,11 +419,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
       if (!cell || cell.hasAttribute('colspan')) return;
       maxPx = Math.max(maxPx, cell.scrollWidth);
     });
+
+    ths[colIndex].style.width = prevColWidth;
     if (maxPx === 0) maxPx = ths[colIndex].offsetWidth;
     maxPx = Math.max(30, maxPx + 2);
-
-    if (wasFixed) tableEl.classList.add('table-fixed');
-    ths[colIndex].style.width = prevColWidth;
 
     const tableWidth = tableEl.offsetWidth || 1;
     const min = DashboardComponent.MIN_COL_PCT;


### PR DESCRIPTION
## Summary

Clicking a column resize handle on the Datasets/Models grids was nudging the boundary ~2px to the right with every click, even though the click was supposed to auto-fit the left column to its content.

**Root cause.** `autoSizeColumn` cleared the host column's inline width and removed `table-fixed` to "release" auto-layout, then read `cell.scrollWidth` on body cells. But the *other* columns still had inline `[style.width.%]` bindings, so in auto-layout the cleared column stretched to fill the leftover space — making each `<td>`'s `scrollWidth` come back equal to its current `clientWidth`, not the content's intrinsic width. Adding the `+2px` padding then bumped the column up by 2px every time.

**Fix.** Keep `table-layout: fixed` and instead collapse the host column to `0px` while measuring. Body cells already have `overflow: hidden`, so they overflow with their content and `scrollWidth` correctly reports the natural content width. Restore the original width afterwards.

## Test plan
- [ ] Open the Datasets grid, click a column resize handle several times in a row — divider should snap to content width and stay put on subsequent clicks.
- [ ] Same on the Models grid.
- [ ] Drag-resize still works and totals stay at 100%.
- [ ] Auto-fit still respects `MIN_COL_PCT` and the shrink-neighbour budget.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vy3uAxUtfcgvcacfS4YJo5)_