### PR TITLE
Fix find-label leaking stale votes from prior dataset

### DIFF
--- a/tests/test_detector_find.py
+++ b/tests/test_detector_find.py
@@ -130,6 +130,36 @@ class TestFindLabel:
         total = data["good_count"] + data["bad_count"]
         assert total == app_module.NUM_MEDIAS
 
+    def test_find_label_drops_stale_votes_outside_dataset(self, client):
+        """Stale votes from a previously loaded dataset must not bleed into Find.
+
+        Reproduces the user-reported bug: the user trained "Mammal" on a demo
+        image dataset (filling DetectorContext.good_votes with that dataset's
+        IDs), then switched to a different (synthetic) dataset and ran Find.
+        Training-time IDs that don't exist in the new dataset showed up in the
+        right-scroll Goods as "Clip #803" with broken thumbnails because the
+        new dataset's medias dict didn't contain those IDs.
+        """
+        model_id = self._create_model_with_detector(client)
+
+        # Stale Dataset-A IDs that are NOT in the current dataset's range.
+        loaded_ids = set(app_module.medias.keys())
+        stale_good = {9001, 9002, 9003}
+        stale_bad = {9101, 9102}
+        assert not (stale_good & loaded_ids)
+        assert not (stale_bad & loaded_ids)
+        app_module.good_votes.update({k: None for k in stale_good})
+        app_module.bad_votes.update({k: None for k in stale_bad})
+
+        resp = client.post("/api/find-label", json={"model_id": model_id})
+        assert resp.status_code == 200
+
+        # After find-label, only the current dataset's IDs should be labeled.
+        all_voted = set(app_module.good_votes) | set(app_module.bad_votes)
+        assert stale_good.isdisjoint(all_voted), "stale good votes leaked into find results"
+        assert stale_bad.isdisjoint(all_voted), "stale bad votes leaked into find results"
+        assert all_voted == loaded_ids
+
     def test_find_label_trainable_model_with_labelset(self, client, tmp_path):
         """find-label should train on-the-fly from a trainable model's labelset.
 

--- a/vtsearch/routes/detectors_scoring.py
+++ b/vtsearch/routes/detectors_scoring.py
@@ -435,7 +435,7 @@ def find_label():
         else:
             label_pairs.append((entry["id"], "bad"))
             bad_count += 1
-    apply_labels_bulk_with_click_time(label_pairs)
+    apply_labels_bulk_with_click_time(label_pairs, replace_all=True)
 
     # Snapshot the detector-assigned labels so that corrections
     # (user-changed labels) can be identified later during export.

--- a/vtsearch/utils/state_votes.py
+++ b/vtsearch/utils/state_votes.py
@@ -222,17 +222,33 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
         diversity_tree_label(media_id)
 
 
-def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]]) -> None:
+def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all: bool = False) -> None:
     """Apply many labels in a single lock acquisition (for find-label scoring).
 
     Each entry is ``(media_id, label)`` where *label* is ``"good"`` or
     ``"bad"``.  All labels are applied atomically with click-time ordinals
     assigned in order.
+
+    When *replace_all* is True, any pre-existing votes/click-times for IDs
+    outside *labels* are cleared first.  This is what ``/api/find-label``
+    wants: a detector trained on Dataset A holds Dataset A's media IDs in
+    its DetectorContext, and switching to Dataset B must not leak those
+    stale IDs into Dataset B's right-scroll Goods/Bads.
     """
     import time as _time
 
     with _state_lock:
         tree = _get_diversity_tree()
+        if replace_all:
+            ctx = get_active_detector_context()
+            kept = {mid for mid, _ in labels}
+            for cid in [c for c in good_votes if c not in kept]:
+                good_votes.pop(cid, None)
+            for cid in [c for c in bad_votes if c not in kept]:
+                bad_votes.pop(cid, None)
+            for cid in [c for c in vote_click_times if c not in kept]:
+                vote_click_times.pop(cid, None)
+            ctx.find_initial_labels.clear()
         for media_id, label in labels:
             if label == "good":
                 bad_votes.pop(media_id, None)


### PR DESCRIPTION
## Summary

Fixes the user-reported bug where training images from a prior dataset show up as bogus "Clip #803" entries with broken thumbnails after running Find on a different dataset.

## Root cause

`DetectorContext` is keyed by detector ID, not (detector, dataset). When the user trained "Mammal" on the demo image dataset, every Y/N vote landed in `DetectorContext.good_votes` / `bad_votes` / `vote_click_times` keyed by **demo dataset's media IDs**. Switching to the synthetic dataset and clicking Find did not unload that detector — `is_model_loaded` short-circuits the load — so those Dataset-A IDs lingered in the context.

`/api/find-label` then called `apply_labels_bulk_with_click_time(label_pairs)` for the synthetic dataset's IDs. The bulk-apply only touches IDs you hand it (overwriting / flipping polarity), so any Dataset-A IDs outside the new dataset's range stayed in `good_votes`. The frontend rendered them as `Clip #<id>` (no metadata in the new dataset) and the broken-image alt text came from the persisted frontend metadata cache filename ("dolphin/image_0044.jpg").

## Fix

Add a `replace_all` flag to `apply_labels_bulk_with_click_time` that, under the same lock, drops votes / click-times / `find_initial_labels` for IDs not in the new label set. `/api/find-label` passes `replace_all=True`. Same-dataset behavior is unaffected because the bulk-applied IDs are a superset of any prior labels.

## Test plan
- [x] New regression test `test_find_label_drops_stale_votes_outside_dataset` seeds out-of-range IDs into `good_votes`/`bad_votes` and verifies they are gone after `/api/find-label`.
- [x] `./run-tests.sh models core sorting integration` — all 1283 tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb1NwMTLKxF28gcFJXxm7k)_