### PR TITLE
Show thumbnails in right-panel label list view

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -15,12 +15,12 @@
         (mouseenter)="onEntryMouseEnter(entry.id)"
         (keydown)="onEntryKeydown($event, entry.id)"
       >
+        @if (hasThumbnailUrl(entry.id)) {
+          <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
+        } @else if (placeholderIcon(entry.id)) {
+          <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>
+        }
         @if (isGrid) {
-          @if (hasThumbnailUrl(entry.id)) {
-            <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
-          } @else if (placeholderIcon(entry.id)) {
-            <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>
-          }
           <span class="vote-name-grid">{{ entry.name }}</span>
         } @else {
           <span class="vote-name">{{ entry.name }}</span>

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -52,6 +52,9 @@ h3 {
   cursor: pointer;
   color: var(--text-vote);
   line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 
   &:hover {
     color: var(--text-primary);
@@ -78,24 +81,40 @@ h3 {
 }
 
 .vote-thumbnail {
-  width: 100%;
-  aspect-ratio: 1;
-  object-fit: contain;
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
   border-radius: 3px;
   background: var(--bg-surface);
+  flex-shrink: 0;
+
+  .vote-entry-grid & {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+    object-fit: contain;
+  }
 }
 
 .vote-placeholder {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  aspect-ratio: 1;
+  width: 28px;
+  height: 28px;
   border-radius: 3px;
   background: var(--bg-surface);
   color: var(--text-muted);
-  font-size: 1.5rem;
+  font-size: 1rem;
   overflow: hidden;
+  flex-shrink: 0;
+
+  .vote-entry-grid & {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+    font-size: 1.5rem;
+  }
 }
 
 .vote-name {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -137,7 +137,6 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   }
 
   placeholderIcon(id: number): string | null {
-    if (!this.isGrid) return null;
     if (this.hasThumbnailUrl(id)) return null;
     const media = this.mediaMap.get(id);
     if (!media) return null;


### PR DESCRIPTION
## Summary
- The right panel's labeled-items list now renders a small thumbnail (or media-type placeholder icon) next to each entry's name in **list** view mode, matching the existing behavior of the left panel's media list.
- Grid view mode is unchanged.
- Affects all media types where a thumbnail is available (image, video, document, audio waveform); audio/text/other types fall back to the same placeholder glyph used in grid mode.

## Test plan
- [ ] Load an image dataset, label a few items, switch the right panel to **List** view — confirm thumbnails appear next to each name.
- [ ] Switch the right panel back to **Grid** — confirm the existing grid layout is unchanged.
- [ ] Try the same on audio (waveform thumbnail), video (frame), and text (¶ placeholder) datasets.

---
_Generated by [Claude Code](https://claude.ai/code/session_017xexbxhCvAM3SpGgs9qNeJ)_