### PR TITLE
Combine trainable models from the dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/combine-models-modal/combine-models-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-models-modal/combine-models-modal.component.html
@@ -1,0 +1,63 @@
+<vt-modal [open]="true" title="Combine Trainable Models" [showCloseButton]="false" (closed)="close()">
+  <form class="combine-form" (ngSubmit)="submit()">
+    <div class="form-group">
+      <label class="col-label" title="Trainable models being combined">Sources</label>
+      <ul class="source-list">
+        @for (row of rows; track row.name) {
+          <li class="source-row">
+            <span class="source-name" [title]="row.name">{{ row.name }}</span>
+            <span class="source-meta">
+              <span class="meta-pill" title="Number of labels in this source">{{ row.numLabels }} labels</span>
+              @if (row.textQuery) {
+                <span class="meta-query" [title]="'Text query: ' + row.textQuery">"{{ row.textQuery }}"</span>
+              }
+            </span>
+          </li>
+        }
+      </ul>
+      <p class="info-text">{{ rows.length }} models · {{ totalLabels }} total labels (will dedupe + drop conflicts) · media type: {{ mediaType }}</p>
+    </div>
+
+    <div class="form-group">
+      <label class="col-label" for="combine-new-name" title="The name of the new combined model">New Name <span class="required">*</span></label>
+      <input
+        id="combine-new-name"
+        class="form-input"
+        [(ngModel)]="newName"
+        name="newName"
+        placeholder="e.g. All Dog Barks"
+        title="A short name for the combined model"
+        autofocus
+      />
+      @if (nameValidationMessage) {
+        <p class="error-text">{{ nameValidationMessage }}</p>
+      }
+    </div>
+
+    <div class="form-group">
+      <label class="col-label" for="combine-policy" title="How to handle labels that disagree across sources">Conflict policy</label>
+      <select
+        id="combine-policy"
+        class="form-select"
+        [(ngModel)]="conflictPolicy"
+        name="conflictPolicy"
+        disabled
+        title="Only one policy is supported today"
+      >
+        <option value="drop">Drop conflicting labels</option>
+      </select>
+      <p class="info-text">Only one policy is supported today.</p>
+    </div>
+
+    @if (error) {
+      <p class="error-text">{{ error }}</p>
+    }
+  </form>
+
+  <div modal-footer>
+    <button type="button" class="btn btn--secondary" [disabled]="submitting" (click)="close()" title="Discard and close the dialog">Cancel</button>
+    <button type="button" class="btn btn--primary" [disabled]="!canSubmit" (click)="submit()" title="Combine the selected models into a new one">
+      {{ submitting ? 'Combining...' : 'Combine' }}
+    </button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/dashboard/combine-models-modal/combine-models-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-models-modal/combine-models-modal.component.scss
@@ -1,0 +1,95 @@
+.combine-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 480px;
+  max-width: 100%;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.col-label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-secondary, var(--text-muted));
+}
+
+.required {
+  color: var(--color-bad);
+}
+
+.info-text {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.error-text {
+  margin: 4px 0 0;
+  color: var(--color-bad);
+  font-size: 0.85rem;
+}
+
+.source-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-subtle);
+}
+
+.source-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.source-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.source-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.meta-pill {
+  padding: 2px 6px;
+  border-radius: 10px;
+  background: var(--bg-hover);
+}
+
+.meta-query {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+}

