### PR TITLE
Merge dev into main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ If a failure is genuinely outside the scope of the current task (e.g. a flaky ne
   - `test_dashboard.py` — Dashboard API endpoint tests
   - `test_exporters.py` — Results exporter base classes, registry, built-in exporters, API routes
   - `test_importers.py` — Importer base class, HTTP archive/folder importer metadata, archive extraction
+  - `test_dynamic_field_options.py` — Dynamic-options importer fields: PluginField `dynamic_options`/`depends_on` serialisation, `DatasetImporter.get_field_options` default + override, `POST /api/dataset/import/<name>/options` route, ReCaller `query_id` dynamic dropdown
   - `test_importer_loading.py` — Folder loader: content_vectors, skip_embedding, custom-metadata flow
   - `test_importer_symlinks.py` — Symlinked importer discovery, rglob following symlinks
   - `test_dataset_importer_media.py` — End-to-end folder/pickle importer paths into media types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,18 @@ Never ask the user whether to subscribe to PR activity, and never call `subscrib
 
 Breaking backwards compatibility is acceptable — do not add shims, feature flags, legacy re-exports, or other compatibility layers to preserve old behavior. Just make the clean change. When a change does break backwards compatibility, mention it to the user so they're aware.
 
+## Fix All Errors (CRITICAL)
+
+When you run a build, typecheck, linter, or test suite, **fix every error and failure you see — not only the ones you introduced**. Do not dismiss errors as "pre-existing", "unrelated to my change", or "not my fault" and move on. Do not announce them and ask the user to triage. The user does not want to scan your output for problems you decided to ignore.
+
+This applies to:
+- TypeScript errors from `tsc` / `npm run build:prod` (including in `*.spec.ts` files, even though specs do not currently run — they must still typecheck).
+- Python test failures from `./run-tests.sh` and `pytest` runs.
+- Linter errors from `ruff`.
+- Any other diagnostics surfaced by tooling you invoke.
+
+If a failure is genuinely outside the scope of the current task (e.g. a flaky network test, a failure in unrelated infrastructure you cannot reproduce), explicitly call it out in your end-of-turn summary with one sentence explaining why you did not fix it. The default is **fix it**; skipping requires justification.
+
 ## Commands
 - **Run tests (CPU, fast)**: `./run-tests.sh` (also checks frontend TypeScript build)
 - **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; `core` includes frontend build check)

--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -32,15 +32,28 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # ---------- pre-download SigLIP weights into the image ----------
 # Bake weights into a non-volume path so they survive volume mounts on
 # /app/data. The app reads MODELS_CACHE_DIR from VTSEARCH_MODELS_DIR.
-ENV VTSEARCH_MODELS_DIR=/opt/vtsearch/models
+#
+# PYTHONUNBUFFERED + python -u + flushed prints surface progress in
+# BuildKit's UI; without them the ~370 MB download looks like a hang.
+# Tip: run `docker build --progress=plain ...` to see step output live.
+# HF_HUB_DOWNLOAD_TIMEOUT makes a stalled connection error out (and
+# huggingface_hub auto-retry) instead of blocking the build forever.
+ENV VTSEARCH_MODELS_DIR=/opt/vtsearch/models \
+    HF_HUB_DOWNLOAD_TIMEOUT=120 \
+    PYTHONUNBUFFERED=1
 RUN mkdir -p "$VTSEARCH_MODELS_DIR" && \
-    python -c "import os; \
+    python -u -c "import os; \
 from vtsearch.config import SIGLIP_MODEL_ID; \
-from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
+print(f'Pre-downloading {SIGLIP_MODEL_ID} to {cache}', flush=True); \
+print('[1/3] importing transformers...', flush=True); \
+from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
+print('[2/3] downloading model weights (~370 MB)...', flush=True); \
 SiglipModel.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
+print('[3/3] downloading image processor + tokenizer...', flush=True); \
 SiglipImageProcessor.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
-SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache)"
+SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
+print('SigLIP weights cached.', flush=True)"
 
 # ---------- application layer ----------
 COPY . .
@@ -60,7 +73,6 @@ EXPOSE 5000
 
 ENV OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
-    PYTHONUNBUFFERED=1 \
     VTSEARCH_SERVER_INIT=1
 
 CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]

--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -45,6 +45,12 @@ SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache)"
 # ---------- application layer ----------
 COPY . .
 
+# Seed default settings so the SigLIP image embedder is preloaded at startup.
+# Docker copies this file into a fresh named volume on first creation, so new
+# deployments come ready-to-serve without the user manually toggling autoload.
+RUN mkdir -p /app/data && \
+    printf '{\n  "autoload_media_embedders": ["siglip"]\n}\n' > /app/data/settings.json
+
 # Runtime data directory (settings, embeddings, datasets, media files).
 # Mount a volume here to persist user data across container restarts.
 # Note: model weights live under /opt/vtsearch/models, NOT this volume.

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -51,6 +51,8 @@ families use the same field type (aliased as `ImporterField`,
 | `default`     | `str`       | `""`     | Pre-filled value                                        |
 | `required`    | `bool`      | `True`   | Whether the field must be filled before submitting      |
 | `placeholder` | `str`       | `""`     | Hint shown as placeholder text in the input widget      |
+| `dynamic_options` | `bool`  | `False`  | When `True`, options for this `"select"` field are fetched at runtime from the plugin's `get_field_options()` method (see [Dynamic field options](#dynamic-field-options)) |
+| `depends_on`  | `list[str]` | `[]`     | Other field keys whose values this field's options depend on; the frontend re-fetches whenever any depended-on field changes |
 
 ### PluginBase
 
@@ -227,6 +229,7 @@ IMPORTER = S3Importer()
 | Member | Signature | Description |
 |--------|-----------|-------------|
 | `run_cli()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | CLI variant; default delegates to `run()`. Override when `run()` expects FileStorage objects |
+| `get_field_options()` | `(field_key: str, current_values: dict) -> list[str]` | Compute dropdown options for fields declared with `dynamic_options=True`. See [Dynamic field options](#dynamic-field-options) |
 | `run_chunked()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | Yield chunks of medias for piecewise processing. Set `supports_chunked = True` |
 | `run_chunked_cli()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | CLI variant of `run_chunked()` |
 | `build_origin()` | `(field_values: dict) -> dict` | Build an origin dict for provenance tracking. Default uses importer name + string field values |
@@ -325,6 +328,49 @@ are not useful per-media).  The post-processing step only backfills
 `origin` on media that have `origin=None`, so per-media origins set
 in `run()` are preserved.
 
+### Dynamic field options
+
+When a `"select"` field's options must be computed at runtime — for
+example, populating a list of remote queries after the user picks a
+media type — declare it with `dynamic_options=True` and list the parent
+fields it depends on in `depends_on`.  Then implement
+`get_field_options(field_key, current_values)` on your importer:
+
+```python
+class ReCallerImporter(DatasetImporter):
+    name = "recaller"
+    fields = [
+        ImporterField("media_type", "Media Type", "select",
+                      options=all_folder_names(), default="audio"),
+        ImporterField(
+            "query_id", "Query ID", "select",
+            dynamic_options=True,
+            depends_on=["media_type"],   # re-fetch when media_type changes
+        ),
+    ]
+
+    def get_field_options(self, field_key, current_values):
+        if field_key == "query_id":
+            return _list_recent_queries(current_values.get("media_type", ""))
+        return super().get_field_options(field_key, current_values)
+```
+
+The frontend wiring is fully automatic:
+
+1. When the user opens your importer, the modal pre-fetches options for
+   every `dynamic_options=True` field.
+2. Whenever a field listed in another field's `depends_on` changes, the
+   modal clears the dependent field's value and re-fetches its options.
+3. While a fetch is in-flight the dropdown is disabled and shows
+   `Loading…`.  Errors raised by `get_field_options()` are surfaced
+   inline next to the field.
+
+API contract: `POST /api/dataset/import/<name>/options` with body
+`{"field_key": "...", "values": {...}}` returns `{"options": [...]}`.
+Any exception your `get_field_options()` raises is returned as a 502
+with the exception message — perfect for surfacing remote-service
+errors directly to the user.
+
 ### How it gets invoked
 
 1. `GET /api/dataset/all-importers` returns all registered importers (your
@@ -332,7 +378,9 @@ in `run()` are preserved.
    returns importers with `ui_mode == "form"`.
 2. `POST /api/dataset/import/<name>` invokes `run()` in a background
    daemon thread.
-3. `GET /api/dataset/progress` provides progress bar data.
+3. `POST /api/dataset/import/<name>/options` invokes `get_field_options()`
+   to populate dynamic-options dropdowns (see above).
+4. `GET /api/dataset/progress` provides progress bar data.
 
 ### Progress reporting
 

--- a/docs/plans/RCDatasetImporter.md
+++ b/docs/plans/RCDatasetImporter.md
@@ -10,7 +10,7 @@ Three external services are involved:
 
 | Service | What it does | VTSearch talks to it via |
 |---------|-------------|------------------------|
-| **ReCaller (RC)** | Browse tool. Given a `queryID`, returns a collection of results: `{contentID, mediaID, media_type, media_url, md5, ...}` | `_rc_fetch_results()` in the RC importer |
+| **ReCaller (RC)** | Browse tool. Given a `queryID`, returns a collection of results: `{contentID, mediaID, media_type, media_url, md5, ...}`.  Also exposes a list of recent queryIDs filtered by `media_type`, used to populate the importer's dynamic `query_id` dropdown | `_rc_fetch_results()` and `_rc_list_queries()` in the RC importer |
 | **DataWrest (DW)** | Given a `mediaID`, returns `{embedding, embedder}`. All media of a given type share the same embedder | `_dw_get_embedding()` in the RC importer |
 | **PullWrest (PW)** | Given a `media_url`, returns the raw media bytes | `_pw_fetch_media()` in the RC importer + PW media source |
 | **Holder** | ContentID storage. Create packages, add folders, write/read contentIDs with metadata | `_holder_*()` functions in the Holder exporter and importer |
@@ -55,6 +55,16 @@ just inline in each plugin) with HTTP functions for each service.
 ### 1a. ReCaller client
 
 ```python
+def _rc_list_queries(media_type: str) -> list[str]:
+    """GET /api/rc/queries?media_type=<type> → list of recent queryIDs.
+
+    Powers the importer's ``query_id`` dropdown (declared with
+    ``dynamic_options=True, depends_on=["media_type"]``).  The frontend
+    re-fetches whenever the user picks a different media type, so the
+    user never has to copy-paste a queryID — they pick from a list.
+    """
+
+
 def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
     """GET /api/rc/query/{query_id} → list of result dicts.
 
@@ -67,7 +77,7 @@ def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
     """
 ```
 
-Replace the `NotImplementedError` stub in
+Replace the `NotImplementedError` stubs in
 `vtsearch/datasets/importers/recaller/__init__.py`.
 
 ### 1b. DataWrest client

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7162,9 +7162,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -137,7 +137,7 @@
   <div class="dashboard-section-wrap">
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="lightbulb" [size]="18"></vt-icon> Models</span>
+      <span class="dashboard-section-title" title="Trained models for scoring and finding media"><vt-icon type="robot" [size]="18"></vt-icon> Models</span>
       <div class="dashboard-section-actions">
         <button class="btn btn--primary btn--sm"
           [disabled]="isLoading"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -189,12 +189,21 @@
                 [id]="'field-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
-                (ngModelChange)="field.key === 'media_type' ? onMediaTypeChange($event) : null"
+                [disabled]="dynamicFieldLoading[field.key] || (field.dynamic_options && optionsFor(field).length === 0)"
+                (ngModelChange)="onFormFieldChanged(field.key)"
               >
-                @for (opt of field.options || []; track opt) {
+                @if (field.dynamic_options && dynamicFieldLoading[field.key]) {
+                  <option [value]="''" disabled>Loading…</option>
+                } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError[field.key]) {
+                  <option [value]="''" disabled>No options available</option>
+                }
+                @for (opt of optionsFor(field); track opt) {
                   <option [value]="opt">{{ opt }}</option>
                 }
               </select>
+              @if (field.dynamic_options && dynamicFieldError[field.key]) {
+                <p class="error-text">{{ dynamicFieldError[field.key] }}</p>
+              }
             } @else {
               <input
                 [id]="'field-' + field.key"
@@ -202,6 +211,7 @@
                 class="form-input"
                 [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.description || field.label || field.key"
+                (change)="onFormFieldChanged(field.key)"
               />
             }
           </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -189,7 +189,7 @@
                 [id]="'field-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
-                [disabled]="dynamicFieldLoading[field.key] || (field.dynamic_options && optionsFor(field).length === 0)"
+                [disabled]="!!dynamicFieldLoading[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
                 (ngModelChange)="onFormFieldChanged(field.key)"
               >
                 @if (field.dynamic_options && dynamicFieldLoading[field.key]) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -1,3 +1,8 @@
+// Picker chrome (importer tabs, demo table, server folder browser, badges)
+// lives in `frontend/src/scss/_picker-shared.scss` so it's defined once
+// globally and shared with the New Model > Browse Media picker — only
+// styles unique to this component remain below.
+
 // Pin the Add Dataset modal to a single large width so flipping between
 // tabs (Services / Server / Local / Demo) and inner widgets doesn't reflow
 // the dialog.  680px (matching the Settings modal) was too narrow for the
@@ -31,87 +36,11 @@
   padding-left: 20px;
 }
 
-.importer-tab-bar {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  width: 100%;
-  border-bottom: 2px solid var(--border);
-}
-
-.importer-tab {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 8px 16px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  background: none;
-  color: var(--text-secondary, var(--text-muted));
-  font-size: .85rem;
-  cursor: pointer;
-  transition: all .15s;
-  margin-bottom: -2px;
-  white-space: nowrap;
-
-  &:hover {
-    color: var(--text-primary);
-    background: var(--bg-subtle);
-  }
-
-  &.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-    font-weight: 600;
-  }
-}
-
-// Inner row of importer "tabs" within the active category.  Uses the same
-// underline-tab styling as the top-level category tabs so all three tab
-// levels (category, importer, demo media-type) feel like one consistent
-// system.
-.importer-subtab-bar {
-  @extend .importer-tab-bar;
-}
-
-.importer-subtab {
-  @extend .importer-tab;
-
-  &.disabled, &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-}
-
-// Hint shown directly below the tab row when no tab/importer/media-type is
-// selected yet — placed where the next-step content will appear so the user's
-// eye lands on it naturally.
-.tab-bar-hint {
-  margin: 8px 0 0 0;
-  color: var(--text-muted);
-  font-size: .85rem;
-  font-style: italic;
-}
-
 // Extra vertical breathing room above grouped sections inside the Local /
 // Folder uploader (Folder picker, Chunk size, Embedder, Clipper). The
 // Recursive checkbox intentionally does NOT get this class — it is a
 // sub-option of the Folder picker above it.
-.form-group--section {
-  margin-top: 16px;
-}
-
-.importer-subtab-icon {
-  display: inline-flex;
-  align-items: center;
-}
-
-.empty-state--inline {
-  padding: 6px 10px;
-  font-size: .8rem;
-  color: var(--text-muted);
-  font-style: italic;
-}
+.form-group--section { margin-top: 16px; }
 
 .clipper-params {
   padding-left: 16px;
@@ -120,12 +49,6 @@
 }
 
 .demo-picker { gap: 12px; }
