### PR TITLE
Add Readme Reader achievement (4 docs, paste-to-claim phrases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,7 @@ VTSearch has a plugin architecture for media types, data importers, results expo
 - **[docs/EXTENDING-plugins.md](docs/EXTENDING-plugins.md)** — data importers, results exporters, label importers, processor importers, settings importers/exporters, settings sources, labelset sources (eight auto-discovered plugin families).
 - **[docs/EXTENDING-media.md](docs/EXTENDING-media.md)** — media types, embedders, clippers, converters, media sources.
 - **[docs/EXTENDING-processors.md](docs/EXTENDING-processors.md)** — detectors, localizers, extractors.
+
+---
+
+*Readme Reader code phrase:* `all aboard the embedding express`

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,3 +37,8 @@ unless otherwise noted. File uploads use `multipart/form-data`.
 Status codes follow standard HTTP semantics: 200 OK, 201 Created, 204 No
 Content, 400 Bad Request, 404 Not Found, 409 Conflict, 500 Internal Server
 Error.
+
+---
+
+*Readme Reader code phrase:* `json all the way down`
+

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -108,3 +108,7 @@ python app.py --login trivial    # multi-user mode with simple username auth
 ```
 
 Without `--login`, the app uses `DefaultLoginProvider` (single-user, always authenticated).
+
+---
+
+*Readme Reader code phrase:* `command palette unlocked`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -415,3 +415,7 @@ Two ways to bring in existing work:
 - Measuring sort quality on demo datasets — [EVAL.md](EVAL.md).
 - How Autopilot and sort modes are implemented — the
   [architecture doc](ARCHITECTURE.md) (developer-oriented).
+
+---
+
+*Readme Reader code phrase:* `label like nobody's watching`

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -22,6 +22,15 @@
           <div class="achievement-head">
             <span class="achievement-name">{{ row.name }}</span>
             <span class="achievement-tier" [attr.data-tier-idx]="row.tier_idx">{{ row.tierName }}</span>
+            @if (row.id === 'docs_read') {
+              <button
+                type="button"
+                class="docs-expand-toggle"
+                (click)="toggleDocsExpanded()"
+                [attr.aria-expanded]="docsExpanded">
+                {{ docsExpanded ? 'Collapse' : 'Expand' }}
+              </button>
+            }
           </div>
           <p class="achievement-desc">{{ row.description }}</p>
           <div class="achievement-progress" [title]="row.progressLabel">
@@ -30,6 +39,48 @@
             </div>
             <span class="achievement-progress-label">{{ row.progressLabel }}</span>
           </div>
+          @if (row.id === 'docs_read' && docsExpanded) {
+            <div class="docs-panel">
+              <ul class="docs-list">
+                @for (doc of docs; track doc.id) {
+                  <li class="docs-list-item" [class.docs-list-item--read]="doc.read">
+                    <span class="docs-list-status" [attr.aria-label]="doc.read ? 'read' : 'unread'">
+                      {{ doc.read ? '✓' : '○' }}
+                    </span>
+                    <a class="docs-list-link" [href]="docRawUrl(doc.id)" target="_blank" rel="noopener noreferrer">
+                      {{ doc.name }}
+                    </a>
+                    <span class="docs-list-path">{{ doc.path }}</span>
+                  </li>
+                }
+              </ul>
+              <form class="docs-phrase-form" (ngSubmit)="submitPhrase()">
+                <label class="docs-phrase-label" for="docs-phrase-input">
+                  Paste a code phrase
+                </label>
+                <input
+                  id="docs-phrase-input"
+                  class="docs-phrase-input"
+                  type="text"
+                  name="phrase"
+                  autocomplete="off"
+                  [(ngModel)]="phraseInput"
+                  [disabled]="submitting"
+                  placeholder="e.g. all systems nominal" />
+                <button
+                  type="submit"
+                  class="docs-phrase-submit"
+                  [disabled]="submitting || !phraseInput.trim()">
+                  {{ submitting ? 'Checking…' : 'Submit' }}
+                </button>
+              </form>
+              @if (phraseStatus.kind !== 'idle') {
+                <p class="docs-phrase-status" [attr.data-kind]="phraseStatus.kind">
+                  {{ phraseStatus.message }}
+                </p>
+              }
+            </div>
+          }
         </div>
       </li>
     }

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -114,3 +114,111 @@
   color: var(--text-muted, #888);
   white-space: nowrap;
 }
