### PR TITLE
Combine trainable models by merging their labelsets

### DIFF
--- a/docs/combine-models-ui.plan.md
+++ b/docs/combine-models-ui.plan.md
@@ -1,0 +1,99 @@
+# Combine Models — UI Plan
+
+## Status
+
+- **Backend:** ✅ shipped
+  - `LabelSet.merge(*others, conflict_policy="drop")` in `vtsearch/datasets/labelset.py`
+  - `POST /api/trainable-models/combine` in `vtsearch/routes/trainable_models.py`
+  - Tests: `tests/test_combine_models.py`
+- **Frontend:** ⏳ this document
+
+## Goal
+
+Let a user pick two or more trainable models of the same media type and produce a new trainable model whose labelset is the merge of the sources. The new model is ordinary in every other way: it appears in the trainable-models list, can be activated against a dataset, trained, and calibrated like any other.
+
+## API contract (already implemented)
+
+`POST /api/trainable-models/combine`
+
+```json
+{
+  "names": ["Dog Barks", "More Dog Barks"],
+  "new_name": "All Dog Barks",
+  "conflict_policy": "drop"
+}
+```
+
+Responses:
+
+| Status | Meaning |
+|--------|---------|
+| `201`  | Combined model created. Body includes `name`, `media_type`, `num_labels`, `combined_from`, `source_label_counts`, `examples`. |
+| `400`  | Bad input: <2 names, missing `new_name`, mixed `media_type`, unsupported `conflict_policy`. |
+| `404`  | At least one source name not found. |
+| `409`  | A trainable model already exists with `new_name`. |
+| `422`  | Merge produced an empty labelset (every key was a conflict). |
+
+## Where it lives in the UI
+
+Mirror **Combine Datasets**:
+- Combine Datasets is a dataset *importer* surfaced inside the dataset-add flow.
+- Combine Models is **not** a dataset operation. Surface it on the **Trainable Models** management surface.
+
+Concretely: the trainable-models list/management view (the screen that already lists all trainable models with `num_labels`, rename, delete) gets a new top-bar button **"Combine…"**. The button opens a modal.
+
+> If trainable-models management is currently embedded in the Detector / Model Registry area rather than its own page, add the button there next to the existing "New trainable model" CTA. The exact host component is whichever one calls `GET /api/trainable-models` to render the list — see `frontend/src/app/services/` for the corresponding service.
+
+## Modal: "Combine Trainable Models"
+
+### Step 1 — Pick sources
+
+- Multi-select list of all trainable models, grouped by `media_type` (audio / image / text / video / document).
+- The first model the user checks **locks the media-type filter**: the rows for other media types either dim out or get hidden, with a small "Showing only audio models" hint and a "Clear" link to reset.
+- Each row shows: name, num_labels, last_trained_at, current text_query.
+- Below the list: a running tally — *"3 selected · 247 total labels (will dedupe + drop conflicts)"*.
+- The button advances to step 2 once ≥2 are checked.
+
+### Step 2 — Name and review
+
+- **New name** text input.
+  - Inline validation: required, no name collision (call `GET /api/trainable-models` to check; show "A model named 'X' already exists" inline).
+- **Sources summary** — read-only list of selected models with their label counts.
+- **Conflict policy** — dropdown with a single option for now: *"Drop conflicting labels"*. Render the dropdown disabled with a tooltip ("Only one policy supported today") so the field is discoverable when we add more.
+- **Examples preview** — show the deduped examples list that will be carried forward (the API will recompute the same way; this is informational).
+- Primary button: **Combine**. Secondary: Back / Cancel.
+
+### Step 3 — Result
+
+After the `POST /api/trainable-models/combine` call:
+
+- **201**: success toast — *"Combined model 'All Dog Barks' created with 247 labels (dropped 12 conflicts)."* Auto-select the new model in the list. Compute `dropped = sum(source_label_counts) - num_labels`; show "+ N labels deduped" if `dropped > 0`.
+- **422 empty**: error banner inside the modal — *"Every label was a conflict — no model was created. Try fewer or more aligned sources."* Keep the modal open.
+- **409 collision**: error banner asking for a different name. Keep the modal open.
+- **400 / 404 / 500**: generic error banner with the server's `error` message.
+
+## Data flow
+
+1. On modal open, fetch `/api/trainable-models` to populate the picker. Already cached by whatever service backs the trainable-models page — reuse it.
+2. On submit, call the endpoint. On success, refresh the list (the existing service should expose a `refresh()` or the equivalent observable trigger).
+3. No new state in `ActiveContextService`; the user can choose to activate the new combined model afterwards through the normal flow.
+
+## Components to add / touch
+
+- New modal component: `frontend/src/app/components/combine-trainable-models-dialog/` (Angular standalone component or whichever pattern the app already uses — match siblings).
+- New method on the trainable-models service (likely `frontend/src/app/services/trainable-models.service.ts` — confirm path): `combine(names: string[], newName: string, conflictPolicy: 'drop'): Observable<CombineResult>`.
+- Trigger button on the trainable-models list view.
+- Type definition for `CombineResult` matching the 201 response shape.
+
+## Out of scope (deliberately)
+
+- **Conflict-resolution UI** — no per-row conflict review. Drop-on-conflict is the only policy; if users want richer resolution we add it later as additional options on the dropdown.
+- **Pre-merge preview** — we don't pre-call a "dry-run" endpoint to show the exact merged count before submit. The result toast tells the user. (If we want this later, add a `dry_run: true` flag to the combine endpoint that returns the would-be counts without writing.)
+- **Re-train on combine** — combining is a labelset op only; the threshold + MLP are computed at activation time, same as any other trainable model. No "train now" checkbox.
+- **Inheriting labelset_source** — never carry a source from the inputs. (Already enforced server-side.)
+
+## Open questions for follow-up
+
+1. Should the modal offer to **delete the source models** after a successful combine? Probably no by default — destructive, irreversible — but a checkbox might be nice. Default unchecked.
+2. Should the combined model's `combined_from` field be **surfaced in the list view** as a badge ("Combined from A + B")? Low-priority but useful for provenance.
+3. When more `conflict_policy` values land (e.g. `majority`, `last_wins`), does the dropdown grow, or do we move to a richer "Conflicts" sub-step? Defer until we actually add a second policy.

