### PR TITLE
Fix sticky gray-box thumbnails after switching datasets mid-training

### DIFF
--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -18,7 +18,7 @@
         (keydown)="onEntryKeydown($event, entry.id)"
       >
         @if (hasThumbnailUrl(entry.id)) {
-          <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
+          <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry.id))" />
         } @else if (placeholderIcon(entry.id)) {
           <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>
         }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -118,10 +118,11 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     return this.viewMode === 'grid';
   }
 
-  private thumbnailFailedIds = new Set<number>();
+  private thumbnailFailedUrls = new Set<string>();
 
   hasThumbnailUrl(id: number): boolean {
-    if (this.thumbnailFailedIds.has(id)) return false;
+    const url = this.thumbnailUrl(id);
+    if (url && this.thumbnailFailedUrls.has(url)) return false;
     const media = this.mediaMap.get(id);
     return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document' || media.type === 'audio');
   }
@@ -132,8 +133,8 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
   }
 
-  onThumbnailError(id: number): void {
-    this.thumbnailFailedIds.add(id);
+  onThumbnailError(url: string): void {
+    if (url) this.thumbnailFailedUrls.add(url);
   }
 
   placeholderIcon(id: number): string | null {

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
@@ -18,7 +18,7 @@
         (keydown)="onEntryKeydown($event, entry)"
       >
         @if (hasThumbnailUrl(entry)) {
-          <img class="vote-thumbnail" [src]="thumbnailUrl(entry)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.id)" />
+          <img class="vote-thumbnail" [src]="thumbnailUrl(entry)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry))" />
         } @else if (placeholderIcon(entry)) {
           <span class="vote-placeholder">{{ placeholderIcon(entry) }}</span>
         }

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -40,7 +40,7 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
 
   sortedEntries: SortedElement[] = [];
   private pendingScrollPct: number | null = null;
-  private thumbnailFailedIds = new Set<string>();
+  private thumbnailFailedUrls = new Set<string>();
 
   constructor(private detectorsApi: DetectorsApiService) {}
 
@@ -105,7 +105,8 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   }
 
   hasThumbnailUrl(entry: LabelElement): boolean {
-    if (this.thumbnailFailedIds.has(entry.id)) return false;
+    const url = this.thumbnailUrl(entry);
+    if (url && this.thumbnailFailedUrls.has(url)) return false;
     return (
       entry.media_type === 'image' ||
       entry.media_type === 'video' ||
@@ -119,8 +120,8 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
     return this.detectorsApi.labelThumbnailUrl(this.modelName, entry.id);
   }
 
-  onThumbnailError(id: string): void {
-    this.thumbnailFailedIds.add(id);
+  onThumbnailError(url: string): void {
+    if (url) this.thumbnailFailedUrls.add(url);
   }
 
   placeholderIcon(entry: LabelElement): string | null {


### PR DESCRIPTION
## Summary

- Train DetectorA on DatasetB, switch active to DatasetC, and the labels carried over from DatasetB rendered as gray-box placeholders that only cleared by quitting to the dashboard and coming back.
- The right-panel label list and labelset list cached "this thumbnail failed" in a `Set<id>`. Once `<img>` fired `(error)` — even transiently, even before the active context settled on the new dataset — the entry was permanently swapped for `□` for the lifetime of the component, even after Angular re-evaluated `thumbnailUrl(entry)` against a now-resolvable URL.
- The earlier fix (d3f638e) added `?dataset_id=…&detector_id=…` so the *first* request had a chance, but didn't fix the stickiness: the cross-dataset origin fallback (`/api/detectors/<name>/labels/<id>/thumbnail` → `importer.resolve_file`) has a brief window during a dataset swap where it can 404, and once that happens the id is poisoned.
- Key the failed-thumbnail Set by URL instead of id in both `labelset-list.component.ts` and `label-list.component.ts`. When the active dataset/detector changes, `thumbnailUrl(entry)` returns a fresh string that isn't in the Set, so `hasThumbnailUrl` flips back to true and the IMG re-renders against the URL that actually works.

## Test plan

- [x] `npm run build:prod` — clean build, no TS errors.
- [x] `pytest tests/test_labelset_elements_api.py tests/test_frontend.py` — 55 passed.
- [ ] Manual: train detector on dataset A, switch active to dataset B, confirm the dataset-A labels in the right panel keep their thumbnails (not `□` placeholders).
- [ ] Manual: same as above with the plain `vt-label-list` (browse mode) by toggling out of train mode.

https://claude.ai/code/session_01DRGJS1kUjCWK4Jcxv8ftgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRGJS1kUjCWK4Jcxv8ftgh)_