### PR TITLE
patch-embedder v2 steps 3-5: region_box through vote API, label sync, training

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -501,33 +501,54 @@ back at the design for semantics.  Items are grouped by surface and
 ordered so the backend can land first and the frontend can build on
 the API once it's stable.
 
-**Backend**
+**Backend** — *all items DONE.*
 
-1. **`LabeledElement.region_box`.** Add optional
-   `region_box: tuple[float, float, float, float] | None = None` to
-   `vtsearch/datasets/labelset.py::LabeledElement`.  Round-trip through
-   the dict-serialisation path used by label export/import.  Replace
-   the v1 contract test
-   `tests/test_patch_embedder.py::TestVoteSemanticsV1::test_labeled_element_has_no_region_box_field_in_v1`
-   with a presence + round-trip test.
-2. **On-the-fly vote-vector pooling.** New pure-numpy helper
-   `box_to_vote_vector(patch_grid, box) -> np.ndarray` in
+1. **`LabeledElement.region_box` — DONE (PR #1271).** Optional
+   `region_box: tuple[float, float, float, float] | None = None` lives on
+   `vtsearch/datasets/labelset.py::LabeledElement`, round-trips through
+   the dict-serialisation path used by label export/import, and is
+   covered by
+   `tests/test_patch_embedder.py::TestRegionBoxOnLabeledElement`.
+2. **On-the-fly vote-vector pooling — DONE (PR #1271).** Pure-numpy
+   helper `box_to_vote_vector(patch_grid, box) -> np.ndarray` lives in
    `vtsearch/models/patch_regions.py`.  Selects grid cells whose
    centers fall inside the normalised box, uniform-means their
    vectors, L2-normalises.  No saliency input — see "v2 → Backend
    semantics §1" above for why uniform mean is the right rule (and
    for why no rule can match HAC node vectors exactly).
-3. **Vote endpoint.** Yes-vote API gains optional `region_box`;
-   persists it on the resulting `LabeledElement`.  No-votes reject
-   `region_box` (contract: no-votes are image-level always).
-4. **Region-aware training.** `vtsearch/models/detector_training.py`
-   reads `region_box` per labelled example; when set, pools the
-   training vector on-the-fly from `media["patch_grid"]` via
-   `box_to_vote_vector`.  Falls back to `media["embedding"]` when
-   `region_box` is None or `patch_grid` is absent (legacy datasets,
-   single-vector embedders).
-5. **Label export.** Once step 1 lands, exporters serialise
-   `region_box` automatically — verify with a round-trip test.
+3. **Vote endpoint — DONE.** `POST /api/medias/<id>/vote` now accepts
+   an optional `region_box`: a 4-float list in `[0, 1]`.  Yes-votes
+   persist the box on
+   `DetectorContext.vote_region_boxes` (and from there into label
+   export, detector sync, and labelset-source sync); no-votes that
+   include a box return HTTP 400 instead of silently dropping it,
+   surfacing the client bug immediately.  Toggling a good vote off
+   evicts the box, as does switching good → bad.  Tests in
+   `tests/test_patch_embedder.py::TestVoteEndpointRegionBox`.
+4. **Region-aware training — DONE.**
+   `vtsearch/models/training.py::_training_vec_for_vote` (used by
+   `train_and_score` and the active-votes learned-sort path) and
+   `vtsearch/models/labelset_training.py::populate_label_embeddings`
+   pool the training vector on-the-fly from `media["patch_grid"]` via
+   `box_to_vote_vector` when `region_box` is set and a patch grid is
+   available.  Falls back to `media["embedding"]` for legacy datasets,
+   single-vector embedders, or cross-dataset elements resolved via
+   their origin importer.  Region-voted labelset elements re-pool on
+   every training pass so `region_box` edits propagate without an
+   explicit cache invalidation; the image-level cache fast path is
+   unchanged.  Tests in
+   `tests/test_patch_embedder.py::TestRegionAwareTraining`.
+5. **Label export — DONE.** `LabelSet.from_clips_and_votes` accepts an
+   optional `vote_region_boxes` map and attaches each box to its
+   matching good vote's `LabeledElement`.  All four call sites
+   (`/api/labels/export`, `POST /api/detectors/<name>/labels`,
+   `sync_labels_to_loaded_detector`, `sync_to_labelset_source`) thread
+   it through, so a region annotation round-trips from the vote API
+   all the way to disk + any configured labelset source.
+   `POST /api/labels/import` rebuilds `vote_region_boxes` on good-vote
+   imports.  Tests in
+   `tests/test_patch_embedder.py::TestLabelExportRegionBox` and
+   `::TestLabelImportRegionBox`.
 
 **Frontend**
 

--- a/tests/test_patch_embedder.py
+++ b/tests/test_patch_embedder.py
@@ -975,3 +975,361 @@ class TestBoxToVoteVector:
         tuple_v = box_to_vote_vector(grid, (0.1, 0.2, 0.7, 0.8))
         list_v = box_to_vote_vector(grid, [0.1, 0.2, 0.7, 0.8])  # type: ignore[arg-type]
         np.testing.assert_array_equal(tuple_v, list_v)
+
+
+# ---------------------------------------------------------------------------
+# v2: vote endpoint, label export, and region-aware training wiring
+# ---------------------------------------------------------------------------
+
+
+class TestVoteEndpointRegionBox:
+    """``POST /api/medias/<id>/vote`` accepts an optional ``region_box`` on
+    yes-votes and rejects it on no-votes.  Patch-embedder v2 step 3.
+    """
+
+    def test_good_vote_with_region_box_persists_in_state(self, client):
+        from vtsearch.utils import good_votes, vote_region_boxes
+
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        assert resp.status_code == 200
+        assert 1 in good_votes
+        assert vote_region_boxes[1] == (0.1, 0.2, 0.7, 0.8)
+
+    def test_good_vote_without_region_box_omits_from_state(self, client):
+        from vtsearch.utils import good_votes, vote_region_boxes
+
+        resp = client.post("/api/medias/1/vote", json={"vote": "good"})
+        assert resp.status_code == 200
+        assert 1 in good_votes
+        assert 1 not in vote_region_boxes
+
+    def test_bad_vote_with_region_box_rejected(self, client):
+        """No-votes are always image-level by design; sending a region_box
+        with a bad-vote is a client bug and the endpoint refuses to silently
+        drop it.  See the patch-embedder v2 interaction-design notes."""
+        from vtsearch.utils import bad_votes, vote_region_boxes
+
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"vote": "bad", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        assert resp.status_code == 400
+        assert 1 not in bad_votes
+        assert 1 not in vote_region_boxes
+
+    def test_bad_vote_without_region_box_unchanged(self, client):
+        from vtsearch.utils import bad_votes, vote_region_boxes
+
+        resp = client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert resp.status_code == 200
+        assert 1 in bad_votes
+        assert 1 not in vote_region_boxes
+
+    def test_malformed_region_box_rejected(self, client):
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.7]},
+        )
+        assert resp.status_code == 400
+        assert "region_box" in resp.get_json()["error"]
+
+    def test_out_of_range_region_box_rejected(self, client):
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 1.5]},
+        )
+        assert resp.status_code == 400
+
+    def test_non_numeric_region_box_rejected(self, client):
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": ["a", "b", "c", "d"]},
+        )
+        assert resp.status_code == 400
+
+    def test_toggle_good_off_clears_region_box(self, client):
+        """Voting good twice toggles off the vote; the region_box must go
+        with it so a subsequent fresh yes-vote isn't tagged with a stale
+        annotation."""
+        from vtsearch.utils import good_votes, vote_region_boxes
+
+        client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        assert 1 in vote_region_boxes
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        assert 1 not in good_votes
+        assert 1 not in vote_region_boxes
+
+    def test_switch_good_to_bad_clears_region_box(self, client):
+        """A region annotation belongs to a yes-vote; flipping the same
+        media to a no-vote drops it."""
+        from vtsearch.utils import bad_votes, good_votes, vote_region_boxes
+
+        client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        assert 1 in vote_region_boxes
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        assert 1 not in good_votes
+        assert 1 in bad_votes
+        assert 1 not in vote_region_boxes
+
+    def test_replacing_region_box_updates_value(self, client):
+        """Re-voting good with a different box after toggling off the
+        previous yes-vote stores the new box, not the previous one."""
+        from vtsearch.utils import vote_region_boxes
+
+        client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.4, 0.4]},
+        )
+        # Toggle off, then vote good again with a different box.
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.3, 0.3, 0.9, 0.9]},
+        )
+        assert vote_region_boxes[1] == (0.3, 0.3, 0.9, 0.9)
+
+
+class TestLabelExportRegionBox:
+    """``GET /api/labels/export`` emits ``region_box`` on yes-votes that
+    carried one and never on no-votes.  Patch-embedder v2 step 5
+    (round-trip of step 1's data-model contract through the API layer).
+    """
+
+    def test_export_emits_region_box_on_good_vote(self, client):
+        client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.7, 0.8]},
+        )
+        resp = client.get("/api/labels/export")
+        assert resp.status_code == 200
+        labels = resp.get_json()["labels"]
+        assert len(labels) == 1
+        assert labels[0]["label"] == "good"
+        assert labels[0]["region_box"] == [0.1, 0.2, 0.7, 0.8]
+
+    def test_export_omits_region_box_on_plain_good_vote(self, client):
+        client.post("/api/medias/1/vote", json={"vote": "good"})
+        resp = client.get("/api/labels/export")
+        labels = resp.get_json()["labels"]
+        assert len(labels) == 1
+        assert "region_box" not in labels[0]
+
+    def test_export_never_emits_region_box_on_bad_vote(self, client):
+        client.post("/api/medias/1/vote", json={"vote": "bad"})
+        resp = client.get("/api/labels/export")
+        labels = resp.get_json()["labels"]
+        assert len(labels) == 1
+        assert labels[0]["label"] == "bad"
+        assert "region_box" not in labels[0]
+
+    def test_export_with_mixed_votes(self, client):
+        """Region-annotated good, plain good, and a bad in the same export."""
+        client.post(
+            "/api/medias/1/vote",
+            json={"vote": "good", "region_box": [0.1, 0.2, 0.3, 0.4]},
+        )
+        client.post("/api/medias/2/vote", json={"vote": "good"})
+        client.post("/api/medias/3/vote", json={"vote": "bad"})
+        resp = client.get("/api/labels/export")
+        labels = resp.get_json()["labels"]
+        by_md5 = {e["md5"]: e for e in labels}
+        # Look up which md5 is which media id via the test medias.
+        from vtsearch.utils import medias
+
+        rb_md5 = medias[1]["md5"]
+        plain_md5 = medias[2]["md5"]
+        bad_md5 = medias[3]["md5"]
+        assert by_md5[rb_md5]["region_box"] == [0.1, 0.2, 0.3, 0.4]
+        assert "region_box" not in by_md5[plain_md5]
+        assert "region_box" not in by_md5[bad_md5]
+
+
+class TestLabelImportRegionBox:
+    """``POST /api/labels/import`` round-trips ``region_box`` from the
+    serialised LabelSet into in-memory state, so a sync_from / explicit
+    import recovers the user's region annotations.
+    """
+
+    def test_import_restores_region_box_on_good(self, client):
+        from vtsearch.utils import good_votes, medias, vote_region_boxes
+
+        md5 = medias[1]["md5"]
+        resp = client.post(
+            "/api/labels/import",
+            json={"labels": [{"md5": md5, "label": "good", "region_box": [0.2, 0.3, 0.5, 0.6]}]},
+        )
+        assert resp.status_code == 200
+        assert 1 in good_votes
+        assert vote_region_boxes[1] == (0.2, 0.3, 0.5, 0.6)
+
+    def test_import_ignores_region_box_on_bad(self, client):
+        from vtsearch.utils import bad_votes, medias, vote_region_boxes
+
+        md5 = medias[1]["md5"]
+        # A no-vote in an imported labelset cannot carry a box (LabeledElement
+        # would never have one for a "bad" label in a well-formed export).
+        # If a malformed import does include one, the importer must not
+        # propagate it.
+        resp = client.post(
+            "/api/labels/import",
+            json={"labels": [{"md5": md5, "label": "bad", "region_box": [0.0, 0.0, 1.0, 1.0]}]},
+        )
+        assert resp.status_code == 200
+        assert 1 in bad_votes
+        assert 1 not in vote_region_boxes
+
+
+class TestRegionAwareTraining:
+    """``train_and_score`` and ``populate_label_embeddings`` pool the
+    training vector on-the-fly from ``media["patch_grid"]`` when an element
+    carries a ``region_box``.  Patch-embedder v2 step 4.
+    """
+
+    def _media_with_patch_grid(self, grid_value: float, cid: int) -> dict:
+        """Build a synthetic image media dict with a one-axis patch grid.
+
+        Each cell is a distinct axis-aligned unit vector, so it's easy to
+        check which cells got pooled by inspecting the resulting vector.
+        """
+        h, w, d = 4, 4, 16
+        n = h * w
+        flat = np.zeros((n, d), dtype=np.float32)
+        for i in range(n):
+            flat[i, i] = 1.0
+        grid = flat.reshape(h, w, d)
+        # Image-level CLS embedding: a different unit vector so we can tell
+        # the two paths apart in assertions.
+        cls = np.zeros(d, dtype=np.float32)
+        cls[15] = grid_value  # mostly axis 15
+        cls[14] = (1.0 - grid_value**2) ** 0.5  # keep unit length
+        return {
+            "id": cid,
+            "md5": f"md5-{cid:04x}",
+            "type": "image",
+            "embedding": cls,
+            "patch_grid": grid,
+        }
+
+    def test_train_and_score_uses_box_pooled_vec_when_grid_present(self):
+        """A yes-vote with region_box on a media that has a patch_grid feeds
+        the MLP with the *pooled* vector, not the CLS embedding."""
+        from vtsearch.models.patch_regions import box_to_vote_vector
+        from vtsearch.models.training import _training_vec_for_vote
+
+        media = self._media_with_patch_grid(0.99, cid=42)
+        box = (0.0, 0.0, 0.5, 0.5)  # top-left quadrant: 4 cells (axes 0,1,4,5)
+
+        vec = _training_vec_for_vote(media, box)
+        expected = box_to_vote_vector(media["patch_grid"], box)
+        np.testing.assert_array_equal(vec, expected)
+        # And the CLS vector is *not* what we got.
+        assert not np.array_equal(vec, media["embedding"])
+
+    def test_train_and_score_falls_back_to_cls_without_patch_grid(self):
+        """Legacy / single-vector datasets have no ``patch_grid``; even with
+        a stashed region_box, training must use the full-image CLS vector."""
+        from vtsearch.models.training import _training_vec_for_vote
+
+        media = {
+            "id": 1,
+            "md5": "abc",
+            "type": "image",
+            "embedding": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        }
+        vec = _training_vec_for_vote(media, (0.1, 0.2, 0.7, 0.8))
+        np.testing.assert_array_equal(vec, media["embedding"])
+
+    def test_train_and_score_falls_back_to_cls_when_no_region_box(self):
+        from vtsearch.models.training import _training_vec_for_vote
+
+        media = self._media_with_patch_grid(0.99, cid=1)
+        vec = _training_vec_for_vote(media, region_box=None)
+        np.testing.assert_array_equal(vec, media["embedding"])
+
+    def test_populate_label_embeddings_pools_when_region_box_set(self):
+        """``populate_label_embeddings`` caches pooled vectors for elements
+        whose ``region_box`` is set and whose source media has a
+        ``patch_grid``.  The cache value matches ``box_to_vote_vector``
+        on the same grid + box."""
+        from vtsearch.datasets.labelset import LabeledElement, LabelSet
+        from vtsearch.models.labelset_elements import stable_element_id
+        from vtsearch.models.labelset_training import populate_label_embeddings
+        from vtsearch.models.patch_regions import box_to_vote_vector
+        from vtsearch.utils.state_core import DetectorContext
+
+        media = self._media_with_patch_grid(0.99, cid=1)
+        # Element matches the media by md5.
+        elem = LabeledElement(md5=media["md5"], label="good", region_box=(0.0, 0.0, 0.5, 0.5))
+        ls = LabelSet([elem])
+
+        det_ctx = DetectorContext("d1")
+        snap = {1: media}
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+
+        eid = stable_element_id(elem)
+        assert eid in det_ctx.label_embeddings
+        expected = box_to_vote_vector(media["patch_grid"], (0.0, 0.0, 0.5, 0.5))
+        np.testing.assert_allclose(det_ctx.label_embeddings[eid], expected, atol=1e-6)
+        # And it's NOT the CLS embedding.
+        assert not np.allclose(det_ctx.label_embeddings[eid], media["embedding"])
+
+    def test_populate_label_embeddings_repools_when_region_box_set(self):
+        """Region-voted elements re-pool on every call so region_box edits
+        propagate without an explicit cache invalidation.  Image-level
+        elements keep their cached vector across calls (fast path)."""
+        from vtsearch.datasets.labelset import LabeledElement, LabelSet
+        from vtsearch.models.labelset_elements import stable_element_id
+        from vtsearch.models.labelset_training import populate_label_embeddings
+        from vtsearch.models.patch_regions import box_to_vote_vector
+        from vtsearch.utils.state_core import DetectorContext
+
+        media = self._media_with_patch_grid(0.99, cid=1)
+        elem = LabeledElement(md5=media["md5"], label="good", region_box=(0.0, 0.0, 0.5, 0.5))
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        snap = {1: media}
+
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        eid = stable_element_id(elem)
+        first = np.array(det_ctx.label_embeddings[eid], copy=True)
+
+        # Simulate a region-box edit by mutating the element in place
+        # and re-running.  The cache *must* refresh.
+        elem.region_box = (0.5, 0.5, 1.0, 1.0)  # bottom-right quadrant
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        second = det_ctx.label_embeddings[eid]
+        expected_second = box_to_vote_vector(media["patch_grid"], (0.5, 0.5, 1.0, 1.0))
+        np.testing.assert_allclose(second, expected_second, atol=1e-6)
+        # The two pooled vectors must be different (top-left vs bottom-right).
+        assert not np.allclose(first, second)
+
+    def test_populate_label_embeddings_keeps_cached_when_no_region_box(self):
+        """Plain image-level elements stay cached across calls — the fast
+        path for non-region datasets is preserved."""
+        from vtsearch.datasets.labelset import LabeledElement, LabelSet
+        from vtsearch.models.labelset_elements import stable_element_id
+        from vtsearch.models.labelset_training import populate_label_embeddings
+        from vtsearch.utils.state_core import DetectorContext
+
+        media = self._media_with_patch_grid(0.99, cid=1)
+        elem = LabeledElement(md5=media["md5"], label="good")  # no region_box
+        ls = LabelSet([elem])
+        det_ctx = DetectorContext("d1")
+        snap = {1: media}
+
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        eid = stable_element_id(elem)
+        # Pre-set a sentinel and verify it survives a second pass (cache hit).
+        sentinel = np.full_like(det_ctx.label_embeddings[eid], 7.0)
+        det_ctx.label_embeddings[eid] = sentinel
+        populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
+        np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)

