### PR TITLE
Left-justify right-panel view buttons; fix grid-snap arithmetic

### DIFF
--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -38,7 +38,7 @@
 .view-row {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   flex-shrink: 0;
   padding: 4px 12px;
   border-bottom: 1px solid var(--border);

--- a/frontend/src/app/utils/grid-icon-size.ts
+++ b/frontend/src/app/utils/grid-icon-size.ts
@@ -57,5 +57,8 @@ export function snapPanelWidthToGridColumns(panelEl: HTMLElement, currentPanelWi
   // Preserve any structural offset between the panel edge and the grid element edge
   const offset = currentPanelWidth - boundingWidth;
 
-  return Math.round(minBoundingWidth + offset);
+  // Round up and add a 1px safety margin so sub-pixel layout rounding can't drop
+  // the snapped panel width below the threshold for `cols` columns (which would
+  // leave the user with cols-1 icons and an empty gap).
+  return Math.ceil(minBoundingWidth + offset) + 1;
 }


### PR DESCRIPTION
## Summary
- Right-panel view-mode toggle was right-aligned via `justify-content: flex-end` while the Sort widget directly above it is left-aligned, making the layout look inconsistent. Switch `.view-row` to `justify-content: flex-start` so the view buttons match the Sort widget.
- `snapPanelWidthToGridColumns` rounded the snapped panel width to the nearest pixel. Sub-pixel layout rounding (fractional `getBoundingClientRect`, scrollbar interactions) could land the result 1px below the threshold for N columns, so dragging to fit 2 icons would snap down to ~1.9 — CSS auto-fill then renders only 1 column with an empty gap. Switch the final round to `Math.ceil` and add a 1px safety margin so the snapped width never falls below the threshold.

## Test plan
- [x] `./run-tests.sh core` — 345 passed, frontend build OK
- [ ] Manual: drag the right panel divider until 2 icons fit, release, confirm it snaps to a width that still shows 2 icons (no empty gap).
- [ ] Manual: confirm the right-panel view-mode buttons are left-aligned, matching the Sort widget above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei2WHvW5g8pnqPPrNsmk3j)_