### PR TITLE
Move right-panel view controls below the Sort dropdown

### DIFF
--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -16,6 +16,9 @@
       [mode]="sortMode"
       (modeChange)="onSortModeChange($event)"
     />
+  </div>
+
+  <div class="view-row">
     <vt-view-controls
       side="right"
       [currentMediaType]="currentMediaType"

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -23,21 +23,25 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  border-bottom: 1px solid var(--border);
 
   vt-label-sort {
     flex: 1;
     min-width: 0;
   }
 
-  // Remove the sort component's own border since the row provides it
+  // Remove the sort component's own border so the view-row below provides it
   ::ng-deep .label-sort-bar {
     border-bottom: none;
   }
 }
 
-.view-controls-slot {
-  margin-right: 12px;
+.view-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-bottom: 1px solid var(--border);
 }
 
 .label-divider {


### PR DESCRIPTION
## Summary
- On the right panel of the labeling/finding interface, give the **Sort** label and dropdown their own row.
- The six view-mode buttons (thumbnail size, list/grid, click/hover focus) now sit on the line below.

## Test plan
- [x] `npm run build:prod` succeeds.
- [ ] Open Find and Label views and confirm the right panel shows Sort on one line with the six view buttons on the line below.


---
_Generated by [Claude Code](https://claude.ai/code/session_0158Z1QCggSTxy3kVc6isqq2)_