### PR TITLE
Fix first labeled image rendering as gray placeholder in Train right panel

### DIFF
--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -9,6 +9,7 @@ import {
   LabelsDetailResponse,
   LoadingTasksResponse,
 } from '../models/api.models';
+import { ActiveContextService } from './active-context.service';
 
 export interface FindLabelWarning {
   detector_name: string;
@@ -25,7 +26,7 @@ export interface FindLabelWarning {
  */
 @Injectable({ providedIn: 'root' })
 export class DetectorsApiService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private activeContext: ActiveContextService) {}
 
   // --- Detector CRUD ---
 
@@ -71,11 +72,15 @@ export class DetectorsApiService {
   }
 
   labelPreviewUrl(name: string, elementId: string): string {
-    return `/api/detectors/${encodeURIComponent(name)}/labels/${encodeURIComponent(elementId)}/preview`;
+    return this.activeContext.mediaUrl(
+      `/api/detectors/${encodeURIComponent(name)}/labels/${encodeURIComponent(elementId)}/preview`,
+    );
   }
 
   labelThumbnailUrl(name: string, elementId: string): string {
-    return `/api/detectors/${encodeURIComponent(name)}/labels/${encodeURIComponent(elementId)}/thumbnail`;
+    return this.activeContext.mediaUrl(
+      `/api/detectors/${encodeURIComponent(name)}/labels/${encodeURIComponent(elementId)}/thumbnail`,
+    );
   }
 
   combine(


### PR DESCRIPTION
## Summary

The Train-mode right panel built per-label thumbnail URLs as a bare path (`/api/detectors/<name>/labels/<id>/thumbnail`). Native `<img>` requests bypass Angular's HTTP interceptor, so the server's `before_request` couldn't resolve a dataset context and the in-memory fast path skipped (`cid` came back `None` from the empty fallback context). The slow origin-resolution fallback could fail on the first freshly-voted image; once the browser fired `(error)`, `labelset-list`'s sticky `thumbnailFailedIds` Set permanently swapped that entry for the `□` placeholder. The only "fix" was destroying the component (quitting to the dashboard and back), which emptied the Set and let the IMG try again.

Routes `labelThumbnailUrl` and `labelPreviewUrl` through `ActiveContextService.mediaUrl()` so the URL carries `?dataset_id=`/`?detector_id=` query params, mirroring the pattern browse-mode thumbnails (`label-list.component.ts`) already use. With dataset context resolved server-side, the in-memory fast path serves `media_bytes` directly and `(error)` no longer fires.

Reproduced first via Flask `test_client` mimicking the browser request shape (HttpClient calls carry `X-Dataset-Id`, `<img>` doesn't): the bare-path thumbnail URL returned 404 `Element media file unavailable`; appending the query params returned 200 image bytes.

## Test plan
- [x] `./run-tests.sh core` — 335 passed (includes frontend `npm run build:prod`)
- [ ] Manual: in Train mode, label an image and confirm its thumbnail appears in the right panel without needing to navigate away

---
_Generated by [Claude Code](https://claude.ai/code/session_013hhR36GmvKvRq1ZQ4U7X8L)_