### PR TITLE
docker(image-embedders): add torchvision and fix gated-model RUN steps

### DIFF
--- a/Dockerfile.image-embedders
+++ b/Dockerfile.image-embedders
@@ -146,21 +146,21 @@ print('DINOv2 weights cached.', flush=True)"
 
 # DINOv3 (gated). The COPY above seeded $VTSEARCH_MODELS_DIR from the
 # host's ./model_cache/. ``local_files_only=True`` makes this RUN succeed
-# whenever the cache script populated the weights, and fail loudly only
+# whenever the cache script populated the weights, and fail with OSError
 # when the user did neither ran the cache script nor accepted that
-# DINOv3 will be unavailable. We swallow the failure so the build still
-# produces a usable image with the other five embedders.
+# DINOv3 will be unavailable. The `|| echo` swallows that failure at the
+# shell level so the build still produces a usable image with the other
+# five embedders — we can't use Python try/except here because the body
+# is a single ``python -c`` line and try/except is a compound statement
+# that can't be flattened with semicolons.
 RUN python -u -c "import os; \
 from vtsearch.config import DINOV3_MODEL_ID; \
 cache=os.environ['VTSEARCH_MODELS_DIR']; \
-try: \
-    from transformers import AutoModel, AutoImageProcessor; \
-    AutoModel.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache, local_files_only=True); \
-    AutoImageProcessor.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache, local_files_only=True); \
-    print('DINOv3 weights loaded from local cache.', flush=True); \
-except Exception as exc: \
-    print(f'DINOv3 not in local cache ({exc.__class__.__name__}); skipping. ' \
-          'Run scripts/cache_gated_models.sh on the host to enable DINOv3.', flush=True)"
+from transformers import AutoModel, AutoImageProcessor; \
+AutoModel.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache, local_files_only=True); \
+AutoImageProcessor.from_pretrained(DINOV3_MODEL_ID, cache_dir=cache, local_files_only=True); \
+print('DINOv3 weights loaded from local cache.', flush=True)" \
+    || echo "DINOv3 not in local cache; skipping. Run scripts/cache_gated_models.sh on the host to enable DINOv3."
 
 # EUPE (facebookresearch/EUPE, ViT-B/16). Loads via torch.hub: a cloned
 # GitHub repo plus a downloaded .pt weights file, both under
@@ -172,15 +172,11 @@ except Exception as exc: \
 ENV TORCH_HOME=${VTSEARCH_MODELS_DIR}
 RUN python -u -c "import os; \
 from vtsearch.config import EUPE_MODEL_ID; \
-try: \
-    import torch; \
-    torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', source='github', \
-                   pretrained=True, weights=EUPE_MODEL_ID, trust_repo=True); \
-    print('EUPE weights cached via torch.hub.', flush=True); \
-except Exception as exc: \
-    print(f'EUPE not cached ({exc.__class__.__name__}: {exc}); skipping. ' \
-          'Run scripts/cache_gated_models.sh on the host to enable EUPE ' \
-          'in offline builds.', flush=True)"
+import torch; \
+torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', source='github', \
+               pretrained=True, weights=EUPE_MODEL_ID, trust_repo=True); \
+print('EUPE weights cached via torch.hub.', flush=True)" \
+    || echo "EUPE not cached; skipping. Run scripts/cache_gated_models.sh on the host to enable EUPE in offline builds."
 
 # ---------- application layer ----------
 COPY . .

--- a/requirements-image-embedders.txt
+++ b/requirements-image-embedders.txt
@@ -31,6 +31,11 @@ scipy
 # ── PyTorch (CPU) ────────────────────────────────────────────────────
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.0.0
+# DINOv2 / DINOv3 use `AutoImageProcessor`, which transformers loads via
+# the torchvision backend (`use_fast=True` default in recent releases).
+# Without torchvision the processor import raises ImportError at build
+# time, so install the matching CPU wheel.
+torchvision
 
 # ── Image media type ─────────────────────────────────────────────────
 Pillow


### PR DESCRIPTION
## Summary

Fixes two distinct issues in `Dockerfile.image-embedders` that broke the build.

### 1. `AutoImageProcessor requires the Torchvision library`

The DINOv2 pre-download step failed because `transformers.AutoImageProcessor` now loads its fast (torchvision-backed) variant by default, but `requirements-image-embedders.txt` only installed `torch` — not `torchvision`. Added the matching CPU wheel.

### 2. SyntaxError (then OSError) on the DINOv3 step

The DINOv3 and EUPE RUN steps wrapped their pre-download logic in an inline Python `try` / `except`, but the body was a single `python -c "…"` invocation with backslash-continued lines. The shell joins those lines into a single Python line, and `try:` / `except:` are compound statements — they can't be flattened with `;`, so Python raises SyntaxError without a useful pinpoint.

Once the try/except was removed, the underlying `local_files_only=True` call raised OSError when the host hadn't run `scripts/cache_gated_models.sh`. That's exactly the case the try/except was meant to tolerate.

Moved the "swallow failure" behavior to the shell with `|| echo …` so a missing host-side `model_cache/` no longer breaks the build. The image still ships with SigLIP / SigLIP 2 / CLIP / DINOv2, and DINOv3 / EUPE become available once the user runs the cache script and rebuilds. Applied the same fix to the EUPE step, which had the identical bug a few lines later.

## Test plan

- [ ] `docker build -f Dockerfile.image-embedders -t vtsearch:image-embedders .` succeeds with an empty `model_cache/` (DINOv3 + EUPE log a skip message instead of failing).
- [ ] `docker build -f Dockerfile.image-embedders -t vtsearch:image-embedders .` after running `scripts/cache_gated_models.sh` actually bakes in DINOv3 + EUPE.
- [ ] DINOv2 step now completes (torchvision is present).


---
_Generated by [Claude Code](https://claude.ai/code/session_011pPcUhhpqhQtV1vuhrAxKD)_