### PR TITLE
Run Docker images as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,21 @@ RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_ver
 
 # Runtime data directory (models, embeddings, settings, media files).
 # Mount a volume here to persist data across container restarts.
+RUN mkdir -p /app/data
 VOLUME /app/data
+
+# Run as a non-root user so the image works under Kubernetes
+# `runAsNonRoot: true`, OpenShift (arbitrary UID in the root group),
+# and other security-hardened environments. The user is created with
+# primary GID 0 and /app is made group-writable so any UID assigned at
+# runtime can still read/write the app tree, the data volume, and the
+# HuggingFace cache under $HOME.
+RUN useradd --uid 1000 --gid 0 --create-home --home-dir /home/vtsearch vtsearch && \
+    chgrp -R 0 /app /home/vtsearch && \
+    chmod -R g=u /app /home/vtsearch
+
+ENV HOME=/home/vtsearch
+USER 1000
 
 EXPOSE 5000
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -53,7 +53,17 @@ COPY . .
 ARG VTSEARCH_VERSION=
 RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_version.txt; fi
 
+RUN mkdir -p /app/data
 VOLUME /app/data
+
+# Run as a non-root user. See the CPU Dockerfile for the rationale and
+# the GID-0 / g=u perm pattern that lets arbitrary OpenShift UIDs write.
+RUN useradd --uid 1000 --gid 0 --create-home --home-dir /home/vtsearch vtsearch && \
+    chgrp -R 0 /app /home/vtsearch && \
+    chmod -R g=u /app /home/vtsearch
+
+ENV HOME=/home/vtsearch
+USER 1000
 
 EXPOSE 5000
 

--- a/Dockerfile.image-embedders
+++ b/Dockerfile.image-embedders
@@ -178,6 +178,17 @@ RUN mkdir -p /app/data && \
 # Note: model weights live under /opt/vtsearch/models, NOT this volume.
 VOLUME /app/data
 
+# Run as a non-root user. See the CPU Dockerfile for the rationale and
+# the GID-0 / g=u perm pattern that lets arbitrary OpenShift UIDs write.
+# /opt/vtsearch/models is also opened up so the baked-in HuggingFace
+# snapshots stay readable when the runtime UID is unknown at build time.
+RUN useradd --uid 1000 --gid 0 --create-home --home-dir /home/vtsearch vtsearch && \
+    chgrp -R 0 /app /home/vtsearch /opt/vtsearch && \
+    chmod -R g=u /app /home/vtsearch /opt/vtsearch
+
+ENV HOME=/home/vtsearch
+USER 1000
+
 EXPOSE 5000
 
 ENV OMP_NUM_THREADS=1 \

--- a/Dockerfile.siglip
+++ b/Dockerfile.siglip
@@ -66,6 +66,17 @@ RUN mkdir -p /app/data && \
 # Note: model weights live under /opt/vtsearch/models, NOT this volume.
 VOLUME /app/data
 
+# Run as a non-root user. See the CPU Dockerfile for the rationale and
+# the GID-0 / g=u perm pattern that lets arbitrary OpenShift UIDs write.
+# /opt/vtsearch/models is also opened up so the baked-in HuggingFace
+# snapshot stays readable when the runtime UID is unknown at build time.
+RUN useradd --uid 1000 --gid 0 --create-home --home-dir /home/vtsearch vtsearch && \
+    chgrp -R 0 /app /home/vtsearch /opt/vtsearch && \
+    chmod -R g=u /app /home/vtsearch /opt/vtsearch
+
+ENV HOME=/home/vtsearch
+USER 1000
+
 EXPOSE 5000
 
 ENV OMP_NUM_THREADS=1 \


### PR DESCRIPTION
## Summary

The four Dockerfiles (`Dockerfile`, `Dockerfile.gpu`, `Dockerfile.siglip`, `Dockerfile.image-embedders`) had no `USER` directive, so the container ran the app as root. That breaks Kubernetes with `runAsNonRoot: true`, OpenShift (which assigns an arbitrary UID in the root group), and other hardened environments.

## Changes

- Add a `vtsearch` user (UID `1000`, primary GID `0`) to each image.
- `chgrp -R 0` and `chmod -R g=u` on `/app`, `/home/vtsearch`, and (for the SigLIP / image-embedders images) `/opt/vtsearch/models`, so any runtime UID that lands in the root group can still read and write the app tree, the data volume, and the baked HuggingFace cache.
- Set `HOME=/home/vtsearch` so the HuggingFace cache fallback (`$HOME/.cache/huggingface`) works when `VTSEARCH_MODELS_DIR` isn't set — and so OpenShift's arbitrary-UID containers still have a writable home.
- Add `USER 1000` so default Docker/Compose runs are also non-root.

`gunicorn` already binds to `:5000` (non-privileged) and writes only to `/app/data` and the HF cache, so no entrypoint changes are needed.

## Test plan

- [ ] `docker build -t vtsearch .` succeeds.
- [ ] `docker run --rm -p 5000:5000 vtsearch` starts and serves `/` as UID 1000.
- [ ] `docker run --rm --user 12345:0 -p 5000:5000 vtsearch` (simulating OpenShift's arbitrary UID + GID 0) starts and can write `/app/data/settings.json`.
- [ ] `docker build -f Dockerfile.gpu -t vtsearch:gpu .` succeeds (build only; GPU runtime not required for this check).
- [ ] `docker build -f Dockerfile.siglip -t vtsearch:siglip .` succeeds and the container starts without permission errors on `/opt/vtsearch/models`.
- [ ] `docker build -f Dockerfile.image-embedders -t vtsearch:image-embedders .` succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AHjhXWcrNCD61z31y5kJJR)_