### PR TITLE
patch-embedder v2: sticky bad-vote armed state + zero-area-click preserve + frontend tests

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -550,53 +550,78 @@ the API once it's stable.
    `tests/test_patch_embedder.py::TestLabelExportRegionBox` and
    `::TestLabelImportRegionBox`.
 
-**Frontend**
+**Frontend** — *items 6–9 DONE.*
 
-6. **`RegionDrawComponent` overlay.** New component (or layer inside
-   `ImageViewerComponent`) that listens for `Shift` keydown/keyup on
-   `window` while the focus pane is mounted.  Shift-held swaps the
-   pan-on-drag gesture for box-draw; cursor → crosshair.  Click-drag-
-   release in image-local coordinates, un-transformed through the
-   current `panX / panY / zoom / rotate`.  Renders the box + 8 resize
-   handles + draggable body as positioned divs inside
-   `.thumbnail-wrap` (same coordinate system as the v1 `best_region`
-   outline).  Zero-area release → no box; Esc clears the box without
-   voting.  Mid-drag Shift release commits the in-progress box on
-   mouseup before mode exits.  See "v2 → Interaction design" above.
-7. **Vote keybindings + buttons.**  `→` with box → yes-vote +
-   `region_box`; `→` without box → plain yes-vote (unchanged); `←`
-   without box → plain no-vote (unchanged); `←` with box → arms a
-   visible sticky "discard & vote no" state (no timeout); second
-   `←` confirms whenever it arrives; Esc, mouse interaction with
-   the box, or navigating away clears the armed state and keeps
-   the box.  Same rules apply to the on-screen vote buttons.
-8. **Vote-dispatch service.** Carry optional `regionBox` into the
-   existing yes-vote API call.  Bad-vote path picks up the "pending
-   discard confirmation" sub-state.  None of this touches the
-   binary-only code paths.
-9. **Gallery `best_region` outline.**  Already shipped in v1 as
-   read-only — leave it as-is.  V2 adds the active draw layer only
-   on the focus pane.
+6. **`RegionDrawComponent` overlay — DONE.** Implemented as a layer
+   inside `ImageViewerComponent` (no separate component): it listens
+   for `Shift` keydown/keyup on `window` while the focus pane is
+   mounted, swaps pan-on-drag for box-draw under Shift, flips the
+   cursor to crosshair, and renders the box + 8 resize handles +
+   draggable body as positioned divs inside a `.region-stage`
+   layer that shares the image's `transform` so box coordinates are
+   anchored in image-local space.  Click-drag-release is un-
+   transformed through the current `panX / panY / zoom / rotate`.
+   Esc clears the box (when not armed — see step 7).  A zero-area
+   Shift-click restores the prior box rather than discarding it
+   (item 13 above) — drawing a box is real work.
+7. **Vote keybindings + buttons — DONE.** Lives in
+   `CenterPanelComponent.castVote`.  `→` with box → yes-vote +
+   `region_box`; `→` without box → plain yes-vote (unchanged);
+   `←` without box → plain no-vote (unchanged); `←` with box →
+   arms a visible sticky "discard & vote no" state with **no
+   timeout** (a red sticky pulse on the box plus an inline hint
+   banner — *"Press ← again to vote no and discard the box, or
+   Esc to keep the box."*); second `←` confirms.  Esc, mouse-
+   interaction with the box (mousedown on body or any handle),
+   a fresh Shift-drag-redraw, or media-item navigation all clear
+   the armed state and keep the box.  Same rules apply to the
+   on-screen vote buttons via the shared `castVote` entry point.
+8. **Vote-dispatch service — DONE.** `MediasApiService.vote(id,
+   label, regionBox?)` accepts an optional `regionBox` and only
+   appends `region_box` to the request body when the array is a
+   non-empty 4-tuple.  `CenterPanelComponent` passes
+   `currentRegionBox` on yes-votes and `null` on no-votes, so the
+   binary-only fast path is byte-for-byte unchanged from v1.
+9. **Gallery `best_region` outline — already shipped in v1.**
+   Read-only outline lives on the gallery card; v2 adds the
+   active draw/edit layer only on the focus pane.
 
-**Tests**
+**Tests** — *items 10–13 + 15–16 DONE; 14 DONE under v2 backend.*
 
-10. Coord-transform: pure-function tests for the screen↔image
-    transform under non-trivial `pan/zoom/rotate`.
-11. Coord-stability: a box drawn at one zoom level stays anchored on
-    the same image pixels when the user zooms in/out.
-12. Box-discard: bad-vote-with-box requires two consecutive `←`
-    presses (no timer — the armed state persists until confirmed
-    or backed out).  Esc, a mouse interaction with the box, or
-    item-navigation while armed clears the armed state and keeps
-    the box; only a second `←` discards.
-13. Box-preserve: a subsequent zero-area Shift-drag click does not
-    clear an already-drawn box.
-14. `LabeledElement.region_box` round-trips through serialisation
-    (replaces the v1 absence assertion).
-15. Vote-API contract: `region_box` present on yes-vote with box,
-    absent on yes-vote without box, absent on every no-vote.
-16. Backend pure-function test for `box_to_vote_vector` against a
-    hand-crafted `patch_grid`.
+10. **Coord-transform — DONE.** Pure-function tests for
+    `screenToImageNormalized` under non-trivial `pan / zoom /
+    rotate` live in
+    `frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts`
+    (`describe('screenToImageNormalized (coord transform)')`).
+11. **Coord-stability — DONE.** Same spec file
+    (`describe('region box coord stability')`) asserts that
+    `regionBox` and `regionBoxStyle` are byte-for-byte stable
+    across zoom and rotation changes — the box is stored in
+    normalised image coordinates and the CSS overlay rides the
+    image's transform.
+12. **Box-discard (sticky armed state) — DONE.** Covered in
+    `center-panel.component.spec.ts`
+    (`describe('sticky bad-vote-confirm armed state')`): first `←`
+    arms without firing a request, second `←` posts the no-vote;
+    Esc / mouse-on-box (routed via `onArmedConfirmCanceled`) cancel
+    armed and keep the box; `regionBoxChange(null)` cancels armed
+    and drops the box; media-item navigation clears both.
+13. **Box-preserve — DONE.** `image-viewer.component.spec.ts`
+    (`describe('region box preservation on zero-area Shift-drag')`)
+    asserts a zero-area Shift-click restores the previous box and
+    that no spurious emit reaches the parent.  Backed by the
+    `DragMode.draw.previousBox` field on `ImageViewerComponent`.
+14. **`LabeledElement.region_box` round-trip — DONE.** Backend test
+    `tests/test_patch_embedder.py::TestRegionBoxOnLabeledElement`
+    (shipped under v2 backend step 1).
+15. **Vote-API contract — DONE.** `center-panel.component.spec.ts`
+    (`describe('vote-API contract for region_box')`) asserts
+    `region_box` is present on yes-with-box, absent on yes-without-
+    box, and absent on every no-vote (including after a two-press
+    bad-vote-confirm).
+16. **`box_to_vote_vector` — DONE.** Backend test
+    `tests/test_patch_embedder.py::TestBoxToVoteVector` (shipped
+    under v2 backend step 2).
 
 **Out of scope for v2 (deferred)**
 

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -8,7 +8,12 @@
           <vt-audio-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" [swipeClass]="swipeClass" (playingChanged)="onPlayingChanged($event)"></vt-audio-player>
         }
         @case ('image') {
-          <vt-image-viewer [media]="media" (regionBoxChange)="onRegionBoxChange($event)"></vt-image-viewer>
+          <vt-image-viewer
+            [media]="media"
+            [pendingBadConfirm]="pendingBadConfirm"
+            (regionBoxChange)="onRegionBoxChange($event)"
+            (armedConfirmCanceled)="onArmedConfirmCanceled()"
+          ></vt-image-viewer>
         }
         @case ('video') {
           <vt-video-player [media]="media" [volume]="volume" [audioPlaying]="audioPlaying" (playingChanged)="onPlayingChanged($event)"></vt-video-player>
@@ -77,6 +82,12 @@
         </div>
       }
     </div>
