### PR TITLE
Auto-load SigLIP embedder in siglip docker image

### DIFF
--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -45,6 +45,12 @@ SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache)"
 # ---------- application layer ----------
 COPY . .
 
+# Seed default settings so the SigLIP image embedder is preloaded at startup.
+# Docker copies this file into a fresh named volume on first creation, so new
+# deployments come ready-to-serve without the user manually toggling autoload.
+RUN mkdir -p /app/data && \
+    printf '{\n  "autoload_media_embedders": ["siglip"]\n}\n' > /app/data/settings.json
+
 # Runtime data directory (settings, embeddings, datasets, media files).
 # Mount a volume here to persist user data across container restarts.
 # Note: model weights live under /opt/vtsearch/models, NOT this volume.


### PR DESCRIPTION
## Summary
- Bake a default `data/settings.json` containing `autoload_media_embedders: ["siglip"]` into `Dockerfile.siglip`, so the SigLIP image embedder is preloaded at container startup without the user toggling autoload manually.
- Docker copies image contents into a fresh named volume on first creation, so new `docker-compose -f docker-compose.siglip.yml up` deployments come ready-to-serve. The Dockerfile already sets `VTSEARCH_SERVER_INIT=1`, which triggers `preload_autoload_media_types()` to read this list.

## Test plan
- [ ] `docker build -f Dockerfile.siglip -t vtsearch:siglip .`
- [ ] `docker compose -f docker-compose.siglip.yml up` against a fresh `vtsearch-data` volume; confirm startup logs show `Preloading siglip embedder...`
- [ ] Hit the UI and verify the SigLIP embedder is already loaded (no first-request stall).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JEYVuzhgkadv8pvrHeR1pU)_