### PR TITLE
Fix SigLIP Docker build looking hung during model preload

### DIFF
--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -32,15 +32,28 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # ---------- pre-download SigLIP weights into the image ----------
 # Bake weights into a non-volume path so they survive volume mounts on
 # /app/data. The app reads MODELS_CACHE_DIR from VTSEARCH_MODELS_DIR.
-ENV VTSEARCH_MODELS_DIR=/opt/vtsearch/models
+#
+# PYTHONUNBUFFERED + python -u + flushed prints surface progress in
+# BuildKit's UI; without them the ~370 MB download looks like a hang.
+# Tip: run `docker build --progress=plain ...` to see step output live.
+# HF_HUB_DOWNLOAD_TIMEOUT makes a stalled connection error out (and
+# huggingface_hub auto-retry) instead of blocking the build forever.
+ENV VTSEARCH_MODELS_DIR=/opt/vtsearch/models \
+    HF_HUB_DOWNLOAD_TIMEOUT=120 \
+    PYTHONUNBUFFERED=1
 RUN mkdir -p "$VTSEARCH_MODELS_DIR" && \
-    python -c "import os; \
+    python -u -c "import os; \
 from vtsearch.config import SIGLIP_MODEL_ID; \
-from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
+print(f'Pre-downloading {SIGLIP_MODEL_ID} to {cache}', flush=True); \
+print('[1/3] importing transformers...', flush=True); \
+from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
+print('[2/3] downloading model weights (~370 MB)...', flush=True); \
 SiglipModel.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
+print('[3/3] downloading image processor + tokenizer...', flush=True); \
 SiglipImageProcessor.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
-SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache)"
+SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
+print('SigLIP weights cached.', flush=True)"
 
 # ---------- application layer ----------
 COPY . .
@@ -60,7 +73,6 @@ EXPOSE 5000
 
 ENV OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
-    PYTHONUNBUFFERED=1 \
     VTSEARCH_SERVER_INIT=1
 
 CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]


### PR DESCRIPTION
## What was happening

You said the SigLIP image build "just hangs at the part it tries to get the model into the image" for 30+ minutes. It wasn't actually hung — it was a visibility problem combined with no network timeout:

1. The preload `RUN` in `Dockerfile.siglip` ran `python -c "..."` with **no print statements at all**.
2. `PYTHONUNBUFFERED=1` was set in the `ENV` block at the *bottom* of the file (line 64), which only applies at container runtime, not during build.
3. BuildKit's default UI collapses `RUN` output, so transformers + huggingface_hub silently downloading ~370 MB looked identical to a frozen build.
4. There was no `HF_HUB_DOWNLOAD_TIMEOUT`, so a stalled connection would block the build forever instead of erroring and letting hf_hub auto-retry.

## Fix

In `Dockerfile.siglip`:

- Move `PYTHONUNBUFFERED=1` **before** the preload `RUN` (and remove the now-redundant duplicate at the bottom).
- Switch to `python -u -c` and add flushed step-by-step prints (`[1/3] importing transformers...`, `[2/3] downloading model weights (~370 MB)...`, `[3/3] downloading image processor + tokenizer...`).
- Add `HF_HUB_DOWNLOAD_TIMEOUT=120` so a stalled HTTP read fails fast instead of hanging.
- Add a comment recommending `docker build --progress=plain ...` for live step output.

After this, the build prints clear progress markers as the SigLIP weights download, and a network stall surfaces as an error (with retries) rather than an infinite hang.

## Test plan

- [ ] `docker build -f Dockerfile.siglip -t vtsearch:siglip .` — build completes and shows the new progress lines.
- [ ] `docker build --progress=plain -f Dockerfile.siglip -t vtsearch:siglip .` — full streaming output is visible during the preload step.
- [ ] `docker run -p 5000:5000 -v vtsearch-data:/app/data vtsearch:siglip` — container starts and serves with SigLIP autoloaded (unchanged behavior).


---
_Generated by [Claude Code](https://claude.ai/code/session_01A31PD2Wie1pu7cLzZjUx5B)_