### PR TITLE
Achievement system: Bronze/Silver/Gold/Platinum tiers across 5 categories

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ from vtsearch.auth import get_login_provider  # noqa: E402
 from vtsearch.medias import init_medias  # noqa: E402, F401 — used by tests via app_module.init_medias()
 from vtsearch.models import initialize_models, preload_autoload_media_types  # noqa: E402
 from vtsearch.routes import (  # noqa: E402
+    achievements_bp,
     auth_bp,
     detector_find_bp,
     detector_scoring_bp,
@@ -178,6 +179,7 @@ def _no_cache_api(response):
 # Register Blueprints
 # ---------------------------------------------------------------------------
 
+app.register_blueprint(achievements_bp)
 app.register_blueprint(auth_bp)
 app.register_blueprint(eval_bp)
 app.register_blueprint(file_browser_bp)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -80,4 +80,5 @@
   <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="onSettingsClosed()" />
 }
 <vt-dialog-host />
+<vt-achievement-unlock-host />
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
+import { AchievementUnlockHostComponent } from './components/achievement-unlock-host/achievement-unlock-host.component';
 import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
 import { LoginComponent } from './components/login/login.component';
 import { MediaStateService } from './services/media-state.service';
@@ -10,9 +11,10 @@ import { DatasetStateService } from './services/dataset-state.service';
 import { ActiveContextService } from './services/active-context.service';
 import { TopBarStateService } from './services/top-bar-state.service';
 import { AuthService } from './services/auth.service';
