### PR TITLE
Drop dead Trainable? column from Dashboard models grid

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -41,7 +41,7 @@ describe('DashboardComponent', () => {
 
   it('should fetch datasets and models on init', () => {
     const datasets = [{ id: 'd1', name: 'Test Dataset', media_type: 'audio', num_items: 10 }];
-    const models = [{ id: 'm1', name: 'Test Model', trainable: true }];
+    const models = [{ id: 'm1', name: 'Test Model' }];
     flushInitialRequests(datasets, models);
     expect(component.datasets.length).toBe(1);
     expect(component.models.length).toBe(1);
@@ -175,31 +175,24 @@ describe('DashboardComponent', () => {
       expect(component.labelEnabled).toBeFalse();
     });
 
-    it('should enable Label with 1 dataset + 1 trainable model', () => {
+    it('should enable Label with 1 dataset + 1 model', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
       // Auto-selected since only 1 each
       expect(component.labelEnabled).toBeTrue();
     });
 
-    it('should disable Label when model is not trainable', () => {
-      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: false, media_type: 'audio' }];
-      flushInitialRequests(datasets, models);
-      expect(component.labelEnabled).toBeFalse();
-    });
-
     it('should disable Label on media type mismatch', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'image' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'image' }];
       flushInitialRequests(datasets, models);
       expect(component.labelEnabled).toBeFalse();
     });
 
     it('should disable Label when model media_type is "any" (not a valid type)', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'any' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'any' }];
       flushInitialRequests(datasets, models);
       expect(component.labelEnabled).toBeFalse();
     });
@@ -251,23 +244,16 @@ describe('DashboardComponent', () => {
       expect(component.findEnabled).toBeTrue();
     });
 
-    it('should disable Find when a trainable model has 0 training', () => {
+    it('should disable Find when the selected model has 0 training', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: true, num_training: 0 }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', num_training: 0 }];
       flushInitialRequests(datasets, models);
       expect(component.findEnabled).toBeFalse();
     });
 
-    it('should enable Find for a trainable model with training', () => {
+    it('should enable Find for a model with training', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: true, num_training: 5 }];
-      flushInitialRequests(datasets, models);
-      expect(component.findEnabled).toBeTrue();
-    });
-
-    it('should enable Find for a non-trainable model with 0 training', () => {
-      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: false, num_training: 0 }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', num_training: 5 }];
       flushInitialRequests(datasets, models);
       expect(component.findEnabled).toBeTrue();
     });
@@ -302,25 +288,18 @@ describe('DashboardComponent', () => {
       expect(component.labelHint).toBe('Select exactly 1 model');
     });
 
-    it('should hint about non-trainable model', () => {
-      const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: false, media_type: 'audio' }];
-      flushInitialRequests(datasets, models);
-      expect(component.labelHint).toBe('Model is not trainable');
-    });
-
     it('should hint about media type mismatch', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'image' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'image' }];
       flushInitialRequests(datasets, models);
       expect(component.labelHint).toBe('Media type mismatch');
     });
 
     it('should return empty hint when label is enabled', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
-      expect(component.labelHint).toBe('');
+      expect(component.labelHint).toBe('Open Train Mode with the selected dataset and model');
     });
   });
 