+
+    @if (pendingBadConfirm) {
+      <div class="bad-confirm-hint" role="status" aria-live="polite">
+        Press &larr; again to vote no and discard the box, or Esc to keep the box.
+      </div>
+    }
 
     <vt-voting-overlay
       [isGood]="isGood"

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -187,3 +187,18 @@
   font-family: monospace;
   font-size: 0.75rem;
 }
+
+// Sticky-armed-state hint banner for the bad-vote-with-box discard flow
+// (v2 patch-embedder plan). Sits between the metadata tray and the voting
+// overlay so it's near the vote buttons without overlapping the image.
+.bad-confirm-hint {
+  flex-shrink: 0;
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid rgba(255, 110, 110, 0.5);
+  border-radius: 4px;
+  background: rgba(255, 110, 110, 0.08);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  text-align: center;
+}

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -3,6 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { CenterPanelComponent } from './center-panel.component';
 import { MediaItem } from '../../models/api.models';
+import { RegionBox } from './image-viewer/image-viewer.component';
 
 describe('CenterPanelComponent', () => {
   let component: CenterPanelComponent;
@@ -144,5 +145,171 @@ describe('CenterPanelComponent', () => {
     expect(component.formatMetadataValue('Duration', 3.5)).toBe('3.5s');
     expect(component.formatMetadataValue('Frequency', 44100)).toBe('44100 Hz');
     expect(component.formatMetadataValue('Other', 'hello')).toBe('hello');
+  });
+
+  /**
+   * v2 patch-embedder plan, item 15: vote-API contract for region annotations.
+   * `region_box` must be present on a yes-vote when a box is drawn, absent on
+   * a yes-vote without a box, and never present on any no-vote (no-votes are
+   * region-agnostic — see "Vote attribution → v2" in docs/plans/patch-embedder.md).
+   */
+  describe('vote-API contract for region_box', () => {
+    const imageMedia: MediaItem = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
+
+    function setup(): void {
+      component.media = imageMedia;
+      component.swipeAnimation = false;
+      fixture.detectChanges();
+    }
+
+    it('attaches region_box to a yes-vote when a box is drawn', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      component.castVote('good');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'good', region_box: [0.1, 0.2, 0.5, 0.6] });
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [1], bad: [], click_times: {}, learned_scores: {} });
+    });
+
+    it('omits region_box from a yes-vote when no box is drawn', () => {
+      setup();
+      component.castVote('good');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'good' });
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [1], bad: [], click_times: {}, learned_scores: {} });
+    });
+
+    it('omits region_box from a no-vote even when a box is drawn (after confirm)', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      // First ← arms the discard-confirm — no request yet.
+      component.castVote('bad');
+      httpMock.expectNone('/api/medias/1/vote');
+      expect(component.pendingBadConfirm).toBeTrue();
+      // Second ← throws the box away and votes no.
+      component.castVote('bad');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'bad' });
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [], bad: [1], click_times: {}, learned_scores: {} });
+    });
+
+    it('omits region_box from a no-vote when no box is drawn (no confirm armed)', () => {
+      setup();
+      component.castVote('bad');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'bad' });
+      expect(component.pendingBadConfirm).toBeFalse();
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [], bad: [1], click_times: {}, learned_scores: {} });
+    });
+  });
+
+  /**
+   * v2 patch-embedder plan, item 12: bad-vote-with-box requires two consecutive
+   * ← presses (no timer). Esc, mouse-on-box, or item navigation while armed
+   * clears the armed state and keeps the box.
+   */
+  describe('sticky bad-vote-confirm armed state', () => {
+    const imageMedia: MediaItem = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
+
+    function setup(): void {
+      component.media = imageMedia;
+      component.swipeAnimation = false;
+      fixture.detectChanges();
+    }
+
+    it('arms on first ← without firing a request, fires on second ←', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      component.castVote('bad');
+      httpMock.expectNone('/api/medias/1/vote');
+      expect(component.pendingBadConfirm).toBeTrue();
+      expect(component.currentRegionBox).toEqual(box);
+
+      component.castVote('bad');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'bad' });
+      expect(component.pendingBadConfirm).toBeFalse();
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [], bad: [1], click_times: {}, learned_scores: {} });
+    });
+
+    it('cancels armed state on onArmedConfirmCanceled (Esc/mouse-on-box) and keeps the box', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      component.castVote('bad');
+      expect(component.pendingBadConfirm).toBeTrue();
+
+      // Esc-while-armed (or mousedown-on-box) routes through this handler from
+      // the image viewer.
+      component.onArmedConfirmCanceled();
+      expect(component.pendingBadConfirm).toBeFalse();
+      expect(component.currentRegionBox).toEqual(box);
+      httpMock.expectNone('/api/medias/1/vote');
+    });
+
+    it('cancels armed state when the box is cleared (Esc-while-not-armed routes via regionBoxChange(null))', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      component.castVote('bad');
+      expect(component.pendingBadConfirm).toBeTrue();
+
+      component.onRegionBoxChange(null);
+      expect(component.pendingBadConfirm).toBeFalse();
+      expect(component.currentRegionBox).toBeNull();
+    });
+
+    it('cancels armed state when the user navigates to another item', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      component.castVote('bad');
+      expect(component.pendingBadConfirm).toBeTrue();
+
+      const next: MediaItem = { ...imageMedia, id: 2, filename: 'next.png' };
+      component.media = next;
+      component.ngOnChanges({
+        media: {
+          currentValue: next,
+          previousValue: imageMedia,
+          firstChange: false,
+          isFirstChange: () => false,
+        },
+      });
+      expect(component.pendingBadConfirm).toBeFalse();
+      expect(component.currentRegionBox).toBeNull();
+    });
+
+    it('does not arm when no box is drawn (single ← votes no immediately)', () => {
+      setup();
+      component.castVote('bad');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'bad' });
+      expect(component.pendingBadConfirm).toBeFalse();
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [], bad: [1], click_times: {}, learned_scores: {} });
+    });
+
+    it('uses the box on a yes-vote even after a first ← would have armed (yes wins over armed-only)', () => {
+      setup();
+      component.onRegionBoxChange(box);
+      // Without arming first: yes-vote attaches the box immediately.
+      component.castVote('good');
+      const req = httpMock.expectOne('/api/medias/1/vote');
+      expect(req.request.body).toEqual({ vote: 'good', region_box: [0.1, 0.2, 0.5, 0.6] });
+      req.flush({ ok: true });
+      const votesReq = httpMock.expectOne('/api/votes');
+      votesReq.flush({ good: [1], bad: [], click_times: {}, learned_scores: {} });
+    });
   });
 });

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -46,10 +46,14 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   swipeClass = '';
   spinningVote: 'good' | 'bad' | null = null;
 
