### PR TITLE
Add dedicated Combine Datasets modal

### DIFF
--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -1,0 +1,96 @@
+<vt-modal title="Combine Datasets" [open]="true" (closed)="close()">
+  <div class="combine-modal-body">
+    <p class="combine-intro">
+      Merge the selected datasets into a single new dataset. Entries that
+      appear in more than one source (matched by content hash) are kept only
+      once.
+    </p>
+
+    @if (rows.length === 0) {
+      <p class="empty-state">
+        No datasets to combine. Close this dialog and pick at least two
+        datasets on the dashboard.
+      </p>
+    } @else {
+      <table class="combine-table">
+        <thead>
+          <tr>
+            <th class="col-name">Dataset</th>
+            <th class="col-type">Type</th>
+            <th class="col-num">#&nbsp;Items</th>
+            <th class="col-actions" aria-label="Remove from combine"></th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of rows; track row.id) {
+            <tr [class.row-mismatch]="distinctMediaTypes.length > 1 && row.media_type !== rows[0].media_type">
+              <td class="col-name">
+                <span class="dataset-name" [title]="row.pkl_path">{{ row.name }}</span>
+              </td>
+              <td class="col-type">
+                @if (mediaTypeIcon(row.media_type)) {
+                  <vt-icon [icon]="mediaTypeIcon(row.media_type)" [size]="14"></vt-icon>
+                }
+                {{ mediaTypeLabel(row.media_type) }}
+              </td>
+              <td class="col-num">{{ row.num_items | number }}</td>
+              <td class="col-actions">
+                <button
+                  class="row-remove-btn"
+                  type="button"
+                  (click)="removeRow(row.id)"
+                  [title]="'Remove ' + row.name + ' from this combine'"
+                  aria-label="Remove from combine"
+                >&times;</button>
+              </td>
+            </tr>
+          }
+        </tbody>
+        <tfoot>
+          <tr>
+            <td class="col-name">{{ rows.length }} datasets</td>
+            <td class="col-type">
+              @if (sharedMediaType) {
+                {{ mediaTypeLabel(sharedMediaType) }}
+              } @else {
+                <span class="mismatch-warning">mismatched</span>
+              }
+            </td>
+            <td class="col-num">{{ totalItems | number }}</td>
+            <td class="col-actions"></td>
+          </tr>
+        </tfoot>
+      </table>
+
+      @if (disabledReason) {
+        <p class="warn-text">{{ disabledReason }}</p>
+      } @else {
+        <p class="info-text">
+          The combined dataset will contain up to {{ totalItems | number }}
+          {{ mediaTypeLabel(sharedMediaType) || sharedMediaType }} items
+          (duplicates removed automatically).
+        </p>
+      }
+
+      @if (error) {
+        <p class="error-text">{{ error }}</p>
+      }
+    }
+  </div>
+
+  <div class="form-actions" modal-footer>
+    <button class="btn btn--secondary" (click)="close()" [disabled]="submitting">Cancel</button>
+    <button
+      class="btn btn--primary"
+      (click)="submit()"
+      [disabled]="submitting || !canCombine"
+      [title]="disabledReason || 'Combine these datasets into a new one'"
+    >
+      @if (submitting) {
+        Combining...
+      } @else {
+        Combine
+      }
+    </button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -1,0 +1,124 @@
+:host {
+  ::ng-deep .modal-content {
+    width: 640px;
+    max-width: 95vw;
+  }
+}
+
+.combine-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.combine-intro {
+  margin: 0;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .9rem;
+  line-height: 1.4;
+}
+
+.combine-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .9rem;
+
+  th, td {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  thead th {
+    font-weight: 600;
+    color: var(--text-secondary, var(--text-muted));
+    font-size: .8rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+
+  tfoot td {
+    font-weight: 600;
+    border-top: 2px solid var(--border);
+    border-bottom: none;
+    background: var(--bg-subtle);
+  }
+
+  .col-num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .col-type {
+    white-space: nowrap;
+
+    vt-icon {
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+  }
+
+  .col-actions {
+    width: 32px;
+    text-align: right;
+  }
+
+  .dataset-name {
+    font-weight: 500;
+  }
+
+  tbody tr.row-mismatch {
+    background: rgba(255, 180, 0, .12);
+
+    .col-type {
+      color: var(--warn, #c47a00);
+      font-weight: 600;
+    }
+  }
+}
+
+.row-remove-btn {
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--text-secondary, var(--text-muted));
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+
+  &:hover {
+    color: var(--danger, #c43a3a);
+    background: var(--bg-subtle);
+  }
+}
+
+.mismatch-warning {
+  color: var(--warn, #c47a00);
+  font-style: italic;
+}
+
+.info-text {
+  margin: 0;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .85rem;
+}
+
+.warn-text {
+  margin: 0;
+  color: var(--warn, #c47a00);
+  font-size: .85rem;
+}
+
+.error-text {
+  margin: 0;
+  color: var(--danger, #c43a3a);
+  font-size: .85rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
@@ -1,0 +1,147 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { CombineDatasetsModalComponent } from './combine-datasets-modal.component';
+import { DatasetRegistryEntry } from '../../../models/api.models';
+
+describe('CombineDatasetsModalComponent', () => {
+  let component: CombineDatasetsModalComponent;
+  let fixture: ComponentFixture<CombineDatasetsModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockMediaTypes = {
+    media_types: [
+      { type_id: 'audio', name: 'Audio', icon: '🎵' },
+      { type_id: 'image', name: 'Image', icon: '🖼' },
+    ],
+  };
+
+  const ds = (id: string, name: string, type: string, num: number, pkl: string): DatasetRegistryEntry => ({
+    id,
+    name,
+    media_type: type,
+    num_items: num,
+    pkl_path: pkl,
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CombineDatasetsModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CombineDatasetsModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function flushMediaTypes() {
+    httpMock.expectOne('/api/media-types').flush(mockMediaTypes);
+  }
+
+  it('builds rows from input datasets, filtering out entries with no pkl_path', () => {
+    component.datasets = [
+      ds('a', 'Alpha', 'audio', 10, '/data/a.pkl'),
+      ds('b', 'Bravo', 'audio', 20, ''),
+      ds('c', 'Charlie', 'audio', 30, '/data/c.pkl'),
+    ];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    expect(component.rows.length).toBe(2);
+    expect(component.rows.map((r) => r.id)).toEqual(['a', 'c']);
+    expect(component.totalItems).toBe(40);
+  });
+
+  it('canCombine is true only when ≥2 rows share a single media type', () => {
+    component.datasets = [
+      ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
+      ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
+    ];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    expect(component.canCombine).toBeTrue();
+    expect(component.disabledReason).toBe('');
+  });
+
+  it('canCombine is false when media types differ', () => {
+    component.datasets = [
+      ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl'),
+    ];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    expect(component.canCombine).toBeFalse();
+    expect(component.disabledReason).toContain('same media type');
+  });
+
+  it('canCombine is false when fewer than two rows remain after removal', () => {
+    component.datasets = [
+      ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
+      ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
+    ];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    component.removeRow('b');
+    expect(component.rows.length).toBe(1);
+    expect(component.canCombine).toBeFalse();
+    expect(component.disabledReason).toContain('at least two');
+  });
+
+  it('submit posts the pkl paths to /api/dataset/combine and emits combineStarted', () => {
+    component.datasets = [
+      ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
+      ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
+    ];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    let started = false;
+    component.combineStarted.subscribe(() => { started = true; });
+
+    component.submit();
+    const req = httpMock.expectOne('/api/dataset/combine');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ datasets: ['/x/a.pkl', '/x/b.pkl'] });
+    req.flush({ ok: true });
+
+    expect(started).toBeTrue();
+    expect(component.submitting).toBeFalse();
+  });
+
+  it('submit surfaces backend errors without emitting combineStarted', () => {
+    component.datasets = [
+      ds('a', 'Alpha', 'audio', 10, '/x/a.pkl'),
+      ds('b', 'Bravo', 'audio', 20, '/x/b.pkl'),
+    ];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    let started = false;
+    component.combineStarted.subscribe(() => { started = true; });
+
+    component.submit();
+    const req = httpMock.expectOne('/api/dataset/combine');
+    req.flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+
+    expect(started).toBeFalse();
+    expect(component.error).toBe('boom');
+    expect(component.submitting).toBeFalse();
+  });
+
+  it('submit is a no-op when canCombine is false', () => {
+    component.datasets = [ds('a', 'Alpha', 'audio', 10, '/x/a.pkl')];
+    fixture.detectChanges();
+    flushMediaTypes();
+
+    component.submit();
+    httpMock.expectNone('/api/dataset/combine');
+  });
+});

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -1,0 +1,118 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../../modal/modal.component';
+import { IconComponent } from '../../icon/icon.component';
+import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { DatasetRegistryEntry, MediaTypeInfo } from '../../../models/api.models';
+
+interface CombineRow {
+  id: string;
+  name: string;
+  media_type: string;
+  num_items: number;
+  pkl_path: string;
+}
+
+@Component({
+  selector: 'vt-combine-datasets-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent],
+  templateUrl: './combine-datasets-modal.component.html',
+  styleUrl: './combine-datasets-modal.component.scss',
+})
+export class CombineDatasetsModalComponent implements OnInit {
+  /** Datasets pre-selected on the dashboard when the modal was opened. */
+  @Input() datasets: DatasetRegistryEntry[] = [];
+
+  @Output() closed = new EventEmitter<void>();
+  @Output() combineStarted = new EventEmitter<void>();
+
+  rows: CombineRow[] = [];
+  mediaTypes: MediaTypeInfo[] = [];
+  submitting = false;
+  error = '';
+
+  constructor(private datasetsApi: DatasetsApiService) {}
+
+  ngOnInit(): void {
+    this.rows = this.datasets
+      .map((d) => ({
+        id: d.id,
+        name: d.name,
+        media_type: d.media_type,
+        num_items: Number(d['num_items'] ?? 0),
+        pkl_path: String(d['pkl_path'] ?? ''),
+      }))
+      .filter((r) => !!r.pkl_path);
+
+    this.datasetsApi.getMediaTypes().subscribe({
+      next: (res) => {
+        this.mediaTypes = res.media_types || [];
+      },
+    });
+  }
+
+  /** Total media items across all selected datasets, before deduplication. */
+  get totalItems(): number {
+    return this.rows.reduce((sum, r) => sum + (r.num_items || 0), 0);
+  }
+
+  get distinctMediaTypes(): string[] {
+    return Array.from(new Set(this.rows.map((r) => r.media_type)));
+  }
+
+  get sharedMediaType(): string {
+    return this.distinctMediaTypes.length === 1 ? this.distinctMediaTypes[0] : '';
+  }
+
+  get canCombine(): boolean {
+    return this.rows.length >= 2 && this.distinctMediaTypes.length === 1;
+  }
+
+  /** Tooltip / inline reason describing why the Combine button is disabled. */
+  get disabledReason(): string {
+    if (this.rows.length < 2) {
+      return 'Need at least two datasets to combine.';
+    }
+    if (this.distinctMediaTypes.length > 1) {
+      return `All datasets must share a media type (got ${this.distinctMediaTypes.join(', ')}).`;
+    }
+    return '';
+  }
+
+  mediaTypeLabel(typeId: string): string {
+    const mt = this.mediaTypes.find((m) => m.type_id === typeId);
+    return mt?.name || typeId;
+  }
+
+  mediaTypeIcon(typeId: string): string {
+    const mt = this.mediaTypes.find((m) => m.type_id === typeId);
+    return mt?.icon || '';
+  }
+
+  removeRow(id: string): void {
+    this.rows = this.rows.filter((r) => r.id !== id);
+  }
+
+  submit(): void {
+    if (!this.canCombine) return;
+    this.submitting = true;
+    this.error = '';
+    const paths = this.rows.map((r) => r.pkl_path);
+    this.datasetsApi.combineDatasets({ datasets: paths }).subscribe({
+      next: () => {
+        this.submitting = false;
+        this.combineStarted.emit();
+      },
+      error: (err) => {
+        this.submitting = false;
+        this.error = (err?.error?.error as string) || 'Combine failed';
+      },
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -274,11 +274,17 @@
   <vt-dataset-importer-modal
     [guessedMediaType]="guessedMediaType"
     [guessedMediaEmbedder]="guessedMediaEmbedder"
-    [initialImporter]="importerInitialName"
-    [initialFormValues]="importerInitialFormValues"
     (closed)="closeImporterModal()"
     (importStarted)="onImportComplete()"
     (demoSelected)="onDemoSelected($event)"
+  />
+}
+
+@if (combineModalOpen) {
+  <vt-combine-datasets-modal
+    [datasets]="combineModalDatasets"
+    (closed)="closeCombineModal()"
+    (combineStarted)="onCombineStarted()"
   />
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -21,6 +21,7 @@ import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-mo
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
+import { CombineDatasetsModalComponent } from './combine-datasets-modal/combine-datasets-modal.component';
 import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
 import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
@@ -37,6 +38,7 @@ import { IconComponent } from '../icon/icon.component';
     DatasetCardComponent,
     ModelCardComponent,
     DatasetImporterModalComponent,
+    CombineDatasetsModalComponent,
     NewModelModalComponent,
     LabelExporterModalComponent,
     LabelImporterModalComponent,
@@ -73,10 +75,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   importerModalOpen = false;
   importerClosing = false;
-  /** Importer name to auto-select when the modal opens (for "Combine Selected"). */
-  importerInitialName = '';
-  /** Pre-filled form values for the auto-selected importer. */
-  importerInitialFormValues: Record<string, unknown> = {};
+  combineModalOpen = false;
+  /** Datasets passed into the Combine modal when it opens. */
+  combineModalDatasets: DatasetRegistryEntry[] = [];
   newModelModalOpen = false;
   newModelClosing = false;
   exportModalOpen = false;
@@ -399,21 +400,25 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Combine the currently-selected datasets into a new one.  Opens the
-   * regular Add Dataset modal, jumped to the (otherwise hidden)
-   * combine_datasets importer with the selected pkl paths pre-filled.
-   * The button is only visible/enabled when ≥2 datasets of the same media
-   * type are selected, so we don't re-validate that here.
+   * Open the dedicated Combine Datasets modal pre-loaded with the
+   * currently-selected datasets. The modal handles its own validation,
+   * row removal, and submission.
    */
   combineSelectedDatasets(): void {
     const targets = this.datasets.filter((d) => this.selectedDatasetIds.has(d.id));
-    const paths = targets
-      .map((d) => (d['pkl_path'] as string) || '')
-      .filter((p) => !!p);
-    if (paths.length < 2) return;
-    this.importerInitialName = 'combine_datasets';
-    this.importerInitialFormValues = { datasets: paths.join(',') };
-    this.openImporterModal();
+    if (targets.length < 2) return;
+    this.combineModalDatasets = targets;
+    this.combineModalOpen = true;
+  }
+
+  closeCombineModal(): void {
+    this.combineModalOpen = false;
+    this.combineModalDatasets = [];
+  }
+
+  onCombineStarted(): void {
+    this.closeCombineModal();
+    this.datasetState.refresh();
   }
 
   /**
@@ -748,8 +753,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   closeImporterModal(): void {
     this.importerModalOpen = false;
     this.importerClosing = true;
-    this.importerInitialName = '';
-    this.importerInitialFormValues = {};
   }
 
   onImporterAnimationEnd(): void {
@@ -759,8 +762,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   onImportComplete(): void {
     this.importerModalOpen = false;
     this.importerClosing = true;
-    this.importerInitialName = '';
-    this.importerInitialFormValues = {};
     this.startProgressPolling();
   }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -21,10 +21,6 @@ export class DatasetImporterModalComponent implements OnInit {
   @Input() guessedMediaType = '';
   /** Embedder name guessed from existing datasets/in-progress loads (e.g. "siglip"). */
   @Input() guessedMediaEmbedder = '';
-  /** When set, jump straight to this importer (even hidden ones) on open. */
-  @Input() initialImporter = '';
-  /** Form values to pre-fill after auto-selecting the initial importer. */
-  @Input() initialFormValues: Record<string, unknown> = {};
 
   @Output() closed = new EventEmitter<void>();
   @Output() importStarted = new EventEmitter<void>();
@@ -132,21 +128,8 @@ export class DatasetImporterModalComponent implements OnInit {
   ngOnInit(): void {
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
-        // Keep ALL importers (including hidden_from_picker ones) so callers
-        // can land on a hidden importer via `initialImporter`.  The picker
-        // UI filters hidden importers in `orderedImporters` instead.
-        this.importers = res.importers || [];
+        this.importers = (res.importers || []).filter((imp) => !imp['hidden_from_picker']);
         this.declaredTabs = res.tabs || [];
-        if (this.initialImporter) {
-          const target = this.importers.find((i) => i.name === this.initialImporter);
-          if (target) {
-            this.selectImporter(target);
-            // Apply pre-fill values after selectImporter resets formValues
-            for (const [k, v] of Object.entries(this.initialFormValues)) {
-              this.formValues[k] = v;
-            }
-          }
-        }
       },
     });
     this.datasetsApi.getEmbedders().subscribe({


### PR DESCRIPTION
## Summary
- The Combine Datasets feature was previously crammed into the Add Dataset modal as a hidden importer that required typing comma-separated paths into a free-form text field. Replaced with a focused dialog designed for the purpose.
- New `vt-combine-datasets-modal` lists each selected dataset (name, media type with icon, item count, per-row remove button), validates media-type consistency inline, shows the projected combined size, and posts directly to `/api/dataset/combine`.
- Dropped the now-unused `initialImporter` / `initialFormValues` plumbing from `vt-dataset-importer-modal` and `DashboardComponent` (its only caller was the combine flow).

## Test plan
- [x] `./run-tests.sh core` — all 345 tests pass, frontend TypeScript build OK
- [ ] Manual: open dashboard, select 2+ datasets of the same media type, click the merge button, verify modal opens with rows pre-populated
- [ ] Manual: remove a row to drop below 2, verify Combine button disables with reason
- [ ] Manual: select datasets of mismatched media types, verify Combine button disables with reason and rows highlight
- [ ] Manual: submit, verify a new combined dataset appears in the registry


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2k7pHHMrUiEXWTv8qQ4T7)_