### PR TITLE
Switch Docker EUPE pre-cache to torch.hub

### DIFF
--- a/Dockerfile.image-embedders
+++ b/Dockerfile.image-embedders
@@ -8,23 +8,36 @@
 #   * SigLIP   (google/siglip-base-patch16-224)         — default, text-capable
 #   * SigLIP 2 (google/siglip2-base-patch16-224)        — text-capable
 #   * CLIP     (openai/clip-vit-base-patch32)           — text-capable
-#   * DINOv2   (facebook/dinov2-base)                   — image-only, ungated
+#   * DINOv2   (facebook/dinov2-base)                     — image-only, ungated
 #   * DINOv3   (facebook/dinov3-vitb16-pretrain-lvd1689m) — image-only, gated
-#   * EUPE     (facebook/PE-Core-B16-224)               — image-only, gated
+#   * EUPE     (facebookresearch/EUPE, ViT-B/16)          — image-only, ungated
+#                                                          (FAIR Noncommercial
+#                                                          Research Licence on
+#                                                          *outputs*, not on
+#                                                          download access)
 #
-# The first four are ungated on Hugging Face and download during the build
-# with no credentials. DINOv3 and EUPE are gated under Meta's research
-# licence; rather than passing an HF token through ``docker build``, we
-# expect the user to run ``scripts/cache_gated_models.sh`` **once** on the
-# host (with their HF credentials), which populates ``./model_cache/``.
-# This Dockerfile then COPYs that local cache into the image — no token
-# ever touches the build, the codebase, or any image layer.
+# SigLIP / SigLIP 2 / CLIP / DINOv2 are ungated on Hugging Face and
+# download during the build with no credentials.
+#
+# DINOv3 is gated under Meta's research licence: rather than passing an
+# HF token through ``docker build``, we expect the user to run
+# ``scripts/cache_gated_models.sh`` **once** on the host (with their HF
+# credentials), which populates ``./model_cache/``. This Dockerfile then
+# COPYs that local cache into the image — no token ever touches the
+# build, the codebase, or any image layer.
+#
+# EUPE no longer needs an HF token (its weights mirror at
+# ``facebook/EUPE-ViT-B`` is ungated), but it loads via ``torch.hub``
+# from ``facebookresearch/EUPE``, which clones a GitHub repo and
+# downloads a ~400 MB ``.pt`` file. The cache script handles both for
+# you so the build can run fully offline; if ``model_cache/`` is empty
+# the build still attempts the download itself.
 #
 # If ``./model_cache/`` is empty (the cache script wasn't run), the build
-# still succeeds; DINOv3 and EUPE simply remain unavailable until the
-# user runs the cache script and rebuilds, or sets an HF_TOKEN at
-# container runtime to download them lazily into the persistent
-# /app/data volume on first use.
+# still succeeds; DINOv3 simply remains unavailable until the user runs
+# the cache script and rebuilds, or sets an HF_TOKEN at container
+# runtime to download it lazily into the persistent /app/data volume
+# on first use.
 #
 # SigLIP stays the default — it's marked is_default=True on the embedder
 # class and is the only entry in `autoload_media_embedders` seeded into
@@ -36,9 +49,12 @@
 # them (see MediaEmbedder.supports_text).
 #
 # Build:
-#   # 1. ONE-TIME setup for the gated weights (skip if you only want
-#   #    SigLIP / SigLIP 2 / CLIP / DINOv2):
+#   # 1. ONE-TIME setup to bake DINOv3 + EUPE into the image (skip if you
+#   #    only want SigLIP / SigLIP 2 / CLIP / DINOv2). HF_TOKEN is needed
+#   #    only for DINOv3; pass SKIP_DINOV3=1 to cache only EUPE:
 #   HF_TOKEN=hf_xxx ./scripts/cache_gated_models.sh
+#   #   …or, EUPE only (no token needed):
+#   SKIP_DINOV3=1 ./scripts/cache_gated_models.sh
 #
 #   # 2. Build the image — no token, no secrets:
 #   docker build -f Dockerfile.image-embedders -t vtsearch:image-embedders .
