### PR TITLE
Rehydrate detector vote dicts when the active dataset changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,6 +141,18 @@ def _set_request_context():
     except Exception:
         logging.getLogger(__name__).exception("Request context resolution failed")
 
+    # If the active (dataset, detector) pair has changed since the detector's
+    # cid-keyed vote dicts were last derived, rehydrate them from the on-disk
+    # labelset against the active dataset's medias.  Media ids are dataset-
+    # specific, so without this the left-pane shows stale cids from the
+    # previous dataset as if they were votes in the current one.
+    try:
+        from vtsearch.models.detector_dataset_sync import ensure_votes_match_active_dataset
+
+        ensure_votes_match_active_dataset()
+    except Exception:
+        logging.getLogger(__name__).exception("Vote rehydrate failed")
+
 
 # ---------------------------------------------------------------------------
 # Prevent browser caching of API responses

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -571,6 +571,86 @@ class TestLoadModelEndpoint:
         assert res.status_code == 200
         assert ids[0] in good_votes, "saved label was not restored on model load"
 
+    def test_dataset_switch_clears_cross_dataset_cids(self, client):
+        """Switching the active dataset must rehydrate the loaded detector's
+        cid-keyed vote dicts from the on-disk labelset against the new dataset's
+        medias.  Without this, ids voted in dataset A leak into dataset B's
+        id-space and unrelated B-medias whose ids happen to coincide with
+        A's voted ids appear as voted in B's labeling UI.
+        """
+        import hashlib
+
+        import numpy as np
+
+        from vtsearch.models.detector_dataset_sync import ensure_votes_match_active_dataset
+        from vtsearch.utils import (
+            DatasetContext,
+            bad_votes,
+            good_votes,
+            medias,
+            register_context,
+            set_thread_dataset_context,
+        )
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        a_ids = list(medias.keys())
+        if len(a_ids) < 2:
+            pytest.skip("Need at least 2 medias")
+        a_good = a_ids[0]
+        a_bad = a_ids[1]
+
+        # Create + load a detector while dataset A is active.
+        client.post(
+            "/api/detectors",
+            json={"name": "CrossDS", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "CrossDS", "media_type": "audio", "text_query": "test"},
+        )
+        mid = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, mid)
+
+        # Vote in dataset A.  Persists to good_votes/bad_votes and to the
+        # detector's on-disk labelset via sync_labels_to_loaded_detector.
+        client.post(f"/api/medias/{a_good}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{a_bad}/vote", json={"vote": "bad"})
+        assert a_good in good_votes
+        assert a_bad in bad_votes
+
+        # Build dataset B with DIFFERENT media (different md5/origin) reusing
+        # the same cids, exactly the situation that produced the bug: the
+        # voted A ids would otherwise show up as votes in B's id-space.
+        ctx_b = DatasetContext("ds_b_for_switch_test")
+        for cid in (a_good, a_bad):
+            ctx_b.medias[cid] = {
+                "id": cid,
+                "type": "audio",
+                "embedder": "clap",
+                "md5": hashlib.md5(f"ds_b_{cid}".encode()).hexdigest(),
+                "embedding": np.zeros(512, dtype=np.float32),
+                "media_bytes": b"fake-b",
+                "filename": f"ds_b_{cid}.wav",
+                "category": "test",
+                "origin": {"importer": "test_b", "params": {"id": cid}},
+                "origin_name": f"ds_b_{cid}.wav",
+            }
+        register_context(ctx_b)
+        set_thread_dataset_context(ctx_b)
+
+        # Simulate the before_request hook firing for a request whose active
+        # dataset is now B.
+        ensure_votes_match_active_dataset()
+
+        assert a_good not in good_votes, (
+            "good cid from dataset A leaked into dataset B's id-space"
+        )
+        assert a_bad not in bad_votes, (
+            "bad cid from dataset A leaked into dataset B's id-space"
+        )
+
 
 class TestVoteSyncsToLoadedModel:
     """Voting while a detector is loaded should auto-update the model's labelset."""

