### PR TITLE
Default to autopilot for already-trained detectors; reset per-dataset learning state

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -185,7 +185,7 @@ describe('AppComponent', () => {
       { id: 'd1', name: 'DS1', media_type: 'audio' },
       { id: 'd2', name: 'DS2', media_type: 'audio' },
     ]);
-    spyOnProperty(datasetState, 'models', 'get').and.returnValue([
+    spyOnProperty(datasetState, 'detectors', 'get').and.returnValue([
       { id: 'm1', name: 'M1', media_type: 'audio' },
     ]);
     fixture.componentInstance.isOnLabelView = false;
@@ -200,7 +200,7 @@ describe('AppComponent', () => {
       { id: 'd1', name: 'DS1', media_type: 'audio' },
       { id: 'd2', name: 'DS2', media_type: 'image' },
     ]);
-    spyOnProperty(datasetState, 'models', 'get').and.returnValue([]);
+    spyOnProperty(datasetState, 'detectors', 'get').and.returnValue([]);
     fixture.componentInstance.isOnLabelView = false;
     fixture.componentInstance.onSettings();
     expect(fixture.componentInstance.settingsViewTab).toBe('');

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -27,11 +27,11 @@ describe('DashboardComponent', () => {
 
   function flushInitialRequests(
     datasets: any[] = [],
-    models: any[] = [],
+    detectors: any[] = [],
   ): void {
     fixture.detectChanges();
     httpMock.expectOne('/api/datasets/registry').flush({ datasets });
-    httpMock.expectOne('/api/detectors/registry').flush({ models });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors });
   }
 
   it('should create', () => {
@@ -39,12 +39,12 @@ describe('DashboardComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should fetch datasets and models on init', () => {
+  it('should fetch datasets and detectors on init', () => {
     const datasets = [{ id: 'd1', name: 'Test Dataset', media_type: 'audio', num_items: 10 }];
-    const models = [{ id: 'm1', name: 'Test Model' }];
-    flushInitialRequests(datasets, models);
+    const detectors = [{ id: 'm1', name: 'Test Detector' }];
+    flushInitialRequests(datasets, detectors);
     expect(component.datasets.length).toBe(1);
-    expect(component.models.length).toBe(1);
+    expect(component.detectors.length).toBe(1);
   });
 
   it('should auto-select single dataset', () => {
@@ -81,7 +81,7 @@ describe('DashboardComponent', () => {
         { id: 'd2', name: 'Second' },
       ],
     });
-    httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
 
     expect(component.selectedDatasetIds.has('d1')).toBeFalse();
     expect(component.selectedDatasetIds.has('d2')).toBeTrue();
@@ -96,7 +96,7 @@ describe('DashboardComponent', () => {
     component.refresh();
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
     httpMock.expectOne('/api/detectors/registry').flush({
-      models: [
+      detectors: [
         { id: 'm1', name: 'First' },
         { id: 'm2', name: 'Second' },
       ],
@@ -359,7 +359,7 @@ describe('DashboardComponent', () => {
 
     // Refresh calls
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-    httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   });
 
   it('should delete a dataset after confirmation', fakeAsync(() => {
@@ -380,7 +380,7 @@ describe('DashboardComponent', () => {
     expect(component.selectedDatasetIds.has('d1')).toBeFalse();
 
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-    httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   }));
 
   it('should open and close importer modal', () => {
@@ -470,7 +470,7 @@ describe('DashboardComponent', () => {
 
       // Refresh after completion
       httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-      httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+      httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
     });
 
     it('should not navigate on load error progress', () => {
@@ -492,7 +492,7 @@ describe('DashboardComponent', () => {
 
       // Refresh after error
       httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-      httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+      httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
     });
 
     it('should do nothing when no dataset is selected', () => {
@@ -527,7 +527,7 @@ describe('DashboardComponent', () => {
 
     // Refresh after completion
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-    httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   }));
 
   it('should load demo dataset on demoSelected', () => {
@@ -551,6 +551,6 @@ describe('DashboardComponent', () => {
 
     // After idle, it should refresh
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
-    httpMock.expectOne('/api/detectors/registry').flush({ models: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   });
 });

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1138,7 +1138,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.labelSession.mediaExample = model?.media_example || '';
     this.labelSession.examples = (model?.['examples'] as { type: string; value: string }[]) || [];
     this.labelSession.modelName = model?.name || '';
-    this.labelSession.alreadyTrained = (model?.num_training ?? 0) > 0;
   }
 
   onLabel(): void {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ModelCardComponent } from './model-card.component';
+import { DetectorCardComponent } from './detector-card.component';
 
-describe('ModelCardComponent', () => {
-  let component: ModelCardComponent;
-  let fixture: ComponentFixture<ModelCardComponent>;
+describe('DetectorCardComponent', () => {
+  let component: DetectorCardComponent;
+  let fixture: ComponentFixture<DetectorCardComponent>;
 
-  const mockModel = {
+  const mockDetector = {
     id: 'm1',
-    name: 'Test Model',
+    name: 'Test Detector',
     media_type: 'audio',
     num_training: 50,
     last_trained_at: 1700000000,
@@ -17,12 +17,12 @@ describe('ModelCardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ModelCardComponent],
+      imports: [DetectorCardComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(ModelCardComponent);
+    fixture = TestBed.createComponent(DetectorCardComponent);
     component = fixture.componentInstance;
-    component.model = { ...mockModel };
+    component.detector = { ...mockDetector };
     fixture.detectChanges();
   });
 
@@ -30,9 +30,9 @@ describe('ModelCardComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display model name', () => {
+  it('should display detector name', () => {
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.textContent).toContain('Test Model');
+    expect(el.textContent).toContain('Test Detector');
   });
 
   it('should display capitalized media type with icon', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { NewDetectorModalComponent } from './new-model-modal.component';
+import { NewDetectorModalComponent } from './new-detector-modal.component';
 
 describe('NewDetectorModalComponent', () => {
   let component: NewDetectorModalComponent;

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -34,7 +34,6 @@
       [datasetName]="datasetName"
       [autopilotCollapsed]="autopilotCollapsed"
       [autopilotEnabled]="autopilotEnabled"
-      [alreadyTrained]="alreadyTrained"
       (autopilotStart)="onAutopilotStart()"
       (autopilotStop)="onAutopilotStop()"
       (autopilotRefocus)="onAutopilotRefocus()"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -54,7 +54,6 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   rightWidth = 300;
   autopilotCollapsed = false;
   autopilotEnabled = true;
-  alreadyTrained = false;
   progressModalMetric: ProgressMetric | null = null;
 
   // Re-sort prompt state
@@ -106,7 +105,6 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit(): void {
     this.autopilotStateService.clear();
     this.voteState.clear();
-    this.alreadyTrained = this.labelSession.alreadyTrained;
     this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     this.mediaState.loadMedias();

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -39,10 +39,10 @@ describe('LeftPanelComponent', () => {
     expect(component.activeTab).toBe('manual');
   });
 
-  it('should default to manual tab when alreadyTrained is true', () => {
+  it('should default to manual tab when autopilotEnabled is false', () => {
     const fresh = TestBed.createComponent(LeftPanelComponent);
     const comp = fresh.componentInstance;
-    comp.alreadyTrained = true;
+    comp.autopilotEnabled = false;
     spyOn(comp.autopilotStart, 'emit');
     fresh.detectChanges();
     expect(comp.activeTab).toBe('manual');

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -53,8 +53,6 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Input() textQuery = '';
   @Input() autopilotCollapsed = false;
   @Input() autopilotEnabled = true;
-  /** When true, the selected model already has training labels; start in Manual mode. */
-  @Input() alreadyTrained = false;
   /** 'label' = full labeling UI (default), 'find' = simplified media-only view */
   @Input() panelMode: 'label' | 'find' = 'label';
   /** Disable all interaction (used during Find scoring). */
@@ -99,9 +97,8 @@ export class LeftPanelComponent implements OnInit, OnChanges {
       // Find mode doesn't use tabs — keep manual as a no-op default
       this.activeTab = 'manual';
     } else {
-      const shouldStartAutopilot = this.autopilotEnabled && !this.alreadyTrained;
-      this.activeTab = shouldStartAutopilot ? 'autopilot' : 'manual';
-      if (shouldStartAutopilot) {
+      this.activeTab = this.autopilotEnabled ? 'autopilot' : 'manual';
+      if (this.autopilotEnabled) {
         this.autopilotStart.emit();
       }
     }

--- a/frontend/src/app/services/dataset-state.service.spec.ts
+++ b/frontend/src/app/services/dataset-state.service.spec.ts
@@ -23,24 +23,24 @@ describe('DatasetStateService', () => {
 
   it('should start with empty state', () => {
     expect(service.datasets).toEqual([]);
-    expect(service.models).toEqual([]);
+    expect(service.detectors).toEqual([]);
     expect(service.loading).toBeFalse();
     expect(service.progressMessage).toBe('');
   });
 
-  it('refresh should fetch datasets and models', () => {
+  it('refresh should fetch datasets and detectors', () => {
     service.refresh();
 
     const datasetsReq = httpMock.expectOne('/api/datasets/registry');
-    const modelsReq = httpMock.expectOne('/api/detectors/registry');
+    const detectorsReq = httpMock.expectOne('/api/detectors/registry');
 
     datasetsReq.flush({ datasets: [{ id: '1', name: 'test' }] });
-    modelsReq.flush({ models: [{ id: 'm1', name: 'model1' }] });
+    detectorsReq.flush({ detectors: [{ id: 'm1', name: 'detector1' }] });
 
     expect(service.datasets.length).toBe(1);
     expect(service.datasets[0].name).toBe('test');
-    expect(service.models.length).toBe(1);
-    expect(service.models[0].name).toBe('model1');
+    expect(service.detectors.length).toBe(1);
+    expect(service.detectors[0].name).toBe('detector1');
   });
 
   it('rapid refresh should cancel stale in-flight requests', fakeAsync(() => {
@@ -48,21 +48,21 @@ describe('DatasetStateService', () => {
     service.refresh();
     tick();
     const staleDs = httpMock.expectOne('/api/datasets/registry');
-    const staleModels = httpMock.expectOne('/api/detectors/registry');
+    const staleDetectors = httpMock.expectOne('/api/detectors/registry');
 
     // Second refresh — this one should win
     service.refresh();
     tick();
     const freshDs = httpMock.expectOne('/api/datasets/registry');
-    const freshModels = httpMock.expectOne('/api/detectors/registry');
+    const freshDetectors = httpMock.expectOne('/api/detectors/registry');
 
     // The first (stale) requests were cancelled by switchMap
     expect(staleDs.cancelled).toBeTrue();
-    expect(staleModels.cancelled).toBeTrue();
+    expect(staleDetectors.cancelled).toBeTrue();
 
     // Flush the fresh responses
     freshDs.flush({ datasets: [{ id: '1', name: 'fresh' }] });
-    freshModels.flush({ models: [] });
+    freshDetectors.flush({ detectors: [] });
 
     expect(service.datasets.length).toBe(1);
     expect(service.datasets[0].name).toBe('fresh');
@@ -82,7 +82,7 @@ describe('DatasetStateService', () => {
     service.clear();
 
     expect(service.datasets).toEqual([]);
-    expect(service.models).toEqual([]);
+    expect(service.detectors).toEqual([]);
     expect(service.loading).toBeFalse();
     expect(service.progressMessage).toBe('');
   });

--- a/frontend/src/app/services/label-session.service.ts
+++ b/frontend/src/app/services/label-session.service.ts
@@ -17,8 +17,6 @@ export class LabelSessionService {
   mediaExample = '';
   examples: ModelExample[] = [];
   modelName = '';
-  /** True when the selected model already has training labels — start in Manual mode rather than Autopilot. */
-  alreadyTrained = false;
 
   /** Total votes cast since the last re-sort prompt. */
   resortVoteCount = 0;

--- a/vtsearch/models/label_restoration.py
+++ b/vtsearch/models/label_restoration.py
@@ -16,6 +16,12 @@ def restore_labels_from_detector(det_data: dict) -> int:
     scenario), resolves the original file from its origin trail, computes its
     MD5, and checks for a match in the loaded dataset.
 
+    Restored labels are applied silently: ``label_history`` is not appended
+    and the diversity tree is not pre-marked, so per-dataset Smart/Stable
+    trends and span/diversity coverage start fresh from the user's session
+    votes.  The good/bad counts still reflect restored labels, so autopilot's
+    initial Find Goods / Find Bads gates can skip ahead.
+
     Returns the number of labels successfully restored.
     """
     from vtsearch.datasets.labelset import LabelSet
@@ -48,7 +54,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
         cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup, name_lookup)
         if cids:
             for cid in cids:
-                apply_label(cid, elem.label)
+                apply_label(cid, elem.label, silent=True)
             restored += 1
         else:
             unresolved.append(elem)
@@ -89,7 +95,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
             cids = md5_lookup.get(resolved_md5, [])
             if cids:
                 for cid in cids:
-                    apply_label(cid, elem.label)
+                    apply_label(cid, elem.label, silent=True)
                 restored += 1
             else:
                 _log.debug(

--- a/vtsearch/utils/state_votes.py
+++ b/vtsearch/utils/state_votes.py
@@ -177,26 +177,37 @@ def toggle_vote(media_id: int, vote: str) -> None:
                     invalidate_progress_cache_from(media_id)
 
 
-def apply_label(media_id: int, label: str) -> None:
+def apply_label(media_id: int, label: str, *, silent: bool = False) -> None:
     """Atomically apply a label to a media (for imports).
 
     Unlike :func:`toggle_vote`, this always sets the label without toggling.
     No click-time is assigned (imported labels have no click-time).
 
+    When *silent* is True, the label is recorded in ``good_votes``/``bad_votes``
+    only — ``label_history`` is not appended and the diversity tree is not
+    marked.  This is used when restoring a detector's saved labels into a new
+    dataset: those labels are seeded so autopilot's good/bad-count gates are
+    satisfied, but they should not contaminate the per-session Smart/Stable
+    trends or pre-fill diversity coverage in the new dataset.
+
     Args:
         media_id: Integer ID of the media to label.
         label: ``"good"`` or ``"bad"``.
+        silent: If True, skip history append and diversity-tree marking.
     """
     with _state_lock:
         if label == "good":
             bad_votes.pop(media_id, None)
             good_votes[media_id] = None
-            add_label_to_history(media_id, "good")
+            if not silent:
+                add_label_to_history(media_id, "good")
         else:
             good_votes.pop(media_id, None)
             bad_votes[media_id] = None
-            add_label_to_history(media_id, "bad")
-        diversity_tree_label(media_id)
+            if not silent:
+                add_label_to_history(media_id, "bad")
+        if not silent:
+            diversity_tree_label(media_id)
 
 
 def apply_label_with_click_time(media_id: int, label: str) -> None:


### PR DESCRIPTION
## Summary

Drop the `alreadyTrained` gate in `LeftPanelComponent` that forced Manual mode whenever the selected detector had any saved labels. The Train window now respects the `autopilotEnabled` default for already-trained detectors, just like fresh ones.

When labels are restored from a detector into a (possibly different) dataset, the per-session learning state now starts fresh:

- `label_history` is **not** appended for restored labels
- The diversity tree is **not** pre-marked

This means Smart/Stable trends and span/diversity coverage start from zero in the new dataset, but `good_votes`/`bad_votes` are still populated so autopilot's good-count and bad-count gates skip ahead automatically. With enough restored labels of each polarity, the user lands directly in step 3 (Refine Boundary).

How it works:
- `LeftPanelComponent.ngOnInit` now picks autopilot/manual from `autopilotEnabled` alone — `alreadyTrained` is gone.
- `AutopilotStateService.checkPhaseTransition` already derives the phase from current good/bad counts and indicator statuses, so cascading past steps 1–2 is automatic when restored votes satisfy the thresholds.
- `apply_label(..., silent=True)` skips `add_label_to_history` and `diversity_tree_label`. `restore_labels_from_detector` is the only caller that uses `silent=True`; CSV/JSON label imports still seed history & diversity as before.

Also fixes pre-existing typecheck errors in spec files left over from the recent `models` → `detectors` rename:
- `model-card.component.spec.ts` → `detector-card.component.spec.ts` (renamed + retargeted)
- `new-detector-modal.component.spec.ts` import path
- `dataset-state.service.spec.ts` and `dashboard.component.spec.ts` references to `models`
- `app.component.spec.ts` `spyOnProperty` for `models` → `detectors`

## Test plan

- [x] `./run-tests.sh` — 2901 passed, 1 skipped
- [x] `npx tsc --noEmit -p tsconfig.json` (frontend) — clean
- [x] `npm run build:prod` — clean
- [ ] Manual: open a detector with existing labels in a new dataset, verify Train window opens in Autopilot tab and lands in step 3 with yellow Smart/Stable
- [ ] Manual: open a fresh detector, verify autopilot still starts at step 1
- [ ] Manual: open a detector when `autopilotEnabled=false`, verify Manual tab is selected

https://claude.ai/code/session_01H3soVgEALjrgnuX2Ei8igZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3soVgEALjrgnuX2Ei8igZ)_