### PR TITLE
test(docker): catch SyntaxErrors in embedded python -c blocks + add import canary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ If a failure is genuinely outside the scope of the current task (e.g. a flaky ne
   - `test_api_contracts.py` — API response shape verification: status codes, content types, required keys, error format consistency
   - `test_ssrf_validation.py` — SSRF URL validation: blocking private/internal network addresses, public URL allowlisting, integration with HTTP archive importer and webhook exporter
   - `test_path_validation.py` — Server file-path validation: path traversal prevention
+  - `test_dockerfile_syntax.py` — Static syntax check for Python embedded in `python -c "..."` blocks inside every `Dockerfile*`. Catches SyntaxErrors (e.g. compound statements flattened with semicolons) without invoking `docker build`.
   - `test_audio.py` — WAV generation
   - `test_medias.py` — Media init, listing, audio endpoint, MD5
   - `test_votes.py` — Voting and vote retrieval

--- a/Dockerfile.image-embedders
+++ b/Dockerfile.image-embedders
@@ -83,6 +83,26 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
         -r requirements-image-embedders.txt && \
     pip install --no-cache-dir --no-deps -e .
 
+# ---------- import-only canary -------------------------------------------
+# Fail fast (in seconds) if any transformers class used in the
+# pre-download blocks below would hit ImportError once we call
+# ``.from_pretrained``. Transformers loads optional backends lazily via
+# ``requires_backends``, so touching ``.from_pretrained`` on each class
+# is what triggers the check — `from transformers import X` alone only
+# returns a placeholder. Adding new pre-download blocks below? Add the
+# class here too. (See PR #1282 for the bug this guards against:
+# AutoImageProcessor required torchvision but the requirements file
+# didn't pull it in, and the failure only surfaced minutes into the
+# DINOv2 weights download.)
+RUN python -c "import torch, torchvision; \
+from transformers import (AutoModel, AutoProcessor, AutoImageProcessor, \
+    SiglipModel, SiglipImageProcessor, SiglipTokenizer, \
+    CLIPModel, CLIPProcessor); \
+[c.from_pretrained for c in (AutoModel, AutoProcessor, AutoImageProcessor, \
+    SiglipModel, SiglipImageProcessor, SiglipTokenizer, \
+    CLIPModel, CLIPProcessor)]; \
+print('image-embedders import canary OK', flush=True)"
+
 # ---------- pre-download every image embedder's weights ------------------
 # Bake weights into a non-volume path so they survive volume mounts on
 # /app/data. The app reads MODELS_CACHE_DIR from VTSEARCH_MODELS_DIR.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ _TEST_GROUPS = {
         "test_frontend",
         "test_resize_handle_centering",
         "test_achievements",
+        "test_dockerfile_syntax",
     ],
     "api": [
         "test_api_contracts",

--- a/tests/test_dockerfile_syntax.py
+++ b/tests/test_dockerfile_syntax.py
@@ -1,0 +1,119 @@
+"""Static syntax checks for Python embedded in our Dockerfiles.
+
+Catches the class of bug fixed in PR #1282: try/except (and other compound
+statements) cannot be flattened into a single ``python -c "..."`` line with
+semicolons + backslash continuations. Without this test, a SyntaxError in
+embedded Python is invisible to ruff, pytest, and CI — it only surfaces
+when somebody actually runs ``docker build``, often after minutes of layer
+work.
+
+Approach: read each ``Dockerfile*``, join Docker's backslash-continued
+lines, pull out every ``python ... -c "..."`` invocation, and run
+``compile()`` on the contents. Pure-text work; no Docker daemon needed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# Match `python` (optionally with a digit like python3) followed by any
+# short flags (-u, -E, etc.), then `-c`, then a double-quoted string.
+# Our Dockerfiles always use double quotes outside and single quotes
+# inside, so we don't need to handle the single-quoted-outside case.
+_PYTHON_DASH_C = re.compile(
+    r'\bpython\d?\b(?:\s+-\w+)*\s+-c\s+"((?:[^"\\]|\\.)*)"',
+    re.DOTALL,
+)
+
+
+def _join_continued_lines(text: str) -> str:
+    """Collapse Docker's backslash-newline continuations into single lines."""
+    return re.sub(r"\\\n\s*", " ", text)
+
+
+def _find_python_c_snippets(dockerfile_text: str) -> list[str]:
+    """Return every Python source string embedded via ``python -c "..."``."""
+    joined = _join_continued_lines(dockerfile_text)
+    return [m.group(1) for m in _PYTHON_DASH_C.finditer(joined)]
+
+
+def _dockerfiles() -> list[Path]:
+    return sorted(REPO_ROOT.glob("Dockerfile*"))
+
+
+@pytest.mark.parametrize("dockerfile", _dockerfiles(), ids=lambda p: p.name)
+def test_python_c_snippets_compile(dockerfile: Path) -> None:
+    """Every ``python -c`` block in every Dockerfile must parse as Python."""
+    snippets = _find_python_c_snippets(dockerfile.read_text())
+    for idx, src in enumerate(snippets):
+        try:
+            compile(src, f"{dockerfile.name}#python-c[{idx}]", "exec")
+        except SyntaxError as exc:
+            pytest.fail(
+                f"{dockerfile.name}: python -c block #{idx} has a SyntaxError "
+                f"({exc.msg} at line {exc.lineno}, col {exc.offset}). Compound "
+                f"statements like try/except can't be flattened with semicolons "
+                f"in a single -c line — use `cmd || echo ...` at the shell level "
+                f"or move the logic into a script file.\n"
+                f"--- offending snippet ---\n{src}\n---"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Self-tests for the parser. These guard against the parser quietly missing a
+# block (which would make the parametrized test above silently no-op) and
+# against false positives.
+# ---------------------------------------------------------------------------
+
+
+def test_parser_finds_simple_block() -> None:
+    text = 'RUN python -c "import os; print(os.name)"\n'
+    assert _find_python_c_snippets(text) == ["import os; print(os.name)"]
+
+
+def test_parser_joins_backslash_continuations() -> None:
+    text = (
+        'RUN python -u -c "import os; \\\n'
+        "from sys import path; \\\n"
+        'print(path)"\n'
+    )
+    snippets = _find_python_c_snippets(text)
+    assert len(snippets) == 1
+    assert "import os" in snippets[0]
+    assert "from sys import path" in snippets[0]
+    assert "print(path)" in snippets[0]
+
+
+def test_parser_catches_inline_try_except_syntax_error() -> None:
+    """Regression for the bug fixed in PR #1282."""
+    text = (
+        'RUN python -u -c "import os; \\\n'
+        "try: \\\n"
+        "    do_thing(); \\\n"
+        "except Exception: \\\n"
+        '    pass"\n'
+    )
+    snippets = _find_python_c_snippets(text)
+    assert len(snippets) == 1
+    with pytest.raises(SyntaxError):
+        compile(snippets[0], "<bad>", "exec")
+
+
+def test_parser_skips_non_dash_c_python_invocations() -> None:
+    """Real script files (``python scripts/foo.py``) are out of scope."""
+    text = (
+        "RUN python -u scripts/preload_siglip.py\n"
+        'RUN python -c "print(1)"\n'
+    )
+    assert _find_python_c_snippets(text) == ["print(1)"]
+
+
+def test_repo_actually_has_dockerfiles() -> None:
+    """Parametrize collects at runtime — make sure we found anything at all."""
+    assert _dockerfiles(), "expected at least one Dockerfile in the repo root"


### PR DESCRIPTION
## Summary

Closes the testing gap that let PR #1282's bugs ship in the first place. Two cheap, deterministic checks that run on every PR — no Docker daemon, no model downloads.

### 1. `tests/test_dockerfile_syntax.py` (new)

Scans every `Dockerfile*` in the repo, joins backslash-continued lines the way Docker does, pulls out each `python -c "..."` invocation, and runs `compile()` on the contents.

Would have caught the DINOv3 try/except SyntaxError in PR #1282 instantly — with a precise line number, instead of an opaque BuildKit failure. Self-tests cover the simple case, line-joining, the inline try/except regression, and the `python script.py` (non-`-c`) skip case so the parser doesn't silently no-op.

Added to the `core` group via `_TEST_GROUPS` in `tests/conftest.py`. Adds ~60ms to the core group.

### 2. Import-only canary `RUN` in `Dockerfile.image-embedders`

Right after `pip install`, before any model weights start downloading:

```dockerfile
RUN python -c "import torch, torchvision; \
from transformers import (AutoModel, AutoProcessor, AutoImageProcessor, \
    SiglipModel, SiglipImageProcessor, SiglipTokenizer, \
    CLIPModel, CLIPProcessor); \
[c.from_pretrained for c in (...)]; \
print('image-embedders import canary OK', flush=True)"
```

Touching `.from_pretrained` triggers `transformers.requires_backends` — which is what raised the original "AutoImageProcessor requires torchvision" error. A missing optional dep (torchvision, sentencepiece for SigLIP's tokenizer, etc.) now raises ImportError in **under a second**, instead of several minutes into the first multi-GB DINOv2 download.

## Why not the other Dockerfiles?

- `Dockerfile`, `Dockerfile.gpu` — no model loading at build time, so a canary buys nothing the regular test suite doesn't already cover.
- `Dockerfile.siglip` — preloads via the real `scripts/preload_siglip.py` script, which already does the right thing (would fail immediately on a missing dep).

## Test plan

- [x] `python -m pytest tests/test_dockerfile_syntax.py -v` — 9/9 pass in 60ms.
- [x] `./run-tests.sh core` — 393/393 pass.
- [x] Reverted `Dockerfile.image-embedders` to its pre-PR-1282 state and confirmed the test fails with a clear pointer to the DINOv3 try/except block.


---
_Generated by [Claude Code](https://claude.ai/code/session_011pPcUhhpqhQtV1vuhrAxKD)_