### PR TITLE
Accept .npz dataset imports (paths + pre-computed vectors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ If a failure is genuinely outside the scope of the current task (e.g. a flaky ne
   - `test_combine_datasets.py` — Combine-datasets importer: metadata, dedup, media type validation, CLI, API routes
   - `test_synthetic_importer.py` — SyntheticDatasetImporter: discovery, metadata (factory icon), field validation, audio/image/video generators, deterministic seeding, idempotent caching, origin round-trip, resolve_file
   - `test_server_files_importer.py` — ServerFilesDatasetImporter: paths-file parsing, symlink staging, origin rewrite to original absolute paths, resolve_file
+  - `test_npz_dataset_import.py` — `.npz` paths-file support: NPZ reader helper (`filenames`+`vectors` and per-key layouts), server_files end-to-end with NPZ vectors, local-folder upload endpoint's optional `vectors_file` multipart field
   - `test_corrections_export.py` — Corrections tracking: _find_initial_labels state, is_correction annotation on label export, label_filter=corrections filtering
   - `test_creation_info.py` — Legacy creation_info handling in pickle datasets
   - `test_parallel_loading.py` — Parallel dataset loading: LoadingTasksTracker, thread-local progress, per-task cancel, loading-tasks API endpoints, build_diversity_tree_for_context

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -66,6 +66,12 @@ Click the hamburger menu (☰) in the top-left. You get two choices:
   existing datasets. Each importer asks for the fields it needs
   (path, URL, media type) in a small form.
 
+  Two of the file-list importers — **Server Files** and **Local
+  Files** — also accept a `.npz` archive of pre-computed embedding
+  vectors so you can import media you have already embedded offline
+  without paying for embedding twice. See
+  [Pre-computed embeddings (.npz)](#pre-computed-embeddings-npz) below.
+
 Loading a dataset does three things: downloads or reads the media,
 generates an embedding for every item using the appropriate model
 (CLAP for audio, SigLIP for images, X-CLIP for video, E5 for text),
@@ -75,6 +81,41 @@ diverse sampling. Progress is shown in a modal while it runs.
 If the model for your media type isn't cached yet, the first dataset
 of that type triggers a one-time download (e.g. CLAP is ~1.1 GB).
 Subsequent datasets of the same type reuse the cached model.
+
+### Pre-computed embeddings (.npz)
+
+If you have already embedded your media offline — for example with
+your own script using the same model VTSearch uses — you can skip the
+server-side re-embedding step by handing VTSearch a NumPy `.npz`
+archive of pre-computed vectors. Two importers accept this:
+
+- **Server Files** — instead of a `.txt`/`.list` paths file, point
+  the *Paths File* field at a `.npz`. The archive holds both the
+  media-file paths AND their vectors; VTSearch reads the paths from
+  disk and reuses the supplied vectors.
+- **Local Files** — alongside the media files you upload, attach a
+  `.npz` to the optional *Pre-computed embeddings* file picker. Files
+  whose name matches an NPZ key reuse the supplied vector; files
+  without a matching entry are embedded normally on the server.
+
+VTSearch accepts two NPZ layouts:
+
+1. **`filenames` + `vectors` arrays** — produced by
+   `np.savez(path, filenames=names, vectors=vecs)` where `names` is
+   a 1-D string array of length *N* and `vecs` is a 2-D float array
+   of shape *(N, D)*. The i-th name maps to the i-th row of `vecs`.
+2. **Per-key** — produced by
+   `np.savez(path, **{name: vec for name, vec in zip(names, vecs)})`.
+   Each archive key is a filename; the corresponding value is its
+   vector.
+
+The vector dimension and the embedding model must match what
+VTSearch would have used (e.g. 512-d CLAP for audio, 768-d SigLIP for
+images). Embedding-model selection is **not** persisted inside the
+NPZ — the importer's *Embedder* setting still controls which model
+is used for any file that doesn't have a pre-computed vector, and
+also acts as the model identifier recorded on each media. Pick an
+embedder that matches the vectors in your NPZ.
 
 ---
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -287,7 +287,7 @@
       @if (lfPickerKind === 'folder') {
         <p class="info-text">Pick a folder on <strong>this computer</strong> (the machine your browser is running on). Its contents will be uploaded to the server and embedded into a new dataset.</p>
       } @else {
-        <p class="info-text">Pick one or more files on <strong>this computer</strong> (the machine your browser is running on). They will be uploaded to the server and embedded into a new dataset.</p>
+        <p class="info-text">Pick one or more files on <strong>this computer</strong> (the machine your browser is running on). They will be uploaded to the server and embedded into a new dataset. If you have already embedded your media, you can <strong>optionally</strong> attach a <code>.npz</code> archive of pre-computed vectors below to skip re-embedding.</p>
       }
 
       <div class="form-group">
@@ -345,6 +345,38 @@
           </p>
         }
       </div>
+
+      @if (lfPickerKind === 'files') {
+        <div class="form-group form-group--section">
+          <label
+            class="form-label"
+            for="lf-vectors-input"
+            title="Optional .npz archive of pre-computed embedding vectors. Each entry's filename must match an uploaded file (by basename) for its vector to be reused. Skipped files are embedded normally on the server."
+          >
+            Pre-computed embeddings (<code>.npz</code>) — optional
+          </label>
+          <input
+            id="lf-vectors-input"
+            type="file"
+            class="form-input"
+            accept=".npz"
+            (change)="lfOnVectorsFileSelected($event)"
+          />
+          <p class="info-text">
+            Supply a NumPy <code>.npz</code> archive holding either
+            <code>filenames</code> + <code>vectors</code> arrays or one key per
+            filename mapping to its vector.  Filenames must match the uploaded
+            files (basenames are matched).  Files without a matching entry are
+            embedded normally on the server.
+          </p>
+          @if (lfVectorsFile) {
+            <p class="info-text">
+              Using vectors from <code>{{ lfVectorsFile.name }}</code>
+              <button type="button" class="btn btn--secondary btn--sm" (click)="lfClearVectorsFile()">Remove</button>
+            </p>
+          }
+        </div>
+      }
 
       @if (lfPickerKind === 'folder') {
         <div class="form-group">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -99,6 +99,10 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Whether the user has manually edited :prop:`lfDatasetName` (so we stop
    *  auto-overwriting it from the picked folder name). */
   private lfDatasetNameDirty = false;
+  /** Optional .npz file of pre-computed embedding vectors (Local Files only).
+   *  When set, the upload endpoint reuses these vectors instead of running
+   *  the embedding model for matching uploaded files. */
+  lfVectorsFile: File | null = null;
 
   // Server folder browser state
   sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
@@ -725,6 +729,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.selectedImporter = resolved;
     this.lfPickerKind = resolved?.name === 'local_files' ? 'files' : 'folder';
     this.lfFiles = [];
+    this.lfVectorsFile = null;
     this.lfError = '';
     this.lfSubmitting = false;
     this.lfRecursive = this.readRecursiveDefault(resolved);
@@ -758,6 +763,16 @@ export class DatasetImporterModalComponent implements OnInit {
     if (!this.lfDatasetNameDirty) {
       this.lfDatasetName = this.lfDerivedDatasetName();
     }
+  }
+
+  lfOnVectorsFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.lfVectorsFile = input.files && input.files.length > 0 ? input.files[0] : null;
+    this.lfError = '';
+  }
+
+  lfClearVectorsFile(): void {
+    this.lfVectorsFile = null;
   }
 
   /** Derive a default dataset name from the currently picked files / folder.
@@ -886,6 +901,9 @@ export class DatasetImporterModalComponent implements OnInit {
       // Browsers only populate webkitRelativePath when the input has the
       // `webkitdirectory` attribute; fall back to the file's own name.
       formData.append('files', file, rel && rel.length > 0 ? rel : file.name);
+    }
+    if (this.lfPickerKind === 'files' && this.lfVectorsFile) {
+      formData.append('vectors_file', this.lfVectorsFile, this.lfVectorsFile.name);
     }
 
     this.datasetsApi.importLocalFolder(formData).subscribe({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ _TEST_GROUPS = {
         "test_settings_io",
         "test_sync_sources",
         "test_bulk_embedding",
+        "test_npz_dataset_import",
     ],
     "detectors": [
         "test_find_label",

--- a/tests/test_npz_dataset_import.py
+++ b/tests/test_npz_dataset_import.py
@@ -1,0 +1,364 @@
+"""Tests for ``.npz`` support in the ``server_files`` and ``local_files`` importers.
+
+The ``server_files`` importer accepts a ``.npz`` archive (in addition to
+plain text) that supplies both the media-file paths and their
+pre-computed embedding vectors.  Listed files are still symlinked into a
+staging dir and run through the regular folder loader, but the loader
+skips re-embedding for files whose names appear in the supplied
+``content_vectors`` map.
+
+The ``/api/dataset/import-local-folder`` endpoint additionally accepts
+an optional ``vectors_file`` multipart form field (a ``.npz`` archive
+keyed by uploaded-file name) so users can attach pre-computed vectors
+to a browser-side multi-file upload.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vtsearch.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
+from vtsearch.datasets.importers.server_files import (
+    ServerFilesDatasetImporter,
+    _read_npz_paths_file,
+    _read_paths_and_vectors,
+    _read_paths_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Low-level NPZ reader helper
+# ---------------------------------------------------------------------------
+
+
+class TestReadNpzFilenamesAndVectors:
+    def test_reads_standard_layout(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        filenames = np.array(["a.wav", "b.wav", "c.wav"])
+        vectors = np.arange(12, dtype=np.float32).reshape(3, 4)
+        np.savez(npz, filenames=filenames, vectors=vectors)
+
+        mapping = read_npz_filenames_and_vectors(npz)
+        assert list(mapping.keys()) == ["a.wav", "b.wav", "c.wav"]
+        np.testing.assert_array_equal(mapping["a.wav"], vectors[0])
+        np.testing.assert_array_equal(mapping["b.wav"], vectors[1])
+        np.testing.assert_array_equal(mapping["c.wav"], vectors[2])
+
+    def test_reads_per_key_layout_fallback(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        v1 = np.array([1, 2, 3], dtype=np.float32)
+        v2 = np.array([4, 5, 6], dtype=np.float32)
+        np.savez(npz, **{"x.wav": v1, "y.wav": v2})
+
+        mapping = read_npz_filenames_and_vectors(npz)
+        assert set(mapping) == {"x.wav", "y.wav"}
+        np.testing.assert_array_equal(mapping["x.wav"], v1)
+        np.testing.assert_array_equal(mapping["y.wav"], v2)
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_npz_filenames_and_vectors(tmp_path / "missing.npz")
+
+    def test_mismatched_lengths_raises(self, tmp_path):
+        npz = tmp_path / "bad.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.wav", "b.wav"]),
+            vectors=np.zeros((3, 4), dtype=np.float32),
+        )
+        with pytest.raises(ValueError, match="mismatched"):
+            read_npz_filenames_and_vectors(npz)
+
+    def test_2d_filenames_array_rejected(self, tmp_path):
+        npz = tmp_path / "bad.npz"
+        np.savez(
+            npz,
+            filenames=np.array([["a", "b"], ["c", "d"]]),
+            vectors=np.zeros((2, 4), dtype=np.float32),
+        )
+        with pytest.raises(ValueError, match="1-D"):
+            read_npz_filenames_and_vectors(npz)
+
+    def test_blank_names_are_skipped(self, tmp_path):
+        npz = tmp_path / "vecs.npz"
+        filenames = np.array(["a.wav", "", "  ", "b.wav"])
+        vectors = np.arange(16, dtype=np.float32).reshape(4, 4)
+        np.savez(npz, filenames=filenames, vectors=vectors)
+        mapping = read_npz_filenames_and_vectors(npz)
+        assert set(mapping) == {"a.wav", "b.wav"}
+
+
+# ---------------------------------------------------------------------------
+# server_files paths-file plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestServerFilesFieldsAdvertiseNpz:
+    """The frontend file-browser uses the ``accept`` attribute to filter
+    the picker.  Make sure both txt/list and npz are advertised."""
+
+    def test_paths_file_accept_includes_npz(self):
+        imp = ServerFilesDatasetImporter()
+        paths_field = next(f for f in imp.fields if f.key == "paths_file")
+        accept_exts = {e.strip() for e in (paths_field.accept or "").split(",")}
+        assert ".txt" in accept_exts
+        assert ".list" in accept_exts
+        assert ".npz" in accept_exts
+
+    def test_paths_file_description_mentions_npz(self):
+        imp = ServerFilesDatasetImporter()
+        paths_field = next(f for f in imp.fields if f.key == "paths_file")
+        assert ".npz" in (paths_field.description or "").lower()
+
+
+class TestServerFilesNpzPathsFile:
+    def test_read_paths_file_dispatches_on_suffix(self, tmp_path):
+        # txt path still works
+        txt = tmp_path / "list.txt"
+        txt.write_text("/a.wav\n/b.wav\n")
+        assert _read_paths_file(txt) == [Path("/a.wav"), Path("/b.wav")]
+
+        # npz with absolute paths
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["/x.wav", "/y.wav"]),
+            vectors=np.zeros((2, 4), dtype=np.float32),
+        )
+        assert _read_paths_file(npz) == [Path("/x.wav"), Path("/y.wav")]
+
+    def test_read_npz_paths_file_returns_paths_and_vectors(self, tmp_path):
+        media_a = tmp_path / "a.wav"
+        media_b = tmp_path / "b.wav"
+        media_a.write_bytes(b"A")
+        media_b.write_bytes(b"B")
+        npz = tmp_path / "list.npz"
+        vectors = np.arange(8, dtype=np.float32).reshape(2, 4)
+        np.savez(npz, filenames=np.array([str(media_a), str(media_b)]), vectors=vectors)
+
+        paths, path_to_vector = _read_npz_paths_file(npz)
+        assert paths == [Path(str(media_a)), Path(str(media_b))]
+        assert set(path_to_vector) == {str(media_a), str(media_b)}
+        np.testing.assert_array_equal(path_to_vector[str(media_a)], vectors[0])
+
+    def test_relative_npz_paths_resolved_against_npz_dir(self, tmp_path):
+        media = tmp_path / "data" / "x.wav"
+        media.parent.mkdir(parents=True)
+        media.write_bytes(b"x")
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["data/x.wav"]),
+            vectors=np.zeros((1, 4), dtype=np.float32),
+        )
+
+        paths, vecs = _read_npz_paths_file(npz)
+        assert paths == [media.resolve()]
+        # Vector is keyed by the resolved absolute path so the staging
+        # rekey step can look it up.
+        assert str(media.resolve()) in vecs
+
+    def test_read_paths_and_vectors_txt_returns_empty_vectors(self, tmp_path):
+        txt = tmp_path / "list.txt"
+        txt.write_text("/a.wav\n")
+        paths, vecs = _read_paths_and_vectors(txt)
+        assert paths == [Path("/a.wav")]
+        assert vecs == {}
+
+
+# ---------------------------------------------------------------------------
+# server_files end-to-end: NPZ vectors skip re-embedding
+# ---------------------------------------------------------------------------
+
+
+class TestServerFilesNpzRunsEndToEnd:
+    def test_npz_vectors_are_used_instead_of_embedder(self, tmp_path):
+        """When the npz supplies a vector for a file, the resulting media's
+        embedding is exactly that vector (the embedder is bypassed)."""
+        from helpers import make_raw_wav_bytes
+
+        src_a = tmp_path / "src_a.wav"
+        src_b = tmp_path / "src_b.wav"
+        src_a.write_bytes(make_raw_wav_bytes())
+        src_b.write_bytes(make_raw_wav_bytes() + b"\x00\x00")
+
+        # Distinctive vectors so we can verify they make it through
+        # unmodified instead of being replaced by the embedder output.
+        rng = np.random.default_rng(42)
+        vec_a = rng.standard_normal(512).astype(np.float32) * 100.0
+        vec_b = rng.standard_normal(512).astype(np.float32) * 100.0
+
+        npz = tmp_path / "list.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(src_a), str(src_b)]),
+            vectors=np.stack([vec_a, vec_b]),
+        )
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        imp.run({"paths_file": str(npz), "media_type": "audio"}, medias)
+
+        assert len(medias) == 2
+        # Index medias by their original source path so we can pair each
+        # with its expected vector.
+        by_source = {m["origin_name"]: m for m in medias.values()}
+        np.testing.assert_array_equal(by_source[str(src_a)]["embedding"], vec_a)
+        np.testing.assert_array_equal(by_source[str(src_b)]["embedding"], vec_b)
+        # Origin still points at the npz so subsequent reloads work.
+        for media in medias.values():
+            assert media["origin"]["importer"] == "server_files"
+            assert media["origin"]["params"]["paths_file"] == str(npz)
+
+    def test_npz_per_key_layout_is_accepted(self, tmp_path):
+        from helpers import make_raw_wav_bytes
+
+        src = tmp_path / "only.wav"
+        src.write_bytes(make_raw_wav_bytes())
+
+        # Per-key layout: each filename is a top-level key in the npz.
+        vec = np.full(256, 7.0, dtype=np.float32)
+        npz = tmp_path / "list.npz"
+        np.savez(npz, **{str(src): vec})
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        imp.run({"paths_file": str(npz), "media_type": "audio"}, medias)
+
+        assert len(medias) == 1
+        media = next(iter(medias.values()))
+        np.testing.assert_array_equal(media["embedding"], vec)
+
+
+# ---------------------------------------------------------------------------
+# /api/dataset/import-local-folder: vectors_file npz alongside media files
+# ---------------------------------------------------------------------------
+
+
+class TestLocalUploadVectorsFile:
+    """The /api/dataset/import-local-folder endpoint parses the optional
+    ``vectors_file`` npz and hands the resulting ``{filename: vector}``
+    map to the server_folder importer via its ``content_vectors``
+    attribute.  The background task runner is stubbed so the test can
+    invoke the importer's ``load_fn`` synchronously and inspect the
+    importer's state at the moment it would have been called."""
+
+    @staticmethod
+    def _stub_run_and_observe(observed: dict):
+        """Build a ``_run_origin_load_in_background`` stub that sniffs the
+        server_folder importer's ``content_vectors`` at the moment the
+        load function would call into the importer.  Works for both the
+        chunked and non-chunked dispatch paths."""
+        from vtsearch.datasets.importers import get_importer
+
+        def _fake_run(load_fn, origin, **kwargs):
+            importer = get_importer("server_folder")
+            assert importer is not None
+
+            def _sniff(field_values, medias=None, thin=False):
+                observed["content_vectors"] = dict(importer.content_vectors or {})
+                # Return an empty generator for the chunked path.
+                return iter(())
+
+            with patch.object(importer, "run", side_effect=_sniff), patch.object(
+                importer, "run_chunked", side_effect=_sniff
+            ):
+                load_fn({})
+            return "task-fake-npz"
+
+        return _fake_run
+
+    def test_upload_with_vectors_file_populates_importer_content_vectors(
+        self, client, tmp_path, monkeypatch
+    ):
+        from vtsearch.datasets.importers import get_importer
+
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR",
+            tmp_path / "uploads",
+        )
+
+        vec = np.full(384, 3.5, dtype=np.float32)
+        npz_bytes_io = io.BytesIO()
+        np.savez(
+            npz_bytes_io,
+            filenames=np.array(["clip.wav"]),
+            vectors=np.stack([vec]),
+        )
+        npz_bytes_io.seek(0)
+
+        observed: dict = {}
+        with patch(
+            "vtsearch.routes.datasets._run_origin_load_in_background",
+            side_effect=self._stub_run_and_observe(observed),
+        ):
+            resp = client.post(
+                "/api/dataset/import-local-folder",
+                data={
+                    "media_type": "audio",
+                    "files": (io.BytesIO(b"AAA"), "clip.wav"),
+                    "vectors_file": (npz_bytes_io, "vectors.npz"),
+                },
+                content_type="multipart/form-data",
+            )
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        # The npz was parsed and forwarded to the importer.
+        assert "clip.wav" in observed["content_vectors"]
+        np.testing.assert_array_equal(observed["content_vectors"]["clip.wav"], vec)
+
+        # After the load returns, content_vectors is restored so the
+        # next upload doesn't inherit stale vectors.
+        assert get_importer("server_folder").content_vectors == {}
+
+    def test_upload_without_vectors_file_leaves_importer_unchanged(
+        self, client, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR",
+            tmp_path / "uploads",
+        )
+
+        observed: dict = {}
+        with patch(
+            "vtsearch.routes.datasets._run_origin_load_in_background",
+            side_effect=self._stub_run_and_observe(observed),
+        ):
+            resp = client.post(
+                "/api/dataset/import-local-folder",
+                data={
+                    "media_type": "audio",
+                    "files": (io.BytesIO(b"AAA"), "clip.wav"),
+                },
+                content_type="multipart/form-data",
+            )
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        # With no npz attached, the importer's content_vectors stays
+        # empty for the run.
+        assert observed["content_vectors"] == {}
+
+    def test_upload_rejects_invalid_vectors_file(self, client, tmp_path, monkeypatch):
+        """A bogus ``vectors_file`` is rejected up front with a 400."""
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.LOCAL_UPLOADS_DIR",
+            tmp_path / "uploads",
+        )
+        bogus = io.BytesIO(b"not really a npz archive")
+        resp = client.post(
+            "/api/dataset/import-local-folder",
+            data={
+                "media_type": "audio",
+                "files": (io.BytesIO(b"RIFF...."), "clip.wav"),
+                "vectors_file": (bogus, "broken.npz"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "vectors_file" in body["error"].lower()

--- a/vtsearch/datasets/importers/_npz_vectors.py
+++ b/vtsearch/datasets/importers/_npz_vectors.py
@@ -1,0 +1,79 @@
+"""Helpers for reading pre-computed embedding vectors from ``.npz`` files.
+
+The ``server_files`` and ``local_files`` importers accept an ``.npz`` archive
+of pre-computed embeddings instead of (or alongside) raw media files, so
+users who have already embedded their data don't have to re-embed it.
+
+Two NPZ layouts are supported:
+
+1. **filenames + vectors** — Two top-level arrays, ``filenames`` (1-D
+   string-like) and ``vectors`` (2-D float).  The i-th filename maps to
+   the i-th row of ``vectors``.  Produced e.g. by
+   ``np.savez(path, filenames=names, vectors=vecs)``.
+2. **per-key** — Each archive key is a filename and the corresponding
+   value is its vector.  Produced e.g. by
+   ``np.savez(path, **{name: vec for name, vec in zip(names, vecs)})``.
+
+The standard layout is tried first; if neither expected key is present
+the per-key layout is assumed.  ``allow_pickle`` is disabled to avoid
+loading arbitrary Python objects from untrusted archives.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+_FILENAMES_KEYS = ("filenames", "names", "paths", "filename")
+_VECTORS_KEYS = ("vectors", "embeddings", "vecs", "embedding")
+
+
+def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
+    """Return a ``{filename: vector}`` mapping read from *npz_path*.
+
+    Preserves insertion order (NumPy ``.npz`` preserves key order).
+    Raises ``FileNotFoundError`` if the file does not exist and
+    ``ValueError`` for malformed archives.
+    """
+    p = Path(npz_path)
+    if not p.is_file():
+        raise FileNotFoundError(f"NPZ file not found: {p}")
+
+    with np.load(p, allow_pickle=False) as data:
+        keys = list(data.files)
+        key_set = set(keys)
+
+        filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
+        vectors_key = next((k for k in _VECTORS_KEYS if k in key_set), None)
+
+        if filenames_key and vectors_key:
+            names_arr = data[filenames_key]
+            vecs_arr = data[vectors_key]
+            if names_arr.ndim != 1:
+                raise ValueError(
+                    f"NPZ '{filenames_key}' array must be 1-D, got shape {names_arr.shape}"
+                )
+            if len(vecs_arr) != len(names_arr):
+                raise ValueError(
+                    f"NPZ '{filenames_key}' and '{vectors_key}' have mismatched lengths "
+                    f"({len(names_arr)} vs {len(vecs_arr)})"
+                )
+            mapping: dict[str, np.ndarray] = {}
+            for i, raw_name in enumerate(names_arr):
+                name = str(raw_name).strip()
+                if not name:
+                    continue
+                mapping[name] = np.asarray(vecs_arr[i])
+            if not mapping:
+                raise ValueError(f"NPZ '{filenames_key}' array is empty")
+            return mapping
+
+        # Per-key layout: every archive key is a filename.
+        if not keys:
+            raise ValueError(f"NPZ archive {p} is empty")
+        mapping = {}
+        for k in keys:
+            mapping[k] = np.asarray(data[k])
+        return mapping

--- a/vtsearch/datasets/importers/local_files/__init__.py
+++ b/vtsearch/datasets/importers/local_files/__init__.py
@@ -12,6 +12,13 @@ webkitdirectory>`` (a single directory pick), while Local Files uses
 ``<input type="file" multiple>`` (one or more individual file picks).
 Both flows deliver the same multipart shape to the same upload
 endpoint.
+
+The Local Files card additionally accepts an optional ``vectors_file``
+form input — a ``.npz`` archive containing pre-computed embedding
+vectors keyed by uploaded-file name.  Files whose name matches an NPZ
+key reuse the supplied vector and skip the embedding model, which lets
+users import media they have already embedded offline without
+re-embedding it on the server.
 """
 
 from __future__ import annotations
@@ -34,7 +41,11 @@ class LocalFilesDatasetImporter(DatasetImporter):
 
     name = "local_files"
     display_name = "Files"
-    description = "Upload one or more individual media files from this computer (your browser machine) to the server"
+    description = (
+        "Upload one or more individual media files from this computer (your browser machine) "
+        "to the server.  Optionally include a .npz archive of pre-computed embedding vectors "
+        "to skip re-embedding for media you have already embedded offline."
+    )
     icon = "\U0001f4c4"  # 📄 — falls back to a generic file icon
     ui_mode = "custom"
     picker_view = "local_files"

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -1,17 +1,26 @@
-"""Server-files importer — embed media files listed in a server-side text file.
+"""Server-files importer — embed media files listed in a server-side file.
 
-The user supplies the absolute path of a UTF-8 text file on the server.
-Each non-empty, non-comment line of that file is treated as the
-absolute path (or path relative to the text file's directory) of a
-media file or directory to embed.  Symlinks (to either files or
-directories) are followed, and directory entries are walked recursively
-for media files.  The importer symlinks every resulting file into a
-temporary directory and then delegates to :mod:`server_folder` for the
-actual scanning/embedding.  After the import each media's origin is
-rewritten to point at this importer so that
-:meth:`resolve_file` can find the original file on disk.
+The user supplies the absolute path of a file on the server that
+identifies the media files to import.  Two file formats are accepted:
 
-Lines beginning with ``#`` are treated as comments and skipped.
+- **Text** (``.txt`` / ``.list``) — a UTF-8 text file with one media
+  path per non-empty, non-comment line.  Lines beginning with ``#`` are
+  comments.  The listed files are embedded by the server.
+- **NumPy archive** (``.npz``) — a ``.npz`` file holding both the media
+  paths and their pre-computed embedding vectors.  See
+  :mod:`vtsearch.datasets.importers._npz_vectors` for the supported
+  array layouts.  When supplied, the importer **skips re-embedding** for
+  every listed file and uses the vector from the archive instead.  This
+  lets users import media that they have already embedded offline
+  without paying for embedding twice.
+
+Each listed entry may be the path of a file or a directory.  Symlinks
+(to either files or directories) are followed, and directory entries
+are walked recursively for media files.  The importer symlinks every
+resulting file into a temporary directory and then delegates to
+:mod:`server_folder` for the actual scanning/embedding.  After the
+import each media's origin is rewritten to point at this importer so
+that :meth:`resolve_file` can find the original file on disk.
 """
 
 from __future__ import annotations
@@ -23,15 +32,13 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from vtsearch.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField
 from vtsearch.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
 
 
-def _read_paths_file(paths_file: Path) -> list[Path]:
-    """Read media file paths from *paths_file*, one per line."""
-    if not paths_file.is_file():
-        raise FileNotFoundError(f"Paths file not found: {paths_file}")
-
+def _read_text_paths_file(paths_file: Path) -> list[Path]:
+    """Read media file paths from a UTF-8 text file, one per line."""
     base_dir = paths_file.resolve().parent
     paths: list[Path] = []
     for raw in paths_file.read_text(encoding="utf-8").splitlines():
@@ -43,6 +50,59 @@ def _read_paths_file(paths_file: Path) -> list[Path]:
             candidate = (base_dir / candidate).resolve()
         paths.append(candidate)
     return paths
+
+
+def _read_npz_paths_file(paths_file: Path) -> tuple[list[Path], dict[str, Any]]:
+    """Read media paths + pre-computed vectors from a ``.npz`` archive.
+
+    Returns ``(paths, path_to_vector)`` where keys of *path_to_vector*
+    are the absolute path strings of the resolved entries (the same
+    strings that appear in *paths*).
+    """
+    name_to_vector = read_npz_filenames_and_vectors(paths_file)
+    base_dir = paths_file.resolve().parent
+    paths: list[Path] = []
+    path_to_vector: dict[str, Any] = {}
+    for raw_name, vec in name_to_vector.items():
+        line = raw_name.strip()
+        if not line:
+            continue
+        candidate = Path(line)
+        if not candidate.is_absolute():
+            candidate = (base_dir / candidate).resolve()
+        paths.append(candidate)
+        path_to_vector[str(candidate)] = vec
+    return paths, path_to_vector
+
+
+def _read_paths_file(paths_file: Path) -> list[Path]:
+    """Read media file paths from *paths_file*.
+
+    Both ``.txt``/``.list`` (one path per line) and ``.npz`` (paths +
+    pre-computed vectors) formats are supported.  This helper returns
+    only the path list; callers that also want the NPZ vectors should
+    use :func:`_read_paths_and_vectors`.
+    """
+    if not paths_file.is_file():
+        raise FileNotFoundError(f"Paths file not found: {paths_file}")
+    if paths_file.suffix.lower() == ".npz":
+        paths, _ = _read_npz_paths_file(paths_file)
+        return paths
+    return _read_text_paths_file(paths_file)
+
+
+def _read_paths_and_vectors(paths_file: Path) -> tuple[list[Path], dict[str, Any]]:
+    """Like :func:`_read_paths_file` but also returns pre-computed vectors.
+
+    For ``.txt`` / ``.list`` inputs the second tuple element is an empty
+    dict.  For ``.npz`` inputs it maps each resolved path string to its
+    pre-computed embedding vector.
+    """
+    if not paths_file.is_file():
+        raise FileNotFoundError(f"Paths file not found: {paths_file}")
+    if paths_file.suffix.lower() == ".npz":
+        return _read_npz_paths_file(paths_file)
+    return _read_text_paths_file(paths_file), {}
 
 
 def _expand_paths(paths: list[Path]) -> list[Path]:
@@ -112,7 +172,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
     name = "server_files"
     display_name = "Files"
     description = (
-        "Read a text file on the server containing media-file paths (one per line) and embed every listed file"
+        "Read a server-side file listing media paths (text file, one per line, "
+        "OR a .npz archive that also supplies pre-computed embedding vectors) "
+        "and embed every listed file"
     )
     icon = "\U0001f5c2"  # 🗂 — falls back to a generic file icon
     picker_view = "form"
@@ -130,11 +192,16 @@ class ServerFilesDatasetImporter(DatasetImporter):
             label="Paths File",
             field_type="server_path",
             description=(
-                "Absolute server path to a text file containing one media-file or "
-                "directory path per line.  Symlinks are followed; directory entries "
-                "are scanned recursively for media files."
+                "Absolute server path to a file listing the media to import.  Either:\n"
+                " • a UTF-8 text file (.txt / .list) with one media-file or directory "
+                "path per line (lines starting with # are comments), or\n"
+                " • a NumPy archive (.npz) that holds both the media paths AND "
+                "their pre-computed embedding vectors — when provided, listed "
+                "files skip re-embedding and use the supplied vectors instead.\n"
+                "Symlinks are followed; directory entries are scanned recursively "
+                "for media files."
             ),
-            accept=".txt,.list",
+            accept=".txt,.list,.npz",
         ),
     ]
 
@@ -147,14 +214,23 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 f.options = all_folder_names()
                 break
 
-    def _stage_paths(self, field_values: dict[str, Any]) -> tuple[Path, dict[str, Path]]:
+    def _stage_paths(
+        self, field_values: dict[str, Any]
+    ) -> tuple[Path, dict[str, Path], dict[str, Any]]:
         """Read the paths file and symlink each entry into a fresh temp dir.
 
-        Returns the staging directory and a name→source-path mapping.  The
-        caller is responsible for ``rmtree``-ing the staging directory.
+        Returns ``(staging_dir, name_to_source, content_vectors)`` where:
+
+        - ``staging_dir`` is the freshly created temp directory holding
+          one symlink per imported file (caller must ``rmtree`` it).
+        - ``name_to_source`` maps each staged symlink basename to the
+          original absolute path it points at.
+        - ``content_vectors`` maps each staged symlink basename to a
+          pre-computed embedding vector when the paths file is a
+          ``.npz`` archive; empty for plain text paths files.
         """
         paths_file = Path(field_values["paths_file"])
-        paths = _read_paths_file(paths_file)
+        paths, path_to_vector = _read_paths_and_vectors(paths_file)
         if not paths:
             raise ValueError(f"No paths found in {paths_file}")
 
@@ -163,7 +239,17 @@ class ServerFilesDatasetImporter(DatasetImporter):
         if not name_to_source:
             shutil.rmtree(staging, ignore_errors=True)
             raise ValueError(f"None of the paths in {paths_file} resolved to existing files")
-        return staging, name_to_source
+
+        # Rekey npz vectors from the original absolute path to the
+        # staged symlink basename, which is what ``server_folder``'s
+        # loader uses as the ``content_vectors`` key.
+        content_vectors: dict[str, Any] = {}
+        if path_to_vector:
+            for name, source in name_to_source.items():
+                vec = path_to_vector.get(str(source))
+                if vec is not None:
+                    content_vectors[name] = vec
+        return staging, name_to_source, content_vectors
 
     def _rewrite_origins(
         self,
@@ -185,7 +271,12 @@ class ServerFilesDatasetImporter(DatasetImporter):
         embedder = field_values.get("embedder", "")
         skip_emb = bool(field_values.get("skip_embedding"))
 
-        staging, name_to_source = self._stage_paths(field_values)
+        staging, name_to_source, npz_vectors = self._stage_paths(field_values)
+        # Merge npz-supplied vectors with any vectors set externally on
+        # ``self.content_vectors``.  NPZ vectors take priority for keys
+        # that overlap.
+        merged_vectors: dict[str, Any] = dict(self.content_vectors or {})
+        merged_vectors.update(npz_vectors)
         try:
             load_dataset_from_folder(
                 staging,
@@ -193,7 +284,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 medias,
                 thin=thin,
                 embedder_name=embedder,
-                content_vectors=self.content_vectors or None,
+                content_vectors=merged_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
                 skip_embedding=skip_emb,
@@ -225,8 +316,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
         embedder = field_values.get("embedder", "")
         skip_emb = bool(field_values.get("skip_embedding"))
 
-        staging, name_to_source = self._stage_paths(field_values)
+        staging, name_to_source, npz_vectors = self._stage_paths(field_values)
         origin = self.build_origin(field_values)
+        merged_vectors: dict[str, Any] = dict(self.content_vectors or {})
+        merged_vectors.update(npz_vectors)
         try:
             for chunk in load_dataset_from_folder_chunked(
                 staging,
@@ -234,7 +327,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 chunk_size,
                 thin=thin,
                 embedder_name=embedder,
-                content_vectors=self.content_vectors or None,
+                content_vectors=merged_vectors or None,
                 content_md5s=self.content_md5s or None,
                 custom_metadata_map=self.custom_metadata_map or None,
                 skip_embedding=skip_emb,

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -600,6 +600,12 @@ def import_local_folder():
     delegate to the regular folder importer to do the actual scanning,
     embedding, and dataset registration.  The temp directory is removed
     once the importer finishes (success or failure).
+
+    Local-files uploads may additionally include a ``vectors_file`` form
+    field carrying a ``.npz`` archive of pre-computed embedding vectors
+    keyed by uploaded-file name (basename or relative path).  Files
+    whose name matches an NPZ key reuse the supplied vector instead of
+    running the embedding model.
     """
     files = request.files.getlist("files")
     if not files:
@@ -650,6 +656,31 @@ def import_local_folder():
         shutil.rmtree(upload_dir, ignore_errors=True)
         return jsonify({"error": "No valid files in upload"}), 400
 
+    # Optional .npz of pre-computed embedding vectors.  Saved into the
+    # upload directory and parsed before kicking off the importer; the
+    # resulting mapping is handed to the server_folder importer via its
+    # ``content_vectors`` attribute (cleared in a ``finally`` block to
+    # avoid bleeding into unrelated runs of the singleton).
+    content_vectors: dict[str, Any] = {}
+    vectors_file_storage = request.files.get("vectors_file")
+    if vectors_file_storage and vectors_file_storage.filename:
+        from vtsearch.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
+
+        npz_path = upload_dir / "__vtsearch_vectors__.npz"
+        try:
+            vectors_file_storage.save(npz_path)
+            content_vectors = dict(read_npz_filenames_and_vectors(npz_path))
+        except Exception as exc:
+            shutil.rmtree(upload_dir, ignore_errors=True)
+            return jsonify({"error": f"Invalid vectors_file: {exc}"}), 400
+        finally:
+            # The npz is no longer needed once it's parsed; remove it so
+            # the importer doesn't see it as a media file.
+            try:
+                npz_path.unlink()
+            except FileNotFoundError:
+                pass
+
     field_values: dict = {
         "path": str(upload_dir),
         "media_type": media_type,
@@ -689,12 +720,17 @@ def import_local_folder():
     chunk_size = auto_chunk_size(media_type) if use_chunked else 0
 
     def _load(target_medias):
+        previous_vectors = importer.content_vectors
+        if content_vectors:
+            importer.content_vectors = content_vectors
         try:
             if use_chunked:
                 consume_chunks_into(target_medias, importer.run_chunked(field_values, chunk_size))
             else:
                 importer.run(field_values, target_medias)
         finally:
+            if content_vectors:
+                importer.content_vectors = previous_vectors
             shutil.rmtree(upload_dir, ignore_errors=True)
 
     task_id = _run_origin_load_in_background(


### PR DESCRIPTION
## Summary

Lets users import media they have **already embedded offline** by handing a `.npz` archive of pre-computed vectors to either the **Server Files** or **Local Files** importer — no re-embedding on the server.

- **Server Files**: the existing *Paths File* field now accepts `.npz` in addition to `.txt` / `.list`. NPZ archives carry both the media paths AND their vectors.
- **Local Files**: the multipart upload endpoint accepts an optional `vectors_file` field carrying the same NPZ archive. Uploaded files whose name matches an NPZ key reuse the supplied vector; files without a matching entry are embedded normally on the server.

Two NPZ layouts are supported (auto-detected):
1. **`filenames` + `vectors` arrays** — `np.savez(path, filenames=names, vectors=vecs)`.
2. **Per-key** — `np.savez(path, **{name: vec})`.

## Implementation

- New helper `vtsearch/datasets/importers/_npz_vectors.py` — `read_npz_filenames_and_vectors(path)` returns an order-preserving `{filename: vector}` dict and rejects malformed archives (`allow_pickle=False`).
- `ServerFilesDatasetImporter` branches on suffix in `_read_paths_file` / `_read_paths_and_vectors`, rekeys NPZ vectors from the original absolute path to the staged symlink basename, and merges them into `content_vectors` before delegating to the folder loader.
- `/api/dataset/import-local-folder` parses `vectors_file` up front (400s on a bad NPZ), temporarily sets `importer.content_vectors` on the singleton, and restores it in a `finally` block so concurrent uploads don't bleed state.
- Frontend modal (`dataset-importer-modal.component.{ts,html}`) renders an optional `.npz` file picker on the Local Files card, passes the file as `vectors_file` in the FormData, and updates copy + `accept` attribute for the Server Files paths file.

## Test plan

- [x] `./run-tests.sh` (full suite): 3059 passed, 1 skipped
- [x] `./run-tests.sh io datasets`: 1012 passed
- [x] `ruff check` clean on changed files
- [x] New `tests/test_npz_dataset_import.py` covers:
  - NPZ reader helper — both layouts, missing file, length mismatch, 2-D names, blank-name skip
  - server_files end-to-end — NPZ vectors flow through to media `embedding` without invoking the embedder
  - server_files NPZ per-key layout
  - server_files paths-file field advertises `.npz` in `accept` and description
  - local-folder upload endpoint — populates importer `content_vectors`, restores afterward, rejects malformed `vectors_file` with 400, leaves importer untouched when no NPZ is attached

## Backwards compatibility

Fully additive — existing `.txt` / `.list` paths files and `vectors_file`-less uploads behave exactly as before.

https://claude.ai/code/session_012AwFFo3Zad8RQkpw9TD3BA

---
_Generated by [Claude Code](https://claude.ai/code/session_012AwFFo3Zad8RQkpw9TD3BA)_