+
+.docs-expand-toggle {
+  margin-left: auto;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 3px;
+  background: var(--surface, rgba(255, 255, 255, 0.08));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  color: inherit;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--surface-hover, rgba(255, 255, 255, 0.12));
+  }
+}
+
+.docs-panel {
+  margin-top: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--surface, rgba(255, 255, 255, 0.06));
+  border-radius: 4px;
+}
+
+.docs-list {
+  list-style: none;
+  margin: 0 0 0.6rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.docs-list-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.docs-list-item--read {
+  color: var(--accent, #4aa3ff);
+}
+
+.docs-list-status {
+  width: 1rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.docs-list-link {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.docs-list-path {
+  color: var(--text-muted, #888);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.78rem;
+}
+
+.docs-phrase-form {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.docs-phrase-label {
+  font-size: 0.78rem;
+  color: var(--text-muted, #888);
+}
+
+.docs-phrase-input {
+  flex: 1;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  background: var(--surface-alt, rgba(0, 0, 0, 0.2));
+  color: inherit;
+}
+
+.docs-phrase-submit {
+  font-size: 0.78rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 3px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  background: var(--accent, #4aa3ff);
+  color: #fff;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+}
+
+.docs-phrase-status {
+  margin: 0.4rem 0 0;
+  font-size: 0.8rem;
+
+  &[data-kind="success"] { color: var(--accent, #4aa3ff); }
+  &[data-kind="already"] { color: var(--text-muted, #888); }
+  &[data-kind="wrong"]   { color: #ff7676; }
+}

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
@@ -7,6 +8,7 @@ import {
   AchievementInfo,
   AchievementsService,
   AchievementsState,
+  DocInfo,
 } from '../../services/achievements.service';
 
 const TIER_NAMES = ['Bronze', 'Silver', 'Gold', 'Platinum'];
@@ -21,14 +23,23 @@ interface AchievementRow extends AchievementInfo {
 @Component({
   selector: 'vt-achievements-tab',
   standalone: true,
-  imports: [CommonModule, AchievementBadgeComponent],
+  imports: [CommonModule, FormsModule, AchievementBadgeComponent],
   templateUrl: './achievements-tab.component.html',
   styleUrl: './achievements-tab.component.scss',
 })
 export class AchievementsTabComponent implements OnInit, OnDestroy {
   rows: AchievementRow[] = [];
+  docs: DocInfo[] = [];
   loading = true;
   totalScore = 0;
+
+  docsExpanded = false;
+  phraseInput = '';
+  phraseStatus: { kind: 'idle' | 'success' | 'already' | 'wrong'; message: string } = {
+    kind: 'idle',
+    message: '',
+  };
+  submitting = false;
 
   private destroy$ = new Subject<void>();
 
@@ -46,8 +57,43 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
+  toggleDocsExpanded(): void {
+    this.docsExpanded = !this.docsExpanded;
+  }
+
+  docRawUrl(docId: string): string {
+    return this.achievements.docRawUrl(docId);
+  }
+
+  submitPhrase(): void {
+    const phrase = this.phraseInput.trim();
+    if (!phrase || this.submitting) return;
+    this.submitting = true;
+    this.achievements.checkPhrase(phrase).subscribe((result) => {
+      this.submitting = false;
+      if (result.matched && !result.already_read) {
+        this.phraseStatus = {
+          kind: 'success',
+          message: `Correct! Credit applied for "${result.doc_name}".`,
+        };
+        this.phraseInput = '';
+      } else if (result.matched && result.already_read) {
+        this.phraseStatus = {
+          kind: 'already',
+          message: `Already credited for "${result.doc_name}". Try a different doc!`,
+        };
+      } else {
+        this.phraseStatus = {
+          kind: 'wrong',
+          message: 'No match. Check spelling and try again.',
+        };
+      }
+    });
+  }
+
   private applyState(state: AchievementsState): void {
     this.rows = state.achievements.map((a) => this.toRow(a));
+    this.docs = state.docs;
     this.loading = state.achievements.length === 0;
     this.totalScore = state.achievements.reduce(
       (sum, a) => sum + (a.tier_idx >= 0 ? 1 << a.tier_idx : 0),

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -23,16 +23,32 @@ export interface PendingAnnouncement {
   threshold: number;
 }
 
+export interface DocInfo {
+  id: string;
+  name: string;
+  path: string;
+  read: boolean;
+}
+
 export interface AchievementsState {
   tier_names: string[];
   achievements: AchievementInfo[];
   pending_announcements: PendingAnnouncement[];
+  docs: DocInfo[];
+}
+
+export interface PhraseCheckResult {
+  matched: boolean;
+  doc_id: string | null;
+  doc_name: string | null;
+  already_read: boolean;
 }
 
 const EMPTY_STATE: AchievementsState = {
   tier_names: [],
   achievements: [],
   pending_announcements: [],
+  docs: [],
 };
 
 /**
@@ -96,5 +112,39 @@ export class AchievementsService {
       })
       .pipe(catchError(() => of(null)))
       .subscribe(() => this.refresh());
+  }
+
+  /**
+   * Submit a Readme Reader phrase guess.  Returns the server's classification
+   * (matched / which doc / whether already credited) and refreshes the state
+   * so the docs panel reflects the new read state on success.
+   */
+  checkPhrase(phrase: string): Observable<PhraseCheckResult> {
+    return new Observable<PhraseCheckResult>((subscriber) => {
+      this.http
+        .post<PhraseCheckResult>('/api/achievements/check-phrase', { phrase })
+        .pipe(
+          catchError(() =>
+            of<PhraseCheckResult>({
+              matched: false,
+              doc_id: null,
+              doc_name: null,
+              already_read: false,
+            }),
+          ),
+        )
+        .subscribe((result) => {
+          if (result.matched && !result.already_read) {
+            this.refresh();
+          }
+          subscriber.next(result);
+          subscriber.complete();
+        });
+    });
+  }
+
+  /** Absolute URL to the raw markdown for a doc. */
+  docRawUrl(docId: string): string {
+    return `/api/achievements/docs/${encodeURIComponent(docId)}/raw`;
   }
 }

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import pathlib
 
 import app as app_module  # noqa: F401 — triggers conftest media init
 from vtsearch import achievements
@@ -44,11 +45,19 @@ class TestEmptyState:
         state = achievements.get_full_state()
         assert state["tier_names"] == ["Bronze", "Silver", "Gold", "Platinum"]
         assert state["pending_announcements"] == []
-        assert len(state["achievements"]) == 9
+        assert len(state["achievements"]) == 10
         for a in state["achievements"]:
             assert a["counter"] == 0
             assert a["tier_idx"] == -1
             assert a["next_threshold"] == a["tiers"][0]
+        # docs field is always present, with read=False for every doc.
+        assert {d["id"] for d in state["docs"]} == {
+            "readme",
+            "user_guide",
+            "cli",
+            "api",
+        }
+        assert all(d["read"] is False for d in state["docs"])
 
     def test_known_categories_present(self):
         ids = {a["id"] for a in achievements.get_full_state()["achievements"]}
@@ -62,6 +71,7 @@ class TestEmptyState:
             "media_types_touched",
             "vote_streak",
             "hours_voted",
+            "docs_read",
         }
 
 
@@ -316,6 +326,151 @@ class TestVoteStateRoundTrip:
         assert state["current_streak"] == 1
         assert state["counters"]["vote_streak"] == 1
         assert state["last_vote_ts"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Readme Reader: record_doc_phrase + docs in get_full_state
+# ---------------------------------------------------------------------------
+
+
+class TestReadmeReader:
+    """Behavioural tests for the docs_read achievement."""
+
+    def _phrase_for(self, doc_id: str) -> str:
+        """Lookup the canonical phrase for *doc_id* from the private list."""
+        for d in achievements._DOCS_RAW:
+            if d["id"] == doc_id:
+                return d["phrase"]
+        raise KeyError(doc_id)
+
+    def test_correct_phrase_credits_doc(self):
+        result = achievements.record_doc_phrase(self._phrase_for("readme"))
+        assert result["matched"] is True
+        assert result["doc_id"] == "readme"
+        assert result["already_read"] is False
+        state = achievements.get_full_state()
+        assert _by_id(state, "docs_read")["counter"] == 1
+        assert [d for d in state["docs"] if d["id"] == "readme"][0]["read"] is True
+
+    def test_wrong_phrase_is_no_op(self):
+        result = achievements.record_doc_phrase("definitely not a real phrase")
+        assert result["matched"] is False
+        assert result["doc_id"] is None
+        state = achievements.get_full_state()
+        assert _by_id(state, "docs_read")["counter"] == 0
+        assert all(d["read"] is False for d in state["docs"])
+
+    def test_case_insensitive_match(self):
+        phrase = self._phrase_for("cli").upper()
+        result = achievements.record_doc_phrase(phrase)
+        assert result["matched"] is True
+        assert result["doc_id"] == "cli"
+
+    def test_whitespace_tolerant_match(self):
+        phrase = "  " + self._phrase_for("api").replace(" ", "   ") + "\n"
+        result = achievements.record_doc_phrase(phrase)
+        assert result["matched"] is True
+        assert result["doc_id"] == "api"
+
+    def test_duplicate_credit_reports_already_read(self):
+        phrase = self._phrase_for("user_guide")
+        first = achievements.record_doc_phrase(phrase)
+        assert first["already_read"] is False
+        second = achievements.record_doc_phrase(phrase)
+        assert second["matched"] is True
+        assert second["already_read"] is True
+        # Counter stays at 1, not 2.
+        assert _by_id(achievements.get_full_state(), "docs_read")["counter"] == 1
+
+    def test_all_four_docs_unlock_platinum(self):
+        for doc_id in ("readme", "user_guide", "cli", "api"):
+            achievements.record_doc_phrase(self._phrase_for(doc_id))
+        state = achievements.get_full_state()
+        docs_read = _by_id(state, "docs_read")
+        assert docs_read["counter"] == 4
+        assert docs_read["tier_idx"] == 3  # Platinum
+        assert docs_read["next_threshold"] is None
+
+    def test_state_round_trips_via_settings(self, isolated_settings):
+        achievements.record_doc_phrase(self._phrase_for("readme"))
+        achievements.record_doc_phrase(self._phrase_for("api"))
+        raw = json.loads(isolated_settings.read_text())
+        state = raw["achievement_state"]
+        assert sorted(state["docs_read_ids"]) == ["api", "readme"]
+        assert state["counters"]["docs_read"] == 2
+
+
+class TestReadmeReaderDocsDriftGuard:
+    """Each doc file must actually contain the phrase listed in the registry.
+
+    This catches silent drift where someone edits one side (the doc or the
+    DOCS_RAW table) without updating the other.
+    """
+
+    def test_each_doc_contains_its_phrase(self):
+        repo_root = pathlib.Path(__file__).resolve().parent.parent
+        for doc in achievements._DOCS_RAW:
+            text = (repo_root / doc["path"]).read_text(encoding="utf-8")
+            assert achievements._normalize_phrase(doc["phrase"]) in achievements._normalize_phrase(text), (
+                f"Doc {doc['path']} is missing its Readme Reader phrase "
+                f"{doc['phrase']!r}; update either the doc footer or "
+                f"_DOCS_RAW in vtsearch/achievements.py."
+            )
+
+    def test_no_two_docs_share_a_phrase(self):
+        phrases = [achievements._normalize_phrase(d["phrase"]) for d in achievements._DOCS_RAW]
+        assert len(phrases) == len(set(phrases))
+
+
+# ---------------------------------------------------------------------------
+# Readme Reader: API routes
+# ---------------------------------------------------------------------------
+
+
+class TestReadmeReaderApi:
+    def _phrase_for(self, doc_id: str) -> str:
+        for d in achievements._DOCS_RAW:
+            if d["id"] == doc_id:
+                return d["phrase"]
+        raise KeyError(doc_id)
+
+    def test_check_phrase_correct(self, client):
+        resp = client.post(
+            "/api/achievements/check-phrase",
+            json={"phrase": self._phrase_for("readme")},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["matched"] is True
+        assert body["doc_id"] == "readme"
+        assert body["already_read"] is False
+
+    def test_check_phrase_wrong(self, client):
+        resp = client.post("/api/achievements/check-phrase", json={"phrase": "nope"})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["matched"] is False
+        assert body["doc_id"] is None
+
+    def test_check_phrase_missing_body(self, client):
+        resp = client.post("/api/achievements/check-phrase", json={})
+        assert resp.status_code == 400
+
+    def test_check_phrase_non_string(self, client):
+        resp = client.post("/api/achievements/check-phrase", json={"phrase": 42})
+        assert resp.status_code == 400
+
+    def test_docs_raw_returns_markdown(self, client):
+        resp = client.get("/api/achievements/docs/readme/raw")
+        assert resp.status_code == 200
+        assert resp.mimetype == "text/plain"
+        body = resp.get_data(as_text=True)
+        # Should contain the README's phrase footer.
+        assert "all aboard the embedding express" in body.lower()
+
+    def test_docs_raw_unknown_id(self, client):
+        resp = client.get("/api/achievements/docs/not-a-doc/raw")
+        assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -13,6 +13,7 @@ announcement via :func:`acknowledge` so the popup doesn't fire on refresh.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import time
 from datetime import datetime, timezone
@@ -91,6 +92,17 @@ ACHIEVEMENTS: list[dict[str, Any]] = [
         "icon": "steering-wheel",
         "tiers": [6, 12, 20, 24],
     },
+    {
+        "id": "docs_read",
+        "name": "Readme Reader",
+        "description": (
+            "Find the code phrase at the bottom of each documentation page and "
+            "paste it in to claim credit. Four docs hide a phrase; Platinum is "
+            "all four."
+        ),
+        "icon": "file-text",
+        "tiers": [1, 2, 3, 4],
+    },
 ]
 
 _ACH_BY_ID: dict[str, dict[str, Any]] = {a["id"]: a for a in ACHIEVEMENTS}
@@ -104,6 +116,62 @@ EXCLUDED_DATASET_IMPORTERS: frozenset[str] = frozenset({"demo", "synthetic"})
 #: Marathoner streak alive.  Anything strictly greater than this resets the
 #: streak counter to 1 on the next vote.
 STREAK_GAP_SECONDS: float = 10 * 60
+
+#: Readme Reader docs.  Each entry pairs a doc with the code phrase printed at
+#: the bottom of it.  The phrase is matched server-side: the user pastes their
+#: guess and we compare it to ``_DOC_HASHES`` (SHA-256 of the normalised
+#: phrase).  Phrases are kept in source so the test suite can verify each doc's
+#: footer is in sync, but :func:`get_full_state` never returns them to the
+#: client — only the per-doc read state.
+#:
+#: ``path`` is repo-relative so the docs route can stream the raw markdown.
+_DOCS_RAW: list[dict[str, str]] = [
+    {
+        "id": "readme",
+        "name": "README",
+        "path": "README.md",
+        "phrase": "all aboard the embedding express",
+    },
+    {
+        "id": "user_guide",
+        "name": "User Guide",
+        "path": "docs/USER_GUIDE.md",
+        "phrase": "label like nobody's watching",
+    },
+    {
+        "id": "cli",
+        "name": "CLI",
+        "path": "docs/CLI.md",
+        "phrase": "command palette unlocked",
+    },
+    {
+        "id": "api",
+        "name": "HTTP API",
+        "path": "docs/API.md",
+        "phrase": "json all the way down",
+    },
+]
+
+
+def _normalize_phrase(phrase: str) -> str:
+    """Lower-case + collapse internal whitespace + strip; the canonical form
+    used for hashing and matching.  Tolerant to copy-paste artefacts (extra
+    spaces, trailing newline, accidental capitalisation)."""
+    return " ".join(phrase.lower().split())
+
+
+def _hash_phrase(phrase: str) -> str:
+    return hashlib.sha256(_normalize_phrase(phrase).encode("utf-8")).hexdigest()
+
+
+#: ``doc_id → sha256(normalised phrase)``.  Precomputed at import time.
+_DOC_HASHES: dict[str, str] = {d["id"]: _hash_phrase(d["phrase"]) for d in _DOCS_RAW}
+
+#: Public, phrase-free copy of the doc list for serialisation.
+DOCS: list[dict[str, str]] = [
+    {"id": d["id"], "name": d["name"], "path": d["path"]} for d in _DOCS_RAW
+]
+_DOC_BY_ID: dict[str, dict[str, str]] = {d["id"]: d for d in DOCS}
 
 
 def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
@@ -123,6 +191,7 @@ def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
     state.setdefault("days_seen", [])
     state.setdefault("media_types_seen", [])
     state.setdefault("hours_seen", [])
+    state.setdefault("docs_read_ids", [])
     if not isinstance(state.get("last_vote_ts"), (int, float)):
         state["last_vote_ts"] = 0.0
     if not isinstance(state.get("current_streak"), int):
@@ -258,6 +327,54 @@ def record_find(n_scored: int) -> None:
         _save(s)
 
 
+def record_doc_phrase(phrase: str) -> dict[str, Any]:
+    """Check a user-submitted phrase against every doc and credit on match.
+
+    The match is case-insensitive and whitespace-normalised — anything that
+    survives :func:`_normalize_phrase` and SHA-256-hashes to a registered doc
+    counts.  A phrase that matches a doc already in ``docs_read_ids`` is
+    reported as ``already_read`` (idempotent, no double-credit).
+
+    Returns a result dict with:
+
+    - ``matched`` (bool): whether the phrase corresponds to a known doc.
+    - ``doc_id`` / ``doc_name`` (str | None): identifying the matched doc.
+    - ``already_read`` (bool): True when the doc was previously credited.
+    """
+    h = _hash_phrase(phrase)
+    matched_id: str | None = None
+    for doc_id, doc_hash in _DOC_HASHES.items():
+        if h == doc_hash:
+            matched_id = doc_id
+            break
+
+    if matched_id is None:
+        return {"matched": False, "doc_id": None, "doc_name": None, "already_read": False}
+
+    doc = _DOC_BY_ID[matched_id]
+    with _settings_lock:
+        s = _ensure_loaded()
+        state = _ensure_state(s)
+        read_ids = state["docs_read_ids"]
+        if matched_id in read_ids:
+            return {
+                "matched": True,
+                "doc_id": matched_id,
+                "doc_name": doc["name"],
+                "already_read": True,
+            }
+        read_ids.append(matched_id)
+        state["counters"]["docs_read"] = len(read_ids)
+        _save(s)
+
+    return {
+        "matched": True,
+        "doc_id": matched_id,
+        "doc_name": doc["name"],
+        "already_read": False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Read-only API
 # ---------------------------------------------------------------------------
@@ -332,10 +449,16 @@ def get_full_state() -> dict[str, Any]:
                         "threshold": a["tiers"][i],
                     }
                 )
+        read_ids = set(state.get("docs_read_ids", []))
+        docs = [
+            {"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids}
+            for d in DOCS
+        ]
         return {
             "tier_names": list(TIER_NAMES),
             "achievements": achievements,
             "pending_announcements": pending,
+            "docs": docs,
         }
 
 

--- a/vtsearch/routes/achievements.py
+++ b/vtsearch/routes/achievements.py
@@ -7,15 +7,29 @@ GET  /api/achievements
 
 POST /api/achievements/<category_id>/acknowledge
     Mark a tier as announced.  Body: ``{"tier_idx": <int>}``.
+
+POST /api/achievements/check-phrase
+    Match a user-submitted phrase against the Readme Reader doc set.
+    Body: ``{"phrase": "<string>"}``.
+
+GET  /api/achievements/docs/<doc_id>/raw
+    Stream the raw markdown of a Readme Reader doc, so the frontend can link
+    to it directly without requiring internet access to GitHub.
 """
 
 from __future__ import annotations
 
-from flask import Blueprint, jsonify, request
+from pathlib import Path
+
+from flask import Blueprint, Response, jsonify, request
 
 from vtsearch import achievements
 
 achievements_bp = Blueprint("achievements", __name__)
+
+#: Repo root resolved at import time.  ``vtsearch/routes/achievements.py``
+#: lives two levels under the repo root.
+_REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 
 
 @achievements_bp.route("/api/achievements", methods=["GET"])
@@ -33,3 +47,28 @@ def acknowledge_achievement(category_id: str):
         return jsonify({"error": "tier_idx (int) is required"}), 400
     changed = achievements.acknowledge(category_id, tier_idx)
     return jsonify({"ok": True, "changed": changed})
+
+
+@achievements_bp.route("/api/achievements/check-phrase", methods=["POST"])
+def check_phrase():
+    """Check a user-submitted phrase against the Readme Reader docs."""
+    body = request.get_json(force=True, silent=True) or {}
+    phrase = body.get("phrase")
+    if not isinstance(phrase, str):
+        return jsonify({"error": "phrase (string) is required"}), 400
+    result = achievements.record_doc_phrase(phrase)
+    return jsonify(result)
+
+
+@achievements_bp.route("/api/achievements/docs/<doc_id>/raw", methods=["GET"])
+def get_doc_raw(doc_id: str):
+    """Return the raw markdown for a Readme Reader doc."""
+    doc = next((d for d in achievements.DOCS if d["id"] == doc_id), None)
+    if doc is None:
+        return jsonify({"error": "unknown doc id"}), 404
+    abs_path = (_REPO_ROOT / doc["path"]).resolve()
+    if _REPO_ROOT not in abs_path.parents and abs_path != _REPO_ROOT:
+        return jsonify({"error": "doc resolved outside repo"}), 500
+    if not abs_path.is_file():
+        return jsonify({"error": "doc file missing"}), 500
+    return Response(abs_path.read_text(encoding="utf-8"), mimetype="text/plain; charset=utf-8")


### PR DESCRIPTION
## Summary

A new `docs_read` (Readme Reader) achievement that rewards users for actually reading the documentation. Each of four docs hides a themed code phrase at the bottom; users paste a phrase into the Achievements tab and the server credits them for that doc.

| Doc | Phrase |
|---|---|
| `README.md` | *all aboard the embedding express* |
| `docs/USER_GUIDE.md` | *label like nobody's watching* |
| `docs/CLI.md` | *command palette unlocked* |
| `docs/API.md` | *json all the way down* |

Tiers: 1 / 2 / 3 / 4 (Bronze → Platinum). Platinum is all four docs.

## Implementation notes

- **Phrases never leave the backend in clear.** They're hashed with SHA-256 after `_normalize_phrase` (lowercase + whitespace-collapsed) at module load. `/api/achievements` returns per-doc `{id, name, path, read}` only — no phrases — so opening the network tab doesn't spoil the hunt.
- Match is **case-insensitive and whitespace-tolerant**, so users won't fail because of a trailing newline or stray capital letter.
- **Persistence** uses the existing `achievement_state` blob in `data/settings.json` — a new `docs_read_ids: list[str]` field. No schema changes outside `achievements.py`.
- **Offline-friendly:** new `GET /api/achievements/docs/<id>/raw` streams the markdown file from the repo, so the frontend's "Open doc" links work without internet access (no GitHub round-trip).
- **Drift guard:** a test reads each doc file and asserts its registered phrase is actually in there, so editing one side without the other fails CI.

## Files

**Backend** (`vtsearch/achievements.py`, `vtsearch/routes/achievements.py`):
- `_DOCS_RAW` (registry with phrases — private), `_DOC_HASHES` (precomputed SHA-256), `_normalize_phrase`, `_hash_phrase`.
- `record_doc_phrase(phrase) → {matched, doc_id, doc_name, already_read}`.
- `get_full_state` emits a new `docs` field with per-doc read state.
- `_ensure_state` initialises `docs_read_ids` for round-trips.
- Routes: `POST /api/achievements/check-phrase`, `GET /api/achievements/docs/<id>/raw`.

**Frontend** (`achievements-tab.component.*`, `achievements.service.ts`):
- Expand button on the Readme Reader row opens a panel showing per-doc read/unread rows with links to the raw markdown, plus a phrase-input form with success / already / wrong status messages.
- New service methods: `checkPhrase`, `docRawUrl`; new `DocInfo`/`PhraseCheckResult` types.

## Test plan

- [x] `./run-tests.sh` — 3197 passed, 1 skipped
- [x] Frontend `npm run build:prod` — clean, no warnings
- [x] New backend tests:
  - `TestReadmeReader` — correct/wrong/dup, case + whitespace tolerance, Platinum at 4 docs, settings round-trip.
  - `TestReadmeReaderDocsDriftGuard` — each doc contains its registered phrase; no two docs share a phrase.
  - `TestReadmeReaderApi` — both new endpoints, valid/invalid bodies, unknown doc id → 404.

https://claude.ai/code/session_01Ev94NTWXt6ATMomU4rTfVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ev94NTWXt6ATMomU4rTfVG)_