--- a/frontend/src/app/components/dashboard/combine-models-modal/combine-models-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-models-modal/combine-models-modal.component.ts
@@ -1,0 +1,119 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../../modal/modal.component';
+import { TrainableModelsApiService } from '../../../services/trainable-models-api.service';
+import { CombineModelsResult, ModelRegistryEntry } from '../../../models/api.models';
+
+interface SourceRow {
+  name: string;
+  numLabels: number;
+  textQuery: string;
+}
+
+@Component({
+  selector: 'vt-combine-models-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent],
+  templateUrl: './combine-models-modal.component.html',
+  styleUrl: './combine-models-modal.component.scss',
+})
+export class CombineModelsModalComponent implements OnInit {
+  /** Trainable models the user has selected on the dashboard. */
+  @Input() sources: ModelRegistryEntry[] = [];
+  /** All registered model names — used for inline name-collision check. */
+  @Input() existingNames: string[] = [];
+
+  @Output() closed = new EventEmitter<void>();
+  @Output() created = new EventEmitter<string>();
+
+  newName = '';
+  conflictPolicy: 'drop' = 'drop';
+  submitting = false;
+  error = '';
+
+  rows: SourceRow[] = [];
+  totalLabels = 0;
+  mediaType = '';
+
+  constructor(private modelsApi: TrainableModelsApiService) {}
+
+  ngOnInit(): void {
+    this.rows = this.sources.map((m) => ({
+      name: this.trainableNameOf(m),
+      numLabels: (m.num_training as number) ?? 0,
+      textQuery: (m.text_query as string) ?? '',
+    }));
+    this.totalLabels = this.rows.reduce((sum, r) => sum + r.numLabels, 0);
+    this.mediaType = this.sources[0]?.media_type ?? '';
+  }
+
+  /**
+   * The combine API operates on trainable-model file names, which match
+   * `trainable_model_name` for UI-created models and fall back to the
+   * registry display name.
+   */
+  private trainableNameOf(m: ModelRegistryEntry): string {
+    return ((m['trainable_model_name'] as string) || m.name || '').trim();
+  }
+
+  get nameCollision(): boolean {
+    const trimmed = this.newName.trim();
+    if (!trimmed) return false;
+    return this.existingNames.some((n) => n === trimmed);
+  }
+
+  get nameValidationMessage(): string {
+    const trimmed = this.newName.trim();
+    if (!trimmed) return '';
+    if (this.nameCollision) return `A model named "${trimmed}" already exists.`;
+    return '';
+  }
+
+  get canSubmit(): boolean {
+    return (
+      !this.submitting &&
+      this.rows.length >= 2 &&
+      !!this.newName.trim() &&
+      !this.nameCollision
+    );
+  }
+
+  submit(): void {
+    if (!this.canSubmit) return;
+    const trimmed = this.newName.trim();
+    const names = this.rows.map((r) => r.name);
+    this.submitting = true;
+    this.error = '';
+
+    this.modelsApi.combine(names, trimmed, this.conflictPolicy).subscribe({
+      next: (resp: CombineModelsResult) => {
+        this.submitting = false;
+        this.created.emit(resp?.name || trimmed);
+      },
+      error: (err) => {
+        this.submitting = false;
+        const status = err?.status;
+        const serverMsg = err?.error?.error || '';
+        if (status === 422) {
+          this.error =
+            serverMsg ||
+            'Every label was a conflict — no model was created. Try fewer or more aligned sources.';
+        } else if (status === 409) {
+          this.error = serverMsg || `A model named "${trimmed}" already exists.`;
+        } else if (status === 404) {
+          this.error = serverMsg || 'A source model was not found.';
+        } else if (status === 400) {
+          this.error = serverMsg || 'Invalid combine request.';
+        } else {
+          this.error = serverMsg || 'Failed to combine models.';
+        }
+      },
+    });
+  }
+
+  close(): void {
+    if (this.submitting) return;
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -216,6 +216,14 @@
       </svg>
     </button>
     <div class="side-action-gap"></div>
+    <button class="side-action-btn" (click)="openCombineModelsModal()" [disabled]="isLoading || !combineSelectedModelsEnabled" [title]="combineSelectedModelsHint" aria-label="Combine selected models">
+      <!-- Two horizontal arrows on the left, merging smoothly into a single arrow on the right. -->
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
+        <path d="M3 17 C 10 17, 10 12, 17 12"/>
+        <polyline points="18 9 21 12 18 15"/>
+      </svg>
+    </button>
     <button class="side-action-btn side-action-delete" (click)="deleteSelectedModels()" [disabled]="isLoading || selectedModelIds.size === 0" [title]="selectedModelIds.size === 0 ? 'No models selected' : 'Delete selected models'" aria-label="Delete selected">
       <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedModelsConfirm" [class.side-action-delete-inactive]="!deletingSelectedModelsConfirm && wasDeletingSelectedModelsConfirm" (animationend)="onDeleteSelectedModelsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
@@ -287,6 +295,15 @@
     [defaultMediaType]="activeDatasetMediaType"
     (closed)="closeNewModelModal()"
     (created)="onModelCreated($event)"
+  />
+}
+
+@if (combineModelsModalOpen) {
+  <vt-combine-models-modal
+    [sources]="combineSelectedModelSources"
+    [existingNames]="allModelNames"
+    (closed)="closeCombineModelsModal()"
+    (created)="onModelsCombined($event)"
   />
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -22,6 +22,7 @@ import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { ModelCardComponent } from './model-card/model-card.component';
 import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
 import { NewModelModalComponent } from './new-model-modal/new-model-modal.component';
+import { CombineModelsModalComponent } from './combine-models-modal/combine-models-modal.component';
 import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
 import { DatasetStatsModalComponent } from '../modals/dataset-stats-modal/dataset-stats-modal.component';
@@ -38,6 +39,7 @@ import { IconComponent } from '../icon/icon.component';
     ModelCardComponent,
     DatasetImporterModalComponent,
     NewModelModalComponent,
+    CombineModelsModalComponent,
     LabelExporterModalComponent,
     LabelImporterModalComponent,
     DatasetStatsModalComponent,
@@ -79,6 +81,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   importerInitialFormValues: Record<string, unknown> = {};
   newModelModalOpen = false;
   newModelClosing = false;
+  combineModelsModalOpen = false;
   exportModalOpen = false;
   exportModelName = '';
   addLabelsModalOpen = false;
@@ -562,6 +565,59 @@ export class DashboardComponent implements OnInit, OnDestroy {
         },
       });
     }
