### PR TITLE
Hold MediaSource alive across resolve+embed (fix stale temp paths)

### DIFF
--- a/tests/test_cli_detectors.py
+++ b/tests/test_cli_detectors.py
@@ -48,13 +48,16 @@ def _write_trainable_model(name: str, labelset: dict) -> Path:
 
 
 def _stub_resolve(monkeypatch, file_map: dict[str, Path]) -> None:
-    """Patch ``resolve_file_from_origin`` to look up *file_map* by origin name."""
+    """Patch ``resolve_file_context`` to look up *file_map* by origin name."""
+    from contextlib import contextmanager
+
     import vtsearch.models.resolver as resolver_mod
 
-    def _fake(origin, origin_name="", filename=""):
-        return file_map.get(origin_name) or file_map.get(filename)
+    @contextmanager
+    def _fake_ctx(origin, origin_name="", filename=""):
+        yield file_map.get(origin_name) or file_map.get(filename)
 
-    monkeypatch.setattr(resolver_mod, "resolve_file_from_origin", _fake)
+    monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
 
 
 def _make_audio_files(tmp_path: Path, names: list[str]) -> dict[str, Path]:
@@ -139,10 +142,16 @@ class TestAutorunDetectorsCLI:
 
     def test_clear_error_when_origins_unresolvable(self, client, tmp_path, monkeypatch):
         """No origins resolve → ValueError with a CLI-friendly explanation."""
-        # Stub returns None for everything (simulates labels from local_folder).
+        # Stub yields None for everything (simulates labels from local_folder).
+        from contextlib import contextmanager
+
         import vtsearch.models.resolver as resolver_mod
 