-  private currentRegionBox: RegionBox | null = null;
-  private pendingBadConfirm = false;
-  private badConfirmTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly BAD_CONFIRM_MS = 2000;
+  // Bad-vote-with-box state: drawing a box is real work, so a stray ← shouldn't
+  // throw it away. The first ← arms a sticky discard-confirm state (no timeout);
+  // the second ← throws the box away and votes no. Esc, a mousedown on the box,
+  // a Shift-drag-redraw, or navigating to another item all clear the armed
+  // state without voting and without discarding the box.
+  // Public so the template can bind it into the image viewer.
+  currentRegionBox: RegionBox | null = null;
+  pendingBadConfirm = false;
 
   private spinTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -66,9 +70,10 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['media']) {
       this.swipeClass = '';
-      this.cancelBadConfirm();
+      // Navigating to another item clears the armed bad-vote-confirm state.
       // ImageViewer also clears its own regionBox on media change and will emit null;
       // resetting eagerly here keeps state coherent across the swap.
+      this.pendingBadConfirm = false;
       this.currentRegionBox = null;
     }
   }
@@ -78,7 +83,6 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.keyboard.stop();
     this.subs.forEach((s) => s.unsubscribe());
     if (this.spinTimer) clearTimeout(this.spinTimer);
-    if (this.badConfirmTimer) clearTimeout(this.badConfirmTimer);
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
   }
 
