### PR TITLE
Document that Claude should rebase onto dev before starting work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 
 ## Branch Policy (CRITICAL)
 
+- **Always base work on `dev`.** At the start of every session, before making any changes, run `git fetch origin --prune && git rebase origin/dev`. The harness cuts the working branch off `main` (the GitHub default), so this rebase is required to pick up work already merged to `dev`. The GitHub default stays `main` so new users land on the stable branch — `dev` is Claude's starting point, not the public default.
 - **All pull requests MUST target `dev`**, never `main`.
 - **Claude must NEVER open a PR that merges into `main`.** The `main` branch is protected and only updated by human maintainers.
 - When creating a PR, always use `--base dev` (e.g., `gh pr create --base dev ...` or the equivalent MCP tool parameter).


### PR DESCRIPTION
## Summary
- Add an explicit pre-work step to the Branch Policy section in `CLAUDE.md`: at session start, run `git fetch origin --prune && git rebase origin/dev` before making any changes.
- The harness cuts session branches off `main` (the GitHub default), so without rebasing, Claude misses commits already merged to `dev`.
- Note in the policy that the GitHub default intentionally stays `main` (so new users land on the stable branch) — `dev` is Claude's starting point, not the public default.

## Test plan
- [x] `CLAUDE.md` renders correctly and the new bullet appears at the top of the Branch Policy section.
- [ ] Next Claude session on this repo follows the new instruction and rebases onto `dev` before working.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194cikahz5hmfqGxhJRhLM1)_