### PR TITLE
Modernize Browse Media picker to share UI with Add Dataset

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,3 +1,8 @@
+// Picker chrome (importer tabs, demo table, server folder browser, badges)
+// lives in `frontend/src/scss/_picker-shared.scss` so it's defined once
+// globally and shared with the New Model > Browse Media picker — only
+// styles unique to this component remain below.
+
 // Pin the Add Dataset modal to a single large width so flipping between
 // tabs (Services / Server / Local / Demo) and inner widgets doesn't reflow
 // the dialog.  680px (matching the Settings modal) was too narrow for the
@@ -31,87 +36,11 @@
   padding-left: 20px;
 }
 
-.importer-tab-bar {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  width: 100%;
-  border-bottom: 2px solid var(--border);
-}
-
-.importer-tab {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 8px 16px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  background: none;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .85rem;
-  cursor: pointer;
-  transition: all .15s;
-  margin-bottom: -2px;
-  white-space: nowrap;
-
-  &:hover {
-    color: var(--text-primary);
-    background: var(--bg-subtle);
-  }
-
-  &.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-    font-weight: 600;
-  }
-}
-
-// Inner row of importer "tabs" within the active category.  Uses the same
-// underline-tab styling as the top-level category tabs so all three tab
-// levels (category, importer, demo media-type) feel like one consistent
-// system.
-.importer-subtab-bar {
-  @extend .importer-tab-bar;
-}
-
-.importer-subtab {
-  @extend .importer-tab;
-
-  &.disabled, &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-}
-
-// Hint shown directly below the tab row when no tab/importer/media-type is
-// selected yet — placed where the next-step content will appear so the user's
-// eye lands on it naturally.
-.tab-bar-hint {
-  margin: 8px 0 0 0;
-  color: var(--text-muted);
-  font-size: .85rem;
-  font-style: italic;
-}
-
 // Extra vertical breathing room above grouped sections inside the Local /
 // Folder uploader (Folder picker, Chunk size, Embedder, Clipper). The
 // Recursive checkbox intentionally does NOT get this class — it is a
 // sub-option of the Folder picker above it.
-.form-group--section {
-  margin-top: 16px;
-}
-
-.importer-subtab-icon {
-  display: inline-flex;
-  align-items: center;
-}
-
-.empty-state--inline {
-  padding: 6px 10px;
-  font-size: .8rem;
-  color: var(--text-muted);
-  font-style: italic;
-}
+.form-group--section { margin-top: 16px; }
 
 .clipper-params {
   padding-left: 16px;
@@ -120,12 +49,6 @@
 }
 
 .demo-picker { gap: 12px; }
-
-// .demo-tab-bar / .demo-tab share the visual styling of the top
-// .importer-tab-bar / .importer-tab.  Define the chrome once via @extend
-// so the compiled output stays under the per-component CSS budget.
-.demo-tab-bar { @extend .importer-tab-bar; }
-.demo-tab { @extend .importer-tab; }
 
 .demo-embedder-row {
   display: flex;
@@ -137,170 +60,6 @@
   .form-select { max-width: 200px; }
 }
 