@@ -174,18 +178,19 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     if (!this.media || this.isVoting) return;
 
     // Region annotations only attach to yes-votes (salient-area semantics).
-    // A no-vote with a box drawn requires a confirming second press so a stray
-    // ArrowLeft can't throw away real work the user did drawing the box.
+    // A no-vote with a box drawn arms a sticky discard-confirm state — the first
+    // ← shake-pulses the box and surfaces a hint; only a second ← while armed
+    // throws the box away and votes no. The state has no timeout: a time-based
+    // modal would expire silently and surprise the user. Esc, mouse-on-box, a
+    // fresh Shift-drag, or item navigation clear armed without voting.
     if (vote === 'bad' && this.currentRegionBox && !this.pendingBadConfirm) {
       this.pendingBadConfirm = true;
       this.imageViewer?.pulseRegionBox();
-      if (this.badConfirmTimer) clearTimeout(this.badConfirmTimer);
-      this.badConfirmTimer = setTimeout(() => this.cancelBadConfirm(), this.BAD_CONFIRM_MS);
       return;
     }
 
     const regionBox = vote === 'good' ? this.currentRegionBox : null;
-    this.cancelBadConfirm();
+    this.pendingBadConfirm = false;
     this.isVoting = true;
 
     this.mediasApi.vote(this.media.id, vote, regionBox).subscribe({
@@ -215,15 +220,12 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.currentRegionBox = box;
     // Clearing the box also clears any pending bad-vote confirmation —
     // there's nothing left to confirm against.
-    if (!box) this.cancelBadConfirm();
+    if (!box) this.pendingBadConfirm = false;
   }
 
-  private cancelBadConfirm(): void {
+  /** Esc-while-armed or mouse interaction with the box: cancel armed, keep the box. */
+  onArmedConfirmCanceled(): void {
     this.pendingBadConfirm = false;
-    if (this.badConfirmTimer) {
-      clearTimeout(this.badConfirmTimer);
-      this.badConfirmTimer = null;
-    }
   }
 
   private loadSettings(): void {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -28,6 +28,7 @@
       <div
         class="region-box"
         [class.shake]="regionBoxShake"
+        [class.armed]="pendingBadConfirm"
         [ngStyle]="regionBoxStyle!"
         (mousedown)="onRegionBodyMouseDown($event)"
         title="Region annotation (Shift-drag to redraw, Esc to clear)"

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.scss
@@ -54,6 +54,14 @@
   &.shake {
     animation: region-box-shake 0.45s ease-in-out;
   }
+
+  // The bad-vote-with-box discard is armed — pulse a red glow so it's
+  // unmistakable that the next ArrowLeft will throw the box away. The state
+  // has no timeout; the user backs out via Esc or by touching the box.
+  &.armed {
+    border-color: rgba(255, 110, 110, 0.95);
+    animation: region-box-armed-pulse 1.4s ease-in-out infinite;
+  }
 }
 
 @keyframes region-box-shake {
@@ -63,6 +71,21 @@
   45% { transform: translateX(-3px); }
   60% { transform: translateX(3px); border-color: rgba(255, 110, 110, 0.95); }
   75% { transform: translateX(-2px); }
+}
+
+@keyframes region-box-armed-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.45) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.35),
+      0 0 8px 2px rgba(255, 110, 110, 0.35);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.45) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.35),
+      0 0 14px 4px rgba(255, 110, 110, 0.7);
+  }
 }
 
 .region-handle {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ImageViewerComponent } from './image-viewer.component';