-        monkeypatch.setattr(resolver_mod, "resolve_file_from_origin", lambda *a, **kw: None)
+        @contextmanager
+        def _fake_ctx(*_a, **_kw):
+            yield None
+
+        monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
 
         labelset = {
             "labels": [

--- a/tests/test_label_import_ingestion.py
+++ b/tests/test_label_import_ingestion.py
@@ -149,15 +149,20 @@ class TestIngestMissingClips:
 
         fake_embedding = rng.standard_normal(512).astype(np.float32)
 
-        # Patch resolve_file_from_origin to return our test file,
-        # embed_file to return a fake embedding, and _media_type_from_origin
-        # to return "image".  The resolver imports are lazy (inside the
-        # function), so patch at the source module.
+        # Patch resolve_file_context to yield our test file, embed_file to
+        # return a fake embedding, and _media_type_from_origin to return
+        # "image".  The resolver imports are lazy (inside the function), so
+        # patch at the source module.
+        from contextlib import contextmanager
         from unittest.mock import patch
+
+        @contextmanager
+        def _fake_resolve_ctx(*_args, **_kwargs):
+            yield img_path
 
         with (
             patch("vtsearch.datasets.ingest._media_type_from_origin", return_value="image"),
-            patch("vtsearch.models.resolver.resolve_file_from_origin", return_value=img_path),
+            patch("vtsearch.models.resolver.resolve_file_context", _fake_resolve_ctx),
             patch("vtsearch.models.resolver.embed_file", return_value=fake_embedding),
         ):
             result = _ingest_via_resolver(origin, entries, existing, noop_progress)

--- a/tests/test_labelset_elements_api.py
+++ b/tests/test_labelset_elements_api.py
@@ -287,10 +287,11 @@ class TestCrossDatasetMLPTraining:
     def _seed_with_resolvable_labelset(self, tmp_path, monkeypatch):
         """Seed a model whose labelset elements are all resolvable.
 
-        Stubs ``resolve_file_from_origin`` to return a unique temp WAV file
+        Stubs ``resolve_file_context`` to yield a unique temp WAV file
         per element, so that ``embed_file`` (already stubbed in conftest to
         fake_embed_audio) yields deterministic, distinct vectors.
         """
+        from contextlib import contextmanager
         from pathlib import Path
 
         from vtsearch.utils.audio_generator import generate_wav
@@ -301,21 +302,21 @@ class TestCrossDatasetMLPTraining:
             path.write_bytes(generate_wav(freq, 0.1))
             files[name] = path
 
-        def _fake_resolve(origin, origin_name="", filename=""):
-            return files.get(origin_name) or files.get(filename)
+        @contextmanager
+        def _fake_resolve_ctx(origin, origin_name="", filename=""):
+            yield files.get(origin_name) or files.get(filename)
 
-        # Patch in both modules that import resolve_file_from_origin via "from ... import"
+        # labelset_training imports resolve_file_context inside _embed_one,
+        # so patching the resolver symbol is enough — the function-level
+        # import picks the patched value.
         import vtsearch.models.labelset_training as lt_mod
         import vtsearch.models.resolver as resolver_mod
 
-        # The labelset_training module imports inside the function body, so
-        # we just patch the resolver's symbol — the function-level import
-        # picks the patched value.
-        monkeypatch.setattr(resolver_mod, "resolve_file_from_origin", _fake_resolve)
+        monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_resolve_ctx)
         # Defensive: patch the binding inside labelset_training too in case
         # it ever moves to a top-level import.
-        if hasattr(lt_mod, "resolve_file_from_origin"):
-            monkeypatch.setattr(lt_mod, "resolve_file_from_origin", _fake_resolve)
+        if hasattr(lt_mod, "resolve_file_context"):
+            monkeypatch.setattr(lt_mod, "resolve_file_context", _fake_resolve_ctx)
 
         return _seed_cross_dataset_model(mark_loaded=False)
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1070,3 +1070,98 @@ class TestResolutionWarningLogs:
         assert result.resolved_count == 1
         assert result.total_count == 2
         assert any("1 of 2 labels resolved" in m for m in caplog.messages)
+
+
+class TestResolveFileContextLifetime:
+    """Regression: temp-backed MediaSources must stay alive across
+    resolve + embed inside a single ``resolve_file_context`` block.
+
+    Before the fix, ``_default_source_resolver`` created the source,
+    asked for the path, and let the source go out of scope.  Sources
+    that owned a ``tempfile.TemporaryDirectory`` (e.g. PullWrest) got
+    finalised by GC and the path went stale before ``embed_file``
+    opened it, raising ``FileNotFoundError`` deep inside the embedder.
+    """
+
+    def test_source_cleanup_deferred_to_context_exit(self, tmp_path, monkeypatch):
+        from contextlib import ExitStack
+
+        from vtsearch.models import resolver as resolver_mod
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        media = staging / "thing.txt"
+        media.write_bytes(b"payload")
+
+        cleaned: list[bool] = []
+
+        class _FakeSource:
+            name = "fake"
+
+            def resolve_path(self, origin_name: str = "", filename: str = ""):
+                return media if media.exists() else None
+
+            def cleanup(self) -> None:
+                cleaned.append(True)
+                if media.exists():
+                    media.unlink()
+
+        def _custom_source_resolver(
+            stack: ExitStack,
+            origin: dict,
+            origin_name: str,
+            filename: str,
+        ):
+            src = _FakeSource()
+            stack.callback(src.cleanup)
+            return src.resolve_path(origin_name, filename)
+
+        monkeypatch.setattr(resolver_mod, "_source_resolver", _custom_source_resolver)
+        monkeypatch.setattr(resolver_mod, "_auto_wired", True)
+
+        origin = {"importer": "fake", "params": {}}
+        with resolver_mod.resolve_file_context(origin, origin_name="thing.txt") as path:
+            assert path is not None
+            assert path.exists(), "file must be alive inside the with-block"
+            assert path.read_bytes() == b"payload"
+            assert cleaned == [], "cleanup() must not fire while context is open"
+
+        assert cleaned == [True], "cleanup() must fire exactly once on exit"
+        assert not media.exists(), "temp file gone after context exit"
+
+    def test_legacy_wrapper_runs_cleanup_immediately(self, tmp_path, monkeypatch):
+        """``resolve_file_from_origin`` is the non-CM wrapper — by design the
+        source is dropped (and its temp dir cleaned) as soon as the call
+        returns.  Callers that hold the returned path past that point are
+        responsible for using ``resolve_file_context`` instead.
+        """
+        from contextlib import ExitStack
+
+        from vtsearch.models import resolver as resolver_mod
+
+        cleaned: list[bool] = []
+
+        class _FakeSource:
+            name = "fake"
+
+            def resolve_path(self, origin_name: str = "", filename: str = ""):
+                return tmp_path / "x.txt"
+
+            def cleanup(self) -> None:
+                cleaned.append(True)
+
+        def _custom_source_resolver(
+            stack: ExitStack,
+            origin: dict,
+            origin_name: str,
+            filename: str,
+        ):
+            src = _FakeSource()
+            stack.callback(src.cleanup)
+            return src.resolve_path(origin_name, filename)
+
+        monkeypatch.setattr(resolver_mod, "_source_resolver", _custom_source_resolver)
+        monkeypatch.setattr(resolver_mod, "_auto_wired", True)
+
+        _ = resolver_mod.resolve_file_from_origin({"importer": "fake"}, "x.txt")
+        assert cleaned == [True], "wrapper exits its context immediately"

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -244,7 +244,7 @@ def _ingest_via_resolver(
 
     embedder_name = _embedder_name_for_type(medias, media_type_id)
 
-    from vtsearch.models.resolver import embed_file, resolve_file_from_origin
+    from vtsearch.models.resolver import embed_file, resolve_file_context
 
     ingested = 0
 
@@ -252,35 +252,40 @@ def _ingest_via_resolver(
         origin_name = entry.get("origin_name", "")
         filename = entry.get("filename", "")
 
-        file_path = resolve_file_from_origin(origin_dict, origin_name, filename)
-        if file_path is None:
-            continue
+        # Hold the source alive through both embed and read_bytes — some
+        # MediaSources materialise the file inside a TemporaryDirectory
+        # they own, and dropping the source before we touch the path
+        # finalises that temp dir under GC and leaves us with a stale path.
+        with resolve_file_context(origin_dict, origin_name, filename) as file_path:
+            if file_path is None:
+                continue
 
-        # Use clip-aware embedding when the origin has clip params, so that
-        # re-ingested clipped media gets the correct (clipped) embedding.
-        if origin_dict.get("params", {}).get("clipper"):
-            from vtsearch.models.resolver import _apply_clip_and_embed
+            # Use clip-aware embedding when the origin has clip params, so
+            # that re-ingested clipped media gets the correct (clipped)
+            # embedding.
+            if origin_dict.get("params", {}).get("clipper"):
+                from vtsearch.models.resolver import _apply_clip_and_embed
 
-            embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict, embedder_name)
-        else:
-            embedding = embed_file(file_path, media_type_id, embedder_name)
-        if embedding is None:
-            continue
+                embedding = _apply_clip_and_embed(file_path, media_type_id, origin_dict, embedder_name)
+            else:
+                embedding = embed_file(file_path, media_type_id, embedder_name)
+            if embedding is None:
+                continue
 
-        file_bytes = file_path.read_bytes()
-        md5 = hashlib.md5(file_bytes).hexdigest()
+            file_bytes = file_path.read_bytes()
+            md5 = hashlib.md5(file_bytes).hexdigest()
 
-        media_data = _build_media_data(
-            origin_dict=origin_dict,
-            entry=entry,
-            media_type_id=media_type_id,
-            origin_name=origin_name,
-            file_path=file_path,
-            file_bytes=file_bytes,
-            md5=md5,
-            embedding=embedding,
-            embedder_name=embedder_name,
-        )
+            media_data = _build_media_data(
+                origin_dict=origin_dict,
+                entry=entry,
+                media_type_id=media_type_id,
+                origin_name=origin_name,
+                file_path=file_path,
+                file_bytes=file_bytes,
+                md5=md5,
+                embedding=embedding,
+                embedder_name=embedder_name,
+            )
 
         # Atomic id allocation + insert, see _ingest_via_source above.
         with _state_lock:

--- a/vtsearch/models/label_restoration.py
+++ b/vtsearch/models/label_restoration.py
@@ -68,7 +68,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
         import hashlib
         import logging
 
-        from vtsearch.models.resolver import resolve_file_from_origin
+        from vtsearch.models.resolver import resolve_file_context
 
         _log = logging.getLogger(__name__)
 
@@ -77,31 +77,31 @@ def restore_labels_from_detector(det_data: dict) -> int:
             origin = entry.get("origin")
             origin_name = entry.get("origin_name", "")
             filename = entry.get("filename", "")
-            resolved_path = resolve_file_from_origin(origin, origin_name, filename)
-            if resolved_path is None:
-                continue
+            with resolve_file_context(origin, origin_name, filename) as resolved_path:
+                if resolved_path is None:
+                    continue
 
-            # Compute MD5 of the resolved file and check against loaded medias
-            try:
-                h = hashlib.md5()
-                with open(resolved_path, "rb") as f:
-                    for chunk in iter(lambda: f.read(8192), b""):
-                        h.update(chunk)
-                resolved_md5 = h.hexdigest()
-            except OSError:
-                _log.debug("restore-labels: could not read resolved file %s", resolved_path)
-                continue
+                # Compute MD5 of the resolved file and check against loaded medias
+                try:
+                    h = hashlib.md5()
+                    with open(resolved_path, "rb") as f:
+                        for chunk in iter(lambda: f.read(8192), b""):
+                            h.update(chunk)
+                    resolved_md5 = h.hexdigest()
+                except OSError:
+                    _log.debug("restore-labels: could not read resolved file %s", resolved_path)
+                    continue
 
-            cids = md5_lookup.get(resolved_md5, [])
-            if cids:
-                for cid in cids:
-                    apply_label(cid, elem.label, silent=True)
-                restored += 1
-            else:
-                _log.debug(
-                    "restore-labels: resolved %s but MD5 %s not in loaded dataset",
-                    resolved_path,
-                    resolved_md5,
-                )
+                cids = md5_lookup.get(resolved_md5, [])
+                if cids:
+                    for cid in cids:
+                        apply_label(cid, elem.label, silent=True)
+                    restored += 1
+                else:
+                    _log.debug(
+                        "restore-labels: resolved %s but MD5 %s not in loaded dataset",
+                        resolved_path,
+                        resolved_md5,
+                    )
 
     return restored

--- a/vtsearch/models/labelset_elements.py
+++ b/vtsearch/models/labelset_elements.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import hashlib
 import json as _json
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from vtsearch.datasets.labelset import LabeledElement, LabelSet, element_key
 
@@ -58,17 +59,25 @@ def resolve_current_dataset_cid(elem: LabeledElement) -> int | None:
     return cids[0] if cids else None
 
 
-def resolve_element_to_path(elem: LabeledElement) -> Path | None:
+@contextmanager
+def resolve_element_to_path(elem: LabeledElement) -> Iterator[Path | None]:
     """Resolve the underlying media file for *elem* via its origin.
 
-    Returns the path on disk if the importer's
+    Yields the path on disk if the importer's
     :meth:`~vtsearch.datasets.importers.base.DatasetImporter.resolve_file`
+    (or the corresponding :class:`~vtsearch.datasets.sources.base.MediaSource`)
     can locate it (e.g. demo, folder, synthetic, server-folder importers
     with a stable cache directory), otherwise ``None``.
-    """
-    from vtsearch.models.resolver import resolve_file_from_origin
 
-    return resolve_file_from_origin(elem.origin, elem.origin_name, elem.filename)
+    Must be used as a ``with`` block: some media sources materialise the
+    file inside a temp dir they own, and the dir is finalised on exit.
+    Callers must read bytes (or otherwise finish with the file) inside
+    the block.
+    """
+    from vtsearch.models.resolver import resolve_file_context
+
+    with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as p:
+        yield p
 
 
 def build_element_view(

--- a/vtsearch/models/labelset_training.py
+++ b/vtsearch/models/labelset_training.py
@@ -42,17 +42,17 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
     from vtsearch.models.resolver import (
         _apply_clip_and_embed,
         embed_file,
-        resolve_file_from_origin,
+        resolve_file_context,
     )
 
-    file_path = resolve_file_from_origin(elem.origin, elem.origin_name, elem.filename)
-    if file_path is None:
-        return None
+    with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
+        if file_path is None:
+            return None
 
-    params = (elem.origin or {}).get("params", {}) if elem.origin else {}
-    if isinstance(params, dict) and params.get("clipper"):
-        return _apply_clip_and_embed(file_path, media_type, elem.origin, embedder_name)
-    return embed_file(file_path, media_type, embedder_name)
+        params = (elem.origin or {}).get("params", {}) if elem.origin else {}
+        if isinstance(params, dict) and params.get("clipper"):
+            return _apply_clip_and_embed(file_path, media_type, elem.origin, embedder_name)
+        return embed_file(file_path, media_type, embedder_name)
 
 
 def populate_label_embeddings(

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -8,12 +8,16 @@ embeddings for training.  This module handles that resolution:
 2. Embed the file using the appropriate embedder for the media type.
 3. Return resolved embeddings with availability stats.
 
-File resolution uses a pluggable :class:`FileResolver` protocol.  Two
-resolver implementations are auto-wired on first use:
+File resolution is split into two pluggable resolvers, auto-wired on
+first use:
 
 - **Source resolver** — delegates to
   :func:`~vtsearch.datasets.sources.get_source_for_origin` and calls
-  :meth:`~MediaSource.resolve_path`.
+  :meth:`~MediaSource.resolve_path`.  Registers the source's
+  :meth:`~MediaSource.cleanup` on the caller's :class:`ExitStack` so
+  per-call temp storage is held alive for the duration of the
+  :func:`resolve_file_context` block (otherwise GC of the source can
+  delete the path before the caller embeds the file).
 - **Importer resolver** — delegates to
   :func:`~vtsearch.datasets.importers.get_importer` and calls
   :meth:`~DatasetImporter.resolve_file`.
@@ -29,9 +33,10 @@ importers.
 from __future__ import annotations
 
 import logging
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Iterator, Protocol, runtime_checkable
 
 import numpy as np
 
@@ -44,12 +49,32 @@ log = logging.getLogger(__name__)
 
 
 @runtime_checkable
-class FileResolver(Protocol):
-    """Callable that resolves a media file from origin metadata.
+class SourceResolver(Protocol):
+    """Callable that resolves an origin to a file via a :class:`MediaSource`.
 
-    Implementations receive the origin dict, origin_name, and filename,
-    and return a :class:`~pathlib.Path` to the resolved file on disk
-    (or ``None`` if resolution fails).
+    Implementations receive an :class:`~contextlib.ExitStack` (so they can
+    register :meth:`~MediaSource.cleanup` to fire when the caller's
+    :func:`resolve_file_context` exits) plus the origin dict,
+    ``origin_name``, and ``filename``.
+    """
+
+    def __call__(
+        self,
+        stack: ExitStack,
+        origin: dict[str, Any],
+        origin_name: str,
+        filename: str,
+    ) -> Path | None: ...
+
+
+@runtime_checkable
+class ImporterResolver(Protocol):
+    """Callable that resolves an origin via its dataset importer.
+
+    Importer-based dispatch does not allocate a per-call source — importers
+    that need to cache materialised content (e.g. ``http_archive``) are
+    expected to write to a stable directory and never call ``cleanup()``,
+    so no :class:`ExitStack` is threaded through.
     """
 
     def __call__(
@@ -64,22 +89,24 @@ class FileResolver(Protocol):
 # Pluggable resolver registry
 # ---------------------------------------------------------------------------
 
-_source_resolver: FileResolver | None = None
-_importer_resolver: FileResolver | None = None
+_source_resolver: SourceResolver | None = None
+_importer_resolver: ImporterResolver | None = None
 _auto_wired = False
 
 
-def register_source_resolver(fn: FileResolver) -> None:
+def register_source_resolver(fn: SourceResolver) -> None:
     """Register a source-based file resolver.
 
-    The resolver is called with ``(origin, origin_name, filename)`` and
-    should return a :class:`~pathlib.Path` or ``None``.
+    The resolver is called with ``(stack, origin, origin_name, filename)``
+    and should return a :class:`~pathlib.Path` or ``None``.  Register the
+    backing source's :meth:`~MediaSource.cleanup` on *stack* so its temp
+    storage is only released once the caller is done with the path.
     """
     global _source_resolver
     _source_resolver = fn
 
 
-def register_importer_resolver(fn: FileResolver) -> None:
+def register_importer_resolver(fn: ImporterResolver) -> None:
     """Register an importer-based file resolver.
 
     The resolver is called with ``(origin, origin_name, filename)`` and
@@ -108,14 +135,18 @@ def _auto_wire_resolvers() -> None:
             from vtsearch.datasets.sources import get_source_for_origin
 
             def _default_source_resolver(
+                stack: ExitStack,
                 origin: dict[str, Any],
                 origin_name: str,
                 filename: str,
             ) -> Path | None:
                 source = get_source_for_origin(origin)
-                if source is not None:
-                    return source.resolve_path(origin_name, filename)
-                return None
+                if source is None:
+                    return None
+                # Keep the source alive — and its temp dir, if any — until
+                # the caller's resolve_file_context exits.
+                stack.callback(source.cleanup)
+                return source.resolve_path(origin_name, filename)
 
             register_source_resolver(_default_source_resolver)
         except ImportError:
@@ -161,6 +192,34 @@ class ResolvedLabels:
         return any(v == 1.0 for v in self.labels) and any(v == 0.0 for v in self.labels)
 
 
+@contextmanager
+def resolve_file_context(
+    origin: dict[str, Any] | None,
+    origin_name: str = "",
+    filename: str = "",
+) -> Iterator[Path | None]:
+    """Resolve a media file from its origin and keep the backing source alive.
+
+    Some :class:`~vtsearch.datasets.sources.base.MediaSource` implementations
+    (e.g. PullWrest) materialise the file inside a
+    :class:`tempfile.TemporaryDirectory` they own.  If the source is dropped
+    before the caller accesses the file, the temp dir is finalized by GC and
+    the path goes stale — ``embed_file`` then crashes with
+    ``FileNotFoundError``.
+
+    This context manager owns the source for the duration of the ``with``
+    block and only invokes :meth:`~MediaSource.cleanup` on exit, so the path
+    is guaranteed to remain valid while the caller embeds or reads bytes
+    from it.
+
+    Yields the resolved :class:`~pathlib.Path`, or ``None`` if no resolver
+    could locate the file.
+    """
+    with ExitStack() as stack:
+        path = _resolve_with_stack(stack, origin, origin_name, filename)
+        yield path
+
+
 def resolve_file_from_origin(
     origin: dict[str, Any] | None,
     origin_name: str = "",
@@ -168,14 +227,34 @@ def resolve_file_from_origin(
 ) -> Path | None:
     """Resolve a media file from its origin information.
 
-    Looks up the importer named in ``origin["importer"]`` from the
-    auto-discovered importer registry and calls its ``resolve_file()``
-    method.  Two synthetic origin types are handled inline:
+    Returns the file path if found, or ``None``.  Convenience wrapper over
+    :func:`resolve_file_context` for callers that only need to test
+    existence or read the file immediately (synchronously, in the same
+    expression).  Callers that hold the returned path across an operation
+    that re-enters Python — embedding, opening with PIL, etc. — must use
+    :func:`resolve_file_context` instead, because some media sources own
+    temporary directories that are garbage-collected as soon as this
+    function returns.
+    """
+    with resolve_file_context(origin, origin_name, filename) as p:
+        return p
+
+
+def _resolve_with_stack(
+    stack: ExitStack,
+    origin: dict[str, Any] | None,
+    origin_name: str = "",
+    filename: str = "",
+) -> Path | None:
+    """Resolve *origin* to a :class:`Path` while registering any source's
+    :meth:`~MediaSource.cleanup` on *stack*.
+
+    Shared core for :func:`resolve_file_context` and (transitively)
+    :func:`resolve_file_from_origin`.  The two synthetic origin types are
+    handled inline because they delegate to real importers:
 
     - ``dupe_set``: tries each member until one resolves.
     - ``converter``: reconstructs the parent origin and delegates.
-
-    Returns the file path if found, or ``None``.
     """
     if origin is None:
         log.debug("resolve_file: origin is None — cannot resolve")
@@ -195,14 +274,14 @@ def resolve_file_from_origin(
     # -- Synthetic origins that delegate to real importers --
 
     if importer_name == "dupe_set":
-        result = _resolve_dupe_set(origin)
+        result = _resolve_dupe_set(stack, origin)
         if result is None:
             members = origin.get("members", [])
             log.debug("resolve_file: dupe_set with %d members — none resolved", len(members))
         return result
 
     if importer_name == "converter":
-        result = _resolve_converter(params)
+        result = _resolve_converter(stack, params)
         if result is None:
             log.debug(
                 "resolve_file: converter origin failed — source_file=%r, parent_importer=%r",
@@ -216,7 +295,7 @@ def resolve_file_from_origin(
     _auto_wire_resolvers()
 
     if _source_resolver is not None:
-        result = _source_resolver(origin, origin_name, filename)
+        result = _source_resolver(stack, origin, origin_name, filename)
         if result is not None:
             log.debug("resolve_file: source-based dispatch succeeded → %s", result)
             return result
@@ -262,10 +341,11 @@ def resolve_file_from_origin(
     return None
 
 
-def _resolve_dupe_set(origin: dict[str, Any]) -> Path | None:
+def _resolve_dupe_set(stack: ExitStack, origin: dict[str, Any]) -> Path | None:
     """Try each member of a dupe_set until one resolves."""
     for m in origin.get("members", []):
-        result = resolve_file_from_origin(
+        result = _resolve_with_stack(
+            stack,
             m.get("origin"),
             m.get("origin_name", ""),
             m.get("filename", ""),
@@ -275,7 +355,7 @@ def _resolve_dupe_set(origin: dict[str, Any]) -> Path | None:
     return None
 
 
-def _resolve_converter(params: dict[str, str]) -> Path | None:
+def _resolve_converter(stack: ExitStack, params: dict[str, str]) -> Path | None:
     """Resolve a converter origin by rebuilding its parent origin."""
     source_file = params.get("source_file", "")
     parent_importer = params.get("parent_importer", "")
@@ -290,7 +370,7 @@ def _resolve_converter(params: dict[str, str]) -> Path | None:
         parent_params["url"] = params["parent_url"]
 
     parent_origin = {"importer": parent_importer, "params": parent_params}
-    return resolve_file_from_origin(parent_origin, origin_name=source_file)
+    return _resolve_with_stack(stack, parent_origin, origin_name=source_file)
 
 
 def embed_file(file_path: Path, media_type: str, embedder_name: str = "") -> np.ndarray | None:
@@ -504,66 +584,66 @@ def resolve_label_embeddings(
         origin_name = entry.get("origin_name", "")
         filename = entry.get("filename", "")
 
-        file_path = resolve_file_from_origin(origin, origin_name, filename)
-        if file_path is None:
-            result.missing_entries.append(entry)
-            if origin is None:
-                _no_origin += 1
-                log.info(
-                    "  label[%d] FAILED (no origin): md5=%s, origin_name=%r, "
-                    "filename=%r — this label has no origin trail and cannot "
-                    "be resolved to a file",
-                    i,
-                    entry.get("md5", "?")[:12],
-                    origin_name,
-                    filename,
-                )
-            else:
-                _file_not_found += 1
-                log.info(
-                    "  label[%d] FAILED (file not found): importer=%r, origin_name=%r, filename=%r, params=%r",
-                    i,
-                    origin.get("importer", "?"),
-                    origin_name,
-                    filename,
-                    origin.get("params", {}),
-                )
-            if progress_callback is not None:
-                progress_callback(current=i + 1, total=_total_entries)
-            continue
+        with resolve_file_context(origin, origin_name, filename) as file_path:
+            if file_path is None:
+                result.missing_entries.append(entry)
+                if origin is None:
+                    _no_origin += 1
+                    log.info(
+                        "  label[%d] FAILED (no origin): md5=%s, origin_name=%r, "
+                        "filename=%r — this label has no origin trail and cannot "
+                        "be resolved to a file",
+                        i,
+                        entry.get("md5", "?")[:12],
+                        origin_name,
+                        filename,
+                    )
+                else:
+                    _file_not_found += 1
+                    log.info(
+                        "  label[%d] FAILED (file not found): importer=%r, origin_name=%r, filename=%r, params=%r",
+                        i,
+                        origin.get("importer", "?"),
+                        origin_name,
+                        filename,
+                        origin.get("params", {}),
+                    )
+                if progress_callback is not None:
+                    progress_callback(current=i + 1, total=_total_entries)
+                continue
 
-        # Use clip-aware embedding when the label has clip params in its
-        # origin (e.g. from a clipped dataset).  This ensures cross-dataset
-        # resolution embeds the clipped content, not the whole parent file.
-        if origin is not None and origin.get("params", {}).get("clipper"):
-            embedding = _apply_clip_and_embed(file_path, media_type, origin)
-        else:
-            embedding = embed_file(file_path, media_type)
-        if embedding is None:
-            result.missing_entries.append(entry)
-            _embed_failed += 1
-            log.info(
-                "  label[%d] FAILED (embed): file resolved to %s but embedding returned None for media_type=%r",
+            # Use clip-aware embedding when the label has clip params in its
+            # origin (e.g. from a clipped dataset).  This ensures cross-dataset
+            # resolution embeds the clipped content, not the whole parent file.
+            if origin is not None and origin.get("params", {}).get("clipper"):
+                embedding = _apply_clip_and_embed(file_path, media_type, origin)
+            else:
+                embedding = embed_file(file_path, media_type)
+            if embedding is None:
+                result.missing_entries.append(entry)
+                _embed_failed += 1
+                log.info(
+                    "  label[%d] FAILED (embed): file resolved to %s but embedding returned None for media_type=%r",
+                    i,
+                    file_path,
+                    media_type,
+                )
+                if progress_callback is not None:
+                    progress_callback(current=i + 1, total=_total_entries)
+                continue
+
+            result.embeddings.append(embedding)
+            result.labels.append(1.0 if label_val == "good" else 0.0)
+            result.resolved_count += 1
+            log.debug(
+                "  label[%d] OK: %s → %s (label=%s)",
                 i,
-                file_path,
-                media_type,
+                origin_name or filename,
+                file_path.name,
+                label_val,
             )
             if progress_callback is not None:
                 progress_callback(current=i + 1, total=_total_entries)
-            continue
-
-        result.embeddings.append(embedding)
-        result.labels.append(1.0 if label_val == "good" else 0.0)
-        result.resolved_count += 1
-        log.debug(
-            "  label[%d] OK: %s → %s (label=%s)",
-            i,
-            origin_name or filename,
-            file_path.name,
-            label_val,
-        )
-        if progress_callback is not None:
-            progress_callback(current=i + 1, total=_total_entries)
 
     # --- Summary ---
     n_good = sum(1 for v in result.labels if v == 1.0)

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -625,34 +625,34 @@ def train_detector_from_origins(
     """
     import torch  # noqa: PLC0415
 
-    from vtsearch.models.resolver import embed_file, resolve_file_from_origin
+    from vtsearch.models.resolver import embed_file, resolve_file_context
 
     X_list: list = []
     y_list: list[float] = []
 
     for entry in good_origins:
-        file_path = resolve_file_from_origin(
+        with resolve_file_context(
             entry.get("origin"),
             entry.get("origin_name", ""),
             entry.get("filename", ""),
-        )
-        if file_path is None:
-            continue
-        emb = embed_file(file_path, media_type)
+        ) as file_path:
+            if file_path is None:
+                continue
+            emb = embed_file(file_path, media_type)
         if emb is None:
             continue
         X_list.append(emb)
         y_list.append(1.0)
 
     for entry in bad_origins:
-        file_path = resolve_file_from_origin(
+        with resolve_file_context(
             entry.get("origin"),
             entry.get("origin_name", ""),
             entry.get("filename", ""),
-        )
-        if file_path is None:
-            continue
-        emb = embed_file(file_path, media_type)
+        ) as file_path:
+            if file_path is None:
+                continue
+            emb = embed_file(file_path, media_type)
         if emb is None:
             continue
         X_list.append(emb)

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -620,30 +620,32 @@ def preview_detector_label(name: str, element_id: str):
         return jsonify({"error": "Label element not found"}), 404
 
     _, elem = found
-    file_path = resolve_element_to_path(elem)
-    if file_path is None or not file_path.is_file():
-        return jsonify({"error": "Element media file unavailable"}), 404
-
     media_type = data.get("media_type", "")
-    if media_type == "text":
+
+    with resolve_element_to_path(elem) as file_path:
+        if file_path is None or not file_path.is_file():
+            return jsonify({"error": "Element media file unavailable"}), 404
+
+        if media_type == "text":
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                return jsonify({"error": "Element media file unreadable"}), 404
+            return jsonify(
+                {
+                    "content": content,
+                    "word_count": len(content.split()),
+                    "character_count": len(content),
+                }
+            )
+
         try:
-            content = file_path.read_text(encoding="utf-8", errors="replace").strip()
+            file_bytes = file_path.read_bytes()
         except OSError:
             return jsonify({"error": "Element media file unreadable"}), 404
-        return jsonify(
-            {
-                "content": content,
-                "word_count": len(content.split()),
-                "character_count": len(content),
-            }
-        )
 
-    try:
-        file_bytes = file_path.read_bytes()
-    except OSError:
-        return jsonify({"error": "Element media file unreadable"}), 404
+        suffix = file_path.suffix.lower()
 
-    suffix = file_path.suffix.lower()
     mimetype = _MIMETYPE_BY_SUFFIX.get(suffix) or _DEFAULT_MIMETYPE_BY_TYPE.get(media_type, "application/octet-stream")
     return send_file(
         io.BytesIO(file_bytes),
@@ -807,11 +809,11 @@ def thumbnail_detector_label(name: str, element_id: str):
             if resp is not None:
                 return resp
 
-    file_path = resolve_element_to_path(elem)
-    if file_path is None or not file_path.is_file():
-        return jsonify({"error": "Element media file unavailable"}), 404
+    with resolve_element_to_path(elem) as file_path:
+        if file_path is None or not file_path.is_file():
+            return jsonify({"error": "Element media file unavailable"}), 404
 
-    return _origin_thumbnail_response(file_path, media_type, elem)
+        return _origin_thumbnail_response(file_path, media_type, elem)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Label import against a temp-backed `MediaSource` (e.g. PullWrest) was crashing inside the embedder with:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/tmp/dx_uuid_kdgg2gr3/copilotId-Siamese_122.jpg'
WARNING vtsearch.models.resolver: embed_file: ImageSiglipEmbedder.embed_media(...) returned None
```

Root cause: `_default_source_resolver` was minting a fresh source, asking for the path, and dropping the source before the caller embedded the file. Sources that own a `tempfile.TemporaryDirectory` got finalised by GC and the path went stale before `embed_file` opened it. The dev's log even shows two consecutive calls landing in two different `/tmp/dx_uuid_*/` dirs — each call re-downloads, returns a path, and the dir vanishes.

Fix: introduce `resolve_file_context(...)` — a context manager that registers each source's `cleanup()` on an `ExitStack` so any temp dir stays alive for the whole `with`-block. Callers that resolve a file and then immediately embed / read it now go through the CM:

- `vtsearch/datasets/ingest.py::_ingest_via_resolver` (the call site the dev pointed at)
- `vtsearch/models/resolver.py::resolve_label_embeddings`
- `vtsearch/models/training.py::train_detector_from_origins`
- `vtsearch/models/labelset_training.py::_embed_one`
- `vtsearch/models/label_restoration.py` MD5 fallback
- `vtsearch/routes/detectors.py` preview + thumbnail handlers (file bytes are now read inside the CM block before `send_file`)

`resolve_file_from_origin` stays as a thin wrapper around the CM for callers that only need an existence check — its docstring now warns that the path is invalidated on return for sources with temp-backed storage.

Source-using fast paths (`_ingest_via_source`) already kept a single source alive across the per-entry loop, so http_archive / server_folder / pullwrest ingest still hit the source once and reuse it.

## Test plan
- [x] Added `TestResolveFileContextLifetime` to `tests/test_resolver.py` covering the source-lifetime invariant (`cleanup()` deferred to context exit) and the legacy-wrapper behavior.
- [x] Migrated three monkeypatch sites (`test_label_import_ingestion`, `test_cli_detectors`, `test_labelset_elements_api`) from `resolve_file_from_origin` to `resolve_file_context` so the production code path is still exercised end-to-end.
- [x] `./run-tests.sh` — 2994 passed, 1 skipped, 2 xpassed.
- [x] `ruff check` on changed files — clean.

https://claude.ai/code/session_017xWbVNxpHoeULJAuKouG2x

---
_Generated by [Claude Code](https://claude.ai/code/session_017xWbVNxpHoeULJAuKouG2x)_