### PR TITLE
Shrink add-to-pile lock to ID allocation + insert

### DIFF
--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -702,26 +702,27 @@ def add_media_to_pile() -> tuple[Response, int] | Response:
 
         thumb = generate_video_thumbnail(file_bytes)
 
+    new_media: dict[str, Any] = {
+        "type": dataset_media_type,
+        "embedder": dataset_embedder_name,
+        "md5": file_md5,
+        "embedding": embedding,
+        "media_bytes": file_bytes,
+        "filename": original_filename,
+        "file_size": len(file_bytes),
+        "category": "",
+        "origin": {
+            "importer": "add_to_pile",
+            "params": {"filename": original_filename},
+        },
+        "origin_name": original_filename,
+    }
+    if thumb is not None:
+        new_media["thumbnail_bytes"] = thumb
+
     with _state_lock:
         new_id = next_media_id(medias)
-        new_media: dict[str, Any] = {
-            "id": new_id,
-            "type": dataset_media_type,
-            "embedder": dataset_embedder_name,
-            "md5": file_md5,
-            "embedding": embedding,
-            "media_bytes": file_bytes,
-            "filename": original_filename,
-            "file_size": len(file_bytes),
-            "category": "",
-            "origin": {
-                "importer": "add_to_pile",
-                "params": {"filename": original_filename},
-            },
-            "origin_name": original_filename,
-        }
-        if thumb is not None:
-            new_media["thumbnail_bytes"] = thumb
+        new_media["id"] = new_id
         medias[new_id] = new_media
 
     apply_label(new_id, label)


### PR DESCRIPTION
## Summary
- In `vtsearch/routes/medias.py::add_media_to_pile`, the `_state_lock` block previously wrapped the entire new-media dict construction (lines 705–725).
- Build the dict outside the lock and only hold `_state_lock` for the two operations that actually race on shared state: `next_media_id(medias)` and `medias[new_id] = new_media`.
- Embed and thumbnail generation already ran outside the lock; this just trims the remaining unnecessary work inside it.

## Test plan
- [x] `./run-tests.sh core api` — 762 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01QonnRMzFHRZCteFrT2g38B)_