### PR TITLE
Combine datasets: name input + progress polling

### DIFF
--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -12,6 +12,17 @@
         datasets on the dashboard.
       </p>
     } @else {
+      <label class="name-field">
+        <span class="name-label">Name</span>
+        <input
+          type="text"
+          class="name-input"
+          [(ngModel)]="name"
+          placeholder="Combined dataset name"
+          [disabled]="submitting"
+        />
+      </label>
+
       <table class="combine-table">
         <thead>
           <tr>

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -18,6 +18,35 @@
   line-height: 1.4;
 }
 
+.name-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: .9rem;
+}
+
+.name-label {
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  font-weight: 600;
+}
+
+.name-input {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg, transparent);
+  color: var(--text, inherit);
+  font-size: .95rem;
+
+  &:focus {
+    outline: none;
+    border-color: var(--accent, #4a8edb);
+  }
+}
+
 .combine-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -32,6 +32,7 @@ export class CombineDatasetsModalComponent implements OnInit {
   mediaTypes: MediaTypeInfo[] = [];
   submitting = false;
   error = '';
+  name = '';
 
   constructor(private datasetsApi: DatasetsApiService) {}
 
@@ -46,11 +47,18 @@ export class CombineDatasetsModalComponent implements OnInit {
       }))
       .filter((r) => !!r.pkl_path);
 
+    this.name = this.defaultName();
+
     this.datasetsApi.getMediaTypes().subscribe({
       next: (res) => {
         this.mediaTypes = res.media_types || [];
       },
     });
+  }
+
+  /** Default combined-dataset name: source names joined with " + ". */
+  private defaultName(): string {
+    return this.rows.map((r) => r.name).filter((n) => !!n).join(' + ');
   }
 
   /** Total media items across all selected datasets, before deduplication. */
@@ -100,7 +108,8 @@ export class CombineDatasetsModalComponent implements OnInit {
     this.submitting = true;
     this.error = '';
     const paths = this.rows.map((r) => r.pkl_path);
-    this.datasetsApi.combineDatasets({ datasets: paths }).subscribe({
+    const name = (this.name || '').trim() || this.defaultName();
+    this.datasetsApi.combineDatasets({ datasets: paths, name }).subscribe({
       next: () => {
         this.submitting = false;
         this.combineStarted.emit();

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -421,7 +421,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   onCombineStarted(): void {
     this.closeCombineModal();
-    this.datasetState.refresh();
+    this.startProgressPolling();
   }
 
   /**

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -53,7 +53,17 @@ class CombineDatasetsImporter(DatasetImporter):
             field_type="text",
             description="Comma-separated paths to .pkl dataset files.",
         ),
+        ImporterField(
+            key="name",
+            label="Name",
+            field_type="text",
+            description="Display name for the new combined dataset.",
+        ),
     ]
+
+    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+        name = (field_values.get("name") or "").strip()
+        return name or self.display_name
 
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Combine datasets specified by *field_values['datasets']*.

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -297,6 +297,7 @@ def combine_datasets_route():
     """Combine multiple pickle datasets in a background thread."""
     body = request.get_json(force=True) or {}
     dataset_paths = body.get("datasets", [])
+    name = str(body.get("name", "") or "").strip()
 
     if not isinstance(dataset_paths, list) or len(dataset_paths) < 2:
         return jsonify({"error": "Provide at least two dataset file paths."}), 400
@@ -314,7 +315,7 @@ def combine_datasets_route():
     if importer is None:
         return jsonify({"error": "combine_datasets importer not available"}), 500
 
-    task_id = _run_importer_in_background(importer, {"datasets": dataset_paths})
+    task_id = _run_importer_in_background(importer, {"datasets": dataset_paths, "name": name})
     return jsonify({"ok": True, "message": "Combining datasets...", "task_id": str(task_id) if task_id else ""})
 
 


### PR DESCRIPTION
## Summary
- The Combine Datasets modal now has a **Name** input, defaulting to the source dataset names joined with " + ", and forwards it to the backend so the new dataset is registered with that label.
- Replaced the immediate registry refresh on combine-start with the standard loading-task polling. Combines run in a background thread, so refreshing the dataset list right after the API call would show the list before the new dataset was registered. Polling now refreshes once the task finishes (same pattern other importers use).

## Changes
- `vtsearch/datasets/importers/combine_datasets/__init__.py`: added a `name` `ImporterField` and overrode `resolve_display_name` to use it.
- `vtsearch/routes/datasets.py`: `/api/dataset/combine` now accepts and forwards `name` in `field_values`.
- `frontend/.../combine-datasets-modal.component.{ts,html,scss}`: name input with default `"A + B + ..."`; submitted along with the dataset paths.
- `frontend/.../dashboard.component.ts`: `onCombineStarted()` calls `startProgressPolling()` so the new dataset shows up automatically when the combine task finishes.

## Test plan
- [x] `./run-tests.sh datasets io core` (1363 passed, 1 skipped)
- [x] `npm run build:prod` (frontend builds clean)
- [ ] Manual: open Combine modal with two datasets selected, confirm default name is `"<A> + <B>"`, edit it, click Combine, confirm progress bar appears and the new dataset shows up in the list when done without a browser refresh.

https://claude.ai/code/session_014xytvf3W953ycPiqkhncs2

---
_Generated by [Claude Code](https://claude.ai/code/session_014xytvf3W953ycPiqkhncs2)_