+import { ElementRef } from '@angular/core';
+import { ImageViewerComponent, RegionBox } from './image-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaItem } from '../../../models/api.models';
 
@@ -111,5 +112,245 @@ describe('ImageViewerComponent', () => {
   it('should generate transform string', () => {
     expect(component.imageTransform).toContain('scale(1)');
     expect(component.imageTransform).toContain('rotate(0deg)');
+  });
+
+  /**
+   * Item 10 of the v2 patch-embedder plan (docs/plans/patch-embedder.md):
+   * pure-function coverage for the screen↔image coordinate transform under
+   * non-trivial pan / zoom / rotate. The transform is what lets the user draw
+   * a box that stays anchored on the right image pixels regardless of how the
+   * viewport is currently transformed; this is the math that backs that.
+   */
+  describe('screenToImageNormalized (coord transform)', () => {
+    // Helper: wire up a 100×100 wrap centred at screen (50, 50) with a 100×100
+    // rendered image. Lets each test focus on the transform math, not on DOM
+    // plumbing.
+    function setupWrap(component: ImageViewerComponent) {
+      component.renderedW = 100;
+      component.renderedH = 100;
+      component.wrapRef = {
+        nativeElement: {
+          getBoundingClientRect: () => ({
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+            right: 100,
+            bottom: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>;
+    }
+
+    function makeEvent(clientX: number, clientY: number): MouseEvent {
+      return { clientX, clientY } as MouseEvent;
+    }
+
+    it('returns null when the image has not been laid out yet', () => {
+      // renderedW/H still 0 → no transform possible.
+      expect(component.screenToImageNormalized(makeEvent(50, 50))).toBeNull();
+    });
+
+    it('maps the wrap centre to the image centre at identity', () => {
+      setupWrap(component);
+      const local = component.screenToImageNormalized(makeEvent(50, 50));
+      expect(local!.x).toBeCloseTo(0.5, 6);
+      expect(local!.y).toBeCloseTo(0.5, 6);
+    });
+
+    it('maps corners correctly at identity', () => {
+      setupWrap(component);
+      const tl = component.screenToImageNormalized(makeEvent(0, 0))!;
+      const br = component.screenToImageNormalized(makeEvent(100, 100))!;
+      expect(tl.x).toBeCloseTo(0, 6);
+      expect(tl.y).toBeCloseTo(0, 6);
+      expect(br.x).toBeCloseTo(1, 6);
+      expect(br.y).toBeCloseTo(1, 6);
+    });
+
+    it('compensates for zoom — screen offsets shrink in image coords as zoom grows', () => {
+      setupWrap(component);
+      component.zoom = 2;
+      // 25px right of centre at 2× zoom should be 12.5px in image coords =
+      // 0.125 normalised, so image x = 0.625.
+      const local = component.screenToImageNormalized(makeEvent(75, 50))!;
+      expect(local.x).toBeCloseTo(0.625, 6);
+      expect(local.y).toBeCloseTo(0.5, 6);
+    });
+
+    it('compensates for pan — translating the image shifts the inferred image coords', () => {
+      setupWrap(component);
+      component.zoom = 2;
+      // Image translated 20px right; a click at screen 70 used to map to image
+      // 0.7 at zoom 2 (50px = 0.5 + 20/100/2 * 2... see math). Concretely:
+      // dx = 70 - 50 - 20 = 0; sx = 0; image x = 0.5.
+      component.panX = 20;
+      const local = component.screenToImageNormalized(makeEvent(70, 50))!;
+      expect(local.x).toBeCloseTo(0.5, 6);
+      expect(local.y).toBeCloseTo(0.5, 6);
+    });
+
+    it('inverts rotation — a click on the screen-right edge maps to the image-top edge at 90° CW', () => {
+      setupWrap(component);
+      component.rotation = 90;
+      // Positive rotation rotates the image clockwise, so screen-right is image-top.
+      const local = component.screenToImageNormalized(makeEvent(100, 50))!;
+      expect(local.x).toBeCloseTo(0.5, 5);
+      expect(local.y).toBeCloseTo(0, 5);
+    });
+
+    it('combines pan + zoom + rotate self-consistently', () => {
+      setupWrap(component);
+      component.zoom = 2;
+      component.panX = 10;
+      component.panY = -5;
+      component.rotation = 90;
+      // Map a couple of points and verify the transform is invertible:
+      // taking two points on screen and rotating by the matching angle, the
+      // image-coord differences should respect rotation (a screen-x delta
+      // becomes an image-y delta at +90°).
+      const a = component.screenToImageNormalized(makeEvent(50, 50))!;
+      const b = component.screenToImageNormalized(makeEvent(60, 50))!;
+      // Screen Δx = +10 → image Δy = -10/zoom/renderedH = -0.05 (the inverse
+      // rotation maps +x → -y); Δx in image coords ≈ 0.
+      expect(b.x - a.x).toBeCloseTo(0, 5);
+      expect(b.y - a.y).toBeCloseTo(-0.05, 5);
+    });
+  });
+
+  /**
+   * Item 11 of the v2 patch-embedder plan: a box drawn at one zoom level
+   * stays anchored on the same image pixels when the user zooms in/out.
+   * The box is stored in normalised image coordinates and the CSS overlay
+   * lives inside `.region-stage` which is rotated/scaled with the image
+   * transform, so the box should remain visually identical relative to the
+   * image regardless of zoom.
+   */
+  describe('region box coord stability', () => {
+    it('does not mutate the box coords when zoom changes', () => {
+      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.zoom = 2;
+      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+      component.zoom = 4;
+      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+      component.zoom = 1;
+      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+    });
+
+    it('keeps regionBoxStyle (percent-of-stage) stable across zoom changes', () => {
+      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      const before = component.regionBoxStyle;
+      component.zoom = 3;
+      expect(component.regionBoxStyle).toEqual(before);
+      component.rotation = 45;
+      expect(component.regionBoxStyle).toEqual(before);
+    });
+
+    it('returns null style when no box is drawn', () => {
+      component.regionBox = null;
+      expect(component.regionBoxStyle).toBeNull();
+    });
+  });
+
+  /**
+   * Item 13 of the v2 patch-embedder plan: a subsequent zero-area Shift-drag
+   * click does not clear an already-drawn box. (Before the v2 sticky-armed-
+   * state work this was a real bug: tooSmall release nuked the prior box.)
+   */
+  describe('region box preservation on zero-area Shift-drag', () => {
+    function setupWrap(component: ImageViewerComponent) {
+      component.renderedW = 100;
+      component.renderedH = 100;
+      component.wrapRef = {
+        nativeElement: {
+          getBoundingClientRect: () => ({
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+            right: 100,
+            bottom: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>;
+    }
+
+    it('keeps the prior box when a Shift-click resolves to zero area', () => {
+      setupWrap(component);
+      const original: RegionBox = [0.2, 0.3, 0.6, 0.7];
+      component.regionBox = original;
+      component.shiftHeld = true;
+
+      let lastEmitted: RegionBox | null | undefined = undefined;
+      component.regionBoxChange.subscribe((v) => (lastEmitted = v));
+
+      // Click at (10, 10) with Shift held — mousedown then mouseup at same point.
+      const ev: MouseEvent = {
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+        preventDefault: () => {},
+      } as unknown as MouseEvent;
+      component.onMouseDown(ev);
+      // During the click regionBox transiently becomes the zero-area anchor;
+      // mouseup with no motion should restore the original box.
+      (component as unknown as { onWindowMouseUp: () => void }).onWindowMouseUp();
+
+      expect(component.regionBox).toEqual(original);
+      // Restored to a state the parent already knew; no emit needed.
+      expect(lastEmitted).toBeUndefined();
+    });
+
+    it('leaves the box null when the canvas was already empty and the click is zero-area', () => {
+      setupWrap(component);
+      component.regionBox = null;
+      component.shiftHeld = true;
+
+      const ev: MouseEvent = {
+        button: 0,
+        clientX: 25,
+        clientY: 25,
+        preventDefault: () => {},
+      } as unknown as MouseEvent;
+      component.onMouseDown(ev);
+      (component as unknown as { onWindowMouseUp: () => void }).onWindowMouseUp();
+
+      expect(component.regionBox).toBeNull();
+    });
+  });
+
+  describe('armed-confirm cancel routing', () => {
+    it('emits armedConfirmCanceled instead of clearing the box when Esc is pressed while armed', () => {
+      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.pendingBadConfirm = true;
+      let canceled = false;
+      let cleared = false;
+      component.armedConfirmCanceled.subscribe(() => (canceled = true));
+      component.regionBoxChange.subscribe((v) => {
+        if (v === null) cleared = true;
+      });
+      const esc = new KeyboardEvent('keydown', { key: 'Escape' });
+      (component as unknown as { onWindowKeyDown: (e: KeyboardEvent) => void }).onWindowKeyDown(esc);
+      expect(canceled).toBeTrue();
+      expect(cleared).toBeFalse();
+      expect(component.regionBox).toEqual([0.1, 0.2, 0.5, 0.6]);
+    });
+
+    it('clears the box on Esc when no armed confirm is pending', () => {
+      component.regionBox = [0.1, 0.2, 0.5, 0.6];
+      component.pendingBadConfirm = false;
+      let emitted: RegionBox | null | undefined = undefined;
+      component.regionBoxChange.subscribe((v) => (emitted = v));
+      const esc = new KeyboardEvent('keydown', { key: 'Escape' });
+      (component as unknown as { onWindowKeyDown: (e: KeyboardEvent) => void }).onWindowKeyDown(esc);
+      expect(component.regionBox).toBeNull();
+      expect(emitted).toBeNull();
+    });
   });
 });

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -18,7 +18,7 @@ export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'nw' | 'ne' | 'sw' | 'se';
 
 type DragMode =
   | { kind: 'pan'; startX: number; startY: number; originX: number; originY: number }
-  | { kind: 'draw'; anchor: { x: number; y: number } }
+  | { kind: 'draw'; anchor: { x: number; y: number }; previousBox: RegionBox | null }
   | { kind: 'move'; startLocal: { x: number; y: number }; startBox: RegionBox }
   | { kind: 'resize'; handle: ResizeHandle; startBox: RegionBox };
 
@@ -33,7 +33,19 @@ const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a s
 })
 export class ImageViewerComponent implements OnChanges, OnDestroy {
   @Input() media!: MediaItem;
+  /**
+   * True while the parent is in the v2 "bad-vote-with-box discard confirm" armed state.
+   * The viewer uses it to (a) render the box with a sticky red pulse, and (b) route Esc /
+   * mouse-on-box back to the parent via `armedConfirmCanceled` instead of clearing the box.
+   */
+  @Input() pendingBadConfirm = false;
   @Output() regionBoxChange = new EventEmitter<RegionBox | null>();
+  /**
+   * Fired when the user does something that cancels the armed bad-vote-confirm without
+   * voting (Esc while armed, or any mousedown on the box body/handles, or starting a
+   * fresh Shift-drag). The parent clears its armed state but keeps the box.
+   */
+  @Output() armedConfirmCanceled = new EventEmitter<void>();
 
   @ViewChild('imageWrap') wrapRef!: ElementRef<HTMLDivElement>;
   @ViewChild('imageEl') imageRef!: ElementRef<HTMLImageElement>;
@@ -51,8 +63,10 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   renderedW = 0;
   renderedH = 0;
 
-  private panX = 0;
-  private panY = 0;
+  // panX/panY are not `private` so tests can drive screenToImageNormalized()
+  // with non-zero pan without simulating a full wheel + drag sequence.
+  panX = 0;
+  panY = 0;
   private drag: DragMode | null = null;
 
   private mouseMoveHandler: ((e: MouseEvent) => void) | null = null;
@@ -161,7 +175,10 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       if (!local) return;
       const x = clamp01(local.x);
       const y = clamp01(local.y);
-      this.drag = { kind: 'draw', anchor: { x, y } };
+      if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
+      // Remember the prior box so we can restore it on a zero-area release —
+      // a stray Shift-click on empty space must not throw away real work.
+      this.drag = { kind: 'draw', anchor: { x, y }, previousBox: this.regionBox };
       this.regionBox = [x, y, x, y];
       event.preventDefault();
       this.setupWindowMouseListeners();
@@ -188,6 +205,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     event.preventDefault();
     const local = this.screenToImageNormalized(event);
     if (!local) return;
+    if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
     this.drag = { kind: 'move', startLocal: local, startBox: this.regionBox };
     this.setupWindowMouseListeners();
   }
@@ -196,6 +214,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     if (event.button !== 0 || !this.regionBox) return;
     event.stopPropagation();
     event.preventDefault();
+    if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
     this.drag = { kind: 'resize', handle, startBox: this.regionBox };
     this.setupWindowMouseListeners();
   }
@@ -296,8 +315,9 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   /** Convert a screen-space mouse event to normalised image coords (pre-rotation).
-   *  Returns null when the image isn't laid out yet. */
-  private screenToImageNormalized(event: MouseEvent): { x: number; y: number } | null {
+   *  Returns null when the image isn't laid out yet. Public so tests can drive it
+   *  with a mocked wrapRef + arbitrary pan/zoom/rotate state. */
+  screenToImageNormalized(event: MouseEvent): { x: number; y: number } | null {
     const wrap = this.wrapRef?.nativeElement;
     if (!wrap || !this.renderedW || !this.renderedH) return null;
     const rect = wrap.getBoundingClientRect();
@@ -381,20 +401,21 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       this.removeWindowMouseListeners();
       return;
     }
-    const wasDraw = this.drag.kind === 'draw';
+    const drag = this.drag;
     this.drag = null;
     this.removeWindowMouseListeners();
-    if (this.regionBox) {
-      const [x0, y0, x1, y1] = this.regionBox;
-      const tooSmall = x1 - x0 < MIN_BOX_SIZE || y1 - y0 < MIN_BOX_SIZE;
-      if (wasDraw && tooSmall) {
-        // Stray click in draw mode — treat as no box.
-        this.regionBox = null;
-        this.regionBoxChange.emit(null);
-        return;
-      }
-      this.regionBoxChange.emit(this.regionBox);
+    if (!this.regionBox) return;
+    const [x0, y0, x1, y1] = this.regionBox;
+    const tooSmall = x1 - x0 < MIN_BOX_SIZE || y1 - y0 < MIN_BOX_SIZE;
+    if (drag.kind === 'draw' && tooSmall) {
+      // Zero-area Shift-drag (a stray click without motion). Restore the
+      // prior box rather than discarding it — drawing a box is real work.
+      // Don't emit: the parent's last-known state was already previousBox
+      // (the transient zero-area draw was never emitted).
+      this.regionBox = drag.previousBox;
+      return;
     }
+    this.regionBoxChange.emit(this.regionBox);
   }
 
   private setupWindowKeyListeners(): void {
@@ -430,7 +451,17 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       this.shiftHeld = true;
       return;
     }
-    if (e.key === 'Escape' && this.regionBox && !this.isTyping()) {
+    if (e.key !== 'Escape' || this.isTyping()) return;
+    // Esc while a bad-vote-with-box discard is armed cancels the armed state but
+    // keeps the box — per the v2 patch-embedder plan, drawing a box is real work
+    // and Esc should be the "I changed my mind about voting no" out, not "throw
+    // away the box". Only consume the key if we actually had an action to take.
+    if (this.pendingBadConfirm) {
+      e.preventDefault();
+      this.armedConfirmCanceled.emit();
+      return;
+    }
+    if (this.regionBox) {
       e.preventDefault();
       this.clearRegionBox({ emit: true });
     }


### PR DESCRIPTION
## Summary

Continues the patch-embedder v2 work from `docs/plans/patch-embedder.md`.  Backend (steps 1–5) already shipped in dev; this PR closes out the matching frontend work (steps 6–9) and the v2 frontend test items (10–13, 15).

- **Sticky bad-vote-confirm armed state** in `CenterPanelComponent`, replacing the prior 2-second timer.  The first `←` while a box is drawn arms a sticky discard-confirm state with no timeout; a second `←` commits the no-vote and discards the box.  Esc, a mousedown on the box body/handles, a fresh Shift-drag-redraw, or media-item navigation all cancel armed *and keep the box* (drawing a box is real work — only an explicit second `←` throws it away).
- **Visible feedback while armed**: the box gains a red sticky pulse animation, and an inline hint banner reads *"Press ← again to vote no and discard the box, or Esc to keep the box."*  The image-viewer routes Esc / mouse-on-box back to the parent via a new `armedConfirmCanceled` output so the parent owns the armed state.
- **Zero-area Shift-click preservation** (v2 plan item 13): the image-viewer now captures the prior box at mousedown of a fresh Shift-drag and restores it on a tooSmall release.  Before this, a stray Shift-click nuked a previously-drawn box.
- **v2 frontend test items 10–13, 15**:
  - `screenToImageNormalized` coord-transform under non-trivial pan / zoom / rotate
  - `regionBox` + `regionBoxStyle` coord-stability across zoom and rotation
  - sticky-armed-state behavior (two ← presses, Esc-while-armed, mouse-on-box, media nav)
  - zero-area Shift-click preserves the prior box and emits nothing
  - vote-API contract: `region_box` present on yes-with-box, absent on yes-without-box and on every no-vote

## Test plan

- [x] `./run-tests.sh` — all 3128 tests pass (1 skipped, 2 xpassed)
- [x] `cd frontend && npm run build:prod` — clean build, no `▲ WARNING` lines
- [x] `cd frontend && npx tsc -p tsconfig.spec.json --noEmit` — specs typecheck
- [ ] Manual: draw a box on the focus pane, press `←` once → box pulses red and hint appears; press `←` again → vote no fires and box is discarded
- [ ] Manual: draw a box, press `←` once, then Esc → armed clears, box stays
- [ ] Manual: draw a box, press `←` once, then mousedown on the box → armed clears, box stays
- [ ] Manual: draw a box at 1× zoom, zoom to 4×, verify the box still hugs the same image pixels
- [ ] Manual: draw a box, Shift-click somewhere else without dragging → original box is preserved

https://claude.ai/code/session_018p5Qve1bR7XQvx9ysb4sNU

---
_Generated by [Claude Code](https://claude.ai/code/session_018p5Qve1bR7XQvx9ysb4sNU)_