### PR TITLE
Forward clipper_params through /api/dataset/import/&lt;name&gt;

### DIFF
--- a/tests/test_chunked_web_flow.py
+++ b/tests/test_chunked_web_flow.py
@@ -227,6 +227,54 @@ class TestImportRouteChunkSize:
             assert mock_run.call_args.kwargs["chunk_size"] == 0
 
 
+class TestImportRouteClipperParams:
+    """``clipper_params`` from the modal must reach the load pipeline so
+    user-tuned values (e.g. tiling duration) override the clipper's
+    registry default.  Regression: the route used to drop them silently,
+    leaving e.g. a 1s tiling clip selection running with the registered
+    default of 2s — a no-op for 2s synthetic videos.
+    """
+
+    def test_clipper_params_passed_through_json(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={
+                    "path": "/tmp/test",
+                    "media_type": "video",
+                    "clipper": "video_tiling",
+                    "clipper_params": {"duration": 1.0, "min_overlap": 0.0},
+                },
+            )
+            assert resp.status_code == 200
+            field_values = mock_run.call_args.args[1]
+            assert field_values["clipper"] == "video_tiling"
+            assert field_values["clipper_params"] == {"duration": 1.0, "min_overlap": 0.0}
+
+    def test_no_clipper_params_when_omitted(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={"path": "/tmp/test", "media_type": "image"},
+            )
+            assert resp.status_code == 200
+            field_values = mock_run.call_args.args[1]
+            assert "clipper_params" not in field_values
+
+    def test_invalid_clipper_params_returns_400(self, client):
+        with patch("vtsearch.routes.datasets._run_importer_in_background") as mock_run:
+            resp = client.post(
+                "/api/dataset/import/server_folder",
+                json={
+                    "path": "/tmp/test",
+                    "media_type": "image",
+                    "clipper_params": "not-a-dict",
+                },
+            )
+            assert resp.status_code == 400
+            mock_run.assert_not_called()
+
+
 # ===========================================================================
 # Route plumbing — POST /api/dataset/import-local-folder
 # ===========================================================================

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -512,6 +512,12 @@ def import_dataset(importer_name: str):
         if val:
             field_values[key] = val
 
+    clipper_params, params_err = _extract_clipper_params(bool(file_keys))
+    if params_err:
+        return params_err
+    if clipper_params is not None:
+        field_values["clipper_params"] = clipper_params
+
     chunk_size = _parse_chunk_size(get_request_field("chunk_size", bool(file_keys)))
 
     task_id = _run_importer_in_background(importer, field_values, chunk_size=chunk_size)
@@ -523,6 +529,32 @@ def import_dataset(importer_name: str):
 # ---------------------------------------------------------------------------
 
 LOCAL_UPLOADS_DIR = DATA_DIR / "local_uploads"
+
+
+def _extract_clipper_params(has_file_fields: bool) -> tuple[dict | None, Any]:
+    """Read optional ``clipper_params`` from form/JSON, returning (params, error_response).
+
+    JSON requests carry the value as a dict directly.  Multipart form
+    requests carry it as a JSON-encoded string (since form fields are
+    flat).  Either form is accepted; anything else is a 400 error.
+    Returns ``(None, None)`` when no value is present.
+    """
+    if has_file_fields:
+        raw = request.form.get("clipper_params") or ""
+        if not raw:
+            return None, None
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            return None, (jsonify({"error": f"Invalid clipper_params: {exc}"}), 400)
+    else:
+        parsed = get_json_safe().get("clipper_params")
+        if parsed is None or parsed == "":
+            return None, None
+
+    if not isinstance(parsed, dict):
+        return None, (jsonify({"error": "clipper_params must be a JSON object"}), 400)
+    return parsed, None
 
 
 def _parse_chunk_size(value: Any) -> int:


### PR DESCRIPTION
## Summary

The generic `POST /api/dataset/import/<importer_name>` route extracted `clipper` from the request but silently dropped `clipper_params`. Any user-tuned value (e.g. tiling `duration=1.0`) was discarded, and the load pipeline ran the clipper's registry-default instead — `VideoTilingClipper(2.0)` for the video tiling clipper.

For a synthetic video dataset (every clip is exactly 2.0 s), tiling at the dropped 1.0 s would have produced two 1 s tiles per video. Falling back to 2.0 s makes `total <= seg` short-circuit in `VideoTilingClipper.clip`, returning each video unchanged — exactly the "videos look unclipped" symptom reported.

## Fix

- Added `_extract_clipper_params` helper that reads `clipper_params` from JSON body or, when the request has file fields, from the form-encoded JSON string. Validates that the parsed value is a dict and returns a 400 otherwise.
- Wired the helper into the importer route alongside the existing `clipper` / `embedder` / `converters` pass-through.
- The `import-local-folder` route already handled `clipper_params` correctly; left it alone to keep the diff minimal.

## Test plan

- [x] `./run-tests.sh` — all 3149 tests pass
- [x] Added `TestImportRouteClipperParams` covering the JSON pass-through, omitted-value default, and 400 on malformed input.

https://claude.ai/code/session_019WJi9TgKENPX5dDsHrvmHR

---
_Generated by [Claude Code](https://claude.ai/code/session_019WJi9TgKENPX5dDsHrvmHR)_