--- a/tests/test_combine_models.py
+++ b/tests/test_combine_models.py
@@ -1,0 +1,317 @@
+"""Tests for combining trainable models via labelset merge.
+
+Covers both the underlying ``LabelSet.merge`` helper and the
+``POST /api/trainable-models/combine`` endpoint.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from vtsearch.datasets.labelset import LabeledElement, LabelSet
+from vtsearch.settings import get_trainable_models_dir
+
+
+@pytest.fixture(autouse=True)
+def clean_trainable_models_dir():
+    tm_dir = get_trainable_models_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+    yield
+    tm_dir = get_trainable_models_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+
+
+def _el(md5, label, *, importer="server_folder", path="/data", name="", metadata=None):
+    """Build a LabeledElement with a fully-populated origin."""
+    origin = {"importer": importer, "params": {"path": path}}
+    return LabeledElement(
+        md5=md5,
+        label=label,
+        origin=origin,
+        origin_name=name or md5,
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LabelSet.merge — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLabelSetMerge:
+    def test_merge_disjoint_origins(self):
+        a = LabelSet([_el("aa", "good", path="/A", name="a1")])
+        b = LabelSet([_el("bb", "bad", path="/B", name="b1")])
+        merged = a.merge(b)
+        assert len(merged) == 2
+        labels = {(e.md5, e.label) for e in merged}
+        assert labels == {("aa", "good"), ("bb", "bad")}
+
+    def test_merge_dedupes_same_origin_same_label(self):
+        e1 = _el("xx", "good", path="/A", name="same")
+        e2 = _el("xx", "good", path="/A", name="same")
+        merged = LabelSet([e1]).merge(LabelSet([e2]))
+        assert len(merged) == 1
+        assert merged.elements[0].label == "good"
+
+    def test_merge_drops_conflicting_origins(self):
+        e_good = _el("xx", "good", path="/A", name="same")
+        e_bad = _el("xx", "bad", path="/A", name="same")
+        e_other = _el("yy", "good", path="/A", name="other")
+        merged = LabelSet([e_good, e_other]).merge(LabelSet([e_bad]))
+        keys = {(e.md5, e.label) for e in merged}
+        assert keys == {("yy", "good")}
+
+    def test_merge_falls_back_to_md5_for_legacy_no_origin(self):
+        # Two legacy entries with no origin but same md5 + label dedupe;
+        # if labels disagree they drop.
+        legacy_good = LabeledElement(md5="aa", label="good")
+        legacy_good_2 = LabeledElement(md5="aa", label="good")
+        legacy_bad = LabeledElement(md5="bb", label="bad")
+        legacy_bad_conflict = LabeledElement(md5="bb", label="good")
+
+        merged = LabelSet([legacy_good, legacy_bad]).merge(
+            LabelSet([legacy_good_2, legacy_bad_conflict])
+        )
+        keys = [(e.md5, e.label) for e in merged]
+        assert keys == [("aa", "good")]  # bb dropped on conflict
+
+    def test_merge_drops_elements_with_neither_origin_nor_md5(self):
+        ghost = LabeledElement(md5="", label="good", origin=None)
+        real = _el("aa", "good")
+        merged = LabelSet([ghost]).merge(LabelSet([real]))
+        assert len(merged) == 1
+        assert merged.elements[0].md5 == "aa"
+
+    def test_merge_shallow_merges_metadata_later_wins(self):
+        e1 = _el("xx", "good", metadata={"src": "A", "shared": 1})
+        e2 = _el("xx", "good", metadata={"shared": 2, "extra": "B"})
+        merged = LabelSet([e1]).merge(LabelSet([e2]))
+        assert len(merged) == 1
+        assert merged.elements[0].metadata == {"src": "A", "shared": 2, "extra": "B"}
+
+    def test_merge_distinguishes_by_origin_name_within_same_origin(self):
+        # Same importer+params but different origin_name → distinct elements.
+        a = _el("a1", "good", path="/A", name="file_1.wav")
+        b = _el("a2", "bad", path="/A", name="file_2.wav")
+        merged = LabelSet([a]).merge(LabelSet([b]))
+        assert len(merged) == 2
+
+    def test_merge_preserves_first_seen_order(self):
+        a = _el("aa", "good", name="a")
+        b = _el("bb", "good", name="b")
+        c = _el("cc", "good", name="c")
+        merged = LabelSet([a, b]).merge(LabelSet([c, a]))  # a duplicated
+        assert [e.origin_name for e in merged] == ["a", "b", "c"]
+
+    def test_merge_rejects_unknown_conflict_policy(self):
+        with pytest.raises(ValueError):
+            LabelSet([]).merge(LabelSet([]), conflict_policy="majority")
+
+    def test_merge_three_way_conflict_drops_all_disputed(self):
+        a = _el("xx", "good")
+        b = _el("xx", "good")
+        c = _el("xx", "bad")
+        merged = LabelSet([a]).merge(LabelSet([b]), LabelSet([c]))
+        assert len(merged) == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/trainable-models/combine endpoint
+# ---------------------------------------------------------------------------
+
+
+def _create_model(client, name, *, media_type="audio", text_query="q"):
+    res = client.post(
+        "/api/trainable-models",
+        json={"name": name, "media_type": media_type, "text_query": text_query},
+    )
+    assert res.status_code == 201, res.get_json()
+
+
+def _save_labelset(client, name, labelset_dict):
+    """Directly write a labelset onto an existing trainable model on disk."""
+    from vtsearch.models.trainable_model_store import _model_path, _read_model, _write_model
+
+    p = _model_path(name)
+    data = _read_model(p)
+    assert data is not None
+    data["labelset"] = labelset_dict
+    _write_model(p, data)
+
+
+class TestCombineEndpointValidation:
+    def test_missing_names(self, client):
+        res = client.post("/api/trainable-models/combine", json={"new_name": "X"})
+        assert res.status_code == 400
+        assert "names" in res.get_json()["error"]
+
+    def test_only_one_name(self, client):
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A"], "new_name": "X"},
+        )
+        assert res.status_code == 400
+
+    def test_missing_new_name(self, client):
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"]},
+        )
+        assert res.status_code == 400
+        assert "new_name" in res.get_json()["error"]
+
+    def test_unknown_source_model(self, client):
+        _create_model(client, "A")
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "Nope"], "new_name": "X"},
+        )
+        assert res.status_code == 404
+
+    def test_media_type_mismatch(self, client):
+        _create_model(client, "A", media_type="audio")
+        _create_model(client, "B", media_type="image")
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "X"},
+        )
+        assert res.status_code == 400
+        assert "media_type" in res.get_json()["error"]
+
+    def test_new_name_collision(self, client):
+        _create_model(client, "A")
+        _create_model(client, "B")
+        _create_model(client, "X")  # already exists
+        # Give A and B at least one matching label so the merge isn't empty.
+        ls = LabelSet([_el("aa", "good")]).to_dict()
+        _save_labelset(client, "A", ls)
+        _save_labelset(client, "B", ls)
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "X"},
+        )
+        assert res.status_code == 409
+
+    def test_unsupported_conflict_policy(self, client):
+        _create_model(client, "A")
+        _create_model(client, "B")
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "X", "conflict_policy": "majority"},
+        )
+        assert res.status_code == 400
+
+    def test_empty_after_merge_rejected(self, client):
+        _create_model(client, "A")
+        _create_model(client, "B")
+        _save_labelset(client, "A", LabelSet([_el("aa", "good")]).to_dict())
+        _save_labelset(client, "B", LabelSet([_el("aa", "bad")]).to_dict())
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "X"},
+        )
+        assert res.status_code == 422
+        assert "empty" in res.get_json()["error"].lower()
+
+
+class TestCombineEndpointSuccess:
+    def test_combine_disjoint_labelsets(self, client):
+        _create_model(client, "A", text_query="alpha")
+        _create_model(client, "B", text_query="beta")
+        _save_labelset(
+            client,
+            "A",
+            LabelSet([_el("aa", "good", name="a1"), _el("bb", "bad", name="b1")]).to_dict(),
+        )
+        _save_labelset(
+            client,
+            "B",
+            LabelSet([_el("cc", "good", name="c1")]).to_dict(),
+        )
+
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "Combined"},
+        )
+        assert res.status_code == 201
+        body = res.get_json()
+        assert body["success"] is True
+        assert body["num_labels"] == 3
+        assert body["combined_from"] == ["A", "B"]
+        assert body["source_label_counts"] == [2, 1]
+        assert body["media_type"] == "audio"
+
+    def test_combine_persists_combined_model(self, client):
+        _create_model(client, "A", text_query="alpha")
+        _create_model(client, "B", text_query="beta")
+        _save_labelset(client, "A", LabelSet([_el("aa", "good")]).to_dict())
+        _save_labelset(client, "B", LabelSet([_el("bb", "good")]).to_dict())
+
+        client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "Combined"},
+        )
+
+        got = client.get("/api/trainable-models/Combined").get_json()
+        assert got["name"] == "Combined"
+        assert got["combined_from"] == ["A", "B"]
+        assert len(got["labelset"]["labels"]) == 2
+        # Should NOT inherit any labelset_source from sources.
+        assert "labelset_source" not in got
+
+    def test_combine_drops_conflicts_keeps_agreements(self, client):
+        _create_model(client, "A")
+        _create_model(client, "B")
+        _save_labelset(
+            client,
+            "A",
+            LabelSet([_el("agree", "good"), _el("conflict", "good")]).to_dict(),
+        )
+        _save_labelset(
+            client,
+            "B",
+            LabelSet([_el("agree", "good"), _el("conflict", "bad")]).to_dict(),
+        )
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "Combined"},
+        )
+        assert res.status_code == 201
+        labels = res.get_json()
+        assert labels["num_labels"] == 1
+
+    def test_combine_dedupes_examples(self, client):
+        _create_model(client, "A", text_query="dog barking")
+        _create_model(client, "B", text_query="dog barking")  # same text_query
+        _save_labelset(client, "A", LabelSet([_el("aa", "good")]).to_dict())
+        _save_labelset(client, "B", LabelSet([_el("bb", "good")]).to_dict())
+
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B"], "new_name": "Combined"},
+        )
+        body = res.get_json()
+        # Both source models auto-created an example for their text_query.
+        # Dedup should collapse the duplicates.
+        assert body["examples"] == [{"type": "text", "value": "dog barking"}]
+
+    def test_combine_three_models(self, client):
+        _create_model(client, "A")
+        _create_model(client, "B")
+        _create_model(client, "C")
+        _save_labelset(client, "A", LabelSet([_el("aa", "good")]).to_dict())
+        _save_labelset(client, "B", LabelSet([_el("bb", "good")]).to_dict())
+        _save_labelset(client, "C", LabelSet([_el("cc", "bad")]).to_dict())
+
+        res = client.post(
+            "/api/trainable-models/combine",
+            json={"names": ["A", "B", "C"], "new_name": "Combined"},
+        )
+        assert res.status_code == 201
+        assert res.get_json()["num_labels"] == 3
+        assert res.get_json()["source_label_counts"] == [1, 1, 1]

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -219,6 +219,102 @@ class LabelSet:
             elements.append(LabeledElement.from_dict(entry))
         return cls(elements)
 
+    # ------------------------------------------------------------------
+    # Merging
+    # ------------------------------------------------------------------
+
+    def merge(self, *others: LabelSet, conflict_policy: str = "drop") -> LabelSet:
+        """Merge this labelset with one or more others.
+
+        Elements are keyed by ``Origin`` (importer + params) when present,
+        falling back to ``md5`` for legacy entries with no origin.  Elements
+        with neither an origin nor an md5 are dropped (no way to dedupe).
+
+        Behaviour:
+
+        * Same key + same label across inputs → kept once.  Metadata dicts
+          from later sources are shallow-merged onto earlier ones (later
+          wins on key collision).
+        * Same key + different labels → conflict; resolved per
+          ``conflict_policy``.
+
+        Args:
+            *others: Additional :class:`LabelSet` instances to merge in.
+            conflict_policy: Currently only ``"drop"`` is supported, which
+                removes every entry that has a label disagreement across
+                the input labelsets.
+
+        Returns:
+            A new :class:`LabelSet`.  Insertion order follows ``self``
+            first, then each ``other`` in turn; on dedup the *first* entry
+            wins position, with later metadata merged in.
+        """
+        if conflict_policy != "drop":
+            raise ValueError(f"Unsupported conflict_policy: {conflict_policy!r}")
+
+        # First pass: collect every label-claim per key so we can detect
+        # disagreement before deciding what to keep.
+        labels_by_key: dict[Any, set[str]] = {}
+        for ls in (self, *others):
+            for el in ls.elements:
+                key = _element_key(el)
+                if key is None:
+                    continue
+                labels_by_key.setdefault(key, set()).add(el.label)
+
+        conflicting_keys = {k for k, labels in labels_by_key.items() if len(labels) > 1}
+
+        # Second pass: emit one element per non-conflicting key, in
+        # first-seen order.  Shallow-merge metadata from later occurrences.
+        merged: list[LabeledElement] = []
+        seen: dict[Any, int] = {}
+        for ls in (self, *others):
+            for el in ls.elements:
+                key = _element_key(el)
+                if key is None or key in conflicting_keys:
+                    continue
+                if key in seen:
+                    existing = merged[seen[key]]
+                    if el.metadata:
+                        merged_meta = dict(existing.metadata or {})
+                        merged_meta.update(el.metadata)
+                        existing.metadata = merged_meta
+                    continue
+                seen[key] = len(merged)
+                merged.append(
+                    LabeledElement(
+                        md5=el.md5,
+                        label=el.label,
+                        origin=dict(el.origin) if el.origin else None,
+                        origin_name=el.origin_name,
+                        filename=el.filename,
+                        category=el.category,
+                        metadata=dict(el.metadata) if el.metadata else None,
+                    )
+                )
+        return LabelSet(merged)
+
+
+def _element_key(el: LabeledElement) -> Any:
+    """Return a hashable identity key for an element, or ``None`` if it has none.
+
+    Prefers the element's ``Origin`` (importer + params) so that the same
+    source media can be deduped across labelsets even when re-embedded with
+    different embedders.  Falls back to ``md5`` for legacy entries that
+    have no origin.
+    """
+    if el.origin:
+        importer = el.origin.get("importer", "")
+        params = el.origin.get("params") or {}
+        try:
+            params_key = tuple(sorted(params.items()))
+        except TypeError:
+            params_key = tuple(sorted((str(k), str(v)) for k, v in params.items()))
+        return ("origin", importer, params_key, el.origin_name)
+    if el.md5:
+        return ("md5", el.md5)
+    return None
+
 
 def _clip_to_elements(media: dict[str, Any], label: str, *, expand_dupes: bool = True) -> list[LabeledElement]:
     """Convert a media dict into one or more :class:`LabeledElement` instances.

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -426,6 +426,133 @@ def import_labels_into_model(name: str, importer_name: str):
     )
 
 
