### PR TITLE
Add dynamic-options support to dataset importer fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ If a failure is genuinely outside the scope of the current task (e.g. a flaky ne
   - `test_dashboard.py` — Dashboard API endpoint tests
   - `test_exporters.py` — Results exporter base classes, registry, built-in exporters, API routes
   - `test_importers.py` — Importer base class, HTTP archive/folder importer metadata, archive extraction
+  - `test_dynamic_field_options.py` — Dynamic-options importer fields: PluginField `dynamic_options`/`depends_on` serialisation, `DatasetImporter.get_field_options` default + override, `POST /api/dataset/import/<name>/options` route, ReCaller `query_id` dynamic dropdown
   - `test_importer_loading.py` — Folder loader: content_vectors, skip_embedding, custom-metadata flow
   - `test_importer_symlinks.py` — Symlinked importer discovery, rglob following symlinks
   - `test_dataset_importer_media.py` — End-to-end folder/pickle importer paths into media types

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -51,6 +51,8 @@ families use the same field type (aliased as `ImporterField`,
 | `default`     | `str`       | `""`     | Pre-filled value                                        |
 | `required`    | `bool`      | `True`   | Whether the field must be filled before submitting      |
 | `placeholder` | `str`       | `""`     | Hint shown as placeholder text in the input widget      |
+| `dynamic_options` | `bool`  | `False`  | When `True`, options for this `"select"` field are fetched at runtime from the plugin's `get_field_options()` method (see [Dynamic field options](#dynamic-field-options)) |
+| `depends_on`  | `list[str]` | `[]`     | Other field keys whose values this field's options depend on; the frontend re-fetches whenever any depended-on field changes |
 
 ### PluginBase
 
@@ -227,6 +229,7 @@ IMPORTER = S3Importer()
 | Member | Signature | Description |
 |--------|-----------|-------------|
 | `run_cli()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | CLI variant; default delegates to `run()`. Override when `run()` expects FileStorage objects |
+| `get_field_options()` | `(field_key: str, current_values: dict) -> list[str]` | Compute dropdown options for fields declared with `dynamic_options=True`. See [Dynamic field options](#dynamic-field-options) |
 | `run_chunked()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | Yield chunks of medias for piecewise processing. Set `supports_chunked = True` |
 | `run_chunked_cli()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | CLI variant of `run_chunked()` |
 | `build_origin()` | `(field_values: dict) -> dict` | Build an origin dict for provenance tracking. Default uses importer name + string field values |
@@ -325,6 +328,49 @@ are not useful per-media).  The post-processing step only backfills
 `origin` on media that have `origin=None`, so per-media origins set
 in `run()` are preserved.
 
+### Dynamic field options
+
+When a `"select"` field's options must be computed at runtime — for
+example, populating a list of remote queries after the user picks a
+media type — declare it with `dynamic_options=True` and list the parent
+fields it depends on in `depends_on`.  Then implement
+`get_field_options(field_key, current_values)` on your importer:
+
+```python
+class ReCallerImporter(DatasetImporter):
+    name = "recaller"
+    fields = [
+        ImporterField("media_type", "Media Type", "select",
+                      options=all_folder_names(), default="audio"),
+        ImporterField(
+            "query_id", "Query ID", "select",
+            dynamic_options=True,
+            depends_on=["media_type"],   # re-fetch when media_type changes
+        ),
+    ]
+
+    def get_field_options(self, field_key, current_values):
+        if field_key == "query_id":
+            return _list_recent_queries(current_values.get("media_type", ""))
+        return super().get_field_options(field_key, current_values)
+```
+
+The frontend wiring is fully automatic:
+
+1. When the user opens your importer, the modal pre-fetches options for
+   every `dynamic_options=True` field.
+2. Whenever a field listed in another field's `depends_on` changes, the
+   modal clears the dependent field's value and re-fetches its options.
+3. While a fetch is in-flight the dropdown is disabled and shows
+   `Loading…`.  Errors raised by `get_field_options()` are surfaced
+   inline next to the field.
+
+API contract: `POST /api/dataset/import/<name>/options` with body
+`{"field_key": "...", "values": {...}}` returns `{"options": [...]}`.
+Any exception your `get_field_options()` raises is returned as a 502
+with the exception message — perfect for surfacing remote-service
+errors directly to the user.
+
 ### How it gets invoked
 
 1. `GET /api/dataset/all-importers` returns all registered importers (your
@@ -332,7 +378,9 @@ in `run()` are preserved.
    returns importers with `ui_mode == "form"`.
 2. `POST /api/dataset/import/<name>` invokes `run()` in a background
    daemon thread.
-3. `GET /api/dataset/progress` provides progress bar data.
+3. `POST /api/dataset/import/<name>/options` invokes `get_field_options()`
+   to populate dynamic-options dropdowns (see above).
+4. `GET /api/dataset/progress` provides progress bar data.
 
 ### Progress reporting
 

--- a/docs/plans/RCDatasetImporter.md
+++ b/docs/plans/RCDatasetImporter.md
@@ -10,7 +10,7 @@ Three external services are involved:
 
 | Service | What it does | VTSearch talks to it via |
 |---------|-------------|------------------------|
-| **ReCaller (RC)** | Browse tool. Given a `queryID`, returns a collection of results: `{contentID, mediaID, media_type, media_url, md5, ...}` | `_rc_fetch_results()` in the RC importer |
+| **ReCaller (RC)** | Browse tool. Given a `queryID`, returns a collection of results: `{contentID, mediaID, media_type, media_url, md5, ...}`.  Also exposes a list of recent queryIDs filtered by `media_type`, used to populate the importer's dynamic `query_id` dropdown | `_rc_fetch_results()` and `_rc_list_queries()` in the RC importer |
 | **DataWrest (DW)** | Given a `mediaID`, returns `{embedding, embedder}`. All media of a given type share the same embedder | `_dw_get_embedding()` in the RC importer |
 | **PullWrest (PW)** | Given a `media_url`, returns the raw media bytes | `_pw_fetch_media()` in the RC importer + PW media source |
 | **Holder** | ContentID storage. Create packages, add folders, write/read contentIDs with metadata | `_holder_*()` functions in the Holder exporter and importer |
@@ -55,6 +55,16 @@ just inline in each plugin) with HTTP functions for each service.
 ### 1a. ReCaller client
 
 ```python
+def _rc_list_queries(media_type: str) -> list[str]:
+    """GET /api/rc/queries?media_type=<type> → list of recent queryIDs.
+
+    Powers the importer's ``query_id`` dropdown (declared with
+    ``dynamic_options=True, depends_on=["media_type"]``).  The frontend
+    re-fetches whenever the user picks a different media type, so the
+    user never has to copy-paste a queryID — they pick from a list.
+    """
+
+
 def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
     """GET /api/rc/query/{query_id} → list of result dicts.
 
@@ -67,7 +77,7 @@ def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
     """
 ```
 
-Replace the `NotImplementedError` stub in
+Replace the `NotImplementedError` stubs in
 `vtsearch/datasets/importers/recaller/__init__.py`.
 
 ### 1b. DataWrest client

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7162,9 +7162,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -189,12 +189,21 @@
                 [id]="'field-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
-                (ngModelChange)="field.key === 'media_type' ? onMediaTypeChange($event) : null"
+                [disabled]="dynamicFieldLoading[field.key] || (field.dynamic_options && optionsFor(field).length === 0)"
+                (ngModelChange)="onFormFieldChanged(field.key)"
               >
-                @for (opt of field.options || []; track opt) {
+                @if (field.dynamic_options && dynamicFieldLoading[field.key]) {
+                  <option [value]="''" disabled>Loading…</option>
+                } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError[field.key]) {
+                  <option [value]="''" disabled>No options available</option>
+                }
+                @for (opt of optionsFor(field); track opt) {
                   <option [value]="opt">{{ opt }}</option>
                 }
               </select>
+              @if (field.dynamic_options && dynamicFieldError[field.key]) {
+                <p class="error-text">{{ dynamicFieldError[field.key] }}</p>
+              }
             } @else {
               <input
                 [id]="'field-' + field.key"
@@ -202,6 +211,7 @@
                 class="form-input"
                 [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.description || field.label || field.key"
+                (change)="onFormFieldChanged(field.key)"
               />
             }
           </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -189,7 +189,7 @@
                 [id]="'field-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
-                [disabled]="dynamicFieldLoading[field.key] || (field.dynamic_options && optionsFor(field).length === 0)"
+                [disabled]="!!dynamicFieldLoading[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
                 (ngModelChange)="onFormFieldChanged(field.key)"
               >
                 @if (field.dynamic_options && dynamicFieldLoading[field.key]) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -6,7 +6,7 @@ import { FileBrowserComponent } from '../../file-browser/file-browser.component'
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
-import { ImporterInfo, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
+import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 @Component({
@@ -116,6 +116,14 @@ export class DatasetImporterModalComponent implements OnInit {
 
   /** Maximum medias per chunk during embedding for the generic form view; 0 means "no chunking". */
   chunkSize = 0;
+
+  // Dynamic-options cache for the generic form view.  Keyed by ImporterField.key.
+  /** Options last fetched from the backend for dynamic-options fields. */
+  dynamicFieldOptions: Record<string, string[]> = {};
+  /** Whether a dynamic-options fetch is currently in flight for a field. */
+  dynamicFieldLoading: Record<string, boolean> = {};
+  /** Last fetch error for a dynamic-options field, if any. */
+  dynamicFieldError: Record<string, string> = {};
 
   // Clipper chooser modal state
   clipperChooserOpen = false;
@@ -273,6 +281,9 @@ export class DatasetImporterModalComponent implements OnInit {
     this.clipperParamValues = {};
     this.selectedEmbedder = '';
     this.availableEmbedders = [];
+    this.dynamicFieldOptions = {};
+    this.dynamicFieldLoading = {};
+    this.dynamicFieldError = {};
 
     // Pre-populate defaults
     if (importer.fields) {
@@ -298,12 +309,76 @@ export class DatasetImporterModalComponent implements OnInit {
       this.loadClippers(defaultType);
       this.loadEmbedders(defaultType);
     }
+
+    // Fetch initial options for dynamic fields whose deps are already filled.
+    for (const field of importer.fields || []) {
+      if (field.dynamic_options) {
+        this.refreshDynamicFieldOptions(field);
+      }
+    }
   }
 
   onMediaTypeChange(mediaType: string): void {
     this.formValues['media_type'] = mediaType;
     this.loadClippers(mediaType);
     this.loadEmbedders(mediaType);
+    this.onFormFieldChanged('media_type');
+  }
+
+  /** Called whenever a form field value changes.  Refreshes options for
+   *  every dynamic-options field whose ``depends_on`` includes *changedKey*.
+   *  Also clears the dependent field's current value so the user can't
+   *  submit a now-stale selection. */
+  onFormFieldChanged(changedKey: string): void {
+    const importer = this.selectedImporter;
+    if (!importer?.fields) return;
+    for (const field of importer.fields) {
+      if (!field.dynamic_options) continue;
+      if (!(field.depends_on || []).includes(changedKey)) continue;
+      this.formValues[field.key] = '';
+      this.refreshDynamicFieldOptions(field);
+    }
+  }
+
+  /** Fetch the option list for a dynamic-options field from the backend. */
+  private refreshDynamicFieldOptions(field: ImporterField): void {
+    const importer = this.selectedImporter;
+    if (!importer) return;
+    const key = field.key;
+    this.dynamicFieldLoading[key] = true;
+    this.dynamicFieldError[key] = '';
+    this.datasetsApi
+      .getImporterFieldOptions(importer.name, key, { ...this.formValues })
+      .subscribe({
+        next: (res) => {
+          this.dynamicFieldOptions[key] = res.options || [];
+          this.dynamicFieldLoading[key] = false;
+          // If the current value isn't in the new option list, clear it so
+          // the displayed select matches the value.  Pre-select the first
+          // option when the field is required and currently empty.
+          const current = this.formValues[key];
+          if (current && !this.dynamicFieldOptions[key].includes(String(current))) {
+            this.formValues[key] = '';
+          }
+          if (!this.formValues[key] && field.required && this.dynamicFieldOptions[key].length > 0) {
+            this.formValues[key] = this.dynamicFieldOptions[key][0];
+          }
+        },
+        error: (err) => {
+          this.dynamicFieldLoading[key] = false;
+          this.dynamicFieldError[key] = err?.error?.error || 'Could not load options';
+          this.dynamicFieldOptions[key] = [];
+        },
+      });
+  }
+
+  /** Effective option list for a select field — dynamic options when set,
+   *  otherwise the static options declared on the field. */
+  optionsFor(field: ImporterField): string[] {
+    if (field.dynamic_options) {
+      return this.dynamicFieldOptions[field.key] || [];
+    }
+    return field.options || [];
   }
 
   private loadClippers(mediaType: string): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -204,6 +204,13 @@ export interface ImporterField {
   default?: string;
   required?: boolean;
   placeholder?: string;
+  /** When true, ``options`` is computed at runtime by calling
+   *  ``POST /api/dataset/import/<importer>/options`` with the current
+   *  field values.  The frontend re-fetches whenever any field listed in
+   *  ``depends_on`` changes. */
+  dynamic_options?: boolean;
+  /** Field keys whose values this field's options depend on. */
+  depends_on?: string[];
 }
 
 export interface ImporterPickerTab {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -124,6 +124,25 @@ export class DatasetsApiService {
   }
 
   /**
+   * Fetch dropdown options for an importer field whose options are computed
+   * at runtime by the importer (``dynamic_options=true``).
+   *
+   * The backend calls the importer's ``get_field_options(field_key, values)``
+   * Python method and returns the resulting list.  Errors from the remote
+   * service are surfaced as HTTP errors with an ``error`` message body.
+   */
+  getImporterFieldOptions(
+    importerName: string,
+    fieldKey: string,
+    values: Record<string, unknown>,
+  ): Observable<{ options: string[] }> {
+    return this.http.post<{ options: string[] }>(
+      `/api/dataset/import/${importerName}/options`,
+      { field_key: fieldKey, values },
+    );
+  }
+
+  /**
    * Upload a folder selected from the user's *browser* machine.
    *
    * The caller is responsible for building the FormData with the files

--- a/tests/test_chunked_web_flow.py
+++ b/tests/test_chunked_web_flow.py
@@ -237,9 +237,7 @@ class TestLocalFolderRouteChunked:
     and route through ``run_chunked`` when set."""
 
     def test_chunk_size_form_field_routes_to_run_chunked(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads"
-        )
+        monkeypatch.setattr("vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads")
 
         captured: dict[str, Any] = {}
 
@@ -289,9 +287,7 @@ class TestLocalFolderRouteChunked:
         assert sorted(captured["target"].keys()) == [1]
 
     def test_no_chunk_size_uses_run(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads"
-        )
+        monkeypatch.setattr("vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads")
 
         from vtsearch.datasets.importers import get_importer
 

--- a/tests/test_combine_models.py
+++ b/tests/test_combine_models.py
@@ -74,9 +74,7 @@ class TestLabelSetMerge:
         legacy_bad = LabeledElement(md5="bb", label="bad")
         legacy_bad_conflict = LabeledElement(md5="bb", label="good")
 
-        merged = LabelSet([legacy_good, legacy_bad]).merge(
-            LabelSet([legacy_good_2, legacy_bad_conflict])
-        )
+        merged = LabelSet([legacy_good, legacy_bad]).merge(LabelSet([legacy_good_2, legacy_bad_conflict]))
         keys = [(e.md5, e.label) for e in merged]
         assert keys == [("aa", "good")]  # bb dropped on conflict
 

--- a/tests/test_converter_selection.py
+++ b/tests/test_converter_selection.py
@@ -709,7 +709,9 @@ class TestFolderImporterWithConverters:
                 "vtsearch.datasets.importers.server_folder.load_dataset_from_folder",
                 side_effect=ValueError("No images files found"),
             ),
-            patch("vtsearch.datasets.importers.server_folder._run_selected_converters", side_effect=_fake_run_converters),
+            patch(
+                "vtsearch.datasets.importers.server_folder._run_selected_converters", side_effect=_fake_run_converters
+            ),
         ):
             medias: dict = {}
             IMPORTER.run(

--- a/tests/test_dynamic_field_options.py
+++ b/tests/test_dynamic_field_options.py
@@ -1,0 +1,282 @@
+"""Tests for dynamic-options dataset importer fields.
+
+Covers:
+
+- :class:`~vtsearch.utils.registry.PluginField` ``dynamic_options`` /
+  ``depends_on`` attributes serialise via ``to_dict``.
+- :meth:`DatasetImporter.get_field_options` default raises
+  ``NotImplementedError``.
+- The ``POST /api/dataset/import/<name>/options`` route returns the
+  importer's options, surfaces ``NotImplementedError`` as 501, and
+  surfaces other plugin exceptions as 502 with the message body.
+- The ReCaller scaffold declares its ``query_id`` field as dynamic and
+  routes ``get_field_options`` through ``_rc_list_queries``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+from vtsearch.utils.registry import PluginField
+
+
+class _StubImporter(DatasetImporter):
+    name = "_stub_dynamic"
+    display_name = "Stub Dynamic"
+    description = "Test importer with dynamic-options field."
+    fields = [
+        ImporterField("media_type", "Media Type", "select", options=["audio", "image"], default="audio"),
+        ImporterField(
+            "query_id",
+            "Query",
+            "select",
+            dynamic_options=True,
+            depends_on=["media_type"],
+        ),
+    ]
+
+    def __init__(self, fail_with: Exception | None = None) -> None:
+        super().__init__()
+        self._fail_with = fail_with
+
+    def get_field_options(self, field_key, current_values):
+        if self._fail_with is not None:
+            raise self._fail_with
+        if field_key == "query_id":
+            mt = current_values.get("media_type", "audio")
+            return [f"{mt}-q1", f"{mt}-q2"]
+        return super().get_field_options(field_key, current_values)
+
+    def run(self, field_values, medias, thin=False):  # pragma: no cover — unused here
+        return None
+
+
+@pytest.fixture
+def registered_stub():
+    """Register a stub importer in the live registry for the duration of a test."""
+    from vtsearch.datasets.importers import get_importer
+
+    registry = get_importer.__self__
+    registry._ensure_discovered()
+
+    stub = _StubImporter()
+    registry._items[stub.name] = stub
+    try:
+        yield stub
+    finally:
+        registry._items.pop(stub.name, None)
+
+
+# ---------------------------------------------------------------------------
+# PluginField — dataclass attributes & serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestPluginFieldDynamicAttrs:
+    def test_defaults(self):
+        f = PluginField(key="x", label="X", field_type="text")
+        assert f.dynamic_options is False
+        assert f.depends_on == []
+
+    def test_to_dict_round_trip(self):
+        f = PluginField(
+            key="q",
+            label="Q",
+            field_type="select",
+            dynamic_options=True,
+            depends_on=["a", "b"],
+        )
+        d = f.to_dict()
+        assert d["dynamic_options"] is True
+        assert d["depends_on"] == ["a", "b"]
+
+    def test_depends_on_is_independent_per_instance(self):
+        # default_factory=list should not be shared between instances.
+        a = PluginField(key="a", label="A", field_type="text")
+        b = PluginField(key="b", label="B", field_type="text")
+        a.depends_on.append("oops")
+        assert b.depends_on == []
+
+
+# ---------------------------------------------------------------------------
+# DatasetImporter.get_field_options default behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGetFieldOptionsDefault:
+    def test_default_raises_not_implemented(self):
+        class Imp(DatasetImporter):
+            name = "_t_default"
+            display_name = "T"
+            description = "T"
+            fields = []
+
+            def run(self, field_values, medias, thin=False):
+                return None
+
+        with pytest.raises(NotImplementedError):
+            Imp().get_field_options("anything", {})
+
+
+# ---------------------------------------------------------------------------
+# /api/dataset/import/<name>/options route
+# ---------------------------------------------------------------------------
+
+
+class TestImporterFieldOptionsRoute:
+    URL_TEMPLATE = "/api/dataset/import/{name}/options"
+
+    def test_returns_options_from_importer(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "query_id", "values": {"media_type": "image"}},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body == {"options": ["image-q1", "image-q2"]}
+
+    def test_unknown_importer_returns_404(self, client):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name="does_not_exist"),
+            json={"field_key": "query_id", "values": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_field_returns_400(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "no_such_field", "values": {}},
+        )
+        assert resp.status_code == 400
+        assert "Unknown field" in resp.get_json()["error"]
+
+    def test_static_field_returns_400(self, client, registered_stub):
+        # ``media_type`` is static, not dynamic — calling options on it is rejected.
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "media_type", "values": {}},
+        )
+        assert resp.status_code == 400
+        assert "not dynamic" in resp.get_json()["error"]
+
+    def test_missing_field_key_returns_400(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"values": {}},
+        )
+        assert resp.status_code == 400
+
+    def test_non_object_values_returns_400(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "query_id", "values": "not-an-object"},
+        )
+        assert resp.status_code == 400
+
+    def test_not_implemented_returns_501(self, client):
+        from vtsearch.datasets.importers import get_importer
+
+        registry = get_importer.__self__
+        registry._ensure_discovered()
+        stub = _StubImporter(fail_with=NotImplementedError("nope"))
+        registry._items[stub.name] = stub
+        try:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "query_id", "values": {}},
+            )
+            assert resp.status_code == 501
+            assert resp.get_json()["error"] == "nope"
+        finally:
+            registry._items.pop(stub.name, None)
+
+    def test_plugin_exception_returns_502(self, client):
+        from vtsearch.datasets.importers import get_importer
+
+        registry = get_importer.__self__
+        registry._ensure_discovered()
+        stub = _StubImporter(fail_with=RuntimeError("remote service down"))
+        registry._items[stub.name] = stub
+        try:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "query_id", "values": {}},
+            )
+            assert resp.status_code == 502
+            assert resp.get_json()["error"] == "remote service down"
+        finally:
+            registry._items.pop(stub.name, None)
+
+
+# ---------------------------------------------------------------------------
+# Importer metadata round-trips through to_dict() so the frontend sees it
+# ---------------------------------------------------------------------------
+
+
+class TestImporterMetadataExposes:
+    def test_to_dict_includes_dynamic_field_props(self):
+        stub = _StubImporter()
+        d = stub.to_dict()
+        query_field = next(f for f in d["fields"] if f["key"] == "query_id")
+        assert query_field["dynamic_options"] is True
+        assert query_field["depends_on"] == ["media_type"]
+
+    def test_static_field_has_default_dynamic_props(self):
+        stub = _StubImporter()
+        d = stub.to_dict()
+        media_type_field = next(f for f in d["fields"] if f["key"] == "media_type")
+        assert media_type_field["dynamic_options"] is False
+        assert media_type_field["depends_on"] == []
+
+
+# ---------------------------------------------------------------------------
+# ReCaller scaffold — exercises the importer-level wiring
+# ---------------------------------------------------------------------------
+
+
+class TestReCallerDynamicQueryId:
+    def test_query_id_field_is_dynamic_with_media_type_dep(self):
+        from vtsearch.datasets.importers import get_importer
+
+        rc = get_importer("recaller")
+        assert rc is not None
+        query_field = next(f for f in rc.fields if f.key == "query_id")
+        assert query_field.dynamic_options is True
+        assert query_field.depends_on == ["media_type"]
+
+    def test_get_field_options_routes_through_rc_list_queries(self, monkeypatch):
+        from vtsearch.datasets.importers import get_importer
+        from vtsearch.datasets.importers import recaller as rc_module
+
+        rc = get_importer("recaller")
+        captured: list[str] = []
+
+        def fake_list(media_type: str) -> list[str]:
+            captured.append(media_type)
+            return ["q-aaa", "q-bbb"]
+
+        monkeypatch.setattr(rc_module, "_rc_list_queries", fake_list)
+
+        out = rc.get_field_options("query_id", {"media_type": "image"})
+        assert out == ["q-aaa", "q-bbb"]
+        assert captured == ["image"]
+
+    def test_get_field_options_default_media_type(self, monkeypatch):
+        from vtsearch.datasets.importers import get_importer
+        from vtsearch.datasets.importers import recaller as rc_module
+
+        rc = get_importer("recaller")
+        seen: list[str] = []
+        monkeypatch.setattr(rc_module, "_rc_list_queries", lambda mt: seen.append(mt) or [])
+
+        # Empty current_values falls back to "audio".
+        rc.get_field_options("query_id", {})
+        assert seen == ["audio"]
+
+    def test_get_field_options_unknown_key_raises(self):
+        from vtsearch.datasets.importers import get_importer
+
+        rc = get_importer("recaller")
+        with pytest.raises(NotImplementedError):
+            rc.get_field_options("not_a_field", {})

--- a/tests/test_importer_loading.py
+++ b/tests/test_importer_loading.py
@@ -926,9 +926,7 @@ class TestLoadDatasetRecursive:
         self._seed_layout(tmp_path)
         medias: dict = {}
         with self._patch_media_registry(self._make_fake_media_type()):
-            load_dataset_from_folder(
-                tmp_path, "audio", medias, on_progress=lambda *a: None, recursive=False
-            )
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None, recursive=False)
 
         names = sorted(m["filename"] for m in medias.values())
         assert names == ["top.wav"]
@@ -966,9 +964,7 @@ class TestServerFolderImporterRecursive:
     def test_build_origin_records_recursive(self):
         from vtsearch.datasets.importers.server_folder import IMPORTER
 
-        origin = IMPORTER.build_origin(
-            {"path": "/tmp/x", "media_type": "audio", "recursive": False}
-        )
+        origin = IMPORTER.build_origin({"path": "/tmp/x", "media_type": "audio", "recursive": False})
         assert origin["params"]["recursive"] == "false"
 
 

--- a/tests/test_local_folder_upload.py
+++ b/tests/test_local_folder_upload.py
@@ -248,9 +248,7 @@ class TestFolderImporterPickerVisibility:
 
     def test_server_folder_importer_description_mentions_server(self, client):
         resp = client.get("/api/dataset/importers")
-        folder_imp = next(
-            i for i in resp.get_json()["importers"] if i["name"] == "server_folder"
-        )
+        folder_imp = next(i for i in resp.get_json()["importers"] if i["name"] == "server_folder")
         # The user reading the picker should not be misled into thinking
         # this scans their browser machine.
         assert "server" in folder_imp["description"].lower()

--- a/tests/test_origin_labelset.py
+++ b/tests/test_origin_labelset.py
@@ -456,8 +456,18 @@ class TestBuildClipLookup:
     def test_md5_lookup_groups_duplicates(self):
         """Two medias with the same MD5 should both appear in the md5_lookup."""
         medias = {
-            1: {"id": 1, "md5": "same_hash", "origin": {"importer": "server_folder", "params": {}}, "origin_name": "a.wav"},
-            2: {"id": 2, "md5": "same_hash", "origin": {"importer": "server_folder", "params": {}}, "origin_name": "b.wav"},
+            1: {
+                "id": 1,
+                "md5": "same_hash",
+                "origin": {"importer": "server_folder", "params": {}},
+                "origin_name": "a.wav",
+            },
+            2: {
+                "id": 2,
+                "md5": "same_hash",
+                "origin": {"importer": "server_folder", "params": {}},
+                "origin_name": "b.wav",
+            },
         }
         _, md5_lookup, _ = build_media_lookup(medias)
         assert sorted(md5_lookup["same_hash"]) == [1, 2]
@@ -497,7 +507,11 @@ class TestResolveClipIds:
 
     def test_match_by_origin(self):
         origin_lookup, md5_lookup, _ = self._make_lookups()
-        entry = {"md5": "wrong", "origin": {"importer": "server_folder", "params": {"path": "/a"}}, "origin_name": "a.wav"}
+        entry = {
+            "md5": "wrong",
+            "origin": {"importer": "server_folder", "params": {"path": "/a"}},
+            "origin_name": "a.wav",
+        }
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert ids == [1]
 

--- a/tests/test_resize_handle_centering.py
+++ b/tests/test_resize_handle_centering.py
@@ -90,9 +90,7 @@ class TestResizeHandleCentering:
             "entirely on one side, and `right: -6px` is covered by the next "
             "<th>'s stacking context."
         )
-        assert _decl(block, "width") == "12px", (
-            f"{scss_path.name}: .col-resize-handle must be `width: 12px`."
-        )
+        assert _decl(block, "width") == "12px", f"{scss_path.name}: .col-resize-handle must be `width: 12px`."
         # The handle must NOT also pin to the right edge — that would shrink or
         # mis-center the grab zone.
         assert _decl(block, "right") is None, (
@@ -111,9 +109,7 @@ class TestResizeHandleCentering:
             "so the 2px visual line is centered on the divider (handle starts "
             "at cell-x -6, so handle-x 5 = divider)."
         )
-        assert _decl(after, "width") == "2px", (
-            f"{scss_path.name}: .col-resize-handle::after must be `width: 2px`."
-        )
+        assert _decl(after, "width") == "2px", f"{scss_path.name}: .col-resize-handle::after must be `width: 2px`."
         assert _decl(after, "right") is None, (
             f"{scss_path.name}: .col-resize-handle::after should not set "
             "`right`; pinning to the right edge of the host cell sits the line "

--- a/tests/test_synthetic_importer.py
+++ b/tests/test_synthetic_importer.py
@@ -241,9 +241,7 @@ class TestRunEndToEnd:
         medias: dict[int, dict] = {}
         imp.run({"media_type": "audio", "size": "3"}, medias)
         media = next(iter(medias.values()))
-        resolved = imp.resolve_file(
-            media["origin"], origin_name=media["origin_name"], filename=media["filename"]
-        )
+        resolved = imp.resolve_file(media["origin"], origin_name=media["origin_name"], filename=media["filename"])
         assert resolved is not None
         assert resolved.is_file()
 

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -196,6 +196,44 @@ class DatasetImporter(PluginBase):
         raise NotImplementedError(f"{type(self).__name__}.run() is not implemented")
 
     # ------------------------------------------------------------------
+    # Dynamic field options
+    # ------------------------------------------------------------------
+
+    def get_field_options(
+        self,
+        field_key: str,
+        current_values: dict[str, Any],
+    ) -> list[str]:
+        """Return the dropdown options for *field_key* given current form values.
+
+        Override this on importers that declare any
+        :class:`~vtsearch.utils.registry.PluginField` with
+        ``dynamic_options=True``.  The frontend calls this via
+        ``POST /api/dataset/import/<name>/options`` whenever a field listed
+        in another field's ``depends_on`` changes — e.g. a ``query_id``
+        select might re-populate after the user picks a ``media_type``.
+
+        Args:
+            field_key: The :attr:`PluginField.key` of the field whose
+                options are being requested.
+            current_values: A snapshot of every form field's current value,
+                keyed by :attr:`PluginField.key`.  Values are plain strings
+                (or empty strings for unfilled fields).
+
+        Returns:
+            The list of allowed option strings for the dropdown.
+
+        Raises:
+            NotImplementedError: When the importer declares no dynamic
+                fields, or has not implemented this hook for *field_key*.
+                Subclasses should raise (or let the default raise) for any
+                ``field_key`` they do not handle.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented"
+        )
+
+    # ------------------------------------------------------------------
     # Chunked / piecewise loading
     # ------------------------------------------------------------------
 

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -229,9 +229,7 @@ class DatasetImporter(PluginBase):
                 Subclasses should raise (or let the default raise) for any
                 ``field_key`` they do not handle.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented"
-        )
+        raise NotImplementedError(f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented")
 
     # ------------------------------------------------------------------
     # Chunked / piecewise loading

--- a/vtsearch/datasets/importers/recaller/__init__.py
+++ b/vtsearch/datasets/importers/recaller/__init__.py
@@ -49,6 +49,15 @@ from vtsearch.media import all_folder_names
 # ---------------------------------------------------------------------------
 
 
+def _rc_list_queries(media_type: str) -> list[str]:
+    """Call ReCaller and return the list of query IDs for *media_type*.
+
+    Used to populate the ``query_id`` dropdown dynamically once the user
+    picks a media type.  Each entry is a ReCaller queryID string.
+    """
+    raise NotImplementedError("TODO: implement ReCaller list-queries API client")
+
+
 def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
     """Call ReCaller and return the result list for *query_id*.
 
@@ -100,12 +109,6 @@ class ReCallerDatasetImporter(DatasetImporter):
     category = "services"
     fields = [
         ImporterField(
-            key="query_id",
-            label="Query ID",
-            field_type="text",
-            description="The ReCaller query ID referencing a recent browsing session.",
-        ),
-        ImporterField(
             key="media_type",
             label="Media Type",
             field_type="select",
@@ -113,7 +116,22 @@ class ReCallerDatasetImporter(DatasetImporter):
             default="audio",
             description="Only results matching this media type will be imported.",
         ),
+        ImporterField(
+            key="query_id",
+            label="Query ID",
+            field_type="select",
+            description="The ReCaller query referencing a recent browsing session.",
+            dynamic_options=True,
+            depends_on=["media_type"],
+        ),
     ]
+
+    def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> list[str]:
+        """Populate ``query_id`` from ReCaller, scoped by the picked media type."""
+        if field_key == "query_id":
+            media_type = current_values.get("media_type") or "audio"
+            return list(_rc_list_queries(media_type))
+        return super().get_field_options(field_key, current_values)
 
     # The dataset-level origin (queryID) is NOT useful for provenance —
     # each media gets its own origin keyed by contentID.  Return an empty

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -134,6 +134,7 @@ def _get_embedder_for_medias(media_dict: dict):
     routes layer, which itself imports from this module.
     """
     from vtsearch.routes.helpers import get_embedder_for_medias as _impl
+
     return _impl(media_dict)
 
 

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -11,17 +11,13 @@ from __future__ import annotations
 import gc
 import hashlib
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 import numpy as np
 from PIL import Image
 
 from vtsearch.datasets.loader import (
     ProgressCallback,
-    _get_embedding_value,
-    _get_md5_value,
-    _pop_md5_key,
-    _pop_embedding_key,
 )
 from vtsearch.datasets.pickle_security import safe_pickle_load
 

--- a/vtsearch/labels/sources/base.py
+++ b/vtsearch/labels/sources/base.py
@@ -17,7 +17,7 @@ from vtsearch.utils.registry import PluginField
 from vtsearch.utils.sync_source import SyncSource
 
 if TYPE_CHECKING:
-    from vtsearch.datasets.labelset import LabelSet
+    pass
 
 LabelsetSourceField = PluginField
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -117,9 +117,7 @@ def _frame_at_time(cap, time_seconds: float) -> "tuple | None":
     return frame
 
 
-def generate_video_thumbnail_at(
-    video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE
-) -> bytes | None:
+def generate_video_thumbnail_at(video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE) -> bytes | None:
     """Extract a frame at *time_seconds* from *video_bytes* and return it as a PNG thumbnail."""
     try:
         import cv2  # noqa: PLC0415

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -23,13 +23,8 @@ from vtsearch.routes.helpers import get_json_or_400, get_json_safe, get_plugin_o
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtsearch.datasets.loader import safe_pickle_load
 from vtsearch.datasets.registry import (
-    is_loaded as _reg_is_loaded,
     list_datasets as _reg_list_all,
     remove_loaded_id as _reg_remove_loaded,
-    add_loaded_id as _reg_add_loaded,
-    unregister_dataset as _reg_unregister,
-    update_dataset as _reg_update,
-    get_dataset as _reg_get,
 )
 from vtsearch.utils import (
     bad_votes,
@@ -839,7 +834,6 @@ def clear_dataset_route():
     else:
         clear_dataset()
     return jsonify({"ok": True})
-
 
 
 @datasets_bp.route("/api/dataset/load-source", methods=["POST"])

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -455,6 +455,50 @@ def clear_staging():
 # ---------------------------------------------------------------------------
 
 
+@datasets_bp.route("/api/dataset/import/<importer_name>/options", methods=["POST"])
+def importer_field_options(importer_name: str):
+    """Return dropdown options for a dynamic-options field.
+
+    Body::
+
+        {"field_key": "query_id", "values": {"media_type": "audio", ...}}
+
+    The importer's ``get_field_options(field_key, current_values)`` is
+    called with the supplied snapshot of current form values.  Returns
+    ``{"options": [...]}`` on success.  Errors from the plugin (network
+    failure, auth error, etc.) are surfaced as a 502 with the original
+    message so the frontend can display them inline.
+    """
+    importer, err = get_plugin_or_404(get_importer, list_importers, importer_name, "importer")
+    if err:
+        return err
+
+    body = request.get_json(force=True, silent=True) or {}
+    field_key = str(body.get("field_key") or "").strip()
+    values = body.get("values") or {}
+    if not field_key:
+        return jsonify({"error": "Missing required field: 'field_key'"}), 400
+    if not isinstance(values, dict):
+        return jsonify({"error": "'values' must be an object"}), 400
+
+    field = next((f for f in importer.fields if f.key == field_key), None)
+    if field is None:
+        return jsonify({"error": f"Unknown field: {field_key!r}"}), 400
+    if not getattr(field, "dynamic_options", False):
+        return jsonify({"error": f"Field {field_key!r} is not dynamic"}), 400
+
+    try:
+        options = importer.get_field_options(field_key, values)
+    except NotImplementedError as exc:
+        return jsonify({"error": str(exc) or "Importer does not implement get_field_options"}), 501
+    except Exception as exc:  # noqa: BLE001 — surface remote-service errors verbatim
+        return jsonify({"error": str(exc) or type(exc).__name__}), 502
+
+    if not isinstance(options, list):
+        return jsonify({"error": "get_field_options must return a list"}), 500
+    return jsonify({"options": [str(o) for o in options]})
+
+
 @datasets_bp.route("/api/dataset/import/<importer_name>", methods=["POST"])
 def import_dataset(importer_name: str):
     """Run a registered importer by name in a background thread."""

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -485,9 +485,7 @@ def combine_trainable_models():
 
     media_types = {s.get("media_type", "") for s in sources}
     if len(media_types) > 1:
-        return jsonify(
-            {"error": f"All source models must share the same media_type; got {sorted(media_types)}"}
-        ), 400
+        return jsonify({"error": f"All source models must share the same media_type; got {sorted(media_types)}"}), 400
     media_type = next(iter(media_types))
     if not media_type or media_type == "any":
         return jsonify({"error": "Source models must have a specific media_type (not empty or 'any')"}), 400
@@ -499,8 +497,7 @@ def combine_trainable_models():
         return jsonify(
             {
                 "error": (
-                    "Combined labelset is empty after applying conflict policy "
-                    f"{conflict_policy!r}; nothing to save."
+                    f"Combined labelset is empty after applying conflict policy {conflict_policy!r}; nothing to save."
                 )
             }
         ), 422
@@ -554,4 +551,3 @@ def combine_trainable_models():
 
 # Canonical location: vtsearch.models.training_workflow
 from vtsearch.models.training_workflow import apply_and_retrain as _apply_and_retrain  # noqa: E402
-

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -32,7 +32,6 @@ import time
 
 from flask import Blueprint, jsonify, request
 
-from vtsearch.auth import get_current_user
 from vtsearch.models.trainable_model_store import (
     _model_path,
     _read_model,

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -69,11 +69,23 @@ class PluginField:
     - ``"text"``     – Generic single-line text input.
     - ``"password"`` – Text input whose characters are masked.
     - ``"email"``    – Text input pre-validated as an e-mail address.
-    - ``"select"``   – Drop-down; ``options`` must be populated.
+    - ``"select"``   – Drop-down; ``options`` must be populated (or
+      :attr:`dynamic_options` set, in which case options are fetched at
+      runtime from the plugin's ``get_field_options`` method).
     - ``"server_path"`` – File-browser picker for server filesystem paths.
     - ``"checkbox"`` – Boolean tick-box.  ``default`` should be ``"true"`` or
       ``"false"``; values arrive at :meth:`run` as plain strings (or already
       coerced bools) and should be parsed via ``str(value).lower() == "true"``.
+
+    Dynamic option fields
+    ---------------------
+    Set ``dynamic_options=True`` on a ``"select"`` field whose options must
+    be computed at runtime — e.g. by querying a remote service.  The plugin
+    must implement ``get_field_options(field_key, current_values)`` to return
+    the list.  The frontend re-fetches options every time any field listed
+    in :attr:`depends_on` changes value.  Currently honoured by dataset
+    importers (``POST /api/dataset/import/<name>/options``); other plugin
+    families may opt in similarly.
     """
 
     key: str
@@ -89,6 +101,14 @@ class PluginField:
     required: bool = True
     #: Hint shown as placeholder text inside the input widget.
     placeholder: str = ""
+    #: When ``True``, :attr:`options` is computed at runtime by the plugin's
+    #: ``get_field_options(field_key, current_values)`` method.  Static
+    #: :attr:`options` (if any) are still served as the initial list.
+    dynamic_options: bool = False
+    #: Field keys whose values this field's options depend on.  When any
+    #: listed field changes, the frontend re-fetches options for this field.
+    #: Only meaningful when :attr:`dynamic_options` is ``True``.
+    depends_on: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -101,6 +121,8 @@ class PluginField:
             "default": self.default,
             "required": self.required,
             "placeholder": self.placeholder,
+            "dynamic_options": self.dynamic_options,
+            "depends_on": list(self.depends_on),
         }
 
 


### PR DESCRIPTION
## Summary

Importer extensions can now declare `select` fields whose options are
computed at runtime by the importer — for example, populating a
`query_id` dropdown by querying a remote service after the user picks a
`media_type`.

### Backend
- `PluginField` gains `dynamic_options: bool` and `depends_on: list[str]`.
- `DatasetImporter.get_field_options(field_key, current_values)` is a new
  optional override that returns the runtime option list. The default
  raises `NotImplementedError`.
- New route `POST /api/dataset/import/<name>/options` invokes the hook
  with the supplied form-value snapshot. Errors from the importer
  (typically remote-service failures) are surfaced as 502 with the
  exception message; `NotImplementedError` becomes 501.

### Frontend
- The dataset-importer modal pre-fetches options for every dynamic field
  when an importer opens, and re-fetches whenever a depended-on field
  changes. The dependent field is cleared so a stale value can't be
  submitted, the dropdown is disabled while loading, and remote errors
  render inline next to the field.

### Demo
- The hidden ReCaller scaffold now uses this: `query_id` is a dynamic
  select scoped by `media_type`, with a `_rc_list_queries(media_type)`
  stub function for the extension developer to implement.

### Tests + docs
- New `tests/test_dynamic_field_options.py` covers PluginField
  serialisation, `get_field_options` default + override, the route's
  success / 400 / 501 / 502 paths, and the ReCaller wiring.
- `docs/EXTENDING-plugins.md` gains a "Dynamic field options" section.
- `docs/plans/RCDatasetImporter.md` and `CLAUDE.md` updated.

## Test plan

- [x] `./run-tests.sh` — 3143 passed
- [x] Frontend `npm run build:prod` — clean
- [x] `ruff check vtsearch/ tests/test_dynamic_field_options.py` — clean
- [ ] Manual smoke: open dataset importer modal, confirm a `dynamic_options=True` select disables/loads/errors as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXRCDKZiKy2wJAT8vDryc3)_