### PR TITLE
Show per-file progress while generating synthetic datasets

### DIFF
--- a/tests/test_synthetic_importer.py
+++ b/tests/test_synthetic_importer.py
@@ -126,6 +126,43 @@ class TestAudioGenerator:
         generate_audio_dataset(tmp_path, 6, seed=1)
         assert paths[0].stat().st_mtime_ns == first_mtime
 
+    def test_emits_per_file_progress(self, tmp_path):
+        from vtsearch.utils.synthetic.audio import generate_audio_dataset  # noqa: PLC0415
+
+        events: list[tuple[str, str, int, int]] = []
+
+        def on_progress(status, message, current, total):
+            events.append((status, message, current, total))
+
+        generate_audio_dataset(tmp_path, 4, seed=1, on_progress=on_progress)
+
+        # Status is "downloading" so it maps to step 1 in the load pipeline.
+        assert all(ev[0] == "downloading" for ev in events)
+        # Total is reported correctly on every event.
+        assert all(ev[3] == 4 for ev in events)
+        # Per-file events count up 0..3 (with start at 0 and final at 4).
+        per_file_currents = [ev[2] for ev in events[1:-1]]
+        assert per_file_currents == [0, 1, 2, 3]
+        # Final event marks completion.
+        assert events[-1][2] == 4
+        # Messages mention "Synthesising" the first time around.
+        assert any("Synthesising" in ev[1] for ev in events)
+
+    def test_progress_marks_cached_runs(self, tmp_path):
+        from vtsearch.utils.synthetic.audio import generate_audio_dataset  # noqa: PLC0415
+
+        generate_audio_dataset(tmp_path, 3, seed=1)
+
+        events: list[str] = []
+        generate_audio_dataset(
+            tmp_path,
+            3,
+            seed=1,
+            on_progress=lambda status, message, current, total: events.append(message),
+        )
+        # On the second run all files are cached, so messages should say so.
+        assert any("Reusing cached" in m for m in events)
+
 
 # ---------------------------------------------------------------------------
 # Image generator (needs Pillow)
@@ -231,6 +268,36 @@ class TestRunEndToEnd:
             assert m["type"] == "audio"
             assert isinstance(m["filename"], str)
             assert Path(m["filename"]).suffix == ".wav"
+
+    def test_importer_forwards_thread_progress_to_generator(self, tmp_path, monkeypatch):
+        """The importer must hand the per-thread progress callback to the
+        generator so the loading-task progress bar updates while files are
+        being synthesised, instead of stalling on "Preparing new dataset…".
+        """
+        from vtsearch.datasets.importers import synthetic as syn  # noqa: PLC0415
+        from vtsearch.utils.progress import (  # noqa: PLC0415
+            clear_thread_progress,
+            set_thread_progress,
+        )
+
+        monkeypatch.setattr(syn, "DATA_DIR", tmp_path)
+        events: list[tuple[str, int, int]] = []
+
+        def cb(status, message="", current=0, total=0, **_kw):
+            events.append((status, current, total))
+
+        set_thread_progress(cb)
+        try:
+            imp = SyntheticDatasetImporter()
+            imp.run({"media_type": "audio", "size": "4"}, {})
+        finally:
+            clear_thread_progress()
+
+        per_file = [(s, c, t) for (s, c, t) in events if s == "downloading" and t == 4]
+        # We expect a start event (current=0), 4 per-file events (0..3), and a final event (current=4).
+        assert any(c == 0 for _, c, _ in per_file)
+        assert any(c == 3 for _, c, _ in per_file)
+        assert any(c == 4 for _, c, _ in per_file)
 
     def test_run_then_resolve_file_round_trip(self, tmp_path, monkeypatch):
         """Origin produced by run() must resolve back to a real file via resolve_file."""

--- a/vtsearch/datasets/importers/synthetic/__init__.py
+++ b/vtsearch/datasets/importers/synthetic/__init__.py
@@ -87,19 +87,22 @@ class SyntheticDatasetImporter(DatasetImporter):
 
     def _generate(self, media_type: str, size: int) -> Path:
         """Render files into the cache dir, return the dir path."""
+        from vtsearch.utils.progress import get_thread_progress  # noqa: PLC0415
+
+        on_progress = get_thread_progress()
         out_dir = _cache_dir(media_type, size)
         if media_type == "image":
             from vtsearch.utils.synthetic import generate_image_dataset  # noqa: PLC0415
 
-            generate_image_dataset(out_dir, size, seed=_DEFAULT_SEED)
+            generate_image_dataset(out_dir, size, seed=_DEFAULT_SEED, on_progress=on_progress)
         elif media_type == "audio":
             from vtsearch.utils.synthetic import generate_audio_dataset  # noqa: PLC0415
 
