### PR TITLE
Fix autorun toggle UI not updating when unmarking a model

### DIFF
--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -250,9 +250,22 @@ class TestAutorunDetectors:
         assert resp.get_json()["autodetect"] is True
         assert "ghost-model" in get_autorun_detector_names()
 
-    def test_set_autodetect_false_on_nonexistent_detector_returns_404(self, client):
+    def test_set_autodetect_false_on_unknown_detector_returns_404(self, client):
         resp = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": False})
         assert resp.status_code == 404
+
+    def test_set_autodetect_false_clears_settings_only_entry(self, client, isolated_settings):
+        """A model-registry entry persisted only in settings must be removable via the toggle."""
+        from vtsearch.settings import get_autorun_detector_names
+
+        on = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": True})
+        assert on.status_code == 200
+        assert "ghost-model" in get_autorun_detector_names()
+
+        off = client.put("/api/autorun-detectors/ghost-model/autodetect", json={"autodetect": False})
+        assert off.status_code == 200
+        assert off.get_json()["autodetect"] is False
+        assert "ghost-model" not in get_autorun_detector_names()
 
     def test_set_autodetect_missing_field_returns_400(self, client):
         resp = client.put("/api/autorun-detectors/any/autodetect", json={})

--- a/vtsearch/routes/detectors_crud.py
+++ b/vtsearch/routes/detectors_crud.py
@@ -228,8 +228,8 @@ def set_autorun_detector_autodetect_route(name):
     if autodetect:
         add_autorun_detector_name(name)
     else:
-        remove_autorun_detector_name(name)
-        if not found_in_memory:
+        removed_from_settings = remove_autorun_detector_name(name)
+        if not found_in_memory and not removed_from_settings:
             return jsonify({"error": "Detector not found"}), 404
     return jsonify({"success": True, "autodetect": bool(autodetect)})
 


### PR DESCRIPTION
## Summary

- `PUT /api/autorun-detectors/<name>/autodetect` returned 404 when unmarking autorun on a detector that wasn't loaded in memory, even though the persisted settings list was correctly updated.
- The dashboard's `toggleAutorun` only refreshes on success, so the 404 left the stale check icon in place until the user reloaded the browser.
- Now the endpoint only 404s when the name is found in neither the in-memory `autorun_detectors` dict nor the persisted `autorun_detector_names` list.

## Test plan

- [x] `python -m pytest tests/test_detectors.py -k autodetect` — 24 passed, including the new `test_set_autodetect_false_clears_settings_only_entry` that exercises the registry-only model path.
- [ ] Manual: in the dashboard, toggle Autorun on, then off — the icon should flip back to X without a reload.

https://claude.ai/code/session_01SBQXeGxQBRGYgkNBA9oZhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBQXeGxQBRGYgkNBA9oZhb)_