--- a/tests/test_patch_embedder.py
+++ b/tests/test_patch_embedder.py
@@ -1255,6 +1255,21 @@ class TestRegionAwareTraining:
         vec = _training_vec_for_vote(media, region_box=None)
         np.testing.assert_array_equal(vec, media["embedding"])
 
+    def _register_synthetic_image(self, cid: int, grid_value: float = 0.99) -> dict:
+        """Insert a synthetic image media into the active dataset context.
+
+        ``populate_label_embeddings`` uses ``resolve_current_dataset_cid``
+        internally, which looks up via the global ``snapshot_medias()``.
+        Registering the media in the active dataset makes that lookup
+        succeed by md5.  Conftest's ``reset_state`` wipes this between
+        tests so there's no cross-test bleed.
+        """
+        from vtsearch.utils.state_core import medias
+
+        media = self._media_with_patch_grid(grid_value, cid=cid)
+        medias[cid] = media
+        return media
+
     def test_populate_label_embeddings_pools_when_region_box_set(self):
         """``populate_label_embeddings`` caches pooled vectors for elements
         whose ``region_box`` is set and whose source media has a
@@ -1266,13 +1281,14 @@ class TestRegionAwareTraining:
         from vtsearch.models.patch_regions import box_to_vote_vector
         from vtsearch.utils.state_core import DetectorContext
 
-        media = self._media_with_patch_grid(0.99, cid=1)
+        cid = 9001
+        media = self._register_synthetic_image(cid)
         # Element matches the media by md5.
         elem = LabeledElement(md5=media["md5"], label="good", region_box=(0.0, 0.0, 0.5, 0.5))
         ls = LabelSet([elem])
 
         det_ctx = DetectorContext("d1")
-        snap = {1: media}
+        snap = {cid: media}
         populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
 
         eid = stable_element_id(elem)
@@ -1292,11 +1308,12 @@ class TestRegionAwareTraining:
         from vtsearch.models.patch_regions import box_to_vote_vector
         from vtsearch.utils.state_core import DetectorContext
 
-        media = self._media_with_patch_grid(0.99, cid=1)
+        cid = 9002
+        media = self._register_synthetic_image(cid)
         elem = LabeledElement(md5=media["md5"], label="good", region_box=(0.0, 0.0, 0.5, 0.5))
         ls = LabelSet([elem])
         det_ctx = DetectorContext("d1")
-        snap = {1: media}
+        snap = {cid: media}
 
         populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
         eid = stable_element_id(elem)
@@ -1320,11 +1337,12 @@ class TestRegionAwareTraining:
         from vtsearch.models.labelset_training import populate_label_embeddings
         from vtsearch.utils.state_core import DetectorContext
 
-        media = self._media_with_patch_grid(0.99, cid=1)
+        cid = 9003
+        media = self._register_synthetic_image(cid)
         elem = LabeledElement(md5=media["md5"], label="good")  # no region_box
         ls = LabelSet([elem])
         det_ctx = DetectorContext("d1")
-        snap = {1: media}
+        snap = {cid: media}
 
         populate_label_embeddings(det_ctx, ls, media_type="image", snap=snap)
         eid = stable_element_id(elem)

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -135,6 +135,7 @@ class LabelSet:
         bad_votes: dict[int, None],
         *,
         expand_dupes: bool = True,
+        vote_region_boxes: dict[int, tuple[float, float, float, float]] | None = None,
     ) -> LabelSet:
         """Build a ``LabelSet`` from the current media and vote state.
 
