### PR TITLE
demo: add Places365 (S/M/L/A) image demo dataset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ If a failure is genuinely outside the scope of the current task (e.g. a flaky ne
   - `test_export_options.py` — Export boolean options, negative_hits in CLI scoring, fill-from-sort
   - `test_frontend.py` — Frontend serving: Angular SPA entry point, static files (main.js, polyfills.js, styles.css), favicon variants, logo, legacy /ng/ redirect, content types
   - `test_gtzan_download.py` — GTZAN dataset download and load_demo_source integration
-  - `test_image_sources_download.py` — Image dataset downloads: Oxford Flowers 102, Food-101, EuroSAT, Stanford Dogs, and load_demo_source integration
+  - `test_image_sources_download.py` — Image dataset downloads: Oxford Flowers 102, Food-101, EuroSAT, Stanford Dogs, Places365, and load_demo_source integration
   - `test_video_datasets_download.py` — Video dataset downloads (UCF-101 subset) and load_demo_source integration
   - `test_multi_media_coverage.py` — Cross-media-type smoke (text sort, learned sort, vote, label export/import) for each registered media type
   - `test_imdb_download.py` — IMDB dataset download and load_demo_source integration

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -51,6 +51,10 @@ Files are deterministic for a given size and cached under `data/synthetic/<media
 | **stanford_dogs_m** | Fine-grained dog breed photos across Stanford Dogs categories (medium) |
 | **stanford_dogs_l** | Fine-grained dog breed photos across Stanford Dogs categories (large) |
 | **stanford_dogs_a** | Fine-grained dog breed photos across 120 Stanford Dogs categories (all) |
+| **places365_s** | Scene photos across 365 Places365 categories (small) |
+| **places365_m** | Scene photos across 365 Places365 categories (medium) |
+| **places365_l** | Scene photos across 365 Places365 categories (large) |
+| **places365_a** | Scene photos across 365 Places365 categories — indoor, outdoor natural, and outdoor man-made environments (all) |
 | **ucsf_documents_a** | Scanned industry document pages from the UCSF Industry Documents Library — tobacco, food, drug, chemical, fossil fuel, and opioids |
 
 ## Text

--- a/tests/test_image_sources_download.py
+++ b/tests/test_image_sources_download.py
@@ -1,6 +1,6 @@
 """Tests for new image dataset downloads and load_demo_source integration.
 
-Covers: Oxford Flowers 102, Food-101, EuroSAT, Stanford Dogs.
+Covers: Oxford Flowers 102, Food-101, EuroSAT, Stanford Dogs, Places365.
 """
 
 import tarfile
@@ -69,6 +69,21 @@ def _make_eurosat_zip(tmp_path: Path) -> Path:
                 zf.writestr(f"EuroSAT_RGB/{cat}/{cat}_{i:05d}.jpg", b"\xff\xd8\xff\xe0" + b"\x00" * 20)
 
     return zip_path
+
+
+def _make_places365_tar(tmp_path: Path) -> Path:
+    """Create a minimal Places365 val_256 tar fixture."""
+    tar_path = tmp_path / "val_256.tar"
+
+    tree_root = tmp_path / "tar_staging" / "val_256"
+    tree_root.mkdir(parents=True)
+    for i in range(1, 5):
+        (tree_root / f"Places365_val_{i:08d}.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+
+    with tarfile.open(tar_path, "w") as tf:
+        tf.add(tree_root, arcname="val_256")
+
+    return tar_path
 
 
 def _make_stanford_dogs_tar(tmp_path: Path) -> Path:
@@ -606,3 +621,245 @@ class TestLoadDemoSourceStanfordDogs:
                 clips={},
                 on_progress=lambda *a: None,
             )
+
+
+# ---------------------------------------------------------------------------
+# download_places365
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadPlaces365:
+    def test_returns_extract_directory(self, tmp_path):
+        """download_places365 returns the places365/ directory with val_256/ and labels."""
+        from vtsearch.datasets import downloader as dl_module
+
+        tar_path = _make_places365_tar(tmp_path)
+        labels_bytes = b"Places365_val_00000001.jpg 0\nPlaces365_val_00000002.jpg 1\n"
+
+        def fake_download(url, dest, size, cb):
+            if url.endswith("places365_val.txt"):
+                dest.write_bytes(labels_bytes)
+            else:
+                import shutil
+
+                shutil.copy(str(tar_path), str(dest))
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "IMAGE_DIR", tmp_path / "images"),
+            patch.object(dl_module.core, "download_file_with_progress", fake_download),
+        ):
+            result = dl_module.download_places365(on_progress=lambda *a: None)
+
+        assert result.name == "places365"
+        assert (result / "val_256").is_dir()
+        assert (result / "places365_val.txt").read_bytes() == labels_bytes
+        assert any(p.name.startswith("Places365_val_") for p in (result / "val_256").iterdir())
+
+    def test_cached_extraction_skips_download(self, tmp_path):
+        """If val_256/ and the labels file already exist, no download is triggered."""
+        from vtsearch.datasets import downloader as dl_module
+
+        extract_dir = tmp_path / "places365"
+        val_dir = extract_dir / "val_256"
+        val_dir.mkdir(parents=True)
+        (val_dir / "Places365_val_00000001.jpg").write_bytes(b"\xff\xd8")
+        (extract_dir / "places365_val.txt").write_text("Places365_val_00000001.jpg 0\n")
+
+        download_called = []
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "IMAGE_DIR", tmp_path / "images"),
+            patch.object(
+                dl_module,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            result = dl_module.download_places365(on_progress=lambda *a: None)
+
+        assert not download_called
+        assert result.exists()
+
+
+# ---------------------------------------------------------------------------
+# load_places365_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPlaces365Metadata:
+    def test_maps_indices_to_categories(self, tmp_path):
+        """Reads places365_val.txt and maps numeric indices to category names."""
+        from vtsearch.datasets.loader import load_places365_metadata
+
+        val_dir = tmp_path / "val_256"
+        val_dir.mkdir()
+        for i in range(1, 4):
+            (val_dir / f"Places365_val_{i:08d}.jpg").write_bytes(b"\xff\xd8")
+
+        labels_text = "Places365_val_00000001.jpg 0\nPlaces365_val_00000002.jpg 2\nPlaces365_val_00000003.jpg 1\n"
+        (tmp_path / "places365_val.txt").write_text(labels_text)
+
+        categories = ["airfield", "alley", "amphitheater"]
+        metadata = load_places365_metadata(tmp_path, categories)
+
+        assert len(metadata) == 3
+        assert metadata["Places365_val_00000001.jpg"]["category"] == "airfield"
+        assert metadata["Places365_val_00000002.jpg"]["category"] == "amphitheater"
+        assert metadata["Places365_val_00000003.jpg"]["category"] == "alley"
+        assert metadata["Places365_val_00000001.jpg"]["path"] == val_dir / "Places365_val_00000001.jpg"
+
+    def test_out_of_range_indices_are_skipped(self, tmp_path):
+        """Label indices outside the categories list are silently ignored."""
+        from vtsearch.datasets.loader import load_places365_metadata
+
+        (tmp_path / "val_256").mkdir()
+        (tmp_path / "places365_val.txt").write_text(
+            "Places365_val_00000001.jpg 0\n"
+            "Places365_val_00000002.jpg 99\n"  # out of range
+            "Places365_val_00000003.jpg -1\n"  # out of range
+            "Places365_val_00000004.jpg bogus\n"  # unparseable
+        )
+
+        metadata = load_places365_metadata(tmp_path, ["airfield"])
+
+        assert list(metadata) == ["Places365_val_00000001.jpg"]
+
+
+# ---------------------------------------------------------------------------
+# load_demo_source — places365
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDemoSourcePlaces365:
+    """ImageMediaType.load_demo_source with source='places365'."""
+
+    def _make_mock_embedder(self):
+        mock_emb = MagicMock()
+        mock_emb.name = "siglip"
+        mock_emb.media_type_id = "image"
+        mock_emb._model = True
+        mock_emb.embed_media = MagicMock(return_value=np.zeros(768))
+        return mock_emb
+
+    def test_places365_populates_clips(self, tmp_path):
+        """load_demo_source with source='places365' fills the clips dict."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import loader as loader_module
+        from vtsearch.media.image.media_type import ImageMediaType
+
+        (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+        (tmp_path / "img2.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+
+        fake_metadata = {
+            "Places365_val_00000001.jpg": {"category": "airfield", "path": tmp_path / "img1.jpg"},
+            "Places365_val_00000002.jpg": {"category": "beach", "path": tmp_path / "img2.jpg"},
+        }
+
+        mt = ImageMediaType()
+        mock_emb = self._make_mock_embedder()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_places365", return_value=tmp_path),
+            patch.object(loader_module, "load_places365_metadata", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="places365",
+                categories=["airfield", "beach"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+            )
+
+        assert len(clips) == 2
+        categories_seen = {c["category"] for c in clips.values()}
+        assert categories_seen == {"airfield", "beach"}
+
+    def test_places365_filters_by_requested_categories(self, tmp_path):
+        """Metadata entries whose category is not requested are dropped."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import loader as loader_module
+        from vtsearch.media.image.media_type import ImageMediaType
+
+        (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+        (tmp_path / "img2.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+
+        fake_metadata = {
+            "Places365_val_00000001.jpg": {"category": "airfield", "path": tmp_path / "img1.jpg"},
+            "Places365_val_00000002.jpg": {"category": "beach", "path": tmp_path / "img2.jpg"},
+        }
+
+        mt = ImageMediaType()
+        mock_emb = self._make_mock_embedder()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_places365", return_value=tmp_path),
+            patch.object(loader_module, "load_places365_metadata", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="places365",
+                categories=["airfield"],
+                slice_start=0,
+                slice_end=10,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+            )
+
+        assert len(clips) == 1
+        assert next(iter(clips.values()))["category"] == "airfield"
+
+    def test_places365_slice_is_applied(self, tmp_path):
+        """slice_start/slice_end limits images per category."""
+        from vtsearch.datasets import downloader as dl_module
+        from vtsearch.datasets import loader as loader_module
+        from vtsearch.media.image.media_type import ImageMediaType
+
+        fake_metadata = {}
+        for i in range(10):
+            p = tmp_path / f"img_{i}.jpg"
+            p.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
+            fake_metadata[f"Places365_val_{i + 1:08d}.jpg"] = {"category": "airfield", "path": p}
+
+        mt = ImageMediaType()
+        mock_emb = self._make_mock_embedder()
+        clips: dict = {}
+
+        with (
+            patch.object(dl_module, "download_places365", return_value=tmp_path),
+            patch.object(loader_module, "load_places365_metadata", return_value=fake_metadata),
+        ):
+            mt.load_demo_source(
+                source="places365",
+                categories=["airfield"],
+                slice_start=2,
+                slice_end=5,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=mock_emb,
+            )
+
+        assert len(clips) == 3
+
+
+class TestPlaces365CategoriesList:
+    """The hardcoded ``_PLACES365_CATEGORIES`` matches the upstream label space."""
+
+    def test_has_365_unique_entries(self):
+        from vtsearch.media.image.media_type import ImageMediaType
+
+        cats = ImageMediaType._PLACES365_CATEGORIES
+        assert len(cats) == 365
+        assert len(set(cats)) == 365
+        # Spot-check entries near the index that previously had an off-by-one
+        # error (swimming_pool/indoor vs swimming_pool/outdoor).
+        assert cats[324] == "swimming_hole"
+        assert cats[325] == "swimming_pool_indoor"
+        assert cats[326] == "swimming_pool_outdoor"
+        assert cats[0] == "airfield"
+        assert cats[364] == "zen_garden"

--- a/vtsearch/datasets/__init__.py
+++ b/vtsearch/datasets/__init__.py
@@ -22,6 +22,7 @@ from vtsearch.datasets.metadata import (
     load_esc50_metadata,
     load_image_metadata_from_folders,
     load_paragraph_metadata_from_folders,
+    load_places365_metadata,
     load_video_metadata_from_folders,
 )
 from vtsearch.datasets.origin import Origin
@@ -50,6 +51,7 @@ __all__ = [
     "load_video_metadata_from_folders",
     "load_image_metadata_from_folders",
     "load_paragraph_metadata_from_folders",
+    "load_places365_metadata",
     "load_dataset_from_folder",
     "load_dataset_from_pickle",
     "load_demo_dataset",

--- a/vtsearch/datasets/downloader/__init__.py
+++ b/vtsearch/datasets/downloader/__init__.py
@@ -7,7 +7,7 @@ This package is split into sub-modules by media type:
 - :mod:`~vtsearch.datasets.downloader.audio` — ESC-50, GTZAN, Speech Commands v2,
   UrbanSound8K
 - :mod:`~vtsearch.datasets.downloader.images` — CIFAR-10, Caltech-101/256, Oxford
-  Flowers, Food-101, EuroSAT, Stanford Dogs
+  Flowers, Food-101, EuroSAT, Stanford Dogs, Places365
 - :mod:`~vtsearch.datasets.downloader.video` — UCF-101 subset
 - :mod:`~vtsearch.datasets.downloader.text` — 20 Newsgroups, BBC News, AG News, IMDB
 - :mod:`~vtsearch.datasets.downloader.documents` — UCSF Industry Documents
@@ -47,6 +47,9 @@ from vtsearch.datasets.downloader.core import (
     OXFORD_FLOWERS_DOWNLOAD_SIZE_MB,
     OXFORD_FLOWERS_LABELS_URL,
     OXFORD_FLOWERS_URL,
+    PLACES365_DOWNLOAD_SIZE_MB,
+    PLACES365_LABELS_URL,
+    PLACES365_URL,
     SAMPLE_VIDEOS_URL,
     SPEECH_COMMANDS_V2_DOWNLOAD_SIZE_MB,
     SPEECH_COMMANDS_V2_URL,
@@ -86,6 +89,7 @@ from vtsearch.datasets.downloader.images import (
     download_eurosat,
     download_food101,
     download_oxford_flowers,
+    download_places365,
     download_stanford_dogs,
 )
 
@@ -145,6 +149,9 @@ __all__ = [
     "OXFORD_FLOWERS_DOWNLOAD_SIZE_MB",
     "OXFORD_FLOWERS_LABELS_URL",
     "OXFORD_FLOWERS_URL",
+    "PLACES365_DOWNLOAD_SIZE_MB",
+    "PLACES365_LABELS_URL",
+    "PLACES365_URL",
     "ProgressCallback",
     "SAMPLE_VIDEOS_URL",
     "SPEECH_COMMANDS_V2_DOWNLOAD_SIZE_MB",
@@ -174,6 +181,7 @@ __all__ = [
     "download_eurosat",
     "download_food101",
     "download_oxford_flowers",
+    "download_places365",
     "download_stanford_dogs",
     # Video
     "download_hmdb51",

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -45,6 +45,8 @@ OXFORD_FLOWERS_LABELS_URL = "https://www.robots.ox.ac.uk/~vgg/data/flowers/102/i
 FOOD101_URL = "http://data.vision.ee.ethz.ch/cvl/food-101.tar.gz"
 EUROSAT_URL = "https://zenodo.org/records/7711810/files/EuroSAT_RGB.zip"
 STANFORD_DOGS_URL = "https://huggingface.co/datasets/Alanox/stanford-dogs/resolve/main/images.tar.gz"
+PLACES365_URL = "http://data.csail.mit.edu/places/places365/val_256.tar"
+PLACES365_LABELS_URL = "https://raw.githubusercontent.com/CSAILVision/places365/master/places365_val.txt"
 UCSF_IDL_API_URL = "https://metadata.idl.ucsf.edu/solr/ltdl3/query"
 UCSF_IDL_DOWNLOAD_URL = "https://download.industrydocuments.ucsf.edu"
 
@@ -75,6 +77,7 @@ OXFORD_FLOWERS_DOWNLOAD_SIZE_MB = 330
 FOOD101_DOWNLOAD_SIZE_MB = 5000
 EUROSAT_DOWNLOAD_SIZE_MB = 90
 STANFORD_DOGS_DOWNLOAD_SIZE_MB = 750
+PLACES365_DOWNLOAD_SIZE_MB = 501
 UCSF_IDL_DOWNLOAD_SIZE_MB = 50
 HMDB51_DOWNLOAD_SIZE_MB = 2000
 UCF101_FULL_DOWNLOAD_SIZE_MB = 6960

--- a/vtsearch/datasets/downloader/images.py
+++ b/vtsearch/datasets/downloader/images.py
@@ -1,4 +1,4 @@
-"""Image dataset downloaders: CIFAR-10, Caltech-101/256, Oxford Flowers, Food-101, EuroSAT, Stanford Dogs."""
+"""Image dataset downloaders: CIFAR-10, Caltech-101/256, Oxford Flowers, Food-101, EuroSAT, Stanford Dogs, Places365."""
 
 import os
 import shutil
@@ -334,3 +334,55 @@ def download_stanford_dogs(on_progress: Optional[ProgressCallback] = None) -> Pa
         on_progress=on_progress,
     )
     return images_dir
+
+
+def download_places365(on_progress: Optional[ProgressCallback] = None) -> Path:
+    """Download and extract the Places365 validation set.
+
+    Downloads ``val_256.tar`` (the 256x256 validation split, ~501 MB) from the
+    MIT CSAIL Places2 server into ``DATA_DIR`` if it is not already present,
+    then extracts it.  The archive is deleted after extraction to reclaim
+    disk space.  The per-image label file ``places365_val.txt`` is also
+    fetched from the CSAILVision GitHub repository so that downstream code
+    can map each image filename to a scene category index.
+
+    The validation set contains 36 500 images across 365 scene categories
+    (100 images per category).  Images are stored in a single flat
+    ``val_256/`` directory with names like ``Places365_val_00000001.jpg``.
+
+    Args:
+        on_progress: Optional progress callback.  Falls back to the
+            application-wide ``update_progress`` when ``None``.
+
+    Returns:
+        Path to the ``places365/`` directory containing ``val_256/`` (the
+        flat image folder) and ``places365_val.txt`` (the label mapping
+        file).
+    """
+    if on_progress is None:
+        on_progress = _core._default_progress()
+
+    _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
+
+    extract_dir = _core.DATA_DIR / "places365"
+    _core._download_and_extract(
+        url=_core.PLACES365_URL,
+        archive_name="val_256.tar",
+        extract_to=extract_dir,
+        check_path=extract_dir / "val_256",
+        download_size_mb=_core.PLACES365_DOWNLOAD_SIZE_MB,
+        dataset_name="Places365",
+        on_progress=on_progress,
+    )
+
+    # Download the per-image label file if not present.  It is a small
+    # text file (~1 MB) listing one "<filename> <category_index>" pair per
+    # validation image.
+    labels_path = extract_dir / "places365_val.txt"
+    if not labels_path.exists():
+        _core.DATA_DIR.mkdir(exist_ok=True)
+        extract_dir.mkdir(exist_ok=True, parents=True)
+        on_progress("downloading", "Downloading Places365 labels...", 0, 0)
+        _core.download_file_with_progress(_core.PLACES365_LABELS_URL, labels_path, 1024 * 1024, on_progress)
+
+    return extract_dir

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -35,6 +35,7 @@ from vtsearch.datasets.metadata import (  # noqa: F401  — re-exported for cons
     load_image_metadata_from_folders,
     load_oxford_flowers_metadata,
     load_paragraph_metadata_from_folders,
+    load_places365_metadata,
     load_urbansound8k_metadata,
     load_video_metadata_from_folders,
 )

--- a/vtsearch/datasets/metadata.py
+++ b/vtsearch/datasets/metadata.py
@@ -174,6 +174,52 @@ def load_oxford_flowers_metadata(flowers_dir: Path, categories: list[str]) -> di
     return metadata
 
 
+def load_places365_metadata(places_dir: Path, categories: list[str]) -> dict[str, dict[str, Any]]:
+    """Load metadata for the Places365 validation set.
+
+    Reads the ``places365_val.txt`` label file and maps each image filename
+    to a scene category name via the integer index into ``categories``.
+    Images live in a flat ``val_256/`` directory with names like
+    ``Places365_val_00000001.jpg``.
+
+    Args:
+        places_dir: Path to the root Places365 directory (contains
+            ``val_256/`` and ``places365_val.txt``).
+        categories: Ordered list of 365 scene category names (index 0
+            corresponds to category index 0 in the label file).
+
+    Returns:
+        A dict mapping image filename to a dict with the keys:
+
+        - ``"category"`` (``str``): Scene category name from *categories*.
+        - ``"path"`` (``Path``): Full path to the image file.
+    """
+    labels_path = places_dir / "places365_val.txt"
+    images_dir = places_dir / "val_256"
+    metadata: dict[str, dict[str, Any]] = {}
+
+    with open(labels_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            fname, _, idx_str = line.rpartition(" ")
+            if not fname:
+                continue
+            try:
+                idx = int(idx_str)
+            except ValueError:
+                continue
+            if idx < 0 or idx >= len(categories):
+                continue
+            metadata[fname] = {
+                "category": categories[idx],
+                "path": images_dir / fname,
+            }
+
+    return metadata
+
+
 def load_cifar10_batch(file_path: Path) -> tuple[np.ndarray, list[int], list[str]]:
     """Load a CIFAR-10 pickle batch file and return images, labels, and label names.
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -24,6 +24,400 @@ _IMAGE_MIME_TYPES: dict[str, str] = {
 }
 
 
+# Raw Places365 category list, copied verbatim from
+# https://github.com/CSAILVision/places365/blob/master/categories_places365.txt
+# Each line is "<path> <index>" where <path> is "/<letter>/<name>" with an
+# optional subcategory.  The list is ordered by index 0..364 so a simple
+# splitlines() yields the categories in label-index order.
+_PLACES365_CATEGORIES_RAW = """\
+/a/airfield 0
+/a/airplane_cabin 1
+/a/airport_terminal 2
+/a/alcove 3
+/a/alley 4
+/a/amphitheater 5
+/a/amusement_arcade 6
+/a/amusement_park 7
+/a/apartment_building/outdoor 8
+/a/aquarium 9
+/a/aqueduct 10
+/a/arcade 11
+/a/arch 12
+/a/archaelogical_excavation 13
+/a/archive 14
+/a/arena/hockey 15
+/a/arena/performance 16
+/a/arena/rodeo 17
+/a/army_base 18
+/a/art_gallery 19
+/a/art_school 20
+/a/art_studio 21
+/a/artists_loft 22
+/a/assembly_line 23
+/a/athletic_field/outdoor 24
+/a/atrium/public 25
+/a/attic 26
+/a/auditorium 27
+/a/auto_factory 28
+/a/auto_showroom 29
+/b/badlands 30
+/b/bakery/shop 31
+/b/balcony/exterior 32
+/b/balcony/interior 33
+/b/ball_pit 34
+/b/ballroom 35
+/b/bamboo_forest 36
+/b/bank_vault 37
+/b/banquet_hall 38
+/b/bar 39
+/b/barn 40
+/b/barndoor 41
+/b/baseball_field 42
+/b/basement 43
+/b/basketball_court/indoor 44
+/b/bathroom 45
+/b/bazaar/indoor 46
+/b/bazaar/outdoor 47
+/b/beach 48
+/b/beach_house 49
+/b/beauty_salon 50
+/b/bedchamber 51
+/b/bedroom 52
+/b/beer_garden 53
+/b/beer_hall 54
+/b/berth 55
+/b/biology_laboratory 56
+/b/boardwalk 57
+/b/boat_deck 58
+/b/boathouse 59
+/b/bookstore 60
+/b/booth/indoor 61
+/b/botanical_garden 62
+/b/bow_window/indoor 63
+/b/bowling_alley 64
+/b/boxing_ring 65
+/b/bridge 66
+/b/building_facade 67
+/b/bullring 68
+/b/burial_chamber 69
+/b/bus_interior 70
+/b/bus_station/indoor 71
+/b/butchers_shop 72
+/b/butte 73
+/c/cabin/outdoor 74
+/c/cafeteria 75
+/c/campsite 76
+/c/campus 77
+/c/canal/natural 78
+/c/canal/urban 79
+/c/candy_store 80
+/c/canyon 81
+/c/car_interior 82
+/c/carrousel 83
+/c/castle 84
+/c/catacomb 85
+/c/cemetery 86
+/c/chalet 87
+/c/chemistry_lab 88
+/c/childs_room 89
+/c/church/indoor 90
+/c/church/outdoor 91
+/c/classroom 92
+/c/clean_room 93
+/c/cliff 94
+/c/closet 95
+/c/clothing_store 96
+/c/coast 97
+/c/cockpit 98
+/c/coffee_shop 99
+/c/computer_room 100
+/c/conference_center 101
+/c/conference_room 102
+/c/construction_site 103
+/c/corn_field 104
+/c/corral 105
+/c/corridor 106
+/c/cottage 107
+/c/courthouse 108
+/c/courtyard 109
+/c/creek 110
+/c/crevasse 111
+/c/crosswalk 112
+/d/dam 113
+/d/delicatessen 114
+/d/department_store 115
+/d/desert/sand 116
+/d/desert/vegetation 117
+/d/desert_road 118
+/d/diner/outdoor 119
+/d/dining_hall 120
+/d/dining_room 121
+/d/discotheque 122
+/d/doorway/outdoor 123
+/d/dorm_room 124
+/d/downtown 125
+/d/dressing_room 126
+/d/driveway 127
+/d/drugstore 128
+/e/elevator/door 129
+/e/elevator_lobby 130
+/e/elevator_shaft 131
+/e/embassy 132
+/e/engine_room 133
+/e/entrance_hall 134
+/e/escalator/indoor 135
+/e/excavation 136
+/f/fabric_store 137
+/f/farm 138
+/f/fastfood_restaurant 139
+/f/field/cultivated 140
+/f/field/wild 141
+/f/field_road 142
+/f/fire_escape 143
+/f/fire_station 144
+/f/fishpond 145
+/f/flea_market/indoor 146
+/f/florist_shop/indoor 147
+/f/food_court 148
+/f/football_field 149
+/f/forest/broadleaf 150
+/f/forest_path 151
+/f/forest_road 152
+/f/formal_garden 153
+/f/fountain 154
+/g/galley 155
+/g/garage/indoor 156
+/g/garage/outdoor 157
+/g/gas_station 158
+/g/gazebo/exterior 159
+/g/general_store/indoor 160
+/g/general_store/outdoor 161
+/g/gift_shop 162
+/g/glacier 163
+/g/golf_course 164
+/g/greenhouse/indoor 165
+/g/greenhouse/outdoor 166
+/g/grotto 167
+/g/gymnasium/indoor 168
+/h/hangar/indoor 169
+/h/hangar/outdoor 170
+/h/harbor 171
+/h/hardware_store 172
+/h/hayfield 173
+/h/heliport 174
+/h/highway 175
+/h/home_office 176
+/h/home_theater 177
+/h/hospital 178
+/h/hospital_room 179
+/h/hot_spring 180
+/h/hotel/outdoor 181
+/h/hotel_room 182
+/h/house 183
+/h/hunting_lodge/outdoor 184
+/i/ice_cream_parlor 185
+/i/ice_floe 186
+/i/ice_shelf 187
+/i/ice_skating_rink/indoor 188
+/i/ice_skating_rink/outdoor 189
+/i/iceberg 190
+/i/igloo 191
+/i/industrial_area 192
+/i/inn/outdoor 193
+/i/islet 194
+/j/jacuzzi/indoor 195
+/j/jail_cell 196
+/j/japanese_garden 197
+/j/jewelry_shop 198
+/j/junkyard 199
+/k/kasbah 200
+/k/kennel/outdoor 201
+/k/kindergarden_classroom 202
+/k/kitchen 203
+/l/lagoon 204
+/l/lake/natural 205
+/l/landfill 206
+/l/landing_deck 207
+/l/laundromat 208
+/l/lawn 209
+/l/lecture_room 210
+/l/legislative_chamber 211
+/l/library/indoor 212
+/l/library/outdoor 213
+/l/lighthouse 214
+/l/living_room 215
+/l/loading_dock 216
+/l/lobby 217
+/l/lock_chamber 218
+/l/locker_room 219
+/m/mansion 220
+/m/manufactured_home 221
+/m/market/indoor 222
+/m/market/outdoor 223
+/m/marsh 224
+/m/martial_arts_gym 225
+/m/mausoleum 226
+/m/medina 227
+/m/mezzanine 228
+/m/moat/water 229
+/m/mosque/outdoor 230
+/m/motel 231
+/m/mountain 232
+/m/mountain_path 233
+/m/mountain_snowy 234
+/m/movie_theater/indoor 235
+/m/museum/indoor 236
+/m/museum/outdoor 237
+/m/music_studio 238
+/n/natural_history_museum 239
+/n/nursery 240
+/n/nursing_home 241
+/o/oast_house 242
+/o/ocean 243
+/o/office 244
+/o/office_building 245
+/o/office_cubicles 246
+/o/oilrig 247
+/o/operating_room 248
+/o/orchard 249
+/o/orchestra_pit 250
+/p/pagoda 251
+/p/palace 252
+/p/pantry 253
+/p/park 254
+/p/parking_garage/indoor 255
+/p/parking_garage/outdoor 256
+/p/parking_lot 257
+/p/pasture 258
+/p/patio 259
+/p/pavilion 260
+/p/pet_shop 261
+/p/pharmacy 262
+/p/phone_booth 263
+/p/physics_laboratory 264
+/p/picnic_area 265
+/p/pier 266
+/p/pizzeria 267
+/p/playground 268
+/p/playroom 269
+/p/plaza 270
+/p/pond 271
+/p/porch 272
+/p/promenade 273
+/p/pub/indoor 274
+/r/racecourse 275
+/r/raceway 276
+/r/raft 277
+/r/railroad_track 278
+/r/rainforest 279
+/r/reception 280
+/r/recreation_room 281
+/r/repair_shop 282
+/r/residential_neighborhood 283
+/r/restaurant 284
+/r/restaurant_kitchen 285
+/r/restaurant_patio 286
+/r/rice_paddy 287
+/r/river 288
+/r/rock_arch 289
+/r/roof_garden 290
+/r/rope_bridge 291
+/r/ruin 292
+/r/runway 293
+/s/sandbox 294
+/s/sauna 295
+/s/schoolhouse 296
+/s/science_museum 297
+/s/server_room 298
+/s/shed 299
+/s/shoe_shop 300
+/s/shopfront 301
+/s/shopping_mall/indoor 302
+/s/shower 303
+/s/ski_resort 304
+/s/ski_slope 305
+/s/sky 306
+/s/skyscraper 307
+/s/slum 308
+/s/snowfield 309
+/s/soccer_field 310
+/s/stable 311
+/s/stadium/baseball 312
+/s/stadium/football 313
+/s/stadium/soccer 314
+/s/stage/indoor 315
+/s/stage/outdoor 316
+/s/staircase 317
+/s/storage_room 318
+/s/street 319
+/s/subway_station/platform 320
+/s/supermarket 321
+/s/sushi_bar 322
+/s/swamp 323
+/s/swimming_hole 324
+/s/swimming_pool/indoor 325
+/s/swimming_pool/outdoor 326
+/s/synagogue/outdoor 327
+/t/television_room 328
+/t/television_studio 329
+/t/temple/asia 330
+/t/throne_room 331
+/t/ticket_booth 332
+/t/topiary_garden 333
+/t/tower 334
+/t/toyshop 335
+/t/train_interior 336
+/t/train_station/platform 337
+/t/tree_farm 338
+/t/tree_house 339
+/t/trench 340
+/t/tundra 341
+/u/underwater/ocean_deep 342
+/u/utility_room 343
+/v/valley 344
+/v/vegetable_garden 345
+/v/veterinarians_office 346
+/v/viaduct 347
+/v/village 348
+/v/vineyard 349
+/v/volcano 350
+/v/volleyball_court/outdoor 351
+/w/waiting_room 352
+/w/water_park 353
+/w/water_tower 354
+/w/waterfall 355
+/w/watering_hole 356
+/w/wave 357
+/w/wet_bar 358
+/w/wheat_field 359
+/w/wind_farm 360
+/w/windmill 361
+/y/yard 362
+/y/youth_hostel 363
+/z/zen_garden 364
+"""
+
+
+def _parse_places365_categories(raw: str) -> list[str]:
+    """Convert raw Places365 category lines into a flat name list.
+
+    Each input line is ``"<path> <index>"`` (e.g. ``"/b/bakery/shop 31"``).
+    The leading ``/<letter>/`` prefix is stripped and remaining ``/`` are
+    replaced with ``_`` so the result is a flat, filesystem-friendly name
+    (``bakery_shop``).  Lines are kept in their original order so the list
+    is indexable by the integer label from ``places365_val.txt``.
+    """
+    out: list[str] = []
+    for line in raw.strip().splitlines():
+        path = line.rsplit(" ", 1)[0]
+        cleaned = path.split("/", 2)[2].replace("/", "_")
+        out.append(cleaned)
+    return out
+
+
+_PLACES365_CATEGORIES_LIST = _parse_places365_categories(_PLACES365_CATEGORIES_RAW)
+
+
 class ImageMediaType(MediaType):
     """Handles image medias — file import, HTTP serving, and demo datasets.
 
@@ -513,6 +907,10 @@ class ImageMediaType(MediaType):
         "Opioids",
     ]
 
+    # Built from the canonical 365-line categories file at module load time
+    # (see ``_PLACES365_CATEGORIES_RAW`` near the top of this module).
+    _PLACES365_CATEGORIES = _PLACES365_CATEGORIES_LIST
+
     @property
     def demo_datasets(self) -> list:
         from vtsearch.datasets.downloader import (  # noqa: PLC0415
@@ -521,6 +919,7 @@ class ImageMediaType(MediaType):
             EUROSAT_DOWNLOAD_SIZE_MB,
             FOOD101_DOWNLOAD_SIZE_MB,
             OXFORD_FLOWERS_DOWNLOAD_SIZE_MB,
+            PLACES365_DOWNLOAD_SIZE_MB,
             STANFORD_DOGS_DOWNLOAD_SIZE_MB,
             UCSF_IDL_DOWNLOAD_SIZE_MB,
         )
@@ -535,6 +934,8 @@ class ImageMediaType(MediaType):
         euro_folder = DATA_DIR / "EuroSAT_RGB"
         dogs_desc = "Fine-grained dog breeds with many visually similar classes."
         dogs_folder = DATA_DIR / "stanford_dogs" / "Images"
+        places_desc = "Scene photos spanning indoor, outdoor natural, and outdoor man-made environments."
+        places_folder = DATA_DIR / "places365" / "val_256"
         return [
             DemoDataset(
                 id="caltech101_s",
@@ -753,6 +1154,54 @@ class ImageMediaType(MediaType):
                 download_size_mb=STANFORD_DOGS_DOWNLOAD_SIZE_MB,
             ),
             DemoDataset(
+                id="places365_s",
+                label="Places365 (S)",
+                description=places_desc,
+                categories=self._PLACES365_CATEGORIES,
+                source="places365",
+                required_folder=places_folder,
+                slice_frac_start=0.0,
+                slice_frac_end=1 / 7,
+                items_per_category=100,
+                download_size_mb=PLACES365_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="places365_m",
+                label="Places365 (M)",
+                description=places_desc,
+                categories=self._PLACES365_CATEGORIES,
+                source="places365",
+                required_folder=places_folder,
+                slice_frac_start=1 / 7,
+                slice_frac_end=3 / 7,
+                items_per_category=100,
+                download_size_mb=PLACES365_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="places365_l",
+                label="Places365 (L)",
+                description=places_desc,
+                categories=self._PLACES365_CATEGORIES,
+                source="places365",
+                required_folder=places_folder,
+                slice_frac_start=3 / 7,
+                slice_frac_end=None,
+                items_per_category=100,
+                download_size_mb=PLACES365_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
+                id="places365_a",
+                label="Places365 (A)",
+                description=places_desc,
+                categories=self._PLACES365_CATEGORIES,
+                source="places365",
+                required_folder=places_folder,
+                slice_frac_start=0.0,
+                slice_frac_end=None,
+                items_per_category=100,
+                download_size_mb=PLACES365_DOWNLOAD_SIZE_MB,
+            ),
+            DemoDataset(
                 id="ucsf_documents_a",
                 label="UCSF Documents (A)",
                 description="Scanned pages from the UCSF Industry Documents Library.",
@@ -965,6 +1414,34 @@ class ImageMediaType(MediaType):
                         by_cat.setdefault(cat, []).append((img_path, cat))
 
             selected = []
+            for cat in categories:
+                selected.extend(
+                    demo_slice(
+                        by_cat.get(cat, []),
+                        slice_start,
+                        slice_end,
+                        slice_frac_start,
+                        slice_frac_end,
+                    )
+                )
+
+            _embed_file_images(selected)
+            return None
+
+        elif source == "places365":
+            from vtsearch.datasets.downloader import download_places365  # noqa: PLC0415
+            from vtsearch.datasets.loader import load_places365_metadata  # noqa: PLC0415
+
+            places_dir = download_places365(on_progress=on_progress)
+            metadata = load_places365_metadata(places_dir, self._PLACES365_CATEGORIES)
+
+            by_cat: dict[str, list[tuple[Path, str]]] = {}
+            for _fname, meta in sorted(metadata.items()):
+                cat = meta["category"]
+                if cat in categories:
+                    by_cat.setdefault(cat, []).append((meta["path"], cat))
+
+            selected: list[tuple[Path, str]] = []
             for cat in categories:
                 selected.extend(
                     demo_slice(


### PR DESCRIPTION
## Summary
- Adds Places365 as a new image demo dataset with the standard S/M/L/A sizing variants.
- Downloader pulls the official MIT validation split (`val_256.tar`, ~501 MB, 36 500 images / 365 scene categories) plus the per-image label file from the `CSAILVision/places365` repo.
- The 365-entry category list is parsed from the canonical `categories_places365.txt` format at module load time so the index space stays in lockstep with upstream (no hand-maintained list to drift).
- New tests mirror the existing `test_image_sources_download.py` pattern: download/cache, metadata loader, `load_demo_source` clip population + category filtering + slicing, plus a structural check on the 365-entry category list.

## Test plan
- [x] `ruff check` + `ruff format --check` on touched files
- [x] `./run-tests.sh downloads -- -k "places365 or image_sources"` — 24 passed
- [x] `./run-tests.sh datasets` — 480 passed, 2 skipped
- [x] `./run-tests.sh` (full suite) — 3136 passed, 1 skipped, 2 xpassed

https://claude.ai/code/session_01YFc2DWKYHeNtdvNfhErg8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFc2DWKYHeNtdvNfhErg8M)_