### PR TITLE
Autopilot: skip text mode when retraining a detector that already has labels

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -8,6 +8,8 @@
       [goodVotes]="voteState.goodVotes"
       [badVotes]="voteState.badVotes"
       [learnedSortAvailable]="voteState.learnedSortAvailable"
+      [labelsetGoodCount]="voteState.labelsetGoodCount"
+      [labelsetBadCount]="voteState.labelsetBadCount"
       [sortMode]="sortState.sortMode"
       [selectMode]="sortState.selectMode"
       [inclusion]="sortState.inclusion"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -148,8 +148,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(pairwise(), takeUntil(this.destroy$))
       .subscribe(([prev, curr]) => {
         if (prev.phase === curr.phase) return;
-        if (curr.phase === 'good') this.sortState.setSelectMode('top');
-        else if (curr.phase === 'bad') this.sortState.setSelectMode('hard');
+        if (curr.phase === 'good') {
+          this.sortState.setSelectMode('top');
+          if (curr.retrainMode) {
+            this.sortState.setSortMode('learned');
+            this.onLearnedSort(false);
+          }
+        }
+        else if (curr.phase === 'bad') {
+          this.sortState.setSelectMode('hard');
+          if (curr.retrainMode) {
+            this.sortState.setSortMode('learned');
+            this.onLearnedSort(false);
+          }
+        }
         else if (curr.phase === 'hard') {
           this.sortState.setSelectMode('hard');
           this.sortState.setSortMode('learned');
@@ -590,13 +602,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.resortVoteCount = 0;
     this.resortNextThreshold = this.resortInterval;
 
-    const phase = this.autopilotStateService.state.phase;
+    const state = this.autopilotStateService.state;
+    const phase = state.phase;
 
     // For phases beyond 'good', the phase-transition subscription already set
     // the correct selectMode and (for 'hard') triggered a learned sort.
     // Only override selectMode for the initial 'good' phase.
     if (phase === 'good') {
       this.sortState.setSelectMode('top');
+    }
+
+    // Retrain mode: the subscription already set sortMode='learned' and
+    // kicked off learned sort for whatever phase we're in.  Nothing more to do.
+    if (state.retrainMode) {
+      return;
     }
 
     // For 'hard' and later phases the subscription already triggered learned
@@ -660,6 +679,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private checkResortPrompt(): void {
     // Only show during autopilot's "good" phase (sorting by example in top mode)
     if (!this.autopilotStateService.running) return;
+    // Retrain mode uses learned sort instead of text/example; there is no
+    // example to swap, so the resort prompt is irrelevant.
+    if (this.autopilotStateService.state.retrainMode) return;
     // Eagerly check phase transition so we don't show the prompt after the user
     // has already found enough greens (the panel's ngOnChanges may not have run yet).
     this.autopilotStateService.checkPhaseTransition(
@@ -742,15 +764,21 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onAutopilotStop(): void {
-    const phase = this.autopilotStateService.state.phase;
+    const state = this.autopilotStateService.state;
+    const phase = state.phase;
     const isMediaBased = !!this.labelSession.mediaExample && !this.labelSession.textQuery;
+    // Retrain mode never used text/example sort, so stopping shouldn't switch
+    // the UI back to it — keep learned sort selected for every phase.
+    const earlySortMode: SortMode = state.retrainMode
+      ? 'learned'
+      : (isMediaBased ? 'load' : 'text');
 
     // Map autopilot phase to the same Sort + Select that autopilot was using.
     if (phase === 'good') {
-      this.sortState.setSortMode(isMediaBased ? 'load' : 'text');
+      this.sortState.setSortMode(earlySortMode);
       this.sortState.setSelectMode('top');
     } else if (phase === 'bad') {
-      this.sortState.setSortMode(isMediaBased ? 'load' : 'text');
+      this.sortState.setSortMode(earlySortMode);
       this.sortState.setSelectMode('hard');
     } else if (phase === 'hard') {
       this.sortState.setSortMode('learned');

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -230,6 +230,30 @@ describe('AutopilotPanelComponent', () => {
     expect(component.refocus.emit).not.toHaveBeenCalled();
   });
 
+  it('activate without labelset labels should not enter retrain mode', () => {
+    autopilotState.clear();
+    const fresh = TestBed.createComponent(AutopilotPanelComponent);
+    fresh.componentInstance.labelsetGoodCount = 0;
+    fresh.componentInstance.labelsetBadCount = 0;
+    fresh.detectChanges();
+    expect(fresh.componentInstance.state.retrainMode).toBeFalse();
+  });
+
+  it('activate with detector labels from another dataset should enter retrain mode', () => {
+    autopilotState.clear();
+    const fresh = TestBed.createComponent(AutopilotPanelComponent);
+    // Simulate "trained on DatasetA, switched to DatasetB with 0 votes here":
+    // current-dataset goodVotes/badVotes empty, but labelset counts positive.
+    fresh.componentInstance.labelsetGoodCount = 5;
+    fresh.componentInstance.labelsetBadCount = 4;
+    fresh.componentInstance.goodVotes = new Set();
+    fresh.componentInstance.badVotes = new Set();
+    fresh.detectChanges();
+    expect(fresh.componentInstance.state.retrainMode).toBeTrue();
+    // Still in 'good' phase since current-dataset votes are below threshold.
+    expect(fresh.componentInstance.state.phase).toBe('good');
+  });
+
   it('should mark current step as active and future steps as future', () => {
     const steps = component.steps;
     expect(steps[0].state).toBe('active');

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -36,6 +36,14 @@ export interface StepDisplay {
 export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
+  /**
+   * Total "good" labels in the active detector's saved labelset, across all
+   * datasets it has been used with.  When both this and ``labelsetBadCount``
+   * are positive at activation time, autopilot enters retrain mode and uses
+   * learned sort throughout instead of starting with text/example sort.
+   */
+  @Input() labelsetGoodCount = 0;
+  @Input() labelsetBadCount = 0;
   @Input() labelingStatus: LabelingStatusResponse | null = null;
   @Input() collapsed = false;
 
@@ -109,7 +117,11 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   activate(): void {
     if (this.running) return;
     this.completionAlerted = false;
-    this.autopilotState.activate();
+    // Retrain mode: the detector already has good+bad labels (carried over
+    // from a previous dataset), so learned sort is available immediately and
+    // autopilot should skip the initial text-mode phase.
+    const retrainMode = this.labelsetGoodCount > 0 && this.labelsetBadCount > 0;
+    this.autopilotState.activate(retrainMode);
     // Immediately check whether existing votes already satisfy early phases
     // (e.g. user labeled 23 goods in Manual mode before switching to Autopilot).
     // ngOnChanges ran before ngOnInit so `running` was false and the check was

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -153,6 +153,8 @@
         <vt-autopilot-panel
           [goodVotes]="goodVotes"
           [badVotes]="badVotes"
+          [labelsetGoodCount]="labelsetGoodCount"
+          [labelsetBadCount]="labelsetBadCount"
           [labelingStatus]="labelingStatus"
           [collapsed]="autopilotCollapsed"
           (started)="autopilotStart.emit()"

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -45,6 +45,9 @@ export class LeftPanelComponent implements OnInit, OnChanges {
    * only contain media IDs in the *currently loaded* dataset.
    */
   @Input() learnedSortAvailable = false;
+  /** Active detector's saved labelset counts (across all datasets). */
+  @Input() labelsetGoodCount = 0;
+  @Input() labelsetBadCount = 0;
   @Input() sortMode: SortMode = 'text';
   @Input() selectMode: SelectMode = 'top';
   @Input() inclusion: number = 0;

--- a/frontend/src/app/services/autopilot-state.service.spec.ts
+++ b/frontend/src/app/services/autopilot-state.service.spec.ts
@@ -225,6 +225,29 @@ describe('AutopilotStateService', () => {
     expect(service.state.smartStatus).toBe('');
   });
 
+  it('activate without retrainMode should default to false', () => {
+    service.activate();
+    expect(service.state.retrainMode).toBeFalse();
+  });
+
+  it('activate with retrainMode=true should set the flag on state', () => {
+    service.activate(true);
+    expect(service.state.retrainMode).toBeTrue();
+    expect(service.state.phase).toBe('good');
+  });
+
+  it('retrainMode should persist through phase transitions until cleared', () => {
+    service.activate(true);
+    service.checkPhaseTransition(3, 4);
+    expect(service.state.phase).toBe('hard');
+    expect(service.state.retrainMode).toBeTrue();
+
+    service.deactivate();
+    expect(service.state.retrainMode).toBeTrue(); // deactivate only flips phase
+    service.clear();
+    expect(service.state.retrainMode).toBeFalse();
+  });
+
   it('state$ should emit on changes', (done) => {
     const phases: string[] = [];
     service.state$.subscribe((s) => phases.push(s.phase));

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -12,6 +12,14 @@ export interface AutopilotState {
   stableStatus: string;
   spanStatus: string;
   fracDiversity: number;
+  /**
+   * True when autopilot started against a detector that already has labels
+   * (e.g. trained on DatasetA, now continuing on DatasetB).  In retrain mode
+   * every phase uses learned sort — the initial "good"/"bad" phases use
+   * Learned-Good and Learned-Hard against the existing model instead of
+   * falling back to text/example sort.
+   */
+  retrainMode: boolean;
 }
 
 const INITIAL_STATE: AutopilotState = {
@@ -22,6 +30,7 @@ const INITIAL_STATE: AutopilotState = {
   stableStatus: '',
   spanStatus: '',
   fracDiversity: 0,
+  retrainMode: false,
 };
 
 @Injectable({ providedIn: 'root' })
@@ -38,7 +47,7 @@ export class AutopilotStateService {
     return this.stateSubject.value.phase !== 'idle';
   }
 
-  activate(): void {
+  activate(retrainMode = false): void {
     if (this.running) return;
     this.stateSubject.next({
       ...this.stateSubject.value,
@@ -47,6 +56,7 @@ export class AutopilotStateService {
       stableStatus: '',
       spanStatus: '',
       fracDiversity: 0,
+      retrainMode,
     });
   }
 


### PR DESCRIPTION
## Summary

When a detector already has labels (e.g. trained on DatasetA), continuing to label it on DatasetB used to start autopilot in **text mode** — even though learned sort was perfectly usable from the existing A-vectors. This change makes autopilot recognize that situation and run in **learn mode** throughout.

### What was wrong

Autopilot's phase transitions are driven by `voteState.goodVotes.size` / `badVotes.size`, which only count the *current dataset's* votes. So on DatasetB with 0 B-votes, autopilot stayed in the `'good'` phase, and `onAutopilotStart()` kicked off a text/example sort (or no sort at all). The detector's existing A-labels — already loaded into `DetectorContext.label_embeddings` and trainable via `/api/learned-sort` — were ignored for sort-mode selection.

### Fix

`AutopilotStateService.activate(retrainMode)` now accepts a flag derived from the labelset counts (which span all datasets):

```
retrainMode = labelsetGoodCount > 0 && labelsetBadCount > 0
```

The phase machine itself is unchanged (still `good → bad → hard → new`, driven by current-dataset votes). What changes is the sort + select mode at each phase:

| Phase  | Select mode | Sort mode (fresh) | Sort mode (retrain) |
|--------|-------------|-------------------|---------------------|
| good   | top         | text / example    | **learned**         |
| bad    | hard        | text / example    | **learned**         |
| hard   | hard        | learned           | learned             |
| new    | new         | learned           | learned             |

So in retrain mode the user sees: Learned-Good → Learned-Hard → Learned-Hard (until Smart+Stable green) → Learned-New (until Span green), matching the requested plan.

Side effects in retrain mode:
- `onAutopilotStart()` skips the text/media sort kickoff (the phase-transition subscription already triggered learned sort).
- The "resort example" prompt is suppressed (there's no example to swap).
- `onAutopilotStop()` keeps `sortMode='learned'` for `good`/`bad` instead of reverting to `text`/`load`.

### Files

- `frontend/src/app/services/autopilot-state.service.ts` — `retrainMode` field, accepted by `activate()`.
- `frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts` — new `labelsetGoodCount` / `labelsetBadCount` inputs; derives `retrainMode` and passes it to `activate()`.
- `frontend/src/app/components/left-panel/left-panel.component.{ts,html}` — passes the labelset counts through.
- `frontend/src/app/components/label-view/label-view.component.{ts,html}` — feeds `voteState.labelsetGoodCount` / `labelsetBadCount`; phase subscription, `onAutopilotStart`, `checkResortPrompt`, `onAutopilotStop` all branch on `retrainMode`.
- `*.spec.ts` — new tests covering retrain activation and persistence through phase transitions.

## Test plan

- [x] `./run-tests.sh` — full suite (3028 passed, 1 skipped)
- [x] Frontend build (`npm run build:prod` via `run-tests.sh`) — clean, 0 vulnerabilities
- [x] New unit tests:
  - `AutopilotStateService` — `activate()` default vs `activate(true)`, retrainMode persists across phase transitions, cleared by `clear()`.
  - `AutopilotPanelComponent` — fresh detector (0/0 labelset) stays out of retrain mode; cross-dataset detector (5 good + 4 bad in labelset, 0 in current dataset) enters retrain mode and stays in `good` phase.
- [ ] Manual: load detector trained on DatasetA, switch to DatasetB, enable autopilot — should land directly in Learned-Good without ever touching text mode.

https://claude.ai/code/session_01U2UYQSacwTkMX21vZkvD9i

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2UYQSacwTkMX21vZkvD9i)_