### PR TITLE
Fix negative skipped count on label import with auto-resolve

### DIFF
--- a/tests/test_label_import_endpoint.py
+++ b/tests/test_label_import_endpoint.py
@@ -536,6 +536,8 @@ class TestLabelImportMissingElements:
             assert result["ingested"] == 1
             assert result["missing_count"] == 0
             assert result["missing"] == []
+            # Auto-resolved entries must not double-decrement skipped (regression).
+            assert result["skipped"] == 0
             # The new media should be in the dataset and labeled
             new_ids = [cid for cid, m in app_module.medias.items() if m.get("md5") == md5]
             assert len(new_ids) == 1

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -156,11 +156,12 @@ def run_label_import(importer_name: str):
         ingested = ingest_missing_medias(missing, medias)
 
         if ingested > 0:
-            # Re-apply labels now that new medias are available
+            # Re-apply labels now that new medias are available.  These entries
+            # were already removed from `skipped` above when we subtracted
+            # `len(missing)`, so we only need to bump `applied` here.
             origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
             resolved_applied, _ = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
             applied += resolved_applied
-            skipped -= resolved_applied
 
         # Check which entries still couldn't be resolved
         if ingested < len(missing):


### PR DESCRIPTION
## Summary
- Label import was reporting "Applied 7, skipped -7" when all entries were missing-but-auto-resolved.
- Root cause: `run_label_import` decremented `skipped` twice for the same entries — once when subtracting `len(missing)` after the initial apply pass, and again with `skipped -= resolved_applied` after auto-ingesting them.
- Removed the redundant decrement; missing entries are already excluded from `skipped` before re-applying, so resolving them only needs to bump `applied`.
- Added a `skipped == 0` assertion to the existing auto-resolve test as a regression guard.

## Test plan
- [x] `./run-tests.sh io` (544 passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AHVNFnCiDkfDod8wkWnz9R)_