### PR TITLE
Format counts with thousands separators in UI

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -313,7 +313,7 @@
         }
         @if (lfFiles.length > 0) {
           <p class="info-text">
-            Selected <strong>{{ lfFiles.length }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
+            Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
             @if (lfFolderName && lfPickerKind === 'folder') { from <code>{{ lfFolderName }}</code> }
           </p>
         }

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -7,7 +7,7 @@
     <div class="tab-panel-manual" role="region" aria-label="Find results">
       <div class="images-header">
         <h3 class="images-header-title">
-          {{ mediaTypeName }}s ({{ medias.length }})
+          {{ mediaTypeName }}s ({{ medias.length | number }})
         </h3>
         <div class="view-btn-wrapper">
           <button class="view-btn" (click)="showLeftViewSettings = true" title="Change display layout: list vs. grid, focus mode, and icon size">View</button>
@@ -115,7 +115,7 @@
 
         <div class="images-header">
           <h3 class="images-header-title">
-            {{ mediaTypeName }}s ({{ medias.length }})
+            {{ mediaTypeName }}s ({{ medias.length | number }})
           </h3>
           <div class="view-btn-wrapper">
             <button class="view-btn" (click)="showLeftViewSettings = true" title="Change display layout: list vs. grid, focus mode, and icon size">View</button>

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -8,11 +8,11 @@
       <tbody>
         <tr>
           <td class="stat-label" title="Total number of unique media items in this dataset">Media items</td>
-          <td class="stat-value">{{ stats.num_items }}</td>
+          <td class="stat-value">{{ stats.num_items | number }}</td>
         </tr>
         <tr>
           <td class="stat-label" title="Number of duplicate items that were detected and collapsed">Duplicate groups</td>
-          <td class="stat-value">{{ stats.num_dupes }}</td>
+          <td class="stat-value">{{ stats.num_dupes | number }}</td>
         </tr>
         <tr>
           <td class="stat-label" title="Timestamp when the dataset import process began">Ingest started</td>
@@ -68,7 +68,7 @@
           @for (ft of fileTypes; track ft.ext) {
             <tr>
               <td>.{{ ft.ext }}</td>
-              <td>{{ ft.count }}</td>
+              <td>{{ ft.count | number }}</td>
             </tr>
           }
         </tbody>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -40,7 +40,7 @@
     <h3>
       Preview
       @if (labelsLoaded) {
-        <span class="preview-count">({{ filteredLabels.length }} rows)</span>
+        <span class="preview-count">({{ filteredLabels.length | number }} rows)</span>
       }
     </h3>
     @if (!labelsLoaded) {
@@ -71,7 +71,7 @@
             @if (filteredLabels.length > 50) {
               <tr class="truncated-row">
                 <td [attr.colspan]="enabledColumns.length">
-                  ... {{ filteredLabels.length - 50 }} more rows
+                  ... {{ filteredLabels.length - 50 | number }} more rows
                 </td>
               </tr>
             }

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -111,7 +111,7 @@
               <button class="file-item" (click)="loadRegistryModel(model)" [title]="'Load model: ' + model.name">
                 {{ model.name }}
                 @if (model.num_training) {
-                  <span class="item-meta">{{ model.num_training }} labels</span>
+                  <span class="item-meta">{{ model.num_training | number }} labels</span>
                 }
               </button>
             }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -1,6 +1,6 @@
 <div class="vote-section">
   <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
-    {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length }})
+    {{ label === 'good' ? 'Goods' : 'Bads' }} ({{ ids.length | number }})
   </h3>
   <div class="vote-list" [class.grid-layout]="isGrid" [style.--grid-goal-width]="gridGoalWidth + 'px'" #voteListContainer>
     @for (entry of sortedEntries; track trackById($index, entry)) {


### PR DESCRIPTION
## Summary

The Dataset Details window was displaying counts as raw integers (e.g. `12345` instead of `12,345`). This PR applies Angular's `number` pipe to those values and to the other places in the frontend that interpolate integer counts which can grow large.

## Changes

- `dataset-stats-modal` — Media items, Duplicate groups, File Types count
- `left-panel` — `{mediaType}s (N)` header (both `find` and main views)
- `label-list` — `Goods (N)` / `Bads (N)` header
- `export-modal` — `(N rows)` preview count and `... N more rows` truncation line
- `load-sort-modal` — `N labels` on registry models
- `dataset-importer-modal` — `Selected N file(s)`

Existing usages (dataset-card, model-card, demo selector, media-item) already used the pipe — this just brings the rest in line.

Locations like step counters (`Step 1/5`) and tiny enum-like counts were intentionally left untouched.

## Test plan

- [x] `npm run build:prod` succeeds
- [ ] Open the Dataset Details modal on a dataset with >1000 items — counts render with commas
- [ ] Vote on enough items to reach >1000 — `Goods (N)` / `Bads (N)` counts render with commas
- [ ] Open Export modal on a large labelset — preview count and "more rows" line render with commas

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuzJcL1q7XWmJ7eSkC8wpS)_