### PR TITLE
Region voting: Shift-drag UI on the image focus pane (v2 of patch-embedder plan)

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -177,15 +177,49 @@ V1 records both Good and Bad against the full image. The `LabeledElement` schema
 
 This is deliberate. "Use the region that triggered the result" misattributes in any sort mode without a query (random shuffle, diversity sort, autopilot exploration, a fresh dataset), and ignores discovery — users vote Good on things the algorithm didn't surface for. Image-level votes with region-level scoring is the standard weakly-supervised setup: the MLP learns "what makes an image good" and the max-pool at scoring time picks the region that best satisfies that learned function.
 
-### v2: region voting via a click-two-corners gesture
+### v2: region voting
 
-When the user explicitly marks a box on the focus pane and votes against it:
+V2 lets the user attach a single rectangular region to a yes-vote on an image. The region is a *salient-area annotation* — it says "the good part is here", not "yes-with-region is a new label class". No-votes never carry a region.
+
+#### Backend semantics
 
 1. **Compute the vote vector on the fly from the patch grid.** Not from any tree node. Take the set of patch cells whose centers fall inside the user's box, attention-weighted-mean their `media["patch_grid"][i, j]` vectors, L2-normalise. That's the vote vector for this vote. We persist the *box* (4 floats), not the vector — the trainer rederives the vector at train time from the already-pickled `patch_grid` (stored from v1, see "Storage"). No re-import required when v2 ships.
 2. **Don't snap to tree nodes.** The HAC tree exists to give *search* a finite set of regions to scan in O(N log N). Voting is a one-off, so on-the-fly computation is fine and gives the user patch-precision without the "slightly-too-big box jumps to the full-image node" failure mode.
 3. **Display-time snapping is different.** When we draw the matched-region outline on a search-result card, we *do* snap to the best-IoU tree node, because the user isn't designating anything there — we're just showing them which scale won.
 
-V2 adds an optional `region_box: (x0, y0, x1, y1)` to `LabeledElement`. Absent → image-level (the v1 default and the forever-legacy fallback).
+V2 adds an optional `region_box: (x0, y0, x1, y1)` (normalised image coords) to `LabeledElement`. Absent → image-level (the v1 default and the forever-legacy fallback).
+
+#### Interaction design
+
+The overriding constraint is **don't degrade the existing fast binary-vote path**. Today a yes-vote is one keypress (`→`); a no-vote is one keypress (`←`). Users who never want region voting must never see new affordances in their way, and their one-keypress rhythm must survive untouched.
+
+**Scope.** Image media only. Other media types (audio, text, video, document) get no region-vote affordance in v2 — `supports_patch_regions` is image-specific and there's no obvious 2D analogue for the others. The center-pane focus view is the only place region voting is offered; the gallery card's `best_region` outline (shipped in v1) remains purely informational.
+
+**Entering region mode: hold `Shift`.** The focus pane already binds mousedown-drag to *pan-when-zoomed*. While `Shift` is held over the image-viewer canvas, that pan gesture is suppressed and replaced with a box-draw gesture; the cursor flips to a crosshair. Release `Shift` and pan is restored. Reasons for `Shift` over a sticky toggle:
+  - Matches Figma/Photoshop muscle memory (drag = move; modifier+drag = select).
+  - One key down, one key up — no mode the user can get stuck in.
+  - Doesn't collide with text input the way letter-key hotkeys do.
+  - Users who never region-vote literally never touch it.
+
+If `Shift` is released mid-drag (mouse button still down), the in-progress draw is committed on mouseup before mode exits. Don't punish a millisecond-early key release.
+
+**Drawing the box.** Click-drag-release in image-local coordinates: the mouse position is un-transformed through the current `panX / panY / zoom / rotate` so a box drawn at 4× zoom stays correctly anchored when the user zooms back out. Stored internally and on `LabeledElement.region_box` as `(x0, y0, x1, y1)` in normalised image coords (0..1, pre-rotation). A zero-area release (just a click, no drag) is treated as "no box drawn" and falls back to the binary path.
+
+**Editing the box.** After release the box stays visible with 8 corner/edge resize handles and a draggable body for translation. There is **no separate submit button** — the box is just transient state attached to the *pending* vote. Re-Shift-dragging from empty space starts a fresh box (discards the prior one).
+
+**Voting still uses Left/Right.**
+  - `→` (good) submits a yes-vote and, if a box is currently drawn, attaches its normalised coordinates as `region_box`. No box → plain yes-vote, identical to today.
+  - `←` (bad) when **no box is drawn** → plain no-vote, identical to today.
+  - `←` (bad) when a box **is drawn** → require a second confirming `←` press (or `Esc` to clear the box first and then a plain `←` works). The first `←` shakes / highlights the box to draw attention; the second within ~2 seconds submits the no-vote and discards the box. Rationale: drawing a box is real work; a stray left-arrow press shouldn't throw it away. Users with no box never see this branch and keep their single-keypress fast path.
+  - `Esc` discards the current box without voting; the user stays on the same item.
+
+The mouse-click vote buttons in the UI follow the same rules.
+
+**Touch.** Deferred to a later phase. Touch has no `Shift` modifier, and v2's audience is power users on desktop. The center-pane toolbar already exposes zoom/rotate/reset buttons; if touch support is needed later, a "draw region" toggle button there is the natural place. Out of scope for v2.
+
+**Frontend implementation surface.** A new overlay layer inside `ImageViewerComponent` (or a sibling `RegionDrawComponent` it composes) listens for `keydown/keyup` of `Shift` on `window` while the focus pane is mounted, swaps pointer handlers when the modifier is active, and renders the box + handles as a positioned div pair inside the existing `.thumbnail-wrap` (same coordinate system as the v1 `best_region` outline). The vote-dispatch service grows an optional `regionBox` parameter that flows into the existing yes-vote API call; the bad-vote path picks up a "pending discard confirmation" sub-state. None of this touches the binary-only code paths.
+
+**Tests.** Beyond the existing v1 patch tests, v2 needs: pure-function coverage for the screen↔image coordinate transform under non-trivial `pan/zoom/rotate`; coordinate stability across zoom changes after the box is drawn; box discarded on bad-vote-after-confirm; box preserved across a second `Shift`-drag attempt that becomes a no-op zero-area click; `region_box` round-tripping through `LabeledElement` serialisation; vote-API contract test that `region_box` is present on yes and absent on no. The on-the-fly patch-grid pooling (box → vote vector) is exercised by a backend test that doesn't touch the UI.
 
 ## Detector MLP
 
