### PR TITLE
fix(theme): apply persisted theme on app startup

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -12,6 +12,7 @@ import { ActiveContextService } from './services/active-context.service';
 import { TopBarStateService } from './services/top-bar-state.service';
 import { AuthService } from './services/auth.service';
 import { AchievementsService } from './services/achievements.service';
+import { ThemeService } from './services/theme.service';
 @Component({
   selector: 'app-root',
   imports: [CommonModule, RouterOutlet, DialogHostComponent, AchievementUnlockHostComponent, SettingsModalComponent, LoginComponent],
@@ -36,9 +37,11 @@ export class AppComponent {
     public topBarState: TopBarStateService,
     public auth: AuthService,
     private achievements: AchievementsService,
+    private themeService: ThemeService,
   ) {
     this.auth.checkStatus();
     this.achievements.refresh();
+    this.themeService.loadFromSettings();
     this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
       .subscribe((e) => {

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.html
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.html
@@ -13,6 +13,8 @@
         </p>
       </div>
     </div>
+  }
+  @if (current) {
     <div modal-footer>
       <button class="btn btn--primary" (click)="acknowledge()">Nice</button>
     </div>

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
-import { IconComponent } from '../icon/icon.component';
 import {
   AchievementInfo,
   AchievementsService,
@@ -22,7 +21,7 @@ interface AchievementRow extends AchievementInfo {
 @Component({
   selector: 'vt-achievements-tab',
   standalone: true,
-  imports: [CommonModule, AchievementBadgeComponent, IconComponent],
+  imports: [CommonModule, AchievementBadgeComponent],
   templateUrl: './achievements-tab.component.html',
   styleUrl: './achievements-tab.component.scss',
 })


### PR DESCRIPTION
## Summary
- `ThemeService.loadFromSettings()` was never called at startup, so a saved theme rendered correctly in the settings dropdown but the actual `data-theme` attribute always stayed at the default `dark`. Calling it from `AppComponent`'s constructor fixes the refresh case.
- Fixed two pre-existing `build:prod` warnings surfaced while verifying the change (per CLAUDE.md "Fix All Errors"):
  - Split the multi-root `@if` in `achievement-unlock-host.component.html` so the `[modal-footer]` slot projects correctly.
  - Removed the unused `IconComponent` import from `achievements-tab.component.ts`.

## Test plan
- [x] `npm run build:prod` — clean, no `▲ [WARNING]` lines
- [x] `./run-tests.sh core` — 365 passed
- [ ] Manual: set theme to Light in settings, refresh, confirm page renders in light theme


---
_Generated by [Claude Code](https://claude.ai/code/session_01AB3FDydMJXRdk5SRxSnzFh)_