### PR TITLE
Center "+" glyph vertically in dashboard add buttons

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -191,6 +191,7 @@
 
   .plus-icon {
     display: inline-block;
+    line-height: 1;
 
     &.plus-open {
       animation: plus-spin-open 0.3s ease-in-out forwards;


### PR DESCRIPTION
## Summary
- The `+` icon in the dashboard's "add dataset" / "create model" buttons looked shifted slightly downward.
- Cause: the glyph sits on the typographic baseline, and the inherited `line-height` (~1.5) made the line box taller than the glyph. With `align-items: center` on the flex button, the line box centered correctly but the visible glyph rendered low inside it.
- Fix: add `line-height: 1` to `.plus-icon` so the line box collapses to the glyph, letting flex centering hit the visual center.

## Test plan
- [ ] Open the dashboard and visually verify the `+` is vertically centered in both the Datasets and Models section buttons.
- [ ] Click `+` to confirm the rotate-to-`x` animation still plays smoothly.

---
_Generated by [Claude Code](https://claude.ai/code/session_016HM8qFztL5rAKz8rDrW3ih)_