### PR TITLE
Replace dashboard select-all/none pair with tristate toggle

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -102,15 +102,25 @@
     }
   </div>
   <div class="dashboard-side-actions">
-    <button class="side-action-btn" (click)="selectAllDatasets()" [disabled]="isLoading || datasets.length === 0" title="Select all datasets" aria-label="Select all">
-      <svg aria-hidden="true" [class.side-action-spin]="spinSelectAllDatasets" (animationend)="onSpinSelectAllDatasetsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-      </svg>
-    </button>
-    <button class="side-action-btn" (click)="selectNoneDatasets()" [disabled]="isLoading || selectedDatasetIds.size === 0" title="Select none" aria-label="Select none">
-      <svg aria-hidden="true" [class.side-action-spin]="spinSelectNoneDatasets" (animationend)="onSpinSelectNoneDatasetsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-      </svg>
+    <button class="side-action-btn" (click)="toggleAllDatasets()" [disabled]="isLoading || datasets.length === 0" [title]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all datasets'" [attr.aria-label]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="datasetSelectionState === 'all' ? 'true' : datasetSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
+      @switch (datasetSelectionState) {
+        @case ('all') {
+          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+            <rect x="3" y="3" width="18" height="18" rx="2"/>
+          </svg>
+        }
+        @case ('some') {
+          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+            <rect x="3" y="3" width="18" height="18" rx="2"/>
+            <line x1="7" y1="12" x2="17" y2="12" stroke-dasharray="0"/>
+          </svg>
+        }
+        @default {
+          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+            <rect x="3" y="3" width="18" height="18" rx="2"/>
+          </svg>
+        }
+      }
     </button>
     <div class="side-action-gap"></div>
     <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isLoading || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
@@ -205,15 +215,25 @@
     }
   </div>
   <div class="dashboard-side-actions">
-    <button class="side-action-btn" (click)="selectAllDetectors()" [disabled]="isLoading || detectors.length === 0" title="Select all detectors" aria-label="Select all">
-      <svg aria-hidden="true" [class.side-action-spin]="spinSelectAllDetectors" (animationend)="onSpinSelectAllDetectorsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-      </svg>
-    </button>
-    <button class="side-action-btn" (click)="selectNoneDetectors()" [disabled]="isLoading || selectedDetectorIds.size === 0" title="Select none" aria-label="Select none">
-      <svg aria-hidden="true" [class.side-action-spin]="spinSelectNoneDetectors" (animationend)="onSpinSelectNoneDetectorsEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-      </svg>
+    <button class="side-action-btn" (click)="toggleAllDetectors()" [disabled]="isLoading || detectors.length === 0" [title]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all detectors'" [attr.aria-label]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="detectorSelectionState === 'all' ? 'true' : detectorSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
+      @switch (detectorSelectionState) {
+        @case ('all') {
+          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+            <rect x="3" y="3" width="18" height="18" rx="2"/>
+          </svg>
+        }
+        @case ('some') {
+          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+            <rect x="3" y="3" width="18" height="18" rx="2"/>
+            <line x1="7" y1="12" x2="17" y2="12" stroke-dasharray="0"/>
+          </svg>
+        }
+        @default {
+          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+            <rect x="3" y="3" width="18" height="18" rx="2"/>
+          </svg>
+        }
+      }
     </button>
     <div class="side-action-gap"></div>
     <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isLoading || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -55,12 +55,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   selectedDetectorIds: Set<string> = new Set();
 
   // Animation flags for the right-side bulk-action column.
-  // Spin flags fire a one-shot 90° rotation on the symmetric select-all/none
-  // squares; the animationend handler clears them so the icon snaps back.
-  spinSelectAllDatasets = false;
-  spinSelectNoneDatasets = false;
-  spinSelectAllDetectors = false;
-  spinSelectNoneDetectors = false;
+  // Spin flags fire a one-shot 90° rotation on the tristate select toggle;
+  // the animationend handler clears them so the icon snaps back.
+  spinDatasetSelectToggle = false;
+  spinDetectorSelectToggle = false;
   // Confirm flags hold the trash icon at 90° while the confirm dialog is up,
   // and play a reverse animation back to 0° once the dialog resolves.
   deletingSelectedDatasetsConfirm = false;