-
-// .demo-tab-bar / .demo-tab share the visual styling of the top
-// .importer-tab-bar / .importer-tab.  Define the chrome once via @extend
-// so the compiled output stays under the per-component CSS budget.
-.demo-tab-bar { @extend .importer-tab-bar; }
-.demo-tab { @extend .importer-tab; }
 
 .demo-embedder-row {
   display: flex;
@@ -137,170 +60,6 @@
   .form-select { max-width: 200px; }
 }
 
-.demo-content-area {
-  min-height: 200px;
-  max-height: 50vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.table-fixed {
-  table-layout: fixed;
-}
-
-.demo-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.83rem;
-
-  th, td {
-    padding: 6px 10px;
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-    white-space: nowrap;
-  }
-
-  // Body cells truncate with ellipsis when the column is narrower than
-  // their content. Header cells must NOT clip — they host the resize handle
-  // which pokes 6px to the left of the cell's edge.
-  td {
-    padding: 6px 12px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  th {
-    padding-right: 0;
-    position: sticky;
-    top: 0;
-    background: var(--bg-surface);
-    z-index: 1;
-    color: var(--text-secondary);
-    font-weight: 500;
-    font-size: 0.78rem;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    user-select: none;
-
-    // Headers are draggable for reordering (matches the Dashboard tables).
-    &[draggable='true'] {
-      cursor: grab;
-
-      &:active {
-        cursor: grabbing;
-      }
-    }
-
-    &.sortable {
-      cursor: pointer;
-
-      &:hover {
-        color: var(--text-primary);
-      }
-    }
-
-    &[draggable='true'].sortable {
-      cursor: grab;
-
-      &:active {
-        cursor: grabbing;
-      }
-    }
-
-    &.col-drop-target {
-      box-shadow: inset 0 0 0 2px var(--accent);
-    }
-
-    &.col-dragging {
-      opacity: 0.4;
-    }
-
-    .sort-indicator {
-      display: inline-block;
-      width: 1em;
-      text-align: center;
-      visibility: hidden;
-
-      &.active {
-        visibility: visible;
-      }
-    }
-
-    // See dashboard.component.scss for the full rationale; the handle sits on
-    // the LEFT of the cell after the divider it controls so it isn't covered
-    // by the next sticky <th>'s stacking context.
-    .col-resize-handle {
-      position: absolute;
-      top: 0;
-      left: -6px;
-      bottom: 0;
-      width: 12px;
-      cursor: col-resize;
-      z-index: 2;
-
-      &::after {
-        content: '';
-        position: absolute;
-        top: 20%;
-        bottom: 20%;
-        left: 5px;
-        width: 2px;
-        background: var(--accent);
-        opacity: 0.35;
-        transition: opacity 0.15s;
-      }
-
-      &:hover::after {
-        opacity: 0.7;
-      }
-    }
-  }
-
-  tbody tr {
-    cursor: pointer;
-    transition: background 0.1s;
-
-    &:hover {
-      background: var(--bg-hover);
-    }
-  }
-}
-
-.col-num { text-align: right; padding-right: 12px; }
-
-.col-desc, .col-name, .sf-dir-name, .col-status {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.col-desc { color: var(--text-muted); font-size: 0.78rem; }
-.col-name { font-weight: 600; color: var(--text-primary); }
-
-.sf-dir-date {
-  margin-left: auto;
-  color: var(--text-muted);
-  font-size: .75rem;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.demo-row {
-  &.ready .col-name { color: var(--color-good); }
-}
-
-.badge-ready, .badge-embedding, .badge-download {
-  display: inline-block;
-  padding: 1px 7px;
-  color: var(--btn-filled-text);
-  font-size: .7rem;
-  border-radius: 3px;
-}
-
-.badge-ready { background: var(--color-good); }
-.badge-embedding { background: var(--badge-embedding, var(--accent)); }
-.badge-download { background: var(--border); color: var(--text-muted); }
-
 .clipper-btn {
   text-align: left;
   white-space: nowrap;
@@ -308,74 +67,3 @@
 
 .server-folder-browser { gap: 12px; }
 .sf-browse-section { gap: 6px; }
-.sf-breadcrumbs { display: flex; align-items: center; gap: 2px; font-size: .8rem; flex-wrap: wrap; }
-
-.sf-breadcrumb {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: .8rem;
-
-  &:hover { background: var(--bg-subtle); }
-
-  &.active {
-    color: var(--text-primary);
-    font-weight: 600;
-    cursor: default;
-    &:hover { background: none; }
-  }
-}
-
-.sf-breadcrumb-sep { color: var(--text-muted); font-size: .75rem; }
-
-.sf-dir-list {
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  max-height: 220px;
-  overflow-y: auto;
-}
-
-.sf-dir-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-  text-align: left;
-  color: var(--text-primary);
-  font-size: .85rem;
-  transition: background .15s;
-
-  &:last-child { border-bottom: none; }
-  &:hover { background: var(--bg-subtle); }
-}
-
-.sf-dir-icon { font-size: .9rem; flex-shrink: 0; }
-
-.sf-empty-dir {
-  color: var(--text-muted);
-  font-size: .8rem;
-  padding: 12px;
-  text-align: center;
-}
-
-.sf-selected-path { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
-
-.sf-path-display {
-  font-size: .8rem;
-  color: var(--text-secondary, var(--text-muted));
-  background: var(--bg-subtle);
-  padding: 3px 8px;
-  border-radius: 3px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -454,17 +454,17 @@ describe('DatasetImporterModalComponent', () => {
     openAndFlushDemoPicker();
 
     // Default sort is num_files ascending
-    expect(component.demoSortKey).toBe('num_files');
-    expect(component.demoSortAsc).toBeTrue();
+    expect(component.demoCols.sortColumn).toBe('num_files');
+    expect(component.demoCols.sortAsc).toBeTrue();
 
     // Click same column to toggle direction
-    component.sortDemoBy('num_files');
-    expect(component.demoSortAsc).toBeFalse();
+    component.demoCols.sortBy('num_files');
+    expect(component.demoCols.sortAsc).toBeFalse();
 
     // Click different column to switch
-    component.sortDemoBy('label');
-    expect(component.demoSortKey).toBe('label');
-    expect(component.demoSortAsc).toBeTrue();
+    component.demoCols.sortBy('label');
+    expect(component.demoCols.sortColumn).toBe('label');
+    expect(component.demoCols.sortAsc).toBeTrue();
   });
 
   it('should emit demoSelected and close on demo selection', () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -6,7 +6,7 @@ import { FileBrowserComponent } from '../../file-browser/file-browser.component'
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
-import { ImporterInfo, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
+import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo } from '../../../models/api.models';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 @Component({
@@ -116,6 +116,14 @@ export class DatasetImporterModalComponent implements OnInit {
 
   /** Maximum medias per chunk during embedding for the generic form view; 0 means "no chunking". */
   chunkSize = 0;
+
+  // Dynamic-options cache for the generic form view.  Keyed by ImporterField.key.
+  /** Options last fetched from the backend for dynamic-options fields. */
+  dynamicFieldOptions: Record<string, string[]> = {};
+  /** Whether a dynamic-options fetch is currently in flight for a field. */
+  dynamicFieldLoading: Record<string, boolean> = {};
+  /** Last fetch error for a dynamic-options field, if any. */
+  dynamicFieldError: Record<string, string> = {};
 
   // Clipper chooser modal state
   clipperChooserOpen = false;
@@ -273,6 +281,9 @@ export class DatasetImporterModalComponent implements OnInit {
     this.clipperParamValues = {};
     this.selectedEmbedder = '';
     this.availableEmbedders = [];
+    this.dynamicFieldOptions = {};
+    this.dynamicFieldLoading = {};
+    this.dynamicFieldError = {};
 
     // Pre-populate defaults
     if (importer.fields) {
@@ -298,12 +309,76 @@ export class DatasetImporterModalComponent implements OnInit {
       this.loadClippers(defaultType);
       this.loadEmbedders(defaultType);
     }
+
+    // Fetch initial options for dynamic fields whose deps are already filled.
+    for (const field of importer.fields || []) {
+      if (field.dynamic_options) {
+        this.refreshDynamicFieldOptions(field);
+      }
+    }
   }
 
   onMediaTypeChange(mediaType: string): void {
     this.formValues['media_type'] = mediaType;
     this.loadClippers(mediaType);
     this.loadEmbedders(mediaType);
+    this.onFormFieldChanged('media_type');
+  }
+
+  /** Called whenever a form field value changes.  Refreshes options for
+   *  every dynamic-options field whose ``depends_on`` includes *changedKey*.
+   *  Also clears the dependent field's current value so the user can't
+   *  submit a now-stale selection. */
+  onFormFieldChanged(changedKey: string): void {
+    const importer = this.selectedImporter;
+    if (!importer?.fields) return;
+    for (const field of importer.fields) {
+      if (!field.dynamic_options) continue;
+      if (!(field.depends_on || []).includes(changedKey)) continue;
+      this.formValues[field.key] = '';
+      this.refreshDynamicFieldOptions(field);
+    }
+  }
+
+  /** Fetch the option list for a dynamic-options field from the backend. */
+  private refreshDynamicFieldOptions(field: ImporterField): void {
+    const importer = this.selectedImporter;
+    if (!importer) return;
+    const key = field.key;
+    this.dynamicFieldLoading[key] = true;
+    this.dynamicFieldError[key] = '';
+    this.datasetsApi
+      .getImporterFieldOptions(importer.name, key, { ...this.formValues })
+      .subscribe({
+        next: (res) => {
+          this.dynamicFieldOptions[key] = res.options || [];
+          this.dynamicFieldLoading[key] = false;
+          // If the current value isn't in the new option list, clear it so
+          // the displayed select matches the value.  Pre-select the first
+          // option when the field is required and currently empty.
+          const current = this.formValues[key];
+          if (current && !this.dynamicFieldOptions[key].includes(String(current))) {
+            this.formValues[key] = '';
+          }
+          if (!this.formValues[key] && field.required && this.dynamicFieldOptions[key].length > 0) {
+            this.formValues[key] = this.dynamicFieldOptions[key][0];
+          }
+        },
+        error: (err) => {
+          this.dynamicFieldLoading[key] = false;
+          this.dynamicFieldError[key] = err?.error?.error || 'Could not load options';
+          this.dynamicFieldOptions[key] = [];
+        },
+      });
+  }
+
+  /** Effective option list for a select field — dynamic options when set,
+   *  otherwise the static options declared on the field. */
+  optionsFor(field: ImporterField): string[] {
+    if (field.dynamic_options) {
+      return this.dynamicFieldOptions[field.key] || [];
+    }
+    return field.options || [];
   }
 
   private loadClippers(mediaType: string): void {

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -83,7 +83,7 @@
             </div>
             <div class="example-col">
               <label class="col-label">Media Example</label>
-              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse loaded media to pick an example">Browse Media...</button>
+              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse demos, server folders, or upload a file to pick an example">Browse Media...</button>
               <input
                 #fileInput
                 type="file"
@@ -243,86 +243,269 @@
     <div class="media-picker">
       <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()" title="Return to the model creation form">&larr; Back</button>
 
-      <!-- Source selection (top level) -->
-      @if (!selectedSource) {
-        <p class="picker-instructions">Choose a source to browse media from:</p>
-        <div class="source-list">
-          @for (src of mediaSources; track src.name) {
-            <button class="importer-card" (click)="selectSource(src)">
-              <span class="importer-name">@if (src.icon) {<span class="importer-icon"><vt-icon [icon]="src.icon"></vt-icon></span> }{{ src.display_name || src.name }}</span>
-              @if (src.description) {
-                <span class="importer-desc">{{ src.description }}</span>
-              }
-            </button>
+      <!-- Category tabs (mirrors the Add Dataset modal so users see the same layout). -->
+      <div class="importer-picker">
+        <div class="importer-tab-bar">
+          @for (tab of visibleImporterTabs; track tab.id) {
+            <button
+              class="importer-tab"
+              [class.active]="activeImporterTab === tab.id"
+              (click)="selectImporterTab(tab.id)"
+              [title]="'Show ' + tab.label + ' media sources'"
+            >@if (tab.icon) {<vt-icon [type]="tab.icon" [size]="14"></vt-icon>}{{ tab.label }}</button>
           }
         </div>
-      }
-
-      <!-- Browse items (demo list or server media files) -->
-      @if (selectedSource && !fileBrowsing && !browseLoading && browseItems.length > 0) {
-        <p class="picker-instructions">Select an item from <strong>{{ selectedSource.display_name || selectedSource.name }}</strong>:</p>
-        <div class="browse-list">
-          @for (item of browseItems; track item.key) {
-            <button class="browse-item" (click)="selectBrowseItem(item)" [title]="item.key">
-              {{ item.display || item.key }}
-            </button>
-          }
-        </div>
-      }
-
-      <!-- File browser (recursive directory navigation) -->
-      @if (fileBrowsing) {
-        <div class="breadcrumbs">
-          @for (seg of browsePath; track $index) {
-            @if ($index > 0) { <span class="breadcrumb-sep">/</span> }
-            @if ($index < browsePath.length - 1) {
-              <button class="breadcrumb-link" (click)="navigateBreadcrumb($index)">{{ seg }}</button>
-            } @else {
-              <span class="breadcrumb-current">{{ seg }}</span>
-            }
-          }
-        </div>
-
-        @if (fileLoading) {
-          <p class="empty-state">Loading...</p>
+        @if (!activeImporterTab) {
+          <p class="tab-bar-hint">Select where to pick a media example from.</p>
         }
 
-        @if (!fileLoading && browseEntries.length > 0) {
-          <div class="browse-list">
-            @for (entry of browseEntries; track entry.path) {
-              @if (entry.isDir) {
-                <button class="browse-item browse-dir" (click)="enterDirectory(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="folder"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                </button>
-              } @else {
-                <button class="browse-item browse-file" (click)="selectFile(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="file-text"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                  @if (entry.size_bytes != null) {
-                    <span class="entry-size">{{ formatSize(entry.size_bytes) }}</span>
-                  }
-                </button>
-              }
+        @if (activeImporterTab) {
+          <div class="importer-subtab-bar">
+            @if (importersForActiveTab.length === 0) {
+              <span class="empty-state empty-state--inline">No sources in this category.</span>
+            }
+            @for (imp of importersForActiveTab; track imp.name) {
+              <button
+                class="importer-subtab"
+                [class.active]="selectedImporter?.name === imp.name"
+                (click)="selectImporter(imp)"
+                [title]="imp.description || ''"
+              >@if (imp.icon) {<span class="importer-subtab-icon"><vt-icon [icon]="imp.icon"></vt-icon></span>}{{ imp.display_name || imp.name }}</button>
             }
           </div>
+          @if (!selectedImporter && importersForActiveTab.length > 0) {
+            <p class="tab-bar-hint">Select a {{ activeImporterTabLabel }} source to browse.</p>
+          }
         }
+      </div>
 
-        @if (!fileLoading && browseEntries.length === 0) {
-          <p class="empty-state">No media files found in this directory.</p>
-        }
+      <!-- Demo picker view: media-type tabs + sortable demo table. -->
+      @if (activePickerView === 'demo' && selectedImporter && !demoFileBrowsing) {
+        <div class="demo-picker">
+          @if (demoLoading) {
+            <p class="empty-state">Loading demo datasets...</p>
+          } @else if (demos.length === 0) {
+            <p class="empty-state">No demo datasets available.</p>
+          } @else {
+            <div class="demo-tab-bar">
+              @for (tab of demoTabs; track tab) {
+                <button
+                  class="demo-tab"
+                  [class.active]="activeDemoTab === tab"
+                  (click)="selectDemoTab(tab)"
+                  [title]="'Filter demos by media type: ' + getDemoTabLabel(tab)"
+                >@if (getDemoTabIcon(tab)) {<vt-icon [icon]="getDemoTabIcon(tab)" [size]="14"></vt-icon>}{{ getDemoTabLabel(tab) }}</button>
+              }
+            </div>
+            @if (!activeDemoTab) {
+              <p class="tab-bar-hint">Select the media type to demonstrate.</p>
+            }
+
+            @if (activeDemoTab) {
+              <div class="demo-content-area">
+                <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
+                  <thead>
+                    <tr>
+                      @for (col of demoCols.columnOrder; track col; let first = $first) {
+                        <th
+                          [class.sortable]="demoCols.meta(col).sortable"
+                          [class.col-drop-target]="demoCols.isDropTarget(col)"
+                          [class.col-dragging]="demoCols.isDragging(col)"
+                          [class.col-num]="col === 'num_files' || col === 'num_categories'"
+                          [attr.data-col]="col"
+                          [title]="demoCols.meta(col).title"
+                          [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
+                          draggable="true"
+                          (click)="onDemoHeaderClick(col)"
+                          (dragstart)="demoCols.onColDragStart($event, col)"
+                          (dragover)="demoCols.onColDragOver($event, col)"
+                          (dragleave)="demoCols.onColDragLeave($event, col)"
+                          (drop)="demoCols.onColDrop($event, col)"
+                          (dragend)="demoCols.onColDragEnd($event)"
+                        >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
+                      }
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @for (demo of filteredDemos; track demo.name) {
+                      <tr
+                        class="demo-row"
+                        [class.ready]="demo.status === 'ready'"
+                        [class.disabled]="!isDemoBrowsable(demo)"
+                        role="button"
+                        tabindex="0"
+                        [attr.aria-label]="demo.label + ': ' + demo.description"
+                        [title]="isDemoBrowsable(demo) ? 'Browse files in ' + demo.label : 'This demo has not been downloaded. Use the Add Dataset window to fetch it first.'"
+                        (click)="selectDemo(demo)"
+                        (keydown.enter)="selectDemo(demo)"
+                        (keydown.space)="$event.preventDefault(); selectDemo(demo)"
+                      >
+                        @for (col of demoCols.columnOrder; track col) {
+                          @switch (col) {
+                            @case ('label') {
+                              <td class="col-name">{{ demo.label }}</td>
+                            }
+                            @case ('num_files') {
+                              <td class="col-num">{{ demo.num_files | number }}</td>
+                            }
+                            @case ('num_categories') {
+                              <td class="col-num">{{ demo.num_categories | number }}</td>
+                            }
+                            @case ('description') {
+                              <td class="col-desc" [title]="demo.description">{{ demo.description }}</td>
+                            }
+                            @case ('status') {
+                              <td class="col-status"><span [class]="statusBadgeClass(demo.status)">{{ statusBadgeLabel(demo.status) }}</span></td>
+                            }
+                          }
+                        }
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              </div>
+            }
+          }
+        </div>
       }
 
-      @if (browseLoading) {
-        <p class="empty-state">Loading items...</p>
+      <!-- Demo file browser: appears after picking a demo from the table.
+           Reuses the server-folder-browser chrome so both file pickers feel
+           the same. -->
+      @if (activePickerView === 'demo' && selectedImporter && demoFileBrowsing) {
+        <div class="server-folder-browser">
+          <button class="btn btn--secondary btn--sm back-btn" (click)="backToDemoTable()" title="Return to the demo list">&larr; Back to demo list</button>
+          <div class="sf-browse-section">
+            <div class="sf-breadcrumbs">
+              @for (seg of demoFileBrowsePath; track $index) {
+                @if ($index > 0) { <span class="sf-breadcrumb-sep">/</span> }
+                <button class="sf-breadcrumb" [class.active]="$index === demoFileBrowsePath.length - 1" (click)="navigateDemoBreadcrumb($index)">{{ seg }}</button>
+              }
+            </div>
+
+            <div class="sf-dir-list">
+              @if (demoFileLoading) {
+                <p class="empty-state">Loading...</p>
+              } @else if (demoFileBrowseEntries.length === 0) {
+                <p class="sf-empty-dir">No media files found in this directory.</p>
+              }
+              @for (entry of demoFileBrowseEntries; track entry.path) {
+                @if (entry.isDir) {
+                  <button class="sf-dir-item" (click)="enterDemoDirectory(entry)" [title]="entry.path">
+                    <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
+                    <span class="sf-dir-name">{{ entry.name }}</span>
+                    @if (entry.modified_at) {
+                      <span class="sf-dir-date">{{ entry.modified_at }}</span>
+                    }
+                  </button>
+                } @else {
+                  <button class="sf-dir-item" (click)="selectDemoFile(entry)" [title]="'Use ' + entry.path + ' as the example'" [disabled]="demoFileLoading">
+                    <span class="sf-dir-icon"><vt-icon type="file-text"></vt-icon></span>
+                    <span class="sf-dir-name">{{ entry.name }}</span>
+                    @if (entry.size_bytes != null) {
+                      <span class="sf-dir-date">{{ formatSize(entry.size_bytes) }}</span>
+                    }
+                  </button>
+                }
+              }
+            </div>
+          </div>
+        </div>
       }
 
-      @if (selectedSource && !fileBrowsing && !browseLoading && browseItems.length === 0) {
-        <p class="empty-state">No items found in this source.</p>
+      <!-- Server folder browser: same breadcrumb chrome as the Add Dataset
+           modal, but lists files alongside directories so the user can pick
+           one to use as an example. -->
+      @if (activePickerView === 'server_folder' && selectedImporter) {
+        <div class="server-folder-browser">
+          <div class="sf-browse-section">
+            <label class="form-label">Browse server folders</label>
+            <div class="sf-breadcrumbs">
+              <button class="sf-breadcrumb" [class.active]="!sfBrowsePath" (click)="sfLoadDirectory('')">Root</button>
+              @for (crumb of sfBreadcrumbs; track $index) {
+                <span class="sf-breadcrumb-sep">/</span>
+                <button class="sf-breadcrumb" [class.active]="$index === sfBreadcrumbs.length - 1" (click)="sfNavigateBreadcrumb($index)">{{ crumb }}</button>
+              }
+            </div>
+
+            <div class="sf-dir-list">
+              @if (sfBrowseLoading) {
+                <p class="empty-state">Loading...</p>
+              } @else if (sfBrowseError) {
+                <p class="error-text">{{ sfBrowseError }}</p>
+              } @else if (sfBrowseDirs.length === 0 && sfBrowseFiles.length === 0) {
+                <p class="sf-empty-dir">No subdirectories or media files in this folder.</p>
+              }
+              @if (sfBrowsePath) {
+                <button class="sf-dir-item" (click)="sfGoUp()" title="Go to parent directory">
+                  <span class="sf-dir-icon"><vt-icon type="arrow-up"></vt-icon></span>
+                  <span class="sf-dir-name">..</span>
+                </button>
+              }
+              @for (dir of sfBrowseDirs; track dir.path) {
+                <button class="sf-dir-item" (click)="sfEnterDirectory(dir)" [title]="dir.path">
+                  <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
+                  <span class="sf-dir-name">{{ dir.name }}</span>
+                  @if (dir.modified_at) {
+                    <span class="sf-dir-date">{{ dir.modified_at }}</span>
+                  }
+                </button>
+              }
+              @for (file of sfBrowseFiles; track file.path) {
+                <button class="sf-dir-item" (click)="sfSelectFile(file)" [title]="'Use ' + file.path + ' as the example'" [disabled]="sfFileSelecting">
+                  <span class="sf-dir-icon"><vt-icon type="file-text"></vt-icon></span>
+                  <span class="sf-dir-name">{{ file.name }}</span>
+                  @if (file.size_bytes != null) {
+                    <span class="sf-dir-date">{{ formatSize(file.size_bytes) }}</span>
+                  }
+                </button>
+              }
+            </div>
+
+            <div class="sf-selected-path">
+              <span class="form-label">Path:</span>
+              <code class="sf-path-display">{{ sfAbsolutePath }}</code>
+            </div>
+          </div>
+
+          @if (sfBrowseError && !sfBrowseLoading) {
+            <p class="error-text">{{ sfBrowseError }}</p>
+          }
+        </div>
+      }
+
+      <!-- Local file upload: pick a single file from the user's machine.
+           local_folder and local_files share this view since only one example
+           file is needed regardless of how many the input collects. -->
+      @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter) {
+        <div class="local-folder-uploader">
+          <p class="info-text">
+            Pick a media file on <strong>this computer</strong>. It will be uploaded to the server
+            and used as the example for this model.
+          </p>
+          @if (activePickerView === 'local_folder') {
+            <input
+              id="nmm-local-folder-input"
+              type="file"
+              class="form-input"
+              webkitdirectory
+              directory
+              multiple
+              (change)="onLocalFileSelected($event)"
+            />
+            <p class="info-text">
+              The first file in the picked folder will be used. To pick a single file directly,
+              switch to the <strong>Local Files</strong> tab.
+            </p>
+          } @else {
+            <input
+              id="nmm-local-files-input"
+              type="file"
+              class="form-input"
+              (change)="onLocalFileSelected($event)"
+            />
+          }
+        </div>
       }
     </div>
   }

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.html
@@ -61,7 +61,11 @@
           <div class="example-display">
             <label class="col-label">Example</label>
             <div class="example-row">
-              <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+              @if (exampleThumbnailUrl) {
+                <img class="example-thumbnail" [src]="exampleThumbnailUrl" [alt]="exampleDisplay" (error)="onExampleThumbError()" />
+              } @else {
+                <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+              }
               <span class="example-label" [title]="exampleDisplay">{{ exampleDisplay }}</span>
               <button type="button" class="btn btn--secondary btn--sm" (click)="clearExample()" title="Remove this example and choose a different one">Change</button>
             </div>

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -142,6 +142,15 @@
   color: var(--accent);
 }
 
+.example-thumbnail {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--radius-sm, 4px);
+  flex-shrink: 0;
+  background: var(--bg, #fff);
+}
+
 .example-label {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.scss
@@ -1,3 +1,23 @@
+// Picker chrome (importer tabs, demo table, server folder browser, badges)
+// lives in `frontend/src/scss/_picker-shared.scss` so it's defined once
+// globally and shared with the Add Dataset modal — only styles unique to
+// this component remain below.
+
+// Pin the modal to a wider size when the media picker is on screen so the
+// demo table and folder browser have room (matches the Add Dataset modal at
+// 900px). The min-height keeps the dialog from collapsing to a thin strip
+// when the picker is in its "no source selected" state.
+:host {
+  ::ng-deep .modal-content {
+    min-height: 200px;
+  }
+
+  &:has(.media-picker) ::ng-deep .modal-content {
+    width: 900px;
+    min-height: 480px;
+  }
+}
+
 .tab-bar {
   display: flex;
   gap: 4px;
@@ -17,9 +37,7 @@
   margin-bottom: -1px;
   transition: color 0.15s, border-color 0.15s;
 
-  &:hover {
-    color: var(--text-primary);
-  }
+  &:hover { color: var(--text-primary); }
 
   &.active {
     color: var(--text-primary);
@@ -53,9 +71,7 @@
   gap: 4px;
 }
 
-.required {
-  color: var(--color-bad);
-}
+.required { color: var(--color-bad); }
 
 .info-text {
   color: var(--text-muted);
@@ -103,14 +119,10 @@
   text-align: center;
 }
 
-.hidden-file-input {
-  display: none;
-}
+.hidden-file-input { display: none; }
 
 // Single example display
-.example-display {
-  margin-top: 4px;
-}
+.example-display { margin-top: 4px; }
 
 .example-row {
   display: flex;
@@ -139,22 +151,55 @@
   font-size: 0.9rem;
 }
 
-// Media picker view
+// Media picker view container
 .media-picker {
-  min-height: 200px;
-  width: 480px;
-  max-width: 100%;
+  min-height: 320px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.back-btn {
-  margin-bottom: 12px;
+.back-btn { align-self: flex-start; }
+
+.btn--sm {
+  padding: 2px 10px;
+  font-size: .85rem;
 }
 
-.picker-instructions {
-  margin: 0 0 8px;
-  font-size: 0.9rem;
-  color: var(--text-primary);
+.importer-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
+
+.demo-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.server-folder-browser {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-left: 20px;
+}
+
+.sf-browse-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.local-folder-uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 20px;
+}
+
+// --- Trained-tab importer cards (label-importer picker) ---
 
 .source-list {
   display: flex;
@@ -186,42 +231,11 @@
   font-size: 0.9rem;
 }
 
-.importer-icon {
-  margin-right: 4px;
-}
+.importer-icon { margin-right: 4px; }
 
 .importer-desc {
   font-size: 0.8rem;
   color: var(--text-muted);
-}
-
-.browse-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.browse-item {
-  display: block;
-  width: 100%;
-  padding: 6px 12px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--bg-subtle);
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  font-size: 0.9rem;
-  transition: border-color 0.15s, background 0.15s;
-  white-space: normal;
-  word-break: break-word;
-
-  &:hover {
-    border-color: var(--accent);
-    background: var(--bg-hover);
-  }
 }
 
 .empty-state {
@@ -231,76 +245,8 @@
   padding: 16px 0;
 }
 
-// Breadcrumbs for file browser navigation
-.breadcrumbs {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 2px;
-  margin-bottom: 8px;
-  font-size: 0.85rem;
-}
-
-.breadcrumb-link {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--accent);
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: 0.85rem;
-
-  &:hover {
-    text-decoration: underline;
-    background: var(--bg-hover);
-  }
-}
-
-.breadcrumb-sep {
-  color: var(--text-muted);
-  margin: 0 1px;
-}
-
-.breadcrumb-current {
-  font-weight: 600;
-  padding: 2px 4px;
-}
-
-// File/directory entries
-.browse-dir {
-  font-weight: 600;
-}
-
-.browse-file {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.entry-icon {
-  flex-shrink: 0;
-}
-
-.entry-date {
-  margin-left: auto;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.entry-size {
-  margin-left: 0;
-  padding-left: 0.5rem;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  flex-shrink: 0;
-}
-
 // Custom select dropdown (supports icons inside options)
-.custom-select {
-  position: relative;
-}
+.custom-select { position: relative; }
 
 .custom-select-trigger {
   display: flex;
@@ -323,9 +269,7 @@
   opacity: 0.6;
   transition: transform 0.15s;
 
-  .custom-select.open & {
-    transform: rotate(180deg);
-  }
+  .custom-select.open & { transform: rotate(180deg); }
 }
 
 .custom-select-options {
@@ -356,9 +300,7 @@
   font-size: inherit;
   transition: background 0.1s;
 
-  &:hover {
-    background: var(--bg-hover);
-  }
+  &:hover { background: var(--bg-hover); }
 
   &.selected {
     background: var(--bg-active, var(--bg-hover));

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
@@ -77,13 +77,13 @@ describe('NewModelModalComponent', () => {
   it('should disable Create button when not ready', () => {
     component.name = '';
     component.pendingText = '';
-    expect(component.canSubmit).toBeFalse();
+    expect(component.canSubmitBlank).toBeFalse();
 
     component.name = 'Test';
-    expect(component.canSubmit).toBeFalse();
+    expect(component.canSubmitBlank).toBeFalse();
 
     component.pendingText = 'query';
-    expect(component.canSubmit).toBeTrue();
+    expect(component.canSubmitBlank).toBeTrue();
   });
 
   it('should disable media buttons when text is entered', () => {

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -71,6 +71,8 @@ export class NewModelModalComponent implements OnInit {
   exampleType: 'text' | 'media' | null = null;
   exampleValue = '';
   exampleDisplay = '';
+  exampleMediaType = '';
+  exampleThumbFailed = false;
 
   // --- Media picker state (shares structure with the Add Dataset modal) ---
 
@@ -485,6 +487,8 @@ export class NewModelModalComponent implements OnInit {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
         this.exampleDisplay = res.original_name || entry.name;
+        this.exampleMediaType = this.activeDemoTab || this.mediaType;
+        this.exampleThumbFailed = false;
         this.pendingText = '';
         this.demoFileLoading = false;
         this.view = 'main';
@@ -581,6 +585,8 @@ export class NewModelModalComponent implements OnInit {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
         this.exampleDisplay = res.original_name || entry.name;
+        this.exampleMediaType = this.mediaType || this.mediaTypeFromFilename(entry.name);
+        this.exampleThumbFailed = false;
         this.pendingText = '';
         this.sfFileSelecting = false;
         this.view = 'main';
@@ -649,6 +655,8 @@ export class NewModelModalComponent implements OnInit {
           this.exampleType = 'media';
           this.exampleValue = res.filename;
           this.exampleDisplay = res.original_name || res.filename;
+          this.exampleMediaType = mediaType || this.mediaType;
+          this.exampleThumbFailed = false;
           this.pendingText = '';
           // Close the picker if it was open so the user lands back on the form.
           if (this.view === 'media-picker') this.view = 'main';
@@ -669,6 +677,27 @@ export class NewModelModalComponent implements OnInit {
     if (m.startsWith('audio/')) return 'audio';
     if (m.startsWith('video/')) return 'video';
     return '';
+  }
+
+  private mediaTypeFromFilename(name: string): string {
+    const ext = name.toLowerCase().split('.').pop() || '';
+    if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext)) return 'image';
+    if (['wav', 'mp3', 'ogg', 'flac', 'm4a', 'aac'].includes(ext)) return 'audio';
+    if (['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(ext)) return 'video';
+    return '';
+  }
+
+  /** URL of the example thumbnail, or null if no media example is selected
+   *  or the thumbnail endpoint already failed (so we fall back to the icon). */
+  get exampleThumbnailUrl(): string | null {
+    if (this.exampleType !== 'media' || !this.exampleValue || this.exampleThumbFailed) {
+      return null;
+    }
+    return `/api/server-media-files/${encodeURIComponent(this.exampleValue)}/thumbnail`;
+  }
+
+  onExampleThumbError(): void {
+    this.exampleThumbFailed = true;
   }
 
   backToMain(): void {
@@ -706,6 +735,8 @@ export class NewModelModalComponent implements OnInit {
     this.exampleType = null;
     this.exampleValue = '';
     this.exampleDisplay = '';
+    this.exampleMediaType = '';
+    this.exampleThumbFailed = false;
     this.pendingText = '';
   }
 

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -8,16 +8,18 @@ import { TrainableModelsApiService } from '../../../services/trainable-models-ap
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
-import { ImporterField, ImporterInfo, MediaTypeInfo } from '../../../models/api.models';
+import {
+  DemoDataset,
+  ImporterField,
+  ImporterInfo,
+  ImporterPickerTab,
+  MediaTypeInfo,
+} from '../../../models/api.models';
 import {
   MediaCropModalComponent,
   MediaCropResult,
 } from '../../modals/media-crop-modal/media-crop-modal.component';
-
-interface BrowseItem {
-  key: string;
-  display: string;
-}
+import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 interface BrowseEntry {
   name: string;
@@ -70,18 +72,81 @@ export class NewModelModalComponent implements OnInit {
   exampleValue = '';
   exampleDisplay = '';
 
-  // Media picker state
-  mediaSources: ImporterInfo[] = [];
-  selectedSource: ImporterInfo | null = null;
-  browseItems: BrowseItem[] = [];
-  browseLoading = false;
+  // --- Media picker state (shares structure with the Add Dataset modal) ---
 
-  // File browser state (for demo & folder drill-down)
-  browseSource = '';
-  browsePath: string[] = [];
-  browseEntries: BrowseEntry[] = [];
-  fileBrowsing = false;
-  fileLoading = false;
+  /** All importers discovered from the backend, filtered to picker_views we
+   *  can use to select a single example file (demo, server_folder,
+   *  local_folder, local_files). */
+  mediaImporters: ImporterInfo[] = [];
+  /** Tab declarations (categories) returned by the backend. */
+  declaredImporterTabs: ImporterPickerTab[] = [];
+  /** Currently selected category tab (e.g. ``"demo"``, ``"server"``). */
+  activeImporterTab = '';
+  /** Currently selected importer within the active category. */
+  selectedImporter: ImporterInfo | null = null;
+
+  /** Front-of-list order for sub-importer tabs.  Mirrors the Add Dataset
+   *  modal's ordering so users see the same layout in both places. */
+  private static readonly PICKER_ORDER = [
+    'local_folder',
+    'local_files',
+    'server_folder',
+    'server_files',
+    'demo',
+  ];
+
+  /** Picker views supported by the single-file example picker.  Importers
+   *  whose ``picker_view`` is anything else (e.g. ``"form"``) are hidden
+   *  here — the user can still use them via the Add Dataset modal. */
+  private static readonly SUPPORTED_PICKER_VIEWS = new Set([
+    'demo',
+    'server_folder',
+    'local_folder',
+    'local_files',
+  ]);
+
+  // --- Demo picker state ---
+  demos: DemoDataset[] = [];
+  demoTabs: string[] = [];
+  activeDemoTab = '';
+  demoLoading = false;
+
+  /** Demo table column metadata + controller.  Reuses the same storage key
+   *  as the Add Dataset modal so column order and sort preferences stay in
+   *  sync between the two demo tables. */
+  static readonly DEMO_COL_META: Record<string, ColMeta> = {
+    label: { label: 'Name', title: 'Demo dataset name (click to sort)', sortable: true },
+    num_files: { label: '# Media', title: 'Number of media files in the demo dataset (click to sort)', sortable: true },
+    num_categories: { label: '# Cat.', title: 'Number of distinct categories or classes in the dataset (click to sort)', sortable: true },
+    description: { label: 'Description', title: 'Short description of the demo dataset contents (click to sort)', sortable: true },
+    status: { label: 'Readiness', title: 'Whether the dataset is pre-downloaded and ready to browse, or still needs to be fetched (click to sort)', sortable: true },
+  };
+  static readonly DEMO_COLUMNS_DEFAULT = ['label', 'num_files', 'num_categories', 'description', 'status'];
+  private static readonly DEMO_COL_ORDER_KEY = 'vtsearch.dashboard.demoColumnOrder';
+
+  demoCols = new ManagedColumns(
+    NewModelModalComponent.DEMO_COLUMNS_DEFAULT,
+    NewModelModalComponent.DEMO_COL_META,
+    { initialSort: 'num_files', storageKey: NewModelModalComponent.DEMO_COL_ORDER_KEY },
+  );
+
+  // --- Demo file browser (shown after picking a demo from the table) ---
+  demoFileBrowsing = false;
+  demoFileBrowseSource = '';
+  demoFileBrowseLabel = '';
+  demoFileBrowsePath: string[] = [];
+  demoFileBrowseEntries: BrowseEntry[] = [];
+  demoFileLoading = false;
+
+  // --- Server folder browser (mirrors the Add Dataset breadcrumb browser
+  //     but lists files too so the user can pick one as an example). ---
+  sfBrowsePath = '';
+  sfBrowseRootPath = '';
+  sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
+  sfBrowseFiles: BrowseEntry[] = [];
+  sfBrowseLoading = false;
+  sfBrowseError = '';
+  sfFileSelecting = false;
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -109,6 +174,16 @@ export class NewModelModalComponent implements OnInit {
     if (this.mediaTypeDropdownOpen && !target.closest('.custom-select')) {
       this.mediaTypeDropdownOpen = false;
     }
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onDocResizeMove(event: MouseEvent): void {
+    this.demoCols.onResizeMove(event);
+  }
+
+  @HostListener('document:mouseup')
+  onDocResizeEnd(): void {
+    this.demoCols.onResizeEnd();
   }
 
   ngOnInit(): void {
@@ -174,144 +249,372 @@ export class NewModelModalComponent implements OnInit {
     this.error = '';
   }
 
-  // --- Media example ---
+  // --- Media picker (shared structure with Add Dataset) ---
 
   openMediaPicker(): void {
     this.view = 'media-picker';
-    this.selectedSource = null;
-    this.browseItems = [];
-    this.fileBrowsing = false;
-    this.browseEntries = [];
-    this.browsePath = [];
-    this.browseSource = '';
-    this.loadMediaSources();
+    this.activeImporterTab = '';
+    this.selectedImporter = null;
+    this.resetDemoPickerState();
+    this.resetServerFolderState();
+    this.loadMediaImporters();
   }
 
-  private loadMediaSources(): void {
+  private loadMediaImporters(): void {
     this.datasetsApi.getAllImporters().subscribe({
       next: (res) => {
-        this.mediaSources = (res.importers || []).filter(
+        this.mediaImporters = (res.importers || []).filter(
           (imp) =>
-            imp.name === 'demo' ||
-            imp.name === 'server_folder' ||
-            (!imp['hidden_from_picker'] && imp.name !== 'combine_datasets'),
+            !imp['hidden_from_picker'] &&
+            NewModelModalComponent.SUPPORTED_PICKER_VIEWS.has(imp.picker_view || ''),
         );
+        this.declaredImporterTabs = res.tabs || [];
       },
     });
   }
 
-  selectSource(source: ImporterInfo): void {
-    this.selectedSource = source;
-    this.browseLoading = true;
-    this.browseItems = [];
-    this.fileBrowsing = false;
+  /** Importers ordered like the Add Dataset modal: known picker_views
+   *  first, then any extras in registry order. */
+  get orderedImporters(): ImporterInfo[] {
+    const order = NewModelModalComponent.PICKER_ORDER;
+    const result: ImporterInfo[] = [];
+    for (const name of order) {
+      const imp = this.mediaImporters.find((i) => i.name === name);
+      if (imp) result.push(imp);
+    }
+    for (const imp of this.mediaImporters) {
+      if (!order.includes(imp.name)) result.push(imp);
+    }
+    return result;
+  }
 
-    if (source.name === 'demo') {
-      this.datasetsApi.getDemoList().subscribe({
-        next: (res) => {
-          this.browseItems = (res.datasets || []).map((d) => ({
-            key: d.name,
-            display: `${d.label} (${d.media_type}, ${d.num_files} items)`,
-          }));
-          this.browseLoading = false;
-        },
-        error: () => { this.browseLoading = false; },
-      });
-    } else if (source.name === 'server_folder') {
-      this.browseLoading = false;
-      this.startFileBrowsing('folder', 'Saved Datasets');
+  private fallbackTabLabel(id: string): string {
+    return id
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+      .map((part) => part[0].toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  /** Visible category tabs.  Only categories that contain at least one
+   *  supported importer are shown — empty categories (e.g. ``"services"``
+   *  on a vanilla install) are hidden so the picker stays focused on
+   *  options the user can act on. */
+  get visibleImporterTabs(): ImporterPickerTab[] {
+    const usedCategories = new Set(
+      this.orderedImporters.map((imp) => imp.category || '').filter(Boolean),
+    );
+    const visible: ImporterPickerTab[] = [];
+    const seen = new Set<string>();
+    const declared = [...this.declaredImporterTabs].sort(
+      (a, b) => (a.order ?? 100) - (b.order ?? 100),
+    );
+    for (const tab of declared) {
+      if (usedCategories.has(tab.id)) {
+        visible.push(tab);
+        seen.add(tab.id);
+      }
+    }
+    for (const id of usedCategories) {
+      if (!seen.has(id)) {
+        visible.push({ id, label: this.fallbackTabLabel(id) });
+      }
+    }
+    return visible;
+  }
+
+  get importersForActiveTab(): ImporterInfo[] {
+    return this.orderedImporters.filter(
+      (imp) => (imp.category || '') === this.activeImporterTab,
+    );
+  }
+
+  get activeImporterTabLabel(): string {
+    const tab = this.visibleImporterTabs.find((t) => t.id === this.activeImporterTab);
+    return tab?.label || '';
+  }
+
+  selectImporterTab(tabId: string): void {
+    this.activeImporterTab = tabId;
+    this.selectedImporter = null;
+    this.resetDemoPickerState();
+    this.resetServerFolderState();
+  }
+
+  selectImporter(importer: ImporterInfo): void {
+    this.selectedImporter = importer;
+    this.error = '';
+    const view = importer.picker_view || '';
+    if (view === 'demo') {
+      this.openDemoPicker();
+    } else if (view === 'server_folder') {
+      this.openServerFolderBrowser();
     } else {
-      this.sortingApi.getServerMediaFiles().subscribe({
-        next: (res) => {
-          this.browseItems = (res.files || []).map((f) => ({
-            key: f.filename || f.name,
-            display: f.name,
-          }));
-          this.browseLoading = false;
-        },
-        error: () => { this.browseLoading = false; },
-      });
+      // local_folder / local_files: just reveal the upload input below.
+      this.resetDemoPickerState();
+      this.resetServerFolderState();
     }
   }
 
-  selectBrowseItem(item: BrowseItem): void {
-    if (this.selectedSource?.name === 'demo') {
-      this.startFileBrowsing(`demo:${item.key}`, item.display);
-      return;
-    }
-
-    // For other sources (server media files), selecting sets the example
-    this.exampleType = 'media';
-    this.exampleValue = item.key;
-    this.exampleDisplay = item.display || item.key;
-    this.pendingText = '';
-    this.view = 'main';
+  /** Picker view of the currently selected importer, or empty when nothing
+   *  is selected.  Drives which inline widget set is rendered below the
+   *  inner sub-tab row. */
+  get activePickerView(): string {
+    return this.selectedImporter?.picker_view || '';
   }
 
-  // --- Recursive file browser ---
+  // --- Demo picker ---
 
-  private startFileBrowsing(source: string, label: string): void {
-    this.fileBrowsing = true;
-    this.browseSource = source;
-    this.browsePath = [label];
-    this.loadDirectory('');
+  private resetDemoPickerState(): void {
+    this.demos = [];
+    this.demoTabs = [];
+    this.activeDemoTab = '';
+    this.demoLoading = false;
+    this.demoFileBrowsing = false;
+    this.demoFileBrowseSource = '';
+    this.demoFileBrowseLabel = '';
+    this.demoFileBrowsePath = [];
+    this.demoFileBrowseEntries = [];
+    this.demoFileLoading = false;
   }
 
-  private loadDirectory(relPath: string): void {
-    this.fileLoading = true;
-    this.browseEntries = [];
-
-    this.datasetsApi.browseMediaFiles(this.browseSource, relPath).subscribe({
+  private openDemoPicker(): void {
+    this.resetDemoPickerState();
+    this.demoLoading = true;
+    this.datasetsApi.getDemoList().subscribe({
       next: (res) => {
-        const entries: BrowseEntry[] = [];
-        for (const d of res.directories || []) {
-          entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
-        }
-        for (const f of res.files || []) {
-          entries.push({ name: f.name, path: f.path, size_bytes: f.size_bytes, modified_at: f.modified_at, isDir: false });
-        }
-        this.browseEntries = entries;
-        this.fileLoading = false;
+        this.demos = res.datasets || [];
+        this.buildDemoTabs();
+        this.demoLoading = false;
       },
       error: () => {
-        this.fileLoading = false;
+        this.demoLoading = false;
       },
     });
   }
 
-  enterDirectory(entry: BrowseEntry): void {
-    this.browsePath.push(entry.name);
-    this.loadDirectory(entry.path);
+  private buildDemoTabs(): void {
+    const grouped = new Set(this.demos.map((d) => d.media_type));
+    const registryOrder = this.mediaTypeInfos.map((mt) => mt.type_id);
+    this.demoTabs = registryOrder.filter((mt) => grouped.has(mt));
+    for (const mt of grouped) {
+      if (!this.demoTabs.includes(mt)) this.demoTabs.push(mt);
+    }
   }
 
-  navigateBreadcrumb(index: number): void {
+  selectDemoTab(tab: string): void {
+    this.activeDemoTab = tab;
+  }
+
+  onDemoHeaderClick(col: string): void {
+    if (this.demoCols.meta(col).sortable) this.demoCols.sortBy(col);
+  }
+
+  get filteredDemos(): DemoDataset[] {
+    const items = this.demos.filter((d) => d.media_type === this.activeDemoTab);
+    const statusOrder: Record<string, number> = { ready: 0, needs_embedding: 1, needs_download: 2 };
+    const sortKey = this.demoCols.sortColumn;
+    const asc = this.demoCols.sortAsc;
+    return [...items].sort((a, b) => {
+      const key = sortKey as keyof DemoDataset;
+      let va: any = a[key];
+      let vb: any = b[key];
+      if (key === 'status') {
+        va = statusOrder[va as string] ?? 3;
+        vb = statusOrder[vb as string] ?? 3;
+      }
+      if (typeof va === 'number' && typeof vb === 'number') {
+        return asc ? va - vb : vb - va;
+      }
+      va = String(va || '').toLowerCase();
+      vb = String(vb || '').toLowerCase();
+      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+    });
+  }
+
+  /** True when the demo's files are on disk and can be browsed.  Demos
+   *  that still need to be downloaded show a tooltip explaining how to
+   *  fetch them via the Add Dataset modal. */
+  isDemoBrowsable(demo: DemoDataset): boolean {
+    return demo.status === 'ready' || demo.status === 'needs_embedding';
+  }
+
+  selectDemo(demo: DemoDataset): void {
+    if (!this.isDemoBrowsable(demo)) return;
+    this.demoFileBrowsing = true;
+    this.demoFileBrowseSource = `demo:${demo.name}`;
+    this.demoFileBrowseLabel = demo.label;
+    this.demoFileBrowsePath = [demo.label];
+    this.loadDemoDirectory('');
+  }
+
+  private loadDemoDirectory(relPath: string): void {
+    this.demoFileLoading = true;
+    this.demoFileBrowseEntries = [];
+    this.datasetsApi.browseMediaFiles(this.demoFileBrowseSource, relPath).subscribe({
+      next: (res) => {
+        this.demoFileBrowseEntries = this.toEntries(res.directories, res.files);
+        this.demoFileLoading = false;
+      },
+      error: () => {
+        this.demoFileLoading = false;
+      },
+    });
+  }
+
+  enterDemoDirectory(entry: BrowseEntry): void {
+    this.demoFileBrowsePath.push(entry.name);
+    this.loadDemoDirectory(entry.path);
+  }
+
+  navigateDemoBreadcrumb(index: number): void {
     if (index === 0) {
-      this.fileBrowsing = false;
-      this.browseEntries = [];
-      this.browsePath = [];
+      this.demoFileBrowsePath = [this.demoFileBrowseLabel];
+      this.loadDemoDirectory('');
       return;
     }
-    this.browsePath = this.browsePath.slice(0, index + 1);
-    const relPath = this.browsePath.slice(1).join('/');
-    this.loadDirectory(relPath);
+    this.demoFileBrowsePath = this.demoFileBrowsePath.slice(0, index + 1);
+    const relPath = this.demoFileBrowsePath.slice(1).join('/');
+    this.loadDemoDirectory(relPath);
   }
 
-  selectFile(entry: BrowseEntry): void {
-    this.fileLoading = true;
-    this.datasetsApi.selectBrowsedFile(this.browseSource, entry.path).subscribe({
+  selectDemoFile(entry: BrowseEntry): void {
+    this.demoFileLoading = true;
+    this.datasetsApi.selectBrowsedFile(this.demoFileBrowseSource, entry.path).subscribe({
       next: (res) => {
         this.exampleType = 'media';
         this.exampleValue = res.filename;
         this.exampleDisplay = res.original_name || entry.name;
         this.pendingText = '';
-        this.fileLoading = false;
+        this.demoFileLoading = false;
         this.view = 'main';
       },
       error: () => {
         this.error = 'Failed to select file';
-        this.fileLoading = false;
+        this.demoFileLoading = false;
       },
     });
+  }
+
+  /** Return to the demo table from the demo file browser. */
+  backToDemoTable(): void {
+    this.demoFileBrowsing = false;
+    this.demoFileBrowseSource = '';
+    this.demoFileBrowseLabel = '';
+    this.demoFileBrowsePath = [];
+    this.demoFileBrowseEntries = [];
+  }
+
+  // --- Server folder browser (with file selection) ---
+
+  private resetServerFolderState(): void {
+    this.sfBrowsePath = '';
+    this.sfBrowseRootPath = '';
+    this.sfBrowseDirs = [];
+    this.sfBrowseFiles = [];
+    this.sfBrowseLoading = false;
+    this.sfBrowseError = '';
+    this.sfFileSelecting = false;
+  }
+
+  private openServerFolderBrowser(): void {
+    this.resetServerFolderState();
+    this.sfLoadDirectory('');
+  }
+
+  sfLoadDirectory(path: string): void {
+    this.sfBrowseLoading = true;
+    this.sfBrowseError = '';
+    this.datasetsApi.browseMediaFiles('folder', path).subscribe({
+      next: (res) => {
+        this.sfBrowseDirs = res.directories || [];
+        this.sfBrowseFiles = (res.files || []).map((f) => ({
+          name: f.name,
+          path: f.path,
+          size_bytes: f.size_bytes,
+          modified_at: f.modified_at,
+          isDir: false,
+        }));
+        this.sfBrowsePath = path;
+        this.sfBrowseRootPath = res.root_path;
+        this.sfBrowseLoading = false;
+      },
+      error: (err) => {
+        this.sfBrowseError =
+          err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
+        this.sfBrowseLoading = false;
+      },
+    });
+  }
+
+  sfEnterDirectory(dir: { name: string; path: string }): void {
+    this.sfLoadDirectory(dir.path);
+  }
+
+  sfGoUp(): void {
+    if (!this.sfBrowsePath) return;
+    const parts = this.sfBrowsePath.split('/');
+    parts.pop();
+    this.sfLoadDirectory(parts.join('/'));
+  }
+
+  get sfBreadcrumbs(): string[] {
+    if (!this.sfBrowsePath) return [];
+    return this.sfBrowsePath.split('/');
+  }
+
+  sfNavigateBreadcrumb(index: number): void {
+    const parts = this.sfBrowsePath.split('/');
+    this.sfLoadDirectory(parts.slice(0, index + 1).join('/'));
+  }
+
+  get sfAbsolutePath(): string {
+    if (!this.sfBrowseRootPath) return '';
+    if (!this.sfBrowsePath) return this.sfBrowseRootPath;
+    return this.sfBrowseRootPath + '/' + this.sfBrowsePath;
+  }
+
+  sfSelectFile(entry: BrowseEntry): void {
+    this.sfFileSelecting = true;
+    this.datasetsApi.selectBrowsedFile('folder', entry.path).subscribe({
+      next: (res) => {
+        this.exampleType = 'media';
+        this.exampleValue = res.filename;
+        this.exampleDisplay = res.original_name || entry.name;
+        this.pendingText = '';
+        this.sfFileSelecting = false;
+        this.view = 'main';
+      },
+      error: () => {
+        this.sfBrowseError = 'Failed to select file';
+        this.sfFileSelecting = false;
+      },
+    });
+  }
+
+  // --- Local file upload (single file for the example) ---
+
+  /** Build a unified entry list (directories first, then files). */
+  private toEntries(
+    directories: { name: string; path: string; modified_at?: string }[] | undefined,
+    files:
+      | { name: string; path: string; size_bytes: number; modified_at?: string }[]
+      | undefined,
+  ): BrowseEntry[] {
+    const entries: BrowseEntry[] = [];
+    for (const d of directories || []) {
+      entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
+    }
+    for (const f of files || []) {
+      entries.push({
+        name: f.name,
+        path: f.path,
+        size_bytes: f.size_bytes,
+        modified_at: f.modified_at,
+        isDir: false,
+      });
+    }
+    return entries;
   }
 
   formatSize(bytes?: number): string {
@@ -321,6 +624,10 @@ export class NewModelModalComponent implements OnInit {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
+  /** Local file picker handler.  Used by both the inline "Upload File…"
+   *  button on the main form and the Local Folder / Local Files cards in
+   *  the picker.  Multi-file selections (e.g. webkitdirectory) are
+   *  collapsed to the first file since only one example is needed. */
   onLocalFileSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
     if (!input.files || input.files.length === 0) return;
@@ -343,6 +650,8 @@ export class NewModelModalComponent implements OnInit {
           this.exampleValue = res.filename;
           this.exampleDisplay = res.original_name || res.filename;
           this.pendingText = '';
+          // Close the picker if it was open so the user lands back on the form.
+          if (this.view === 'media-picker') this.view = 'main';
         },
         error: () => {
           this.error = 'Failed to upload file';
@@ -364,6 +673,31 @@ export class NewModelModalComponent implements OnInit {
 
   backToMain(): void {
     this.view = 'main';
+  }
+
+  // --- Media-type tab labels (mirrors Add Dataset's helpers) ---
+
+  getDemoTabLabel(typeId: string): string {
+    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
+    if (mt) return (mt.tab_title || mt.name).trim();
+    return typeId;
+  }
+
+  getDemoTabIcon(typeId: string): string {
+    const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
+    return mt?.icon || '';
+  }
+
+  statusBadgeClass(status: string): string {
+    if (status === 'ready') return 'badge-ready';
+    if (status === 'needs_embedding') return 'badge-embedding';
+    return 'badge-download';
+  }
+
+  statusBadgeLabel(status: string): string {
+    if (status === 'ready') return 'Ready';
+    if (status === 'needs_embedding') return 'Needs Embed';
+    return 'Needs Download';
   }
 
   // --- Clear example ---

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -10,7 +10,7 @@ const KNOWN_TYPES = new Set([
   'server', 'globe', 'email', 'satellite',
   'folder', 'folder-open', 'upload',
   'graduation', 'arrow-up', 'shuffle', 'elephant', 'cloud',
-  'check', 'warning', 'x-circle', 'info', 'file', 'lightbulb',
+  'check', 'warning', 'x-circle', 'info', 'file', 'robot',
   'list', 'grid', 'cursor-click', 'cursor-hover',
   'palette', 'sort-descending', 'steering-wheel', 'cloud-upload',
   'thumbs-up', 'thumbs-down', 'factory',
@@ -128,8 +128,8 @@ function emojiToType(icon: string): string {
       @case ('info') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
       }
-      @case ('lightbulb') {
-        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z"/></svg>
+      @case ('robot') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="3" r="1.5"/><line x1="12" y1="4.5" x2="12" y2="7"/><rect x="4" y="7" width="16" height="12" rx="2.5"/><path d="M4 11a2 2 0 0 0 0 4"/><path d="M20 11a2 2 0 0 1 0 4"/><circle cx="9.5" cy="12.5" r="1.2"/><circle cx="14.5" cy="12.5" r="1.2"/><line x1="10" y1="16" x2="14" y2="16"/></svg>
       }
       @case ('file') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -156,15 +156,10 @@ describe('LabelListComponent', () => {
       expect(component.hasThumbnailUrl(1)).toBeTrue();
     });
 
-    it('should identify video type', () => {
-      expect(component.isVideo(3)).toBeTrue();
-      expect(component.isVideo(2)).toBeFalse();
-    });
-
     it('should generate correct thumbnail URLs', () => {
       expect(component.thumbnailUrl(1)).toBe('/api/medias/1/image');
       expect(component.thumbnailUrl(2)).toBe('/api/medias/2/image');
-      expect(component.thumbnailUrl(3)).toBe('/api/medias/3/video');
+      expect(component.thumbnailUrl(3)).toBe('/api/medias/3/image');
     });
 
     it('should be in grid mode when viewMode is grid', () => {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -204,6 +204,13 @@ export interface ImporterField {
   default?: string;
   required?: boolean;
   placeholder?: string;
+  /** When true, ``options`` is computed at runtime by calling
+   *  ``POST /api/dataset/import/<importer>/options`` with the current
+   *  field values.  The frontend re-fetches whenever any field listed in
+   *  ``depends_on`` changes. */
+  dynamic_options?: boolean;
+  /** Field keys whose values this field's options depend on. */
+  depends_on?: string[];
 }
 
 export interface ImporterPickerTab {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -124,6 +124,25 @@ export class DatasetsApiService {
   }
 
   /**
+   * Fetch dropdown options for an importer field whose options are computed
+   * at runtime by the importer (``dynamic_options=true``).
+   *
+   * The backend calls the importer's ``get_field_options(field_key, values)``
+   * Python method and returns the resulting list.  Errors from the remote
+   * service are surfaced as HTTP errors with an ``error`` message body.
+   */
+  getImporterFieldOptions(
+    importerName: string,
+    fieldKey: string,
+    values: Record<string, unknown>,
+  ): Observable<{ options: string[] }> {
+    return this.http.post<{ options: string[] }>(
+      `/api/dataset/import/${importerName}/options`,
+      { field_key: fieldKey, values },
+    );
+  }
+
+  /**
    * Upload a folder selected from the user's *browser* machine.
    *
    * The caller is responsible for building the FormData with the files

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -1,0 +1,297 @@
+// Shared importer-picker styles used by both the Add Dataset modal
+// (DatasetImporterModalComponent) and the New Model > Browse Media picker
+// (NewModelModalComponent).  Lives in the global stylesheet so the rules
+// only ship once instead of being duplicated inside each component's
+// scoped CSS bundle.
+//
+// All selectors here are class-only and only used by these two modals, so
+// they can safely apply globally without bleeding into other components.
+
+// --- Importer category / sub-importer tabs ---
+
+.importer-tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  border-bottom: 2px solid var(--border);
+}
+
+.importer-tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 16px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-secondary, var(--text-muted));
+  font-size: .85rem;
+  cursor: pointer;
+  transition: all .15s;
+  margin-bottom: -2px;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-subtle);
+  }
+
+  &.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+    font-weight: 600;
+  }
+}
+
+.importer-subtab-bar { @extend .importer-tab-bar; }
+
+.importer-subtab {
+  @extend .importer-tab;
+
+  &.disabled, &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.importer-subtab-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.tab-bar-hint {
+  margin: 8px 0 0 0;
+  color: var(--text-muted);
+  font-size: .85rem;
+  font-style: italic;
+}
+
+.empty-state--inline {
+  padding: 6px 10px;
+  font-size: .8rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+// --- Demo media-type tabs ---
+
+.demo-tab-bar { @extend .importer-tab-bar; }
+.demo-tab { @extend .importer-tab; }
+
+// --- Demo table ---
+
+.demo-content-area {
+  min-height: 200px;
+  max-height: 50vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.table-fixed { table-layout: fixed; }
+
+.demo-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+
+  th, td {
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 6px 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  th {
+    padding-right: 0;
+    position: sticky;
+    top: 0;
+    background: var(--bg-surface);
+    z-index: 1;
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    user-select: none;
+
+    &[draggable='true'] { cursor: grab; &:active { cursor: grabbing; } }
+
+    &.sortable {
+      cursor: pointer;
+      &:hover { color: var(--text-primary); }
+    }
+
+    &[draggable='true'].sortable { cursor: grab; &:active { cursor: grabbing; } }
+
+    &.col-drop-target { box-shadow: inset 0 0 0 2px var(--accent); }
+    &.col-dragging { opacity: 0.4; }
+
+    .sort-indicator {
+      display: inline-block;
+      width: 1em;
+      text-align: center;
+      visibility: hidden;
+      &.active { visibility: visible; }
+    }
+
+    .col-resize-handle {
+      position: absolute;
+      top: 0;
+      left: -6px;
+      bottom: 0;
+      width: 12px;
+      cursor: col-resize;
+      z-index: 2;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 20%;
+        bottom: 20%;
+        left: 5px;
+        width: 2px;
+        background: var(--accent);
+        opacity: 0.35;
+        transition: opacity 0.15s;
+      }
+
+      &:hover::after { opacity: 0.7; }
+    }
+  }
+
+  tbody tr {
+    cursor: pointer;
+    transition: background 0.1s;
+
+    &:hover { background: var(--bg-hover); }
+
+    &.disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+      &:hover { background: none; }
+    }
+  }
+}
+
+.col-num { text-align: right; padding-right: 12px; }
+
+.col-desc, .col-name, .sf-dir-name, .col-status {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.col-desc { color: var(--text-muted); font-size: 0.78rem; }
+.col-name { font-weight: 600; color: var(--text-primary); }
+
+.demo-row {
+  &.ready .col-name { color: var(--color-good); }
+}
+
+.badge-ready, .badge-embedding, .badge-download {
+  display: inline-block;
+  padding: 1px 7px;
+  color: var(--btn-filled-text);
+  font-size: .7rem;
+  border-radius: 3px;
+}
+
+.badge-ready { background: var(--color-good); }
+.badge-embedding { background: var(--badge-embedding, var(--accent)); }
+.badge-download { background: var(--border); color: var(--text-muted); }
+
+// --- Server folder browser ---
+
+.sf-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: .8rem;
+  flex-wrap: wrap;
+}
+
+.sf-breadcrumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: .8rem;
+
+  &:hover { background: var(--bg-subtle); }
+
+  &.active {
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: default;
+    &:hover { background: none; }
+  }
+}
+
+.sf-breadcrumb-sep { color: var(--text-muted); font-size: .75rem; }
+
+.sf-dir-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.sf-dir-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: .85rem;
+  transition: background .15s;
+
+  &:last-child { border-bottom: none; }
+  &:hover:not(:disabled) { background: var(--bg-subtle); }
+  &:disabled { opacity: 0.55; cursor: wait; }
+}
+
+.sf-dir-icon { font-size: .9rem; flex-shrink: 0; }
+
+.sf-dir-date {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: .75rem;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.sf-empty-dir {
+  color: var(--text-muted);
+  font-size: .8rem;
+  padding: 12px;
+  text-align: center;
+}
+
+.sf-selected-path { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
+
+.sf-path-display {
+  font-size: .8rem;
+  color: var(--text-secondary, var(--text-muted));
+  background: var(--bg-subtle);
+  padding: 3px 8px;
+  border-radius: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,6 +1,7 @@
 @use 'scss/variables';
 @use 'scss/layout';
 @use 'scss/components';
+@use 'scss/picker-shared';
 
 *,
 *::before,

--- a/tests/test_chunked_web_flow.py
+++ b/tests/test_chunked_web_flow.py
@@ -237,9 +237,7 @@ class TestLocalFolderRouteChunked:
     and route through ``run_chunked`` when set."""
 
     def test_chunk_size_form_field_routes_to_run_chunked(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads"
-        )
+        monkeypatch.setattr("vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads")
 
         captured: dict[str, Any] = {}
 
@@ -289,9 +287,7 @@ class TestLocalFolderRouteChunked:
         assert sorted(captured["target"].keys()) == [1]
 
     def test_no_chunk_size_uses_run(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads"
-        )
+        monkeypatch.setattr("vtsearch.routes.datasets.LOCAL_UPLOADS_DIR", tmp_path / "uploads")
 
         from vtsearch.datasets.importers import get_importer
 

--- a/tests/test_clipper_workflow.py
+++ b/tests/test_clipper_workflow.py
@@ -101,6 +101,49 @@ def _make_video_media(media_id: int, duration: float = 10.0) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# _apply_clipper — clip thumbnail regeneration
+# ---------------------------------------------------------------------------
+
+
+class TestApplyClipperThumbnails:
+    """Clipped audio/video sub-items must get fresh thumbnail_bytes so the
+    find/label list shows the clip's range, not the parent media."""
+
+    def test_audio_clips_get_fresh_waveform_thumbnails(self):
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        parent = _make_audio_media(1, duration=5.1)
+        # Pretend the loader generated a thumbnail from the full waveform.
+        parent["thumbnail_bytes"] = b"PARENT_WAVEFORM_PNG"
+        clips_dict = {1: parent}
+
+        _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0})
+
+        assert len(clips_dict) > 1
+        for clip in clips_dict.values():
+            assert clip.get("thumbnail_bytes") not in (None, b"PARENT_WAVEFORM_PNG"), (
+                "clip thumbnail should be regenerated from the clip's own bytes"
+            )
+            # PNG header check
+            assert clip["thumbnail_bytes"][:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_passthrough_clipper_keeps_parent_thumbnail(self):
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        parent = _make_audio_media(1, duration=2.0)
+        parent["thumbnail_bytes"] = b"PARENT_WAVEFORM_PNG"
+        clips_dict = {1: parent}
+
+        # sound_default returns the media unchanged — no clipping happens.
+        _apply_clipper(clips_dict, "sound_default")
+
+        assert len(clips_dict) == 1
+        clip = next(iter(clips_dict.values()))
+        # No regeneration needed for a non-clip; parent thumbnail preserved.
+        assert clip["thumbnail_bytes"] == b"PARENT_WAVEFORM_PNG"
+
+
+# ---------------------------------------------------------------------------
 # _apply_clipper — MD5 recomputation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_combine_models.py
+++ b/tests/test_combine_models.py
@@ -74,9 +74,7 @@ class TestLabelSetMerge:
         legacy_bad = LabeledElement(md5="bb", label="bad")
         legacy_bad_conflict = LabeledElement(md5="bb", label="good")
 
-        merged = LabelSet([legacy_good, legacy_bad]).merge(
-            LabelSet([legacy_good_2, legacy_bad_conflict])
-        )
+        merged = LabelSet([legacy_good, legacy_bad]).merge(LabelSet([legacy_good_2, legacy_bad_conflict]))
         keys = [(e.md5, e.label) for e in merged]
         assert keys == [("aa", "good")]  # bb dropped on conflict
 

--- a/tests/test_converter_selection.py
+++ b/tests/test_converter_selection.py
@@ -709,7 +709,9 @@ class TestFolderImporterWithConverters:
                 "vtsearch.datasets.importers.server_folder.load_dataset_from_folder",
                 side_effect=ValueError("No images files found"),
             ),
-            patch("vtsearch.datasets.importers.server_folder._run_selected_converters", side_effect=_fake_run_converters),
+            patch(
+                "vtsearch.datasets.importers.server_folder._run_selected_converters", side_effect=_fake_run_converters
+            ),
         ):
             medias: dict = {}
             IMPORTER.run(

--- a/tests/test_dynamic_field_options.py
+++ b/tests/test_dynamic_field_options.py
@@ -1,0 +1,282 @@
+"""Tests for dynamic-options dataset importer fields.
+
+Covers:
+
+- :class:`~vtsearch.utils.registry.PluginField` ``dynamic_options`` /
+  ``depends_on`` attributes serialise via ``to_dict``.
+- :meth:`DatasetImporter.get_field_options` default raises
+  ``NotImplementedError``.
+- The ``POST /api/dataset/import/<name>/options`` route returns the
+  importer's options, surfaces ``NotImplementedError`` as 501, and
+  surfaces other plugin exceptions as 502 with the message body.
+- The ReCaller scaffold declares its ``query_id`` field as dynamic and
+  routes ``get_field_options`` through ``_rc_list_queries``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+from vtsearch.utils.registry import PluginField
+
+
+class _StubImporter(DatasetImporter):
+    name = "_stub_dynamic"
+    display_name = "Stub Dynamic"
+    description = "Test importer with dynamic-options field."
+    fields = [
+        ImporterField("media_type", "Media Type", "select", options=["audio", "image"], default="audio"),
+        ImporterField(
+            "query_id",
+            "Query",
+            "select",
+            dynamic_options=True,
+            depends_on=["media_type"],
+        ),
+    ]
+
+    def __init__(self, fail_with: Exception | None = None) -> None:
+        super().__init__()
+        self._fail_with = fail_with
+
+    def get_field_options(self, field_key, current_values):
+        if self._fail_with is not None:
+            raise self._fail_with
+        if field_key == "query_id":
+            mt = current_values.get("media_type", "audio")
+            return [f"{mt}-q1", f"{mt}-q2"]
+        return super().get_field_options(field_key, current_values)
+
+    def run(self, field_values, medias, thin=False):  # pragma: no cover — unused here
+        return None
+
+
+@pytest.fixture
+def registered_stub():
+    """Register a stub importer in the live registry for the duration of a test."""
+    from vtsearch.datasets.importers import get_importer
+
+    registry = get_importer.__self__
+    registry._ensure_discovered()
+
+    stub = _StubImporter()
+    registry._items[stub.name] = stub
+    try:
+        yield stub
+    finally:
+        registry._items.pop(stub.name, None)
+
+
+# ---------------------------------------------------------------------------
+# PluginField — dataclass attributes & serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestPluginFieldDynamicAttrs:
+    def test_defaults(self):
+        f = PluginField(key="x", label="X", field_type="text")
+        assert f.dynamic_options is False
+        assert f.depends_on == []
+
+    def test_to_dict_round_trip(self):
+        f = PluginField(
+            key="q",
+            label="Q",
+            field_type="select",
+            dynamic_options=True,
+            depends_on=["a", "b"],
+        )
+        d = f.to_dict()
+        assert d["dynamic_options"] is True
+        assert d["depends_on"] == ["a", "b"]
+
+    def test_depends_on_is_independent_per_instance(self):
+        # default_factory=list should not be shared between instances.
+        a = PluginField(key="a", label="A", field_type="text")
+        b = PluginField(key="b", label="B", field_type="text")
+        a.depends_on.append("oops")
+        assert b.depends_on == []
+
+
+# ---------------------------------------------------------------------------
+# DatasetImporter.get_field_options default behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGetFieldOptionsDefault:
+    def test_default_raises_not_implemented(self):
+        class Imp(DatasetImporter):
+            name = "_t_default"
+            display_name = "T"
+            description = "T"
+            fields = []
+
+            def run(self, field_values, medias, thin=False):
+                return None
+
+        with pytest.raises(NotImplementedError):
+            Imp().get_field_options("anything", {})
+
+
+# ---------------------------------------------------------------------------
+# /api/dataset/import/<name>/options route
+# ---------------------------------------------------------------------------
+
+
+class TestImporterFieldOptionsRoute:
+    URL_TEMPLATE = "/api/dataset/import/{name}/options"
+
+    def test_returns_options_from_importer(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "query_id", "values": {"media_type": "image"}},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body == {"options": ["image-q1", "image-q2"]}
+
+    def test_unknown_importer_returns_404(self, client):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name="does_not_exist"),
+            json={"field_key": "query_id", "values": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_field_returns_400(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "no_such_field", "values": {}},
+        )
+        assert resp.status_code == 400
+        assert "Unknown field" in resp.get_json()["error"]
+
+    def test_static_field_returns_400(self, client, registered_stub):
+        # ``media_type`` is static, not dynamic — calling options on it is rejected.
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "media_type", "values": {}},
+        )
+        assert resp.status_code == 400
+        assert "not dynamic" in resp.get_json()["error"]
+
+    def test_missing_field_key_returns_400(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"values": {}},
+        )
+        assert resp.status_code == 400
+
+    def test_non_object_values_returns_400(self, client, registered_stub):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name=registered_stub.name),
+            json={"field_key": "query_id", "values": "not-an-object"},
+        )
+        assert resp.status_code == 400
+
+    def test_not_implemented_returns_501(self, client):
+        from vtsearch.datasets.importers import get_importer
+
+        registry = get_importer.__self__
+        registry._ensure_discovered()
+        stub = _StubImporter(fail_with=NotImplementedError("nope"))
+        registry._items[stub.name] = stub
+        try:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "query_id", "values": {}},
+            )
+            assert resp.status_code == 501
+            assert resp.get_json()["error"] == "nope"
+        finally:
+            registry._items.pop(stub.name, None)
+
+    def test_plugin_exception_returns_502(self, client):
+        from vtsearch.datasets.importers import get_importer
+
+        registry = get_importer.__self__
+        registry._ensure_discovered()
+        stub = _StubImporter(fail_with=RuntimeError("remote service down"))
+        registry._items[stub.name] = stub
+        try:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "query_id", "values": {}},
+            )
+            assert resp.status_code == 502
+            assert resp.get_json()["error"] == "remote service down"
+        finally:
+            registry._items.pop(stub.name, None)
+
+
+# ---------------------------------------------------------------------------
+# Importer metadata round-trips through to_dict() so the frontend sees it
+# ---------------------------------------------------------------------------
+
+
+class TestImporterMetadataExposes:
+    def test_to_dict_includes_dynamic_field_props(self):
+        stub = _StubImporter()
+        d = stub.to_dict()
+        query_field = next(f for f in d["fields"] if f["key"] == "query_id")
+        assert query_field["dynamic_options"] is True
+        assert query_field["depends_on"] == ["media_type"]
+
+    def test_static_field_has_default_dynamic_props(self):
+        stub = _StubImporter()
+        d = stub.to_dict()
+        media_type_field = next(f for f in d["fields"] if f["key"] == "media_type")
+        assert media_type_field["dynamic_options"] is False
+        assert media_type_field["depends_on"] == []
+
+
+# ---------------------------------------------------------------------------
+# ReCaller scaffold — exercises the importer-level wiring
+# ---------------------------------------------------------------------------
+
+
+class TestReCallerDynamicQueryId:
+    def test_query_id_field_is_dynamic_with_media_type_dep(self):
+        from vtsearch.datasets.importers import get_importer
+
+        rc = get_importer("recaller")
+        assert rc is not None
+        query_field = next(f for f in rc.fields if f.key == "query_id")
+        assert query_field.dynamic_options is True
+        assert query_field.depends_on == ["media_type"]
+
+    def test_get_field_options_routes_through_rc_list_queries(self, monkeypatch):
+        from vtsearch.datasets.importers import get_importer
+        from vtsearch.datasets.importers import recaller as rc_module
+
+        rc = get_importer("recaller")
+        captured: list[str] = []
+
+        def fake_list(media_type: str) -> list[str]:
+            captured.append(media_type)
+            return ["q-aaa", "q-bbb"]
+
+        monkeypatch.setattr(rc_module, "_rc_list_queries", fake_list)
+
+        out = rc.get_field_options("query_id", {"media_type": "image"})
+        assert out == ["q-aaa", "q-bbb"]
+        assert captured == ["image"]
+
+    def test_get_field_options_default_media_type(self, monkeypatch):
+        from vtsearch.datasets.importers import get_importer
+        from vtsearch.datasets.importers import recaller as rc_module
+
+        rc = get_importer("recaller")
+        seen: list[str] = []
+        monkeypatch.setattr(rc_module, "_rc_list_queries", lambda mt: seen.append(mt) or [])
+
+        # Empty current_values falls back to "audio".
+        rc.get_field_options("query_id", {})
+        assert seen == ["audio"]
+
+    def test_get_field_options_unknown_key_raises(self):
+        from vtsearch.datasets.importers import get_importer
+
+        rc = get_importer("recaller")
+        with pytest.raises(NotImplementedError):
+            rc.get_field_options("not_a_field", {})

--- a/tests/test_importer_loading.py
+++ b/tests/test_importer_loading.py
@@ -926,9 +926,7 @@ class TestLoadDatasetRecursive:
         self._seed_layout(tmp_path)
         medias: dict = {}
         with self._patch_media_registry(self._make_fake_media_type()):
-            load_dataset_from_folder(
-                tmp_path, "audio", medias, on_progress=lambda *a: None, recursive=False
-            )
+            load_dataset_from_folder(tmp_path, "audio", medias, on_progress=lambda *a: None, recursive=False)
 
         names = sorted(m["filename"] for m in medias.values())
         assert names == ["top.wav"]
@@ -966,9 +964,7 @@ class TestServerFolderImporterRecursive:
     def test_build_origin_records_recursive(self):
         from vtsearch.datasets.importers.server_folder import IMPORTER
 
-        origin = IMPORTER.build_origin(
-            {"path": "/tmp/x", "media_type": "audio", "recursive": False}
-        )
+        origin = IMPORTER.build_origin({"path": "/tmp/x", "media_type": "audio", "recursive": False})
         assert origin["params"]["recursive"] == "false"
 
 

--- a/tests/test_load_sort_window.py
+++ b/tests/test_load_sort_window.py
@@ -159,6 +159,62 @@ class TestServerMediaFiles:
         assert files[0]["filename"] == "visible.wav"
 
 
+class TestServerMediaFileThumbnail:
+    """Tests for /api/server-media-files/<filename>/thumbnail."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_media_dir(self, tmp_path, monkeypatch):
+        from vtsearch.routes import media_server as media_server_module
+
+        self._media_dir = tmp_path / "example_media"
+        self._media_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(media_server_module, "SERVER_MEDIA_DIR", self._media_dir)
+
+    def _make_wav(self, name="example.wav", duration=0.1):
+        sample_rate = 16000
+        num_samples = int(sample_rate * duration)
+        samples = [int(32767 * np.sin(2 * np.pi * 440 * i / sample_rate)) for i in range(num_samples)]
+        path = self._media_dir / name
+        with wave.open(str(path), "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(sample_rate)
+            wf.writeframes(struct.pack(f"<{num_samples}h", *samples))
+        return path
+
+    def test_image_returns_file_bytes(self, client):
+        from PIL import Image
+
+        path = self._media_dir / "example.png"
+        Image.new("RGB", (16, 16), color=(123, 45, 67)).save(path)
+
+        resp = client.get("/api/server-media-files/example.png/thumbnail")
+        assert resp.status_code == 200
+        assert resp.mimetype == "image/png"
+        assert resp.data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_audio_returns_waveform_png(self, client):
+        self._make_wav("example.wav")
+        resp = client.get("/api/server-media-files/example.wav/thumbnail")
+        assert resp.status_code == 200
+        assert resp.mimetype == "image/png"
+        assert resp.data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_missing_file_returns_404(self, client):
+        resp = client.get("/api/server-media-files/nope.wav/thumbnail")
+        assert resp.status_code == 404
+
+    def test_path_traversal_rejected(self, client):
+        resp = client.get("/api/server-media-files/..%2F..%2Fetc%2Fpasswd/thumbnail")
+        # 400 (rejected by validation) or 404 (path doesn't resolve to a file)
+        assert resp.status_code in (400, 404)
+
+    def test_unsupported_extension_returns_404(self, client):
+        (self._media_dir / "doc.txt").write_text("hello")
+        resp = client.get("/api/server-media-files/doc.txt/thumbnail")
+        assert resp.status_code == 404
+
+
 class TestExampleSortServer:
     """Tests for /api/example-sort-server (sort by server-side media file)."""
 

--- a/tests/test_local_folder_upload.py
+++ b/tests/test_local_folder_upload.py
@@ -248,9 +248,7 @@ class TestFolderImporterPickerVisibility:
 
     def test_server_folder_importer_description_mentions_server(self, client):
         resp = client.get("/api/dataset/importers")
-        folder_imp = next(
-            i for i in resp.get_json()["importers"] if i["name"] == "server_folder"
-        )
+        folder_imp = next(i for i in resp.get_json()["importers"] if i["name"] == "server_folder")
         # The user reading the picker should not be misled into thinking
         # this scans their browser machine.
         assert "server" in folder_imp["description"].lower()

--- a/tests/test_origin_labelset.py
+++ b/tests/test_origin_labelset.py
@@ -456,8 +456,18 @@ class TestBuildClipLookup:
     def test_md5_lookup_groups_duplicates(self):
         """Two medias with the same MD5 should both appear in the md5_lookup."""
         medias = {
-            1: {"id": 1, "md5": "same_hash", "origin": {"importer": "server_folder", "params": {}}, "origin_name": "a.wav"},
-            2: {"id": 2, "md5": "same_hash", "origin": {"importer": "server_folder", "params": {}}, "origin_name": "b.wav"},
+            1: {
+                "id": 1,
+                "md5": "same_hash",
+                "origin": {"importer": "server_folder", "params": {}},
+                "origin_name": "a.wav",
+            },
+            2: {
+                "id": 2,
+                "md5": "same_hash",
+                "origin": {"importer": "server_folder", "params": {}},
+                "origin_name": "b.wav",
+            },
         }
         _, md5_lookup, _ = build_media_lookup(medias)
         assert sorted(md5_lookup["same_hash"]) == [1, 2]
@@ -497,7 +507,11 @@ class TestResolveClipIds:
 
     def test_match_by_origin(self):
         origin_lookup, md5_lookup, _ = self._make_lookups()
-        entry = {"md5": "wrong", "origin": {"importer": "server_folder", "params": {"path": "/a"}}, "origin_name": "a.wav"}
+        entry = {
+            "md5": "wrong",
+            "origin": {"importer": "server_folder", "params": {"path": "/a"}},
+            "origin_name": "a.wav",
+        }
         ids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert ids == [1]
 

--- a/tests/test_resize_handle_centering.py
+++ b/tests/test_resize_handle_centering.py
@@ -90,9 +90,7 @@ class TestResizeHandleCentering:
             "entirely on one side, and `right: -6px` is covered by the next "
             "<th>'s stacking context."
         )
-        assert _decl(block, "width") == "12px", (
-            f"{scss_path.name}: .col-resize-handle must be `width: 12px`."
-        )
+        assert _decl(block, "width") == "12px", f"{scss_path.name}: .col-resize-handle must be `width: 12px`."
         # The handle must NOT also pin to the right edge — that would shrink or
         # mis-center the grab zone.
         assert _decl(block, "right") is None, (
@@ -111,9 +109,7 @@ class TestResizeHandleCentering:
             "so the 2px visual line is centered on the divider (handle starts "
             "at cell-x -6, so handle-x 5 = divider)."
         )
-        assert _decl(after, "width") == "2px", (
-            f"{scss_path.name}: .col-resize-handle::after must be `width: 2px`."
-        )
+        assert _decl(after, "width") == "2px", f"{scss_path.name}: .col-resize-handle::after must be `width: 2px`."
         assert _decl(after, "right") is None, (
             f"{scss_path.name}: .col-resize-handle::after should not set "
             "`right`; pinning to the right edge of the host cell sits the line "

--- a/tests/test_resize_handle_centering.py
+++ b/tests/test_resize_handle_centering.py
@@ -27,10 +27,14 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parent.parent
+# Both dashboard tables (datagrid) and the shared importer-picker demo table
+# (used by both the Add Dataset and New Model > Browse Media modals) host
+# their own copies of the resize-handle rule.  The picker version lives in
+# the global ``_picker-shared.scss`` partial so the two modals don't have
+# duplicate scoped copies.
 SCSS_FILES = [
     REPO / "frontend/src/app/components/dashboard/dashboard.component.scss",
-    REPO
-    / "frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss",
+    REPO / "frontend/src/scss/_picker-shared.scss",
 ]
 
 

--- a/tests/test_synthetic_importer.py
+++ b/tests/test_synthetic_importer.py
@@ -241,9 +241,7 @@ class TestRunEndToEnd:
         medias: dict[int, dict] = {}
         imp.run({"media_type": "audio", "size": "3"}, medias)
         media = next(iter(medias.values()))
-        resolved = imp.resolve_file(
-            media["origin"], origin_name=media["origin_name"], filename=media["filename"]
-        )
+        resolved = imp.resolve_file(media["origin"], origin_name=media["origin_name"], filename=media["filename"])
         assert resolved is not None
         assert resolved.is_file()
 

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -196,6 +196,44 @@ class DatasetImporter(PluginBase):
         raise NotImplementedError(f"{type(self).__name__}.run() is not implemented")
 
     # ------------------------------------------------------------------
+    # Dynamic field options
+    # ------------------------------------------------------------------
+
+    def get_field_options(
+        self,
+        field_key: str,
+        current_values: dict[str, Any],
+    ) -> list[str]:
+        """Return the dropdown options for *field_key* given current form values.
+
+        Override this on importers that declare any
+        :class:`~vtsearch.utils.registry.PluginField` with
+        ``dynamic_options=True``.  The frontend calls this via
+        ``POST /api/dataset/import/<name>/options`` whenever a field listed
+        in another field's ``depends_on`` changes — e.g. a ``query_id``
+        select might re-populate after the user picks a ``media_type``.
+
+        Args:
+            field_key: The :attr:`PluginField.key` of the field whose
+                options are being requested.
+            current_values: A snapshot of every form field's current value,
+                keyed by :attr:`PluginField.key`.  Values are plain strings
+                (or empty strings for unfilled fields).
+
+        Returns:
+            The list of allowed option strings for the dropdown.
+
+        Raises:
+            NotImplementedError: When the importer declares no dynamic
+                fields, or has not implemented this hook for *field_key*.
+                Subclasses should raise (or let the default raise) for any
+                ``field_key`` they do not handle.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented"
+        )
+
+    # ------------------------------------------------------------------
     # Chunked / piecewise loading
     # ------------------------------------------------------------------
 

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -229,9 +229,7 @@ class DatasetImporter(PluginBase):
                 Subclasses should raise (or let the default raise) for any
                 ``field_key`` they do not handle.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented"
-        )
+        raise NotImplementedError(f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented")
 
     # ------------------------------------------------------------------
     # Chunked / piecewise loading

--- a/vtsearch/datasets/importers/recaller/__init__.py
+++ b/vtsearch/datasets/importers/recaller/__init__.py
@@ -49,6 +49,15 @@ from vtsearch.media import all_folder_names
 # ---------------------------------------------------------------------------
 
 
+def _rc_list_queries(media_type: str) -> list[str]:
+    """Call ReCaller and return the list of query IDs for *media_type*.
+
+    Used to populate the ``query_id`` dropdown dynamically once the user
+    picks a media type.  Each entry is a ReCaller queryID string.
+    """
+    raise NotImplementedError("TODO: implement ReCaller list-queries API client")
+
+
 def _rc_fetch_results(query_id: str) -> list[dict[str, Any]]:
     """Call ReCaller and return the result list for *query_id*.
 
@@ -100,12 +109,6 @@ class ReCallerDatasetImporter(DatasetImporter):
     category = "services"
     fields = [
         ImporterField(
-            key="query_id",
-            label="Query ID",
-            field_type="text",
-            description="The ReCaller query ID referencing a recent browsing session.",
-        ),
-        ImporterField(
             key="media_type",
             label="Media Type",
             field_type="select",
@@ -113,7 +116,22 @@ class ReCallerDatasetImporter(DatasetImporter):
             default="audio",
             description="Only results matching this media type will be imported.",
         ),
+        ImporterField(
+            key="query_id",
+            label="Query ID",
+            field_type="select",
+            description="The ReCaller query referencing a recent browsing session.",
+            dynamic_options=True,
+            depends_on=["media_type"],
+        ),
     ]
+
+    def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> list[str]:
+        """Populate ``query_id`` from ReCaller, scoped by the picked media type."""
+        if field_key == "query_id":
+            media_type = current_values.get("media_type") or "audio"
+            return list(_rc_list_queries(media_type))
+        return super().get_field_options(field_key, current_values)
 
     # The dataset-level origin (queryID) is NOT useful for provenance —
     # each media gets its own origin keyed by contentID.  Return an empty

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -310,10 +310,75 @@ def _apply_clipper(
     # Recompute MD5 and re-embed every genuine sub-item.
     _fixup_clip_md5_and_embeddings(all_clipped, needs_recompute, clipper.media_type, on_progress=on_progress)
 
+    # Regenerate thumbnails so audio/video clips show their own range
+    # rather than the parent's full waveform / mid-frame.
+    _regenerate_clip_thumbnails(all_clipped, needs_recompute, clipper.media_type)
+
     clips_dict.clear()
     for new_id, clip in enumerate(all_clipped, 1):
         clip["id"] = new_id
         clips_dict[new_id] = clip
+
+
+def _regenerate_clip_thumbnails(
+    clips: list[dict],
+    needs_recompute: list[bool],
+    media_type: str,
+) -> None:
+    """Refresh ``thumbnail_bytes`` on clipped audio/video sub-items.
+
+    Audio and video clippers copy ``thumbnail_bytes`` verbatim from the parent
+    media; without this fixup, every sub-item would render the parent's
+    waveform or middle-frame thumbnail in the find/label list.
+
+    Image clips don't go through this path — their thumbnail is the cropped
+    ``media_bytes`` itself, served directly by the media-image route.
+    """
+    if media_type == "audio":
+        from vtsearch.media.audio.media_type import (
+            generate_waveform_thumbnail,
+            generate_waveform_thumbnail_from_file,
+        )
+
+        for clip, recompute in zip(clips, needs_recompute):
+            if not recompute:
+                continue
+            wav = clip.get("media_bytes")
+            thumb: bytes | None = None
+            if wav is not None:
+                thumb = generate_waveform_thumbnail(wav)
+            else:
+                path = clip.get("media_path")
+                if path:
+                    thumb = generate_waveform_thumbnail_from_file(Path(path))
+            if thumb is not None:
+                clip["thumbnail_bytes"] = thumb
+        return
+
+    if media_type == "video":
+        from vtsearch.media.video.media_type import (
+            generate_video_thumbnail_at,
+            generate_video_thumbnail_from_file_at,
+        )
+
+        for clip, recompute in zip(clips, needs_recompute):
+            if not recompute:
+                continue
+            t0 = clip.get("clip_start")
+            t1 = clip.get("clip_end")
+            if t0 is None or t1 is None:
+                continue
+            mid = (float(t0) + float(t1)) / 2.0
+            video_bytes = clip.get("media_bytes")
+            thumb: bytes | None = None
+            if video_bytes is not None:
+                thumb = generate_video_thumbnail_at(video_bytes, mid)
+            else:
+                path = clip.get("media_path")
+                if path:
+                    thumb = generate_video_thumbnail_from_file_at(Path(path), mid)
+            if thumb is not None:
+                clip["thumbnail_bytes"] = thumb
 
 
 def _fixup_clip_md5_and_embeddings(

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -134,6 +134,7 @@ def _get_embedder_for_medias(media_dict: dict):
     routes layer, which itself imports from this module.
     """
     from vtsearch.routes.helpers import get_embedder_for_medias as _impl
+
     return _impl(media_dict)
 
 

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -11,17 +11,13 @@ from __future__ import annotations
 import gc
 import hashlib
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 import numpy as np
 from PIL import Image
 
 from vtsearch.datasets.loader import (
     ProgressCallback,
-    _get_embedding_value,
-    _get_md5_value,
-    _pop_md5_key,
-    _pop_embedding_key,
 )
 from vtsearch.datasets.pickle_security import safe_pickle_load
 

--- a/vtsearch/labels/sources/base.py
+++ b/vtsearch/labels/sources/base.py
@@ -17,7 +17,7 @@ from vtsearch.utils.registry import PluginField
 from vtsearch.utils.sync_source import SyncSource
 
 if TYPE_CHECKING:
-    from vtsearch.datasets.labelset import LabelSet
+    pass
 
 LabelsetSourceField = PluginField
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -117,9 +117,7 @@ def _frame_at_time(cap, time_seconds: float) -> "tuple | None":
     return frame
 
 
-def generate_video_thumbnail_at(
-    video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE
-) -> bytes | None:
+def generate_video_thumbnail_at(video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE) -> bytes | None:
     """Extract a frame at *time_seconds* from *video_bytes* and return it as a PNG thumbnail."""
     try:
         import cv2  # noqa: PLC0415

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -98,6 +98,95 @@ def generate_video_thumbnail_from_file(file_path: Path, *, size: int = _THUMB_SI
     return buf.getvalue()
 
 
+def _frame_at_time(cap, time_seconds: float) -> "tuple | None":
+    """Seek *cap* to *time_seconds* and read one frame.  Returns ``(ok, frame)`` or ``None``."""
+    import cv2  # noqa: PLC0415
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    if frame_count <= 0:
+        return None
+    if fps and fps > 0:
+        target = max(0, min(int(round(time_seconds * fps)), frame_count - 1))
+    else:
+        target = frame_count // 2
+    cap.set(cv2.CAP_PROP_POS_FRAMES, target)
+    ret, frame = cap.read()
+    if not ret:
+        return None
+    return frame
+
+
+def generate_video_thumbnail_at(
+    video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE
+) -> bytes | None:
+    """Extract a frame at *time_seconds* from *video_bytes* and return it as a PNG thumbnail."""
+    try:
+        import cv2  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+    except Exception:
+        return None
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    try:
+        tmp.write(video_bytes)
+        tmp.close()
+
+        cap = cv2.VideoCapture(tmp.name)
+        try:
+            if not cap.isOpened():
+                return None
+            frame = _frame_at_time(cap, time_seconds)
+            if frame is None:
+                return None
+        finally:
+            cap.release()
+    finally:
+        import os  # noqa: PLC0415
+
+        os.unlink(tmp.name)
+
+    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(frame_rgb)
+    img.thumbnail((size, size))
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+def generate_video_thumbnail_from_file_at(
+    file_path: Path, time_seconds: float, *, size: int = _THUMB_SIZE
+) -> bytes | None:
+    """Extract a frame at *time_seconds* from a video file and return it as a PNG thumbnail."""
+    try:
+        import cv2  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+    except Exception:
+        return None
+
+    try:
+        cap = cv2.VideoCapture(str(file_path))
+        try:
+            if not cap.isOpened():
+                return None
+            frame = _frame_at_time(cap, time_seconds)
+            if frame is None:
+                return None
+        finally:
+            cap.release()
+    except Exception:
+        return None
+
+    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(frame_rgb)
+    img.thumbnail((size, size))
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
 _VIDEO_MIME_TYPES: dict[str, str] = {
     ".webm": "video/webm",
     ".mov": "video/quicktime",

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -23,13 +23,8 @@ from vtsearch.routes.helpers import get_json_or_400, get_json_safe, get_plugin_o
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtsearch.datasets.loader import safe_pickle_load
 from vtsearch.datasets.registry import (
-    is_loaded as _reg_is_loaded,
     list_datasets as _reg_list_all,
     remove_loaded_id as _reg_remove_loaded,
-    add_loaded_id as _reg_add_loaded,
-    unregister_dataset as _reg_unregister,
-    update_dataset as _reg_update,
-    get_dataset as _reg_get,
 )
 from vtsearch.utils import (
     bad_votes,
@@ -839,7 +834,6 @@ def clear_dataset_route():
     else:
         clear_dataset()
     return jsonify({"ok": True})
-
 
 
 @datasets_bp.route("/api/dataset/load-source", methods=["POST"])

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -455,6 +455,50 @@ def clear_staging():
 # ---------------------------------------------------------------------------
 
 
+@datasets_bp.route("/api/dataset/import/<importer_name>/options", methods=["POST"])
+def importer_field_options(importer_name: str):
+    """Return dropdown options for a dynamic-options field.
+
+    Body::
+
+        {"field_key": "query_id", "values": {"media_type": "audio", ...}}
+
+    The importer's ``get_field_options(field_key, current_values)`` is
+    called with the supplied snapshot of current form values.  Returns
+    ``{"options": [...]}`` on success.  Errors from the plugin (network
+    failure, auth error, etc.) are surfaced as a 502 with the original
+    message so the frontend can display them inline.
+    """
+    importer, err = get_plugin_or_404(get_importer, list_importers, importer_name, "importer")
+    if err:
+        return err
+
+    body = request.get_json(force=True, silent=True) or {}
+    field_key = str(body.get("field_key") or "").strip()
+    values = body.get("values") or {}
+    if not field_key:
+        return jsonify({"error": "Missing required field: 'field_key'"}), 400
+    if not isinstance(values, dict):
+        return jsonify({"error": "'values' must be an object"}), 400
+
+    field = next((f for f in importer.fields if f.key == field_key), None)
+    if field is None:
+        return jsonify({"error": f"Unknown field: {field_key!r}"}), 400
+    if not getattr(field, "dynamic_options", False):
+        return jsonify({"error": f"Field {field_key!r} is not dynamic"}), 400
+
+    try:
+        options = importer.get_field_options(field_key, values)
+    except NotImplementedError as exc:
+        return jsonify({"error": str(exc) or "Importer does not implement get_field_options"}), 501
+    except Exception as exc:  # noqa: BLE001 — surface remote-service errors verbatim
+        return jsonify({"error": str(exc) or type(exc).__name__}), 502
+
+    if not isinstance(options, list):
+        return jsonify({"error": "get_field_options must return a list"}), 500
+    return jsonify({"options": [str(o) for o in options]})
+
+
 @datasets_bp.route("/api/dataset/import/<importer_name>", methods=["POST"])
 def import_dataset(importer_name: str):
     """Run a registered importer by name in a background thread."""

--- a/vtsearch/routes/media_server.py
+++ b/vtsearch/routes/media_server.py
@@ -1,14 +1,39 @@
 """Blueprint for server media file management and example-sort routes."""
 
+import io
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, send_file
 
 from vtsearch.config import DATA_DIR
 from vtsearch.routes.helpers import get_json_or_400
 from vtsearch.utils import snapshot_medias
 
 media_server_bp = Blueprint("media_server", __name__)
+
+
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+_AUDIO_EXTS = {".wav", ".mp3", ".ogg", ".flac", ".m4a", ".aac"}
+_VIDEO_EXTS = {".mp4", ".webm", ".mov", ".avi", ".mkv"}
+
+
+def _media_type_from_ext(suffix: str) -> str:
+    s = suffix.lower()
+    if s in _IMAGE_EXTS:
+        return "image"
+    if s in _AUDIO_EXTS:
+        return "audio"
+    if s in _VIDEO_EXTS:
+        return "video"
+    return ""
+
+
+_IMAGE_MIMETYPES = {
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
 
 #: Default directory for server-side example media files (single-user fallback).
 SERVER_MEDIA_DIR = DATA_DIR / "example_media"
@@ -76,6 +101,63 @@ def upload_server_media_file():
                 return jsonify({"error": "Invalid crop_params for this media type"}), 400
 
     return jsonify({"filename": safe_name, "original_name": file.filename}), 201
+
+
+@media_server_bp.route("/api/server-media-files/<path:filename>/thumbnail", methods=["GET"])
+def server_media_file_thumbnail(filename: str):
+    """Return a small image preview of an example media file.
+
+    Used by the new-model dialog to show the user which example was selected.
+    For images this serves the file bytes; for audio it returns a waveform PNG;
+    for video it returns the middle-frame PNG.  Other media types return 404.
+    """
+    media_dir = _get_server_media_dir()
+    file_path = media_dir / filename
+
+    try:
+        file_path.resolve().relative_to(media_dir.resolve())
+    except ValueError:
+        return jsonify({"error": "Invalid filename"}), 400
+
+    if not file_path.is_file():
+        return jsonify({"error": f"File not found: {filename}"}), 404
+
+    suffix = file_path.suffix.lower()
+    media_type = _media_type_from_ext(suffix)
+
+    if media_type == "image":
+        mimetype = _IMAGE_MIMETYPES.get(suffix, "image/jpeg")
+        return send_file(
+            io.BytesIO(file_path.read_bytes()),
+            mimetype=mimetype,
+            download_name=file_path.name,
+        )
+
+    if media_type == "audio":
+        from vtsearch.media.audio.media_type import generate_waveform_thumbnail_from_file
+
+        thumb = generate_waveform_thumbnail_from_file(file_path)
+        if thumb is None:
+            return jsonify({"error": "Could not generate audio thumbnail"}), 500
+        return send_file(
+            io.BytesIO(thumb),
+            mimetype="image/png",
+            download_name=f"{file_path.stem}_waveform.png",
+        )
+
+    if media_type == "video":
+        from vtsearch.media.video.media_type import generate_video_thumbnail_from_file
+
+        thumb = generate_video_thumbnail_from_file(file_path)
+        if thumb is None:
+            return jsonify({"error": "Could not generate video thumbnail"}), 500
+        return send_file(
+            io.BytesIO(thumb),
+            mimetype="image/png",
+            download_name=f"{file_path.stem}_frame.png",
+        )
+
+    return jsonify({"error": f"No thumbnail available for {suffix}"}), 404
 
 
 @media_server_bp.route("/api/server-media-files", methods=["GET"])

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -485,9 +485,7 @@ def combine_trainable_models():
 
     media_types = {s.get("media_type", "") for s in sources}
     if len(media_types) > 1:
-        return jsonify(
-            {"error": f"All source models must share the same media_type; got {sorted(media_types)}"}
-        ), 400
+        return jsonify({"error": f"All source models must share the same media_type; got {sorted(media_types)}"}), 400
     media_type = next(iter(media_types))
     if not media_type or media_type == "any":
         return jsonify({"error": "Source models must have a specific media_type (not empty or 'any')"}), 400
@@ -499,8 +497,7 @@ def combine_trainable_models():
         return jsonify(
             {
                 "error": (
-                    "Combined labelset is empty after applying conflict policy "
-                    f"{conflict_policy!r}; nothing to save."
+                    f"Combined labelset is empty after applying conflict policy {conflict_policy!r}; nothing to save."
                 )
             }
         ), 422
@@ -554,4 +551,3 @@ def combine_trainable_models():
 
 # Canonical location: vtsearch.models.training_workflow
 from vtsearch.models.training_workflow import apply_and_retrain as _apply_and_retrain  # noqa: E402
-

--- a/vtsearch/routes/trainable_models.py
+++ b/vtsearch/routes/trainable_models.py
@@ -32,7 +32,6 @@ import time
 
 from flask import Blueprint, jsonify, request
 
-from vtsearch.auth import get_current_user
 from vtsearch.models.trainable_model_store import (
     _model_path,
     _read_model,

--- a/vtsearch/utils/registry.py
+++ b/vtsearch/utils/registry.py
@@ -69,11 +69,23 @@ class PluginField:
     - ``"text"``     – Generic single-line text input.
     - ``"password"`` – Text input whose characters are masked.
     - ``"email"``    – Text input pre-validated as an e-mail address.
-    - ``"select"``   – Drop-down; ``options`` must be populated.
+    - ``"select"``   – Drop-down; ``options`` must be populated (or
+      :attr:`dynamic_options` set, in which case options are fetched at
+      runtime from the plugin's ``get_field_options`` method).
     - ``"server_path"`` – File-browser picker for server filesystem paths.
     - ``"checkbox"`` – Boolean tick-box.  ``default`` should be ``"true"`` or
       ``"false"``; values arrive at :meth:`run` as plain strings (or already
       coerced bools) and should be parsed via ``str(value).lower() == "true"``.
+
+    Dynamic option fields
+    ---------------------
+    Set ``dynamic_options=True`` on a ``"select"`` field whose options must
+    be computed at runtime — e.g. by querying a remote service.  The plugin
+    must implement ``get_field_options(field_key, current_values)`` to return
+    the list.  The frontend re-fetches options every time any field listed
+    in :attr:`depends_on` changes value.  Currently honoured by dataset
+    importers (``POST /api/dataset/import/<name>/options``); other plugin
+    families may opt in similarly.
     """
 
     key: str
@@ -89,6 +101,14 @@ class PluginField:
     required: bool = True
     #: Hint shown as placeholder text inside the input widget.
     placeholder: str = ""
+    #: When ``True``, :attr:`options` is computed at runtime by the plugin's
+    #: ``get_field_options(field_key, current_values)`` method.  Static
+    #: :attr:`options` (if any) are still served as the initial list.
+    dynamic_options: bool = False
+    #: Field keys whose values this field's options depend on.  When any
+    #: listed field changes, the frontend re-fetches options for this field.
+    #: Only meaningful when :attr:`dynamic_options` is ``True``.
+    depends_on: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -101,6 +121,8 @@ class PluginField:
             "default": self.default,
             "required": self.required,
             "placeholder": self.placeholder,
+            "dynamic_options": self.dynamic_options,
+            "depends_on": list(self.depends_on),
         }
 
 


### PR DESCRIPTION
## Summary

UI: Models grid lightbulb icon swapped for a robot head. Find/label lists and the new-model dialog example row now render cropped thumbnails for clipped audio/video sub-items via a new server-media-files thumbnail endpoint. Stale TypeScript spec errors fixed; resize-handle test updated to the shared SCSS partial.

Importers: Dataset importer fields gain dynamic-options support — selects can declare `dynamic_options=True` and `depends_on` other fields, with options computed server-side via `get_field_options`. The modal pre-fetches on open and re-fetches on dependency change, showing remote errors inline. Demoed on the ReCaller scaffold's `query_id`.

Docker: SigLIP image bakes a default settings.json so the embedder preloads on startup; preload step prints flushed progress with an HF download timeout so it no longer appears to hang.

Misc: lint/format pass, template type fix, npm audit lockfile bump, and a CLAUDE.md rule to fix all errors not just newly introduced ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9bEfyNTZ6L1qtvDUDGJGR)_