### PR TITLE
Add bulk-record hooks to DatasetImporter for batched / async fetches

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -218,16 +218,18 @@ IMPORTER = S3Importer()
 
 ### DatasetImporter class reference
 
-**Required to implement:**
+**Required to implement (pick one approach):**
 
 | Member | Signature | Description |
 |--------|-----------|-------------|
 | `run()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | Populate `medias` in-place with loaded data |
+| `list_records()` + `fetch_record()` | see [Bulk-record hooks](#bulk-record-hooks) | Per-record / bulk-record split that mirrors `MediaEmbedder`. The default `run()` lists records, hands them all to `fetch_records_bulk()`, and assigns IDs |
 
 **Optional overrides:**
 
 | Member | Signature | Description |
 |--------|-----------|-------------|
+| `_fetch_records_bulk_impl()` | `(records: list, field_values: dict, thin: bool) -> list[dict | None]` | Batched fetch hook. Default loops `fetch_record`. Override to issue concurrent / batched I/O |
 | `run_cli()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | CLI variant; default delegates to `run()`. Override when `run()` expects FileStorage objects |
 | `get_field_options()` | `(field_key: str, current_values: dict) -> list[str]` | Compute dropdown options for fields declared with `dynamic_options=True`. See [Dynamic field options](#dynamic-field-options) |
 | `run_chunked()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | Yield chunks of medias for piecewise processing. Set `supports_chunked = True` |
@@ -327,6 +329,69 @@ implementation captures dataset-level field values like query IDs that
 are not useful per-media).  The post-processing step only backfills
 `origin` on media that have `origin=None`, so per-media origins set
 in `run()` are preserved.
+
+### Bulk-record hooks
+
+For service-style importers — those that fetch records from a remote
+source rather than scanning a local folder — override the per-record /
+bulk-record hooks instead of writing `run()` from scratch.  The split
+mirrors the embedder's `embed_media` / `embed_media_bulk` pattern: a
+working baseline comes from the per-item method, and you can opt into
+batched / concurrent I/O by overriding the bulk hook.
+
+```python
+class MyServiceImporter(DatasetImporter):
+    def list_records(self, field_values):
+        # Return whatever shape you want — opaque to the framework.
+        return _api.list(query=field_values["query"])
+
+    def fetch_record(self, record, field_values, thin=False):
+        # Default per-item path. The framework loops this when no
+        # bulk override is provided. Return None to skip a record.
+        return {
+            "type": "audio",
+            "filename": record["id"],
+            "embedding": _api.get_embedding(record["id"]),
+            "media_bytes": None if thin else _api.fetch_bytes(record["url"]),
+            "media_url": record["url"],
+            # origin / origin_name auto-filled from build_origin if omitted
+        }
+
+    def _fetch_records_bulk_impl(self, records, field_values, thin=False):
+        # Optional: replace the per-item loop with a single bulk request,
+        # a thread/async pool, or whatever the source supports.
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            embeddings = list(pool.map(lambda r: _api.get_embedding(r["id"]), records))
+            blobs = ([] if thin else
+                     list(pool.map(lambda r: _api.fetch_bytes(r["url"]), records)))
+        return [
+            {"type": "audio", "filename": r["id"], "embedding": e,
+             "media_bytes": (None if thin else b), "media_url": r["url"]}
+            for r, e, b in zip(records, embeddings, blobs or [None] * len(records))
+        ]
+```
+
+The default `run()`:
+
+1. Calls `list_records(field_values)` to get the work list.
+2. Calls `fetch_records_bulk(records, field_values, thin)` once with all
+   records (which dispatches to `_fetch_records_bulk_impl`; the default
+   impl loops `fetch_record` and emits per-item progress).
+3. Assigns sequential integer IDs starting at 1 and stores the resulting
+   media dicts in *medias*.
+4. Backfills `media["origin"]` from `build_origin(field_values)` and
+   `media["origin_name"]` from `media["filename"]` for any record that
+   didn't set them.
+
+Records returning `None` are skipped (gaps are squeezed out, IDs stay
+sequential).
+
+For an end-to-end example see
+`vtsearch/datasets/importers/recaller/__init__.py`, which overrides the
+bulk hook to issue DataWrest embedding lookups and PullWrest downloads
+concurrently via a thread pool.
 
 ### Dynamic field options
 

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -452,5 +452,197 @@ class TestExtractArchive:
 
 
 # ---------------------------------------------------------------------------
+# DatasetImporter bulk-record hooks (list_records / fetch_record /
+# fetch_records_bulk).
+# ---------------------------------------------------------------------------
+
+
+class TestImporterBulkHooks:
+    """Verify the per-record / bulk-record split mirrors the embedder pattern."""
+
+    def _make_importer(self, *, fetch_one=None, fetch_bulk=None, records=None):
+        from vtsearch.datasets.importers.base import DatasetImporter
+
+        class _BulkTestImporter(DatasetImporter):
+            name = "bulk_test"
+            display_name = "Bulk Test"
+            description = "Test importer for bulk hooks."
+            fields = []
+
+            def list_records(self, field_values):
+                return list(records or [])
+
+            if fetch_one is not None:
+
+                def fetch_record(self, record, field_values, thin=False):
+                    return fetch_one(record, field_values, thin)
+
+            if fetch_bulk is not None:
+
+                def _fetch_records_bulk_impl(self, recs, field_values, thin=False):
+                    return fetch_bulk(recs, field_values, thin)
+
+        return _BulkTestImporter()
+
+    def test_default_run_uses_list_and_fetch_record(self):
+        records = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
+
+        def fetch_one(record, _fv, _thin):
+            return {"type": "audio", "filename": record["name"], "embedding": None}
+
+        imp = self._make_importer(records=records, fetch_one=fetch_one)
+        medias: dict = {}
+        imp.run({}, medias)
+
+        assert list(medias.keys()) == [1, 2, 3]
+        assert [medias[i]["filename"] for i in (1, 2, 3)] == ["a", "b", "c"]
+        # ID is assigned by the framework even though fetch_record didn't set one.
+        assert medias[1]["id"] == 1
+
+    def test_default_run_fills_origin_from_build_origin(self):
+        records = [{"name": "x"}]
+
+        def fetch_one(record, _fv, _thin):
+            # fetch_record may omit origin / origin_name — run() fills them in.
+            return {"type": "audio", "filename": record["name"], "embedding": None}
+
+        imp = self._make_importer(records=records, fetch_one=fetch_one)
+        medias: dict = {}
+        imp.run({"foo": "bar"}, medias)
+
+        assert medias[1]["origin"] == imp.build_origin({"foo": "bar"})
+        assert medias[1]["origin_name"] == "x"
+
+    def test_default_run_skips_none_records(self):
+        records = ["a", "skip", "b"]
+
+        def fetch_one(record, _fv, _thin):
+            if record == "skip":
+                return None
+            return {"type": "audio", "filename": record, "embedding": None}
+
+        imp = self._make_importer(records=records, fetch_one=fetch_one)
+        medias: dict = {}
+        imp.run({}, medias)
+
+        assert list(medias.keys()) == [1, 2]
+        assert [medias[i]["filename"] for i in (1, 2)] == ["a", "b"]
+
+    def test_default_bulk_impl_loops_fetch_record(self):
+        # If a subclass implements fetch_record but NOT _fetch_records_bulk_impl,
+        # the default bulk impl loops fetch_record once per record.
+        seen: list = []
+
+        def fetch_one(record, _fv, _thin):
+            seen.append(record)
+            return {"type": "audio", "filename": record, "embedding": None}
+
+        imp = self._make_importer(records=["x", "y"], fetch_one=fetch_one)
+        out = imp.fetch_records_bulk(["x", "y"], {})
+
+        assert seen == ["x", "y"]
+        assert [m["filename"] for m in out] == ["x", "y"]
+
+    def test_bulk_override_used_when_implemented(self):
+        # When a subclass overrides _fetch_records_bulk_impl, fetch_record must
+        # NOT be called — the bulk path takes over completely.
+        per_item_calls: list = []
+
+        def fetch_one(record, _fv, _thin):
+            per_item_calls.append(record)
+            return {"type": "audio", "filename": record, "embedding": None}
+
+        def fetch_bulk(records, _fv, _thin):
+            # Pretend we did one batched call.
+            return [
+                {"type": "audio", "filename": f"bulk:{r}", "embedding": None}
+                for r in records
+            ]
+
+        imp = self._make_importer(
+            records=["a", "b"], fetch_one=fetch_one, fetch_bulk=fetch_bulk
+        )
+        medias: dict = {}
+        imp.run({}, medias)
+
+        assert per_item_calls == []  # bulk override replaced the per-item loop
+        assert [medias[i]["filename"] for i in (1, 2)] == ["bulk:a", "bulk:b"]
+
+    def test_fetch_records_bulk_empty_returns_empty(self):
+        imp = self._make_importer(records=[], fetch_one=lambda *a: None)
+        assert imp.fetch_records_bulk([], {}) == []
+
+    def test_run_raises_when_neither_run_nor_hooks_implemented(self):
+        from vtsearch.datasets.importers.base import DatasetImporter
+
+        class _BareImporter(DatasetImporter):
+            name = "bare"
+            display_name = "Bare"
+            description = ""
+            fields = []
+
+        imp = _BareImporter()
+        with pytest.raises(NotImplementedError, match="list_records"):
+            imp.run({}, {})
+
+
+class TestReCallerBulkOverride:
+    """ReCaller is the worked example — verify its hooks return the same
+    media dicts whether the per-item or bulk path is used."""
+
+    def _stub_apis(self, monkeypatch):
+        import numpy as np
+
+        from vtsearch.datasets.importers import recaller as rc
+
+        results = [
+            {"contentID": f"C{i}", "mediaID": f"M{i}", "media_url": f"http://pw/{i}",
+             "media_type": "audio", "md5": f"md5_{i}"}
+            for i in range(3)
+        ]
+        monkeypatch.setattr(rc, "_rc_fetch_results", lambda _q: list(results))
+
+        rng = np.random.default_rng(42)
+        embeddings = {f"M{i}": rng.standard_normal(8).astype(np.float32) for i in range(3)}
+        monkeypatch.setattr(
+            rc,
+            "_dw_get_embedding",
+            lambda mid: {"embedding": embeddings[mid], "embedder": "fake-embedder"},
+        )
+        monkeypatch.setattr(rc, "_pw_fetch_media", lambda url: f"bytes-for-{url}".encode())
+        return results
+
+    def test_per_item_and_bulk_paths_agree(self, monkeypatch):
+        from vtsearch.datasets.importers.recaller import ReCallerDatasetImporter
+
+        records = self._stub_apis(monkeypatch)
+        field_values = {"query_id": "Q1", "media_type": "audio"}
+
+        imp = ReCallerDatasetImporter()
+        per_item = [imp.fetch_record(r, field_values, thin=True) for r in records]
+        bulk = imp._fetch_records_bulk_impl(records, field_values, thin=True)
+
+        assert len(per_item) == len(bulk) == 3
+        for a, b in zip(per_item, bulk):
+            assert a["filename"] == b["filename"]
+            assert a["origin"] == b["origin"]
+            assert a["custom_metadata"] == b["custom_metadata"]
+            assert (a["embedding"] == b["embedding"]).all()
+
+    def test_run_uses_bulk_override(self, monkeypatch):
+        from vtsearch.datasets.importers.recaller import ReCallerDatasetImporter
+
+        self._stub_apis(monkeypatch)
+        imp = ReCallerDatasetImporter()
+        medias: dict = {}
+        imp.run({"query_id": "Q1", "media_type": "audio"}, medias, thin=True)
+
+        assert list(medias.keys()) == [1, 2, 3]
+        for i in (1, 2, 3):
+            assert medias[i]["origin"]["params"]["contentID"] == f"C{i - 1}"
+            assert medias[i]["origin"]["params"]["mediaID"] == f"M{i - 1}"
+
+
+# ---------------------------------------------------------------------------
 # load_dataset_from_folder – content_vectors support
 # ---------------------------------------------------------------------------

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -177,6 +177,18 @@ class DatasetImporter(PluginBase):
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """Perform the import, populating *medias* in-place.
 
+        Subclasses can override either this method directly (full control over
+        the import flow) **or** the per-record / bulk-record hooks:
+        :meth:`list_records`, :meth:`fetch_record`, and optionally
+        :meth:`_fetch_records_bulk_impl` for batched fetches.  When the hooks
+        are implemented, the default :meth:`run` here lists the records, hands
+        them all to :meth:`fetch_records_bulk` in one call (so subclasses that
+        override the bulk impl can issue concurrent / batched I/O), and stores
+        each returned media dict in *medias* with sequential integer IDs
+        starting at 1.  The default per-media origin is filled in from
+        :meth:`build_origin` when the importer's :meth:`fetch_record` did not
+        set its own.
+
         Args:
             field_values: Mapping of :attr:`ImporterField.key` → value.
                 Fields with ``field_type="file"`` receive a Werkzeug
@@ -189,11 +201,119 @@ class DatasetImporter(PluginBase):
                 saves memory for CLI workflows that only need embeddings.
 
         Raises:
-            NotImplementedError: If the subclass has not implemented this.
+            NotImplementedError: If neither :meth:`run` nor the
+                :meth:`list_records` + :meth:`fetch_record` hooks are
+                implemented by the subclass.
             Exception: Any exception propagates to the route handler, which
                 stores it in the progress tracker as an error message.
         """
-        raise NotImplementedError(f"{type(self).__name__}.run() is not implemented")
+        records = self.list_records(field_values)
+        fetched = self.fetch_records_bulk(records, field_values, thin=thin)
+        default_origin = self.build_origin(field_values)
+        next_id = 1
+        for media in fetched:
+            if media is None:
+                continue
+            media["id"] = next_id
+            media.setdefault("origin", default_origin)
+            media.setdefault("origin_name", media.get("filename") or str(next_id))
+            medias[next_id] = media
+            next_id += 1
+
+    # ------------------------------------------------------------------
+    # Per-record / bulk-record hooks
+    # ------------------------------------------------------------------
+    #
+    # Subclasses implementing a service-style importer (one that fetches
+    # records from a remote source) can override these instead of writing
+    # ``run()`` from scratch.  The split mirrors :class:`MediaEmbedder`:
+    # implement the per-item method and you get a working importer; override
+    # the bulk hook to batch the I/O when the source supports it.
+
+    def list_records(self, field_values: dict[str, Any]) -> list[Any]:
+        """Return the opaque list of records to import.
+
+        Each "record" is whatever shape the importer wants — typically a
+        dict with the identifiers and URLs needed by :meth:`fetch_record`.
+        The framework only cares about the count (for progress) and order
+        (preserved into *medias*).
+
+        Override this together with :meth:`fetch_record` to use the default
+        :meth:`run` implementation.  Importers that override :meth:`run`
+        directly do not need to implement this.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.list_records() is not implemented "
+            "(override this and fetch_record(), or override run() directly)"
+        )
+
+    def fetch_record(
+        self,
+        record: Any,
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> dict[str, Any] | None:
+        """Convert a single *record* into a media dict.
+
+        The returned dict should contain the standard media fields
+        (``type``, ``filename``, ``embedding``, ``md5``, ``media_bytes`` /
+        ``media_path``, etc.).  ``id`` is assigned by the framework and may
+        be omitted.  ``origin`` and ``origin_name`` may also be omitted —
+        :meth:`run` falls back to :meth:`build_origin` and the filename.
+
+        Return ``None`` to skip the record (e.g. unsupported media type).
+
+        Override together with :meth:`list_records`.  For batched fetching,
+        override :meth:`_fetch_records_bulk_impl` instead — the default
+        bulk impl loops over this method.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.fetch_record() is not implemented"
+        )
+
+    def fetch_records_bulk(
+        self,
+        records: list[Any],
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> list[dict[str, Any] | None]:
+        """Fetch every record in *records* and return a same-length list of
+        media dicts (or ``None`` for skipped records).
+
+        Default dispatches to :meth:`_fetch_records_bulk_impl`, which loops
+        over :meth:`fetch_record` one record at a time.  Subclasses backed
+        by a service that natively accepts many items per request — or that
+        can pipeline downloads concurrently — should override
+        :meth:`_fetch_records_bulk_impl`.
+
+        The order of the returned list matches the order of *records*.
+        """
+        if not records:
+            return []
+        return self._fetch_records_bulk_impl(records, field_values, thin=thin)
+
+    def _fetch_records_bulk_impl(
+        self,
+        records: list[Any],
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> list[dict[str, Any] | None]:
+        """Subclass hook: fetch a list of records.
+
+        Default loops over :meth:`fetch_record`, emitting per-item progress
+        via :func:`vtsearch.utils.update_progress` so long imports stay
+        visible in the UI.  Override to replace the per-item loop with a
+        single bulk request, batched HTTP, or a thread/async pool.  Bulk
+        overrides are responsible for emitting their own progress updates.
+        """
+        from vtsearch.utils import update_progress
+
+        total = len(records)
+        results: list[dict[str, Any] | None] = []
+        for i, record in enumerate(records):
+            update_progress("loading", f"Importing {i + 1} of {total}…", i + 1, total)
+            results.append(self.fetch_record(record, field_values, thin=thin))
+        return results
 
     # ------------------------------------------------------------------
     # Dynamic field options

--- a/vtsearch/datasets/importers/recaller/__init__.py
+++ b/vtsearch/datasets/importers/recaller/__init__.py
@@ -33,6 +33,18 @@ stores ``media_url`` instead of ``media_bytes``/``media_path``, relying on
 VTSearch's URL-based lazy-fetch in :meth:`MediaType._resolve_media_bytes`.
 Embeddings still come from DataWrest, so sorting and scoring work without
 downloading the actual media.
+
+Bulk fetch
+----------
+This importer overrides
+:meth:`~vtsearch.datasets.importers.base.DatasetImporter._fetch_records_bulk_impl`
+to issue DataWrest embedding lookups and PullWrest media-byte downloads
+concurrently via a thread pool.  The per-record :meth:`fetch_record` is
+kept as a serial fallback (and as the simplest possible reference
+implementation).  Importers built on top of this base get the same
+per-record / bulk-record split: implement :meth:`fetch_record` for a
+working baseline, override :meth:`_fetch_records_bulk_impl` when the
+backing service can be batched.
 """
 
 from __future__ import annotations
@@ -94,6 +106,53 @@ def _pw_fetch_media(media_url: str) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# Media-dict assembly (shared by per-item and bulk paths)
+# ---------------------------------------------------------------------------
+
+
+def _build_media(
+    record: dict[str, Any],
+    media_type: str,
+    embedding_info: dict[str, Any],
+    media_bytes: bytes | None,
+    importer_name: str,
+) -> dict[str, Any]:
+    content_id = record["contentID"]
+    media_id = record["mediaID"]
+    media_url = record["media_url"]
+    origin = {
+        "importer": importer_name,
+        "params": {
+            "contentID": content_id,
+            "mediaID": media_id,
+            "media_url": media_url,
+            "media_type": media_type,
+        },
+    }
+    return {
+        "type": media_type,
+        "filename": content_id,
+        "md5": record["md5"],
+        "embedding": embedding_info["embedding"],
+        "embedder": embedding_info["embedder"],
+        "media_bytes": media_bytes,
+        "media_path": None,
+        "media_url": media_url,
+        "media_string": None,
+        "file_size": len(media_bytes) if media_bytes else 0,
+        "duration": 0,
+        "category": "",
+        "origin": origin,
+        "origin_name": content_id,
+        "custom_metadata": {
+            "contentID": content_id,
+            "mediaID": media_id,
+            "media_url": media_url,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
 # Importer
 # ---------------------------------------------------------------------------
 
@@ -134,79 +193,79 @@ class ReCallerDatasetImporter(DatasetImporter):
         return super().get_field_options(field_key, current_values)
 
     # The dataset-level origin (queryID) is NOT useful for provenance —
-    # each media gets its own origin keyed by contentID.  Return an empty
-    # origin here; run() sets per-media origins.
+    # each media gets its own origin keyed by contentID via fetch_record.
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         return {"importer": self.name, "params": {}}
 
-    def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+    # ------------------------------------------------------------------
+    # Bulk import hooks
+    # ------------------------------------------------------------------
+
+    def list_records(self, field_values: dict[str, Any]) -> list[dict[str, Any]]:
         query_id = (field_values.get("query_id") or "").strip()
         if not query_id:
             raise ValueError("A query ID is required.")
         media_type = field_values.get("media_type", "audio")
 
-        # 1. Fetch and filter RC results
         all_results = _rc_fetch_results(query_id)
         results = [r for r in all_results if r.get("media_type") == media_type]
         if not results:
             raise ValueError(f"No results of type '{media_type}' found for query '{query_id}'.")
+        return results
 
-        # 2. Build media dicts
-        for i, rc in enumerate(results, start=1):
-            content_id = rc["contentID"]
-            media_id = rc["mediaID"]
-            media_url = rc["media_url"]
-            md5 = rc["md5"]
+    def fetch_record(
+        self,
+        record: dict[str, Any],
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch a single ReCaller record into a media dict.
 
-            # --- Embedding from DataWrest ---
-            dw = _dw_get_embedding(media_id)
-            embedding = dw["embedding"]
-            embedder = dw["embedder"]
+        Per-item path: one DataWrest call for the embedding plus (in
+        non-thin mode) one PullWrest call for the bytes.  Override
+        :meth:`_fetch_records_bulk_impl` to batch these across many
+        records concurrently.
+        """
+        media_type = field_values.get("media_type", "audio")
+        embedding_info = _dw_get_embedding(record["mediaID"])
+        media_bytes = None if thin else _pw_fetch_media(record["media_url"])
+        return _build_media(record, media_type, embedding_info, media_bytes, self.name)
 
-            # --- Media bytes (skip in thin mode) ---
-            media_bytes = None
-            media_path = None
-            if not thin:
-                media_bytes = _pw_fetch_media(media_url)
-                # Optionally write to a temp folder and set media_path:
-                # media_path = _save_to_temp(media_bytes, content_id, media_type)
+    def _fetch_records_bulk_impl(
+        self,
+        records: list[dict[str, Any]],
+        field_values: dict[str, Any],
+        thin: bool = False,
+    ) -> list[dict[str, Any] | None]:
+        """Concurrent bulk fetch.
 
-            # --- Per-media origin (NOT queryID) ---
-            origin = {
-                "importer": self.name,
-                "params": {
-                    "contentID": content_id,
-                    "mediaID": media_id,
-                    "media_url": media_url,
-                    "media_type": media_type,
-                },
-            }
+        Issues all DataWrest embedding lookups and PullWrest media-byte
+        downloads in parallel via a thread pool, then assembles the media
+        dicts in the original order.  Each record still goes through
+        :func:`_build_media`, so the per-item shape stays identical to
+        :meth:`fetch_record`.
+        """
+        from concurrent.futures import ThreadPoolExecutor
 
-            # --- Custom metadata (visible in enriched label exports) ---
-            custom_metadata = {
-                "contentID": content_id,
-                "mediaID": media_id,
-                "media_url": media_url,
-            }
+        from vtsearch.utils import update_progress
 
-            medias[i] = {
-                "id": i,
-                "type": media_type,
-                "filename": content_id,  # use contentID as the filename key
-                "md5": md5,
-                "embedding": embedding,
-                "embedder": embedder,
-                "media_bytes": media_bytes,
-                "media_path": media_path,
-                "media_url": media_url,  # URL-based lazy-fetch fallback
-                "media_string": None,
-                "file_size": len(media_bytes) if media_bytes else 0,
-                "duration": 0,
-                "category": "",
-                "origin": origin,
-                "origin_name": content_id,
-                "custom_metadata": custom_metadata,
-            }
+        media_type = field_values.get("media_type", "audio")
+        total = len(records)
+        update_progress("loading", f"Fetching {total} ReCaller records…", 0, total)
+
+        max_workers = min(16, max(1, total))
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            embed_infos = list(pool.map(lambda r: _dw_get_embedding(r["mediaID"]), records))
+            if thin:
+                byte_blobs: list[bytes | None] = [None] * total
+            else:
+                byte_blobs = list(pool.map(lambda r: _pw_fetch_media(r["media_url"]), records))
+
+        results: list[dict[str, Any] | None] = []
+        for i, (rec, ei, mb) in enumerate(zip(records, embed_infos, byte_blobs)):
+            update_progress("loading", f"Importing {i + 1} of {total}…", i + 1, total)
+            results.append(_build_media(rec, media_type, ei, mb, self.name))
+        return results
 
     def origin_display(self, origin: dict[str, Any]) -> str:
         content_id = origin.get("params", {}).get("contentID", "")


### PR DESCRIPTION
## Summary

Adds a per-record / bulk-record hook split to `DatasetImporter`, mirroring the embedder's `embed_media` / `embed_media_bulk` pattern. Service-style importers can now issue concurrent or batched I/O instead of grabbing each item synchronously.

- New hooks on `DatasetImporter`:
  - `list_records(field_values)` — return the opaque record list to import.
  - `fetch_record(record, field_values, thin)` — convert one record to a media dict (the framework's default `run()` loops this for you with per-item progress).
  - `fetch_records_bulk(records, field_values, thin)` → `_fetch_records_bulk_impl(...)` — overridable batch hook. Default loops `fetch_record`; override to replace the loop with a thread pool, async batch, or single bulk request.
- Default `run()` now lists records, calls `fetch_records_bulk()` once with all of them, assigns sequential IDs, and backfills `origin` / `origin_name` from `build_origin()` and `filename`. Existing importers (which all override `run()` directly) are unchanged.
- ReCaller refactored as the worked example: `fetch_record()` is the simple per-item path, and `_fetch_records_bulk_impl()` fans DataWrest embedding lookups and PullWrest media-byte downloads across a `ThreadPoolExecutor`.
- Docs: new "Bulk-record hooks" section in `docs/EXTENDING-plugins.md` with code template; class-reference table updated.

## Test plan

- [x] `./run-tests.sh` — 3158 passed, 1 skipped.
- [x] `./run-tests.sh datasets io` — 1031 passed.
- [x] `ruff check` on changed files — clean.
- [x] New tests in `tests/test_importers.py`:
  - default `run()` walks `list_records` + `fetch_record`, assigns sequential IDs, backfills origin/origin_name.
  - `None` from `fetch_record` skips the record without leaving a gap.
  - default `_fetch_records_bulk_impl` loops `fetch_record`.
  - bulk override replaces the per-item loop (per-item method is never called).
  - bare importer (no `run`, no `list_records`) raises `NotImplementedError`.
  - ReCaller per-item and bulk paths produce equivalent media dicts; `run()` exercises the bulk path end-to-end.

https://claude.ai/code/session_01LJ2eq7Lq1doRtqa745gFcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJ2eq7Lq1doRtqa745gFcG)_