+  }
+
+  /**
+   * True when the "Combine Selected Models" button should be enabled:
+   * at least two trainable models selected AND all of them share a media type.
+   */
+  get combineSelectedModelsEnabled(): boolean {
+    if (this.selectedModelIds.size < 2) return false;
+    const targets = this.models.filter((m) => this.selectedModelIds.has(m.id));
+    if (targets.length < 2) return false;
+    if (!targets.every((m) => m.trainable)) return false;
+    const types = new Set(targets.map((m) => m.media_type));
+    return types.size === 1;
+  }
+
+  get combineSelectedModelsHint(): string {
+    if (this.selectedModelIds.size < 2) {
+      return 'Select two or more trainable models to combine';
+    }
+    const targets = this.models.filter((m) => this.selectedModelIds.has(m.id));
+    if (!targets.every((m) => m.trainable)) {
+      return 'Only trainable models can be combined';
+    }
+    const types = new Set(targets.map((m) => m.media_type));
+    if (types.size !== 1) {
+      return 'All selected models must be of the same media type';
+    }
+    return 'Combine selected models into a new one';
+  }
+
+  get combineSelectedModelSources(): ModelRegistryEntry[] {
+    return this.models.filter((m) => this.selectedModelIds.has(m.id));
+  }
+
+  get allModelNames(): string[] {
+    return this.models.map((m) => m.name);
+  }
+
+  openCombineModelsModal(): void {
+    if (!this.combineSelectedModelsEnabled) return;
+    this.combineModelsModalOpen = true;
+  }
+
+  closeCombineModelsModal(): void {
+    this.combineModelsModalOpen = false;
+  }
+
+  onModelsCombined(newName: string): void {
+    this.combineModelsModalOpen = false;
+    // The new model will appear via the datasets$/models$ subscription's
+    // new-id auto-select logic; nothing more to do besides refreshing.
+    this.datasetState.refresh();
+    void newName;
   }
 
   onSpinSelectAllModelsEnd(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -392,6 +392,16 @@ export interface ModelsRegistryResponse {
   models: ModelRegistryEntry[];
 }
 
+export interface CombineModelsResult {
+  success: boolean;
+  name: string;
+  media_type: string;
+  num_labels: number;
+  combined_from: string[];
+  source_label_counts: number[];
+  examples: { type: string; value: string }[];
+}
+
 // --- Label Importers ---
 
 export interface LabelImporterInfo {

--- a/frontend/src/app/services/trainable-models-api.service.ts
+++ b/frontend/src/app/services/trainable-models-api.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { LoadingTasksResponse, TrainableModelsResponse, ModelsRegistryResponse } from '../models/api.models';
+import {
+  CombineModelsResult,
+  LoadingTasksResponse,
+  TrainableModelsResponse,
+  ModelsRegistryResponse,
+} from '../models/api.models';
 
 @Injectable({ providedIn: 'root' })
 export class TrainableModelsApiService {
@@ -33,6 +38,18 @@ export class TrainableModelsApiService {
 
   saveLabels(name: string): Observable<unknown> {
     return this.http.post(`/api/trainable-models/${name}/labels`, {});
+  }
+
+  combine(
+    names: string[],
+    newName: string,
+    conflictPolicy: 'drop' = 'drop',
+  ): Observable<CombineModelsResult> {
+    return this.http.post<CombineModelsResult>('/api/trainable-models/combine', {
+      names,
+      new_name: newName,
+      conflict_policy: conflictPolicy,
+    });
   }
 
   // --- Models Registry ---


### PR DESCRIPTION
## Summary

Adds the frontend half of "combine models" — the backend endpoint and `LabelSet.merge` already shipped (see `docs/combine-models-ui.plan.md`).

- New side-action button on the Dashboard's **Models** section, mirroring the existing **Combine Datasets** button. Enabled only when ≥2 trainable models of the same media type are selected; tooltip explains the disabled reason.
- New `CombineModelsModalComponent` that lists the source models with their label counts and current text query, asks for a new name (with inline collision check against the existing model registry), exposes the `conflict_policy` dropdown (currently single-option, disabled with a "Only one policy supported today" note), and surfaces server errors inline (422 empty merge, 409 name collision, 400/404/500 generic).
- `TrainableModelsApiService.combine(names, newName, conflictPolicy)` posts to `POST /api/trainable-models/combine`. New `CombineModelsResult` type captures the 201 response shape.
- On success, the modal closes and the existing dashboard auto-select-new-id logic surfaces the combined model in the list (no toast — using the existing dialog/alert system would be visually inconsistent here, so the new row is the affordance).

Deliberately out of scope per the plan: per-row conflict review, dry-run preview, retraining on combine, deleting source models, surfacing `combined_from` in the list.

## Test plan

- [x] `npm run build:prod` succeeds (frontend TS build is the standard pre-test gate).
- [ ] In the running app, select two trainable audio models, click the new **Combine** button, name the result, and verify a new row appears in the Models table.
- [ ] Same flow with mixed media types: button is disabled with the "All selected models must be of the same media type" tooltip.
- [ ] Same flow with a non-trainable model in the selection: button is disabled with the "Only trainable models can be combined" tooltip.
- [ ] Submit with a colliding name: inline validation surfaces the conflict before submit, and a 409 from the server is also rendered inside the modal.
- [ ] Submit with sources whose labels all conflict: 422 message renders inside the modal and the modal stays open.


---
_Generated by [Claude Code](https://claude.ai/code/session_012E4pJUKz5iojQa9LZiUY7E)_