### PR TITLE
Shorten demo dataset descriptions to 9 words max

### DIFF
--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -297,7 +297,7 @@ class AudioMediaType(MediaType):
 
         cats = self._DEMO_CATEGORIES
         folder = DATA_DIR / "ESC-50-master" / "audio"
-        esc_desc = "Real-world environmental recordings — animals, nature, cities, homes, and people."
+        esc_desc = "Environmental recordings of animals, nature, cities, and homes."
         sc_desc = "One-second keyword utterances from crowd-sourced speakers."
         us_desc = "Real urban field recordings, pre-segmented into labeled sounds."
         return [

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -527,13 +527,13 @@ class ImageMediaType(MediaType):
 
         cats101 = self._DEMO_CATEGORIES_CALTECH101
         cats256 = self._DEMO_CATEGORIES_CALTECH256
-        ct101_desc = "Centered, well-lit object photos — a classic vision benchmark."
+        ct101_desc = "Centered object photos — a classic vision benchmark."
         ct101_folder = DATA_DIR / "caltech-101" / "101_ObjectCategories"
-        food_desc = "Crowd-sourced food photos, some mislabeled — a deliberately noisy benchmark."
+        food_desc = "Crowd-sourced food photos — a deliberately noisy benchmark."
         food_folder = DATA_DIR / "food-101" / "images"
         euro_desc = "Sentinel-2 satellite imagery classified by land use type."
         euro_folder = DATA_DIR / "EuroSAT_RGB"
-        dogs_desc = "Fine-grained dog breed photos — many visually similar breeds."
+        dogs_desc = "Fine-grained dog breeds with many visually similar classes."
         dogs_folder = DATA_DIR / "stanford_dogs" / "Images"
         return [
             DemoDataset(
@@ -587,7 +587,7 @@ class ImageMediaType(MediaType):
             DemoDataset(
                 id="caltech256_a",
                 label="Caltech-256 (A)",
-                description="Harder object photos with more varied, cluttered backgrounds than Caltech-101.",
+                description="Harder object photos with cluttered backgrounds than Caltech-101.",
                 categories=cats256,
                 source="caltech256",
                 required_folder=DATA_DIR / "caltech-256" / "256_ObjectCategories",
@@ -755,7 +755,7 @@ class ImageMediaType(MediaType):
             DemoDataset(
                 id="ucsf_documents_a",
                 label="UCSF Documents (A)",
-                description="Scanned industry document pages from the UCSF Industry Documents Library.",
+                description="Scanned pages from the UCSF Industry Documents Library.",
                 categories=self._UCSF_DOCUMENTS_CATEGORIES,
                 source="ucsf_documents",
                 required_folder=DATA_DIR / "ucsf_documents",

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -125,9 +125,9 @@ class TextMediaType(MediaType):
     @property
     def demo_datasets(self) -> list:
         cats = self._DEMO_CATEGORIES
-        ng_desc = "Usenet posts from the early 1990s across technical, recreational, and political topics."
-        ag_desc = "Short news summaries, well-balanced across world, sports, business, and tech."
-        imdb_desc = "Long-form user-written movie reviews with binary positive/negative sentiment labels."
+        ng_desc = "Early-1990s Usenet posts across technical and political topics."
+        ag_desc = "Short news summaries across world, sports, business, tech."
+        imdb_desc = "Long-form movie reviews with positive/negative sentiment labels."
         return [
             DemoDataset(
                 id="20newsgroups_s",
@@ -220,7 +220,7 @@ class TextMediaType(MediaType):
             DemoDataset(
                 id="bbc_news_a",
                 label="BBC News (A)",
-                description="Full BBC news articles — professionally written and cleanly labeled.",
+                description="BBC news articles — professionally written and cleanly labeled.",
                 categories=self._BBC_NEWS_CATEGORIES,
                 source="bbc_news",
                 slice_frac_start=0.0,

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -383,10 +383,10 @@ class VideoMediaType(MediaType):
         kth_cats = self._KTH_CATEGORIES
         kth_folder = VIDEO_DIR / "kth"
 
-        desc = "Action recognition videos sourced from YouTube, covering sports and everyday activities."
-        hmdb_desc = "Human motion clips from movies and web videos, covering 51 diverse action categories."
-        ucf_full_desc = "Full UCF-101 with all 101 action classes — sports, instruments, daily activities."
-        kth_desc = "Simple human actions in controlled settings — a classic action recognition benchmark."
+        desc = "YouTube action videos covering sports and everyday activities."
+        hmdb_desc = "Human motion clips spanning 51 diverse action categories."
+        ucf_full_desc = "Full UCF-101 with 101 action classes across activities."
+        kth_desc = "Simple human actions — a classic recognition benchmark."
         return [
             # UCF-101 subset (10 classes, 171 MB download)
             DemoDataset(


### PR DESCRIPTION
## Summary
- Trim demo dataset descriptions across audio, image, video, and text media types so each fits in 9 words or fewer
- Affects ESC-50, Caltech-101/256, Food-101, Stanford Dogs, UCSF Documents, UCF-101 (subset/full), HMDB51, KTH, 20 Newsgroups, AG News, IMDB, and BBC News (others were already within the limit)

## Test plan
- [ ] Open the demo dataset picker UI and confirm each description is concise and reads cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmefkBWWtPjpgmNczwbd1a)_