### PR TITLE
Show cropped thumbnails in find/label list and new-model example

### DIFF
--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -61,7 +61,11 @@
           <div class="example-display">
             <label class="col-label">Example</label>
             <div class="example-row">
-              <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+              @if (exampleThumbnailUrl) {
+                <img class="example-thumbnail" [src]="exampleThumbnailUrl" [alt]="exampleDisplay" (error)="onExampleThumbError()" />
+              } @else {
+                <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+              }
               <span class="example-label" [title]="exampleDisplay">{{ exampleDisplay }}</span>
               <button type="button" class="btn btn--secondary btn--sm" (click)="clearExample()" title="Remove this example and choose a different one">Change</button>
             </div>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -142,6 +142,15 @@
   color: var(--accent);
 }
 
+.example-thumbnail {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--radius-sm, 4px);
+  flex-shrink: 0;
+  background: var(--bg, #fff);
+}
+
 .example-label {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -71,6 +71,8 @@ export class NewModelModalComponent implements OnInit {
   exampleType: 'text' | 'media' | null = null;
   exampleValue = '';
   exampleDisplay = '';
+  exampleMediaType = '';
+  exampleThumbFailed = false;
 
   // --- Media picker state (shares structure with the Add Dataset modal) ---
 
@@ -485,6 +487,8 @@ export class NewModelModalComponent implements OnInit {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
         this.exampleDisplay = res.original_name || entry.name;
+        this.exampleMediaType = this.activeDemoTab || this.mediaType;
+        this.exampleThumbFailed = false;
         this.pendingText = '';
         this.demoFileLoading = false;
         this.view = 'main';
@@ -581,6 +585,8 @@ export class NewModelModalComponent implements OnInit {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
         this.exampleDisplay = res.original_name || entry.name;
+        this.exampleMediaType = this.mediaType || this.mediaTypeFromFilename(entry.name);
+        this.exampleThumbFailed = false;
         this.pendingText = '';
         this.sfFileSelecting = false;
         this.view = 'main';
@@ -649,6 +655,8 @@ export class NewModelModalComponent implements OnInit {
           this.exampleType = 'media';
           this.exampleValue = res.filename;
           this.exampleDisplay = res.original_name || res.filename;
+          this.exampleMediaType = mediaType || this.mediaType;
+          this.exampleThumbFailed = false;
           this.pendingText = '';
           // Close the picker if it was open so the user lands back on the form.
           if (this.view === 'media-picker') this.view = 'main';
@@ -669,6 +677,27 @@ export class NewModelModalComponent implements OnInit {
     if (m.startsWith('audio/')) return 'audio';
     if (m.startsWith('video/')) return 'video';
     return '';
+  }
+
+  private mediaTypeFromFilename(name: string): string {
+    const ext = name.toLowerCase().split('.').pop() || '';
+    if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext)) return 'image';
+    if (['wav', 'mp3', 'ogg', 'flac', 'm4a', 'aac'].includes(ext)) return 'audio';
+    if (['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(ext)) return 'video';
+    return '';
+  }
+
+  /** URL of the example thumbnail, or null if no media example is selected
+   *  or the thumbnail endpoint already failed (so we fall back to the icon). */
+  get exampleThumbnailUrl(): string | null {
+    if (this.exampleType !== 'media' || !this.exampleValue || this.exampleThumbFailed) {
+      return null;
+    }
+    return `/api/server-media-files/${encodeURIComponent(this.exampleValue)}/thumbnail`;
+  }
+
+  onExampleThumbError(): void {
+    this.exampleThumbFailed = true;
   }
 
   backToMain(): void {
@@ -706,6 +735,8 @@ export class NewModelModalComponent implements OnInit {
     this.exampleType = null;
     this.exampleValue = '';
     this.exampleDisplay = '';
+    this.exampleMediaType = '';
+    this.exampleThumbFailed = false;
     this.pendingText = '';
   }
 

--- a/tests/test_clipper_workflow.py
+++ b/tests/test_clipper_workflow.py
@@ -101,6 +101,49 @@ def _make_video_media(media_id: int, duration: float = 10.0) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# _apply_clipper — clip thumbnail regeneration
+# ---------------------------------------------------------------------------
+
+
+class TestApplyClipperThumbnails:
+    """Clipped audio/video sub-items must get fresh thumbnail_bytes so the
+    find/label list shows the clip's range, not the parent media."""
+
+    def test_audio_clips_get_fresh_waveform_thumbnails(self):
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        parent = _make_audio_media(1, duration=5.1)
+        # Pretend the loader generated a thumbnail from the full waveform.
+        parent["thumbnail_bytes"] = b"PARENT_WAVEFORM_PNG"
+        clips_dict = {1: parent}
+
+        _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0})
+
+        assert len(clips_dict) > 1
+        for clip in clips_dict.values():
+            assert clip.get("thumbnail_bytes") not in (None, b"PARENT_WAVEFORM_PNG"), (
+                "clip thumbnail should be regenerated from the clip's own bytes"
+            )
+            # PNG header check
+            assert clip["thumbnail_bytes"][:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_passthrough_clipper_keeps_parent_thumbnail(self):
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        parent = _make_audio_media(1, duration=2.0)
+        parent["thumbnail_bytes"] = b"PARENT_WAVEFORM_PNG"
+        clips_dict = {1: parent}
+
+        # sound_default returns the media unchanged — no clipping happens.
+        _apply_clipper(clips_dict, "sound_default")
+
+        assert len(clips_dict) == 1
+        clip = next(iter(clips_dict.values()))
+        # No regeneration needed for a non-clip; parent thumbnail preserved.
+        assert clip["thumbnail_bytes"] == b"PARENT_WAVEFORM_PNG"
+
+
+# ---------------------------------------------------------------------------
 # _apply_clipper — MD5 recomputation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_load_sort_window.py
+++ b/tests/test_load_sort_window.py
@@ -159,6 +159,62 @@ class TestServerMediaFiles:
         assert files[0]["filename"] == "visible.wav"
 
 
+class TestServerMediaFileThumbnail:
+    """Tests for /api/server-media-files/<filename>/thumbnail."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_media_dir(self, tmp_path, monkeypatch):
+        from vtsearch.routes import media_server as media_server_module
+
+        self._media_dir = tmp_path / "example_media"
+        self._media_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(media_server_module, "SERVER_MEDIA_DIR", self._media_dir)
+
+    def _make_wav(self, name="example.wav", duration=0.1):
+        sample_rate = 16000
+        num_samples = int(sample_rate * duration)
+        samples = [int(32767 * np.sin(2 * np.pi * 440 * i / sample_rate)) for i in range(num_samples)]
+        path = self._media_dir / name
+        with wave.open(str(path), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(sample_rate)
+            wf.writeframes(struct.pack(f"<{num_samples}h", *samples))
+        return path
+
+    def test_image_returns_file_bytes(self, client):
+        from PIL import Image
+
+        path = self._media_dir / "example.png"
+        Image.new("RGB", (16, 16), color=(123, 45, 67)).save(path)
+
+        resp = client.get("/api/server-media-files/example.png/thumbnail")
+        assert resp.status_code == 200
+        assert resp.mimetype == "image/png"
+        assert resp.data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_audio_returns_waveform_png(self, client):
+        self._make_wav("example.wav")
+        resp = client.get("/api/server-media-files/example.wav/thumbnail")
+        assert resp.status_code == 200
+        assert resp.mimetype == "image/png"
+        assert resp.data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_missing_file_returns_404(self, client):
+        resp = client.get("/api/server-media-files/nope.wav/thumbnail")
+        assert resp.status_code == 404
+
+    def test_path_traversal_rejected(self, client):
+        resp = client.get("/api/server-media-files/..%2F..%2Fetc%2Fpasswd/thumbnail")
+        # 400 (rejected by validation) or 404 (path doesn't resolve to a file)
+        assert resp.status_code in (400, 404)
+
+    def test_unsupported_extension_returns_404(self, client):
+        (self._media_dir / "doc.txt").write_text("hello")
+        resp = client.get("/api/server-media-files/doc.txt/thumbnail")
+        assert resp.status_code == 404
+
+
 class TestExampleSortServer:
     """Tests for /api/example-sort-server (sort by server-side media file)."""
 

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -310,10 +310,75 @@ def _apply_clipper(
     # Recompute MD5 and re-embed every genuine sub-item.
     _fixup_clip_md5_and_embeddings(all_clipped, needs_recompute, clipper.media_type, on_progress=on_progress)
 
+    # Regenerate thumbnails so audio/video clips show their own range
+    # rather than the parent's full waveform / mid-frame.
+    _regenerate_clip_thumbnails(all_clipped, needs_recompute, clipper.media_type)
+
     clips_dict.clear()
     for new_id, clip in enumerate(all_clipped, 1):
         clip["id"] = new_id
         clips_dict[new_id] = clip
+
+
+def _regenerate_clip_thumbnails(
+    clips: list[dict],
+    needs_recompute: list[bool],
+    media_type: str,
+) -> None:
+    """Refresh ``thumbnail_bytes`` on clipped audio/video sub-items.
+
+    Audio and video clippers copy ``thumbnail_bytes`` verbatim from the parent
+    media; without this fixup, every sub-item would render the parent's
+    waveform or middle-frame thumbnail in the find/label list.
+
+    Image clips don't go through this path — their thumbnail is the cropped
+    ``media_bytes`` itself, served directly by the media-image route.
+    """
+    if media_type == "audio":
+        from vtsearch.media.audio.media_type import (
+            generate_waveform_thumbnail,
+            generate_waveform_thumbnail_from_file,
+        )
+
+        for clip, recompute in zip(clips, needs_recompute):
+            if not recompute:
+                continue
+            wav = clip.get("media_bytes")
+            thumb: bytes | None = None
+            if wav is not None:
+                thumb = generate_waveform_thumbnail(wav)
+            else:
+                path = clip.get("media_path")
+                if path:
+                    thumb = generate_waveform_thumbnail_from_file(Path(path))
+            if thumb is not None:
+                clip["thumbnail_bytes"] = thumb
+        return
+
+    if media_type == "video":
+        from vtsearch.media.video.media_type import (
+            generate_video_thumbnail_at,
+            generate_video_thumbnail_from_file_at,
+        )
+
+        for clip, recompute in zip(clips, needs_recompute):
+            if not recompute:
+                continue
+            t0 = clip.get("clip_start")
+            t1 = clip.get("clip_end")
+            if t0 is None or t1 is None:
+                continue
+            mid = (float(t0) + float(t1)) / 2.0
+            video_bytes = clip.get("media_bytes")
+            thumb: bytes | None = None
+            if video_bytes is not None:
+                thumb = generate_video_thumbnail_at(video_bytes, mid)
+            else:
+                path = clip.get("media_path")
+                if path:
+                    thumb = generate_video_thumbnail_from_file_at(Path(path), mid)
+            if thumb is not None:
+                clip["thumbnail_bytes"] = thumb
 
 
 def _fixup_clip_md5_and_embeddings(

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -98,6 +98,95 @@ def generate_video_thumbnail_from_file(file_path: Path, *, size: int = _THUMB_SI
     return buf.getvalue()
 
 
+def _frame_at_time(cap, time_seconds: float) -> "tuple | None":
+    """Seek *cap* to *time_seconds* and read one frame.  Returns ``(ok, frame)`` or ``None``."""
+    import cv2  # noqa: PLC0415
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    if frame_count <= 0:
+        return None
+    if fps and fps > 0:
+        target = max(0, min(int(round(time_seconds * fps)), frame_count - 1))
+    else:
+        target = frame_count // 2
+    cap.set(cv2.CAP_PROP_POS_FRAMES, target)
+    ret, frame = cap.read()
+    if not ret:
+        return None
+    return frame
+
+
+def generate_video_thumbnail_at(
+    video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE
+) -> bytes | None:
+    """Extract a frame at *time_seconds* from *video_bytes* and return it as a PNG thumbnail."""
+    try:
+        import cv2  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+    except Exception:
+        return None
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    try:
+        tmp.write(video_bytes)
+        tmp.close()
+
+        cap = cv2.VideoCapture(tmp.name)
+        try:
+            if not cap.isOpened():
+                return None
+            frame = _frame_at_time(cap, time_seconds)
+            if frame is None:
+                return None
+        finally:
+            cap.release()
+    finally:
+        import os  # noqa: PLC0415
+
+        os.unlink(tmp.name)
+
+    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(frame_rgb)
+    img.thumbnail((size, size))
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+def generate_video_thumbnail_from_file_at(
+    file_path: Path, time_seconds: float, *, size: int = _THUMB_SIZE
+) -> bytes | None:
+    """Extract a frame at *time_seconds* from a video file and return it as a PNG thumbnail."""
+    try:
+        import cv2  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+    except Exception:
+        return None
+
+    try:
+        cap = cv2.VideoCapture(str(file_path))
+        try:
+            if not cap.isOpened():
+                return None
+            frame = _frame_at_time(cap, time_seconds)
+            if frame is None:
+                return None
+        finally:
+            cap.release()
+    except Exception:
+        return None
+
+    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(frame_rgb)
+    img.thumbnail((size, size))
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
 _VIDEO_MIME_TYPES: dict[str, str] = {
     ".webm": "video/webm",
     ".mov": "video/quicktime",

--- a/vtsearch/routes/media_server.py
+++ b/vtsearch/routes/media_server.py
@@ -1,14 +1,39 @@
 """Blueprint for server media file management and example-sort routes."""
 
+import io
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, send_file
 
 from vtsearch.config import DATA_DIR
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.utils import snapshot_medias
 
 media_server_bp = Blueprint("media_server", __name__)
+
+
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+_AUDIO_EXTS = {".wav", ".mp3", ".ogg", ".flac", ".m4a", ".aac"}
+_VIDEO_EXTS = {".mp4", ".webm", ".mov", ".avi", ".mkv"}
+
+
+def _media_type_from_ext(suffix: str) -> str:
+    s = suffix.lower()
+    if s in _IMAGE_EXTS:
+        return "image"
+    if s in _AUDIO_EXTS:
+        return "audio"
+    if s in _VIDEO_EXTS:
+        return "video"
+    return ""
+
+
+_IMAGE_MIMETYPES = {
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
 
 #: Default directory for server-side example media files (single-user fallback).
 SERVER_MEDIA_DIR = DATA_DIR / "example_media"
@@ -76,6 +101,63 @@ def upload_server_media_file():
                 return jsonify({"error": "Invalid crop_params for this media type"}), 400
 
     return jsonify({"filename": safe_name, "original_name": file.filename}), 201
+
+
+@media_server_bp.route("/api/server-media-files/<path:filename>/thumbnail", methods=["GET"])
+def server_media_file_thumbnail(filename: str):
+    """Return a small image preview of an example media file.
+
+    Used by the new-model dialog to show the user which example was selected.
+    For images this serves the file bytes; for audio it returns a waveform PNG;
+    for video it returns the middle-frame PNG.  Other media types return 404.
+    """
+    media_dir = _get_server_media_dir()
+    file_path = media_dir / filename
+
+    try:
+        file_path.resolve().relative_to(media_dir.resolve())
+    except ValueError:
+        return jsonify({"error": "Invalid filename"}), 400
+
+    if not file_path.is_file():
+        return jsonify({"error": f"File not found: {filename}"}), 404
+
+    suffix = file_path.suffix.lower()
+    media_type = _media_type_from_ext(suffix)
+
+    if media_type == "image":
+        mimetype = _IMAGE_MIMETYPES.get(suffix, "image/jpeg")
+        return send_file(
+            io.BytesIO(file_path.read_bytes()),
+            mimetype=mimetype,
+            download_name=file_path.name,
+        )
+
+    if media_type == "audio":
+        from vtsearch.media.audio.media_type import generate_waveform_thumbnail_from_file
+
+        thumb = generate_waveform_thumbnail_from_file(file_path)
+        if thumb is None:
+            return jsonify({"error": "Could not generate audio thumbnail"}), 500
+        return send_file(
+            io.BytesIO(thumb),
+            mimetype="image/png",
+            download_name=f"{file_path.stem}_waveform.png",
+        )
+
+    if media_type == "video":
+        from vtsearch.media.video.media_type import generate_video_thumbnail_from_file
+
+        thumb = generate_video_thumbnail_from_file(file_path)
+        if thumb is None:
+            return jsonify({"error": "Could not generate video thumbnail"}), 500
+        return send_file(
+            io.BytesIO(thumb),
+            mimetype="image/png",
+            download_name=f"{file_path.stem}_frame.png",
+        )
+
+    return jsonify({"error": f"No thumbnail available for {suffix}"}), 404
 
 
 @media_server_bp.route("/api/server-media-files", methods=["GET"])


### PR DESCRIPTION
## Summary

Two fixes around how cropped media surfaces in the UI.

### 1. Audio/video clip thumbnails in the find/label list

The image clipper already rewrites `media_bytes` to the cropped bytes, so image clips render correctly. Audio and video clippers, however, do `tile = dict(media)`, which copies `thumbnail_bytes` verbatim from the parent — so every clipped sub-item in the find/label list rendered the parent's full waveform (audio) or middle frame of the full source (video).

After `_apply_clipper` finishes recomputing MD5s and embeddings, regenerate `thumbnail_bytes` for genuine sub-items:
- **Audio**: regenerate the waveform PNG from the clip's sliced `media_bytes` (or `media_path` if bytes are not in memory).
- **Video**: extract a frame at the midpoint of `[clip_start, clip_end]`. Two new helpers in `vtsearch/media/video/media_type.py` — `generate_video_thumbnail_at` and `generate_video_thumbnail_from_file_at` — share a `_frame_at_time` seek helper.

Pass-through clippers (`*_default`) leave `thumbnail_bytes` alone, so non-clipped media keep their original parent thumbnail.

### 2. Thumbnail in the new-model dialog "Example" row

The Example row showed only a generic icon + filename after the user picked or uploaded media — no preview of what was selected.

- New backend route: `GET /api/server-media-files/<filename>/thumbnail`. For images it serves the file bytes (the upload path already saves the cropped image, so the served bytes are already cropped). For audio it returns a waveform PNG; for video, a middle-frame PNG. Other extensions return 404.
- Frontend: `new-model-modal` tracks `exampleMediaType` across the demo-picker, server-folder, and upload paths and renders an `<img>` thumbnail in the Example row, with the existing icon as the fallback if the thumbnail fails to load.

### Tests

- `TestServerMediaFileThumbnail` — image bytes, audio waveform, missing file 404, path-traversal rejection, unsupported extension 404.
- `TestApplyClipperThumbnails` — audio sub-item gets fresh waveform PNG, pass-through clipper leaves parent thumbnail untouched.

Full suite: 3125 passed, 1 skipped, 2 xpassed. Frontend `npm run build:prod` clean.

## Test plan

- [ ] Load a dataset with the audio tiling clipper applied and confirm each tile in the find/label list shows its own slice of the waveform rather than the full source waveform.
- [ ] Same for a video dataset with the tiling clipper — clip thumbnails should differ across tiles for a video that varies over time.
- [ ] Open the New Model dialog, browse a demo, pick an image — example row shows an image thumbnail.
- [ ] Repeat with audio (waveform thumbnail) and video (frame thumbnail).
- [ ] Upload a file via the file picker, crop it in the crop modal, confirm — Example row shows the cropped preview.
- [ ] Click "Change", confirm thumbnail clears.

https://claude.ai/code/session_01LH4a86zFe79ppuYRHm59AG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH4a86zFe79ppuYRHm59AG)_