@@ -148,16 +149,29 @@ class LabelSet:
                 labelset will be re-imported into the same system (e.g.
                 detector persistence) to avoid inflating the label
                 count.
+            vote_region_boxes: Optional ``media_id -> (x0, y0, x1, y1)``
+                map populated by yes-votes that designated a region.  Each
+                box is attached to the corresponding good vote's
+                :class:`LabeledElement`.  Ignored for bad votes (no-votes
+                are always image-level — see the patch-embedder v2 design).
 
         Returns:
             A new ``LabelSet`` containing one :class:`LabeledElement` per
             voted media, in vote-insertion order (good votes first, then bad).
         """
+        region_boxes = vote_region_boxes or {}
         elements: list[LabeledElement] = []
         for cid in good_votes:
             media = medias.get(cid)
             if media:
-                elements.extend(_clip_to_elements(media, "good", expand_dupes=expand_dupes))
+                elements.extend(
+                    _clip_to_elements(
+                        media,
+                        "good",
+                        expand_dupes=expand_dupes,
+                        region_box=region_boxes.get(cid),
+                    )
+                )
         for cid in bad_votes:
             media = medias.get(cid)
             if media:
@@ -349,7 +363,13 @@ def media_element_key(media: dict[str, Any]) -> Any:
     return element_key(fake)
 
 
-def _clip_to_elements(media: dict[str, Any], label: str, *, expand_dupes: bool = True) -> list[LabeledElement]:
+def _clip_to_elements(
+    media: dict[str, Any],
+    label: str,
+    *,
+    expand_dupes: bool = True,
+    region_box: tuple[float, float, float, float] | None = None,
+) -> list[LabeledElement]:
     """Convert a media dict into one or more :class:`LabeledElement` instances.
 
     When *expand_dupes* is ``True`` and the media is a dupe-set