@@ -146,18 +162,25 @@ except Exception as exc: \
     print(f'DINOv3 not in local cache ({exc.__class__.__name__}); skipping. ' \
           'Run scripts/cache_gated_models.sh on the host to enable DINOv3.', flush=True)"
 
-# EUPE (gated; Meta Perception Encoder). Same fallback as DINOv3.
+# EUPE (facebookresearch/EUPE, ViT-B/16). Loads via torch.hub: a cloned
+# GitHub repo plus a downloaded .pt weights file, both under
+# $TORCH_HOME/hub/. We point TORCH_HOME at the same dir the COPY above
+# seeded from ./model_cache/ so a host-cache run skips both the clone
+# and the weights download. If neither is present we still attempt the
+# fetch (EUPE's HF mirror is ungated — no token required) and fall back
+# to skipping EUPE if the build host has no network access.
+ENV TORCH_HOME=${VTSEARCH_MODELS_DIR}
 RUN python -u -c "import os; \
 from vtsearch.config import EUPE_MODEL_ID; \
-cache=os.environ['VTSEARCH_MODELS_DIR']; \
 try: \
-    from transformers import AutoModel, AutoImageProcessor; \
-    AutoModel.from_pretrained(EUPE_MODEL_ID, cache_dir=cache, local_files_only=True, trust_remote_code=True); \
-    AutoImageProcessor.from_pretrained(EUPE_MODEL_ID, cache_dir=cache, local_files_only=True, trust_remote_code=True); \
-    print('EUPE weights loaded from local cache.', flush=True); \
+    import torch; \
+    torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', source='github', \
+                   pretrained=True, weights=EUPE_MODEL_ID, trust_repo=True); \
+    print('EUPE weights cached via torch.hub.', flush=True); \
 except Exception as exc: \
-    print(f'EUPE not in local cache ({exc.__class__.__name__}); skipping. ' \
-          'Run scripts/cache_gated_models.sh on the host to enable EUPE.', flush=True)"
+    print(f'EUPE not cached ({exc.__class__.__name__}: {exc}); skipping. ' \
+          'Run scripts/cache_gated_models.sh on the host to enable EUPE ' \
+          'in offline builds.', flush=True)"
 
 # ---------- application layer ----------
 COPY . .

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -319,23 +319,25 @@ each other.
      vote semantics attached.
 
 2. **`Dockerfile.image-embedders` + `scripts/cache_gated_models.sh`
-   off the broken PE-Core AutoModel path.**
-   - Both files still call `AutoModel.from_pretrained(EUPE_MODEL_ID,
-     ..., trust_remote_code=True)`, which no longer matches the
-     embedder's actual load path (now `torch.hub.load` against
-     `facebookresearch/EUPE` with a HF weights URL).  At runtime the
-     embedder fetches its own weights via torch hub, so the bake
-     step in Docker is now ineffective (and the `trust_remote_code`
-     call would also have failed had it ever run for real).
-   - Fix: switch both files to a torch-hub-based pre-cache.  Set
-     `TORCH_HOME` to the shared `model_cache/` dir and run
+   off the broken PE-Core AutoModel path — DONE.**
+   - Both files used to call `AutoModel.from_pretrained(EUPE_MODEL_ID,
+     ..., trust_remote_code=True)`, which no longer matched the
+     embedder's actual load path (`torch.hub.load` against
+     `facebookresearch/EUPE` with a HF weights URL).  Switched both
+     to a torch-hub-based pre-cache: `TORCH_HOME` points at the
+     shared `model_cache/` dir (Dockerfile sets it equal to
+     `VTSEARCH_MODELS_DIR`; the host script sets it to the cache
+     directory it was passed) and we call
      `torch.hub.load("facebookresearch/EUPE", "eupe_vitb16",
      source="github", pretrained=True, weights=EUPE_MODEL_ID,
      trust_repo=True)` once at build / host-cache time so the
      EUPE repo clone + weights file are baked in.  No HF token
-     needed (the EUPE-ViT-B HF repo is ungated).  See "EUPE backbone
-     & licence" section for the constants.
-   - Build-time concern only; runtime works without it.
+     needed for EUPE (the EUPE-ViT-B HF repo is ungated); the
+     cache script grew a `SKIP_DINOV3=1` knob so users who only
+     need EUPE can run it without an HF login.  The Dockerfile's
+     EUPE bake step is also wrapped in a try/except so the build
+     succeeds even when no host cache is present and the build
+     environment has no network.
 
 3. **caltech101_s pre-implementation experiments.**
    - The design pins `K = 12` and `α = 0.5` as v1 defaults; the

--- a/scripts/cache_gated_models.sh
+++ b/scripts/cache_gated_models.sh
@@ -1,22 +1,33 @@
 #!/usr/bin/env bash
-# Cache gated Hugging Face model weights to a local directory **once**, so that
+# Cache image-embedder model weights to a local directory **once**, so that
 # Dockerfile.image-embedders can bake them into the image without ever needing
 # an HF token during ``docker build``.
 #
-# The gated models are:
-#   * DINOv3  (facebook/dinov3-vitb16-pretrain-lvd1689m) — Meta research licence
-#   * EUPE    (facebook/PE-Core-B16-224)                 — Meta research licence
+# Two embedders need a host-side cache step:
 #
-# Both require you to:
+#   * DINOv3  (facebook/dinov3-vitb16-pretrain-lvd1689m) — gated under Meta's
+#     research licence; you must accept it on HF and provide an HF token here.
+#   * EUPE    (facebookresearch/EUPE, ViT-B/16 LVD-1689M weights mirrored on
+#     facebook/EUPE-ViT-B) — the HF mirror is ungated and needs no token, but
+#     loading still requires cloning the EUPE repo via ``torch.hub`` and
+#     downloading the .pt weights file. Doing that once on the host means
+#     ``docker build`` can run fully offline.
+#
+# For DINOv3 only, you must:
 #   1. Have a Hugging Face account.
-#   2. Visit each model page and click "Agree and access" to accept the licence.
+#   2. Visit https://huggingface.co/facebook/dinov3-vitb16-pretrain-lvd1689m
+#      and click "Agree and access" to accept the licence.
 #   3. Create a User Access Token at https://huggingface.co/settings/tokens
 #      (a read-only token is enough).
 #
-# Run this script **once** on the host, with your token available either as an
-# env var or via a prior ``huggingface-cli login``. The script downloads
-# everything into ``./model_cache/`` (or any directory you pass as $1). After
-# that, ``docker build`` reads from the cache and never needs your token again.
+# Run this script **once** on the host. The script downloads everything into
+# ``./model_cache/`` (or any directory you pass as $1):
+#   * DINOv3 lands under ``$CACHE/models--facebook--dinov3-...``
+#     (the standard HuggingFace cache layout).
+#   * EUPE lands under ``$CACHE/hub/`` (torch.hub layout: cloned repo +
+#     ``checkpoints/EUPE-ViT-B.pt``).
+# After that, ``docker build`` reads from the cache and never needs your
+# token (or the network) again.
 #
 # Usage:
 #   HF_TOKEN=hf_xxx ./scripts/cache_gated_models.sh
@@ -24,6 +35,10 @@
 #   ./scripts/cache_gated_models.sh
 #   # or, custom output dir:
 #   ./scripts/cache_gated_models.sh /path/to/cache
+#
+# If you only want EUPE (no HF token, no licence acceptance), run with
+# ``SKIP_DINOV3=1``:
+#   SKIP_DINOV3=1 ./scripts/cache_gated_models.sh
 #
 # The cache directory is ``./model_cache/`` by default and is gitignored —
 # weights never end up in the repo or in a Docker image layer except via the
@@ -34,19 +49,22 @@ set -euo pipefail
 CACHE_DIR="${1:-./model_cache}"
 mkdir -p "$CACHE_DIR"
 