+# ---------------------------------------------------------------------------
+# POST /api/trainable-models/combine
+# ---------------------------------------------------------------------------
+
+
+@trainable_models_bp.route("/api/trainable-models/combine", methods=["POST"])
+def combine_trainable_models():
+    """Combine the labelsets of two or more trainable models into a new model.
+
+    Expects JSON::
+
+        {
+            "names": ["Dog Barks", "More Dog Barks"],
+            "new_name": "All Dog Barks",
+            "conflict_policy": "drop"        # optional; default "drop"
+        }
+
+    All source models must share the same ``media_type``.  The new model's
+    labelset is the merge of all source labelsets, keyed by ``Origin``
+    (importer + params + origin_name) and falling back to ``md5`` for
+    legacy entries.  Per ``conflict_policy="drop"`` (the only supported
+    policy today), any element key that appears with disagreeing labels
+    across the sources is removed entirely.
+
+    The combined model is *purely a labelset entry* — no labelset-source
+    is inherited from the sources, and the threshold/MLP are computed
+    later when the model is activated against a dataset.
+
+    Returns ``201`` with a summary on success, or ``4xx`` on validation
+    errors (missing names, unknown source, media-type mismatch, name
+    collision, empty merged result).
+    """
+    body = request.get_json(force=True, silent=True) or {}
+    names = body.get("names") or []
+    new_name = (body.get("new_name") or "").strip()
+    conflict_policy = (body.get("conflict_policy") or "drop").strip()
+
+    if not isinstance(names, list) or len(names) < 2:
+        return jsonify({"error": "names must be a list of at least 2 trainable model names"}), 400
+    if not new_name:
+        return jsonify({"error": "new_name is required"}), 400
+    if conflict_policy != "drop":
+        return jsonify({"error": f"Unsupported conflict_policy: {conflict_policy!r}"}), 400
+
+    new_path = _model_path(new_name)
+    if new_path.exists():
+        return jsonify({"error": f"A trainable model named '{new_name}' already exists"}), 409
+
+    from vtsearch.datasets.labelset import LabelSet
+
+    sources: list[dict] = []
+    for src_name in names:
+        src_path = _model_path(src_name)
+        src_data = _read_model(src_path)
+        if src_data is None:
+            return jsonify({"error": f"Trainable model '{src_name}' not found"}), 404
+        sources.append(src_data)
+
+    media_types = {s.get("media_type", "") for s in sources}
+    if len(media_types) > 1:
+        return jsonify(
+            {"error": f"All source models must share the same media_type; got {sorted(media_types)}"}
+        ), 400
+    media_type = next(iter(media_types))
+    if not media_type or media_type == "any":
+        return jsonify({"error": "Source models must have a specific media_type (not empty or 'any')"}), 400
+
+    labelsets = [LabelSet.from_dict(s.get("labelset") or {}) for s in sources]
+    merged = labelsets[0].merge(*labelsets[1:], conflict_policy=conflict_policy)
+
+    if len(merged) == 0:
+        return jsonify(
+            {
+                "error": (
+                    "Combined labelset is empty after applying conflict policy "
+                    f"{conflict_policy!r}; nothing to save."
+                )
+            }
+        ), 422
+
+    # Dedupe examples across sources by (type, value)
+    merged_examples: list[dict] = []
+    seen_ex: set[tuple[str, str]] = set()
+    for s in sources:
+        for ex in s.get("examples") or []:
+            key = (ex.get("type", ""), ex.get("value", ""))
+            if key in seen_ex:
+                continue
+            seen_ex.add(key)
+            merged_examples.append(ex)
+
+    text_query = ""
+    for ex in merged_examples:
+        if ex.get("type") == "text" and ex.get("value"):
+            text_query = ex["value"]
+            break
+    if not text_query:
+        for s in sources:
+            if s.get("text_query"):
+                text_query = s["text_query"]
+                break
+
+    new_data = {
+        "name": new_name,
+        "text_query": text_query,
+        "media_example": "",
+        "media_type": media_type,
+        "examples": merged_examples,
+        "created_at": time.time(),
+        "labelset": merged.to_dict(),
+        "combined_from": list(names),
+    }
+    _write_model(new_path, new_data)
+
+    return jsonify(
+        {
+            "success": True,
+            "name": new_name,
+            "media_type": media_type,
+            "num_labels": len(merged),
+            "combined_from": list(names),
+            "source_label_counts": [len(ls) for ls in labelsets],
+            "examples": merged_examples,
+        }
+    ), 201
+
+
 # Canonical location: vtsearch.models.training_workflow
 from vtsearch.models.training_workflow import apply_and_retrain as _apply_and_retrain  # noqa: E402
 


