### PR TITLE
Bump fast-uri to 3.1.2 to fix path-traversal vuln

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6350,9 +6350,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Resolves the high-severity `npm audit` finding [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — `fast-uri` path traversal via percent-encoded dot segments.
- Applied via `npm audit fix`; the only change is `frontend/package-lock.json` bumping `fast-uri` from 3.1.0 → 3.1.2 (transitive dep, no `package.json` edit needed).

## Test plan
- [x] `cd frontend && npm audit` — reports 0 vulnerabilities.
- [x] `cd frontend && npm run build:prod` — builds cleanly with no warnings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqrfwsnvW5zzJ7NXKUhLDM)_