### PR TITLE
fix(diversity-tree): hoist sklearn import so the progress bar doesn't freeze at 0

### DIFF
--- a/vtsearch/models/diversity_tree.py
+++ b/vtsearch/models/diversity_tree.py
@@ -19,6 +19,12 @@ from collections.abc import Callable
 
 import numpy as np
 
+# Imported eagerly so the ~1s sklearn cold-import is paid *before* the
+# progress bar reports `(0, estimated_total_work)`.  When the import was
+# lazy (inside `_build_node`) the bar appeared stuck at `(0, N)` while
+# sklearn loaded on the first `_build_node` call.
+from sklearn.cluster import KMeans
+
 DIVERSITY_TREE_DEFAULT_K = 2
 DIVERSITY_TREE_MAX_DEPTH = 10
 DIVERSITY_TREE_MIN_NODE_SIZE = 20
@@ -130,8 +136,6 @@ class DiversityTree:
         # Each of the N_INIT runs reports progress separately, so the UI
         # updates during the expensive root clustering instead of sitting
         # at 0% until it finishes.
-        from sklearn.cluster import KMeans  # noqa: PLC0415
-
         best_labels = None
         best_inertia = float("inf")
         for init_i in range(_N_INIT):


### PR DESCRIPTION
## Summary

`[Step 2/3] (0/12,360) Building diversity index…` appeared frozen at exactly that value for several seconds before popping to Step 3. The clustering itself was fine — 242 per-init progress callbacks were already firing — but the FE was getting (0, N) for two polls in a row, then by the third poll Step 2 was already done.

## Root cause

`from sklearn.cluster import KMeans` was lazy inside `_build_node` (marked `# noqa: PLC0415`). The chain was:

1. `_diversity_progress(0, 0)` — bar shows "Building diversity index…" with no fraction
2. `DiversityTree.__init__` — bar shows `(0, est)` ← total non-zero now
3. `_build_node` first call → **sklearn cold import (~1 sec on dev box, plausibly 3–5 sec on slower disks)**
4. Root k-means runs and the first non-zero tick finally fires

At 1 Hz polling, the FE samples step 3 (sklearn loading) one or two times while the bar reads `(0, est)`, then by the next poll the build is done and Step 2 has flipped to Step 3.

Measured on the user's exact scenario (n=412, d=1024, k=3 — gives the 12,360 estimate):

| | first non-zero tick |
|---|---|
| before | **948 ms** after `(0, 12,360)` |
| after | **41 ms** after `(0, 12,360)` |

## Fix

Move `from sklearn.cluster import KMeans` to module scope in `vtsearch/models/diversity_tree.py`. Same total wall-clock — the sklearn import now happens while the bar is in its no-fraction "Building diversity index…" state (where there's nothing to update), instead of after the bar has shown a specific frozen number.

No change to clustering work or cost weighting. The existing per-init tick mechanism (10 ticks per node, weighted by `len(ids)`) was already correct.

## Test plan
- [x] `./run-tests.sh sorting` → 216/216 pass (includes diversity-tree progress tests)
- [x] `./run-tests.sh` → 3028 pass, 1 skipped
- [x] Empirical reproduction confirmed: first non-zero tick latency dropped from 948 ms → 41 ms

https://claude.ai/code/session_01RSDNxQL3hMpKHUTW9WcomB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSDNxQL3hMpKHUTW9WcomB)_