### PR TITLE
Add POST /api/embed for on-demand media and text embedding

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,6 +49,7 @@ from vtsearch.routes import (  # noqa: E402
     detector_scoring_bp,
     detectors_bp,
     detectors_registry_bp,
+    embed_bp,
     eval_bp,
     file_browser_bp,
     labels_bp,
@@ -200,6 +201,7 @@ app.register_blueprint(detectors_bp)
 app.register_blueprint(detectors_registry_bp)
 app.register_blueprint(detector_scoring_bp)
 app.register_blueprint(detector_find_bp)
+app.register_blueprint(embed_bp)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -39,6 +39,53 @@ GET /api/embedders
 
 → `{"embedders": [{"name": "siglip", "display_name": "SigLIP", "media_type_id": "image", ...}]}`
 
+### Embed on demand
+
+```
+POST /api/embed
+```
+
+Embed a single media file or text snippet with a chosen embedder, without
+loading a dataset.  Two input modes share the endpoint — the embedder
+declares its own `media_type_id`, so the caller does not pass a media
+type separately.
+
+**Media upload (`multipart/form-data`)** — form fields:
+
+| Field | Description |
+|-------|-------------|
+| `embedder` | Required. Embedder name from `GET /api/embedders`. |
+| `file` | Required. Binary upload. The extension is checked against the embedder's `media_type_id` before any model load. |
+
+**Text (`application/json`)** — body:
+
+```json
+{"embedder": "e5", "text": "a cat on a mat"}
+```
+
+Calls `embed_text(...)` — only embedders whose `supports_text` is `true`
+accept this mode (image/audio cross-modal embedders like CLIP, SigLIP, CLAP
+support it; vision-only embedders like DINOv3 do not).
+
+→
+```json
+{
+  "embedding": [0.123, -0.045, ...],
+  "dim": 512,
+  "norm": 1.0,
+  "embedder": "clip",
+  "media_type": "image"
+}
+```
+
+**Errors:**
+
+| Status | Cause |
+|--------|-------|
+| `400` | Missing `embedder`; missing `file` (multipart) or `text` (JSON); text sent to an embedder where `supports_text == false`; file extension does not match the embedder's media type; embedder returned no vector for the upload. |
+| `404` | Unknown embedder name. Response body lists every registered embedder's `name`. |
+| `500` | Model load failure, or text embedding returned `None`. |
+
 ### Clippers
 
 ```

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,210 @@
+"""Tests for the on-demand embedding API (``POST /api/embed``)."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import numpy as np
+import pytest
+
+from vtsearch.media import _embedder_registry
+from vtsearch.media.embedder import MediaEmbedder
+
+
+class _FakeImageEmbedder(MediaEmbedder):
+    """Image-modality fake that records the path it was asked to embed.
+
+    Returns a deterministic 4-d vector for both media and text inputs so
+    tests can assert exact response shapes.  Setting ``return_none_media``
+    or ``return_none_text`` lets individual tests exercise the failure
+    branches.
+    """
+
+    name = "fake_image"  # type: ignore[assignment]
+    media_type_id = "image"  # type: ignore[assignment]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._model = "loaded"
+        self.last_media_path: str | None = None
+        self.last_text: str | None = None
+        self.return_none_media = False
+        self.return_none_text = False
+        self._supports_text = True
+
+    @property
+    def supports_text(self) -> bool:
+        return self._supports_text
+
+    def _load_models_impl(self) -> None:  # pragma: no cover — pre-loaded
+        return
+
+    def _embed_media_impl(self, media):
+        self.last_media_path = media.get("media_path")
+        if self.return_none_media:
+            return None
+        return np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+
+    def embed_text(self, text):
+        self.last_text = text
+        if self.return_none_text:
+            return None
+        return np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+
+
+@pytest.fixture
+def fake_image_embedder():
+    """Register a fake image embedder for one test, then unregister it."""
+    emb = _FakeImageEmbedder()
+    saved_name = _embedder_registry.pop("fake_image", None)
+    _embedder_registry["fake_image"] = emb
+    try:
+        yield emb
+    finally:
+        _embedder_registry.pop("fake_image", None)
+        if saved_name is not None:
+            _embedder_registry["fake_image"] = saved_name
+
+
+class TestEmbedMediaUpload:
+    """Multipart upload mode."""
+
+    def test_embeds_uploaded_image(self, client, fake_image_embedder):
+        resp = client.post(
+            "/api/embed",
+            data={"embedder": "fake_image", "file": (BytesIO(b"\x89PNGfake"), "pic.png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["embedder"] == "fake_image"
+        assert body["media_type"] == "image"
+        assert body["dim"] == 4
+        assert body["embedding"] == [1.0, 2.0, 3.0, 4.0]
+        # norm = sqrt(1+4+9+16) = sqrt(30)
+        assert body["norm"] == pytest.approx(np.sqrt(30.0), rel=1e-5)
+        # Embedder saw a real file on disk that was cleaned up afterwards.
+        assert fake_image_embedder.last_media_path is not None
+
+    def test_unknown_embedder_returns_404(self, client):
+        resp = client.post(
+            "/api/embed",
+            data={"embedder": "nope", "file": (BytesIO(b"x"), "pic.png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 404
+        body = resp.get_json()
+        assert "Unknown embedder 'nope'" in body["error"]
+        assert "Available:" in body["error"]
+
+    def test_missing_embedder_field_returns_400(self, client):
+        resp = client.post(
+            "/api/embed",
+            data={"file": (BytesIO(b"x"), "pic.png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "embedder is required" in resp.get_json()["error"]
+
+    def test_missing_file_returns_400(self, client, fake_image_embedder):
+        resp = client.post(
+            "/api/embed",
+            data={"embedder": "fake_image"},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "file is required" in resp.get_json()["error"]
+
+    def test_wrong_extension_returns_400(self, client, fake_image_embedder):
+        """An audio file uploaded to an image embedder is rejected fast."""
+        resp = client.post(
+            "/api/embed",
+            data={"embedder": "fake_image", "file": (BytesIO(b"RIFF"), "sound.wav")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["expected_media_type"] == "image"
+        assert body["detected_media_type"] == "audio"
+
+    def test_unknown_extension_passes_through_to_embedder(self, client, fake_image_embedder):
+        """A file with no recognised extension is still attempted."""
+        resp = client.post(
+            "/api/embed",
+            data={"embedder": "fake_image", "file": (BytesIO(b"x"), "blob.xyz")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["dim"] == 4
+
+    def test_embedder_returns_none_yields_400(self, client, fake_image_embedder):
+        fake_image_embedder.return_none_media = True
+        resp = client.post(
+            "/api/embed",
+            data={"embedder": "fake_image", "file": (BytesIO(b"\x89PNGfake"), "pic.png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "could not embed" in body["error"]
+        assert body["media_type"] == "image"
+
+
+class TestEmbedTextJson:
+    """JSON body mode."""
+
+    def test_embeds_text(self, client, fake_image_embedder):
+        resp = client.post(
+            "/api/embed",
+            json={"embedder": "fake_image", "text": "a cat"},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["embedder"] == "fake_image"
+        assert body["media_type"] == "image"
+        assert body["dim"] == 4
+        assert body["embedding"] == pytest.approx([0.1, 0.2, 0.3, 0.4])
+        assert fake_image_embedder.last_text == "a cat"
+
+    def test_unknown_embedder_returns_404(self, client):
+        resp = client.post("/api/embed", json={"embedder": "nope", "text": "hi"})
+        assert resp.status_code == 404
+        assert "Unknown embedder 'nope'" in resp.get_json()["error"]
+
+    def test_missing_embedder_returns_400(self, client):
+        resp = client.post("/api/embed", json={"text": "hi"})
+        assert resp.status_code == 400
+        assert "embedder is required" in resp.get_json()["error"]
+
+    def test_missing_text_returns_400(self, client, fake_image_embedder):
+        resp = client.post("/api/embed", json={"embedder": "fake_image"})
+        assert resp.status_code == 400
+        assert "text is required" in resp.get_json()["error"]
+
+    def test_non_text_embedder_returns_400(self, client, fake_image_embedder):
+        fake_image_embedder._supports_text = False
+        resp = client.post(
+            "/api/embed",
+            json={"embedder": "fake_image", "text": "a cat"},
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["supports_text"] is False
+        assert "does not support text" in body["error"]
+
+    def test_embedder_returns_none_yields_500(self, client, fake_image_embedder):
+        fake_image_embedder.return_none_text = True
+        resp = client.post(
+            "/api/embed",
+            json={"embedder": "fake_image", "text": "a cat"},
+        )
+        assert resp.status_code == 500
+        assert "returned no vector" in resp.get_json()["error"]
+
+    def test_invalid_json_returns_400(self, client):
+        resp = client.post(
+            "/api/embed",
+            data="not json",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -6,6 +6,7 @@ from vtsearch.routes.detector_find import detector_find_bp
 from vtsearch.routes.detector_scoring import detector_scoring_bp
 from vtsearch.routes.detectors import detectors_bp
 from vtsearch.routes.detectors_registry import detectors_registry_bp
+from vtsearch.routes.embed import embed_bp
 from vtsearch.routes.eval import eval_bp
 from vtsearch.routes.file_browser import file_browser_bp
 from vtsearch.routes.labels import labels_bp
@@ -29,6 +30,7 @@ __all__ = [
     "detector_scoring_bp",
     "detectors_bp",
     "detectors_registry_bp",
+    "embed_bp",
     "eval_bp",
     "file_browser_bp",
     "labels_bp",

--- a/vtsearch/routes/embed.py
+++ b/vtsearch/routes/embed.py
@@ -1,0 +1,189 @@
+"""Blueprint for on-demand media/text embedding.
+
+Exposes a single endpoint, ``POST /api/embed``, that turns a media file
+or a text snippet into a vector using a caller-chosen embedder.  Two
+input modes share the route:
+
+* ``multipart/form-data`` with ``embedder=<name>`` and ``file=<binary>``
+  — runs :meth:`MediaEmbedder.embed_media` on the upload.
+* ``application/json`` with ``{"embedder": "<name>", "text": "..."}``
+  — runs :meth:`MediaEmbedder.embed_text`.
+
+The user does not pass a ``media_type``: every embedder declares its
+``media_type_id``, so picking the embedder already determines the
+expected modality.  Wrong-modality requests (e.g. an audio file sent to
+an image embedder) are caught by a fast extension pre-check before any
+model weights are loaded.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+
+import numpy as np
+from flask import Blueprint, jsonify, request
+
+from vtsearch.config import DATA_DIR
+from vtsearch.media import all_embedders, get_by_extension, get_embedder
+from vtsearch.media.embedder import media_from_path
+from vtsearch.routes.helpers import get_json_or_400
+
+embed_bp = Blueprint("embed", __name__)
+logger = logging.getLogger(__name__)
+
+
+def _unknown_embedder_response(name: str):
+    available = sorted(e.name for e in all_embedders())
+    return (
+        jsonify({"error": f"Unknown embedder '{name}'. Available: {available}"}),
+        404,
+    )
+
+
+def _vector_response(vec, embedder):
+    arr = np.asarray(vec, dtype=np.float32).reshape(-1)
+    return jsonify(
+        {
+            "embedding": arr.tolist(),
+            "dim": int(arr.shape[0]),
+            "norm": float(np.linalg.norm(arr)),
+            "embedder": embedder.name,
+            "media_type": embedder.media_type_id,
+        }
+    )
+
+
+def _is_multipart_request() -> bool:
+    """True when the request carries a file upload or form fields.
+
+    Falls back to inspecting ``Content-Type`` so callers that send
+    multipart with no plain form fields (just the file) are still routed
+    to the media path.
+    """
+    if request.files or request.form:
+        return True
+    content_type = (request.content_type or "").lower()
+    return "multipart/form-data" in content_type
+
+
+@embed_bp.route("/api/embed", methods=["POST"])
+def embed():
+    """Embed a media file (multipart) or text snippet (JSON) on demand."""
+    if _is_multipart_request():
+        return _embed_media_upload()
+    return _embed_text_json()
+
+
+def _embed_text_json():
+    data = get_json_or_400()
+    if not isinstance(data, dict):
+        return data
+
+    name = str(data.get("embedder") or "").strip()
+    if not name:
+        return jsonify({"error": "embedder is required"}), 400
+
+    try:
+        embedder = get_embedder(name)
+    except KeyError:
+        return _unknown_embedder_response(name)
+
+    text = data.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "text is required for JSON input. "
+                        "To embed a media file instead, send a multipart/form-data "
+                        "request with a 'file' field."
+                    )
+                }
+            ),
+            400,
+        )
+
+    if not embedder.supports_text:
+        return (
+            jsonify(
+                {
+                    "error": f"Embedder '{embedder.name}' does not support text input.",
+                    "supports_text": False,
+                }
+            ),
+            400,
+        )
+
+    try:
+        embedder.load_models()
+        vec = embedder.embed_text(text)
+    except Exception as exc:
+        logger.exception("embed text failed for '%s'", name)
+        return jsonify({"error": f"Embedding failed: {exc}"}), 500
+
+    if vec is None:
+        return jsonify({"error": f"Embedder '{embedder.name}' returned no vector for the text"}), 500
+
+    return _vector_response(vec, embedder)
+
+
+def _embed_media_upload():
+    name = str(request.form.get("embedder") or "").strip()
+    if not name:
+        return jsonify({"error": "embedder is required"}), 400
+
+    try:
+        embedder = get_embedder(name)
+    except KeyError:
+        return _unknown_embedder_response(name)
+
+    file = request.files.get("file")
+    if file is None or not file.filename:
+        return jsonify({"error": "file is required"}), 400
+
+    suffix = Path(file.filename).suffix
+    detected = get_by_extension(suffix.lower()) if suffix else None
+    if detected is not None and detected.type_id != embedder.media_type_id:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        f"Embedder '{embedder.name}' expects {embedder.media_type_id} files, "
+                        f"but the uploaded file looks like {detected.type_id} (extension '{suffix}')."
+                    ),
+                    "expected_media_type": embedder.media_type_id,
+                    "detected_media_type": detected.type_id,
+                }
+            ),
+            400,
+        )
+
+    DATA_DIR.mkdir(exist_ok=True)
+    temp_path = DATA_DIR / f"temp_embed_{uuid.uuid4().hex}{suffix or '.bin'}"
+    try:
+        file.save(temp_path)
+        try:
+            embedder.load_models()
+            vec = embedder.embed_media(media_from_path(temp_path))
+        except Exception as exc:
+            logger.exception("embed media failed for '%s'", name)
+            return jsonify({"error": f"Embedding failed: {exc}"}), 500
+
+        if vec is None:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            f"Embedder '{embedder.name}' (media_type={embedder.media_type_id}) "
+                            f"could not embed the uploaded file."
+                        ),
+                        "media_type": embedder.media_type_id,
+                    }
+                ),
+                400,
+            )
+        return _vector_response(vec, embedder)
+    finally:
+        temp_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Adds `POST /api/embed`, a single endpoint that returns a vector for a media file or text snippet using a caller-chosen embedder. No dataset load required.

**Two input modes share the route:**

- **Media upload (`multipart/form-data`)** — form fields `embedder=<name>` and `file=<binary>`. Calls `embedder.embed_media(...)`. The embedder declares its `media_type_id`, so the caller does not pass a media type — the file extension is checked against it before any model load so wrong-modality uploads (e.g. `.wav` to an image embedder) fail fast.
- **Text (`application/json`)** — body `{"embedder": "<name>", "text": "..."}`. Calls `embedder.embed_text(text)`. Only embedders where `supports_text == true` accept this mode (CLIP / SigLIP / CLAP / E5 etc.; vision-only embedders like DINOv3 are rejected with a clear error).

**Response shape:**

```json
{"embedding": [...], "dim": 512, "norm": 1.0, "embedder": "clip", "media_type": "image"}
```

**Error responses follow existing conventions:**

| Status | Cause |
|--------|-------|
| 400 | Missing `embedder`; missing `file` (multipart) or `text` (JSON); text sent to a non-text embedder; file extension mismatches embedder media type; embedder returned no vector for the upload. |
| 404 | Unknown embedder name. Response lists every registered embedder name, matching the existing `get_plugin_or_404` pattern. |
| 500 | Model load failure or text embedding returned `None`. |

## Files

- `vtsearch/routes/embed.py` — new blueprint with the `/api/embed` route.
- `vtsearch/routes/__init__.py`, `app.py` — register the blueprint.
- `docs/api/datasets.md` — endpoint reference under the existing "Embedders" section.
- `tests/test_embed.py` — 14 tests covering both modes and every error branch with a fake image embedder.

## Test plan

- [x] `./run-tests.sh` — 3042 tests pass.
- [x] `python -m pytest tests/test_embed.py -v` — all 14 new tests pass.
- [x] `ruff check vtsearch/routes/embed.py tests/test_embed.py` — clean.

https://claude.ai/code/session_01LMmGMzdesh94i2DLH3baK5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMmGMzdesh94i2DLH3baK5)_