### PR DESCRIPTION
## Summary
- New `LabelSet.merge(*others, conflict_policy="drop")` keyed by `Origin` (importer + params + origin_name), falling back to md5 for legacy origin-less entries. Same key + same label dedupes (with shallow metadata merge, later wins); same key + different labels drops entirely.
- New `POST /api/trainable-models/combine` endpoint: validates that all sources share the same `media_type`, rejects empty merge results (422), name collisions (409), and unknown sources (404). Examples are concatenated and deduped by `(type, value)`. The combined model never inherits a `labelset_source` from inputs and records a `combined_from` provenance field.
- Combining is purely a labelset op — embedder mismatch between sources is a non-issue because no vectors are merged. Threshold + MLP are computed at activation time against whatever dataset the new model is later loaded against, exactly like any other trainable model.
- Tests: `tests/test_combine_models.py` covers origin-keyed dedup, three-way conflict drop, md5 fallback, metadata merge, examples dedup, and every endpoint validation path.
- UI design: `docs/combine-models-ui.plan.md` lays out the modal flow on the trainable-models management surface — pick ≥2 sources of the same media type, name the result, submit, toast.

## Test plan
- [x] `./run-tests.sh` — full default suite passes (3091 passed, 1 skipped, 2 xpassed)
- [x] `pytest tests/test_combine_models.py tests/test_trainable_models.py tests/test_origin_labelset.py` — 124 passed

https://claude.ai/code/session_019tttuyNq2mz17WReV3e5Lo

---
_Generated by [Claude Code](https://claude.ai/code/session_019tttuyNq2mz17WReV3e5Lo)_