@@ -374,5 +408,5 @@ each other.
 ## Phasing
 
 - **v1 (this plan):** three patch embedders — DINOv2 (ungated default), DINOv3 (gated, premium), and real-EUPE (FAIR Noncommercial). `supports_patch_regions` + `license_notice` flags on `MediaEmbedder`; each patch embedder populates `media["patch_regions"]` (HAC tree) and `media["patch_grid"]` (raw H × W × 768 fp16); `PatchEmbedOutput` protocol; max-region similarity; region-aware MLP scoring (image-level training and image-level voting unchanged); gallery-card region highlight; license-notice surfacing on the embedder picker. Text sort stays grey via the already-shipped `supports_text` gate. Pre-implementation experiments run on `caltech101_s` and inform `K`, `α`, and the EUPE-real attention path.
-- **v2:** region voting (click two corners on the focus pane); on-the-fly vote-vector computation from the v1-pickled `patch_grid` (no re-import needed); optional `LabeledElement.region_box`; region-level training examples; per-region label export.
+- **v2:** region voting on image media via Shift-drag on the focus pane (single rectangular box, salient-area annotation on yes-votes only; binary fast path via `←`/`→` preserved); on-the-fly vote-vector computation from the v1-pickled `patch_grid` (no re-import needed); optional `LabeledElement.region_box`; region-level training examples; per-region label export. Touch deferred.
 - **v3:** one text embedder + one patch embedder per dataset (text queries → text embedder; region similarity / votes → patch embedder). Requires a real schema change (`media["embeddings"]` dict, `media["patch_regions"]` dict). Gets its own design doc when we get there.

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -8,7 +8,7 @@
           <vt-audio-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" [swipeClass]="swipeClass" (playingChanged)="onPlayingChanged($event)"></vt-audio-player>
         }
         @case ('image') {
-          <vt-image-viewer [media]="media"></vt-image-viewer>
+          <vt-image-viewer [media]="media" (regionBoxChange)="onRegionBoxChange($event)"></vt-image-viewer>
         }
         @case ('video') {
           <vt-video-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" (playingChanged)="onPlayingChanged($event)"></vt-video-player>

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -7,7 +7,7 @@ import { KeyboardService } from '../../services/keyboard.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { AudioPlayerComponent } from './audio-player/audio-player.component';
-import { ImageViewerComponent } from './image-viewer/image-viewer.component';
+import { ImageViewerComponent, RegionBox } from './image-viewer/image-viewer.component';
 import { VideoPlayerComponent } from './video-player/video-player.component';
 import { TextViewerComponent } from './text-viewer/text-viewer.component';
 import { DocumentViewerComponent } from './document-viewer/document-viewer.component';
@@ -46,6 +46,11 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   swipeClass = '';
   spinningVote: 'good' | 'bad' | null = null;
 
+  private currentRegionBox: RegionBox | null = null;
+  private pendingBadConfirm = false;
+  private badConfirmTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly BAD_CONFIRM_MS = 2000;
+
   private spinTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _pausedByVisibility = false;
@@ -61,6 +66,10 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media']) {
       this.swipeClass = '';
+      this.cancelBadConfirm();
+      // ImageViewer also clears its own regionBox on media change and will emit null;
+      // resetting eagerly here keeps state coherent across the swap.
+      this.currentRegionBox = null;
     }
   }
 
