### PR TITLE
Fix tristate select-all icons in dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -105,18 +105,19 @@
     <button class="side-action-btn" (click)="toggleAllDatasets()" [disabled]="isLoading || datasets.length === 0" [title]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all datasets'" [attr.aria-label]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="datasetSelectionState === 'all' ? 'true' : datasetSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
       @switch (datasetSelectionState) {
         @case ('all') {
-          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2"/>
+            <polyline points="7 12 11 16 17 8"/>
           </svg>
         }
         @case ('some') {
-          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2"/>
-            <line x1="7" y1="12" x2="17" y2="12" stroke-dasharray="0"/>
+            <line x1="7" y1="12" x2="17" y2="12"/>
           </svg>
         }
         @default {
-          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+          <svg aria-hidden="true" [class.side-action-spin]="spinDatasetSelectToggle" (animationend)="onSpinDatasetSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2"/>
           </svg>
         }
@@ -218,18 +219,19 @@
     <button class="side-action-btn" (click)="toggleAllDetectors()" [disabled]="isLoading || detectors.length === 0" [title]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all detectors'" [attr.aria-label]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="detectorSelectionState === 'all' ? 'true' : detectorSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
       @switch (detectorSelectionState) {
         @case ('all') {
-          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" stroke-dasharray="2 2.2">
+          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2"/>
+            <polyline points="7 12 11 16 17 8"/>
           </svg>
         }
         @case ('some') {
-          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2"/>
-            <line x1="7" y1="12" x2="17" y2="12" stroke-dasharray="0"/>
+            <line x1="7" y1="12" x2="17" y2="12"/>
           </svg>
         }
         @default {
-          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2.2">
+          <svg aria-hidden="true" [class.side-action-spin]="spinDetectorSelectToggle" (animationend)="onSpinDetectorSelectToggleEnd()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2"/>
           </svg>
         }


### PR DESCRIPTION
## Summary
- The "select all / select some / select none" toggles in the Datasets and Detectors sections now render like a standard tristate checkbox: a checkmark inside the box for "all", a dash for "some", and an empty box for "none".
- The "all" state previously rendered as a solid-filled rectangle with no check mark, and all three states had a dashed border that made them read as not-really-checkboxes. Borders are now solid in every state.

## Test plan
- [ ] In the dashboard with no datasets selected, the top toggle is an empty box.
- [ ] After selecting some (but not all) datasets, the toggle shows a dash.
- [ ] After selecting every dataset, the toggle shows a checkmark.
- [ ] Same three states for the Detectors section toggle.
- [ ] Click animation (one-shot 90° rotation) still fires on toggle.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YEqHZszJVEdvjUXMc9uKqF)_