--- a/vtsearch/models/detector_dataset_sync.py
+++ b/vtsearch/models/detector_dataset_sync.py
@@ -1,0 +1,96 @@
+"""Keep a loaded detector's cid-keyed vote state aligned with the active dataset.
+
+A ``DetectorContext``'s ``good_votes`` / ``bad_votes`` (and related per-vote
+state) are dicts keyed by integer media id — but media ids are only meaningful
+within a single dataset.  When the same detector is used across two datasets
+(e.g. trained on dataset A, then reused with dataset B), the in-memory cids
+from A leak into B's space, so unrelated B-medias whose ids happen to coincide
+with A's voted ids appear as voted in the labeling UI.  Worse, the next vote
+in B feeds those stale cids into ``sync_labels_to_loaded_detector``, which
+silently writes corrupt entries back to the on-disk labelset.
+
+The on-disk labelset is the canonical source of truth (dataset-agnostic — its
+elements are keyed by origin / md5).  This module re-derives the cid dicts
+from that labelset whenever the active dataset has changed.
+"""
+
+from __future__ import annotations
+
+
+def ensure_votes_match_active_dataset() -> None:
+    """Rehydrate the active detector's cid-keyed vote state against the active dataset.
+
+    No-op unless all of these hold:
+
+    * a detector is loaded,
+    * a dataset is loaded (and its id is non-empty),
+    * the detector has a registry entry that points at a real on-disk file
+      (so we have a labelset to rehydrate from), and
+    * the detector's recorded ``votes_dataset_id`` differs from the active
+      dataset id.
+
+    When triggered, clears the per-dataset detector state (good_votes,
+    bad_votes, label_history, vote_click_times, click_counter,
+    last_learned_scores, find_initial_labels, training_medias) and replays
+    ``restore_labels_from_detector`` against the active dataset's medias,
+    then stamps ``votes_dataset_id`` so subsequent requests within the same
+    dataset are no-ops.
+    """
+    from vtsearch.utils.state_core import (
+        _state_lock,
+        get_active_context,
+        get_active_detector_context,
+    )
+
+    det_ctx = get_active_detector_context()
+    if not det_ctx.detector_id:
+        return
+    ds_ctx = get_active_context()
+    if not ds_ctx.dataset_id:
+        # No active dataset; preserve whatever the detector last saw so a
+        # request that happens to omit the dataset header doesn't wipe state.
+        return
+    if det_ctx.votes_dataset_id == ds_ctx.dataset_id:
+        return
+
+    from vtsearch.models.detector_registry import get_detector
+    from vtsearch.models.detector_store import _detector_path, _read_detector
+    from vtsearch.models.label_restoration import restore_labels_from_detector
+
+    entry = get_detector(det_ctx.detector_id)
+    if not entry or not entry.get("name"):
+        # No registry entry (typical in unit tests that build DetectorContext
+        # directly); nothing to rehydrate from.
+        return
+
+    path = _detector_path(entry["name"])
+    data = _read_detector(path)
+    if data is None:
+        # Detector file missing — still mark the dataset transition so we
+        # don't keep stale cids around.
+        with _state_lock:
+            det_ctx.good_votes.clear()
+            det_ctx.bad_votes.clear()
+            det_ctx.label_history.clear()
+            det_ctx.vote_click_times.clear()
+            det_ctx.click_counter = 0
+            det_ctx.last_learned_scores.clear()
+            det_ctx.find_initial_labels.clear()
+            det_ctx.training_medias.clear()
+            det_ctx.votes_dataset_id = ds_ctx.dataset_id
+        return
+
+    with _state_lock:
+        # Re-check inside the lock — another request may have rehydrated us.
+        if det_ctx.votes_dataset_id == ds_ctx.dataset_id:
+            return
+        det_ctx.good_votes.clear()
+        det_ctx.bad_votes.clear()
+        det_ctx.label_history.clear()
+        det_ctx.vote_click_times.clear()
+        det_ctx.click_counter = 0
+        det_ctx.last_learned_scores.clear()
+        det_ctx.find_initial_labels.clear()
+        det_ctx.training_medias.clear()
+        restore_labels_from_detector(data)
+        det_ctx.votes_dataset_id = ds_ctx.dataset_id

