### PR TITLE
Fix nine audit-discovered bugs (SSRF, eval leakage, path traversal, frontend leaks)

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -248,16 +248,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   /** Check for in-progress loading tasks (e.g. after a page reload) and resume polling. */
   private resumeActivePolling(): void {
-    this.datasetsApi.getLoadingTasks().subscribe((tasks) => {
-      if (tasks.some((t) => t.status !== 'idle')) {
-        this.startProgressPolling();
-      }
-    });
-    this.detectorsApi.getDetectorLoadingTasks().subscribe((resp) => {
-      if ((resp.tasks ?? []).some((t: LoadingTask) => t.status !== 'idle')) {
-        this.startDetectorProgressPolling();
-      }
-    });
+    this.datasetsApi
+      .getLoadingTasks()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((tasks) => {
+        if (tasks.some((t) => t.status !== 'idle')) {
+          this.startProgressPolling();
+        }
+      });
+    this.detectorsApi
+      .getDetectorLoadingTasks()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((resp) => {
+        if ((resp.tasks ?? []).some((t: LoadingTask) => t.status !== 'idle')) {
+          this.startDetectorProgressPolling();
+        }
+      });
   }
 
   // --- Column resize / drag-reorder ---

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -1,7 +1,8 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { forkJoin } from 'rxjs';
+import { forkJoin, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsImporterModalComponent } from '../settings-importer-modal/settings-importer-modal.component';
@@ -19,7 +20,7 @@ import { Theme, ThemeService } from '../../../services/theme.service';
   templateUrl: './settings-modal.component.html',
   styleUrl: './settings-modal.component.scss',
 })
