### PR TITLE
Add zoom in/out buttons and keyboard shortcuts for image viewer

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -27,8 +27,10 @@
 
     @if (mediaType === 'image' && imageViewer) {
       <div class="image-view-controls">
-        <button class="ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left" aria-label="Rotate image left">&#x21BA;</button>
-        <button class="ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right" aria-label="Rotate image right">&#x21BB;</button>
+        <button class="ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left">&#x21BA;</button>
+        <button class="ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right">&#x21BB;</button>
+        <button class="ivc-btn" (click)="imageViewer.zoomOut()" title="Zoom out (-)" aria-label="Zoom out">&minus;</button>
+        <button class="ivc-btn" (click)="imageViewer.zoomIn()" title="Zoom in (+)" aria-label="Zoom in">+</button>
         <label for="ivc-zoom" class="sr-only">Zoom</label>
         <input
           type="range"

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -107,6 +107,18 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
           case 'playback':
             this.togglePlayback();
             break;
+          case 'zoom':
+            if (this.imageViewer && action.zoomDirection) {
+              if (action.zoomDirection === 'in') this.imageViewer.zoomIn();
+              else this.imageViewer.zoomOut();
+            }
+            break;
+          case 'rotate':
+            if (this.imageViewer && action.rotateDirection) {
+              if (action.rotateDirection === 'left') this.imageViewer.rotateLeft();
+              else this.imageViewer.rotateRight();
+            }
+            break;
         }
       }),
     );

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -79,6 +79,16 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     this.applyTransform();
   }
 
+  zoomIn(): void {
+    this.zoom = this.clampZoom(this.zoom + 0.15 * this.zoom);
+    this.applyTransform();
+  }
+
+  zoomOut(): void {
+    this.zoom = this.clampZoom(this.zoom - 0.15 * this.zoom);
+    this.applyTransform();
+  }
+
   resetView(): void {
     this.zoom = 1;
     this.rotation = 0;

--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -2,11 +2,15 @@ import { Injectable, NgZone, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs';
 
 export type VoteDirection = 'good' | 'bad';
+export type ZoomDirection = 'in' | 'out';
+export type RotateDirection = 'left' | 'right';
 
 export interface KeyboardAction {
-  type: 'vote' | 'volume' | 'playback';
+  type: 'vote' | 'volume' | 'playback' | 'zoom' | 'rotate';
   direction?: VoteDirection;
   volumeDelta?: number;
+  zoomDirection?: ZoomDirection;
+  rotateDirection?: RotateDirection;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -74,6 +78,28 @@ export class KeyboardService implements OnDestroy {
         e.preventDefault();
         (document.activeElement as HTMLElement)?.blur();
         this.zone.run(() => this.action$.next({ type: 'playback' }));
+        break;
+      case '+':
+      case '=':
+        e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
+        this.zone.run(() => this.action$.next({ type: 'zoom', zoomDirection: 'in' }));
+        break;
+      case '-':
+      case '_':
+        e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
+        this.zone.run(() => this.action$.next({ type: 'zoom', zoomDirection: 'out' }));
+        break;
+      case '[':
+        e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
+        this.zone.run(() => this.action$.next({ type: 'rotate', rotateDirection: 'left' }));
+        break;
+      case ']':
+        e.preventDefault();
+        (document.activeElement as HTMLElement)?.blur();
+        this.zone.run(() => this.action$.next({ type: 'rotate', rotateDirection: 'right' }));
         break;
     }
   }


### PR DESCRIPTION
## Summary

- Adds dedicated **ZoomOut** / **ZoomIn** buttons in the image-view controls, placed between the rotation buttons and the zoom slider.
- Adds keyboard shortcuts on the labeling/finding interface (alongside the existing left/right arrows for voting):
  - `-` / `+` (also `_` / `=`): zoom out / zoom in
  - `[` / `]`: rotate left / rotate right
- New `zoomIn()` / `zoomOut()` methods on `ImageViewerComponent` use the same proportional step (`0.15 * zoom`) as the existing mouse-wheel handler, clamped to `[minZoom, maxZoom]`.

## Test plan

- [ ] Build frontend (`cd frontend && npm run build:prod`) — passes locally.
- [ ] In the labeling and finding views, with an image media item selected:
  - [ ] Verify the new `−` / `+` buttons appear between the rotate buttons and the zoom slider, and clicking them changes zoom.
  - [ ] Verify pressing `-` / `+` zooms out / in (and `_` / `=` work too).
  - [ ] Verify pressing `[` / `]` rotates left / right.
  - [ ] Verify shortcuts do not fire when typing in a text input or when a modal is open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGU5f22GSGufMwZikspRep)_