@@ -362,7 +341,7 @@ describe('DashboardComponent', () => {
 
     it('should hint about untrained model', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
-      const models = [{ id: 'm1', name: 'M', media_type: 'audio', trainable: true, num_training: 0 }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', num_training: 0 }];
       flushInitialRequests(datasets, models);
       expect(component.findHint).toBe('Selected model has no training labels');
     });
@@ -431,7 +410,7 @@ describe('DashboardComponent', () => {
   describe('onLabel', () => {
     it('should navigate directly when dataset is already loaded', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: true }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
 
       const routerSpy = spyOn(component['router'], 'navigate');
@@ -449,7 +428,7 @@ describe('DashboardComponent', () => {
 
     it('should store selected model text_query in session before navigating', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: true }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio', text_query: 'dog barking' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio', text_query: 'dog barking' }];
       flushInitialRequests(datasets, models);
 
       const session = TestBed.inject(LabelSessionService);
@@ -464,7 +443,7 @@ describe('DashboardComponent', () => {
 
     it('should load dataset first when not loaded, then navigate', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: false }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
 
       const routerSpy = spyOn(component['router'], 'navigate');
@@ -496,7 +475,7 @@ describe('DashboardComponent', () => {
 
     it('should not navigate on load error progress', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: false }];
-      const models = [{ id: 'm1', name: 'M', trainable: true, media_type: 'audio' }];
+      const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
 
       const routerSpy = spyOn(component['router'], 'navigate');

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -105,7 +105,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     'media_type', 'num_items', 'created_at', 'created_by', 'readers', 'loaded',
   ];
   static readonly MODEL_COLUMNS_DEFAULT = [
-    'media_type', 'num_training', 'trainable', 'autodetect', 'last_trained_at',
+    'media_type', 'num_training', 'autodetect', 'last_trained_at',
     'created_at', 'detector_loaded',
   ];
   private static readonly DATASET_COL_ORDER_KEY = 'vtsearch.dashboard.datasetColumnOrder';
@@ -127,7 +127,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     name: { label: 'Name', title: 'Model display name (click to sort)', sortable: true },
     media_type: { label: 'Type', title: 'Media type this model operates on (click to sort)', sortable: true },
     num_training: { label: '# Training', title: 'Number of labeled training examples (click to sort)', sortable: true },
-    trainable: { label: 'Trainable?', title: 'Is this Model one we can load into Train Mode and improve?', sortable: false },
     autodetect: { label: 'Autorun?', title: 'Include this model in CLI autorun (click to sort)', sortable: true },
     last_trained_at: { label: 'Last Trained', title: 'When the model was last trained (click to sort)', sortable: true },
     created_at: { label: 'Created', title: 'When the model was created (click to sort)', sortable: true },

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.html
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.html
@@ -73,24 +73,6 @@
       @case ('num_training') {
         <td>{{ (model.num_training ?? 0) | number }}</td>
       }
-      @case ('trainable') {
-        <td>
-          @if (model.trainable) {
-            <span class="status-icon" title="Model supports training" aria-label="Trainable">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="20 6 9 17 4 12"></polyline>
-              </svg>
-            </span>
-          } @else {
-            <span class="status-icon" title="Model does not support training" aria-label="Not trainable">
-              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </span>
-          }
-        </td>
-      }
       @case ('autodetect') {
         <td>
           <button class="autorun-toggle" (click)="onAutorunToggle($event)" aria-label="Autorun" title="Include in CLI autorun">

--- a/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/model-card/model-card.component.spec.ts
@@ -9,7 +9,6 @@ describe('ModelCardComponent', () => {
     id: 'm1',
     name: 'Test Model',
     media_type: 'audio',
-    trainable: true,
     num_training: 50,
     last_trained_at: 1700000000,
     created_at: 1699000000,
@@ -45,20 +44,6 @@ describe('ModelCardComponent', () => {
   it('should display training count', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('50');
-  });
-
-  it('should show trainable checkmark', () => {
-    const el = fixture.nativeElement as HTMLElement;
-    const checks = el.querySelectorAll('.check');
-    expect(checks.length).toBeGreaterThan(0);
-  });
-
-  it('should show dash when not trainable', () => {
-    component.model = { ...mockModel, trainable: false };
-    fixture.detectChanges();
-    const el = fixture.nativeElement as HTMLElement;
-    const dims = el.querySelectorAll('.dim');
-    expect(dims.length).toBeGreaterThan(0);
   });
 
   it('should enter rename mode on rename button click', () => {

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.spec.ts
@@ -68,7 +68,6 @@ describe('NewModelModalComponent', () => {
     expect(req.request.body.name).toBe('Dog Barks');
     expect(req.request.body.media_type).toBe('audio');
     expect(req.request.body.text_query).toBe('dog barking sounds');
-    expect(req.request.body.trainable).toBe(true);
     req.flush({ id: '123', name: 'Dog Barks' });
 
     expect(component.created.emit).toHaveBeenCalled();

--- a/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-model-modal/new-model-modal.component.ts
@@ -825,7 +825,6 @@ export class NewModelModalComponent implements OnInit {
             this.error = 'Server did not return a model id';
             return;
           }
-          // Kick off loading so the detector becomes trainable in the grid.
           this.modelsApi.loadModel(newId).subscribe({
             next: () => {
               this.submitting = false;
@@ -883,7 +882,6 @@ export class NewModelModalComponent implements OnInit {
       .registerModel({
         name: trimmedName,
         media_type: this.mediaType,
-        trainable: true,
         text_query: textQuery,
         media_example: mediaExample,
         examples: examplesPayload,


### PR DESCRIPTION
## Summary

Since the detector concept was deleted, every entry in the model registry is a trainable model — and the backend stopped sending a `trainable` field on `/api/models/registry`. The Dashboard's "Trainable?" column read `model.trainable`, got `undefined`, and rendered the red "not trainable" X for every row. This PR removes the column and the surrounding dead code.

- `dashboard.component.ts` — drop `trainable` from `MODEL_COLUMNS_DEFAULT` and `MODEL_COL_META`
- `model-card.component.html` — drop the `@case ('trainable')` block
- `new-model-modal.component.ts` — stop sending the unread `trainable: true` field on POST `/api/models/registry`, and drop the now-misleading "becomes trainable in the grid" comment
- Specs — delete tests covering removed code paths ("disable Label when model is not trainable", "enable Find for a non-trainable model with 0 training", "hint about non-trainable model"), and strip `trainable: true/false` from remaining test mocks; fix one stale `labelHint` assertion that pre-dated the most recent hint refactor.

## Test plan
- [x] `npm run build:prod` — clean
- [x] `tsc -p tsconfig.spec.json --noEmit` — clean
- [x] `./run-tests.sh core api` — 684 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01H46ufBH7BtbVGPXGB8e1qi)_