### PR TITLE
Default to Manual mode when training an already-trained detector

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1138,6 +1138,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.labelSession.mediaExample = model?.media_example || '';
     this.labelSession.examples = (model?.['examples'] as { type: string; value: string }[]) || [];
     this.labelSession.modelName = model?.name || '';
+    this.labelSession.alreadyTrained = (model?.num_training ?? 0) > 0;
   }
 
   onLabel(): void {

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -34,6 +34,7 @@
       [datasetName]="datasetName"
       [autopilotCollapsed]="autopilotCollapsed"
       [autopilotEnabled]="autopilotEnabled"
+      [alreadyTrained]="alreadyTrained"
       (autopilotStart)="onAutopilotStart()"
       (autopilotStop)="onAutopilotStop()"
       (autopilotRefocus)="onAutopilotRefocus()"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -48,6 +48,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   rightWidth = 300;
   autopilotCollapsed = false;
   autopilotEnabled = true;
+  alreadyTrained = false;
   progressModalMetric: ProgressMetric | null = null;
 
   // Re-sort prompt state
@@ -98,6 +99,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit(): void {
     this.autopilotStateService.clear();
     this.voteState.clear();
+    this.alreadyTrained = this.labelSession.alreadyTrained;
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     this.mediaState.loadMedias();

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -39,6 +39,16 @@ describe('LeftPanelComponent', () => {
     expect(component.activeTab).toBe('manual');
   });
 
+  it('should default to manual tab when alreadyTrained is true', () => {
+    const fresh = TestBed.createComponent(LeftPanelComponent);
+    const comp = fresh.componentInstance;
+    comp.alreadyTrained = true;
+    spyOn(comp.autopilotStart, 'emit');
+    fresh.detectChanges();
+    expect(comp.activeTab).toBe('manual');
+    expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
+  });
+
   it('should render autopilot tab content by default', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.tab-panel-autopilot')).toBeTruthy();

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -53,6 +53,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() textQuery = '';
   @Input() autopilotCollapsed = false;
   @Input() autopilotEnabled = true;
+  /** When true, the selected model already has training labels; start in Manual mode. */
+  @Input() alreadyTrained = false;
   /** 'label' = full labeling UI (default), 'find' = simplified media-only view */
   @Input() panelMode: 'label' | 'find' = 'label';
   /** Disable all interaction (used during Find scoring). */
@@ -97,8 +99,9 @@ export class LeftPanelComponent implements OnInit, OnChanges {
       // Find mode doesn't use tabs — keep manual as a no-op default
       this.activeTab = 'manual';
     } else {
-      this.activeTab = this.autopilotEnabled ? 'autopilot' : 'manual';
-      if (this.autopilotEnabled) {
+      const shouldStartAutopilot = this.autopilotEnabled && !this.alreadyTrained;
+      this.activeTab = shouldStartAutopilot ? 'autopilot' : 'manual';
+      if (shouldStartAutopilot) {
         this.autopilotStart.emit();
       }
     }

--- a/frontend/src/app/services/label-session.service.ts
+++ b/frontend/src/app/services/label-session.service.ts
@@ -17,6 +17,8 @@ export class LabelSessionService {
   mediaExample = '';
   examples: ModelExample[] = [];
   modelName = '';
+  /** True when the selected model already has training labels — start in Manual mode rather than Autopilot. */
+  alreadyTrained = false;
 
   /** Total votes cast since the last re-sort prompt. */
   resortVoteCount = 0;


### PR DESCRIPTION
## Summary
- When the user clicks Train on a dataset and a detector that already has training labels (`num_training > 0`), the label view now opens in **Manual** mode instead of auto-starting Autopilot.
- Fresh/untrained detectors still default to Autopilot when `autopilot_enabled` is on, preserving the existing first-time-labeling experience.

## Implementation
- `LabelSessionService` gains an `alreadyTrained` flag.
- `DashboardComponent.storeSelectedModelTextQuery()` sets it from the selected model's `num_training`.
- `LabelViewComponent` reads it on init and forwards it to `LeftPanelComponent` via a new `[alreadyTrained]` input.
- `LeftPanelComponent.ngOnInit` gates the autopilot default on both `autopilotEnabled` **and** `!alreadyTrained`, and skips the `autopilotStart` emit when starting in Manual.
- New spec verifies the Manual default when `alreadyTrained` is true.

## Test plan
- [x] `npm run build:prod` passes.
- [x] `tsc -p tsconfig.spec.json --noEmit` passes.
- [ ] Manual: Train an untrained model → opens in Autopilot (unchanged).
- [ ] Manual: Train a model with existing labels → opens in Manual.
- [ ] Manual: Toggling the autopilot tab still works in both cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvxV56ATnXQ8DH1dMEZnmz)_