### PR TITLE
Cut learned-sort training cost per click

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -22,7 +22,8 @@ The model outputs raw logits (not probabilities) during training. This allows th
 |---------|-------|-------|
 | **Loss function** | `BCEWithLogitsLoss` | Per-sample (unreduced), with manual class weighting |
 | **Optimizer** | Adam | `lr=0.001`, `weight_decay=1e-4` |
-| **Epochs** | 200 | Configurable via `TRAIN_EPOCHS` in `config.py` |
+| **Epochs (cap)** | 200 | Configurable via `TRAIN_EPOCHS` in `config.py` or the `VTSEARCH_TRAIN_EPOCHS` env var |
+| **Early-stop patience** | 10 | Training halts when the loss fails to improve for this many consecutive epochs (configurable via `TRAIN_PATIENCE` / `VTSEARCH_TRAIN_PATIENCE`; set 0 to disable) |
 | **Hidden layer** | 4–32 neurons | `max(4, min(32, n_train // 3))` via `_auto_hidden_dim()` |
 | **Dropout** | 0.5 | Applied after ReLU, active only during training |
 | **Batching** | Full-batch | All labeled data in every forward pass |
@@ -46,6 +47,8 @@ A decision threshold separating "good" from "bad" predictions is computed via **
 3. Train a fold model on Train **using the full-data `hidden_dim`**, find the optimal threshold by evaluating on Calibrate.
 4. Repeat for `calibrate_count` independent random splits.
 5. Return the mean of all thresholds.
+
+The `calibrate_count` setting defaults to `2` but can be lowered (`VTSEARCH_CALIBRATE_COUNT`) to trade calibration quality for latency. When `safe_thresholds` is enabled and fewer than 6 labels exist, the cross-calibration step is skipped entirely — the `calculate_safe_threshold` blender weights the calibrated value at 0 in that regime, so paying for the fold trainings would be pure waste.
 
 **Why fold models use the full-data hidden_dim:** The hidden-layer width is normally auto-sized from the training-set size (`n_train // 3`, clamped to 4–32). Without intervention, each fold model would train on fewer examples and therefore get a smaller hidden layer than the final model. A smaller architecture produces a different score distribution, so thresholds found on fold models would not transfer faithfully to the final model. By forcing fold models to use the same `hidden_dim` as the final model, the architectures match: same capacity, same score distribution shape. The only difference is the fold models see less data, which is the whole point — you want held-out calibration data. Existing regularization (dropout 0.5, weight decay 1e-4) and the small max width (32) prevent the slightly "oversized" fold models from overfitting meaningfully.
 

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -237,6 +237,157 @@ class TestTrainModelConfig:
             assert 0.0 <= s <= 1.0
 
 