@@ -429,17 +427,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.pushTopBarLabels();
   }
 
-  selectAllDatasets(): void {
-    this.spinSelectAllDatasets = true;
-    for (const d of this.datasets) {
-      this.selectedDatasetIds.add(d.id);
-    }
-    this.pushTopBarLabels();
+  get datasetSelectionState(): 'none' | 'some' | 'all' {
+    const sel = this.selectedDatasetIds.size;
+    if (sel === 0) return 'none';
+    if (sel >= this.datasets.length) return 'all';
+    return 'some';
   }
 
-  selectNoneDatasets(): void {
-    this.spinSelectNoneDatasets = true;
-    this.selectedDatasetIds.clear();
+  toggleAllDatasets(): void {
+    this.spinDatasetSelectToggle = true;
+    if (this.datasetSelectionState === 'all') {
+      this.selectedDatasetIds.clear();
+    } else {
+      for (const d of this.datasets) {
+        this.selectedDatasetIds.add(d.id);
+      }
+    }
     this.pushTopBarLabels();
   }
 
@@ -520,12 +523,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
   }
 
-  onSpinSelectAllDatasetsEnd(): void {
-    this.spinSelectAllDatasets = false;
-  }
-
-  onSpinSelectNoneDatasetsEnd(): void {
-    this.spinSelectNoneDatasets = false;
+  onSpinDatasetSelectToggleEnd(): void {
+    this.spinDatasetSelectToggle = false;
   }
 
   onDeleteSelectedDatasetsAnimationEnd(): void {
@@ -567,17 +566,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.pushTopBarLabels();
   }
 
-  selectAllDetectors(): void {
-    this.spinSelectAllDetectors = true;
-    for (const m of this.detectors) {
-      this.selectedDetectorIds.add(m.id);
-    }
-    this.pushTopBarLabels();
+  get detectorSelectionState(): 'none' | 'some' | 'all' {
+    const sel = this.selectedDetectorIds.size;
+    if (sel === 0) return 'none';
+    if (sel >= this.detectors.length) return 'all';
+    return 'some';
   }
 
-  selectNoneDetectors(): void {
-    this.spinSelectNoneDetectors = true;
-    this.selectedDetectorIds.clear();
+  toggleAllDetectors(): void {
+    this.spinDetectorSelectToggle = true;
+    if (this.detectorSelectionState === 'all') {
+      this.selectedDetectorIds.clear();
+    } else {
+      for (const m of this.detectors) {
+        this.selectedDetectorIds.add(m.id);
+      }
+    }
     this.pushTopBarLabels();
   }
 
@@ -662,12 +666,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     void newName;
   }
 
-  onSpinSelectAllDetectorsEnd(): void {
-    this.spinSelectAllDetectors = false;
-  }
-
-  onSpinSelectNoneDetectorsEnd(): void {
-    this.spinSelectNoneDetectors = false;
+  onSpinDetectorSelectToggleEnd(): void {
+    this.spinDetectorSelectToggle = false;
   }
 
   onDeleteSelectedDetectorsAnimationEnd(): void {


### PR DESCRIPTION
## Summary
- Collapsed the two side-action buttons (Select all + Select none) on each dashboard grid into a single tristate toggle.
- The button renders one of three checkbox icons based on current selection: empty (none), dashed-line through middle (some), filled (all).
- Click toggles between all and none: if everything is selected, clear; otherwise select all. Partial state ("some") arises from row selections.
- Exposes `role="checkbox"` with `aria-checked="false" | "mixed" | "true"` for assistive tech, and the tooltip / aria-label flip between "Select all" and "Deselect all" based on current state.
- The existing 90° spin animation is preserved on click for visual feedback.

## Test plan
- [x] `npm run build:prod` succeeds with no warnings.
- [ ] Manual check: open dashboard, verify dataset grid button cycles correctly through none → all → none, that selecting a single row shows the "mixed" icon, and that clicking from "mixed" selects all.
- [ ] Same manual check for the detector grid.


---
_Generated by [Claude Code](https://claude.ai/code/session_015xnMfWrW7JjxgRU1crwmaw)_