### PR TITLE
Update Autopilot diversity score immediately on each vote

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -498,6 +498,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           if (response.id !== null) {
             this.mediaState.selectMedia(response.id);
           }
+          if (typeof response.diversity_level === 'number') {
+            this.autopilotStateService.updateDiversityLevel(response.diversity_level);
+          }
         },
       });
   }

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -68,6 +68,12 @@ export class AutopilotStateService {
     });
   }
 
+  updateDiversityLevel(level: number): void {
+    const current = this.stateSubject.value;
+    if (current.fracDiversity === level) return;
+    this.stateSubject.next({ ...current, fracDiversity: level });
+  }
+
   checkPhaseTransition(goodCount: number, badCount: number): void {
     const st = this.stateSubject.value;
     if (st.phase === 'idle') return;


### PR DESCRIPTION
## Why the diversity number lagged

The DiversityTree itself is already efficient — `label`/`unlabel` are O(log n) and `diversity_level()` is a BFS that breaks at the first unseen node. `toggle_vote()` updates the runtime tree incrementally on every vote, so the live tree state is correct the instant the vote endpoint returns.

The lag was entirely in the **delivery path** to the Autopilot panel:

1. The panel reads `fracDiversity` from `AutopilotStateService`.
2. That field was only updated inside `updateFromLabelingStatus()`, which fires when the `/api/labeling-status` poll returns.
3. The poll runs on a 2 s timer, and its handler calls `compute_labeling_status` → `_ensure_cache`, which **trains a fresh MLP for each new label-history step** (plus runs forward passes for the Smart indicator). The fast diversity number was bundled behind that training.

Net effect: in Diversity mode, the score waited up to 2 s for the next poll, then several hundred ms (or more, depending on labelset size) for the MLP — even though we don't even use the MLP at this stage; recommendations come straight from the tree.

## Fix

`fetchDiversityNext()` already calls `/api/diversity-tree/next` after every vote in `selectMode === 'new'`, and that endpoint already returns `diversity_level` from the live runtime tree. We just weren't piping it into autopilot state.

- Add `AutopilotStateService.updateDiversityLevel(level)`.
- Call it from `fetchDiversityNext()`'s success handler.

The Smart/Stable poll cadence is unchanged — those still drive the autopilot's `done` transition. Only the Diversity number now updates on the same tick as the vote.

## Test plan
- [x] `cd frontend && npm run build:prod` — production build succeeds, types check.
- [x] `./run-tests.sh core` — 331 passed.
- [ ] Manual: enter Autopilot Diversity phase and confirm the "Diversity: N" detail increments immediately after each vote (no 2 s wait).

---
_Generated by [Claude Code](https://claude.ai/code/session_015xd1qykyakSzqTuLa3DtRm)_