-export class SettingsModalComponent implements OnInit {
+export class SettingsModalComponent implements OnInit, OnDestroy {
   @Input() preselectedViewTab = '';
   @Output() closed = new EventEmitter<void>();
 
@@ -34,6 +35,8 @@ export class SettingsModalComponent implements OnInit {
   showExporterModal = false;
   version = '';
 
+  private destroy$ = new Subject<void>();
+
   constructor(
     private settingsApi: SettingsApiService,
     private settingsState: SettingsStateService,
@@ -41,13 +44,20 @@ export class SettingsModalComponent implements OnInit {
     private themeService: ThemeService,
   ) {}
 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
   ngOnInit(): void {
     forkJoin({
       settings: this.settingsApi.getSettings(),
       embedders: this.settingsApi.getEmbedders(),
       mediaTypes: this.datasetsApi.getMediaTypes(),
       version: this.settingsApi.getVersion(),
-    }).subscribe({
+    })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
       next: (res) => {
         this.settings = res.settings;
         this.version = res.version.version;
@@ -153,15 +163,18 @@ export class SettingsModalComponent implements OnInit {
   }
 
   resetDefaults(): void {
-    this.settingsApi.getDefaults().subscribe({
-      next: (defaults) => {
-        this.settings = defaults;
-        if (defaults.theme) {
-          this.themeService.setTheme(defaults.theme as Theme);
-        }
-        this.save();
-      },
-    });
+    this.settingsApi
+      .getDefaults()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (defaults) => {
+          this.settings = defaults;
+          if (defaults.theme) {
+            this.themeService.setTheme(defaults.theme as Theme);
+          }
+          this.save();
+        },
+      });
   }
 
 
@@ -171,14 +184,17 @@ export class SettingsModalComponent implements OnInit {
 
   onImportComplete(): void {
     // Reload settings from the server after import
-    this.settingsApi.getSettings().subscribe({
-      next: (s) => {
-        this.settings = s;
-        if (s.theme) {
-          this.themeService.setTheme(s.theme as Theme);
-        }
-      },
-    });
+    this.settingsApi
+      .getSettings()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (s) => {
+          this.settings = s;
+          if (s.theme) {
+            this.themeService.setTheme(s.theme as Theme);
+          }
+        },
+      });
   }
 
   openExporter(): void {
@@ -186,11 +202,14 @@ export class SettingsModalComponent implements OnInit {
   }
 
   private save(): void {
-    this.settingsState.update(this.settings).subscribe({
-      error: () => {
-        this.error = 'Failed to save settings';
-      },
-    });
+    this.settingsState
+      .update(this.settings)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        error: () => {
+          this.error = 'Failed to save settings';
+        },
+      });
   }
 
   close(): void {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -53,7 +53,7 @@ export class DatasetsApiService {
   }
 
   getDemoCategories(name: string): Observable<{ categories: string[] }> {
-    return this.http.get<{ categories: string[] }>(`/api/dataset/demo-categories/${name}`);
+    return this.http.get<{ categories: string[] }>(`/api/dataset/demo-categories/${encodeURIComponent(name)}`);
   }
 
   browseMediaFiles(
@@ -120,7 +120,7 @@ export class DatasetsApiService {
   }
 
   runImporter(importerName: string, params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post(`/api/dataset/import/${importerName}`, params);
+    return this.http.post(`/api/dataset/import/${encodeURIComponent(importerName)}`, params);
   }
 
   /**
@@ -137,7 +137,7 @@ export class DatasetsApiService {
     values: Record<string, unknown>,
   ): Observable<{ options: string[] }> {
     return this.http.post<{ options: string[] }>(
-      `/api/dataset/import/${importerName}/options`,
+      `/api/dataset/import/${encodeURIComponent(importerName)}/options`,
       { field_key: fieldKey, values },
     );
   }
@@ -172,11 +172,11 @@ export class DatasetsApiService {
   }
 
   stageImport(importerName: string, params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post(`/api/dataset/stage-import/${importerName}`, params);
+    return this.http.post(`/api/dataset/stage-import/${encodeURIComponent(importerName)}`, params);
   }
 
   stageDemo(name: string): Observable<unknown> {
-    return this.http.post(`/api/dataset/stage-demo/${name}`, {});
+    return this.http.post(`/api/dataset/stage-demo/${encodeURIComponent(name)}`, {});
   }
 
   clearStaging(): Observable<unknown> {
@@ -198,7 +198,7 @@ export class DatasetsApiService {
   }
 
   cancelTask(taskId: string): Observable<OkResponse> {
-    return this.http.post<OkResponse>(`/api/dataset/cancel/${taskId}`, {});
+    return this.http.post<OkResponse>(`/api/dataset/cancel/${encodeURIComponent(taskId)}`, {});
   }
 
   clearDataset(): Observable<OkResponse> {
@@ -214,23 +214,23 @@ export class DatasetsApiService {
   }
 
   loadRegistered(datasetId: string): Observable<unknown> {
-    return this.http.post(`/api/datasets/registry/${datasetId}/load`, {});
+    return this.http.post(`/api/datasets/registry/${encodeURIComponent(datasetId)}/load`, {});
   }
 
   unloadRegistered(datasetId: string): Observable<unknown> {
-    return this.http.post(`/api/datasets/registry/${datasetId}/unload`, {});
+    return this.http.post(`/api/datasets/registry/${encodeURIComponent(datasetId)}/unload`, {});
   }
 
   deleteRegistered(datasetId: string): Observable<unknown> {
-    return this.http.delete(`/api/datasets/registry/${datasetId}`);
+    return this.http.delete(`/api/datasets/registry/${encodeURIComponent(datasetId)}`);
   }
 
   renameRegistered(datasetId: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/datasets/registry/${datasetId}/rename`, { name: newName });
+    return this.http.put(`/api/datasets/registry/${encodeURIComponent(datasetId)}/rename`, { name: newName });
   }
 
   updateReaders(datasetId: string, readers: string[]): Observable<unknown> {
-    return this.http.put(`/api/datasets/registry/${datasetId}/readers`, { readers });
+    return this.http.put(`/api/datasets/registry/${encodeURIComponent(datasetId)}/readers`, { readers });
   }
 
   loadSource(params: Record<string, unknown>): Observable<unknown> {
@@ -238,6 +238,6 @@ export class DatasetsApiService {
   }
 
   getDatasetStats(datasetId: string): Observable<DatasetStatsResponse> {
-    return this.http.get<DatasetStatsResponse>(`/api/datasets/registry/${datasetId}/stats`);
+    return this.http.get<DatasetStatsResponse>(`/api/datasets/registry/${encodeURIComponent(datasetId)}/stats`);
   }
 }

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -38,23 +38,23 @@ export class DetectorsApiService {
   }
 
   get(name: string): Observable<unknown> {
-    return this.http.get(`/api/detectors/${name}`);
+    return this.http.get(`/api/detectors/${encodeURIComponent(name)}`);
   }
 
   delete(name: string): Observable<unknown> {
-    return this.http.delete(`/api/detectors/${name}`);
+    return this.http.delete(`/api/detectors/${encodeURIComponent(name)}`);
   }
 
   rename(name: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/detectors/${name}/rename`, { new_name: newName });
+    return this.http.put(`/api/detectors/${encodeURIComponent(name)}/rename`, { new_name: newName });
   }
 
   setExamples(name: string, examples: unknown[]): Observable<unknown> {
-    return this.http.put(`/api/detectors/${name}/examples`, { examples });
+    return this.http.put(`/api/detectors/${encodeURIComponent(name)}/examples`, { examples });
   }
 
   saveLabels(name: string): Observable<unknown> {
-    return this.http.post(`/api/detectors/${name}/labels`, {});
+    return this.http.post(`/api/detectors/${encodeURIComponent(name)}/labels`, {});
   }
 
   getLabelsDetail(name: string): Observable<LabelsDetailResponse> {
@@ -102,7 +102,7 @@ export class DetectorsApiService {
     file?: File,
     fileFieldKey?: string,
   ): Observable<unknown> {
-    const url = `/api/detectors/registry/from-labelset/${importerName}`;
+    const url = `/api/detectors/registry/from-labelset/${encodeURIComponent(importerName)}`;
     if (file && fileFieldKey) {
       const formData = new FormData();
       formData.append(fileFieldKey, file, file.name);
@@ -117,11 +117,11 @@ export class DetectorsApiService {
   }
 
   deleteFromRegistry(detectorId: string): Observable<unknown> {
-    return this.http.delete(`/api/detectors/registry/${detectorId}`);
+    return this.http.delete(`/api/detectors/registry/${encodeURIComponent(detectorId)}`);
   }
 
   renameInRegistry(detectorId: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/detectors/registry/${detectorId}/rename`, { name: newName });
+    return this.http.put(`/api/detectors/registry/${encodeURIComponent(detectorId)}/rename`, { name: newName });
   }
 
   loadDetector(detectorId: string | null): Observable<unknown> {
@@ -129,7 +129,7 @@ export class DetectorsApiService {
   }
 
   unloadDetector(detectorId: string): Observable<unknown> {
-    return this.http.post(`/api/detectors/registry/${detectorId}/unload`, {});
+    return this.http.post(`/api/detectors/registry/${encodeURIComponent(detectorId)}/unload`, {});
   }
 
   getDetectorLoadingTasks(): Observable<LoadingTasksResponse> {
@@ -137,11 +137,11 @@ export class DetectorsApiService {
   }
 
   cancelDetectorLoadingTask(taskId: string): Observable<unknown> {
-    return this.http.post(`/api/detectors/cancel/${taskId}`, {});
+    return this.http.post(`/api/detectors/cancel/${encodeURIComponent(taskId)}`, {});
   }
 
   setAutorun(detectorId: string, autorun: boolean): Observable<unknown> {
-    return this.http.put(`/api/detectors/registry/${detectorId}/autorun`, { autorun });
+    return this.http.put(`/api/detectors/registry/${encodeURIComponent(detectorId)}/autorun`, { autorun });
   }
 
   // --- Extractors ---
@@ -155,11 +155,11 @@ export class DetectorsApiService {
   }
 
   deleteExtractor(name: string): Observable<unknown> {
-    return this.http.delete(`/api/autorun-extractors/${name}`);
+    return this.http.delete(`/api/autorun-extractors/${encodeURIComponent(name)}`);
   }
 
   renameExtractor(name: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/autorun-extractors/${name}/rename`, { new_name: newName });
+    return this.http.put(`/api/autorun-extractors/${encodeURIComponent(name)}/rename`, { new_name: newName });
   }
 
   // --- Localizers ---
@@ -173,11 +173,11 @@ export class DetectorsApiService {
   }
 
   deleteLocalizer(name: string): Observable<unknown> {
-    return this.http.delete(`/api/autorun-localizers/${name}`);
+    return this.http.delete(`/api/autorun-localizers/${encodeURIComponent(name)}`);
   }
 
   renameLocalizer(name: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/autorun-localizers/${name}/rename`, { new_name: newName });
+    return this.http.put(`/api/autorun-localizers/${encodeURIComponent(name)}/rename`, { new_name: newName });
   }
 
   // --- Scoring ---

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -20,9 +20,9 @@ export class LabelImportersApiService {
           formData.append(key, String(value ?? ''));
         }
       }
-      return this.http.post(`/api/label-importers/import/${importerName}`, formData);
+      return this.http.post(`/api/label-importers/import/${encodeURIComponent(importerName)}`, formData);
     }
-    return this.http.post(`/api/label-importers/import/${importerName}`, params);
+    return this.http.post(`/api/label-importers/import/${encodeURIComponent(importerName)}`, params);
   }
 
   runModelImport(
@@ -32,7 +32,7 @@ export class LabelImportersApiService {
     file?: File,
     fileFieldKey?: string,
   ): Observable<unknown> {
-    const url = `/api/detectors/${encodeURIComponent(modelName)}/import-labels/${importerName}`;
+    const url = `/api/detectors/${encodeURIComponent(modelName)}/import-labels/${encodeURIComponent(importerName)}`;
     if (file && fileFieldKey) {
       const formData = new FormData();
       formData.append(fileFieldKey, file, file.name);

--- a/frontend/src/app/services/processor-importers-api.service.ts
+++ b/frontend/src/app/services/processor-importers-api.service.ts
@@ -12,6 +12,6 @@ export class ProcessorImportersApiService {
   }
 
   runImport(importerName: string, params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post(`/api/processor-importers/import/${importerName}`, params);
+    return this.http.post(`/api/processor-importers/import/${encodeURIComponent(importerName)}`, params);
   }
 }

--- a/frontend/src/app/services/settings-io-api.service.ts
+++ b/frontend/src/app/services/settings-io-api.service.ts
@@ -41,12 +41,12 @@ export class SettingsIoApiService {
         }
       }
       return this.http.post<SettingsImportResponse>(
-        `/api/settings-importers/import/${importerName}`,
+        `/api/settings-importers/import/${encodeURIComponent(importerName)}`,
         formData,
       );
     }
     return this.http.post<SettingsImportResponse>(
-      `/api/settings-importers/import/${importerName}`,
+      `/api/settings-importers/import/${encodeURIComponent(importerName)}`,
       params,
     );
   }

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -14,10 +14,14 @@ import uuid
 import zipfile
 from pathlib import Path
 from typing import Callable, Optional
+from urllib.parse import urljoin
 
 import requests
 
 from vtsearch.config import DATA_DIR
+from vtsearch.utils.url_validation import validate_url
+
+_MAX_REDIRECTS = 10
 
 # Demo dataset directory paths (derived from DATA_DIR)
 IMAGE_DIR = DATA_DIR / "images"
@@ -119,7 +123,26 @@ def download_file_with_progress(
 
     # (connect_timeout, read_timeout): fail fast on unresponsive hosts
     # and abort if the server stops streaming bytes for 60s mid-download.
-    response = requests.get(url, stream=True, timeout=(10, 60))
+    # We follow redirects manually so that every hop is re-checked by
+    # validate_url() — otherwise a public URL could redirect to an internal
+    # host (SSRF), bypassing the up-front check that callers performed.
+    session = requests.Session()
+    current_url = url
+    response = session.get(current_url, stream=True, timeout=(10, 60), allow_redirects=False)
+    redirects = 0
+    while response.is_redirect or response.is_permanent_redirect:
+        if redirects >= _MAX_REDIRECTS:
+            response.close()
+            raise requests.TooManyRedirects(f"Exceeded {_MAX_REDIRECTS} redirects following {url}")
+        location = response.headers.get("Location")
+        if not location:
+            break
+        next_url = urljoin(current_url, location)
+        validate_url(next_url)
+        response.close()
+        current_url = next_url
+        response = session.get(current_url, stream=True, timeout=(10, 60), allow_redirects=False)
+        redirects += 1
     response.raise_for_status()
     total_size = int(response.headers.get("content-length", 0))
     if total_size == 0:

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -288,6 +288,7 @@ def load_dataset_from_pickle_chunked(
                 media_data: dict[str, Any] = {
                     "id": new_id,
                     "type": media_type,
+                    "embedder": media_info.get("embedder", ""),
                     "duration": media_info.get("duration", 0),
                     "file_size": media_info.get("file_size", 0),
                     "md5": media_info.get("md5", ""),
@@ -343,6 +344,7 @@ def load_dataset_from_pickle_chunked(
                 media_data = {
                     "id": new_id,
                     "type": media_type,
+                    "embedder": media_info.get("embedder", ""),
                     "duration": media_info.get("duration", 0),
                     "file_size": media_info.get("file_size", len(media_bytes)),
                     "md5": media_info.get("md5") or hashlib.md5(media_bytes).hexdigest(),

--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -167,11 +167,14 @@ def simulate_voting_iterations(
 
     vote_seq = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
 
-    # Pre-compute all-media embeddings for safe threshold GMM scoring
+    # Pre-compute embeddings for safe-threshold GMM scoring.  Restrict to the
+    # simulation set so the held-out ``test_ids`` never feed into the GMM that
+    # picks the threshold — otherwise the test scores leak into calibration
+    # and the reported metrics are biased upward.
     if safe_thresholds:
-        all_media_ids = sorted(clips_dict.keys())
-        all_clip_embs = np.array([clips_dict[cid]["embedding"] for cid in all_media_ids])
-        X_all_clips = torch.tensor(all_clip_embs, dtype=torch.float32)
+        gmm_media_ids = sorted(sim_ids)
+        gmm_clip_embs = np.array([clips_dict[cid]["embedding"] for cid in gmm_media_ids])
+        X_all_clips = torch.tensor(gmm_clip_embs, dtype=torch.float32)
 
     good_votes: dict[int, None] = {}
     bad_votes: dict[int, None] = {}

--- a/vtsearch/exporters/webhook/__init__.py
+++ b/vtsearch/exporters/webhook/__init__.py
@@ -53,7 +53,7 @@ class WebhookLabelsetExporter(LabelsetExporter):
         if auth_header:
             headers["Authorization"] = auth_header
 
-        resp = requests.post(url, json=results, headers=headers, timeout=30)
+        resp = requests.post(url, json=results, headers=headers, timeout=30, allow_redirects=False)
         resp.raise_for_status()
 
         if "labels" in results:

--- a/vtsearch/labels/sources/server_json_file/__init__.py
+++ b/vtsearch/labels/sources/server_json_file/__init__.py
@@ -67,18 +67,24 @@ class ServerFileLabelsetSource(LabelsetSource):
 
 
 def _resolve_filepath(field_values: dict[str, Any]) -> str:
-    """Resolve the filepath, expanding template variables."""
+    """Resolve the filepath, expanding template variables.
+
+    Substituted values are sanitized so that an attacker-controlled detector
+    name like ``../../etc/passwd`` cannot escape the directory implied by the
+    admin-configured template.
+    """
     filepath = (field_values.get("filepath") or "").strip()
     if not filepath:
         raise ValueError("A file path is required.")
 
     if "{detector_id}" in filepath or "{detector_name}" in filepath:
+        from vtsearch.utils.paths import sanitize_template_value
         from vtsearch.utils.state_core import get_active_detector_context
 
         ctx = get_active_detector_context()
         if ctx is not None:
-            filepath = filepath.replace("{detector_id}", ctx.detector_id)
-            filepath = filepath.replace("{detector_name}", ctx.name)
+            filepath = filepath.replace("{detector_id}", sanitize_template_value(ctx.detector_id))
+            filepath = filepath.replace("{detector_name}", sanitize_template_value(ctx.name))
 
     return filepath
 

--- a/vtsearch/settings_io/sources/server_json_file/__init__.py
+++ b/vtsearch/settings_io/sources/server_json_file/__init__.py
@@ -62,16 +62,22 @@ class ServerFileSettingsSource(SettingsSource):
 
 
 def _resolve_filepath(field_values: dict[str, Any]) -> str:
-    """Resolve the filepath, expanding {username} template."""
+    """Resolve the filepath, expanding the ``{username}`` template.
+
+    The substituted username is sanitized so that a name containing path
+    separators or ``..`` cannot escape the directory implied by the
+    admin-configured template.
+    """
     filepath = (field_values.get("filepath") or "").strip()
     if not filepath:
         raise ValueError("A file path is required.")
 
     if "{username}" in filepath:
         from vtsearch.auth import get_current_user
+        from vtsearch.utils.paths import sanitize_template_value
 
         username = get_current_user() or "default"
-        filepath = filepath.replace("{username}", username)
+        filepath = filepath.replace("{username}", sanitize_template_value(username))
 
     return filepath
 

--- a/vtsearch/utils/paths.py
+++ b/vtsearch/utils/paths.py
@@ -75,6 +75,24 @@ def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) ->
     return resolved
 
 
+def sanitize_template_value(value: str) -> str:
+    """Make *value* safe to splice into a filesystem-path template.
+
+    Server-side sync sources accept admin-defined templates like
+    ``data/labels/{detector_name}.json`` and substitute user-controlled
+    fields (``{detector_name}``, ``{username}``, …) at runtime.  Without
+    sanitization, a value containing ``../`` would let the substitution
+    escape the intended directory.
+
+    Returns a value with path separators and parent-directory tokens
+    replaced by ``_``.  Empty / ``.`` / ``..`` collapse to ``_``.
+    """
+    sanitized = value.replace("/", "_").replace("\\", "_").replace("\0", "_")
+    if sanitized in ("", ".", ".."):
+        return "_"
+    return sanitized
+
+
 def rglob_follow_symlinks(root: Path, pattern: str) -> list[Path]:
     """Like ``Path.rglob(pattern)`` but follows symlinks into directories.
 


### PR DESCRIPTION
## Summary

Nine verified bugs from a thorough codebase audit:

**Backend / security**

1. **SSRF via redirect-following in webhook exporter** (`vtsearch/exporters/webhook/__init__.py`): `validate_url()` only checked the initial URL; `requests.post` followed redirects by default, so a public URL could 30x to `http://127.0.0.1:6379/`. Fix: `allow_redirects=False`.
2. **SSRF via redirect-following in the archive downloader** (`vtsearch/datasets/downloader/core.py`): same class. Fix: follow redirects manually with per-hop `validate_url()` and a 10-hop cap, so legitimate CDN redirects keep working while internal hosts are blocked.
3. **Test-set leakage in safe-threshold evaluation** (`vtsearch/eval/voting_iterations.py`): the GMM threshold was being fitted on every media in `clips_dict`, including the held-out `test_ids`. Restrict the GMM input to `sim_ids` so test scores no longer leak into calibration.
4. **Path traversal via `{detector_id}` / `{detector_name}` template substitution** (`vtsearch/labels/sources/server_json_file/__init__.py`): a malicious detector name like `../../etc/passwd` would escape the configured directory. Fix: sanitize substituted values with a new helper.
5. **Path traversal via `{username}` template substitution** (`vtsearch/settings_io/sources/server_json_file/__init__.py`): same class for settings sources.

**Backend / correctness**

6. **`embedder` field dropped in chunked pickle loader** (`vtsearch/datasets/loader_pickle.py`): chunked thin- and full-mode loaders didn't carry `embedder` through, so chunked-loaded medias silently lost the field present on non-chunked-loaded ones. Fix: emit `embedder` in both chunked branches to match the non-chunked path.

**Frontend**

7. **Dataset/model/detector IDs not URL-encoded in path params** (across `frontend/src/app/services/*.service.ts`): a name with `/`, `?`, or `#` produced a wrong URL (404 / route hijacking). Fix: every interpolated string segment now goes through `encodeURIComponent`.
8. **`resumeActivePolling` subscriptions leak past component teardown** (`frontend/src/app/components/dashboard/dashboard.component.ts`): two `getLoadingTasks()` / `getModelLoadingTasks()` calls weren't piped through `takeUntil(this.destroy$)`. Fix: route both through `destroy$`.
9. **Settings modal had no `OnDestroy` / unsubscribe** (`frontend/src/app/components/modals/settings-modal/settings-modal.component.ts`): `forkJoin`, `getDefaults`, `getSettings`, and `save()` subscriptions could outlive the component. Fix: implement `OnDestroy`, add a `destroy$` subject, gate every subscription with `takeUntil`.

Adds `sanitize_template_value()` helper in `vtsearch/utils/paths.py` and uses it from both server-file sync sources.

## Test plan

- [x] `./run-tests.sh` (full default suite + frontend `build:prod`) — **3161 passed, 1 skipped, frontend build OK**

https://claude.ai/code/session_014tBYNtnccUZqmTz8Cv5Jpk