@@ -69,6 +78,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.keyboard.stop();
     this.subs.forEach((s) => s.unsubscribe());
     if (this.spinTimer) clearTimeout(this.spinTimer);
+    if (this.badConfirmTimer) clearTimeout(this.badConfirmTimer);
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
   }
 
@@ -162,9 +172,23 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   castVote(vote: 'good' | 'bad'): void {
     if (!this.media || this.isVoting) return;
+
+    // Region annotations only attach to yes-votes (salient-area semantics).
+    // A no-vote with a box drawn requires a confirming second press so a stray
+    // ArrowLeft can't throw away real work the user did drawing the box.
+    if (vote === 'bad' && this.currentRegionBox && !this.pendingBadConfirm) {
+      this.pendingBadConfirm = true;
+      this.imageViewer?.pulseRegionBox();
+      if (this.badConfirmTimer) clearTimeout(this.badConfirmTimer);
+      this.badConfirmTimer = setTimeout(() => this.cancelBadConfirm(), this.BAD_CONFIRM_MS);
+      return;
+    }
+
+    const regionBox = vote === 'good' ? this.currentRegionBox : null;
+    this.cancelBadConfirm();
     this.isVoting = true;
 
-    this.mediasApi.vote(this.media.id, vote).subscribe({
+    this.mediasApi.vote(this.media.id, vote, regionBox).subscribe({
       next: () => {
         const animate = this.swipeAnimation && !!this.media && !prefersReducedMotion();
         if (animate) {
@@ -185,6 +209,21 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
         this.isVoting = false;
       },
     });
+  }
+
+  onRegionBoxChange(box: RegionBox | null): void {
+    this.currentRegionBox = box;
+    // Clearing the box also clears any pending bad-vote confirmation —
+    // there's nothing left to confirm against.
+    if (!box) this.cancelBadConfirm();
+  }
+
+  private cancelBadConfirm(): void {
+    this.pendingBadConfirm = false;
+    if (this.badConfirmTimer) {
+      clearTimeout(this.badConfirmTimer);
+      this.badConfirmTimer = null;
+    }
   }
 
   private loadSettings(): void {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -1,6 +1,7 @@
 <div
   #imageWrap
   class="image-wrap"
+  [class.region-mode]="shiftHeld"
   [style.cursor]="wrapCursor"
   (wheel)="onWheel($event)"
   (mousedown)="onMouseDown($event)"
@@ -17,4 +18,29 @@
     draggable="false"
     fetchpriority="high"
   />
+  @if (regionBox && renderedW > 0 && renderedH > 0) {
+    <div
+      class="region-stage"
+      [style.width.px]="renderedW"
+      [style.height.px]="renderedH"
+      [style.transform]="'translate(-50%, -50%) ' + imageTransform"
+    >
+      <div
+        class="region-box"
+        [class.shake]="regionBoxShake"
+        [ngStyle]="regionBoxStyle!"
+        (mousedown)="onRegionBodyMouseDown($event)"
+        title="Region annotation (Shift-drag to redraw, Esc to clear)"
+      >
+        <div class="region-handle region-handle-nw" (mousedown)="onResizeHandleMouseDown('nw', $event)"></div>
+        <div class="region-handle region-handle-n" (mousedown)="onResizeHandleMouseDown('n', $event)"></div>
+        <div class="region-handle region-handle-ne" (mousedown)="onResizeHandleMouseDown('ne', $event)"></div>
+        <div class="region-handle region-handle-e" (mousedown)="onResizeHandleMouseDown('e', $event)"></div>
+        <div class="region-handle region-handle-se" (mousedown)="onResizeHandleMouseDown('se', $event)"></div>
+        <div class="region-handle region-handle-s" (mousedown)="onResizeHandleMouseDown('s', $event)"></div>
+        <div class="region-handle region-handle-sw" (mousedown)="onResizeHandleMouseDown('sw', $event)"></div>
+        <div class="region-handle region-handle-w" (mousedown)="onResizeHandleMouseDown('w', $event)"></div>
+      </div>
+    </div>
+  }
 </div>

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -8,6 +8,7 @@
 }
 
 .image-wrap {
+  position: relative;
   flex: 1;
   min-height: 0;
   width: 100%;
@@ -31,3 +32,68 @@
   }
 }
 
+.region-stage {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  pointer-events: none;
+  transform-origin: 50% 50%;
+}
+
+.region-box {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1.5px solid rgba(255, 224, 102, 0.95);
+  background: rgba(255, 224, 102, 0.06);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.45) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+  cursor: move;
+
+  &.shake {
+    animation: region-box-shake 0.45s ease-in-out;
+  }
+}
+
+@keyframes region-box-shake {
+  0%, 100% { transform: translateX(0); border-color: rgba(255, 224, 102, 0.95); }
+  15% { transform: translateX(-3px); border-color: rgba(255, 110, 110, 0.95); }
+  30% { transform: translateX(3px); }
+  45% { transform: translateX(-3px); }
+  60% { transform: translateX(3px); border-color: rgba(255, 110, 110, 0.95); }
+  75% { transform: translateX(-2px); }
+}
+
+.region-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: rgba(255, 224, 102, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  box-sizing: border-box;
+  pointer-events: auto;
+}
+
+.region-handle-n,
+.region-handle-s {
+  left: 50%;
+  margin-left: -5px;
+  cursor: ns-resize;
+}
+.region-handle-n { top: -5px; }
+.region-handle-s { bottom: -5px; }
+
+.region-handle-e,
+.region-handle-w {
+  top: 50%;
+  margin-top: -5px;
+  cursor: ew-resize;
+}
+.region-handle-e { right: -5px; }
+.region-handle-w { left: -5px; }
+
+.region-handle-nw { top: -5px; left: -5px; cursor: nwse-resize; }
+.region-handle-se { bottom: -5px; right: -5px; cursor: nwse-resize; }
+.region-handle-ne { top: -5px; right: -5px; cursor: nesw-resize; }
+.region-handle-sw { bottom: -5px; left: -5px; cursor: nesw-resize; }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -1,59 +1,89 @@
 import {
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
+  Output,
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
+import { NgStyle } from '@angular/common';
 import { MediaItem } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
+
+export type RegionBox = readonly [number, number, number, number];
+export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'nw' | 'ne' | 'sw' | 'se';
+
+type DragMode =
+  | { kind: 'pan'; startX: number; startY: number; originX: number; originY: number }
+  | { kind: 'draw'; anchor: { x: number; y: number } }
+  | { kind: 'move'; startLocal: { x: number; y: number }; startBox: RegionBox }
+  | { kind: 'resize'; handle: ResizeHandle; startBox: RegionBox };
+
+const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a stray click
 
 @Component({
   selector: 'vt-image-viewer',
   standalone: true,
+  imports: [NgStyle],
   templateUrl: './image-viewer.component.html',
   styleUrl: './image-viewer.component.scss',
 })
 export class ImageViewerComponent implements OnChanges, OnDestroy {
   @Input() media!: MediaItem;
+  @Output() regionBoxChange = new EventEmitter<RegionBox | null>();
 
   @ViewChild('imageWrap') wrapRef!: ElementRef<HTMLDivElement>;
   @ViewChild('imageEl') imageRef!: ElementRef<HTMLImageElement>;
 
   imageSrc = '';
-
-  constructor(private activeContext: ActiveContextService) {}
   imageReady = false;
   zoom = 1;
   rotation = 0;
-  zoomLabel = '1\u00d7';
+  zoomLabel = '1×';
+
+  // Region voting state (v2 of the patch-embedder plan, UI only — see docs/plans/patch-embedder.md).
+  regionBox: RegionBox | null = null;
+  regionBoxShake = false;
+  shiftHeld = false;
+  renderedW = 0;
+  renderedH = 0;
 
   private panX = 0;
   private panY = 0;
-  private isPanning = false;
-  private panStartX = 0;
-  private panStartY = 0;
-  private panOriginX = 0;
-  private panOriginY = 0;
+  private drag: DragMode | null = null;
+
   private mouseMoveHandler: ((e: MouseEvent) => void) | null = null;
   private mouseUpHandler: (() => void) | null = null;
+  private keyDownHandler: ((e: KeyboardEvent) => void) | null = null;
+  private keyUpHandler: ((e: KeyboardEvent) => void) | null = null;
+  private blurHandler: (() => void) | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private shakeTimer: ReturnType<typeof setTimeout> | null = null;
 
   readonly minZoom = 1;
   readonly maxZoom = 5;
   readonly zoomStep = 0.05;
+
+  constructor(private activeContext: ActiveContextService) {
+    this.setupWindowKeyListeners();
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media'] && this.media) {
       this.imageReady = false;
       this.imageSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
       this.resetView();
+      this.clearRegionBox({ emit: true });
     }
   }
 
   onImageLoad(): void {
     this.imageReady = true;
+    this.recomputeRenderedSize();
+    this.attachWrapResizeObserver();
   }
 
   onImageError(): void {
@@ -61,7 +91,13 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.removeWindowListeners();
+    this.removeWindowMouseListeners();
+    this.removeWindowKeyListeners();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    if (this.shakeTimer) clearTimeout(this.shakeTimer);
   }
 
   onZoomInput(event: Event): void {
@@ -116,15 +152,67 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   onMouseDown(event: MouseEvent): void {
+    if (event.button !== 0) return;
+
+    if (this.shiftHeld && this.renderedW > 0 && this.renderedH > 0) {
+      // Shift-drag from anywhere on the canvas starts a fresh box. If an
+      // older box existed, discard it before recording the new anchor.
+      const local = this.screenToImageNormalized(event);
+      if (!local) return;
+      const x = clamp01(local.x);
+      const y = clamp01(local.y);
+      this.drag = { kind: 'draw', anchor: { x, y } };
+      this.regionBox = [x, y, x, y];
+      event.preventDefault();
+      this.setupWindowMouseListeners();
+      return;
+    }
+
+    // Default: pan-when-zoomed.
     const max = this.getMaxPan();
-    if ((max.x <= 0 && max.y <= 0) || event.button !== 0) return;
-    this.isPanning = true;
-    this.panStartX = event.clientX;
-    this.panStartY = event.clientY;
-    this.panOriginX = this.panX;
-    this.panOriginY = this.panY;
+    if (max.x <= 0 && max.y <= 0) return;
+    this.drag = {
+      kind: 'pan',
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: this.panX,
+      originY: this.panY,
+    };
     event.preventDefault();
-    this.setupWindowListeners();
+    this.setupWindowMouseListeners();
+  }
+
+  onRegionBodyMouseDown(event: MouseEvent): void {
+    if (event.button !== 0 || !this.regionBox) return;
+    event.stopPropagation();
+    event.preventDefault();
+    const local = this.screenToImageNormalized(event);
+    if (!local) return;
+    this.drag = { kind: 'move', startLocal: local, startBox: this.regionBox };
+    this.setupWindowMouseListeners();
+  }
+
+  onResizeHandleMouseDown(handle: ResizeHandle, event: MouseEvent): void {
+    if (event.button !== 0 || !this.regionBox) return;
+    event.stopPropagation();
+    event.preventDefault();
+    this.drag = { kind: 'resize', handle, startBox: this.regionBox };
+    this.setupWindowMouseListeners();
+  }
+
+  /** Clear the current region box and notify the parent. */
+  clearRegionBox(opts: { emit: boolean } = { emit: true }): void {
+    if (this.regionBox === null) return;
+    this.regionBox = null;
+    if (opts.emit) this.regionBoxChange.emit(null);
+  }
+
+  /** Visually flash the region box (used by bad-vote-confirm flow). */
+  pulseRegionBox(): void {
+    if (!this.regionBox) return;
+    this.regionBoxShake = true;
+    if (this.shakeTimer) clearTimeout(this.shakeTimer);
+    this.shakeTimer = setTimeout(() => (this.regionBoxShake = false), 500);
   }
 
   get imageTransform(): string {
@@ -132,8 +220,20 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   get wrapCursor(): string {
+    if (this.shiftHeld) return 'crosshair';
     const max = this.getMaxPan();
-    return (max.x > 0 || max.y > 0) ? 'grab' : '';
+    return max.x > 0 || max.y > 0 ? 'grab' : '';
+  }
+
+  get regionBoxStyle(): { [k: string]: string } | null {
+    if (!this.regionBox) return null;
+    const [x0, y0, x1, y1] = this.regionBox;
+    return {
+      left: pct(x0),
+      top: pct(y0),
+      width: pct(x1 - x0),
+      height: pct(y1 - y0),
+    };
   }
 
   private applyTransform(): void {
@@ -141,64 +241,90 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     this.panX = Math.max(-max.x, Math.min(max.x, this.panX));
     this.panY = Math.max(-max.y, Math.min(max.y, this.panY));
     const zoomVal = this.zoom;
-    this.zoomLabel = (zoomVal === Math.floor(zoomVal) ? zoomVal.toFixed(0) : zoomVal.toFixed(1)) + '\u00d7';
+    this.zoomLabel = (zoomVal === Math.floor(zoomVal) ? zoomVal.toFixed(0) : zoomVal.toFixed(1)) + '×';
   }
 
   private clampZoom(val: number): number {
     return Math.min(this.maxZoom, Math.max(this.minZoom, val));
   }
 
-  private getMaxPan(): { x: number; y: number } {
+  private recomputeRenderedSize(): void {
     const img = this.imageRef?.nativeElement;
     const wrap = this.wrapRef?.nativeElement;
-    if (!img || !wrap) return { x: 0, y: 0 };
-
+    if (!img || !wrap) return;
     const natW = img.naturalWidth;
     const natH = img.naturalHeight;
-    if (!natW || !natH) return { x: 0, y: 0 };
-
     const wrapW = wrap.clientWidth;
     const wrapH = wrap.clientHeight;
-    if (!wrapW || !wrapH) return { x: 0, y: 0 };
-
+    if (!natW || !natH || !wrapW || !wrapH) {
+      this.renderedW = 0;
+      this.renderedH = 0;
+      return;
+    }
     const imgAspect = natW / natH;
     const wrapAspect = wrapW / wrapH;
-    let rendW: number, rendH: number;
     if (imgAspect > wrapAspect) {
-      rendW = wrapW;
-      rendH = wrapW / imgAspect;
+      this.renderedW = wrapW;
+      this.renderedH = wrapW / imgAspect;
     } else {
-      rendH = wrapH;
-      rendW = wrapH * imgAspect;
+      this.renderedH = wrapH;
+      this.renderedW = wrapH * imgAspect;
     }
+  }
 
+  private attachWrapResizeObserver(): void {
+    const wrap = this.wrapRef?.nativeElement;
+    if (!wrap || this.resizeObserver) return;
+    if (typeof ResizeObserver === 'undefined') return;
+    this.resizeObserver = new ResizeObserver(() => this.recomputeRenderedSize());
+    this.resizeObserver.observe(wrap);
+  }
+
+  private getMaxPan(): { x: number; y: number } {
+    const wrap = this.wrapRef?.nativeElement;
+    if (!wrap || !this.renderedW || !this.renderedH) return { x: 0, y: 0 };
+    const wrapW = wrap.clientWidth;
+    const wrapH = wrap.clientHeight;
     const rot = ((this.rotation % 360) + 360) % 360;
     const swapped = rot === 90 || rot === 270;
-    const effW = swapped ? rendH : rendW;
-    const effH = swapped ? rendW : rendH;
-
+    const effW = swapped ? this.renderedH : this.renderedW;
+    const effH = swapped ? this.renderedW : this.renderedH;
     return {
       x: Math.max(0, (effW * this.zoom - wrapW) / 2),
       y: Math.max(0, (effH * this.zoom - wrapH) / 2),
     };
   }
 
-  private setupWindowListeners(): void {
-    this.removeWindowListeners();
-    this.mouseMoveHandler = (e: MouseEvent) => {
-      if (!this.isPanning) return;
-      this.panX = this.panOriginX + (e.clientX - this.panStartX);
-      this.panY = this.panOriginY + (e.clientY - this.panStartY);
-      this.applyTransform();
+  /** Convert a screen-space mouse event to normalised image coords (pre-rotation).
+   *  Returns null when the image isn't laid out yet. */
+  private screenToImageNormalized(event: MouseEvent): { x: number; y: number } | null {
+    const wrap = this.wrapRef?.nativeElement;
+    if (!wrap || !this.renderedW || !this.renderedH) return null;
+    const rect = wrap.getBoundingClientRect();
+    const dx = event.clientX - (rect.left + rect.width / 2) - this.panX;
+    const dy = event.clientY - (rect.top + rect.height / 2) - this.panY;
+    const sx = dx / this.zoom;
+    const sy = dy / this.zoom;
+    const rad = (-this.rotation * Math.PI) / 180;
+    const cos = Math.cos(rad);
+    const sin = Math.sin(rad);
+    const rx = sx * cos - sy * sin;
+    const ry = sx * sin + sy * cos;
+    return {
+      x: (rx + this.renderedW / 2) / this.renderedW,
+      y: (ry + this.renderedH / 2) / this.renderedH,
     };
-    this.mouseUpHandler = () => {
-      this.isPanning = false;
-    };
+  }
+
+  private setupWindowMouseListeners(): void {
+    this.removeWindowMouseListeners();
+    this.mouseMoveHandler = (e: MouseEvent) => this.onWindowMouseMove(e);
+    this.mouseUpHandler = () => this.onWindowMouseUp();
     window.addEventListener('mousemove', this.mouseMoveHandler);
     window.addEventListener('mouseup', this.mouseUpHandler);
   }
 
-  private removeWindowListeners(): void {
+  private removeWindowMouseListeners(): void {
     if (this.mouseMoveHandler) {
       window.removeEventListener('mousemove', this.mouseMoveHandler);
       this.mouseMoveHandler = null;
@@ -208,4 +334,134 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       this.mouseUpHandler = null;
     }
   }
+
+  private onWindowMouseMove(e: MouseEvent): void {
+    if (!this.drag) return;
+    const d = this.drag;
+    if (d.kind === 'pan') {
+      this.panX = d.originX + (e.clientX - d.startX);
+      this.panY = d.originY + (e.clientY - d.startY);
+      this.applyTransform();
+      return;
+    }
+    const local = this.screenToImageNormalized(e);
+    if (!local) return;
+    if (d.kind === 'draw') {
+      const ax = d.anchor.x;
+      const ay = d.anchor.y;
+      const bx = clamp01(local.x);
+      const by = clamp01(local.y);
+      this.regionBox = [Math.min(ax, bx), Math.min(ay, by), Math.max(ax, bx), Math.max(ay, by)];
+      return;
+    }
+    if (d.kind === 'move') {
+      const dx = local.x - d.startLocal.x;
+      const dy = local.y - d.startLocal.y;
+      const [sx0, sy0, sx1, sy1] = d.startBox;
+      const w = sx1 - sx0;
+      const h = sy1 - sy0;
+      const x0 = clamp(sx0 + dx, 0, 1 - w);
+      const y0 = clamp(sy0 + dy, 0, 1 - h);
+      this.regionBox = [x0, y0, x0 + w, y0 + h];
+      return;
+    }
+    // resize
+    let [x0, y0, x1, y1] = d.startBox;
+    const lx = clamp01(local.x);
+    const ly = clamp01(local.y);
+    if (d.handle.includes('n')) y0 = Math.min(ly, y1 - MIN_BOX_SIZE);
+    if (d.handle.includes('s')) y1 = Math.max(ly, y0 + MIN_BOX_SIZE);
+    if (d.handle.includes('w')) x0 = Math.min(lx, x1 - MIN_BOX_SIZE);
+    if (d.handle.includes('e')) x1 = Math.max(lx, x0 + MIN_BOX_SIZE);
+    this.regionBox = [x0, y0, x1, y1];
+  }
+
+  private onWindowMouseUp(): void {
+    if (!this.drag) {
+      this.removeWindowMouseListeners();
+      return;
+    }
+    const wasDraw = this.drag.kind === 'draw';
+    this.drag = null;
+    this.removeWindowMouseListeners();
+    if (this.regionBox) {
+      const [x0, y0, x1, y1] = this.regionBox;
+      const tooSmall = x1 - x0 < MIN_BOX_SIZE || y1 - y0 < MIN_BOX_SIZE;
+      if (wasDraw && tooSmall) {
+        // Stray click in draw mode — treat as no box.
+        this.regionBox = null;
+        this.regionBoxChange.emit(null);
+        return;
+      }
+      this.regionBoxChange.emit(this.regionBox);
+    }
+  }
+
+  private setupWindowKeyListeners(): void {
+    this.keyDownHandler = (e: KeyboardEvent) => this.onWindowKeyDown(e);
+    this.keyUpHandler = (e: KeyboardEvent) => this.onWindowKeyUp(e);
+    this.blurHandler = () => {
+      // Releasing focus (alt-tab, etc.) drops the Shift state — don't leave the
+      // user stuck in region mode invisibly.
+      this.shiftHeld = false;
+    };
+    window.addEventListener('keydown', this.keyDownHandler);
+    window.addEventListener('keyup', this.keyUpHandler);
+    window.addEventListener('blur', this.blurHandler);
+  }
+
+  private removeWindowKeyListeners(): void {
+    if (this.keyDownHandler) {
+      window.removeEventListener('keydown', this.keyDownHandler);
+      this.keyDownHandler = null;
+    }
+    if (this.keyUpHandler) {
+      window.removeEventListener('keyup', this.keyUpHandler);
+      this.keyUpHandler = null;
+    }
+    if (this.blurHandler) {
+      window.removeEventListener('blur', this.blurHandler);
+      this.blurHandler = null;
+    }
+  }
+
+  private onWindowKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Shift') {
+      this.shiftHeld = true;
+      return;
+    }
+    if (e.key === 'Escape' && this.regionBox && !this.isTyping()) {
+      e.preventDefault();
+      this.clearRegionBox({ emit: true });
+    }
+  }
+
+  private onWindowKeyUp(e: KeyboardEvent): void {
+    if (e.key === 'Shift') this.shiftHeld = false;
+  }
+
+  private isTyping(): boolean {
+    const el = document.activeElement;
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === 'INPUT') {
+      const type = (el as HTMLInputElement).type;
+      if (type !== 'checkbox' && type !== 'radio' && type !== 'range') return true;
+    }
+    if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if ((el as HTMLElement).isContentEditable) return true;
+    return false;
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function clamp01(v: number): number {
+  return clamp(v, 0, 1);
+}
+
+function pct(v: number): string {
+  return (v * 100).toFixed(3) + '%';
 }

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -39,8 +39,14 @@ export class MediasApiService {
     return this.http.get(`/api/medias/${id}/media`, { responseType: 'blob' });
   }
 
-  vote(id: number, label: 'good' | 'bad'): Observable<VoteResponse> {
-    return this.http.post<VoteResponse>(`/api/medias/${id}/vote`, { vote: label });
+  vote(
+    id: number,
+    label: 'good' | 'bad',
+    regionBox?: readonly number[] | null,
+  ): Observable<VoteResponse> {
+    const body: { vote: string; region_box?: number[] } = { vote: label };
+    if (regionBox && regionBox.length === 4) body.region_box = [...regionBox];
+    return this.http.post<VoteResponse>(`/api/medias/${id}/vote`, body);
   }
 
   addToPile(file: File, label: 'good' | 'bad'): Observable<{ ok: boolean; media_id: number; is_new: boolean }> {


### PR DESCRIPTION
## Summary

Lands the v2 region-voting interaction from `docs/plans/patch-embedder.md`. Two commits:

1. **Plan update** — replaces the placeholder "click two corners" v2 section with a full interaction design covering modifier-key entry, draw/edit gestures, vote-keystroke semantics, and salient-area data semantics. Also updates the Phasing-summary bullet.
2. **Implementation** — the UI itself, as described in the plan:
   - Hold **Shift** on the image focus pane to switch the canvas from pan-on-drag to **box-draw-on-drag** (crosshair cursor). Release Shift to return to pan. Mid-drag Shift releases finish the in-progress box on mouseup.
   - **Click-drag-release** to draw. After release, **8 corner/edge handles** + drag-the-body translate. **Esc** clears the box. Re-Shift-drag from empty space discards the prior box and starts fresh. Zero-area release ⇒ no box.
   - Box stored in **normalised (0..1) pre-rotation image coordinates** and rendered inside a sibling `.region-stage` div that co-transforms with the image, so the box stays anchored across pan, zoom, and rotation.
   - Voting still uses **Left/Right**. Right (good) attaches the current box as `region_box` on the vote API call. Left (bad) with a box drawn requires a **confirming second press within 2 seconds**; the first press shake-highlights the box (briefly turns the stroke red). Users without a box keep their single-keypress fast path identical to today.
   - `MediasApiService.vote()` now accepts an optional `regionBox` parameter and includes `region_box` in the request body when present. The backend currently ignores unknown fields, so this UI ships ahead of the backend (a deliberate sequencing choice — users won't know to hold Shift until it's wired).

**Still deferred** (per the plan): touch support, region-aware backend handling, and region-level trainer examples.

## Files

- `docs/plans/patch-embedder.md` — v2 interaction design.
- `frontend/src/app/components/center-panel/image-viewer/image-viewer.component.{ts,html,scss}` — box drawing/editing, screen↔image coordinate transform, Shift/Esc key handling, ResizeObserver-driven `renderedW/H`.
- `frontend/src/app/components/center-panel/center-panel.component.{ts,html}` — `currentRegionBox` state, vote-dispatch wiring, bad-vote-confirm flow.
- `frontend/src/app/services/medias-api.service.ts` — optional `regionBox` param on `vote()`.

## Test plan

- [x] `npm run build:prod` clean (no TS errors, no Angular budget warnings).
- [x] `npx tsc -p tsconfig.spec.json --noEmit` clean.
- [x] `./run-tests.sh core` — 365 passed.
- [ ] Manual smoke (cannot run from this environment — no Chrome): load an image, hold Shift, drag a box, resize handles, Esc, vote Right with box attached, vote Left with box → first press shakes, second press submits, vote Left without box → single-keypress as today.