@@ -359,6 +379,14 @@ def _clip_to_elements(media: dict[str, Any], label: str, *, expand_dupes: bool =
     using the representative's own MD5 and origin, which avoids inflating
     the label count for internal round-trip use cases (e.g. detector
     persistence).
+
+    When *region_box* is provided (only ever populated for ``label == "good"``
+    by the caller), it is attached to every emitted element so the region
+    annotation rides along through label export / detector sync.  Dupe-set
+    members share the representative's box — the user voted "this region is
+    good in *this* image" and the representative is what the user actually
+    saw, so cloning the box across structurally-identical members is the
+    right default.
     """
     origin = media.get("origin")
     cm = media.get("custom_metadata") or None
@@ -374,6 +402,7 @@ def _clip_to_elements(media: dict[str, Any], label: str, *, expand_dupes: bool =
                     filename=m.get("filename", ""),
                     category=m.get("category", ""),
                     metadata=cm,
+                    region_box=region_box,
                 )
                 for m in members
             ]
@@ -388,5 +417,6 @@ def _clip_to_elements(media: dict[str, Any], label: str, *, expand_dupes: bool =
             filename=media.get("filename", ""),
             category=media.get("category", ""),
             metadata=cm,
+            region_box=region_box,
         )
     ]

--- a/vtsearch/labels/sync.py
+++ b/vtsearch/labels/sync.py
@@ -51,7 +51,7 @@ def sync_to_labelset_source() -> None:
     field_values = cfg.get("field_values", {})
 
     from vtsearch.datasets.labelset import LabelSet
-    from vtsearch.utils.state_core import good_votes, bad_votes, medias
+    from vtsearch.utils.state_core import good_votes, bad_votes, medias, vote_region_boxes
 
     # Serialize against any in-progress sync_from on another thread.
     # Re-check the flag inside the lock so we never push partial state
@@ -60,7 +60,12 @@ def sync_to_labelset_source() -> None:
         if _syncing:
             return
         try:
-            labelset = LabelSet.from_clips_and_votes(dict(medias), dict(good_votes), dict(bad_votes))
+            labelset = LabelSet.from_clips_and_votes(
+                dict(medias),
+                dict(good_votes),
+                dict(bad_votes),
+                vote_region_boxes=dict(vote_region_boxes),
+            )
             source.save(labelset, field_values)
         except Exception as exc:
             logger.exception("Failed to sync labels to source: %s", exc)

--- a/vtsearch/models/label_sync.py
+++ b/vtsearch/models/label_sync.py
@@ -47,10 +47,16 @@ def sync_labels_to_loaded_detector() -> None:
         return
 
     from vtsearch.datasets.labelset import LabelSet, element_key, media_element_key
-    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+    from vtsearch.utils import bad_votes, good_votes, snapshot_medias, vote_region_boxes
 
     snap = snapshot_medias()
-    current_ls = LabelSet.from_clips_and_votes(snap, good_votes, bad_votes, expand_dupes=False)
+    current_ls = LabelSet.from_clips_and_votes(
+        snap,
+        good_votes,
+        bad_votes,
+        expand_dupes=False,
+        vote_region_boxes=dict(vote_region_boxes),
+    )
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
 
     # Origin keys for *every* media in the active dataset (voted or not).

--- a/vtsearch/models/labelset_training.py
+++ b/vtsearch/models/labelset_training.py
@@ -55,6 +55,30 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
         return embed_file(file_path, media_type, embedder_name)
 
 
+def _pool_box_from_media(
+    media: dict[str, Any],
+    region_box: tuple[float, float, float, float] | None,
+) -> np.ndarray | None:
+    """Return the region-pooled training vector for *media*, if applicable.
+
+    When *region_box* is set **and** the media has a stored ``patch_grid``,
+    pool the box on-the-fly via
+    :func:`vtsearch.models.patch_regions.box_to_vote_vector` and return that
+    vector.  Otherwise return ``None`` so the caller can fall back to
+    ``media["embedding"]`` — i.e. the legacy image-level training vector for
+    image-level votes, single-vector embedders, and patch datasets that
+    haven't been re-loaded under the v1 storage scheme.  Patch-embedder v2.
+    """
+    if region_box is None:
+        return None
+    grid = media.get("patch_grid")
+    if grid is None:
+        return None
+    from vtsearch.models.patch_regions import box_to_vote_vector
+
+    return box_to_vote_vector(np.asarray(grid), region_box)
+
+
 def populate_label_embeddings(
     det_ctx,
     labelset: LabelSet,
@@ -90,13 +114,26 @@ def populate_label_embeddings(
 
     for idx, elem in enumerate(labelset.elements):
         eid = stable_element_id(elem)
-        if eid in cache:
+        # Region-voted elements always re-pool from the source patch grid:
+        # the cache is keyed by ``stable_element_id`` (origin / md5), which
+        # is intentionally stable across region edits.  Re-pooling per
+        # training pass is cheap (one patch grid + uniform mean) and is the
+        # only way region_box changes propagate without an explicit cache
+        # invalidation.  Image-level elements keep the cached embedding so
+        # the existing fast path for non-region datasets is unchanged.
+        if eid in cache and elem.region_box is None:
             cached += 1
             continue
 
         cid = resolve_current_dataset_cid(elem) if snap else None
         if cid is not None and snap and cid in snap:
-            emb = snap[cid].get("embedding")
+            media = snap[cid]
+            # Region-aware path: pool from ``patch_grid`` when the element has
+            # a ``region_box`` annotation and the source media has a stored
+            # patch grid (i.e. the dataset was loaded with a patch-region
+            # embedder).  Otherwise fall back to the full-image embedding.
+            pooled = _pool_box_from_media(media, elem.region_box)
+            emb = pooled if pooled is not None else media.get("embedding")
             if emb is not None:
                 cache[eid] = np.asarray(emb)
                 cached += 1
@@ -104,6 +141,10 @@ def populate_label_embeddings(
                     on_progress(elem.origin_name or elem.filename or eid, idx + 1, total)
                 continue
 
+        # Cross-dataset path: we resolve the element via its importer and
+        # embed it freshly.  No patch_grid is available here, so a stashed
+        # ``region_box`` falls back to the image-level embedding — exactly
+        # the design's fallback for legacy / non-patch datasets.
         emb = _embed_one(elem, media_type=media_type, embedder_name=embedder_name)
         if emb is not None:
             cache[eid] = np.asarray(emb)

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -14,6 +14,27 @@ if TYPE_CHECKING:
     import torch.nn as nn
 
 
+def _training_vec_for_vote(
+    media: dict[str, Any],
+    region_box: tuple[float, float, float, float] | None,
+) -> np.ndarray:
+    """Return the training vector for one vote on *media*.
+
+    When *region_box* is set **and** *media* has a stored ``patch_grid``,
+    pool the box on-the-fly via
+    :func:`vtsearch.models.patch_regions.box_to_vote_vector`.  Otherwise
+    fall back to ``media["embedding"]`` — the v1/legacy image-level vector.
+    Patch-embedder v2.
+    """
+    if region_box is not None:
+        grid = media.get("patch_grid")
+        if grid is not None:
+            from vtsearch.models.patch_regions import box_to_vote_vector  # noqa: PLC0415
+
+            return box_to_vote_vector(np.asarray(grid), region_box)
+    return media["embedding"]
+
+
 def calculate_gmm_threshold(scores: list[float]) -> float:
     """Use a Gaussian Mixture Model to find a threshold between two score distributions.
 
@@ -461,6 +482,7 @@ def train_and_score(
     safe_thresholds: bool = False,
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
+    vote_region_boxes: dict[int, tuple[float, float, float, float]] | None = None,
 ) -> tuple[list[dict[str, Any]], float, nn.Sequential | None]:
     """Train a small MLP on voted media embeddings and score every media.
 
@@ -482,6 +504,15 @@ def train_and_score(
         calibration_fraction: Fraction of labelled data reserved for calibration
             in each split (default 0.5).  For example, 0.2 means 80% Train /
             20% Calibrate.
+        vote_region_boxes: Optional ``media_id -> (x0, y0, x1, y1)`` map from
+            yes-votes that designated a region.  When set and the source
+            media has a stored ``patch_grid``, the training vector for that
+            vote is pooled on-the-fly via
+            :func:`vtsearch.models.patch_regions.box_to_vote_vector` instead
+            of using ``media["embedding"]``.  Falls back to the full-image
+            vector when the media lacks a patch grid (legacy datasets,
+            single-vector embedders) or when the box is missing.  Patch-
+            embedder v2.
 
     Returns:
         A tuple ``(results, threshold, model)`` where:
@@ -495,11 +526,13 @@ def train_and_score(
     """
     import torch  # noqa: PLC0415
 
+    region_boxes = vote_region_boxes or {}
+
     X_list = []
     y_list = []
     for cid in good_votes:
         if cid in clips_dict:
-            X_list.append(clips_dict[cid]["embedding"])
+            X_list.append(_training_vec_for_vote(clips_dict[cid], region_boxes.get(cid)))
             y_list.append(1.0)
     for cid in bad_votes:
         if cid in clips_dict:

--- a/vtsearch/models/training_workflow.py
+++ b/vtsearch/models/training_workflow.py
@@ -61,7 +61,7 @@ def apply_and_retrain(
         sync_labels_to_loaded_detector()
 
         # Retrain MLP if we have at least one good and one bad vote.
-        from vtsearch.utils import bad_votes, good_votes
+        from vtsearch.utils import bad_votes, good_votes, vote_region_boxes
 
         trained = False
         if good_votes and bad_votes:
@@ -81,6 +81,7 @@ def apply_and_retrain(
                 safe_thresholds=get_safe_thresholds(),
                 calibrate_count=get_calibrate_count(),
                 calibration_fraction=get_calibration_fraction(),
+                vote_region_boxes=dict(vote_region_boxes),
             )
             if model is not None:
                 det_ctx.model = model

--- a/vtsearch/routes/detectors.py
+++ b/vtsearch/routes/detectors.py
@@ -280,9 +280,15 @@ def save_detector_labels(name: str):
         return jsonify({"error": f"Detector '{name}' not found"}), 404
 
     from vtsearch.datasets.labelset import LabelSet
-    from vtsearch.utils import bad_votes, good_votes, snapshot_medias
+    from vtsearch.utils import bad_votes, good_votes, snapshot_medias, vote_region_boxes
 
-    labelset = LabelSet.from_clips_and_votes(snapshot_medias(), good_votes, bad_votes, expand_dupes=False)
+    labelset = LabelSet.from_clips_and_votes(
+        snapshot_medias(),
+        good_votes,
+        bad_votes,
+        expand_dupes=False,
+        vote_region_boxes=dict(vote_region_boxes),
+    )
     data["labelset"] = labelset.to_dict()
     _write_detector(path, data)
 

--- a/vtsearch/routes/labels.py
+++ b/vtsearch/routes/labels.py
@@ -13,6 +13,7 @@ from vtsearch.utils import (
     good_votes,
     resolve_media_ids,
     snapshot_medias,
+    vote_region_boxes,
 )
 
 labels_bp = Blueprint("labels", __name__)
@@ -58,7 +59,12 @@ def export_labels():
             goods, bads = good_votes, bad_votes
 
     all_medias = snapshot_medias()
-    labelset = LabelSet.from_clips_and_votes(all_medias, goods, bads)
+    labelset = LabelSet.from_clips_and_votes(
+        all_medias,
+        goods,
+        bads,
+        vote_region_boxes=dict(vote_region_boxes),
+    )
     result: dict = labelset.to_dict()
 
     # Annotate corrections: items where the user changed the detector's label.
@@ -149,8 +155,19 @@ def import_labels():
             skipped += 1
             continue
 
+        # Round-trip region_box on good-vote imports.  ``LabeledElement.from_dict``
+        # already coerces list↔tuple, so we just check shape and pass through.
+        rb_raw = entry.get("region_box") if label == "good" else None
+        region_box: tuple[float, float, float, float] | None = None
+        if (
+            isinstance(rb_raw, (list, tuple))
+            and len(rb_raw) == 4
+            and all(isinstance(v, (int, float)) for v in rb_raw)
+        ):
+            region_box = (float(rb_raw[0]), float(rb_raw[1]), float(rb_raw[2]), float(rb_raw[3]))
+
         for cid in cids:
-            apply_label(cid, label)
+            apply_label(cid, label, region_box=region_box)
         applied += 1
 
     from vtsearch.models.label_sync import sync_labels_to_loaded_detector

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -31,6 +31,28 @@ medias_bp = Blueprint("medias", __name__)
 _BROWSER_VIDEO_EXTS = {".mp4", ".m4v", ".webm", ".ogg", ".ogv"}
 
 
+def _parse_region_box(raw: Any) -> tuple[float, float, float, float] | None:
+    """Validate a ``region_box`` field from a vote request body.
+
+    Returns ``None`` when the field is absent or explicitly null.  Otherwise
+    coerces a 4-element list/tuple of numbers in ``[0, 1]`` into a float
+    4-tuple.  Raises :class:`ValueError` with a user-facing message when the
+    value is malformed.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, (list, tuple)) or len(raw) != 4:
+        raise ValueError("region_box must be a 4-element list of numbers")
+    try:
+        x0, y0, x1, y1 = (float(v) for v in raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("region_box entries must be numbers") from exc
+    for v in (x0, y0, x1, y1):
+        if not (0.0 <= v <= 1.0):
+            raise ValueError("region_box entries must be in [0, 1]")
+    return (x0, y0, x1, y1)
+
+
 def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:
     """Transcode video bytes to browser-playable MP4.
 
@@ -540,7 +562,11 @@ def vote_media(media_id: int) -> tuple[Response, int] | Response:
         media_id: Integer media ID from the URL path.
 
     Request body (JSON):
-        ``{"vote": "good"}`` or ``{"vote": "bad"}``.
+        ``{"vote": "good"}`` or ``{"vote": "bad"}``.  Yes-votes may
+        additionally carry ``"region_box": [x0, y0, x1, y1]`` (normalised
+        image coords in ``[0, 1]``) to designate the good region.
+        No-votes that include ``region_box`` are rejected — by design
+        no-votes are image-level always (patch-embedder v2).
 
     Returns:
         ``{"ok": True}`` (HTTP 200) on success, or a JSON error response for:
@@ -560,7 +586,14 @@ def vote_media(media_id: int) -> tuple[Response, int] | Response:
     if vote not in ("good", "bad"):
         return jsonify({"error": "vote must be 'good' or 'bad'"}), 400
 
-    toggle_vote(media_id, vote)
+    try:
+        region_box = _parse_region_box(data.get("region_box"))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    if vote == "bad" and region_box is not None:
+        return jsonify({"error": "no-votes cannot carry a region_box"}), 400
+
+    toggle_vote(media_id, vote, region_box=region_box)
 
     from vtsearch.models.label_sync import sync_labels_to_loaded_detector
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -37,6 +37,7 @@ from vtsearch.utils import (
     snapshot_medias,
     update_learned_scores,
     update_sort_progress,
+    vote_region_boxes,
 )
 
 sorting_bp = Blueprint("sorting", __name__)
@@ -233,6 +234,7 @@ def learned_sort():
             safe_thresholds=get_safe_thresholds(),
             calibrate_count=get_calibrate_count(),
             calibration_fraction=get_calibration_fraction(),
+            vote_region_boxes=dict(vote_region_boxes),
         )
 
     # Store scores so the /api/votes endpoint can provide confidence info.

--- a/vtsearch/utils/__init__.py
+++ b/vtsearch/utils/__init__.py
@@ -93,6 +93,7 @@ from vtsearch.utils.state import (
     toggle_vote,
     update_learned_scores,
     vote_click_times,
+    vote_region_boxes,
 )
 
 __all__ = [
@@ -115,6 +116,7 @@ __all__ = [
     "autorun_extractors",
     "autorun_localizers",
     "vote_click_times",
+    "vote_region_boxes",
     "last_learned_scores",
     "clear_votes",
     "clear_medias",

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -27,6 +27,7 @@ from vtsearch.utils.state_core import (  # noqa: F401
     medias,
     textsort_suggestions,
     vote_click_times,
+    vote_region_boxes,
 )
 
 # Re-export context management functions ---------------------------------

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -116,6 +116,7 @@ class DetectorContext:
         "bad_votes",
         "label_history",
         "vote_click_times",
+        "vote_region_boxes",
         "click_counter",
         # Training artifacts
         "last_learned_scores",
@@ -154,6 +155,10 @@ class DetectorContext:
         self.bad_votes: dict[int, None] = {}
         self.label_history: list[tuple[int, str, float]] = []
         self.vote_click_times: dict[int, int] = {}
+        # Per-good-vote region boxes (normalised x0, y0, x1, y1).  Only set when
+        # the user drew a region as part of a yes-vote; absent for image-level
+        # yes-votes and for every no-vote.  Patch-embedder v2.
+        self.vote_region_boxes: dict[int, tuple[float, float, float, float]] = {}
         self.click_counter: int = 0
         # Training artifacts
         self.last_learned_scores: dict[int, float] = {}
@@ -567,6 +572,14 @@ label_history: list[tuple[int, str, float]] = _ProxyList("label_history", get_ac
 
 # Click-time tracking: media_id -> click order (1-indexed).
 vote_click_times: dict[int, int] = _ProxyDict("vote_click_times", get_active_detector_context)  # type: ignore[assignment]
+
+# Per-good-vote region boxes: media_id -> (x0, y0, x1, y1) in normalised image
+# coords.  Only populated when the user drew a region as part of a yes-vote;
+# absent for image-level yes-votes and for every no-vote.  Patch-embedder v2.
+vote_region_boxes: dict[int, tuple[float, float, float, float]] = _ProxyDict(  # type: ignore[assignment]
+    "vote_region_boxes",
+    get_active_detector_context,
+)
 
 # Last learned-sort scores: media_id -> score (float in [0, 1]).
 last_learned_scores: dict[int, float] = _ProxyDict("last_learned_scores", get_active_detector_context)  # type: ignore[assignment]

--- a/vtsearch/utils/state_votes.py
+++ b/vtsearch/utils/state_votes.py
@@ -14,6 +14,7 @@ from vtsearch.utils.state_core import (
     last_learned_scores,
     textsort_suggestions,
     vote_click_times,
+    vote_region_boxes,
 )
 from vtsearch.utils.state_core import (
     _get_click_counter,
@@ -41,6 +42,7 @@ def clear_votes() -> None:
         label_history.clear()
         textsort_suggestions.clear()
         vote_click_times.clear()
+        vote_region_boxes.clear()
         _set_click_counter(0)
         last_learned_scores.clear()
         ctx = get_active_detector_context()
@@ -120,7 +122,11 @@ def get_find_initial_labels() -> dict[int, str]:
 # ---------------------------------------------------------------------------
 
 
-def toggle_vote(media_id: int, vote: str) -> None:
+def toggle_vote(
+    media_id: int,
+    vote: str,
+    region_box: tuple[float, float, float, float] | None = None,
+) -> None:
     """Atomically toggle a good/bad vote for a media item.
 
     Implements the same toggle semantics as the ``/api/medias/<id>/vote``
@@ -139,6 +145,13 @@ def toggle_vote(media_id: int, vote: str) -> None:
     Args:
         media_id: Integer ID of the media to vote on.
         vote: ``"good"`` or ``"bad"``.
+        region_box: Optional normalised ``(x0, y0, x1, y1)`` box that the
+            user drew as part of a yes-vote.  Only honoured when *vote* is
+            ``"good"`` and the vote is being *added* (not toggled off);
+            stored in :attr:`DetectorContext.vote_region_boxes` so label
+            export / detector sync emit it on the resulting LabeledElement.
+            Ignored for no-votes (which are always image-level — see the
+            patch-embedder v2 design).  Patch-embedder v2.
     """
     from vtsearch.models.progress import invalidate_progress_cache_from
 
@@ -147,6 +160,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
         if vote == "good":
             if media_id in good_votes:
                 good_votes.pop(media_id, None)
+                vote_region_boxes.pop(media_id, None)
                 remove_click_time(media_id)
                 add_label_to_history(media_id, "unlabel")
                 if media_id not in bad_votes:
@@ -155,6 +169,10 @@ def toggle_vote(media_id: int, vote: str) -> None:
                 was_opposite = media_id in bad_votes
                 bad_votes.pop(media_id, None)
                 good_votes[media_id] = None
+                if region_box is not None:
+                    vote_region_boxes[media_id] = region_box
+                else:
+                    vote_region_boxes.pop(media_id, None)
                 assign_click_time(media_id)
                 add_label_to_history(media_id, "good")
                 diversity_tree_label(media_id)
@@ -171,6 +189,7 @@ def toggle_vote(media_id: int, vote: str) -> None:
             else:
                 was_opposite = media_id in good_votes
                 good_votes.pop(media_id, None)
+                vote_region_boxes.pop(media_id, None)
                 bad_votes[media_id] = None
                 assign_click_time(media_id)
                 add_label_to_history(media_id, "bad")
@@ -186,7 +205,13 @@ def toggle_vote(media_id: int, vote: str) -> None:
         record_vote(detector_id)
 
 
-def apply_label(media_id: int, label: str, *, silent: bool = False) -> None:
+def apply_label(
+    media_id: int,
+    label: str,
+    *,
+    silent: bool = False,
+    region_box: tuple[float, float, float, float] | None = None,
+) -> None:
     """Atomically apply a label to a media (for imports).
 
     Unlike :func:`toggle_vote`, this always sets the label without toggling.
@@ -203,15 +228,23 @@ def apply_label(media_id: int, label: str, *, silent: bool = False) -> None:
         media_id: Integer ID of the media to label.
         label: ``"good"`` or ``"bad"``.
         silent: If True, skip history append and diversity-tree marking.
+        region_box: Optional normalised ``(x0, y0, x1, y1)`` box from an
+            imported labelset entry.  Only stored when *label* is ``"good"``
+            (no-votes are always image-level).  Patch-embedder v2.
     """
     with _state_lock:
         if label == "good":
             bad_votes.pop(media_id, None)
             good_votes[media_id] = None
+            if region_box is not None:
+                vote_region_boxes[media_id] = region_box
+            else:
+                vote_region_boxes.pop(media_id, None)
             if not silent:
                 add_label_to_history(media_id, "good")
         else:
             good_votes.pop(media_id, None)
+            vote_region_boxes.pop(media_id, None)
             bad_votes[media_id] = None
             if not silent:
                 add_label_to_history(media_id, "bad")
@@ -233,9 +266,11 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
         if label == "good":
             bad_votes.pop(media_id, None)
             good_votes[media_id] = None
+            vote_region_boxes.pop(media_id, None)
             add_label_to_history(media_id, "good")
         else:
             good_votes.pop(media_id, None)
+            vote_region_boxes.pop(media_id, None)
             bad_votes[media_id] = None
             add_label_to_history(media_id, "bad")
         assign_click_time(media_id)
@@ -268,14 +303,18 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
                 bad_votes.pop(cid, None)
             for cid in [c for c in vote_click_times if c not in kept]:
                 vote_click_times.pop(cid, None)
+            for cid in [c for c in vote_region_boxes if c not in kept]:
+                vote_region_boxes.pop(cid, None)
             ctx.find_initial_labels.clear()
         for media_id, label in labels:
             if label == "good":
                 bad_votes.pop(media_id, None)
                 good_votes[media_id] = None
+                vote_region_boxes.pop(media_id, None)
                 label_history.append((media_id, "good", _time.time()))
             else:
                 good_votes.pop(media_id, None)
+                vote_region_boxes.pop(media_id, None)
                 bad_votes[media_id] = None
                 label_history.append((media_id, "bad", _time.time()))
             new_val = _get_click_counter() + 1


### PR DESCRIPTION
## Summary

Continues the patch-embedder v2 plan on `dev`.  Steps 1-2
(`LabeledElement.region_box`, `box_to_vote_vector`) landed in
PR #1271; this PR finishes the remaining three backend punchlist items
so that a yes-vote's region annotation now travels end-to-end through
the vote API → in-memory state → label export / detector sync /
labelset source → region-aware MLP training.

### Vote endpoint (step 3)

* `POST /api/medias/<id>/vote` accepts an optional `region_box`: a
  4-float list in `[0, 1]`.  Yes-votes persist the box on
  `DetectorContext.vote_region_boxes`; no-votes that include a box
  return HTTP 400 (rather than silently dropping it — by design,
  no-votes are image-level always).  Toggling a good vote off evicts
  the box; switching good → bad evicts the box.
* Malformed / out-of-range / non-numeric boxes 400 with a clear error.

### Label export and sync (step 5)

* `LabelSet.from_clips_and_votes` grows an optional
  `vote_region_boxes` kwarg.  All four call sites
  (`/api/labels/export`, `POST /api/detectors/<name>/labels`,
  `sync_labels_to_loaded_detector`, `sync_to_labelset_source`) pass it
  through, so a region annotation round-trips from the vote API all
  the way to the on-disk detector labelset and any configured
  labelset source.
* `POST /api/labels/import` rebuilds `vote_region_boxes` on good-vote
  imports; bad-vote imports drop any stray `region_box` (malformed
  exports).

### Region-aware training (step 4)

* New helper `_training_vec_for_vote(media, region_box)` returns the
  box-pooled patch vector via `box_to_vote_vector` when `region_box`
  is set and the source media has a `patch_grid`, otherwise the legacy
  `media["embedding"]`.
* `train_and_score` grows an optional `vote_region_boxes` kwarg
  threaded by the no-detector learned-sort path and the detector-load
  retrain path.
* `populate_label_embeddings` pools from `snap[cid]["patch_grid"]`
  when `LabeledElement.region_box` is set.  Region-voted elements
  re-pool on every call so region_box edits propagate without an
  explicit cache invalidation; image-level elements keep the cached
  fast path.
* When the source media lacks a `patch_grid` (legacy datasets,
  single-vector embedders, cross-dataset elements resolved via origin
  importer), the trainer falls back to the full-image vector — the
  design's documented fallback.

### Storage rule

No on-disk persistence of vectors or MLPs is added.
`vote_region_boxes` is process-scoped on `DetectorContext`.  The
single serialised form of `region_box` remains
`LabeledElement.region_box` on the labelset (4 floats), as designed.

## Test plan

- [x] `./run-tests.sh` — all 3128 tests pass (1 skipped, 2 xpassed).
- [x] New tests in `tests/test_patch_embedder.py`:
  - `TestVoteEndpointRegionBox` — vote API persists/evicts/rejects
    region_box across the full toggle matrix.
  - `TestLabelExportRegionBox` — `/api/labels/export` emits
    region_box on yes-votes only.
  - `TestLabelImportRegionBox` — `/api/labels/import` restores
    region_box on good imports, ignores it on bad imports.
  - `TestRegionAwareTraining` — `_training_vec_for_vote` and
    `populate_label_embeddings` pool from `patch_grid` when region_box
    is present, fall back to `embedding` otherwise; region-voted
    elements re-pool on every pass; image-level cache fast path is
    preserved.

https://claude.ai/code/session_01FC4xsQzfRB4g3C7LkrDCNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC4xsQzfRB4g3C7LkrDCNc)_