--- a/vtsearch/routes/detectors_registry.py
+++ b/vtsearch/routes/detectors_registry.py
@@ -373,6 +373,11 @@ def load_detector_route():
                         on_progress=_embed_progress,
                     )
 
+            # Stamp the dataset whose medias the cid-keyed vote dicts were
+            # derived against, so before_request's rehydrate hook can detect
+            # subsequent dataset switches and re-derive against the new
+            # dataset's medias.
+            det_ctx.votes_dataset_id = _thread_ds_ctx.dataset_id
             add_loaded_detector_id(detector_id)
             tracker.update("idle", "", 0, 0, step=None, total_steps=None)
         except CancelledError:

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -134,6 +134,12 @@ class DetectorContext:
         # A stays trainable when the user switches to dataset B.
         "labelset_good_count",
         "labelset_bad_count",
+        # Dataset ID for which the cid-keyed vote state above is valid.
+        # Media IDs are only meaningful within a single dataset, so when the
+        # active dataset changes for a loaded detector we must clear the cid
+        # dicts and re-derive them from the on-disk labelset against the new
+        # dataset's medias.  See ``ensure_votes_match_active_dataset``.
+        "votes_dataset_id",
         # Sync source
         "labelset_source",  # dict | None — {"source_name": "...", "field_values": {...}}
     )
@@ -166,6 +172,7 @@ class DetectorContext:
         self.threshold: float = 0.5
         self.labelset_good_count: int = 0
         self.labelset_bad_count: int = 0
+        self.votes_dataset_id: str = ""
         # Sync source
         self.labelset_source: dict[str, Any] | None = None
 


### PR DESCRIPTION
## Summary

Fix a cross-dataset id collision that caused a loaded detector's vote dicts to display wrong items as voted in a newly-switched dataset, and to silently corrupt the on-disk labelset on the next vote.

### Repro

1. Load dataset A, train detector B (B's `good_votes` / `bad_votes` now hold A's media ids).
2. Click Train with dataset C + detector B.
3. Open the labeling UI: C's left panel already shows unrelated C-medias as good/bad — the integer ids that were voted in A happen to be valid C-ids.
4. Cast any vote in C: `sync_labels_to_loaded_detector` rebuilds the labelset from the polluted `good_votes`, treating those stale A-ids as C-medias and writing corrupt entries to disk.

### Cause

`DetectorContext.good_votes` (and the surrounding cid-keyed state — `bad_votes`, `label_history`, `vote_click_times`, `click_counter`, `last_learned_scores`, `find_initial_labels`, `training_medias`) are dicts keyed by integer media id, but media ids are only meaningful within a single dataset. The same `DetectorContext` is reused when a previously-loaded detector is opened with a different dataset, so cids from the old dataset's id-space leak into the new one.

### Fix

* Track `votes_dataset_id` on `DetectorContext` — the dataset whose medias the cid dicts were derived against.
* Stamp it after `restore_labels_from_detector` runs in the detector load task.
* Add `ensure_votes_match_active_dataset()` that, when the active dataset id differs from `votes_dataset_id`, clears the per-dataset cid state and re-runs `restore_labels_from_detector` against the new dataset's medias (the on-disk labelset, keyed by origin/md5, is the canonical source of truth).
* Call it from `before_request` so the dataset-switch is detected on the very first request after the user navigates from A to C — before any `/api/votes` poll, and before any vote can corrupt the labelset.

The hook is a no-op when the detector has no registry entry (so unit-test fixtures that build `DetectorContext` directly are unaffected) and when the active dataset id is empty (so requests that omit the dataset header don't wipe state).

## Test plan

- [x] Existing detector / multi-dataset / request-context tests still pass (213 in the focused subset, 2910 overall, 1 skipped).
- [x] New `test_dataset_switch_clears_cross_dataset_cids` reproduces the bug: votes A → register dataset B with different content reusing A's cids → switch to B → assert A's cids are gone from `good_votes` / `bad_votes`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M2PVU1U6M5RZJr5yPEUVge)_