-echo "Caching gated VTSearch image-embedder weights to: $CACHE_DIR"
+echo "Caching VTSearch image-embedder weights to: $CACHE_DIR"
 echo
 
-# Resolve a token from the env, but don't echo it. If HF_TOKEN isn't set,
-# huggingface_hub falls back to the credential saved by ``huggingface-cli
-# login`` — both paths use the same underlying loader.
-if [[ -n "${HF_TOKEN:-}" ]]; then
-    echo "Using HF token from \$HF_TOKEN env var."
-elif [[ -f "$HOME/.cache/huggingface/token" ]] || [[ -f "$HOME/.huggingface/token" ]]; then
-    echo "Using HF token from cached huggingface-cli login."
-else
-    cat <<'EOF' >&2
-ERROR: No Hugging Face credentials found.
+SKIP_DINOV3="${SKIP_DINOV3:-0}"
+
+if [[ "$SKIP_DINOV3" != "1" ]]; then
+    # Resolve a token from the env, but don't echo it. If HF_TOKEN isn't
+    # set, huggingface_hub falls back to the credential saved by
+    # ``huggingface-cli login`` — both paths use the same underlying loader.
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+        echo "Using HF token from \$HF_TOKEN env var (DINOv3)."
+    elif [[ -f "$HOME/.cache/huggingface/token" ]] || [[ -f "$HOME/.huggingface/token" ]]; then
+        echo "Using HF token from cached huggingface-cli login (DINOv3)."
+    else
+        cat <<'EOF' >&2
+ERROR: No Hugging Face credentials found (needed for DINOv3).
 
 Either set HF_TOKEN in your environment, e.g.:
     export HF_TOKEN=hf_xxx
@@ -56,41 +74,73 @@ Or log in interactively first:
     huggingface-cli login
     ./scripts/cache_gated_models.sh
 
-You also need to visit each model page once and click "Agree and access":
+You also need to visit the DINOv3 model page once and click "Agree and access":
     https://huggingface.co/facebook/dinov3-vitb16-pretrain-lvd1689m
-    https://huggingface.co/facebook/PE-Core-B16-224
-EOF
-    exit 1
-fi
-echo
 
-python3 - "$CACHE_DIR" <<'PYEOF'
+If you don't want DINOv3, re-run with SKIP_DINOV3=1 to cache only EUPE:
+    SKIP_DINOV3=1 ./scripts/cache_gated_models.sh
+EOF
+        exit 1
+    fi
+    echo
+fi
+
+export VTSEARCH_CACHE_DIR="$CACHE_DIR"
+export VTSEARCH_SKIP_DINOV3="$SKIP_DINOV3"
+
+python3 - <<'PYEOF'
 import os
 import sys
 
-cache_dir = sys.argv[1]
-# ``token=True`` tells huggingface_hub to use whichever token the user
-# previously set (HF_TOKEN env var or ``huggingface-cli login``), without
-# us having to splice it into a string anywhere.
-token = os.environ.get("HF_TOKEN") or True
+cache_dir = os.environ["VTSEARCH_CACHE_DIR"]
+skip_dinov3 = os.environ.get("VTSEARCH_SKIP_DINOV3", "0") == "1"
 
-print("[1/2] Downloading DINOv3 (facebook/dinov3-vitb16-pretrain-lvd1689m)...", flush=True)
-from transformers import AutoImageProcessor, AutoModel
+steps = []
+if not skip_dinov3:
+    steps.append("DINOv3")
+steps.append("EUPE")
+total = len(steps)
+step_no = 0
 
-from vtsearch.config import DINOV3_MODEL_ID
+if not skip_dinov3:
+    step_no += 1
+    print(
+        f"[{step_no}/{total}] Downloading DINOv3 (facebook/dinov3-vitb16-pretrain-lvd1689m)...",
+        flush=True,
+    )
+    # ``token=True`` tells huggingface_hub to use whichever token the user
+    # previously set (HF_TOKEN env var or ``huggingface-cli login``),
+    # without us having to splice it into a string anywhere.
+    token = os.environ.get("HF_TOKEN") or True
+    from transformers import AutoImageProcessor, AutoModel
 