+import { AchievementsService } from './services/achievements.service';
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, RouterOutlet, DialogHostComponent, SettingsModalComponent, LoginComponent],
+  imports: [CommonModule, RouterOutlet, DialogHostComponent, AchievementUnlockHostComponent, SettingsModalComponent, LoginComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
@@ -33,8 +35,10 @@ export class AppComponent {
     private activeContext: ActiveContextService,
     public topBarState: TopBarStateService,
     public auth: AuthService,
+    private achievements: AchievementsService,
   ) {
     this.auth.checkStatus();
+    this.achievements.refresh();
     this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
       .subscribe((e) => {

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -4,11 +4,12 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { activeContextInterceptor } from './interceptors/active-context.interceptor';
+import { achievementsRefreshInterceptor } from './interceptors/achievements-refresh.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([activeContextInterceptor])),
+    provideHttpClient(withInterceptors([activeContextInterceptor, achievementsRefreshInterceptor])),
   ],
 };

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.html
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.html
@@ -1,0 +1,48 @@
+<div
+  class="achievement-badge"
+  [ngClass]="tierClass"
+  [style.width.px]="size"
+  [style.height.px]="size"
+  [attr.aria-label]="iconType + ' badge'">
+  @if (showOuterRing || tierIdx === -1) {
+    <svg
+      class="achievement-decoration"
+      [attr.width]="size"
+      [attr.height]="size"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true">
+      @if (tierIdx === -1) {
+        <circle cx="50" cy="50" r="46" stroke-width="3" stroke-dasharray="4 4" />
+      }
+      @if (showOuterRing) {
+        <circle cx="50" cy="50" r="46" stroke-width="3.5" />
+      }
+      @if (showDoubleRing) {
+        <circle cx="50" cy="50" r="40" stroke-width="2" />
+      }
+      @if (showLaurel) {
+        <path d="M14 56 q-4 14 8 30 q4 4 10 4" stroke-width="3" />
+        <path d="M18 60 q4 0 7 -2" stroke-width="2.5" />
+        <path d="M16 70 q5 0 9 -3" stroke-width="2.5" />
+        <path d="M18 80 q5 0 10 -4" stroke-width="2.5" />
+        <path d="M86 56 q4 14 -8 30 q-4 4 -10 4" stroke-width="3" />
+        <path d="M82 60 q-4 0 -7 -2" stroke-width="2.5" />
+        <path d="M84 70 q-5 0 -9 -3" stroke-width="2.5" />
+        <path d="M82 80 q-5 0 -10 -4" stroke-width="2.5" />
+      }
+      @if (showSparkles) {
+        <path d="M16 16 l3 6 l6 3 l-6 3 l-3 6 l-3 -6 l-6 -3 l6 -3 z" fill="currentColor" stroke-width="0" />
+        <path d="M84 16 l2 4 l4 2 l-4 2 l-2 4 l-2 -4 l-4 -2 l4 -2 z" fill="currentColor" stroke-width="0" />
+        <path d="M50 6 l1.5 3 l3 1.5 l-3 1.5 l-1.5 3 l-1.5 -3 l-3 -1.5 l3 -1.5 z" fill="currentColor" stroke-width="0" />
+      }
+    </svg>
+  }
+  <span class="achievement-symbol">
+    <vt-icon [type]="iconType" [size]="innerIconSize"></vt-icon>
+  </span>
+</div>

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
@@ -1,0 +1,44 @@
+.achievement-badge {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  line-height: 0;
+}
+
+.achievement-decoration {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.achievement-symbol {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// Color themes — currentColor is consumed by both the ring SVG and the inner icon.
+.tier-bronze {
+  color: #cd7f32;
+}
+
+.tier-silver {
+  color: #d9d9d9;
+}
+
+.tier-gold {
+  color: #f0c419;
+}
+
+.tier-platinum {
+  color: #f5f6fa;
+  filter: drop-shadow(0 0 4px rgba(245, 246, 250, 0.45));
+}
+
+.tier-locked {
+  color: var(--text-muted, #666);
+  opacity: 0.55;
+}

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IconComponent } from '../icon/icon.component';
+
+/**
+ * Renders an achievement icon with a tier-specific decoration layer:
+ * - Bronze (0): single circle, brown.
+ * - Silver (1): double circle, light-gray.
+ * - Gold (2): single circle + laurel branches, gold.
+ * - Platinum (3): single circle + sparkle accents, white.
+ * - Locked (-1): silhouette icon, dim.
+ *
+ * The base symbol comes from the existing vt-icon set via *iconType*.
+ */
+@Component({
+  selector: 'vt-achievement-badge',
+  standalone: true,
+  imports: [CommonModule, IconComponent],
+  templateUrl: './achievement-badge.component.html',
+  styleUrl: './achievement-badge.component.scss',
+})
+export class AchievementBadgeComponent {
+  @Input() iconType = 'trophy';
+  @Input() tierIdx = -1;
+  /** Outer badge size in pixels (the inner icon is auto-scaled). */
+  @Input() size = 56;
+
+  get tierClass(): string {
+    switch (this.tierIdx) {
+      case 0:
+        return 'tier-bronze';
+      case 1:
+        return 'tier-silver';
+      case 2:
+        return 'tier-gold';
+      case 3:
+        return 'tier-platinum';
+      default:
+        return 'tier-locked';
+    }
+  }
+
+  get innerIconSize(): number {
+    return Math.max(12, Math.round(this.size * 0.55));
+  }
+
+  get showOuterRing(): boolean {
+    return this.tierIdx >= 0;
+  }
+
+  get showDoubleRing(): boolean {
+    return this.tierIdx >= 1;
+  }
+
+  get showLaurel(): boolean {
+    return this.tierIdx >= 2;
+  }
+
+  get showSparkles(): boolean {
+    return this.tierIdx >= 3;
+  }
+}

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.html
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.html
@@ -1,0 +1,20 @@
+<vt-modal [open]="open" [showCloseButton]="false" (closed)="acknowledge()">
+  @if (current) {
+    <div class="unlock-body">
+      <vt-achievement-badge
+        [iconType]="current.icon"
+        [tierIdx]="current.tier_idx"
+        [size]="96">
+      </vt-achievement-badge>
+      <div class="unlock-text">
+        <h3 class="unlock-title">{{ current.tier_name }}: {{ current.name }}</h3>
+        <p class="unlock-message">
+          Milestone reached: {{ current.threshold | number }}.
+        </p>
+      </div>
+    </div>
+    <div modal-footer>
+      <button class="btn btn--primary" (click)="acknowledge()">Nice</button>
+    </div>
+  }
+</vt-modal>

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.scss
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.scss
@@ -1,0 +1,24 @@
+.unlock-body {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.5rem 0 1rem;
+}
+
+.unlock-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.unlock-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.unlock-message {
+  margin: 0;
+  color: var(--text-muted, #888);
+  font-size: 0.9rem;
+}

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ModalComponent } from '../modal/modal.component';
+import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
+import {
+  AchievementsService,
+  PendingAnnouncement,
+} from '../../services/achievements.service';
+
+/**
+ * Global host that listens to `AchievementsService.unlocks` and pops a
+ * VtModal for each one — same shell as the "Are you sure?" dialog, but
+ * branded with the tier-decorated badge for the unlocked tier.  Multiple
+ * unlocks queue and play back one at a time.
+ */
+@Component({
+  selector: 'vt-achievement-unlock-host',
+  standalone: true,
+  imports: [CommonModule, ModalComponent, AchievementBadgeComponent],
+  templateUrl: './achievement-unlock-host.component.html',
+  styleUrl: './achievement-unlock-host.component.scss',
+})
+export class AchievementUnlockHostComponent implements OnInit, OnDestroy {
+  current: PendingAnnouncement | null = null;
+  private queue: PendingAnnouncement[] = [];
+  private destroy$ = new Subject<void>();
+
+  constructor(private achievements: AchievementsService) {}
+
+  ngOnInit(): void {
+    this.achievements.unlocks
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((unlock) => this.enqueue(unlock));
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  get open(): boolean {
+    return this.current !== null;
+  }
+
+  acknowledge(): void {
+    if (this.current === null) return;
+    const { id, tier_idx } = this.current;
+    this.achievements.acknowledge(id, tier_idx);
+    this.current = null;
+    this.popNext();
+  }
+
+  private enqueue(unlock: PendingAnnouncement): void {
+    const key = (p: PendingAnnouncement) => `${p.id}:${p.tier_idx}`;
+    if (this.current && key(this.current) === key(unlock)) return;
+    if (this.queue.some((p) => key(p) === key(unlock))) return;
+    this.queue.push(unlock);
+    if (this.current === null) {
+      this.popNext();
+    }
+  }
+
+  private popNext(): void {
+    this.current = this.queue.shift() ?? null;
+  }
+}

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -1,0 +1,33 @@
+<h3>Achievements</h3>
+<p class="achievements-intro">
+  Milestones tracked as you use VTSearch. Counters live in your settings —
+  if you have a settings source configured they round-trip between sessions.
+</p>
+@if (loading) {
+  <p class="empty-state">Loading achievements…</p>
+} @else {
+  <ul class="achievements-list">
+    @for (row of rows; track row.id) {
+      <li class="achievement-row" [class.achievement-row--locked]="row.tier_idx === -1">
+        <vt-achievement-badge
+          [iconType]="row.icon"
+          [tierIdx]="row.tier_idx"
+          [size]="64">
+        </vt-achievement-badge>
+        <div class="achievement-info">
+          <div class="achievement-head">
+            <span class="achievement-name">{{ row.name }}</span>
+            <span class="achievement-tier" [attr.data-tier-idx]="row.tier_idx">{{ row.tierName }}</span>
+          </div>
+          <p class="achievement-desc">{{ row.description }}</p>
+          <div class="achievement-progress" [title]="row.progressLabel">
+            <div class="achievement-progress-track">
+              <div class="achievement-progress-fill" [style.width.%]="row.progressPct"></div>
+            </div>
+            <span class="achievement-progress-label">{{ row.progressLabel }}</span>
+          </div>
+        </div>
+      </li>
+    }
+  </ul>
+}

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -1,0 +1,92 @@
+.achievements-intro {
+  margin: 0 0 1rem;
+  color: var(--text-muted, #888);
+  font-size: 0.9rem;
+}
+
+.achievements-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.achievement-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: var(--surface-alt, rgba(255, 255, 255, 0.04));
+  border-radius: 6px;
+}
+
+.achievement-row--locked {
+  opacity: 0.75;
+}
+
+.achievement-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.achievement-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.15rem;
+}
+
+.achievement-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.achievement-tier {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  background: var(--surface, rgba(255, 255, 255, 0.08));
+  color: var(--text-muted, #888);
+
+  &[data-tier-idx="0"] { color: #cd7f32; }
+  &[data-tier-idx="1"] { color: #d9d9d9; }
+  &[data-tier-idx="2"] { color: #f0c419; }
+  &[data-tier-idx="3"] { color: #f5f6fa; }
+}
+
+.achievement-desc {
+  margin: 0 0 0.35rem;
+  font-size: 0.83rem;
+  color: var(--text-muted, #888);
+}
+
+.achievement-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.achievement-progress-track {
+  flex: 1;
+  height: 6px;
+  background: var(--surface, rgba(255, 255, 255, 0.08));
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.achievement-progress-fill {
+  height: 100%;
+  background: var(--accent, #4aa3ff);
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.achievement-progress-label {
+  font-size: 0.78rem;
+  color: var(--text-muted, #888);
+  white-space: nowrap;
+}

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -1,0 +1,76 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
+import { IconComponent } from '../icon/icon.component';
+import {
+  AchievementInfo,
+  AchievementsService,
+  AchievementsState,
+} from '../../services/achievements.service';
+
+const TIER_NAMES = ['Bronze', 'Silver', 'Gold', 'Platinum'];
+
+interface AchievementRow extends AchievementInfo {
+  tierName: string;
+  prevThreshold: number;
+  progressPct: number;
+  progressLabel: string;
+}
+
+@Component({
+  selector: 'vt-achievements-tab',
+  standalone: true,
+  imports: [CommonModule, AchievementBadgeComponent, IconComponent],
+  templateUrl: './achievements-tab.component.html',
+  styleUrl: './achievements-tab.component.scss',
+})
+export class AchievementsTabComponent implements OnInit, OnDestroy {
+  rows: AchievementRow[] = [];
+  loading = true;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private achievements: AchievementsService) {}
+
+  ngOnInit(): void {
+    this.achievements.state
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((state) => this.applyState(state));
+    this.achievements.refresh();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private applyState(state: AchievementsState): void {
+    this.rows = state.achievements.map((a) => this.toRow(a));
+    this.loading = state.achievements.length === 0;
+  }
+
+  private toRow(a: AchievementInfo): AchievementRow {
+    const tierName = a.tier_idx >= 0 ? TIER_NAMES[a.tier_idx] : 'Locked';
+    const prevThreshold = a.tier_idx >= 0 ? a.tiers[a.tier_idx] : 0;
+    let progressPct = 100;
+    let progressLabel = '';
+    if (a.next_threshold !== null) {
+      const span = Math.max(1, a.next_threshold - prevThreshold);
+      const filled = Math.max(0, a.counter - prevThreshold);
+      progressPct = Math.min(100, Math.round((filled / span) * 100));
+      const nextTierName = TIER_NAMES[a.tier_idx + 1] ?? 'Next';
+      progressLabel = `${a.counter.toLocaleString()} / ${a.next_threshold.toLocaleString()} → ${nextTierName}`;
+    } else {
+      progressLabel = `${a.counter.toLocaleString()} — maxed out`;
+    }
+    return {
+      ...a,
+      tierName,
+      prevThreshold,
+      progressPct,
+      progressLabel,
+    };
+  }
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -12,6 +12,7 @@ import { DatasetStateService } from '../../services/dataset-state.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
+import { AchievementsService } from '../../services/achievements.service';
 import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, LoadingTasksResponse, DetectorRegistryEntry } from '../../models/api.models';
 import { formatProgressFraction } from '../../utils/format-progress';
 import { ColMeta, ManagedColumns } from '../../utils/managed-columns';
@@ -190,6 +191,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private activeContext: ActiveContextService,
     private authService: AuthService,
     private topBarState: TopBarStateService,
+    private achievements: AchievementsService,
   ) {}
 
   ngOnInit(): void {
@@ -996,6 +998,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           }
           if (justFinished.length > 0) {
             this.datasetState.refresh();
+            this.achievements.refresh();
           }
 
           // Also set the top-level error banner for failed tasks
@@ -1054,6 +1057,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           }
           if (justFinished.length > 0) {
             this.datasetState.refresh();
+            this.achievements.refresh();
           }
 
           for (const t of failed) {

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -14,7 +14,8 @@ const KNOWN_TYPES = new Set([
   'list', 'grid', 'cursor-click', 'cursor-hover',
   'palette', 'sort-descending', 'steering-wheel', 'cloud-upload',
   'thumbs-up', 'thumbs-down', 'factory',
-  'house', 'lightning', 'flask', 'cubes',
+  'house', 'lightning', 'flask', 'cubes', 'database',
+  'checkbox-checked', 'search', 'trophy',
 ]);
 
 function emojiToType(icon: string): string {
@@ -178,6 +179,15 @@ function emojiToType(icon: string): string {
       }
       @case ('cubes') {
         <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h18v18H2z"/><path d="M2 4l2-2h18v18l-2 2"/><path d="M20 4l2-2"/><path d="M11 4v18M2 13h18"/><path d="M11 4l2-2"/><path d="M20 13l2-2"/></svg>
+      }
+      @case ('checkbox-checked') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3" ry="3"/><polyline points="8 12 11 15 16 9"/></svg>
+      }
+      @case ('search') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/></svg>
+      }
+      @case ('trophy') {
+        <svg xmlns="http://www.w3.org/2000/svg" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4h12v4a6 6 0 0 1-12 0z"/><path d="M6 6H3a2 2 0 0 0 0 4h3"/><path d="M18 6h3a2 2 0 0 1 0 4h-3"/><line x1="10" y1="14" x2="10" y2="18"/><line x1="14" y1="14" x2="14" y2="18"/><rect x="7" y="18" width="10" height="3" rx="1"/></svg>
       }
     } }
   `,

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -36,6 +36,14 @@
           <vt-icon type="sort-descending" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'sorting'"></vt-icon>
           Sorting
         </button>
+        <button
+          class="settings-tab"
+          [class.settings-tab--active]="activeSettingsTab === 'achievements'"
+          (click)="activeSettingsTab = 'achievements'"
+          title="See your usage milestones and current Bronze/Silver/Gold/Platinum tiers">
+          <vt-icon type="trophy" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'achievements'"></vt-icon>
+          Achievements
+        </button>
       </nav>
 
       <div class="settings-panel">
@@ -213,6 +221,11 @@
           } @else {
             <p class="empty-state">No embedders available.</p>
           }
+        }
+
+        <!-- Achievements -->
+        @if (activeSettingsTab === 'achievements') {
+          <vt-achievements-tab />
         }
       </div>
     </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -7,6 +7,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsImporterModalComponent } from '../settings-importer-modal/settings-importer-modal.component';
 import { SettingsExporterModalComponent } from '../settings-exporter-modal/settings-exporter-modal.component';
+import { AchievementsTabComponent } from '../../achievements-tab/achievements-tab.component';
 import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
@@ -16,7 +17,7 @@ import { Theme, ThemeService } from '../../../services/theme.service';
 @Component({
   selector: 'vt-settings-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, AchievementsTabComponent],
   templateUrl: './settings-modal.component.html',
   styleUrl: './settings-modal.component.scss',
 })

--- a/frontend/src/app/interceptors/achievements-refresh.interceptor.ts
+++ b/frontend/src/app/interceptors/achievements-refresh.interceptor.ts
@@ -1,0 +1,48 @@
+import { HttpInterceptorFn, HttpResponse } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { tap } from 'rxjs/operators';
+import { AchievementsService } from '../services/achievements.service';
+
+/**
+ * After any action endpoint that could unlock an achievement, schedule a
+ * refresh of the AchievementsService.  The refresh itself coalesces
+ * concurrent calls so bursts of votes don't fan out to N requests.
+ *
+ * Endpoints watched:
+ * - POST /api/medias/:id/vote                 (votes_cast, detectors_trained)
+ * - POST /api/detectors/:name/labels/:id/vote (votes_cast, detectors_trained)
+ * - POST /api/find-label                      (find_media)
+ * - POST /api/auto-detect                     (find_media)
+ * - POST /api/label-importers/import/:name    (detectors_imported)
+ * - POST /api/datasets/registry/:id/load      (datasets_loaded — fires when the load completes)
+ */
+const WATCHED_PATTERNS: RegExp[] = [
+  /^\/api\/medias\/[^/]+\/vote$/,
+  /^\/api\/detectors\/[^/]+\/labels\/[^/]+\/vote$/,
+  /^\/api\/find-label$/,
+  /^\/api\/auto-detect$/,
+  /^\/api\/label-importers\/import\/[^/]+$/,
+  /^\/api\/datasets\/registry\/[^/]+\/load$/,
+];
+
+export const achievementsRefreshInterceptor: HttpInterceptorFn = (req, next) => {
+  if (req.method !== 'POST') {
+    return next(req);
+  }
+  const path = req.url.split('?')[0];
+  const watch = WATCHED_PATTERNS.some((re) => re.test(path));
+  if (!watch) {
+    return next(req);
+  }
+
+  const achievements = inject(AchievementsService);
+  return next(req).pipe(
+    tap({
+      next: (event) => {
+        if (event instanceof HttpResponse && event.status >= 200 && event.status < 300) {
+          achievements.refresh();
+        }
+      },
+    }),
+  );
+};

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+export interface AchievementInfo {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  tiers: number[];
+  counter: number;
+  tier_idx: number;
+  next_threshold: number | null;
+}
+
+export interface PendingAnnouncement {
+  id: string;
+  name: string;
+  icon: string;
+  tier_idx: number;
+  tier_name: string;
+  threshold: number;
+}
+
+export interface AchievementsState {
+  tier_names: string[];
+  achievements: AchievementInfo[];
+  pending_announcements: PendingAnnouncement[];
+}
+
+const EMPTY_STATE: AchievementsState = {
+  tier_names: [],
+  achievements: [],
+  pending_announcements: [],
+};
+
+/**
+ * AchievementsService — polls /api/achievements, exposes the current state
+ * as an observable, and queues unlock notifications one at a time so the
+ * consumer (a global host component) can render dialogs sequentially.
+ *
+ * Trigger `refresh()` after any action that might unlock a tier (vote,
+ * find, dataset load complete, label import).  Acknowledged announcements
+ * are persisted server-side so they don't replay on reload.
+ */
+@Injectable({ providedIn: 'root' })
+export class AchievementsService {
+  private readonly state$ = new BehaviorSubject<AchievementsState>(EMPTY_STATE);
+  private readonly unlock$ = new Subject<PendingAnnouncement>();
+  private inFlight = false;
+
+  constructor(private http: HttpClient) {}
+
+  /** Stream of state snapshots for UI binding. */
+  get state(): Observable<AchievementsState> {
+    return this.state$.asObservable();
+  }
+
+  /** Stream of unlocks to display one at a time. */
+  get unlocks(): Observable<PendingAnnouncement> {
+    return this.unlock$.asObservable();
+  }
+
+  get snapshot(): AchievementsState {
+    return this.state$.value;
+  }
+
+  /**
+   * Fetch latest state and emit any new unlocks.  Coalesces concurrent
+   * calls so a tight burst of actions doesn't fire N requests.
+   */
+  refresh(): void {
+    if (this.inFlight) return;
+    this.inFlight = true;
+    this.http
+      .get<AchievementsState>('/api/achievements')
+      .pipe(catchError(() => of(EMPTY_STATE)))
+      .subscribe((next) => {
+        this.inFlight = false;
+        this.state$.next(next);
+        for (const p of next.pending_announcements) {
+          this.unlock$.next(p);
+        }
+      });
+  }
+
+  /**
+   * Acknowledge an unlock so it isn't shown again on the next refresh.
+   * Refreshes state afterward to update the panel display.
+   */
+  acknowledge(categoryId: string, tierIdx: number): void {
+    this.http
+      .post(`/api/achievements/${encodeURIComponent(categoryId)}/acknowledge`, {
+        tier_idx: tierIdx,
+      })
+      .pipe(catchError(() => of(null)))
+      .subscribe(() => this.refresh());
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ _TEST_GROUPS = {
         "test_settings_directories",
         "test_frontend",
         "test_resize_handle_centering",
+        "test_achievements",
     ],
     "api": [
         "test_api_contracts",

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -1,0 +1,311 @@
+"""Tests for the Achievement system.
+
+Covers:
+- record_* helpers (vote, dataset load, detector import, find)
+- counter → tier index mapping
+- pending_announcements computation
+- acknowledge tracking
+- importer exclusion for datasets_loaded
+- /api/achievements and /api/achievements/<id>/acknowledge routes
+"""
+
+from __future__ import annotations
+
+import json
+
+import app as app_module  # noqa: F401 — triggers conftest media init
+from vtsearch import achievements
+from vtsearch import settings as settings_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _by_id(state: dict, category: str) -> dict:
+    for a in state["achievements"]:
+        if a["id"] == category:
+            return a
+    raise KeyError(category)
+
+
+def _pending_for(state: dict, category: str) -> list[dict]:
+    return [p for p in state["pending_announcements"] if p["id"] == category]
+
+
+# ---------------------------------------------------------------------------
+# Empty / defaults
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyState:
+    def test_empty_state_when_no_history(self):
+        state = achievements.get_full_state()
+        assert state["tier_names"] == ["Bronze", "Silver", "Gold", "Platinum"]
+        assert state["pending_announcements"] == []
+        assert len(state["achievements"]) == 5
+        for a in state["achievements"]:
+            assert a["counter"] == 0
+            assert a["tier_idx"] == -1
+            assert a["next_threshold"] == a["tiers"][0]
+
+    def test_known_categories_present(self):
+        ids = {a["id"] for a in achievements.get_full_state()["achievements"]}
+        assert ids == {
+            "datasets_loaded",
+            "votes_cast",
+            "detectors_trained",
+            "detectors_imported",
+            "find_media",
+        }
+
+
+# ---------------------------------------------------------------------------
+# record_vote
+# ---------------------------------------------------------------------------
+
+
+class TestRecordVote:
+    def test_vote_increments_votes_cast(self):
+        for _ in range(3):
+            achievements.record_vote("det-1")
+        state = achievements.get_full_state()
+        votes = _by_id(state, "votes_cast")
+        assert votes["counter"] == 3
+        assert votes["tier_idx"] == -1  # 3 < 100
+
+    def test_first_vote_credits_detector_trained(self):
+        achievements.record_vote("det-1")
+        state = achievements.get_full_state()
+        assert _by_id(state, "detectors_trained")["counter"] == 1
+
+    def test_subsequent_votes_same_detector_dont_double_count(self):
+        for _ in range(5):
+            achievements.record_vote("det-1")
+        state = achievements.get_full_state()
+        assert _by_id(state, "detectors_trained")["counter"] == 1
+        assert _by_id(state, "votes_cast")["counter"] == 5
+
+    def test_distinct_detectors_each_count_once(self):
+        for did in ("a", "b", "c"):
+            for _ in range(2):
+                achievements.record_vote(did)
+        state = achievements.get_full_state()
+        assert _by_id(state, "detectors_trained")["counter"] == 3
+        assert _by_id(state, "votes_cast")["counter"] == 6
+
+    def test_empty_detector_id_does_not_credit(self):
+        achievements.record_vote("")
+        state = achievements.get_full_state()
+        assert _by_id(state, "votes_cast")["counter"] == 1
+        assert _by_id(state, "detectors_trained")["counter"] == 0
+
+
+# ---------------------------------------------------------------------------
+# record_dataset_load
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDatasetLoad:
+    def test_real_importer_counts(self):
+        achievements.record_dataset_load("server_folder")
+        state = achievements.get_full_state()
+        ds = _by_id(state, "datasets_loaded")
+        assert ds["counter"] == 1
+        assert ds["tier_idx"] == 0  # Bronze threshold is 1
+
+    def test_demo_does_not_count(self):
+        achievements.record_dataset_load("demo")
+        assert _by_id(achievements.get_full_state(), "datasets_loaded")["counter"] == 0
+
+    def test_synthetic_does_not_count(self):
+        achievements.record_dataset_load("synthetic")
+        assert _by_id(achievements.get_full_state(), "datasets_loaded")["counter"] == 0
+
+    def test_mixed_runs(self):
+        for name in ["server_folder", "demo", "pickle", "synthetic", "http_archive", "server_files"]:
+            achievements.record_dataset_load(name)
+        # server_folder + pickle + http_archive + server_files = 4
+        assert _by_id(achievements.get_full_state(), "datasets_loaded")["counter"] == 4
+
+
+# ---------------------------------------------------------------------------
+# record_detector_import / record_find
+# ---------------------------------------------------------------------------
+
+
+class TestImportAndFind:
+    def test_import_dedupes_by_detector_id(self):
+        for _ in range(3):
+            achievements.record_detector_import("det-X")
+        assert _by_id(achievements.get_full_state(), "detectors_imported")["counter"] == 1
+
+    def test_import_distinct_detectors_count_separately(self):
+        for did in ("a", "b", "c"):
+            achievements.record_detector_import(did)
+        assert _by_id(achievements.get_full_state(), "detectors_imported")["counter"] == 3
+
+    def test_import_empty_id_is_noop(self):
+        achievements.record_detector_import("")
+        assert _by_id(achievements.get_full_state(), "detectors_imported")["counter"] == 0
+
+    def test_find_accumulates(self):
+        achievements.record_find(50)
+        achievements.record_find(150)
+        assert _by_id(achievements.get_full_state(), "find_media")["counter"] == 200
+
+    def test_find_zero_or_negative_is_noop(self):
+        achievements.record_find(0)
+        achievements.record_find(-5)
+        assert _by_id(achievements.get_full_state(), "find_media")["counter"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier progression and announcements
+# ---------------------------------------------------------------------------
+
+
+class TestTiers:
+    def test_bronze_at_first_threshold(self):
+        # votes_cast: Bronze=100
+        for _ in range(100):
+            achievements.record_vote("d")
+        state = achievements.get_full_state()
+        votes = _by_id(state, "votes_cast")
+        assert votes["tier_idx"] == 0
+        assert votes["next_threshold"] == 1000
+
+    def test_pending_announcements_for_unannounced_tiers(self):
+        achievements.record_dataset_load("server_folder")  # Bronze
+        state = achievements.get_full_state()
+        pending = _pending_for(state, "datasets_loaded")
+        assert len(pending) == 1
+        assert pending[0]["tier_idx"] == 0
+        assert pending[0]["tier_name"] == "Bronze"
+        assert pending[0]["threshold"] == 1
+
+    def test_acknowledge_clears_pending(self):
+        achievements.record_dataset_load("server_folder")
+        achievements.acknowledge("datasets_loaded", 0)
+        state = achievements.get_full_state()
+        assert _pending_for(state, "datasets_loaded") == []
+
+    def test_acknowledge_lower_tier_is_noop(self):
+        achievements.record_dataset_load("server_folder")
+        achievements.acknowledge("datasets_loaded", 0)
+        # Acknowledging the same tier again should not change anything.
+        assert achievements.acknowledge("datasets_loaded", 0) is False
+
+    def test_jumping_multiple_tiers_pends_each(self):
+        # find_media: 200 / 2000 / 20000 / 200000
+        achievements.record_find(2500)  # Bronze + Silver in one go
+        state = achievements.get_full_state()
+        pending = _pending_for(state, "find_media")
+        assert [p["tier_idx"] for p in pending] == [0, 1]
+
+    def test_invalid_category_acknowledge_returns_false(self):
+        assert achievements.acknowledge("not_a_real_category", 0) is False
+
+    def test_invalid_tier_idx_acknowledge_returns_false(self):
+        assert achievements.acknowledge("datasets_loaded", 99) is False
+        assert achievements.acknowledge("datasets_loaded", -1) is False
+
+
+# ---------------------------------------------------------------------------
+# Persistence in settings.json
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_state_round_trips_via_settings(self, isolated_settings):
+        achievements.record_vote("det-1")
+        achievements.record_find(50)
+        raw = json.loads(isolated_settings.read_text())
+        state = raw["achievement_state"]
+        assert state["counters"]["votes_cast"] == 1
+        assert state["counters"]["detectors_trained"] == 1
+        assert state["counters"]["find_media"] == 50
+        assert state["trained_detector_ids"] == ["det-1"]
+
+    def test_load_reads_existing_state(self, isolated_settings):
+        # Write directly and reload.
+        isolated_settings.write_text(
+            json.dumps(
+                {
+                    "achievement_state": {
+                        "counters": {"votes_cast": 500},
+                        "announced": {"votes_cast": 0},
+                        "trained_detector_ids": [],
+                        "imported_detector_ids": [],
+                    }
+                }
+            )
+        )
+        settings_mod.reset()
+        state = achievements.get_full_state()
+        votes = _by_id(state, "votes_cast")
+        assert votes["counter"] == 500
+        # Bronze already announced — no pending for tier 0.
+        pending = _pending_for(state, "votes_cast")
+        assert [p["tier_idx"] for p in pending] == []
+
+
+# ---------------------------------------------------------------------------
+# Flask API routes
+# ---------------------------------------------------------------------------
+
+
+class TestAchievementsApi:
+    def test_get_endpoint_returns_state(self, client):
+        achievements.record_vote("d")
+        resp = client.get("/api/achievements")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tier_names"] == ["Bronze", "Silver", "Gold", "Platinum"]
+        ids = {a["id"] for a in body["achievements"]}
+        assert "votes_cast" in ids
+
+    def test_acknowledge_endpoint(self, client):
+        achievements.record_dataset_load("server_folder")
+        resp = client.post(
+            "/api/achievements/datasets_loaded/acknowledge",
+            json={"tier_idx": 0},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["changed"] is True
+
+        # Second call returns changed=False.
+        resp = client.post(
+            "/api/achievements/datasets_loaded/acknowledge",
+            json={"tier_idx": 0},
+        )
+        assert resp.get_json()["changed"] is False
+
+    def test_acknowledge_requires_tier_idx(self, client):
+        resp = client.post("/api/achievements/votes_cast/acknowledge", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Integration hooks via real action endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestActionHooks:
+    def test_vote_endpoint_increments_counter(self, client):
+        # Find any media id from the test fixture.
+        listing = client.get("/api/medias").get_json()
+        media_id = listing[0]["id"]
+        resp = client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})
+        assert resp.status_code == 200
+        state = achievements.get_full_state()
+        assert _by_id(state, "votes_cast")["counter"] == 1
+
+    def test_unvote_does_not_decrement(self, client):
+        listing = client.get("/api/medias").get_json()
+        media_id = listing[0]["id"]
+        client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})
+        client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})  # toggle off
+        # Counter should be 1: only the add counts, not the remove.
+        assert _by_id(achievements.get_full_state(), "votes_cast")["counter"] == 1

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -1,0 +1,266 @@
+"""Achievement system: persistent per-user milestone tracking.
+
+State lives inside ``data/settings.json`` under the ``achievement_state`` key,
+so it round-trips through the settings sync source like every other setting.
+
+Categories and their tier thresholds are declared statically in
+:data:`ACHIEVEMENTS`.  Counters are incremented from hook points across the
+codebase (vote toggle, dataset load completion, label import, find).  The UI
+polls :func:`get_full_state` to render the Achievements tab and to discover
+newly-unlocked tiers (``pending_announcements``); the client ACKs each
+announcement via :func:`acknowledge` so the popup doesn't fire on refresh.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from vtsearch.settings import _ensure_loaded, _save, _settings_lock
+
+logger = logging.getLogger(__name__)
+
+#: Tier display names, indexed 0..3.
+TIER_NAMES: tuple[str, ...] = ("Bronze", "Silver", "Gold", "Platinum")
+
+#: Achievement category definitions.  Each tier list MUST be ascending and
+#: aligned with :data:`TIER_NAMES`.
+ACHIEVEMENTS: list[dict[str, Any]] = [
+    {
+        "id": "datasets_loaded",
+        "name": "Datasets Loaded",
+        "description": "Load datasets you imported. Demos and synthetic don't count.",
+        "icon": "cubes",
+        "tiers": [1, 10, 100, 1000],
+    },
+    {
+        "id": "votes_cast",
+        "name": "Votes Cast",
+        "description": "Every Good or Bad you cast on a media item.",
+        "icon": "checkbox-checked",
+        "tiers": [100, 1000, 10000, 100000],
+    },
+    {
+        "id": "detectors_trained",
+        "name": "Detectors Trained",
+        "description": "Each detector you trained — counted on its first vote.",
+        "icon": "graduation",
+        "tiers": [2, 20, 200, 2000],
+    },
+    {
+        "id": "detectors_imported",
+        "name": "Detectors Imported",
+        "description": "Detectors built up from imported labels.",
+        "icon": "robot",
+        "tiers": [1, 10, 100, 1000],
+    },
+    {
+        "id": "find_media",
+        "name": "Find Media",
+        "description": "Media items scored by Find (GUI and CLI combined).",
+        "icon": "search",
+        "tiers": [200, 2000, 20000, 200000],
+    },
+]
+
+_ACH_BY_ID: dict[str, dict[str, Any]] = {a["id"]: a for a in ACHIEVEMENTS}
+
+#: Importer names whose successful dataset loads do NOT count toward
+#: ``datasets_loaded``.  These are the demo/synthetic data paths users
+#: don't have ownership over.
+EXCLUDED_DATASET_IMPORTERS: frozenset[str] = frozenset({"demo", "synthetic"})
+
+
+def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return the mutable ``achievement_state`` sub-dict inside *settings*.
+
+    Initializes missing keys in place so callers don't have to.  Must be
+    called while holding ``_settings_lock``.
+    """
+    state = settings.get("achievement_state")
+    if not isinstance(state, dict):
+        state = {}
+        settings["achievement_state"] = state
+    counters = state.setdefault("counters", {})
+    announced = state.setdefault("announced", {})
+    state.setdefault("trained_detector_ids", [])
+    state.setdefault("imported_detector_ids", [])
+    for a in ACHIEVEMENTS:
+        cid = a["id"]
+        if cid not in counters or not isinstance(counters[cid], int):
+            counters[cid] = 0
+        if cid not in announced or not isinstance(announced[cid], int):
+            announced[cid] = -1
+    return state
+
+
+def _current_tier_idx(category_id: str, counter: int) -> int:
+    """Highest tier index (0..3) reached by *counter*, or -1 for none."""
+    tiers = _ACH_BY_ID[category_id]["tiers"]
+    idx = -1
+    for i, threshold in enumerate(tiers):
+        if counter >= threshold:
+            idx = i
+    return idx
+
+
+# ---------------------------------------------------------------------------
+# Event recording
+# ---------------------------------------------------------------------------
+
+
+def record_vote(detector_id: str = "") -> None:
+    """Record one user vote and credit detector training on its first vote.
+
+    Args:
+        detector_id: ID of the detector the vote belongs to.  Empty string
+            (no active detector) skips the training credit.
+    """
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        state["counters"]["votes_cast"] += 1
+        if detector_id:
+            trained = state["trained_detector_ids"]
+            if detector_id not in trained:
+                trained.append(detector_id)
+                state["counters"]["detectors_trained"] += 1
+        _save(s)
+
+
+def record_dataset_load(importer_name: str) -> None:
+    """Record one dataset load (skipping demos/synthetic)."""
+    if importer_name in EXCLUDED_DATASET_IMPORTERS:
+        return
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        state["counters"]["datasets_loaded"] += 1
+        _save(s)
+
+
+def record_detector_import(detector_id: str) -> None:
+    """Record one detector receiving imported labels.  Dedupes by detector_id."""
+    if not detector_id:
+        return
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        imported = state["imported_detector_ids"]
+        if detector_id in imported:
+            return
+        imported.append(detector_id)
+        state["counters"]["detectors_imported"] += 1
+        _save(s)
+
+
+def record_find(n_scored: int) -> None:
+    """Record *n_scored* media items processed by a Find operation."""
+    if n_scored <= 0:
+        return
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        state["counters"]["find_media"] += int(n_scored)
+        _save(s)
+
+
+# ---------------------------------------------------------------------------
+# Read-only API
+# ---------------------------------------------------------------------------
+
+
+def get_full_state() -> dict[str, Any]:
+    """Return the achievement state shaped for the frontend.
+
+    The shape is::
+
+        {
+            "tier_names": ["Bronze", "Silver", "Gold", "Platinum"],
+            "achievements": [
+                {
+                    "id": "...",
+                    "name": "...",
+                    "description": "...",
+                    "icon": "...",
+                    "tiers": [..., ..., ..., ...],
+                    "counter": <int>,
+                    "tier_idx": <int, -1 = locked>,
+                    "next_threshold": <int | null>,
+                },
+                ...
+            ],
+            "pending_announcements": [
+                {
+                    "id": "...",
+                    "name": "...",
+                    "icon": "...",
+                    "tier_idx": <int>,
+                    "tier_name": "Bronze" | ...,
+                    "threshold": <int>,
+                },
+                ...
+            ],
+        }
+    """
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        achievements: list[dict[str, Any]] = []
+        pending: list[dict[str, Any]] = []
+        for a in ACHIEVEMENTS:
+            cid = a["id"]
+            counter = int(state["counters"].get(cid, 0))
+            tier_idx = _current_tier_idx(cid, counter)
+            announced_idx = int(state["announced"].get(cid, -1))
+            next_threshold: int | None = (
+                a["tiers"][tier_idx + 1] if tier_idx + 1 < len(a["tiers"]) else None
+            )
+            achievements.append(
+                {
+                    "id": cid,
+                    "name": a["name"],
+                    "description": a["description"],
+                    "icon": a["icon"],
+                    "tiers": list(a["tiers"]),
+                    "counter": counter,
+                    "tier_idx": tier_idx,
+                    "next_threshold": next_threshold,
+                }
+            )
+            for i in range(announced_idx + 1, tier_idx + 1):
+                pending.append(
+                    {
+                        "id": cid,
+                        "name": a["name"],
+                        "icon": a["icon"],
+                        "tier_idx": i,
+                        "tier_name": TIER_NAMES[i],
+                        "threshold": a["tiers"][i],
+                    }
+                )
+        return {
+            "tier_names": list(TIER_NAMES),
+            "achievements": achievements,
+            "pending_announcements": pending,
+        }
+
+
+def acknowledge(category_id: str, tier_idx: int) -> bool:
+    """Mark a tier as announced so it isn't popped again.
+
+    Returns True if the announced index advanced, False otherwise.
+    """
+    if category_id not in _ACH_BY_ID:
+        return False
+    if tier_idx < 0 or tier_idx >= len(TIER_NAMES):
+        return False
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        prev = int(state["announced"].get(category_id, -1))
+        if tier_idx <= prev:
+            return False
+        state["announced"][category_id] = tier_idx
+        _save(s)
+        return True

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -133,6 +133,12 @@ def _score_medias_with_detectors(
             "hits": positive_hits,
             "negative_hits": negative_hits,
         }
+
+    if results:
+        from vtsearch.achievements import record_find
+
+        record_find(len(medias) * len(results))
+
     return results
 
 

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -782,6 +782,11 @@ def _run_origin_load_in_background(
                 tracker.update(status, message, current, total, **kw)
 
             _load_embedder_with_progress(ctx.medias, _task_progress)
+
+            # Achievement: dataset load succeeded (demos/synthetic excluded).
+            from vtsearch.achievements import record_dataset_load
+
+            record_dataset_load(str(origin.get("importer", "")))
         except CancelledError:
             from vtsearch.utils.state_core import unregister_context
 

--- a/vtsearch/labels/sync.py
+++ b/vtsearch/labels/sync.py
@@ -114,6 +114,7 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
     # re-entry from this same thread) instead of pushing the pre-import
     # state back to the source.
     global _syncing
+    applied_any = False
     with _sync_lock:
         _syncing = True
         try:
@@ -131,8 +132,14 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
                 for mid, media in medias.items():
                     if media.get("md5") == md5:
                         apply_label(mid, label)
+                        applied_any = True
                         break
         finally:
             _syncing = False
+
+    if applied_any:
+        from vtsearch.achievements import record_detector_import
+
+        record_detector_import(ctx.detector_id)
 
     return labels

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -1,5 +1,6 @@
 """Flask blueprints for organizing application routes."""
 
+from vtsearch.routes.achievements import achievements_bp
 from vtsearch.routes.auth import auth_bp
 from vtsearch.routes.detector_find import detector_find_bp
 from vtsearch.routes.detector_scoring import detector_scoring_bp
@@ -22,6 +23,7 @@ from vtsearch.routes.sorting import sorting_bp
 from vtsearch.routes.sync_sources import sync_sources_bp
 
 __all__ = [
+    "achievements_bp",
     "auth_bp",
     "detector_find_bp",
     "detector_scoring_bp",

--- a/vtsearch/routes/achievements.py
+++ b/vtsearch/routes/achievements.py
@@ -1,0 +1,35 @@
+"""Flask routes for the Achievements API.
+
+Endpoints
+---------
+GET  /api/achievements
+    Return current achievement state for the UI.
+
+POST /api/achievements/<category_id>/acknowledge
+    Mark a tier as announced.  Body: ``{"tier_idx": <int>}``.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from vtsearch import achievements
+
+achievements_bp = Blueprint("achievements", __name__)
+
+
+@achievements_bp.route("/api/achievements", methods=["GET"])
+def get_achievements():
+    """Return the full achievement state."""
+    return jsonify(achievements.get_full_state())
+
+
+@achievements_bp.route("/api/achievements/<category_id>/acknowledge", methods=["POST"])
+def acknowledge_achievement(category_id: str):
+    """Mark *category_id*'s tier as announced."""
+    body = request.get_json(force=True, silent=True) or {}
+    tier_idx = body.get("tier_idx")
+    if not isinstance(tier_idx, int):
+        return jsonify({"error": "tier_idx (int) is required"}), 400
+    changed = achievements.acknowledge(category_id, tier_idx)
+    return jsonify({"ok": True, "changed": changed})

--- a/vtsearch/routes/detector_scoring.py
+++ b/vtsearch/routes/detector_scoring.py
@@ -342,6 +342,10 @@ def find_label():
         total_steps=_FIND_LABEL_STEPS,
     )
 
+    from vtsearch.achievements import record_find
+
+    record_find(n_total)
+
     return jsonify(
         {
             "ok": True,
@@ -464,6 +468,11 @@ def auto_detect():
             if outcome is not None:
                 name, result = outcome
                 results[name] = result
+
+    if results:
+        from vtsearch.achievements import record_find
+
+        record_find(len(all_ids) * len(results))
 
     return jsonify(
         {

--- a/vtsearch/routes/label_importers.py
+++ b/vtsearch/routes/label_importers.py
@@ -179,6 +179,11 @@ def run_label_import(importer_name: str):
 
         sync_to_labelset_source()
 
+        from vtsearch.achievements import record_detector_import
+        from vtsearch.utils.state_core import get_active_detector_context
+
+        record_detector_import(get_active_detector_context().detector_id)
+
     msg = f"Applied {applied} label(s), skipped {skipped}."
     if ingested > 0:
         msg += f" Auto-resolved {ingested} missing element(s) from their sources."

--- a/vtsearch/utils/state_votes.py
+++ b/vtsearch/utils/state_votes.py
@@ -142,6 +142,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
     """
     from vtsearch.models.progress import invalidate_progress_cache_from
 
+    added = False
     with _state_lock:
         if vote == "good":
             if media_id in good_votes:
@@ -159,6 +160,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 diversity_tree_label(media_id)
                 if was_opposite:
                     invalidate_progress_cache_from(media_id)
+                added = True
         else:
             if media_id in bad_votes:
                 bad_votes.pop(media_id, None)
@@ -175,6 +177,13 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 diversity_tree_label(media_id)
                 if was_opposite:
                     invalidate_progress_cache_from(media_id)
+                added = True
+
+    if added:
+        from vtsearch.achievements import record_vote
+
+        detector_id = get_active_detector_context().detector_id
+        record_vote(detector_id)
 
 
 def apply_label(media_id: int, label: str, *, silent: bool = False) -> None:


### PR DESCRIPTION
## Summary

Adds a milestone tracking system that records five categories of usage and unlocks Bronze / Silver / Gold / Platinum tiers as each crosses its thresholds. Counters live in `data/settings.json` under `achievement_state`, so progress rides along on whatever settings sync source the user has configured.

### Categories and thresholds

| Category | Bronze | Silver | Gold | Platinum | Icon |
|---|---:|---:|---:|---:|---|
| Datasets Loaded *(demos and synthetic excluded)* | 1 | 10 | 100 | 1 000 | `cubes` |
| Votes Cast | 100 | 1 000 | 10 000 | 100 000 | `checkbox-checked` |
| Detectors Trained *(credited on first vote per detector)* | 2 | 20 | 200 | 2 000 | `graduation` |
| Detectors Imported *(credited per detector, deduped)* | 1 | 10 | 100 | 1 000 | `robot` |
| Find Media *(media items scored, GUI + CLI)* | 200 | 2 000 | 20 000 | 200 000 | `search` |

### Hooks

- `toggle_vote` (votes_cast + first-vote-credits-detector)
- `_run_origin_load_in_background` on successful load (datasets_loaded — demos/synthetic skipped via importer name)
- `/api/find-label`, `/api/auto-detect`, and CLI `_score_medias_with_detectors` (find_media)
- `/api/label-importers/import/...` and `sync_from_labelset_source` (detectors_imported, deduped by detector_id)

### API

- `GET /api/achievements` — full state for the UI, including a `pending_announcements` array for any unlocked-but-not-yet-popped tiers.
- `POST /api/achievements/<id>/acknowledge` — body `{"tier_idx": <int>}`, marks an unlock as seen so it doesn't fire again on refresh.

### Frontend

- `AchievementsService` exposes a state observable and queues unlocks one at a time.
- HTTP interceptor refreshes the service after any POST to a watched action endpoint (vote / find / import / dataset-load), and the dashboard's loading-task poller refreshes when a dataset/detector load finishes.
- `vt-achievement-badge` composes the existing `vt-icon` set with tier decorations: dashed silhouette (locked), single ring (Bronze), double ring (Silver), ring + laurel (Gold), ring + sparkles (Platinum). Colors: brown / light-gray / gold / white.
- New **Achievements** tab in Settings shows a row per category with the current badge, description, and a progress bar to the next tier.
- `vt-achievement-unlock-host` reuses `vt-modal` (same shell as the "Are you sure?" confirm) but renders the new badge in the unlocked tier's color.

### Notes

- Cheat-resistance is intentionally not implemented — counters round-trip through the user-owned settings file. No obfuscation.
- Thresholds are deliberately non-trivial so a first-run user doesn't get spammed: bronze fires on the first real dataset load (which gates the rest), 100 votes, 200 finds, 2 detectors trained, 1 detector imported.

## Test plan

- [x] `./run-tests.sh core` (frontend build + 365 backend tests)
- [x] `./run-tests.sh` (2940 passed, 1 skipped, 2 xpassed)
- [x] `tests/test_achievements.py` covers helpers, tier progression, persistence round-trip, importer exclusion, both API routes, and end-to-end vote increment via `/api/medias/<id>/vote`
- [ ] Manual: open Settings → Achievements after a few votes, see Bronze badge and progress bar
- [ ] Manual: cast 100 votes, verify the unlock modal pops with the brown Bronze badge for "Votes Cast" and doesn't re-pop on reload

https://claude.ai/code/session_012fkRXE2akPsoUtyVVRHcEu

---
_Generated by [Claude Code](https://claude.ai/code/session_012fkRXE2akPsoUtyVVRHcEu)_