### PR TITLE
Derive __version__ from git HEAD timestamp (no merge conflicts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ frontend/.angular/
 
 /venv/
 *symbolic_link
+
+# Build-baked version stamp (Docker build arg writes this; never commit it).
+vtsearch/_version.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ When you're done with your changes, open a PR targeting `dev`. Do not ask — ju
 
 Never ask the user whether to subscribe to PR activity, and never call `subscribe_pr_activity`. The user does not want Claude to watch PRs or respond to review comments / CI. This overrides the default GitHub Integration instruction to offer PR subscription after creating a PR.
 
+## Versioning (do NOT bump by hand)
+
+`vtsearch.__version__` is the UTC timestamp of `HEAD`'s commit (ISO 8601, Z-terminated), computed from git at import time in `vtsearch/__init__.py`. There is no tracked version constant to bump — every commit on `dev` automatically becomes the new version, and parallel branches cannot collide on a hand-edited version line. Do not add a `VERSION` file, do not write a hand-bumped string into `vtsearch/__init__.py`, and do not include version bumps in feature PRs. For Docker images (where `.git` is excluded from the build context), the host passes `--build-arg VTSEARCH_VERSION=$(TZ=UTC git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ HEAD)` and the Dockerfile bakes it into `vtsearch/_version.txt` (gitignored). If git is unavailable and the baked file is missing, the version falls back to `0.0.0-unknown`.
+
 ## Backwards Compatibility
 
 Breaking backwards compatibility is acceptable — do not add shims, feature flags, legacy re-exports, or other compatibility layers to preserve old behavior. Just make the clean change. When a change does break backwards compatibility, mention it to the user so they're aware.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # ---------- application layer ----------
 COPY . .
 
+# Bake the version into the image. The host computes it from git
+# (e.g. `TZ=UTC git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ`)
+# and passes it as a build arg, since .git is excluded from the build context.
+# Without this, vtsearch.__version__ falls back to "0.0.0-unknown".
+ARG VTSEARCH_VERSION=
+RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_version.txt; fi
+
 # Runtime data directory (models, embeddings, settings, media files).
 # Mount a volume here to persist data across container restarts.
 VOLUME /app/data

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -49,6 +49,10 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # ---------- application layer ----------
 COPY . .
 
+# Bake the version into the image. See Dockerfile for the pattern.
+ARG VTSEARCH_VERSION=
+RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_version.txt; fi
+
 VOLUME /app/data
 
 EXPOSE 5000

--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -58,6 +58,10 @@ print('SigLIP weights cached.', flush=True)"
 # ---------- application layer ----------
 COPY . .
 
+# Bake the version into the image. See Dockerfile for the pattern.
+ARG VTSEARCH_VERSION=
+RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_version.txt; fi
+
 # Seed default settings so the SigLIP image embedder is preloaded at startup.
 # Docker copies this file into a fresh named volume on first creation, so new
 # deployments come ready-to-serve without the user manually toggling autoload.

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -236,3 +236,35 @@ class TestVersionEndpoint:
         # Must be parseable as an ISO 8601 timestamp ending in Z (UTC).
         assert version.endswith("Z")
         datetime.fromisoformat(version.replace("Z", "+00:00"))
+
+
+class TestVersionResolution:
+    """`vtsearch.__init__` resolves __version__ from git, then a baked file, then a fallback."""
+
+    def test_git_resolver_returns_iso_utc_for_real_repo(self):
+        from vtsearch import _version_from_git
+
+        version = _version_from_git()
+        assert version is not None, "tests run from a git checkout — git resolution must succeed"
+        assert version.endswith("Z")
+
+    def test_file_resolver_reads_baked_version(self, tmp_path, monkeypatch):
+        import vtsearch as pkg
+
+        baked = tmp_path / "_version.txt"
+        baked.write_text("2030-01-02T03:04:05Z\n", encoding="utf-8")
+        monkeypatch.setattr(pkg, "__file__", str(tmp_path / "__init__.py"))
+        assert pkg._version_from_file() == "2030-01-02T03:04:05Z"
+
+    def test_file_resolver_returns_none_when_missing(self, tmp_path, monkeypatch):
+        import vtsearch as pkg
+
+        monkeypatch.setattr(pkg, "__file__", str(tmp_path / "__init__.py"))
+        assert pkg._version_from_file() is None
+
+    def test_fallback_when_git_and_file_unavailable(self, monkeypatch):
+        import vtsearch as pkg
+
+        monkeypatch.setattr(pkg, "_version_from_git", lambda: None)
+        monkeypatch.setattr(pkg, "_version_from_file", lambda: None)
+        assert pkg._resolve_version() == "0.0.0-unknown"

--- a/vtsearch/__init__.py
+++ b/vtsearch/__init__.py
@@ -1,7 +1,56 @@
 """VTSearch - Interactive ML-powered media similarity explorer."""
 
-# Version is the UTC timestamp of the last dev->main merge, in ISO 8601.
-# Bumped automatically by the dev->main merge routine; see docs/RELEASING.md.
-__version__ = "2026-05-07T00:00:00Z"
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Version is the UTC timestamp of HEAD's commit (ISO 8601, Z-terminated).
+# Derived from git at import time — never stored in a tracked file — so
+# parallel branches can't collide on a hand-bumped version constant.
+# At deploy time (Docker, sdist) where .git is absent, we fall back to a
+# baked `_version.txt` written by the build step.
+
+_FALLBACK_VERSION = "0.0.0-unknown"
+
+
+def _format_iso_utc(unix_ts: int) -> str:
+    return datetime.fromtimestamp(unix_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _version_from_git() -> str | None:
+    repo_root = Path(__file__).resolve().parent.parent
+    if not (repo_root / ".git").exists():
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "log", "-1", "--format=%ct", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    ts = out.stdout.strip()
+    if not ts.isdigit():
+        return None
+    return _format_iso_utc(int(ts))
+
+
+def _version_from_file() -> str | None:
+    baked = Path(__file__).resolve().parent / "_version.txt"
+    if not baked.exists():
+        return None
+    text = baked.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def _resolve_version() -> str:
+    return _version_from_git() or _version_from_file() or _FALLBACK_VERSION
+
+
+__version__ = _resolve_version()
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `__version__` constant in `vtsearch/__init__.py` with a value derived from `HEAD`'s commit timestamp (UTC, ISO 8601, Z-terminated) at import time. Every commit on `dev` automatically becomes the new version, so parallel Claude branches can never collide on a hand-bumped version line.
- Adds a build-time fallback: each `Dockerfile*` accepts `--build-arg VTSEARCH_VERSION=...` and bakes it into a gitignored `vtsearch/_version.txt` (since `.git` is excluded from the Docker build context). If both git and the baked file are unavailable, version falls back to `0.0.0-unknown`.
- Documents the policy in `CLAUDE.md` ("do NOT bump by hand") so future Claudes don't re-introduce a tracked version constant.

## Test plan
- [x] `./run-tests.sh` — 2908 passed, 1 skipped
- [x] `./run-tests.sh core` — 335 passed
- [x] `ruff check` clean
- [x] Manually verified `python -c "from vtsearch import __version__; print(__version__)"` returns a Z-terminated ISO timestamp matching `HEAD`'s commit time
- [x] Existing `/api/version` endpoint shape preserved (status 200, `{version: ...}`, ISO-Z format)

## Notes
- **Backwards-compat note**: Docker image builders should now pass `--build-arg VTSEARCH_VERSION=$(TZ=UTC git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ HEAD)` to bake the version into the image. Without it, deployed images report `0.0.0-unknown`.

https://claude.ai/code/session_01GwVL5MAzjjC75jykFdztW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwVL5MAzjjC75jykFdztW3)_