-AutoModel.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache_dir, token=token)
-AutoImageProcessor.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache_dir, token=token)
-print("  DINOv3 cached.", flush=True)
+    from vtsearch.config import DINOV3_MODEL_ID
 
-print("[2/2] Downloading EUPE (facebook/PE-Core-B16-224)...", flush=True)
-from vtsearch.config import EUPE_MODEL_ID
+    AutoModel.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache_dir, token=token)
+    AutoImageProcessor.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache_dir, token=token)
+    print("  DINOv3 cached.", flush=True)
 
-AutoModel.from_pretrained(
-    EUPE_MODEL_ID, cache_dir=cache_dir, token=token, trust_remote_code=True
+step_no += 1
+print(
+    f"[{step_no}/{total}] Downloading EUPE (facebookresearch/EUPE, ViT-B/16)...",
+    flush=True,
 )
-AutoImageProcessor.from_pretrained(
-    EUPE_MODEL_ID, cache_dir=cache_dir, token=token, trust_remote_code=True
+# EUPE loads via torch.hub: a cloned GitHub repo plus a downloaded .pt
+# weights file. Both land under $TORCH_HOME/hub/, so we point TORCH_HOME
+# at the same directory the Dockerfile will COPY into the image.
+os.environ["TORCH_HOME"] = cache_dir
+
+import torch  # noqa: E402
+
+from vtsearch.config import EUPE_MODEL_ID  # noqa: E402
+
+torch.hub.load(
+    "facebookresearch/EUPE",
+    "eupe_vitb16",
+    source="github",
+    pretrained=True,
+    weights=EUPE_MODEL_ID,
+    trust_repo=True,
 )
 print("  EUPE cached.", flush=True)
 PYEOF


### PR DESCRIPTION
## Summary

- Both `Dockerfile.image-embedders` and `scripts/cache_gated_models.sh` were still baking EUPE via `AutoModel.from_pretrained(EUPE_MODEL_ID, ..., trust_remote_code=True)` — leftover from the dropped PE-Core load path. The real embedder loads EUPE via `torch.hub.load("facebookresearch/EUPE", "eupe_vitb16", ...)` against a HF weights URL, so the pre-cache step was ineffective (and `trust_remote_code` would have errored had it ever run).
- Switched both files to a torch-hub pre-cache that points `TORCH_HOME` at the shared `model_cache/` dir. The cache script grew a `SKIP_DINOV3=1` escape hatch since EUPE's HF mirror is ungated and no longer needs an HF token.
- Wrapped the Dockerfile EUPE bake in try/except so an offline build still produces a usable image (EUPE is just unavailable until the cache script runs and the image is rebuilt).
- Marked plan item 2 ("Remaining v1 work") **DONE** in `docs/plans/patch-embedder.md`.

## Test plan

- [ ] Run `scripts/cache_gated_models.sh` on the host and confirm `model_cache/hub/checkpoints/EUPE-ViT-B.pt` and `model_cache/hub/facebookresearch_EUPE_*` appear.
- [ ] Run `SKIP_DINOV3=1 ./scripts/cache_gated_models.sh` without an HF token and confirm only the EUPE step runs.
- [ ] `docker build -f Dockerfile.image-embedders -t vtsearch:image-embedders .` after caching, and confirm EUPE loads from the local cache (no network during the build's EUPE step).
- [ ] `docker build -f Dockerfile.image-embedders -t vtsearch:image-embedders .` with `model_cache/` empty in an offline environment and confirm the build still succeeds with EUPE skipped.
- [ ] Start the container and select EUPE; confirm it loads against the baked weights.

https://claude.ai/code/session_013Uq4BEYnzP9kWEvAbVgzZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_013Uq4BEYnzP9kWEvAbVgzZ4)_