### PR TITLE
Mark right-panel votes for media missing from current dataset

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -7,9 +7,11 @@
       <div
         class="vote-entry"
         [class.vote-entry-grid]="isGrid"
+        [class.vote-entry-missing]="isMissing(entry.id)"
+        [attr.title]="isMissing(entry.id) ? entry.name + ' — not in the current dataset' : null"
         role="button"
         tabindex="0"
-        [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name"
+        [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (isMissing(entry.id) ? ' (not in current dataset)' : '')"
         (click)="onEntryClick(entry.id)"
         (contextmenu)="onEntryContextMenu($event, entry.id)"
         (mouseenter)="onEntryMouseEnter(entry.id)"

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -81,6 +81,12 @@ h3 {
   }
 }
 
+.vote-entry-missing {
+  outline: 1px solid var(--missing-border);
+  outline-offset: -1px;
+  border-radius: 3px;
+}
+
 .vote-thumbnail {
   width: 28px;
   height: 28px;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -145,6 +145,10 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     return '\u25A1';
   }
 
+  isMissing(id: number): boolean {
+    return !this.mediaMap.has(id);
+  }
+
   onEntryClick(id: number): void {
     if (this.focusMode === 'hover') {
       this.mediaVote.emit({ id, vote: 'bad' });

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
@@ -7,9 +7,11 @@
       <div
         class="vote-entry"
         [class.vote-entry-grid]="isGrid"
+        [class.vote-entry-missing]="isMissing(entry)"
+        [attr.title]="isMissing(entry) ? entry.name + ' — not in the current dataset' : null"
         role="button"
         tabindex="0"
-        [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name"
+        [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (isMissing(entry) ? ' (not in current dataset)' : '')"
         (click)="onEntryClick(entry)"
         (contextmenu)="onEntryContextMenu($event, entry)"
         (mouseenter)="onEntryMouseEnter(entry)"

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -130,6 +130,10 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
     return '□';
   }
 
+  isMissing(entry: LabelElement): boolean {
+    return entry.cid === null || entry.cid === undefined;
+  }
+
   onEntryClick(entry: LabelElement): void {
     if (this.focusMode === 'hover') {
       this.elementVote.emit({ id: entry.id, vote: 'bad' });

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -69,6 +69,7 @@
   --bad-bg: rgba(244, 67, 54, 0.08);
   --accent-highlight-bg: rgba(124, 138, 255, 0.2);
   --accent-highlight-border: rgba(124, 138, 255, 0.5);
+  --missing-border: #3b82f6;
   --status-red-border: #c0392b;
   --status-red-dot: #e74c3c;
   --status-red-label: #e88;
@@ -140,6 +141,7 @@
   --bad-bg: rgba(211, 47, 47, 0.1);
   --accent-highlight-bg: rgba(90, 104, 216, 0.25);
   --accent-highlight-border: rgba(90, 104, 216, 0.6);
+  --missing-border: #2563eb;
   --status-red-border: #e57373;
   --status-red-dot: #e53935;
   --status-red-label: #c62828;
@@ -211,6 +213,7 @@
   --bad-bg: rgba(255, 0, 0, 0.12);
   --accent-highlight-bg: rgba(255, 255, 0, 0.2);
   --accent-highlight-border: rgba(255, 255, 0, 0.6);
+  --missing-border: #00bfff;
   --status-red-border: #ff0000;
   --status-red-dot: #ff3333;
   --status-red-label: #ff4444;


### PR DESCRIPTION
## Summary
- Right-panel vote entries whose media isn't loaded in the active dataset now get a thin blue border + a "not in the current dataset" tooltip, so users can tell at a glance which votes were carried over from a previous dataset/labelset versus ones cast against the current one.
- Applies to both the plain-votes list (when the id has no entry in `mediaMap`) and the labelset list (when a `LabelElement` has no resolved `cid`).
- Adds a `--missing-border` theme token (blue in dark/light, cyan in highviz for contrast against pure black) and a shared `.vote-entry-missing` SCSS modifier.

## Why
Previously these "ghost" votes rendered identically to live ones, but clicking them does nothing on the main panel, and (in plain-votes mode) the vote endpoint 404s because `get_media` doesn't find them. The visual cue makes that state discoverable instead of silently confusing.

## Test plan
- [x] `npm run build:prod` — clean, no warnings
- [ ] Manually verify in dark / light / highviz themes that the border reads as blue and doesn't shift layout (uses `outline` with `outline-offset: -1px`)
- [ ] Manually verify hover/focus styles still work on missing entries

https://claude.ai/code/session_01KCyEabjD7fUQQiTtquZnk2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCyEabjD7fUQQiTtquZnk2)_