+class TestTrainModelEpochs:
+    """Tests for env-tunable epochs and early-stopping on loss plateau."""
+
+    @staticmethod
+    def _count_optimizer_steps(fn):
+        """Run ``fn`` and return the number of ``Adam.step`` invocations.
+
+        The training loop calls ``optimizer.step()`` exactly once per epoch,
+        so this counter equals the number of epochs actually executed.
+        """
+        calls = {"n": 0}
+        real_step = torch.optim.Adam.step
+
+        def counting_step(self, *args, **kwargs):
+            calls["n"] += 1
+            return real_step(self, *args, **kwargs)
+
+        with unittest.mock.patch.object(torch.optim.Adam, "step", counting_step):
+            fn()
+        return calls["n"]
+
+    def test_early_stop_fires_on_loss_plateau(self):
+        """With a small patience, training stops well before TRAIN_EPOCHS."""
+        import vtsearch.config as config
+        from vtsearch.models import training
+
+        saved_epochs = config.TRAIN_EPOCHS
+        saved_patience = config.TRAIN_PATIENCE
+        config.TRAIN_EPOCHS = 500
+        try:
+            rng = np.random.RandomState(11)
+            # Trivially separable so the loss plateaus quickly.
+            good = rng.randn(8, 16).astype(np.float32) + 5.0
+            bad = rng.randn(8, 16).astype(np.float32) - 5.0
+            X = torch.tensor(np.vstack([good, bad]))
+            y = torch.tensor([1.0] * 8 + [0.0] * 8).unsqueeze(1)
+
+            config.TRAIN_PATIENCE = 0
+            full_epochs = self._count_optimizer_steps(lambda: training.train_model(X, y, 16))
+
+            config.TRAIN_PATIENCE = 5
+            stopped_epochs = self._count_optimizer_steps(lambda: training.train_model(X, y, 16))
+
+            assert full_epochs == 500
+            assert stopped_epochs < full_epochs
+        finally:
+            config.TRAIN_EPOCHS = saved_epochs
+            config.TRAIN_PATIENCE = saved_patience
+
+    def test_patience_zero_disables_early_stop(self):
+        """``TRAIN_PATIENCE=0`` should always run the full ``TRAIN_EPOCHS``."""
+        import vtsearch.config as config
+        from vtsearch.models import training
+
+        saved_epochs = config.TRAIN_EPOCHS
+        saved_patience = config.TRAIN_PATIENCE
+        config.TRAIN_EPOCHS = 42
+        config.TRAIN_PATIENCE = 0
+        try:
+            rng = np.random.RandomState(2)
+            X = torch.tensor(rng.randn(8, 16).astype(np.float32))
+            y = torch.tensor([1.0] * 4 + [0.0] * 4).unsqueeze(1)
+            n_epochs = self._count_optimizer_steps(lambda: training.train_model(X, y, 16))
+            assert n_epochs == 42
+        finally:
+            config.TRAIN_EPOCHS = saved_epochs
+            config.TRAIN_PATIENCE = saved_patience
+
+
+class TestCalibrationSkippedForTinyLabels:
+    """``train_and_score`` should skip cross-calibration when safe_thresholds
+    is on and there are too few labels for the blend to use the xcal output."""
+
+    def test_skips_calibration_when_safe_and_under_six_labels(self):
+        """With safe_thresholds=True and n_labels<6, calculate_cross_calibration_threshold
+        must not be invoked — its output is entirely discarded by the blender."""
+        from vtsearch.models import training
+
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3, 4, 5]})  # 5 labels < 6
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            side_effect=AssertionError("calibration should be skipped for tiny label sets"),
+        ) as patched:
+            _, threshold, _model = training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+                safe_thresholds=True,
+            )
+        patched.assert_not_called()
+        assert 0.0 <= threshold <= 1.0
+
+    def test_still_calibrates_when_safe_off(self):
+        """With safe_thresholds=False, the xcal threshold is always required."""
+        from vtsearch.models import training
+
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3, 4, 5]})
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            wraps=training.calculate_cross_calibration_threshold,
+        ) as patched:
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+                safe_thresholds=False,
+            )
+        assert patched.call_count == 1
+
+    def test_still_calibrates_when_enough_labels(self):
+        """With safe_thresholds=True and n_labels>=6, calibration still runs."""
+        from vtsearch.models import training
+
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})  # 6 labels
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            wraps=training.calculate_cross_calibration_threshold,
+        ) as patched:
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+                safe_thresholds=True,
+            )
+        assert patched.call_count == 1
+
+
+class TestCalibrateCountEnvDefault:
+    """``VTSEARCH_CALIBRATE_COUNT`` should drive the settings default."""
+
+    def test_default_calibrate_count_constant_exists(self):
+        from vtsearch import config
+
+        assert isinstance(config.DEFAULT_CALIBRATE_COUNT, int)
+        assert config.DEFAULT_CALIBRATE_COUNT >= 1
+
+    def test_settings_default_matches_config(self):
+        from vtsearch import config, settings
+
+        assert settings._DEFAULTS["calibrate_count"] == config.DEFAULT_CALIBRATE_COUNT
+
+
 class TestLearnedSort:
     def test_returns_all_clips(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -16,7 +16,20 @@ MODELS_CACHE_DIR = (
 )
 
 # Training
-TRAIN_EPOCHS = 200
+#
+# ``TRAIN_EPOCHS`` is an *upper bound* — :func:`vtsearch.models.training.train_model`
+# also short-circuits on a loss plateau (see ``TRAIN_PATIENCE``).  Override with
+# ``VTSEARCH_TRAIN_EPOCHS`` for benchmarking or to disable early-stop entirely
+# by pairing with ``VTSEARCH_TRAIN_PATIENCE=0``.
+TRAIN_EPOCHS = int(os.environ.get("VTSEARCH_TRAIN_EPOCHS", "200"))
+# Number of epochs the training loss must fail to improve before training
+# stops early.  Set to 0 to disable early-stop and always run ``TRAIN_EPOCHS``.
+TRAIN_PATIENCE = int(os.environ.get("VTSEARCH_TRAIN_PATIENCE", "10"))
+# Default ``calibrate_count`` baked into ``data/settings.json`` on first run.
+# Each unit adds one full fold-training pass per learned-sort; lower it to
+# trade calibration quality for latency.  Min 1 (clamped in
+# :mod:`vtsearch.settings`).
+DEFAULT_CALIBRATE_COUNT = max(1, int(os.environ.get("VTSEARCH_CALIBRATE_COUNT", "2")))
 MLP_HIDDEN_MIN = 4
 MLP_HIDDEN_MAX = 32
 MLP_DROPOUT = 0.5

--- a/vtsearch/models/detector_training.py
+++ b/vtsearch/models/detector_training.py
@@ -65,18 +65,24 @@ def train_and_threshold(
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 
-    threshold = calculate_cross_calibration_threshold(
-        X_list,
-        y_list,
-        input_dim,
-        get_inclusion(),
-        calibrate_count=get_calibrate_count(),
-        calibration_fraction=get_calibration_fraction(),
-    )
+    safe = bool(get_safe_thresholds() and snap)
+    # Below the safe-threshold ramp floor the cross-cal output is blended
+    # away (pure GMM), so don't pay for the fold trainings.
+    if safe and len(X_list) < 6:
+        threshold = float("inf")
+    else:
+        threshold = calculate_cross_calibration_threshold(
+            X_list,
+            y_list,
+            input_dim,
+            get_inclusion(),
+            calibrate_count=get_calibrate_count(),
+            calibration_fraction=get_calibration_fraction(),
+        )
 
     model = train_model(X, y, input_dim, get_inclusion())
 
-    if get_safe_thresholds() and snap:
+    if safe:
         all_ids = sorted(snap.keys())
         all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
         X_all = torch.tensor(all_embs, dtype=torch.float32)

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vtsearch.config import MLP_DROPOUT, MLP_HIDDEN_MAX, MLP_HIDDEN_MIN, TRAIN_EPOCHS
+from vtsearch import config
+from vtsearch.config import MLP_DROPOUT, MLP_HIDDEN_MAX, MLP_HIDDEN_MIN
+
+# ``TRAIN_EPOCHS`` and ``TRAIN_PATIENCE`` are read off ``config`` at call time
+# (not import time) so env-var / monkey-patched overrides take effect.
 
 if TYPE_CHECKING:
     import torch
@@ -258,15 +262,31 @@ def train_model(
     # Fork the global RNG so the Dropout seed is isolated per call —
     # concurrent training invocations each get their own RNG state.
     model.train()
+    epochs = config.TRAIN_EPOCHS
+    patience = config.TRAIN_PATIENCE
+    best_loss = float("inf")
+    epochs_since_improve = 0
+    # Require at least this much absolute decrease to count as progress —
+    # without it, float noise drifts the loss down forever and the early-stop
+    # never fires.
+    min_delta = 1e-4
     with torch.random.fork_rng(), torch.enable_grad():
         torch.manual_seed(seed)
-        for _ in range(TRAIN_EPOCHS):
+        for _ in range(epochs):
             optimizer.zero_grad()
             logits = model(X_train)
             losses = loss_fn(logits, y_train)
             weighted_loss = (losses.squeeze() * weights).mean()
             weighted_loss.backward()
             optimizer.step()
+            cur = weighted_loss.item()
+            if cur < best_loss - min_delta:
+                best_loss = cur
+                epochs_since_improve = 0
+            else:
+                epochs_since_improve += 1
+                if patience > 0 and epochs_since_improve >= patience:
+                    break
 
     model.eval()
     return model
@@ -559,17 +579,25 @@ def train_and_score(
     # Calculate threshold using k-fold calibration.
     # Use a seeded RNG so that train/calibrate splits are deterministic —
     # without this, the global np.random state makes results non-reproducible.
-    cal_rng = np.random.RandomState(42)
-    threshold = calculate_cross_calibration_threshold(
-        X_list,
-        y_list,
-        input_dim,
-        inclusion_value,
-        rng=cal_rng,
-        calibrate_count=calibrate_count,
-        calibration_fraction=calibration_fraction,
-        hidden_dim=hidden_dim,
-    )
+    # When ``safe_thresholds`` is on and the label count is below the
+    # ``calculate_safe_threshold`` ramp floor, the blended weight on the
+    # cross-cal threshold is exactly 0 (pure GMM), so the calibration
+    # trainings would be discarded.  Skip them and pass ``inf`` to signal
+    # "use the GMM threshold" downstream.
+    if safe_thresholds and len(X_list) < 6:
+        threshold = float("inf")
+    else:
+        cal_rng = np.random.RandomState(42)
+        threshold = calculate_cross_calibration_threshold(
+            X_list,
+            y_list,
+            input_dim,
+            inclusion_value,
+            rng=cal_rng,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+            hidden_dim=hidden_dim,
+        )
 
     # Train final model on all data.  Training is image-level in v1 — the
     # MLP only ever sees one vector per voted media (``media["embedding"]``,

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -12,7 +12,7 @@ import threading
 from pathlib import Path
 from typing import Any
 
-from vtsearch.config import DATA_DIR
+from vtsearch.config import DATA_DIR, DEFAULT_CALIBRATE_COUNT
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ _DEFAULTS: dict[str, Any] = {
     "theme": "dark",
     "enrich_descriptions": False,
     "safe_thresholds": False,
-    "calibrate_count": 2,
+    "calibrate_count": DEFAULT_CALIBRATE_COUNT,
     "calibration_fraction": 0.5,
     "audio_playing": True,
     "swipe_animation": True,


### PR DESCRIPTION
## Summary

Every learned-sort click previously paid for three full MLP trainings — two cross-calibration folds plus the final model — at a hard-coded 200 epochs each (~600 epochs of compute per click). This PR addresses that on three axes:

- **Env-tunable knobs.** `VTSEARCH_TRAIN_EPOCHS`, `VTSEARCH_TRAIN_PATIENCE`, and `VTSEARCH_CALIBRATE_COUNT` now override the previously hard-coded values in `vtsearch/config.py`. The first two are read dynamically by `train_model` (off `config`, not bound at import) so monkey-patching and env overrides actually take effect — the prior tests that saved/restored `config.TRAIN_EPOCHS` were no-ops.
- **Early-stop on loss plateau.** `train_model` exits the epoch loop once the training loss has failed to improve (by ≥ 1e-4) for `TRAIN_PATIENCE` consecutive epochs (default 10). Set patience to 0 to disable.
- **Skip calibration when it's wasted.** In `train_and_score` and `detector_training.train_and_threshold`, when `safe_thresholds` is on and `len(X_list) < 6`, `calculate_safe_threshold` blends the cross-cal threshold at weight 0 (pure GMM). The cross-cal fold trainings are now skipped entirely in that regime and `inf` is passed to the blender (which already handles `inf` as "use GMM only").

`docs/ML.md` updated accordingly. The settings clamp on `calibrate_count` stays at `[1, 100]`; the env var is clamped to `>= 1` for the same reason.

## Test plan

- [x] `./run-tests.sh` — full suite, 3211 passed / 1 skipped / 2 xpassed.
- [x] New unit tests in `tests/test_sorting.py`:
  - Early-stop fires on an obviously-separable loss (5-patience run < 500-epoch full run).
  - Patience-0 disables early-stop (42-epoch run does exactly 42 optimizer steps).
  - `train_and_score` does **not** invoke `calculate_cross_calibration_threshold` when `safe_thresholds=True and n_labels<6`.
  - It does invoke it when `safe_thresholds=False` (any n) and when `safe_thresholds=True and n_labels>=6`.
  - `DEFAULT_CALIBRATE_COUNT` is exposed on `config` and drives the settings default.
- [ ] Manual smoke (out of scope for this PR): run the app with `VTSEARCH_TRAIN_EPOCHS=50 VTSEARCH_CALIBRATE_COUNT=1` and verify learned-sort still produces sensible rankings on the demo dataset.

https://claude.ai/code/session_01N87GGNXCbFbViVQcsqD9s1

---
_Generated by [Claude Code](https://claude.ai/code/session_01N87GGNXCbFbViVQcsqD9s1)_