-.demo-content-area {
-  min-height: 200px;
-  max-height: 50vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.table-fixed {
-  table-layout: fixed;
-}
-
-.demo-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.83rem;
-
-  th, td {
-    padding: 6px 10px;
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-    white-space: nowrap;
-  }
-
-  // Body cells truncate with ellipsis when the column is narrower than
-  // their content. Header cells must NOT clip — they host the resize handle
-  // which pokes 6px to the left of the cell's edge.
-  td {
-    padding: 6px 12px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  th {
-    padding-right: 0;
-    position: sticky;
-    top: 0;
-    background: var(--bg-surface);
-    z-index: 1;
-    color: var(--text-secondary);
-    font-weight: 500;
-    font-size: 0.78rem;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    user-select: none;
-
-    // Headers are draggable for reordering (matches the Dashboard tables).
-    &[draggable='true'] {
-      cursor: grab;
-
-      &:active {
-        cursor: grabbing;
-      }
-    }
-
-    &.sortable {
-      cursor: pointer;
-
-      &:hover {
-        color: var(--text-primary);
-      }
-    }
-
-    &[draggable='true'].sortable {
-      cursor: grab;
-
-      &:active {
-        cursor: grabbing;
-      }
-    }
-
-    &.col-drop-target {
-      box-shadow: inset 0 0 0 2px var(--accent);
-    }
-
-    &.col-dragging {
-      opacity: 0.4;
-    }
-
-    .sort-indicator {
-      display: inline-block;
-      width: 1em;
-      text-align: center;
-      visibility: hidden;
-
-      &.active {
-        visibility: visible;
-      }
-    }
-
-    // See dashboard.component.scss for the full rationale; the handle sits on
-    // the LEFT of the cell after the divider it controls so it isn't covered
-    // by the next sticky <th>'s stacking context.
-    .col-resize-handle {
-      position: absolute;
-      top: 0;
-      left: -6px;
-      bottom: 0;
-      width: 12px;
-      cursor: col-resize;
-      z-index: 2;
-
-      &::after {
-        content: '';
-        position: absolute;
-        top: 20%;
-        bottom: 20%;
-        left: 5px;
-        width: 2px;
-        background: var(--accent);
-        opacity: 0.35;
-        transition: opacity 0.15s;
-      }
-
-      &:hover::after {
-        opacity: 0.7;
-      }
-    }
-  }
-
-  tbody tr {
-    cursor: pointer;
-    transition: background 0.1s;
-
-    &:hover {
-      background: var(--bg-hover);
-    }
-  }
-}
-
-.col-num { text-align: right; padding-right: 12px; }
-
-.col-desc, .col-name, .sf-dir-name, .col-status {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.col-desc { color: var(--text-muted); font-size: 0.78rem; }
-.col-name { font-weight: 600; color: var(--text-primary); }
-
-.sf-dir-date {
-  margin-left: auto;
-  color: var(--text-muted);
-  font-size: .75rem;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.demo-row {
-  &.ready .col-name { color: var(--color-good); }
-}
-
-.badge-ready, .badge-embedding, .badge-download {
-  display: inline-block;
-  padding: 1px 7px;
-  color: var(--btn-filled-text);
-  font-size: .7rem;
-  border-radius: 3px;
-}
-
-.badge-ready { background: var(--color-good); }
-.badge-embedding { background: var(--badge-embedding, var(--accent)); }
-.badge-download { background: var(--border); color: var(--text-muted); }
-
 .clipper-btn {
   text-align: left;
   white-space: nowrap;
@@ -308,74 +67,3 @@
 
 .server-folder-browser { gap: 12px; }
 .sf-browse-section { gap: 6px; }
-.sf-breadcrumbs { display: flex; align-items: center; gap: 2px; font-size: .8rem; flex-wrap: wrap; }
-
-.sf-breadcrumb {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: .8rem;
-
-  &:hover { background: var(--bg-subtle); }
-
-  &.active {
-    color: var(--text-primary);
-    font-weight: 600;
-    cursor: default;
-    &:hover { background: none; }
-  }
-}
-
-.sf-breadcrumb-sep { color: var(--text-muted); font-size: .75rem; }
-
-.sf-dir-list {
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  max-height: 220px;
-  overflow-y: auto;
-}
-
-.sf-dir-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-  text-align: left;
-  color: var(--text-primary);
-  font-size: .85rem;
-  transition: background .15s;
-
-  &:last-child { border-bottom: none; }
-  &:hover { background: var(--bg-subtle); }
-}
-
-.sf-dir-icon { font-size: .9rem; flex-shrink: 0; }
-
-.sf-empty-dir {
-  color: var(--text-muted);
-  font-size: .8rem;
-  padding: 12px;
-  text-align: center;
-}
-
-.sf-selected-path { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
-
-.sf-path-display {
-  font-size: .8rem;
-  color: var(--text-secondary, var(--text-muted));
-  background: var(--bg-subtle);
-  padding: 3px 8px;
-  border-radius: 3px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-}

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -83,7 +83,7 @@
             </div>
             <div class="example-col">
               <label class="col-label">Media Example</label>
-              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse loaded media to pick an example">Browse Media...</button>
+              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse demos, server folders, or upload a file to pick an example">Browse Media...</button>
               <input
                 #fileInput
                 type="file"
@@ -243,86 +243,269 @@
     <div class="media-picker">
       <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()" title="Return to the model creation form">&larr; Back</button>
 
-      <!-- Source selection (top level) -->
-      @if (!selectedSource) {
-        <p class="picker-instructions">Choose a source to browse media from:</p>
-        <div class="source-list">
-          @for (src of mediaSources; track src.name) {
-            <button class="importer-card" (click)="selectSource(src)">
-              <span class="importer-name">@if (src.icon) {<span class="importer-icon"><vt-icon [icon]="src.icon"></vt-icon></span> }{{ src.display_name || src.name }}</span>
-              @if (src.description) {
-                <span class="importer-desc">{{ src.description }}</span>
-              }
-            </button>
+      <!-- Category tabs (mirrors the Add Dataset modal so users see the same layout). -->
+      <div class="importer-picker">
+        <div class="importer-tab-bar">
+          @for (tab of visibleImporterTabs; track tab.id) {
+            <button
+              class="importer-tab"
+              [class.active]="activeImporterTab === tab.id"
+              (click)="selectImporterTab(tab.id)"
+              [title]="'Show ' + tab.label + ' media sources'"
+            >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
           }
         </div>
-      }
-
-      <!-- Browse items (demo list or server media files) -->
-      @if (selectedSource && !fileBrowsing && !browseLoading && browseItems.length > 0) {
-        <p class="picker-instructions">Select an item from <strong>{{ selectedSource.display_name || selectedSource.name }}</strong>:</p>
-        <div class="browse-list">
-          @for (item of browseItems; track item.key) {
-            <button class="browse-item" (click)="selectBrowseItem(item)" [title]="item.key">
-              {{ item.display || item.key }}
-            </button>
-          }
-        </div>
-      }
-
-      <!-- File browser (recursive directory navigation) -->
-      @if (fileBrowsing) {
-        <div class="breadcrumbs">
-          @for (seg of browsePath; track $index) {
-            @if ($index > 0) { <span class="breadcrumb-sep">/</span> }
-            @if ($index < browsePath.length - 1) {
-              <button class="breadcrumb-link" (click)="navigateBreadcrumb($index)">{{ seg }}</button>
-            } @else {
-              <span class="breadcrumb-current">{{ seg }}</span>
-            }
-          }
-        </div>
-
-        @if (fileLoading) {
-          <p class="empty-state">Loading...</p>
+        @if (!activeImporterTab) {
+          <p class="tab-bar-hint">Select where to pick a media example from.</p>
         }
 
-        @if (!fileLoading && browseEntries.length > 0) {
-          <div class="browse-list">
-            @for (entry of browseEntries; track entry.path) {
-              @if (entry.isDir) {
-                <button class="browse-item browse-dir" (click)="enterDirectory(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="folder"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                </button>
-              } @else {
-                <button class="browse-item browse-file" (click)="selectFile(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="file-text"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                  @if (entry.size_bytes != null) {
-                    <span class="entry-size">{{ formatSize(entry.size_bytes) }}</span>
-                  }
-                </button>
-              }
+        @if (activeImporterTab) {
+          <div class="importer-subtab-bar">
+            @if (importersForActiveTab.length === 0) {
+              <span class="empty-state empty-state--inline">No sources in this category.</span>
+            }
+            @for (imp of importersForActiveTab; track imp.name) {
+              <button
+                class="importer-subtab"
+                [class.active]="selectedImporter?.name === imp.name"
+                (click)="selectImporter(imp)"
+                [title]="imp.description || ''"
+              >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
             }
           </div>
+          @if (!selectedImporter && importersForActiveTab.length > 0) {
+            <p class="tab-bar-hint">Select a {{ activeImporterTabLabel }} source to browse.</p>
+          }
         }
+      </div>
 
-        @if (!fileLoading && browseEntries.length === 0) {
-          <p class="empty-state">No media files found in this directory.</p>
-        }
+      <!-- Demo picker view: media-type tabs + sortable demo table. -->
+      @if (activePickerView === 'demo' && selectedImporter && !demoFileBrowsing) {
+        <div class="demo-picker">
+          @if (demoLoading) {
+            <p class="empty-state">Loading demo datasets...</p>
+          } @else if (demos.length === 0) {
+            <p class="empty-state">No demo datasets available.</p>
+          } @else {
+            <div class="demo-tab-bar">
+              @for (tab of demoTabs; track tab) {
+                <button
+                  class="demo-tab"
+                  [class.active]="activeDemoTab === tab"
+                  (click)="selectDemoTab(tab)"
+                  [title]="'Filter demos by media type: ' + getDemoTabLabel(tab)"
+                >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabLabel(tab) }}</button>
+              }
+            </div>
+            @if (!activeDemoTab) {
+              <p class="tab-bar-hint">Select the media type to demonstrate.</p>
+            }
+
+            @if (activeDemoTab) {
+              <div class="demo-content-area">
+                <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
+                  <thead>
+                    <tr>
+                      @for (col of demoCols.columnOrder; track col; let first = $first) {
+                        <th
+                          [class.sortable]="demoCols.meta(col).sortable"
+                          [class.col-drop-target]="demoCols.isDropTarget(col)"
+                          [class.col-dragging]="demoCols.isDragging(col)"
+                          [class.col-num]="col === 'num_files' || col === 'num_categories'"
+                          [attr.data-col]="col"
+                          [title]="demoCols.meta(col).title"
+                          [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
+                          draggable="true"
+                          (click)="onDemoHeaderClick(col)"
+                          (dragstart)="demoCols.onColDragStart($event, col)"
+                          (dragover)="demoCols.onColDragOver($event, col)"
+                          (dragleave)="demoCols.onColDragLeave($event, col)"
+                          (drop)="demoCols.onColDrop($event, col)"
+                          (dragend)="demoCols.onColDragEnd($event)"
+                        >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
+                      }
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @for (demo of filteredDemos; track demo.name) {
+                      <tr
+                        class="demo-row"
+                        [class.ready]="demo.status === 'ready'"
+                        [class.disabled]="!isDemoBrowsable(demo)"
+                        role="button"
+                        tabindex="0"
+                        [attr.aria-label]="demo.label + ': ' + demo.description"
+                        [title]="isDemoBrowsable(demo) ? 'Browse files in ' + demo.label : 'This demo has not been downloaded. Use the Add Dataset window to fetch it first.'"
+                        (click)="selectDemo(demo)"
+                        (keydown.enter)="selectDemo(demo)"
+                        (keydown.space)="$event.preventDefault(); selectDemo(demo)"
+                      >
+                        @for (col of demoCols.columnOrder; track col) {
+                          @switch (col) {
+                            @case ('label') {
+                              <td class="col-name">{{ demo.label }}</td>
+                            }
+                            @case ('num_files') {
+                              <td class="col-num">{{ demo.num_files | number }}</td>
+                            }
+                            @case ('num_categories') {
+                              <td class="col-num">{{ demo.num_categories | number }}</td>
+                            }
+                            @case ('description') {
+                              <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
+                            }
+                            @case ('status') {
+                              <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+                            }
+                          }
+                        }
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              </div>
+            }
+          }
+        </div>
       }
 
-      @if (browseLoading) {
-        <p class="empty-state">Loading items...</p>
+      <!-- Demo file browser: appears after picking a demo from the table.
+           Reuses the server-folder-browser chrome so both file pickers feel
+           the same. -->
+      @if (activePickerView === 'demo' && selectedImporter && demoFileBrowsing) {
+        <div class="server-folder-browser">
+          <button class="btn btn--secondary btn--sm back-btn" (click)="backToDemoTable()" title="Return to the demo list">&larr; Back to demo list</button>
+          <div class="sf-browse-section">
+            <div class="sf-breadcrumbs">
+              @for (seg of demoFileBrowsePath; track $index) {
+                @if ($index > 0) { <span class="sf-breadcrumb-sep">/</span> }
+                <button class="sf-breadcrumb" [class.active]="$index === demoFileBrowsePath.length - 1" (click)="navigateDemoBreadcrumb($index)">{{ seg }}</button>
+              }
+            </div>
+
+            <div class="sf-dir-list">
+              @if (demoFileLoading) {
+                <p class="empty-state">Loading...</p>
+              } @else if (demoFileBrowseEntries.length === 0) {
+                <p class="sf-empty-dir">No media files found in this directory.</p>
+              }
+              @for (entry of demoFileBrowseEntries; track entry.path) {
+                @if (entry.isDir) {
+                  <button class="sf-dir-item" (click)="enterDemoDirectory(entry)" [title]="entry.path">
+                    <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
+                    <span class="sf-dir-name">{{ entry.name }}</span>
+                    @if (entry.modified_at) {
+                      <span class="sf-dir-date">{{ entry.modified_at }}</span>
+                    }
+                  </button>
+                } @else {
+                  <button class="sf-dir-item" (click)="selectDemoFile(entry)" [title]="'Use ' + entry.path + ' as the example'" [disabled]="demoFileLoading">
+                    <span class="sf-dir-icon"><vt-icon type="file-text"></vt-icon></span>
+                    <span class="sf-dir-name">{{ entry.name }}</span>
+                    @if (entry.size_bytes != null) {
+                      <span class="sf-dir-date">{{ formatSize(entry.size_bytes) }}</span>
+                    }
+                  </button>
+                }
+              }
+            </div>
+          </div>
+        </div>
       }
 
-      @if (selectedSource && !fileBrowsing && !browseLoading && browseItems.length === 0) {
-        <p class="empty-state">No items found in this source.</p>
+      <!-- Server folder browser: same breadcrumb chrome as the Add Dataset
+           modal, but lists files alongside directories so the user can pick
+           one to use as an example. -->
+      @if (activePickerView === 'server_folder' && selectedImporter) {
+        <div class="server-folder-browser">
+          <div class="sf-browse-section">
+            <label class="form-label">Browse server folders</label>
+            <div class="sf-breadcrumbs">
+              <button class="sf-breadcrumb" [class.active]="!sfBrowsePath" (click)="sfLoadDirectory('')">Root</button>
+              @for (crumb of sfBreadcrumbs; track $index) {
+                <span class="sf-breadcrumb-sep">/</span>
+                <button class="sf-breadcrumb" [class.active]="$index === sfBreadcrumbs.length - 1" (click)="sfNavigateBreadcrumb($index)">{{ crumb }}</button>
+              }
+            </div>
+
+            <div class="sf-dir-list">
+              @if (sfBrowseLoading) {
+                <p class="empty-state">Loading...</p>
+              } @else if (sfBrowseError) {
+                <p class="error-text">{{ sfBrowseError }}</p>
+              } @else if (sfBrowseDirs.length === 0 && sfBrowseFiles.length === 0) {
+                <p class="sf-empty-dir">No subdirectories or media files in this folder.</p>
+              }
+              @if (sfBrowsePath) {
+                <button class="sf-dir-item" (click)="sfGoUp()" title="Go to parent directory">
+                  <span class="sf-dir-icon"><vt-icon type="arrow-up"></vt-icon></span>
+                  <span class="sf-dir-name">..</span>
+                </button>
+              }
+              @for (dir of sfBrowseDirs; track dir.path) {
+                <button class="sf-dir-item" (click)="sfEnterDirectory(dir)" [title]="dir.path">
+                  <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
+                  <span class="sf-dir-name">{{ dir.name }}</span>
+                  @if (dir.modified_at) {
+                    <span class="sf-dir-date">{{ dir.modified_at }}</span>
+                  }
+                </button>
+              }
+              @for (file of sfBrowseFiles; track file.path) {
+                <button class="sf-dir-item" (click)="sfSelectFile(file)" [title]="'Use ' + file.path + ' as the example'" [disabled]="sfFileSelecting">
+                  <span class="sf-dir-icon"><vt-icon type="file-text"></vt-icon></span>
+                  <span class="sf-dir-name">{{ file.name }}</span>
+                  @if (file.size_bytes != null) {
+                    <span class="sf-dir-date">{{ formatSize(file.size_bytes) }}</span>
+                  }
+                </button>
+              }
+            </div>
+
+            <div class="sf-selected-path">
+              <span class="form-label">Path:</span>
+              <code class="sf-path-display">{{ sfAbsolutePath }}</code>
+            </div>
+          </div>
+
+          @if (sfBrowseError && !sfBrowseLoading) {
+            <p class="error-text">{{ sfBrowseError }}</p>
+          }
+        </div>
+      }
+
+      <!-- Local file upload: pick a single file from the user's machine.
+           local_folder and local_files share this view since only one example
+           file is needed regardless of how many the input collects. -->
+      @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
+        <div class="local-folder-uploader">
+          <p class="info-text">
+            Pick a media file on <strong>this computer</strong>. It will be uploaded to the server
+            and used as the example for this model.
+          </p>
+          @if (activePickerView === 'local_folder') {
+            <input
+              id="nmm-local-folder-input"
+              type="file"
+              class="form-input"
+              webkitdirectory
+              directory
+              multiple
+              (change)="onLocalFileSelected($event)"
+            />
+            <p class="info-text">
+              The first file in the picked folder will be used. To pick a single file directly,
+              switch to the <strong>Local Files</strong> tab.
+            </p>
+          } @else {
+            <input
+              id="nmm-local-files-input"
+              type="file"
+              class="form-input"
+              (change)="onLocalFileSelected($event)"
+            />
+          }
+        </div>
       }
     </div>
   }

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -1,3 +1,23 @@
+// Picker chrome (importer tabs, demo table, server folder browser, badges)
+// lives in `frontend/src/scss/_picker-shared.scss` so it's defined once
+// globally and shared with the Add Dataset modal — only styles unique to
+// this component remain below.
+
+// Pin the modal to a wider size when the media picker is on screen so the
+// demo table and folder browser have room (matches the Add Dataset modal at
+// 900px). The min-height keeps the dialog from collapsing to a thin strip
+// when the picker is in its "no source selected" state.
+:host {
+  ::ng-deep .modal-content {
+    min-height: 200px;
+  }
+
+  &:has(.media-picker) ::ng-deep .modal-content {
+    width: 900px;
+    min-height: 480px;
+  }
+}
+
 .tab-bar {
   display: flex;
   gap: 4px;
@@ -17,9 +37,7 @@
   margin-bottom: -1px;
   transition: color 0.15s, border-color 0.15s;
 
-  &:hover {
-    color: var(--text-primary);
-  }
+  &:hover { color: var(--text-primary); }
 
   &.active {
     color: var(--text-primary);
@@ -53,9 +71,7 @@
   gap: 4px;
 }
 
-.required {
-  color: var(--color-bad);
-}
+.required { color: var(--color-bad); }
 
 .info-text {
   color: var(--text-muted);
@@ -103,14 +119,10 @@
   text-align: center;
 }
 
-.hidden-file-input {
-  display: none;
-}
+.hidden-file-input { display: none; }
 
 // Single example display
-.example-display {
-  margin-top: 4px;
-}
+.example-display { margin-top: 4px; }
 
 .example-row {
   display: flex;
@@ -139,22 +151,55 @@
   font-size: 0.9rem;
 }
 
-// Media picker view
+// Media picker view container
 .media-picker {
-  min-height: 200px;
-  width: 480px;
-  max-width: 100%;
+  min-height: 320px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.back-btn {
-  margin-bottom: 12px;
+.back-btn { align-self: flex-start; }
+
+.btn--sm {
+  padding: 2px 10px;
+  font-size: .85rem;
 }
 
-.picker-instructions {
-  margin: 0 0 8px;
-  font-size: 0.9rem;
-  color: var(--text-primary);
+.importer-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
+
+.demo-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.server-folder-browser {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-left: 20px;
+}
+
+.sf-browse-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.local-folder-uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 20px;
+}
+
+// --- Trained-tab importer cards (label-importer picker) ---
 
 .source-list {
   display: flex;
@@ -186,42 +231,11 @@
   font-size: 0.9rem;
 }
 
-.importer-icon {
-  margin-right: 4px;
-}
+.importer-icon { margin-right: 4px; }
 
 .importer-desc {
   font-size: 0.8rem;
   color: var(--text-muted);
-}
-
-.browse-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.browse-item {
-  display: block;
-  width: 100%;
-  padding: 6px 12px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--bg-subtle);
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  font-size: 0.9rem;
-  transition: border-color 0.15s, background 0.15s;
-  white-space: normal;
-  word-break: break-word;
-
-  &:hover {
-    border-color: var(--accent);
-    background: var(--bg-hover);
-  }
 }
 
 .empty-state {
@@ -231,76 +245,8 @@
   padding: 16px 0;
 }
 
-// Breadcrumbs for file browser navigation
-.breadcrumbs {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 2px;
-  margin-bottom: 8px;
-  font-size: 0.85rem;
-}
-
-.breadcrumb-link {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--accent);
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: 0.85rem;
-
-  &:hover {
-    text-decoration: underline;
-    background: var(--bg-hover);
-  }
-}
-
-.breadcrumb-sep {
-  color: var(--text-muted);
-  margin: 0 1px;
-}
-
-.breadcrumb-current {
-  font-weight: 600;
-  padding: 2px 4px;
-}
-
-// File/directory entries
-.browse-dir {
-  font-weight: 600;
-}
-
-.browse-file {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.entry-icon {
-  flex-shrink: 0;
-}
-
-.entry-date {
-  margin-left: auto;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.entry-size {
-  margin-left: 0;
-  padding-left: 0.5rem;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  flex-shrink: 0;
-}
-
 // Custom select dropdown (supports icons inside options)
-.custom-select {
-  position: relative;
-}
+.custom-select { position: relative; }
 
 .custom-select-trigger {
   display: flex;
@@ -323,9 +269,7 @@
   opacity: 0.6;
   transition: transform 0.15s;
 
-  .custom-select.open & {
-    transform: rotate(180deg);
-  }
+  .custom-select.open & { transform: rotate(180deg); }
 }
 
 .custom-select-options {
@@ -356,9 +300,7 @@
   font-size: inherit;
   transition: background 0.1s;
 
-  &:hover {
-    background: var(--bg-hover);
-  }
+  &:hover { background: var(--bg-hover); }
 
   &.selected {
     background: var(--bg-active, var(--bg-hover));

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -8,16 +8,18 @@ import { TrainableModelsApiService } from '../../../services/trainable-models-ap
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
-import { ImporterField, ImporterInfo, MediaTypeInfo } from '../../../models/api.models';
+import {
+  DemoDataset,
+  ImporterField,
+  ImporterInfo,
+  ImporterPickerTab,
+  MediaTypeInfo,
+} from '../../../models/api.models';
 import {
   MediaCropModalComponent,
   MediaCropResult,
 } from '../../modals/media-crop-modal/media-crop-modal.component';
-
-interface BrowseItem {
-  key: string;
-  display: string;
-}
+import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 interface BrowseEntry {
   name: string;
@@ -70,18 +72,81 @@ export class NewModelModalComponent implements OnInit {
   exampleValue = '';
   exampleDisplay = '';
 
-  // Media picker state
-  mediaSources: ImporterInfo[] = [];
-  selectedSource: ImporterInfo | null = null;
-  browseItems: BrowseItem[] = [];
-  browseLoading = false;
+  // --- Media picker state (shares structure with the Add Dataset modal) ---
 
-  // File browser state (for demo & folder drill-down)
-  browseSource = '';
-  browsePath: string[] = [];
-  browseEntries: BrowseEntry[] = [];
-  fileBrowsing = false;
-  fileLoading = false;
+  /** All importers discovered from the backend, filtered to picker_views we
+   *  can use to select a single example file (demo, server_folder,
+   *  local_folder, local_files). */
+  mediaImporters: ImporterInfo[] = [];
+  /** Tab declarations (categories) returned by the backend. */
+  declaredImporterTabs: ImporterPickerTab[] = [];
+  /** Currently selected category tab (e.g. ``"demo"``, ``"server"``). */
+  activeImporterTab = '';
+  /** Currently selected importer within the active category. */
+  selectedImporter: ImporterInfo | null = null;
+
+  /** Front-of-list order for sub-importer tabs.  Mirrors the Add Dataset
+   *  modal's ordering so users see the same layout in both places. */
+  private static readonly PICKER_ORDER = [
+    'local_folder',
+    'local_files',
+    'server_folder',
+    'server_files',
+    'demo',
+  ];
+
+  /** Picker views supported by the single-file example picker.  Importers
+   *  whose ``picker_view`` is anything else (e.g. ``"form"``) are hidden
+   *  here — the user can still use them via the Add Dataset modal. */
+  private static readonly SUPPORTED_PICKER_VIEWS = new Set([
+    'demo',
+    'server_folder',
+    'local_folder',
+    'local_files',
+  ]);
+
+  // --- Demo picker state ---
+  demos: DemoDataset[] = [];
+  demoTabs: string[] = [];
+  activeDemoTab = '';
+  demoLoading = false;
+
+  /** Demo table column metadata + controller.  Reuses the same storage key
+   *  as the Add Dataset modal so column order and sort preferences stay in
+   *  sync between the two demo tables. */
+  static readonly DEMO_COL_META: Record<string, ColMeta> = {
+    label: { label: 'Name', title: 'Demo dataset name (click to sort)', sortable: true },
+    num_files: { label: '# Media', title: 'Number of media files in the demo dataset (click to sort)', sortable: true },
+    num_categories: { label: '# Cat.', title: 'Number of distinct categories or classes in the dataset (click to sort)', sortable: true },
+    description: { label: 'Description', title: 'Short description of the demo dataset contents (click to sort)', sortable: true },
+    status: { label: 'Readiness', title: 'Whether the dataset is pre-downloaded and ready to browse, or still needs to be fetched (click to sort)', sortable: true },
+  };
+  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'num_categories', 'description', 'status'];
+  private static readonly DEMO_COL_ORDER_KEY = 'vtsearch.dashboard.demoColumnOrder';
+
+  demoCols = new ManagedColumns(
+    NewModelModalComponent.DEMO_COLUMNS_DEFAULT,
+    NewModelModalComponent.DEMO_COL_META,
+    { initialSort: 'num_files', storageKey: NewModelModalComponent.DEMO_COL_ORDER_KEY },
+  );
+
+  // --- Demo file browser (shown after picking a demo from the table) ---
+  demoFileBrowsing = false;
+  demoFileBrowseSource = '';
+  demoFileBrowseLabel = '';
+  demoFileBrowsePath: string[] = [];
+  demoFileBrowseEntries: BrowseEntry[] = [];
+  demoFileLoading = false;
+
+  // --- Server folder browser (mirrors the Add Dataset breadcrumb browser
+  //     but lists files too so the user can pick one as an example). ---
+  sfBrowsePath = '';
+  sfBrowseRootPath = '';
+  sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
+  sfBrowseFiles: BrowseEntry[] = [];
+  sfBrowseLoading = false;
+  sfBrowseError = '';
+  sfFileSelecting = false;
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -109,6 +174,16 @@ export class NewModelModalComponent implements OnInit {
     if (this.mediaTypeDropdownOpen && !target.closest('.custom-select')) {
       this.mediaTypeDropdownOpen = false;
     }
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onDocResizeMove(event: MouseEvent): void {
+    this.demoCols.onResizeMove(event);
+  }
+
+  @HostListener('document:mouseup')
+  onDocResizeEnd(): void {
+    this.demoCols.onResizeEnd();
   }
 
   ngOnInit(): void {
@@ -174,144 +249,372 @@ export class NewModelModalComponent implements OnInit {
     this.error = '';
   }
 
-  // --- Media example ---
+  // --- Media picker (shared structure with Add Dataset) ---
 
   openMediaPicker(): void {
     this.view = 'media-picker';
-    this.selectedSource = null;
-    this.browseItems = [];
-    this.fileBrowsing = false;
-    this.browseEntries = [];
-    this.browsePath = [];
-    this.browseSource = '';
-    this.loadMediaSources();
+    this.activeImporterTab = '';
+    this.selectedImporter = null;
+    this.resetDemoPickerState();
+    this.resetServerFolderState();
+    this.loadMediaImporters();
   }
 
-  private loadMediaSources(): void {
+  private loadMediaImporters(): void {
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
-        this.mediaSources = (res.importers || []).filter(
+        this.mediaImporters = (res.importers || []).filter(
           (imp) =>
-            imp.name === 'demo' ||
-            imp.name === 'server_folder' ||
-            (!imp['hidden_from_picker'] && imp.name !== 'combine_datasets'),
+            !imp['hidden_from_picker'] &&
+            NewModelModalComponent.SUPPORTED_PICKER_VIEWS.has(imp.picker_view || ''),
         );
+        this.declaredImporterTabs = res.tabs || [];
       },
     });
   }
 
-  selectSource(source: ImporterInfo): void {
-    this.selectedSource = source;
-    this.browseLoading = true;
-    this.browseItems = [];
-    this.fileBrowsing = false;
+  /** Importers ordered like the Add Dataset modal: known picker_views
+   *  first, then any extras in registry order. */
+  get orderedImporters(): ImporterInfo[] {
+    const order = NewModelModalComponent.PICKER_ORDER;
+    const result: ImporterInfo[] = [];
+    for (const name of order) {
+      const imp = this.mediaImporters.find((i) => i.name === name);
+      if (imp) result.push(imp);
+    }
+    for (const imp of this.mediaImporters) {
+      if (!order.includes(imp.name)) result.push(imp);
+    }
+    return result;
+  }
 
-    if (source.name === 'demo') {
-      this.datasetsApi.getDemoList().subscribe({
-        next: (res) => {
-          this.browseItems = (res.datasets || []).map((d) => ({
-            key: d.name,
-            display: `${d.label} (${d.media_type}, ${d.num_files} items)`,
-          }));
-          this.browseLoading = false;
-        },
-        error: () => { this.browseLoading = false; },
-      });
-    } else if (source.name === 'server_folder') {
-      this.browseLoading = false;
-      this.startFileBrowsing('folder', 'Saved Datasets');
+  private fallbackTabLabel(id: string): string {
+    return id
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+      .map((part) => part[0].toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  /** Visible category tabs.  Only categories that contain at least one
+   *  supported importer are shown — empty categories (e.g. ``"services"``
+   *  on a vanilla install) are hidden so the picker stays focused on
+   *  options the user can act on. */
+  get visibleImporterTabs(): ImporterPickerTab[] {
+    const usedCategories = new Set(
+      this.orderedImporters.map((imp) => imp.category || '').filter(Boolean),
+    );
+    const visible: ImporterPickerTab[] = [];
+    const seen = new Set<string>();
+    const declared = [...this.declaredImporterTabs].sort(
+      (a, b) => (a.order ?? 100) - (b.order ?? 100),
+    );
+    for (const tab of declared) {
+      if (usedCategories.has(tab.id)) {
+        visible.push(tab);
+        seen.add(tab.id);
+      }
+    }
+    for (const id of usedCategories) {
+      if (!seen.has(id)) {
+        visible.push({ id, label: this.fallbackTabLabel(id) });
+      }
+    }
+    return visible;
+  }
+
+  get importersForActiveTab(): ImporterInfo[] {
+    return this.orderedImporters.filter(
+      (imp) => (imp.category || '') === this.activeImporterTab,
+    );
+  }
+
+  get activeImporterTabLabel(): string {
+    const tab = this.visibleImporterTabs.find((t) => t.id === this.activeImporterTab);
+    return tab?.label || '';
+  }
+
+  selectImporterTab(tabId: string): void {
+    this.activeImporterTab = tabId;
+    this.selectedImporter = null;
+    this.resetDemoPickerState();
+    this.resetServerFolderState();
+  }
+
+  selectImporter(importer: ImporterInfo): void {
+    this.selectedImporter = importer;
+    this.error = '';
+    const view = importer.picker_view || '';
+    if (view === 'demo') {
+      this.openDemoPicker();
+    } else if (view === 'server_folder') {
+      this.openServerFolderBrowser();
     } else {
-      this.sortingApi.getServerMediaFiles().subscribe({
-        next: (res) => {
-          this.browseItems = (res.files || []).map((f) => ({
-            key: f.filename || f.name,
-            display: f.name,
-          }));
-          this.browseLoading = false;
-        },
-        error: () => { this.browseLoading = false; },
-      });
+      // local_folder / local_files: just reveal the upload input below.
+      this.resetDemoPickerState();
+      this.resetServerFolderState();
     }
   }
 
-  selectBrowseItem(item: BrowseItem): void {
-    if (this.selectedSource?.name === 'demo') {
-      this.startFileBrowsing(`demo:${item.key}`, item.display);
-      return;
-    }
-
-    // For other sources (server media files), selecting sets the example
-    this.exampleType = 'media';
-    this.exampleValue = item.key;
-    this.exampleDisplay = item.display || item.key;
-    this.pendingText = '';
-    this.view = 'main';
+  /** Picker view of the currently selected importer, or empty when nothing
+   *  is selected.  Drives which inline widget set is rendered below the
+   *  inner sub-tab row. */
+  get activePickerView(): string {
+    return this.selectedImporter?.picker_view || '';
   }
 
-  // --- Recursive file browser ---
+  // --- Demo picker ---
 
-  private startFileBrowsing(source: string, label: string): void {
-    this.fileBrowsing = true;
-    this.browseSource = source;
-    this.browsePath = [label];
-    this.loadDirectory('');
+  private resetDemoPickerState(): void {
+    this.demos = [];
+    this.demoTabs = [];
+    this.activeDemoTab = '';
+    this.demoLoading = false;
+    this.demoFileBrowsing = false;
+    this.demoFileBrowseSource = '';
+    this.demoFileBrowseLabel = '';
+    this.demoFileBrowsePath = [];
+    this.demoFileBrowseEntries = [];
+    this.demoFileLoading = false;
   }
 
-  private loadDirectory(relPath: string): void {
-    this.fileLoading = true;
-    this.browseEntries = [];
-
-    this.datasetsApi.browseMediaFiles(this.browseSource, relPath).subscribe({
+  private openDemoPicker(): void {
+    this.resetDemoPickerState();
+    this.demoLoading = true;
+    this.datasetsApi.getDemoList().subscribe({
       next: (res) => {
-        const entries: BrowseEntry[] = [];
-        for (const d of res.directories || []) {
-          entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
-        }
-        for (const f of res.files || []) {
-          entries.push({ name: f.name, path: f.path, size_bytes: f.size_bytes, modified_at: f.modified_at, isDir: false });
-        }
-        this.browseEntries = entries;
-        this.fileLoading = false;
+        this.demos = res.datasets || [];
+        this.buildDemoTabs();
+        this.demoLoading = false;
       },
       error: () => {
-        this.fileLoading = false;
+        this.demoLoading = false;
       },
     });
   }
 
-  enterDirectory(entry: BrowseEntry): void {
-    this.browsePath.push(entry.name);
-    this.loadDirectory(entry.path);
+  private buildDemoTabs(): void {
+    const grouped = new Set(this.demos.map((d) => d.media_type));
+    const registryOrder = this.mediaTypeInfos.map((mt) => mt.type_id);
+    this.demoTabs = registryOrder.filter((mt) => grouped.has(mt));
+    for (const mt of grouped) {
+      if (!this.demoTabs.includes(mt)) this.demoTabs.push(mt);
+    }
   }
 
-  navigateBreadcrumb(index: number): void {
+  selectDemoTab(tab: string): void {
+    this.activeDemoTab = tab;
+  }
+
+  onDemoHeaderClick(col: string): void {
+    if (this.demoCols.meta(col).sortable) this.demoCols.sortBy(col);
+  }
+
+  get filteredDemos(): DemoDataset[] {
+    const items = this.demos.filter((d) => d.media_type === this.activeDemoTab);
+    const statusOrder: Record<string, number> = { ready: 0, needs_embedding: 1, needs_download: 2 };
+    const sortKey = this.demoCols.sortColumn;
+    const asc = this.demoCols.sortAsc;
+    return [...items].sort((a, b) => {
+      const key = sortKey as keyof DemoDataset;
+      let va: any = a[key];
+      let vb: any = b[key];
+      if (key === 'status') {
+        va = statusOrder[va as string] ?? 3;
+        vb = statusOrder[vb as string] ?? 3;
+      }
+      if (typeof va === 'number' && typeof vb === 'number') {
+        return asc ? va - vb : vb - va;
+      }
+      va = String(va || '').toLowerCase();
+      vb = String(vb || '').toLowerCase();
+      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+    });
+  }
+
+  /** True when the demo's files are on disk and can be browsed.  Demos
+   *  that still need to be downloaded show a tooltip explaining how to
+   *  fetch them via the Add Dataset modal. */
+  isDemoBrowsable(demo: DemoDataset): boolean {
+    return demo.status === 'ready' || demo.status === 'needs_embedding';
+  }
+
+  selectDemo(demo: DemoDataset): void {
+    if (!this.isDemoBrowsable(demo)) return;
+    this.demoFileBrowsing = true;
+    this.demoFileBrowseSource = `demo:${demo.name}`;
+    this.demoFileBrowseLabel = demo.label;
+    this.demoFileBrowsePath = [demo.label];
+    this.loadDemoDirectory('');
+  }
+
+  private loadDemoDirectory(relPath: string): void {
+    this.demoFileLoading = true;
+    this.demoFileBrowseEntries = [];
+    this.datasetsApi.browseMediaFiles(this.demoFileBrowseSource, relPath).subscribe({
+      next: (res) => {
+        this.demoFileBrowseEntries = this.toEntries(res.directories, res.files);
+        this.demoFileLoading = false;
+      },
+      error: () => {
+        this.demoFileLoading = false;
+      },
+    });
+  }
+
+  enterDemoDirectory(entry: BrowseEntry): void {
+    this.demoFileBrowsePath.push(entry.name);
+    this.loadDemoDirectory(entry.path);
+  }
+
+  navigateDemoBreadcrumb(index: number): void {
     if (index === 0) {
-      this.fileBrowsing = false;
-      this.browseEntries = [];
-      this.browsePath = [];
+      this.demoFileBrowsePath = [this.demoFileBrowseLabel];
+      this.loadDemoDirectory('');
       return;
     }
-    this.browsePath = this.browsePath.slice(0, index + 1);
-    const relPath = this.browsePath.slice(1).join('/');
-    this.loadDirectory(relPath);
+    this.demoFileBrowsePath = this.demoFileBrowsePath.slice(0, index + 1);
+    const relPath = this.demoFileBrowsePath.slice(1).join('/');
+    this.loadDemoDirectory(relPath);
   }
 
-  selectFile(entry: BrowseEntry): void {
-    this.fileLoading = true;
-    this.datasetsApi.selectBrowsedFile(this.browseSource, entry.path).subscribe({
+  selectDemoFile(entry: BrowseEntry): void {
+    this.demoFileLoading = true;
+    this.datasetsApi.selectBrowsedFile(this.demoFileBrowseSource, entry.path).subscribe({
       next: (res) => {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
         this.exampleDisplay = res.original_name || entry.name;
         this.pendingText = '';
-        this.fileLoading = false;
+        this.demoFileLoading = false;
         this.view = 'main';
       },
       error: () => {
         this.error = 'Failed to select file';
-        this.fileLoading = false;
+        this.demoFileLoading = false;
       },
     });
+  }
+
+  /** Return to the demo table from the demo file browser. */
+  backToDemoTable(): void {
+    this.demoFileBrowsing = false;
+    this.demoFileBrowseSource = '';
+    this.demoFileBrowseLabel = '';
+    this.demoFileBrowsePath = [];
+    this.demoFileBrowseEntries = [];
+  }
+
+  // --- Server folder browser (with file selection) ---
+
+  private resetServerFolderState(): void {
+    this.sfBrowsePath = '';
+    this.sfBrowseRootPath = '';
+    this.sfBrowseDirs = [];
+    this.sfBrowseFiles = [];
+    this.sfBrowseLoading = false;
+    this.sfBrowseError = '';
+    this.sfFileSelecting = false;
+  }
+
+  private openServerFolderBrowser(): void {
+    this.resetServerFolderState();
+    this.sfLoadDirectory('');
+  }
+
+  sfLoadDirectory(path: string): void {
+    this.sfBrowseLoading = true;
+    this.sfBrowseError = '';
+    this.datasetsApi.browseMediaFiles('folder', path).subscribe({
+      next: (res) => {
+        this.sfBrowseDirs = res.directories || [];
+        this.sfBrowseFiles = (res.files || []).map((f) => ({
+          name: f.name,
+          path: f.path,
+          size_bytes: f.size_bytes,
+          modified_at: f.modified_at,
+          isDir: false,
+        }));
+        this.sfBrowsePath = path;
+        this.sfBrowseRootPath = res.root_path;
+        this.sfBrowseLoading = false;
+      },
+      error: (err) => {
+        this.sfBrowseError =
+          err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
+        this.sfBrowseLoading = false;
+      },
+    });
+  }
+
+  sfEnterDirectory(dir: { name: string; path: string }): void {
+    this.sfLoadDirectory(dir.path);
+  }
+
+  sfGoUp(): void {
+    if (!this.sfBrowsePath) return;
+    const parts = this.sfBrowsePath.split('/');
+    parts.pop();
+    this.sfLoadDirectory(parts.join('/'));
+  }
+
+  get sfBreadcrumbs(): string[] {
+    if (!this.sfBrowsePath) return [];
+    return this.sfBrowsePath.split('/');
+  }
+
+  sfNavigateBreadcrumb(index: number): void {
+    const parts = this.sfBrowsePath.split('/');
+    this.sfLoadDirectory(parts.slice(0, index + 1).join('/'));
+  }
+
+  get sfAbsolutePath(): string {
+    if (!this.sfBrowseRootPath) return '';
+    if (!this.sfBrowsePath) return this.sfBrowseRootPath;
+    return this.sfBrowseRootPath + '/' + this.sfBrowsePath;
+  }
+
+  sfSelectFile(entry: BrowseEntry): void {
+    this.sfFileSelecting = true;
+    this.datasetsApi.selectBrowsedFile('folder', entry.path).subscribe({
+      next: (res) => {
+        this.exampleType = 'media';
+        this.exampleValue = res.filename;
+        this.exampleDisplay = res.original_name || entry.name;
+        this.pendingText = '';
+        this.sfFileSelecting = false;
+        this.view = 'main';
+      },
+      error: () => {
+        this.sfBrowseError = 'Failed to select file';
+        this.sfFileSelecting = false;
+      },
+    });
+  }
+
+  // --- Local file upload (single file for the example) ---
+
+  /** Build a unified entry list (directories first, then files). */
+  private toEntries(
+    directories: { name: string; path: string; modified_at?: string }[] | undefined,
+    files:
+      | { name: string; path: string; size_bytes: number; modified_at?: string }[]
+      | undefined,
+  ): BrowseEntry[] {
+    const entries: BrowseEntry[] = [];
+    for (const d of directories || []) {
+      entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
+    }
+    for (const f of files || []) {
+      entries.push({
+        name: f.name,
+        path: f.path,
+        size_bytes: f.size_bytes,
+        modified_at: f.modified_at,
+        isDir: false,
+      });
+    }
+    return entries;
   }
 
   formatSize(bytes?: number): string {
@@ -321,6 +624,10 @@ export class NewModelModalComponent implements OnInit {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
+  /** Local file picker handler.  Used by both the inline "Upload File…"
+   *  button on the main form and the Local Folder / Local Files cards in
+   *  the picker.  Multi-file selections (e.g. webkitdirectory) are
+   *  collapsed to the first file since only one example is needed. */
   onLocalFileSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
     if (!input.files || input.files.length === 0) return;
@@ -343,6 +650,8 @@ export class NewModelModalComponent implements OnInit {
           this.exampleValue = res.filename;
           this.exampleDisplay = res.original_name || res.filename;
           this.pendingText = '';
+          // Close the picker if it was open so the user lands back on the form.
+          if (this.view === 'media-picker') this.view = 'main';
         },
         error: () => {
           this.error = 'Failed to upload file';
@@ -364,6 +673,31 @@ export class NewModelModalComponent implements OnInit {
 
   backToMain(): void {
     this.view = 'main';
+  }
+
+  // --- Media-type tab labels (mirrors Add Dataset's helpers) ---
+
+  getDemoTabLabel(typeId: string): string {
+    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
+    if (mt) return (mt.tab_title || mt.name).trim();
+    return typeId;
+  }
+
+  getDemoTabIcon(typeId: string): string {
+    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
+    return mt?.icon || '';
+  }
+
+  statusBadgeClass(status: string): string {
+    if (status === 'ready') return 'badge-ready';
+    if (status === 'needs_embedding') return 'badge-embedding';
+    return 'badge-download';
+  }
+
+  statusBadgeLabel(status: string): string {
+    if (status === 'ready') return 'Ready';
+    if (status === 'needs_embedding') return 'Needs Embed';
+    return 'Needs Download';
   }
 
   // --- Clear example ---

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -1,0 +1,297 @@
+// Shared importer-picker styles used by both the Add Dataset modal
+// (DatasetImporterModalComponent) and the New Model > Browse Media picker
+// (NewModelModalComponent).  Lives in the global stylesheet so the rules
+// only ship once instead of being duplicated inside each component's
+// scoped CSS bundle.
+//
+// All selectors here are class-only and only used by these two modals, so
+// they can safely apply globally without bleeding into other components.
+
+// --- Importer category / sub-importer tabs ---
+
+.importer-tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  border-bottom: 2px solid var(--border);
+}
+
+.importer-tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 16px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .85rem;
+  cursor: pointer;
+  transition: all .15s;
+  margin-bottom: -2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-subtle);
+  }
+
+  &.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+    font-weight: 600;
+  }
+}
+
+.importer-subtab-bar { @extend .importer-tab-bar; }
+
+.importer-subtab {
+  @extend .importer-tab;
+
+  &.disabled, &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.importer-subtab-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.tab-bar-hint {
+  margin: 8px 0 0 0;
+  color: var(--text-muted);
+  font-size: .85rem;
+  font-style: italic;
+}
+
+.empty-state--inline {
+  padding: 6px 10px;
+  font-size: .8rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+// --- Demo media-type tabs ---
+
+.demo-tab-bar { @extend .importer-tab-bar; }
+.demo-tab { @extend .importer-tab; }
+
+// --- Demo table ---
+
+.demo-content-area {
+  min-height: 200px;
+  max-height: 50vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.table-fixed { table-layout: fixed; }
+
+.demo-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+
+  th, td {
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 6px 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  th {
+    padding-right: 0;
+    position: sticky;
+    top: 0;
+    background: var(--bg-surface);
+    z-index: 1;
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    user-select: none;
+
+    &[draggable='true'] { cursor: grab; &:active { cursor: grabbing; } }
+
+    &.sortable {
+      cursor: pointer;
+      &:hover { color: var(--text-primary); }
+    }
+
+    &[draggable='true'].sortable { cursor: grab; &:active { cursor: grabbing; } }
+
+    &.col-drop-target { box-shadow: inset 0 0 0 2px var(--accent); }
+    &.col-dragging { opacity: 0.4; }
+
+    .sort-indicator {
+      display: inline-block;
+      width: 1em;
+      text-align: center;
+      visibility: hidden;
+      &.active { visibility: visible; }
+    }
+
+    .col-resize-handle {
+      position: absolute;
+      top: 0;
+      left: -6px;
+      bottom: 0;
+      width: 12px;
+      cursor: col-resize;
+      z-index: 2;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 20%;
+        bottom: 20%;
+        left: 5px;
+        width: 2px;
+        background: var(--accent);
+        opacity: 0.35;
+        transition: opacity 0.15s;
+      }
+
+      &:hover::after { opacity: 0.7; }
+    }
+  }
+
+  tbody tr {
+    cursor: pointer;
+    transition: background 0.1s;
+
+    &:hover { background: var(--bg-hover); }
+
+    &.disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+      &:hover { background: none; }
+    }
+  }
+}
+
+.col-num { text-align: right; padding-right: 12px; }
+
+.col-desc, .col-name, .sf-dir-name, .col-status {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.col-desc { color: var(--text-muted); font-size: 0.78rem; }
+.col-name { font-weight: 600; color: var(--text-primary); }
+
+.demo-row {
+  &.ready .col-name { color: var(--color-good); }
+}
+
+.badge-ready, .badge-embedding, .badge-download {
+  display: inline-block;
+  padding: 1px 7px;
+  color: var(--btn-filled-text);
+  font-size: .7rem;
+  border-radius: 3px;
+}
+
+.badge-ready { background: var(--color-good); }
+.badge-embedding { background: var(--badge-embedding, var(--accent)); }
+.badge-download { background: var(--border); color: var(--text-muted); }
+
+// --- Server folder browser ---
+
+.sf-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: .8rem;
+  flex-wrap: wrap;
+}
+
+.sf-breadcrumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: .8rem;
+
+  &:hover { background: var(--bg-subtle); }
+
+  &.active {
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: default;
+    &:hover { background: none; }
+  }
+}
+
+.sf-breadcrumb-sep { color: var(--text-muted); font-size: .75rem; }
+
+.sf-dir-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.sf-dir-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: .85rem;
+  transition: background .15s;
+
+  &:last-child { border-bottom: none; }
+  &:hover:not(:disabled) { background: var(--bg-subtle); }
+  &:disabled { opacity: 0.55; cursor: wait; }
+}
+
+.sf-dir-icon { font-size: .9rem; flex-shrink: 0; }
+
+.sf-dir-date {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: .75rem;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.sf-empty-dir {
+  color: var(--text-muted);
+  font-size: .8rem;
+  padding: 12px;
+  text-align: center;
+}
+
+.sf-selected-path { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
+
+.sf-path-display {
+  font-size: .8rem;
+  color: var(--text-secondary, var(--text-muted));
+  background: var(--bg-subtle);
+  padding: 3px 8px;
+  border-radius: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,6 +1,7 @@
 @use 'scss/variables';
 @use 'scss/layout';
 @use 'scss/components';
+@use 'scss/picker-shared';
 
 *,
 *::before,

--- a/tests/test_resize_handle_centering.py
+++ b/tests/test_resize_handle_centering.py
@@ -27,10 +27,14 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parent.parent
+# Both dashboard tables (datagrid) and the shared importer-picker demo table
+# (used by both the Add Dataset and New Model > Browse Media modals) host
+# their own copies of the resize-handle rule.  The picker version lives in
+# the global ``_picker-shared.scss`` partial so the two modals don't have
+# duplicate scoped copies.
 SCSS_FILES = [
     REPO / "frontend/src/app/components/dashboard/dashboard.component.scss",
-    REPO
-    / "frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss",
+    REPO / "frontend/src/scss/_picker-shared.scss",
 ]
 
 


### PR DESCRIPTION
## Summary

The "Browse Media…" window launched from Dashboard → Add Model was running on a stale flat-list UI. This PR rebuilds it to share visual structure and code with the current Add Dataset modal so the two pickers feel like one consistent system.

### What changed in `NewModelModalComponent`

- **Category + sub-importer tabs**: the picker now renders the same `visibleImporterTabs` / `importersForActiveTab` two-tier tab bar as `DatasetImporterModalComponent`, populated from `/api/dataset/all-importers` (filtered to picker_views that make sense for selecting a single example file: `demo`, `server_folder`, `local_folder`, `local_files`).
- **Demo picker**: replaces the old flat list with the rich Add Dataset demo experience — media-type sub-tabs, sortable/draggable columns, status badges, and the same `ManagedColumns` controller (sharing the `vtsearch.dashboard.demoColumnOrder` storage key so column preferences stay in sync between both modals). Clicking a Ready/Needs-Embed demo drills into its files via the existing breadcrumb browser; not-yet-downloaded demos are dimmed with a tooltip pointing the user to Add Dataset.
- **Server folder picker**: uses the Add Dataset breadcrumb browser (`sf-breadcrumbs` / `sf-dir-list` / `sf-selected-path`), but lists media files alongside subdirectories so the user can click a file to select it.
- **Local file uploader**: `local_folder` and `local_files` importers each get their own pane with a single-file upload that flows through the existing `MediaCropModalComponent`.

### Shared SCSS partial

To avoid duplicating ~5 kB of picker chrome between the two modals (and keep both under their `anyComponentStyle` budget), I extracted the importer-tabs / demo-table / server-folder-browser / badge styles to a new global partial `frontend/src/scss/_picker-shared.scss`, imported once in `styles.scss`. Both modals now reference the same rules, and `dataset-importer-modal.component.scss` shrinks accordingly.

### Test update

`tests/test_resize_handle_centering.py` is a regression guard for the column-resize handle's exact pixel positioning. The handle rule moved into the new shared partial, so the test's `SCSS_FILES` list now points at `_picker-shared.scss` instead of `dataset-importer-modal.component.scss`.

### Backwards compatibility

Removes the legacy "uploaded server media files" flat list (previously surfaced for any non-demo / non-folder importer). Users can re-upload via the Local pane or pick the file from a server folder. Per CLAUDE.md, breaking BC is acceptable — flagging it here so reviewers know.

## Test plan

- [x] `cd frontend && npm run build:prod` — clean build, no SCSS-budget warnings, dashboard chunk shrinks ~15 kB
- [x] `./run-tests.sh` — 3118 passed, 1 skipped, 0 failed
- [ ] Manual smoke: open Dashboard → Add Model → Browse Media… and verify Demo / Server / Local tabs all populate, demo table sorts and drills into files, server folder picker selects a file, and Upload File still routes through the crop modal


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGTYv4gSXH7G3hseHJLykP)_