### PR TITLE
Add server disk-usage indicator to the dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -275,6 +275,14 @@
       </button>
       <span class="btn-disabled-reason" [style.visibility]="(!findEnabled && findHint) ? 'visible' : 'hidden'">{{ findHint || '&nbsp;' }}</span>
     </div>
+    @if (diskUsage) {
+      <div class="disk-usage" [title]="'Server disk: ' + diskFreeText">
+        <div class="disk-usage-label">Disk: {{ diskFreeText }}</div>
+        <div class="disk-usage-bar" [class.warn]="diskUsedPct >= 80" [class.critical]="diskUsedPct >= 95">
+          <div class="disk-usage-fill" [style.width.%]="diskUsedPct"></div>
+        </div>
+      </div>
+    }
   </div>
 </div>
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -417,6 +417,7 @@
   display: flex;
   gap: 12px;
   justify-content: center;
+  position: relative;
 
   .btn {
     min-width: 120px;
@@ -465,6 +466,49 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+}
+
+// Disk-usage indicator: positioned absolute so adding/removing it never
+// shifts the centered Train/Find buttons.
+.disk-usage {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.disk-usage-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.disk-usage-bar {
+  height: 8px;
+  background: var(--bg-elevated, rgba(127, 127, 127, 0.2));
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.disk-usage-fill {
+  height: 100%;
+  background: var(--accent, #4caf50);
+  transition: width 0.4s ease, background-color 0.3s ease;
+}
+
+.disk-usage-bar.warn .disk-usage-fill {
+  background: #f0a020;
+}
+
+.disk-usage-bar.critical .disk-usage-fill {
+  background: #d04030;
 }
 
 // Waggle for Train/Find icons while loading: rotate to 90° (0.3s), hold,

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -177,6 +177,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   currentUser = '';
   isDefaultLogin = true;
 
+  diskUsage: { total: number; used: number; free: number } | null = null;
+
   constructor(
     private router: Router,
     private datasetsApi: DatasetsApiService,
@@ -244,6 +246,40 @@ export class DashboardComponent implements OnInit, OnDestroy {
       });
     this.refresh();
     this.resumeActivePolling();
+    this.startDiskUsagePolling();
+  }
+
+  private startDiskUsagePolling(): void {
+    timer(0, 10000)
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap(() => this.datasetsApi.getDiskUsage().pipe(catchError(() => EMPTY))),
+      )
+      .subscribe((usage) => {
+        this.diskUsage = { total: usage.total, used: usage.used, free: usage.free };
+      });
+  }
+
+  get diskUsedPct(): number {
+    if (!this.diskUsage || this.diskUsage.total <= 0) return 0;
+    return (this.diskUsage.used / this.diskUsage.total) * 100;
+  }
+
+  get diskFreeText(): string {
+    if (!this.diskUsage) return '';
+    return `${this.formatBytes(this.diskUsage.free)} free of ${this.formatBytes(this.diskUsage.total)}`;
+  }
+
+  private formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    const units = ['KB', 'MB', 'GB', 'TB', 'PB'];
+    let v = n / 1024;
+    let i = 0;
+    while (v >= 1024 && i < units.length - 1) {
+      v /= 1024;
+      i++;
+    }
+    return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
   }
 
   /** Check for in-progress loading tasks (e.g. after a page reload) and resume polling. */

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -240,4 +240,10 @@ export class DatasetsApiService {
   getDatasetStats(datasetId: string): Observable<DatasetStatsResponse> {
     return this.http.get<DatasetStatsResponse>(`/api/datasets/registry/${encodeURIComponent(datasetId)}/stats`);
   }
+
+  getDiskUsage(): Observable<{ total: number; used: number; free: number; path: string }> {
+    return this.http.get<{ total: number; used: number; free: number; path: string }>(
+      '/api/dashboard/disk-usage',
+    );
+  }
 }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -103,6 +103,25 @@ class TestDashboardDatasetInfo:
                     v["origin"] = saved_origins[k]
 
 
+class TestDashboardDiskUsage:
+    """Tests for GET /api/dashboard/disk-usage."""
+
+    def test_returns_disk_usage(self, client):
+        """Endpoint returns total/used/free byte counts and a path."""
+        resp = client.get("/api/dashboard/disk-usage")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        for key in ("total", "used", "free", "path"):
+            assert key in data
+        assert isinstance(data["total"], int)
+        assert isinstance(data["used"], int)
+        assert isinstance(data["free"], int)
+        assert data["total"] > 0
+        assert data["used"] >= 0
+        assert data["free"] >= 0
+        assert data["used"] + data["free"] <= data["total"] + 1  # rounding tolerance
+
+
 class TestDashboardHtmlPresent:
     """Test that the dashboard-related content is present in the Angular bundle."""
 

--- a/vtsearch/routes/datasets_ui.py
+++ b/vtsearch/routes/datasets_ui.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 
-from vtsearch.config import EMBEDDINGS_DIR
+from vtsearch.config import DATA_DIR, EMBEDDINGS_DIR
 from vtsearch.datasets import DEMO_DATASETS
 from vtsearch.datasets.loader import read_pkl_clipper, read_pkl_embedder
 from vtsearch.datasets.load_pipeline import _origin_to_str
@@ -407,3 +408,18 @@ def dashboard_dataset_rename():
 
     set_dataset_display_name(new_name)
     return jsonify({"success": True, "name": new_name})
+
+
+@datasets_ui_bp.route("/api/dashboard/disk-usage")
+def dashboard_disk_usage():
+    """Return free / used / total bytes for the partition holding ``DATA_DIR``."""
+    probe = DATA_DIR if DATA_DIR.exists() else DATA_DIR.parent
+    usage = shutil.disk_usage(str(probe))
+    return jsonify(
+        {
+            "total": usage.total,
+            "used": usage.used,
+            "free": usage.free,
+            "path": str(probe),
+        }
+    )


### PR DESCRIPTION
## Summary
- New `GET /api/dashboard/disk-usage` endpoint returning total / used / free bytes (and probed path) for the partition that holds `DATA_DIR`.
- Dashboard polls every 10s and shows a horizontal disk-usage bar with `Disk: <free> free of <total>` to the right of the Train / Find buttons.
- Bar turns amber at ≥80% used and red at ≥95% used; absolutely positioned so adding it does not shift the centered Train / Find buttons.

## Test plan
- [x] `./run-tests.sh core` — 331 passed (includes frontend TypeScript build check).
- [x] `./run-tests.sh api` — 354 passed.
- [x] New backend test `TestDashboardDiskUsage::test_returns_disk_usage` verifies response shape and byte invariants.
- [ ] Visual smoke test in the dashboard once deployed.

https://claude.ai/code/session_016Vx5ht5u8YrsCGxCf7DjF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016Vx5ht5u8YrsCGxCf7DjF3)_