### PR TITLE
Add user-overrideable Dataset Name field to all DatasetImporters

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -815,7 +815,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.startProgressPolling();
   }
 
-  onDemoSelected(demo: { label: string; name: string; embedder?: string; clipper?: string }): void {
+  onDemoSelected(demo: { label: string; name: string; embedder?: string; clipper?: string; dataset_name?: string }): void {
     this.importerModalOpen = false;
     this.importerClosing = true;
     const params: Record<string, string> = {};
@@ -824,6 +824,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
     if (demo.clipper) {
       params['clipper'] = demo.clipper;
+    }
+    const userName = (demo.dataset_name || '').trim();
+    if (userName) {
+      params['dataset_name'] = userName;
     }
     this.datasetsApi.loadDemo(demo.name, params).subscribe({
       next: () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -57,6 +57,19 @@
           <p class="tab-bar-hint">Select the media type to demonstrate.</p>
         }
 
+        @if (activeTab) {
+          <div class="form-group">
+            <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
+            <input
+              id="demo-dataset-name"
+              type="text"
+              class="form-input"
+              [(ngModel)]="demoDatasetName"
+              placeholder="Leave blank to use the demo's name"
+            />
+          </div>
+        }
+
         @if (activeTab && (demoEmbedders.length > 1 || demoClippers.length > 1)) {
           <div class="demo-embedder-row">
             @if (demoEmbedders.length > 1) {
@@ -286,6 +299,18 @@
       }
 
       <div class="form-group">
+        <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>
+        <input
+          id="lf-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="lfDatasetName"
+          (ngModelChange)="lfOnDatasetNameInput($event)"
+          placeholder="Leave blank to use a default name"
+        />
+      </div>
+
+      <div class="form-group">
         <label class="form-label" for="lf-media-type" title="The type of media files (audio, image, text, video, or document)">Media Type</label>
         <select
           id="lf-media-type"
@@ -401,6 +426,18 @@
 
   @if (activePickerView === 'server_folder' && selectedImporter) {
     <div class="server-folder-browser">
+      <div class="form-group">
+        <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
+        <input
+          id="sf-dataset-name"
+          type="text"
+          class="form-input"
+          [ngModel]="sfDatasetName"
+          (ngModelChange)="sfOnDatasetNameInput($event)"
+          placeholder="Leave blank to use a default name"
+        />
+      </div>
+
       <div class="form-group">
         <label class="form-label" for="sf-media-type" title="The type of media files in the folder (audio, image, text, video, or document)">Media Type</label>
         <select

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -54,6 +54,9 @@ export class DatasetImporterModalComponent implements OnInit {
   demoEmbedder = '';
   demoClippers: ClipperInfo[] = [];
   selectedDemoClipper = '';
+  /** Optional user-supplied dataset name for demo imports.  Empty means
+   *  "use the demo entry's label". */
+  demoDatasetName = '';
 
   // Demo table column metadata + controller. Mirrors the Dashboard datagrid:
   // percentage widths summing to 100, draggable column reorder, click-to-sort
@@ -93,6 +96,11 @@ export class DatasetImporterModalComponent implements OnInit {
   lfRecursive = true;
   /** Maximum medias per chunk during embedding; 0 means "no chunking". */
   lfChunkSize = 0;
+  /** Optional user-supplied dataset name for local-folder uploads. */
+  lfDatasetName = '';
+  /** Whether the user has manually edited :prop:`lfDatasetName` (so we stop
+   *  auto-overwriting it from the picked folder name). */
+  private lfDatasetNameDirty = false;
 
   // Server folder browser state
   sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
@@ -113,6 +121,10 @@ export class DatasetImporterModalComponent implements OnInit {
   sfRecursive = true;
   /** Maximum medias per chunk during embedding; 0 means "no chunking". */
   sfChunkSize = 0;
+  /** Optional user-supplied dataset name for server-folder imports. */
+  sfDatasetName = '';
+  /** Whether the user has manually edited :prop:`sfDatasetName`. */
+  private sfDatasetNameDirty = false;
 
   /** Maximum medias per chunk during embedding for the generic form view; 0 means "no chunking". */
   chunkSize = 0;
@@ -438,6 +450,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.demos = [];
     this.demoTabs = [];
     this.activeTab = '';
+    this.demoDatasetName = '';
 
     this.datasetsApi.getMediaTypes().subscribe({
       next: (res) => {
@@ -671,7 +684,13 @@ export class DatasetImporterModalComponent implements OnInit {
   }
 
   selectDemo(demo: DemoDataset): void {
-    this.demoSelected.emit({ ...demo, embedder: this.selectedDemoEmbedder, clipper: this.selectedDemoClipper } as any);
+    const userName = (this.demoDatasetName || '').trim();
+    this.demoSelected.emit({
+      ...demo,
+      embedder: this.selectedDemoEmbedder,
+      clipper: this.selectedDemoClipper,
+      dataset_name: userName,
+    } as any);
     this.closed.emit();
   }
 
@@ -703,6 +722,8 @@ export class DatasetImporterModalComponent implements OnInit {
     this.lfError = '';
     this.lfSubmitting = false;
     this.lfRecursive = this.readRecursiveDefault(resolved);
+    this.lfDatasetName = '';
+    this.lfDatasetNameDirty = false;
 
     // Reuse the server_folder importer's media_type options for consistency.
     const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
@@ -728,6 +749,28 @@ export class DatasetImporterModalComponent implements OnInit {
     }
     this.lfFiles = Array.from(input.files);
     this.lfError = '';
+    if (!this.lfDatasetNameDirty) {
+      this.lfDatasetName = this.lfDerivedDatasetName();
+    }
+  }
+
+  /** Derive a default dataset name from the currently picked files / folder.
+   *  Used to pre-fill the Dataset Name input until the user edits it. */
+  private lfDerivedDatasetName(): string {
+    if (this.lfPickerKind === 'folder' && this.lfFolderName) {
+      return this.lfFolderName;
+    }
+    if (this.lfFiles.length === 1) {
+      const name = this.lfFiles[0].name || '';
+      const dot = name.lastIndexOf('.');
+      return dot > 0 ? name.slice(0, dot) : name;
+    }
+    return '';
+  }
+
+  lfOnDatasetNameInput(value: string): void {
+    this.lfDatasetName = value;
+    this.lfDatasetNameDirty = true;
   }
 
   lfOnMediaTypeChange(mediaType: string): void {
@@ -819,6 +862,10 @@ export class DatasetImporterModalComponent implements OnInit {
     const formData = new FormData();
     formData.append('media_type', this.lfMediaType);
     formData.append('recursive', this.lfRecursive ? 'true' : 'false');
+    const lfName = (this.lfDatasetName || '').trim();
+    if (lfName) {
+      formData.append('dataset_name', lfName);
+    }
     if (this.lfChunkSize && this.lfChunkSize > 0) {
       formData.append('chunk_size', String(Math.floor(this.lfChunkSize)));
     }
@@ -860,6 +907,8 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfBrowseError = '';
     this.sfSubmitting = false;
     this.sfRecursive = this.readRecursiveDefault(this.selectedImporter);
+    this.sfDatasetName = '';
+    this.sfDatasetNameDirty = false;
 
     // Load media type options from the folder importer's fields
     const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
@@ -888,12 +937,28 @@ export class DatasetImporterModalComponent implements OnInit {
         this.sfBrowsePath = path;
         this.sfBrowseRootPath = res.root_path;
         this.sfBrowseLoading = false;
+        if (!this.sfDatasetNameDirty) {
+          this.sfDatasetName = this.sfDerivedDatasetName();
+        }
       },
       error: (err) => {
         this.sfBrowseError = err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
         this.sfBrowseLoading = false;
       },
     });
+  }
+
+  /** Derive a default dataset name from the currently selected server folder.
+   *  Returns the leaf path component, or empty string when at the root. */
+  private sfDerivedDatasetName(): string {
+    if (!this.sfBrowsePath) return '';
+    const parts = this.sfBrowsePath.split('/').filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : '';
+  }
+
+  sfOnDatasetNameInput(value: string): void {
+    this.sfDatasetName = value;
+    this.sfDatasetNameDirty = true;
   }
 
   sfEnterDirectory(dir: { name: string; path: string }): void {
@@ -1066,6 +1131,10 @@ export class DatasetImporterModalComponent implements OnInit {
       media_type: this.sfMediaType,
       recursive: this.sfRecursive,
     };
+    const sfName = (this.sfDatasetName || '').trim();
+    if (sfName) {
+      params['dataset_name'] = sfName;
+    }
     if (this.sfChunkSize && this.sfChunkSize > 0) {
       params['chunk_size'] = Math.floor(this.sfChunkSize);
     }

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -616,6 +616,20 @@ class TestImporterMetadata:
         keys = [f["key"] for f in folder_imp["fields"]]
         assert keys.index("media_type") < keys.index("path")
 
+    def test_every_importer_exposes_dataset_name_field(self, client):
+        """Every importer's serialised field list begins with a non-required
+        ``dataset_name`` text field so the user can override the auto-generated
+        display name."""
+        resp = client.get("/api/dataset/importers")
+        data = resp.get_json()
+        assert data["importers"], "expected at least one importer"
+        for imp in data["importers"]:
+            keys = [f["key"] for f in imp["fields"]]
+            assert keys[0] == "dataset_name", f"{imp['name']} missing dataset_name field at index 0"
+            ds_field = imp["fields"][0]
+            assert ds_field["field_type"] == "text"
+            assert ds_field["required"] is False
+
 
 class TestLoadEmbedderForClips:
     """_load_embedder_for_clips should warm up the text encoder at dataset load time."""

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -330,6 +330,167 @@ class TestFolderImporterMetadata:
 
 
 # ---------------------------------------------------------------------------
+# DatasetImporter base class — user-typed dataset name
+# ---------------------------------------------------------------------------
+
+
+class TestImporterDatasetName:
+    """The base DatasetImporter exposes a user-typeable ``dataset_name``
+    field that overrides the per-importer default name."""
+
+    def _make_importer(self):
+        from vtsearch.datasets.importers.base import DatasetImporter
+
+        class Imp(DatasetImporter):
+            name = "named"
+            display_name = "Named"
+            description = "Has a default name."
+            fields = []
+
+            def default_display_name(self, field_values):
+                return field_values.get("flavour") or self.display_name
+
+            def run(self, field_values, medias):
+                pass
+
+        return Imp()
+
+    def test_to_dict_prepends_dataset_name_field(self):
+        from vtsearch.datasets.importers.base import (
+            DATASET_NAME_FIELD_KEY,
+            DatasetImporter,
+            ImporterField,
+        )
+
+        class Imp(DatasetImporter):
+            name = "imp"
+            display_name = "Imp"
+            description = "."
+            fields = [ImporterField("path", "Path", "text")]
+
+            def run(self, field_values, medias):
+                pass
+
+        d = Imp().to_dict()
+        assert d["fields"][0]["key"] == DATASET_NAME_FIELD_KEY
+        assert d["fields"][0]["required"] is False
+        assert d["fields"][0]["field_type"] == "text"
+        assert d["fields"][1]["key"] == "path"
+
+    def test_class_fields_attribute_unchanged_by_to_dict(self):
+        """to_dict() prepends dataset_name only on the serialised payload —
+        the class-level ``fields`` attribute remains as the developer wrote it."""
+        from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
+
+        class Imp(DatasetImporter):
+            name = "imp2"
+            display_name = "Imp"
+            description = "."
+            fields = [ImporterField("path", "Path", "text")]
+
+            def run(self, field_values, medias):
+                pass
+
+        imp = Imp()
+        # to_dict shouldn't mutate the class attribute.
+        imp.to_dict()
+        keys = [f.key for f in Imp.fields]
+        assert keys == ["path"]
+        assert "dataset_name" not in keys
+
+    def test_resolve_display_name_prefers_user_value(self):
+        imp = self._make_importer()
+        assert (
+            imp.resolve_display_name({"dataset_name": "My Pictures", "flavour": "blue"})
+            == "My Pictures"
+        )
+
+    def test_resolve_display_name_falls_back_to_default(self):
+        imp = self._make_importer()
+        assert imp.resolve_display_name({"flavour": "blue"}) == "blue"
+
+    def test_resolve_display_name_strips_whitespace(self):
+        imp = self._make_importer()
+        # An all-whitespace name is treated as empty — the default wins.
+        assert imp.resolve_display_name({"dataset_name": "   "}) == imp.display_name
+
+    def test_resolve_display_name_empty_field_values(self):
+        imp = self._make_importer()
+        # Defensive: still returns *something* for empty input.
+        assert imp.resolve_display_name({}) == imp.display_name
+        assert imp.resolve_display_name(None) == imp.display_name
+
+
+class TestImporterDefaultDisplayName:
+    """Each importer derives a sensible default name from its field values."""
+
+    def test_demo_uses_entry_label(self):
+        from vtsearch.datasets.config import DEMO_DATASETS
+        from vtsearch.datasets.importers.demo import IMPORTER
+
+        first_name = next(iter(DEMO_DATASETS.keys()))
+        first_label = DEMO_DATASETS[first_name].get("label", first_name)
+        assert IMPORTER.default_display_name({"name": first_name}) == first_label
+
+    def test_demo_user_typed_name_wins(self):
+        from vtsearch.datasets.config import DEMO_DATASETS
+        from vtsearch.datasets.importers.demo import IMPORTER
+
+        first_name = next(iter(DEMO_DATASETS.keys()))
+        assert (
+            IMPORTER.resolve_display_name({"name": first_name, "dataset_name": "Override"})
+            == "Override"
+        )
+
+    def test_synthetic_default_name_matches_size_and_type(self):
+        from vtsearch.datasets.importers.synthetic import IMPORTER
+
+        out = IMPORTER.default_display_name({"media_type": "audio", "size": "12"})
+        assert "audio" in out
+        assert "12" in out
+
+    def test_server_folder_uses_leaf_path(self):
+        from vtsearch.datasets.importers.server_folder import IMPORTER
+
+        assert IMPORTER.default_display_name({"path": "/data/sounds/sirens"}) == "sirens"
+        assert IMPORTER.default_display_name({}) == IMPORTER.display_name
+
+    def test_http_archive_strips_archive_extension(self):
+        from vtsearch.datasets.importers.http_archive import IMPORTER
+
+        assert (
+            IMPORTER.default_display_name({"url": "https://example.org/data/genres.tar.gz"})
+            == "genres"
+        )
+        assert (
+            IMPORTER.default_display_name({"url": "https://example.org/data/photos.zip"})
+            == "photos"
+        )
+        # No URL → falls back to display_name
+        assert IMPORTER.default_display_name({}) == IMPORTER.display_name
+
+    def test_pickle_default_name_strips_extension(self):
+        from vtsearch.datasets.importers.pickle import IMPORTER
+
+        assert IMPORTER.default_display_name({"file": "/tmp/genres.pkl"}) == "genres"
+
+    def test_server_files_default_name_uses_paths_file_stem(self):
+        from vtsearch.datasets.importers.server_files import IMPORTER
+
+        assert IMPORTER.default_display_name({"paths_file": "/tmp/audio_list.txt"}) == "audio_list"
+
+    def test_origin_does_not_include_dataset_name(self):
+        """The user-typed display name is UI metadata, not provenance —
+        it must NOT leak into origin params (which feed Detector reload)."""
+        from vtsearch.datasets.importers.server_folder import IMPORTER
+
+        origin = IMPORTER.build_origin(
+            {"path": "/data/x", "media_type": "audio", "dataset_name": "My Set"}
+        )
+        assert "dataset_name" not in origin["params"]
+
+
+# ---------------------------------------------------------------------------
 # Folder importer not in builtin names
 # ---------------------------------------------------------------------------
 

--- a/tests/test_synthetic_importer.py
+++ b/tests/test_synthetic_importer.py
@@ -76,6 +76,13 @@ class TestSyntheticImporterValidation:
         assert "audio" in imp.resolve_display_name({"media_type": "audio", "size": "7"})
         assert "7" in imp.resolve_display_name({"media_type": "audio", "size": "7"})
 
+    def test_user_dataset_name_overrides_default(self):
+        imp = SyntheticDatasetImporter()
+        out = imp.resolve_display_name(
+            {"media_type": "audio", "size": "7", "dataset_name": "My Tones"}
+        )
+        assert out == "My Tones"
+
 
 class TestOriginRoundTrip:
     def test_build_and_reload_origin(self):

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -63,6 +63,26 @@ __all__ = ["DatasetImporter", "ImporterField"]
 PickerView = str  # one of: "form", "demo", "server_folder", "local_folder"
 
 
+# Synthetic per-importer field that lets the user pick a name for the new
+# dataset.  Injected at the front of every importer's serialised field list
+# in :meth:`DatasetImporter.to_dict`, so the frontend renders it generically
+# without each subclass having to duplicate the declaration.  The field is
+# extracted out of band by the import route handler — see
+# :func:`vtsearch.routes.datasets._extract_importer_fields`.
+DATASET_NAME_FIELD_KEY = "dataset_name"
+
+
+def _dataset_name_field() -> PluginField:
+    return PluginField(
+        key=DATASET_NAME_FIELD_KEY,
+        label="Dataset Name",
+        field_type="text",
+        description="Leave blank to use a default name",
+        required=False,
+        placeholder="Leave blank to use a default name",
+    )
+
+
 class DatasetImporter(PluginBase):
     """Abstract base class for dataset importers.
 
@@ -146,7 +166,32 @@ class DatasetImporter(PluginBase):
         d = super().to_dict()
         d["picker_view"] = self.picker_view
         d["category"] = self.category
+        d["fields"] = [_dataset_name_field().to_dict()] + d["fields"]
         return d
+
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
+        """Return the importer-computed default name for a dataset.
+
+        Subclasses override this to derive a sensible default from
+        *field_values* (e.g. the demo importer reads the demo entry's
+        label).  The base implementation just returns :attr:`display_name`.
+        The user-typed ``dataset_name`` (when present) takes priority over
+        whatever this method returns — see :meth:`resolve_display_name`.
+        """
+        return self.display_name
+
+    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+        """Return the human-readable name to use for a dataset loaded with *field_values*.
+
+        Importer subclasses should override :meth:`default_display_name`
+        rather than this method.  ``resolve_display_name`` first honours
+        the user-typed ``dataset_name`` field (when non-empty) and falls
+        back to :meth:`default_display_name` otherwise.
+        """
+        user_name = (field_values.get("dataset_name") or "").strip() if field_values else ""
+        if user_name:
+            return user_name
+        return self.default_display_name(field_values or {})
 
     def __init__(self) -> None:
         #: Mapping of filename to pre-computed embedding vector.  Importers

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -61,7 +61,7 @@ class CombineDatasetsImporter(DatasetImporter):
         ),
     ]
 
-    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
         name = (field_values.get("name") or "").strip()
         return name or self.display_name
 

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -72,7 +72,7 @@ class DemoDatasetImporter(DatasetImporter):
                 f.options = list(DEMO_DATASETS.keys())
                 break
 
-    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
         from vtsearch.datasets.config import DEMO_DATASETS
 
         dataset_name = field_values.get("name", "")

--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -341,6 +341,19 @@ class HttpArchiveDatasetImporter(DatasetImporter):
             base += f" --converters {converters}"
         return base
 
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
+        url = (field_values.get("url") or "").strip()
+        if url:
+            url_path = url.split("?")[0].rstrip("/")
+            tail = url_path.split("/")[-1]
+            if tail:
+                # Strip a few common archive extensions for a tidier label.
+                for suffix in (".tar.gz", ".tar.bz2", ".tar.xz", ".tar", ".zip", ".rar"):
+                    if tail.lower().endswith(suffix):
+                        return tail[: -len(suffix)] or self.display_name
+                return tail
+        return self.display_name
+
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         origin = super().build_origin(field_values)
         converters = field_values.get("converters", "")

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -88,6 +88,21 @@ class PickleDatasetImporter(DatasetImporter):
             raise FileNotFoundError(f"Dataset file not found: {file_path}")
         yield from load_dataset_from_pickle_chunked(file_path, chunk_size, thin=thin)
 
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
+        file_obj = field_values.get("file")
+        candidate = ""
+        if hasattr(file_obj, "filename") and file_obj.filename:
+            candidate = file_obj.filename
+        elif hasattr(file_obj, "name") and file_obj.name:
+            candidate = file_obj.name
+        elif isinstance(file_obj, str):
+            candidate = file_obj
+        if candidate:
+            stem = Path(candidate).stem
+            if stem:
+                return stem
+        return self.display_name
+
     def origin_display(self, origin: dict[str, Any]) -> str:
         params = origin.get("params", {})
         filename = params.get("filename", params.get("path", ""))

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -257,6 +257,14 @@ class ServerFilesDatasetImporter(DatasetImporter):
             raise IsADirectoryError(f"Paths file must be a file: {paths_file}")
         yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
+        paths_file = (field_values.get("paths_file") or "").strip()
+        if paths_file:
+            stem = Path(paths_file).stem
+            if stem:
+                return stem
+        return self.display_name
+
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         params: dict[str, str] = {}
         paths_file = field_values.get("paths_file", "")

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -345,6 +345,14 @@ class ServerFolderDatasetImporter(DatasetImporter):
             base += f" --converters {converters}"
         return base
 
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
+        path_str = (field_values.get("path") or "").strip()
+        if path_str:
+            leaf = Path(path_str).name
+            if leaf:
+                return leaf
+        return self.display_name
+
     def build_origin(self, field_values: dict[str, Any]) -> dict[str, Any]:
         origin = super().build_origin(field_values)
         converters = field_values.get("converters", "")

--- a/vtsearch/datasets/importers/synthetic/__init__.py
+++ b/vtsearch/datasets/importers/synthetic/__init__.py
@@ -127,7 +127,7 @@ class SyntheticDatasetImporter(DatasetImporter):
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         self.run(field_values, medias, thin=thin)
 
-    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+    def default_display_name(self, field_values: dict[str, Any]) -> str:
         try:
             mt = self._media_type(field_values)
             n = self._parse_size(field_values)

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -381,12 +381,17 @@ def _extract_importer_fields(importer):
         for f in importer.fields:
             if f.field_type != "file":
                 field_values[f.key] = request.form.get(f.key, f.default)
+        dataset_name = (request.form.get("dataset_name") or "").strip()
     else:
         body = request.get_json(force=True) or {}
         for f in importer.fields:
             if f.key not in body and f.required:
                 return None, (jsonify({"error": f"Missing required field: {f.key!r}"}), 400)
             field_values[f.key] = body.get(f.key, f.default)
+        dataset_name = str(body.get("dataset_name") or "").strip()
+
+    if dataset_name:
+        field_values["dataset_name"] = dataset_name
 
     return field_values, None
 
@@ -425,12 +430,15 @@ def stage_demo(name: str):
 
     body = request.get_json(force=True, silent=True) or {}
     converter_name = body.get("converter", "")
+    dataset_name = str(body.get("dataset_name") or "").strip()
 
     field_values: dict = {"name": name}
     if converter_name:
         field_values["converter"] = converter_name
+    if dataset_name:
+        field_values["dataset_name"] = dataset_name
 
-    label = DEMO_DATASETS[name].get("label", name)
+    label = dataset_name or DEMO_DATASETS[name].get("label", name)
     _stage_importer_in_background(importer, field_values, label=label)
     return jsonify({"ok": True, "message": "Staging demo dataset..."})
 
@@ -628,6 +636,7 @@ def import_local_folder():
     recursive_raw = (request.form.get("recursive") or "true").strip().lower()
     recursive = recursive_raw not in ("false", "0", "no", "off")
     chunk_size = _parse_chunk_size(request.form.get("chunk_size"))
+    user_dataset_name = (request.form.get("dataset_name") or "").strip()
     clipper_params_raw = request.form.get("clipper_params") or ""
     clipper_params: dict | None = None
     if clipper_params_raw:
@@ -704,7 +713,7 @@ def import_local_folder():
     task_id = _run_origin_load_in_background(
         _load,
         origin,
-        name="Local folder upload",
+        name=user_dataset_name or "Local folder upload",
         clipper=clipper_name,
         clipper_params=inner_clipper_params,
         embedder=embedder,
@@ -736,6 +745,7 @@ def load_demo_dataset_route():
     embedder_name = data.get("embedder", "")
     clipper_name = data.get("clipper", "")
     converter_name = data.get("converter", "")
+    user_dataset_name = str(data.get("dataset_name") or "").strip()
 
     if not dataset_name or dataset_name not in DEMO_DATASETS:
         return jsonify({"error": "Invalid dataset name"}), 400
@@ -746,6 +756,8 @@ def load_demo_dataset_route():
 
     demo_info = DEMO_DATASETS[dataset_name]
     field_values: dict = {"name": dataset_name}
+    if user_dataset_name:
+        field_values["dataset_name"] = user_dataset_name
     # Inject media_type so the loading task exposes it to the frontend,
     # allowing the "guessed type" logic to consider in-progress loads.
     if converter_name:


### PR DESCRIPTION
## Summary
- Every importer's serialised field list now begins with an optional **Dataset Name** text input (auto-injected by `DatasetImporter.to_dict()`), so the user can rename the new dataset without each subclass re-declaring the field.
- A user-typed value short-circuits `resolve_display_name()`. Subclasses now override `default_display_name()` (renamed from `resolve_display_name`) to derive a sensible fallback from their own field values — folder leaf for `server_folder`, archive filename for `http_archive`, demo entry label for `demo`, pickle stem for `pickle`, paths-file stem for `server_files`, etc.
- The dataset-importer modal now renders a **Dataset Name** input on the demo, server-folder, and local-folder/files views (with auto-prefill from the picked folder/file and a "dirty" flag so user edits stick). The generic form view picks up the auto-injected field for free.
- Route handlers (`/api/dataset/import/<name>`, `load-demo`, `import-local-folder`, `stage-demo`) read `dataset_name` out of band so subclasses don't need to know about it. The value never leaks into origin params, since `build_origin` continues to iterate `self.fields` (which doesn't include the synthetic field).

## Test plan
- [x] `./run-tests.sh datasets io` — 995 passed
- [x] `./run-tests.sh` — 2901 passed (full suite)
- [x] `cd frontend && npm run build:prod` — clean build
- [x] `ruff check vtsearch tests` — clean
- [x] New tests cover: `to_dict()` field injection, `resolve_display_name()` precedence, per-subclass `default_display_name()` defaults (demo / synthetic / server_folder / http_archive / pickle / server_files), and that `dataset_name` is excluded from origin params.

https://claude.ai/code/session_01HPwj5TT8fhFmLFck3QKmae

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPwj5TT8fhFmLFck3QKmae)_