### PR TITLE
Fix Train flow stalling after creating a new detector

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -68,9 +68,9 @@ describe('NewDetectorModalComponent', () => {
     expect(req.request.body.name).toBe('Dog Barks');
     expect(req.request.body.media_type).toBe('audio');
     expect(req.request.body.text_query).toBe('dog barking sounds');
-    req.flush({ id: '123', name: 'Dog Barks' });
+    req.flush({ ok: true, detector: { id: '123', name: 'Dog Barks' } });
 
-    expect(component.created.emit).toHaveBeenCalled();
+    expect(component.created.emit).toHaveBeenCalledWith('123');
   });
 
   it('should disable Create button when not ready', () => {
@@ -110,11 +110,11 @@ describe('NewDetectorModalComponent', () => {
     component.submit();
 
     httpMock.expectOne('/api/detectors/registry').flush(
-      { error: 'Model already exists' },
+      { error: 'Detector already exists' },
       { status: 409, statusText: 'Conflict' },
     );
 
-    expect(component.error).toBe('Model already exists');
+    expect(component.error).toBe('Detector already exists');
   });
 
   it('should return media type icon', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -819,10 +819,10 @@ export class NewDetectorModalComponent implements OnInit {
       )
       .subscribe({
         next: (resp: any) => {
-          const newId = resp?.model?.id || '';
+          const newId = resp?.detector?.id || '';
           if (!newId) {
             this.submitting = false;
-            this.error = 'Server did not return a model id';
+            this.error = 'Server did not return a detector id';
             return;
           }
           this.detectorsApi.loadDetector(newId).subscribe({
@@ -839,7 +839,7 @@ export class NewDetectorModalComponent implements OnInit {
         },
         error: (err) => {
           this.submitting = false;
-          this.error = err.error?.error || 'Failed to create model from labelset';
+          this.error = err.error?.error || 'Failed to create detector from labelset';
         },
       });
   }
@@ -889,11 +889,11 @@ export class NewDetectorModalComponent implements OnInit {
       .subscribe({
         next: (resp: any) => {
           this.submitting = false;
-          this.created.emit(resp?.model?.id || '');
+          this.created.emit(resp?.detector?.id || '');
         },
         error: (err) => {
           this.submitting = false;
-          this.error = err.error?.error || 'Failed to create model';
+          this.error = err.error?.error || 'Failed to create detector';
         },
       });
   }


### PR DESCRIPTION
## Summary

When the user has a dataset selected but no detector and clicks Train, the dashboard opens the New Detector modal with `trainAfterModelCreation = true`, then expects the modal's `created` event to fire with the new detector's id so it can select that detector and re-enter `onLabel()` to navigate to `/label`.

The "model" → "detector" rename changed the registry POST response from `{"model": entry}` to `{"detector": entry}`, but `new-detector-modal` still read `resp?.model?.id`. The emitted id ended up empty, so `onDetectorCreated`'s `if (trainAfterModelCreation && modelId)` guard failed and the user was left on the dashboard.

## Changes

- Read `resp?.detector?.id` in both `submit()` and `submitTrained()`.
- Update the corresponding user-facing error strings ("model" → "detector").
- Spec: flush a realistic `{ ok, detector: { id, name } }` response and assert `created.emit` is called with the id.

## Test plan

- [x] `npm run build:prod` passes
- [ ] Manually verify: with a dataset selected and no detector, clicking Train opens the New Detector modal; submitting a blank detector navigates to the Train view with that dataset/detector pair
- [ ] Manually verify the same flow via the "Trained" tab (labelset import path)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Pb5RzddQeEryh4jeS7cwv)_