-            generate_audio_dataset(out_dir, size, seed=_DEFAULT_SEED)
+            generate_audio_dataset(out_dir, size, seed=_DEFAULT_SEED, on_progress=on_progress)
         elif media_type == "video":
             from vtsearch.utils.synthetic import generate_video_dataset  # noqa: PLC0415
 
-            generate_video_dataset(out_dir, size, seed=_DEFAULT_SEED)
+            generate_video_dataset(out_dir, size, seed=_DEFAULT_SEED, on_progress=on_progress)
         else:
             raise ValueError(f"Unsupported media_type {media_type!r}")
         return out_dir

--- a/vtsearch/utils/synthetic/audio.py
+++ b/vtsearch/utils/synthetic/audio.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import math
 import wave
 from pathlib import Path
+from typing import Callable, Optional
 
 import numpy as np
+
+ProgressCallback = Callable[[str, str, int, int], None]
 
 SAMPLE_RATE = 48000
 
@@ -166,24 +169,46 @@ _GENERATORS = [
 ]
 
 
-def generate_audio_dataset(output_dir: Path, count: int, seed: int = 42) -> list[Path]:
+def generate_audio_dataset(
+    output_dir: Path,
+    count: int,
+    seed: int = 42,
+    on_progress: Optional[ProgressCallback] = None,
+) -> list[Path]:
     """Generate ``count`` synthetic WAV files into ``output_dir``.
 
     Cycles through six ideas (tone, chord, drum, rain, wind, bird) so the
     resulting dataset has clear semantic clusters. Existing files are kept,
     so reloads are fast.
+
+    If *on_progress* is supplied, it is called as
+    ``on_progress(status, message, current, total)`` once per file (and
+    once at the start and end) so the caller can drive a progress bar.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
     width = max(4, len(str(count)))
+    if on_progress is not None:
+        on_progress("downloading", f"Generating {count} synthetic audio clips…", 0, count)
     for i in range(count):
         idea, gen = _GENERATORS[i % len(_GENERATORS)]
         path = output_dir / f"{idea}_{i:0{width}d}.wav"
         paths.append(path)
-        if path.exists():
+        cached = path.exists()
+        if on_progress is not None:
+            verb = "Reusing cached" if cached else "Synthesising"
+            on_progress(
+                "downloading",
+                f"{verb} synthetic audio {i + 1}/{count} ({idea})…",
+                i,
+                count,
+            )
+        if cached:
             continue
         rng = np.random.default_rng(seed + i)
         duration = float(rng.uniform(1.0, 2.5))
         samples, _meta = gen(rng, duration)
         _write_wav(path, samples)
+    if on_progress is not None:
+        on_progress("downloading", f"Generated {count} synthetic audio clips", count, count)
     return paths

--- a/vtsearch/utils/synthetic/images.py
+++ b/vtsearch/utils/synthetic/images.py
@@ -14,8 +14,11 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Callable, Optional
 
 import numpy as np
+
+ProgressCallback = Callable[[str, str, int, int], None]
 
 CANVAS_SIZE = 256
 
@@ -134,28 +137,50 @@ def _draw_shapes(rng: np.random.Generator, draw, size: int) -> tuple[str, dict]:
 _GENERATORS = [_draw_smiley, _draw_shapes]
 
 
-def generate_image_dataset(output_dir: Path, count: int, seed: int = 42) -> list[Path]:
+def generate_image_dataset(
+    output_dir: Path,
+    count: int,
+    seed: int = 42,
+    on_progress: Optional[ProgressCallback] = None,
+) -> list[Path]:
     """Generate ``count`` synthetic images into ``output_dir``.
 
     Existing files matching the deterministic naming scheme are kept (the
     importer caches its output dir across reloads). Returns the list of
     image paths in generation order.
