### PR TITLE
Add /api/version endpoint and Settings modal version display

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -223,6 +223,9 @@
   }
 
   <div class="settings-actions" modal-footer>
+    @if (version) {
+      <span class="settings-version" title="App version (UTC timestamp of the last dev to main merge). Include this when reporting issues.">v {{ version }}</span>
+    }
     <button class="btn btn--secondary" (click)="resetDefaults()" title="Reset all settings to their factory defaults">Default</button>
     <button class="btn btn--secondary" (click)="openImporter()" title="Import settings from a file">Import</button>
     <button class="btn btn--secondary" (click)="openExporter()" title="Export settings to a file">Export</button>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -252,4 +252,13 @@
   display: flex;
   gap: var(--space-md);
   justify-content: flex-end;
+  align-items: center;
+}
+
+.settings-version {
+  margin-right: auto;
+  font-size: var(--font-xs);
+  font-family: var(--font-mono, monospace);
+  color: var(--text-secondary);
+  user-select: text;
 }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -53,9 +53,11 @@ describe('SettingsModalComponent', () => {
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
     const mediaTypesReq = httpMock.expectOne('/api/media-types');
+    const versionReq = httpMock.expectOne('/api/version');
     settingsReq.flush(mockSettings);
     embeddersReq.flush({ embedders: [{ name: 'audio', media_type_id: 'audio' }, { name: 'images', media_type_id: 'image' }, { name: 'text', media_type_id: 'text' }] });
     mediaTypesReq.flush(mockMediaTypes);
+    versionReq.flush({ version: '2026-05-07T00:00:00Z' });
   }
 
   it('should create', () => {
@@ -141,6 +143,7 @@ describe('SettingsModalComponent', () => {
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
     const mediaTypesReq = httpMock.expectOne('/api/media-types');
+    const versionReq = httpMock.expectOne('/api/version');
     settingsReq.flush(mockSettings);
     embeddersReq.flush({
       embedders: [
@@ -152,6 +155,7 @@ describe('SettingsModalComponent', () => {
       ],
     });
     mediaTypesReq.flush(mockMediaTypes);
+    versionReq.flush({ version: '2026-05-07T00:00:00Z' });
     expect(component.embedders.map((e) => `${e.media_type_id}:${e.name}`)).toEqual([
       'audio:alpha',
       'audio:beta',
@@ -199,9 +203,11 @@ describe('SettingsModalComponent', () => {
     const settingsReq = httpMock.expectOne('/api/settings');
     const embeddersReq = httpMock.expectOne('/api/embedders');
     const mediaTypesReq = httpMock.expectOne('/api/media-types');
+    const versionReq = httpMock.expectOne('/api/version');
     settingsReq.flush({}, { status: 500, statusText: 'Error' });
     embeddersReq.flush({ embedders: [] });
     mediaTypesReq.flush({ media_types: [] });
+    versionReq.flush({ version: '2026-05-07T00:00:00Z' });
     expect(component.loading).toBeFalse();
     expect(component.error).toBe('Failed to load settings');
   });

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -32,6 +32,7 @@ export class SettingsModalComponent implements OnInit {
   error = '';
   showImporterModal = false;
   showExporterModal = false;
+  version = '';
 
   constructor(
     private settingsApi: SettingsApiService,
@@ -45,9 +46,11 @@ export class SettingsModalComponent implements OnInit {
       settings: this.settingsApi.getSettings(),
       embedders: this.settingsApi.getEmbedders(),
       mediaTypes: this.datasetsApi.getMediaTypes(),
+      version: this.settingsApi.getVersion(),
     }).subscribe({
       next: (res) => {
         this.settings = res.settings;
+        this.version = res.version.version;
         this.embedders = (res.embedders.embedders || []).sort(
           (a, b) => a.media_type_id.localeCompare(b.media_type_id) || a.name.localeCompare(b.name),
         );

--- a/frontend/src/app/services/settings-api.service.ts
+++ b/frontend/src/app/services/settings-api.service.ts
@@ -34,4 +34,8 @@ export class SettingsApiService {
   getEmbedders(): Observable<EmbeddersResponse> {
     return this.http.get<EmbeddersResponse>('/api/embedders');
   }
+
+  getVersion(): Observable<{ version: string }> {
+    return this.http.get<{ version: string }>('/api/version');
+  }
 }

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -212,3 +212,27 @@ class TestFrontendContentIntegrity:
         text = resp.data.decode("utf-8")
         # Angular global styles contain layout and panel classes
         assert "panel" in text or "grid" in text or "--bg-body" in text
+
+
+class TestVersionEndpoint:
+    """GET /api/version should return the app version string."""
+
+    def test_returns_200(self, client):
+        resp = client.get("/api/version")
+        assert resp.status_code == 200
+
+    def test_returns_version_field(self, client):
+        from vtsearch import __version__
+
+        resp = client.get("/api/version")
+        data = resp.get_json()
+        assert data == {"version": __version__}
+
+    def test_version_is_iso_utc_timestamp(self, client):
+        from datetime import datetime
+
+        resp = client.get("/api/version")
+        version = resp.get_json()["version"]
+        # Must be parseable as an ISO 8601 timestamp ending in Z (UTC).
+        assert version.endswith("Z")
+        datetime.fromisoformat(version.replace("Z", "+00:00"))

--- a/vtsearch/__init__.py
+++ b/vtsearch/__init__.py
@@ -1,5 +1,7 @@
 """VTSearch - Interactive ML-powered media similarity explorer."""
 
-__version__ = "0.1.0"
+# Version is the UTC timestamp of the last dev->main merge, in ISO 8601.
+# Bumped automatically by the dev->main merge routine; see docs/RELEASING.md.
+__version__ = "2026-05-07T00:00:00Z"
 
 __all__ = ["__version__"]

--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from flask import Blueprint, Response, current_app, send_from_directory
+from flask import Blueprint, Response, current_app, jsonify, send_from_directory
+
+from vtsearch import __version__
 
 main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/api/version")
+def version() -> Response:
+    """Return the app version (UTC timestamp of the last dev->main merge)."""
+    return jsonify({"version": __version__})
 
 
 def _static_dir() -> Path:


### PR DESCRIPTION
## Summary
- `vtsearch/__init__.py` keeps `__version__` as the UTC ISO-8601 timestamp of the last `dev` → `main` merge (e.g. `2026-05-07T00:00:00Z`).
- New `GET /api/version` returns `{ "version": __version__ }`.
- The Settings modal fetches the version on open and shows a small monospace `v <timestamp>` on the left of the modal footer (only place it appears in the UI). Users can copy-paste it into bug reports.
- Backend tests cover the endpoint shape and ISO-UTC format; the `settings-modal` spec accounts for the new `forkJoin` request.

## How the version gets bumped
Each time the `dev` → `main` merge routine runs, it should:
1. On `dev`, set `__version__` in `vtsearch/__init__.py` to the current UTC timestamp (`YYYY-MM-DDTHH:MM:SSZ`).
2. Commit on `dev` with message `Bump version to <timestamp>`.
3. Push `dev`, then perform the `dev` → `main` merge.

That keeps `dev` and `main` in sync and makes the version reflect "what's currently in `main`".

## Test plan
- [x] `./run-tests.sh core` → 348 passed (covers `/api/version` tests + frontend TS build).
- [ ] Manual: open Settings modal, confirm `v 2026-05-07T00:00:00Z` appears on the left of the footer.
- [ ] Manual: `curl localhost:5000/api/version` returns the same string.


---
_Generated by [Claude Code](https://claude.ai/code/session_0167twZVp1dbnoKrpn1kVY68)_