### PR TITLE
fix(docker-siglip): use snapshot_download so the build stops hanging on model bake

### DIFF
--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -33,27 +33,20 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # Bake weights into a non-volume path so they survive volume mounts on
 # /app/data. The app reads MODELS_CACHE_DIR from VTSEARCH_MODELS_DIR.
 #
-# PYTHONUNBUFFERED + python -u + flushed prints surface progress in
-# BuildKit's UI; without them the ~370 MB download looks like a hang.
+# scripts/preload_siglip.py uses huggingface_hub.snapshot_download so we
+# only fetch the repo files — torch is not imported and the model is not
+# constructed during the build. That is much faster, uses far less RAM,
+# and emits per-file tqdm progress so the build never looks like a hang.
+# PYTHONUNBUFFERED + python -u keep those prints flowing to BuildKit.
 # Tip: run `docker build --progress=plain ...` to see step output live.
 # HF_HUB_DOWNLOAD_TIMEOUT makes a stalled connection error out (and
 # huggingface_hub auto-retry) instead of blocking the build forever.
 ENV VTSEARCH_MODELS_DIR=/opt/vtsearch/models \
     HF_HUB_DOWNLOAD_TIMEOUT=120 \
     PYTHONUNBUFFERED=1
+COPY scripts/preload_siglip.py scripts/preload_siglip.py
 RUN mkdir -p "$VTSEARCH_MODELS_DIR" && \
-    python -u -c "import os; \
-from vtsearch.config import SIGLIP_MODEL_ID; \
-cache=os.environ['VTSEARCH_MODELS_DIR']; \
-print(f'Pre-downloading {SIGLIP_MODEL_ID} to {cache}', flush=True); \
-print('[1/3] importing transformers...', flush=True); \
-from transformers import SiglipModel, SiglipImageProcessor, SiglipTokenizer; \
-print('[2/3] downloading model weights (~370 MB)...', flush=True); \
-SiglipModel.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
-print('[3/3] downloading image processor + tokenizer...', flush=True); \
-SiglipImageProcessor.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
-SiglipTokenizer.from_pretrained(SIGLIP_MODEL_ID, cache_dir=cache); \
-print('SigLIP weights cached.', flush=True)"
+    python -u scripts/preload_siglip.py
 
 # ---------- application layer ----------
 COPY . .

--- a/scripts/preload_siglip.py
+++ b/scripts/preload_siglip.py
@@ -1,0 +1,47 @@
+"""Pre-download SigLIP weights into ``$VTSEARCH_MODELS_DIR``.
+
+Used by ``Dockerfile.siglip`` to bake weights into the image. Uses
+``huggingface_hub.snapshot_download`` rather than
+``SiglipModel.from_pretrained`` so the build step only downloads files —
+it does not import torch, does not construct the model, and does not
+allocate a CPU copy of the weights. That makes the step substantially
+faster, uses far less RAM (the build no longer needs to hold the full
+model in memory), and surfaces per-file tqdm progress so the BuildKit
+log never looks like a 30-minute hang.
+
+Run on the host to debug:
+    VTSEARCH_MODELS_DIR=/tmp/m python -u scripts/preload_siglip.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from huggingface_hub import snapshot_download
+
+from vtsearch.config import SIGLIP_MODEL_ID
+
+
+def main() -> int:
+    cache_dir = os.environ.get("VTSEARCH_MODELS_DIR")
+    if not cache_dir:
+        print("VTSEARCH_MODELS_DIR is not set", file=sys.stderr, flush=True)
+        return 1
+
+    print(f"[preload-siglip] repo={SIGLIP_MODEL_ID} cache={cache_dir}", flush=True)
+    # SigLIP ships safetensors AND pytorch_model.bin; transformers prefers
+    # safetensors, so skip the duplicate .bin (~370 MB) plus other framework
+    # formats we never load.
+    path = snapshot_download(
+        repo_id=SIGLIP_MODEL_ID,
+        cache_dir=cache_dir,
+        ignore_patterns=["*.bin", "*.h5", "*.msgpack", "*.ot", "*.onnx"],
+        max_workers=4,
+    )
+    print(f"[preload-siglip] cached at {path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- The model-bake step in `Dockerfile.siglip` was an inline `python -c "...SiglipModel.from_pretrained..."` that, on top of downloading ~370 MB, imported torch and instantiated the full SigLIP model in CPU RAM — slow, memory-hungry, and easy to mistake for a 30-minute hang because progress was hidden inside three chained `from_pretrained` calls.
- Replaced it with a dedicated `scripts/preload_siglip.py` that uses `huggingface_hub.snapshot_download`: files-only, no torch import, no model construction, parallel workers, per-file tqdm progress so BuildKit's log keeps moving, and built-in retries (paired with the existing `HF_HUB_DOWNLOAD_TIMEOUT=120`).
- Also skips the duplicate `pytorch_model.bin` (transformers already prefers `model.safetensors`), trimming the cached weights baked into the image.

## Test plan
- [ ] `docker build -f Dockerfile.siglip -t vtsearch:siglip .` completes without hanging and emits per-file progress lines from `[preload-siglip]` / tqdm.
- [ ] `docker run -p 5000:5000 vtsearch:siglip` starts and the SigLIP embedder loads from the baked cache at `/opt/vtsearch/models` without hitting Hugging Face.
- [ ] (Optional) `VTSEARCH_MODELS_DIR=/tmp/m python -u scripts/preload_siglip.py` on the host downloads the SigLIP files into `/tmp/m`.

https://claude.ai/code/session_018RbRhAei6vLxnFCqFJgU7s

---
_Generated by [Claude Code](https://claude.ai/code/session_018RbRhAei6vLxnFCqFJgU7s)_