+
+    If *on_progress* is supplied, it is called as
+    ``on_progress(status, message, current, total)`` once per file (and
+    once at the start and end) so the caller can drive a progress bar.
     """
     from PIL import Image, ImageDraw  # noqa: PLC0415
 
     output_dir.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
     width = max(4, len(str(count)))
+    if on_progress is not None:
+        on_progress("downloading", f"Generating {count} synthetic images…", 0, count)
     for i in range(count):
         gen = _GENERATORS[i % len(_GENERATORS)]
         idea = "smiley" if gen is _draw_smiley else "shapes"
         path = output_dir / f"{idea}_{i:0{width}d}.png"
         paths.append(path)
-        if path.exists():
+        cached = path.exists()
+        if on_progress is not None:
+            verb = "Reusing cached" if cached else "Rendering"
+            on_progress(
+                "downloading",
+                f"{verb} synthetic image {i + 1}/{count} ({idea})…",
+                i,
+                count,
+            )
+        if cached:
             continue
         rng = np.random.default_rng(seed + i)
         img = Image.new("RGB", (CANVAS_SIZE, CANVAS_SIZE), (255, 255, 255))
         draw = ImageDraw.Draw(img)
         gen(rng, draw, CANVAS_SIZE)
         img.save(path, format="PNG")
+    if on_progress is not None:
+        on_progress("downloading", f"Generated {count} synthetic images", count, count)
     return paths

--- a/vtsearch/utils/synthetic/video.py
+++ b/vtsearch/utils/synthetic/video.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Callable, Optional
 
 import numpy as np
+
+ProgressCallback = Callable[[str, str, int, int], None]
 
 CANVAS_SIZE = 224
 FPS = 12
@@ -184,24 +187,46 @@ def _encode_frames(path: Path, frames: list[np.ndarray], fps: int) -> None:
         writer.close()
 
 
-def generate_video_dataset(output_dir: Path, count: int, seed: int = 42) -> list[Path]:
+def generate_video_dataset(
+    output_dir: Path,
+    count: int,
+    seed: int = 42,
+    on_progress: Optional[ProgressCallback] = None,
+) -> list[Path]:
     """Generate ``count`` short synthetic mp4s into ``output_dir``.
 
     Cycles through four ideas (bouncing ball, walking smiley, rotating
     shape, scrolling marquee) so the dataset has both motion and
     appearance variety. Existing files are kept across reloads.
+
+    If *on_progress* is supplied, it is called as
+    ``on_progress(status, message, current, total)`` once per file (and
+    once at the start) so the caller can drive a progress bar. The
+    ``status`` is always ``"downloading"`` so it maps to the dataset
+    pipeline's "fetching files" step.
     """
     from PIL import Image, ImageDraw  # noqa: PLC0415
 
     output_dir.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
     width = max(4, len(str(count)))
+    if on_progress is not None:
+        on_progress("downloading", f"Generating {count} synthetic videos…", 0, count)
     for i in range(count):
         make_params, render = _GENERATORS[i % len(_GENERATORS)]
         idea, _ = make_params(np.random.default_rng(seed + i))
         path = output_dir / f"{idea}_{i:0{width}d}.mp4"
         paths.append(path)
-        if path.exists():
+        cached = path.exists()
+        if on_progress is not None:
+            verb = "Reusing cached" if cached else "Rendering"
+            on_progress(
+                "downloading",
+                f"{verb} synthetic video {i + 1}/{count} ({idea})…",
+                i,
+                count,
+            )
+        if cached:
             continue
         rng = np.random.default_rng(seed + i)
         _name, params = make_params(rng)
@@ -213,4 +238,6 @@ def generate_video_dataset(output_dir: Path, count: int, seed: int = 42) -> list
             render(rng, t, params, draw, CANVAS_SIZE)
             frames.append(np.asarray(img, dtype=np.uint8))
         _encode_frames(path, frames, FPS)
+    if on_progress is not None:
+        on_progress("downloading", f"Generated {count} synthetic videos", count, count)
     return paths


### PR DESCRIPTION
## Summary
- Add an optional `on_progress` callback to `generate_video_dataset` / `generate_image_dataset` / `generate_audio_dataset` so they emit a `"downloading"`-status event per file (e.g. "Rendering synthetic video 12/100 (ball)…", "Reusing cached synthetic image 5/100 (smiley)…").
- Wire the synthetic importer's `_generate()` through `get_thread_progress()` so the dataset-loading task tracker now updates while files are being synthesised, instead of stalling on `[Step 1/4] Preparing new dataset…` until folder loading begins.
- Cancellation keeps working because the per-thread callback set by the load pipeline already calls `tracker.check_cancelled()` on every update.

## Motivation
For a fresh synthetic video dataset, every file requires encoding 24 frames via ffmpeg. With `size=100`, that took long enough that the bar appeared frozen — same problem (smaller magnitude) for images/audio.

## Test plan
- [x] `./run-tests.sh datasets io` — 1022 passed, 2 skipped
- [x] New tests in `tests/test_synthetic_importer.py`:
  - `test_emits_per_file_progress` — start/per-file/end events with correct `current`/`total`
  - `test_progress_marks_cached_runs` — second run with same params reports "Reusing cached"
  - `test_importer_forwards_thread_progress_to_generator` — `set_thread_progress` set before `imp.run({"media_type": "audio", ...})` receives the per-file events

https://claude.ai/code/session_014naJMNfQVePktmKfRvxweb

---
_Generated by [Claude Code](https://claude.ai/code/session_014naJMNfQVePktmKfRvxweb)_