### PR TITLE
feat(achievements): show total score at top of Achievements tab

### DIFF
--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -1,4 +1,8 @@
 <h3>Achievements</h3>
+<div class="achievements-total" title="1pt Bronze · 2pts Silver · 4pts Gold · 8pts Platinum">
+  <span class="achievements-total-label">Total Score</span>
+  <span class="achievements-total-value">{{ totalScore.toLocaleString() }}</span>
+</div>
 <p class="achievements-intro">
   Milestones tracked as you use VTSearch. Counters live in your settings —
   if you have a settings source configured they round-trip between sessions.

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -1,3 +1,27 @@
+.achievements-total {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0 0 0.75rem;
+  padding: 0.6rem 0.9rem;
+  background: var(--surface-alt, rgba(255, 255, 255, 0.04));
+  border-radius: 6px;
+}
+
+.achievements-total-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #888);
+}
+
+.achievements-total-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--accent, #4aa3ff);
+}
+
 .achievements-intro {
   margin: 0 0 1rem;
   color: var(--text-muted, #888);

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -28,6 +28,7 @@ interface AchievementRow extends AchievementInfo {
 export class AchievementsTabComponent implements OnInit, OnDestroy {
   rows: AchievementRow[] = [];
   loading = true;
+  totalScore = 0;
 
   private destroy$ = new Subject<void>();
 
@@ -48,6 +49,10 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   private applyState(state: AchievementsState): void {
     this.rows = state.achievements.map((a) => this.toRow(a));
     this.loading = state.achievements.length === 0;
+    this.totalScore = state.achievements.reduce(
+      (sum, a) => sum + (a.tier_idx >= 0 ? 1 << a.tier_idx : 0),
+      0,
+    );
   }
 
   private toRow(a: AchievementInfo): AchievementRow {


### PR DESCRIPTION
## Summary
- Add a "Total Score" header at the top of the Achievements tab.
- Score sums `2^tier_idx` across all achievements: 1pt Bronze, 2pts Silver, 4pts Gold, 8pts Platinum. Locked (no tier) contributes 0. This yields the requested net increments (Null→Bronze +1, Bronze→Silver +1, Silver→Gold +2, Gold→Plat +4).
- Pure frontend change: computed in `AchievementsTabComponent` from the existing `AchievementsState` — no backend changes.

## Test plan
- [x] `npm run build:prod` succeeds with no new warnings (component SCSS ~2.1 kB, well under the 8 kB budget).
- [ ] Open the Achievements tab and verify the "Total Score" pill renders above the intro text.
- [ ] Earn / unlock a tier and confirm the score updates after refresh.

https://claude.ai/code/session_01G6LQqepnpqsSL3XsZgmzJh

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6LQqepnpqsSL3XsZgmzJh)_