### PR TITLE
Cache parsed labelset to skip redundant rehydrates per request

### DIFF
--- a/vtsearch/models/detector_dataset_sync.py
+++ b/vtsearch/models/detector_dataset_sync.py
@@ -17,6 +17,14 @@ from that labelset whenever the active dataset has changed.
 from __future__ import annotations
 
 
+def _detector_file_mtime(path) -> float:
+    """Return the mtime of ``path`` in seconds, or 0.0 if it doesn't exist."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def ensure_votes_match_active_dataset() -> None:
     """Rehydrate the active detector's cid-keyed vote state against the active dataset.
 
@@ -26,15 +34,17 @@ def ensure_votes_match_active_dataset() -> None:
     * a dataset is loaded (and its id is non-empty),
     * the detector has a registry entry that points at a real on-disk file
       (so we have a labelset to rehydrate from), and
-    * the detector's recorded ``votes_dataset_id`` differs from the active
-      dataset id.
+    * either the detector's recorded ``votes_dataset_id`` differs from the
+      active dataset id, or the on-disk detector file's mtime has changed
+      since the cached labelset was loaded.
 
     When triggered, clears the per-dataset detector state (good_votes,
     bad_votes, label_history, vote_click_times, click_counter,
     last_learned_scores, find_initial_labels, training_medias) and replays
     ``restore_labels_from_detector`` against the active dataset's medias,
-    then stamps ``votes_dataset_id`` so subsequent requests within the same
-    dataset are no-ops.
+    then stamps ``votes_dataset_id`` and caches the parsed labelset +
+    file mtime on the detector context so subsequent requests within the
+    same (dataset, file-mtime) tuple are no-ops.
     """
     from vtsearch.utils.state_core import (
         _state_lock,
@@ -50,8 +60,6 @@ def ensure_votes_match_active_dataset() -> None:
         # No active dataset; preserve whatever the detector last saw so a
         # request that happens to omit the dataset header doesn't wipe state.
         return
-    if det_ctx.votes_dataset_id == ds_ctx.dataset_id:
-        return
 
     from vtsearch.models.detector_registry import get_detector
     from vtsearch.models.detector_store import _detector_path, _read_detector
@@ -64,6 +72,16 @@ def ensure_votes_match_active_dataset() -> None:
         return
 
     path = _detector_path(entry["name"])
+    current_mtime = _detector_file_mtime(path)
+
+    if (
+        det_ctx.votes_dataset_id == ds_ctx.dataset_id
+        and det_ctx.cached_labelset is not None
+        and det_ctx.cached_labelset_mtime == current_mtime
+        and current_mtime != 0.0
+    ):
+        return
+
     data = _read_detector(path)
     if data is None:
         # Detector file missing — still mark the dataset transition so we
@@ -78,11 +96,22 @@ def ensure_votes_match_active_dataset() -> None:
             det_ctx.find_initial_labels.clear()
             det_ctx.training_medias.clear()
             det_ctx.votes_dataset_id = ds_ctx.dataset_id
+            det_ctx.cached_labelset = None
+            det_ctx.cached_labelset_mtime = 0.0
+            det_ctx.cached_labelset_media_type = ""
         return
+
+    from vtsearch.datasets.labelset import LabelSet
 
     with _state_lock:
         # Re-check inside the lock — another request may have rehydrated us.
-        if det_ctx.votes_dataset_id == ds_ctx.dataset_id:
+        refreshed_mtime = _detector_file_mtime(path)
+        if (
+            det_ctx.votes_dataset_id == ds_ctx.dataset_id
+            and det_ctx.cached_labelset is not None
+            and det_ctx.cached_labelset_mtime == refreshed_mtime
+            and refreshed_mtime != 0.0
+        ):
             return
         det_ctx.good_votes.clear()
         det_ctx.bad_votes.clear()
@@ -94,3 +123,6 @@ def ensure_votes_match_active_dataset() -> None:
         det_ctx.training_medias.clear()
         restore_labels_from_detector(data)
         det_ctx.votes_dataset_id = ds_ctx.dataset_id
+        det_ctx.cached_labelset = LabelSet.from_dict(data.get("labelset") or {})
+        det_ctx.cached_labelset_mtime = refreshed_mtime
+        det_ctx.cached_labelset_media_type = data.get("media_type", "") or ""

--- a/vtsearch/models/label_sync.py
+++ b/vtsearch/models/label_sync.py
@@ -95,6 +95,14 @@ def sync_labels_to_loaded_detector() -> None:
 
     det_ctx.labelset_good_count = sum(1 for el in merged.elements if el.label == "good")
     det_ctx.labelset_bad_count = sum(1 for el in merged.elements if el.label == "bad")
+    # Refresh the cached labelset + mtime so ``ensure_votes_match_active_dataset``
+    # doesn't trip on the file we just rewrote and needlessly rehydrate.
+    det_ctx.cached_labelset = merged
+    det_ctx.cached_labelset_media_type = data.get("media_type", "") or det_ctx.cached_labelset_media_type
+    try:
+        det_ctx.cached_labelset_mtime = path.stat().st_mtime
+    except OSError:
+        det_ctx.cached_labelset_mtime = 0.0
 
     import time as _time
 

--- a/vtsearch/routes/detectors_registry.py
+++ b/vtsearch/routes/detectors_registry.py
@@ -353,6 +353,14 @@ def load_detector_route():
 
                     det_ctx.labelset_good_count = sum(1 for el in labelset.elements if el.label == "good")
                     det_ctx.labelset_bad_count = sum(1 for el in labelset.elements if el.label == "bad")
+                    # Cache the parsed labelset so before_request's rehydrate
+                    # hook and learned_sort don't re-read the JSON file.
+                    det_ctx.cached_labelset = labelset
+                    det_ctx.cached_labelset_media_type = media_type
+                    try:
+                        det_ctx.cached_labelset_mtime = _detector_path(det_name).stat().st_mtime
+                    except OSError:
+                        det_ctx.cached_labelset_mtime = 0.0
 
                     def _embed_progress(name: str, done: int, total: int) -> None:
                         tracker.check_cancelled()

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -196,17 +196,23 @@ def learned_sort():
 
     snap = snapshot_medias()
 
-    # Resolve the active detector's labelset (if any).
+    # Resolve the active detector's labelset (if any).  Prefer the parsed
+    # labelset cached on det_ctx by ``ensure_votes_match_active_dataset`` to
+    # avoid re-reading the JSON file on every click.
     det_ctx = get_active_detector_context()
     labelset: LabelSet | None = None
     det_media_type = ""
     if det_ctx is not _empty_detector_context and det_ctx.detector_id:
-        entry = get_detector(det_ctx.detector_id)
-        if entry and entry.get("name"):
-            det_data = _read_detector(_detector_path(entry["name"]))
-            if det_data:
-                labelset = LabelSet.from_dict(det_data.get("labelset") or {})
-                det_media_type = det_data.get("media_type", "") or ""
+        if det_ctx.cached_labelset is not None:
+            labelset = det_ctx.cached_labelset
+            det_media_type = det_ctx.cached_labelset_media_type
+        else:
+            entry = get_detector(det_ctx.detector_id)
+            if entry and entry.get("name"):
+                det_data = _read_detector(_detector_path(entry["name"]))
+                if det_data:
+                    labelset = LabelSet.from_dict(det_data.get("labelset") or {})
+                    det_media_type = det_data.get("media_type", "") or ""
 
     if labelset is not None:
         good_count = sum(1 for el in labelset.elements if el.label == "good")

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -141,6 +141,14 @@ class DetectorContext:
         # dicts and re-derive them from the on-disk labelset against the new
         # dataset's medias.  See ``ensure_votes_match_active_dataset``.
         "votes_dataset_id",
+        # Cached parsed labelset + mtime of the on-disk detector JSON the cache
+        # was derived from.  Lets ``ensure_votes_match_active_dataset`` skip the
+        # rehydrate (read+parse) when neither the active dataset nor the file
+        # has changed, and lets ``learned_sort`` reuse the parsed labelset
+        # instead of re-reading the JSON from disk on every click.
+        "cached_labelset",  # LabelSet | None
+        "cached_labelset_mtime",  # float
+        "cached_labelset_media_type",  # str
         # Sync source
         "labelset_source",  # dict | None — {"source_name": "...", "field_values": {...}}
     )
@@ -178,6 +186,9 @@ class DetectorContext:
         self.labelset_good_count: int = 0
         self.labelset_bad_count: int = 0
         self.votes_dataset_id: str = ""
+        self.cached_labelset: Any = None  # LabelSet | None
+        self.cached_labelset_mtime: float = 0.0
+        self.cached_labelset_media_type: str = ""
         # Sync source
         self.labelset_source: dict[str, Any] | None = None
 


### PR DESCRIPTION
## Summary

- `app.py`'s `before_request` (via `ensure_votes_match_active_dataset`) re-read the active detector's JSON file from disk on every request, and `learned_sort` did the same on every click. Both fired far more than necessary under rapid voting.
- Add `cached_labelset` + `cached_labelset_mtime` (+ `cached_labelset_media_type`) to `DetectorContext`. `ensure_votes_match_active_dataset` now short-circuits when both the active dataset id and the on-disk file's mtime match the cache. `learned_sort` reuses `det_ctx.cached_labelset` instead of re-parsing the JSON.
- Cache is populated when the detector is loaded and refreshed after `sync_labels_to_loaded_detector` rewrites the file, so it stays consistent with disk. External writes (rename, manual edits) bump mtime and naturally invalidate the cache.

## Test plan

- [x] `./run-tests.sh` — all 3211 tests pass
- [x] `./run-tests.sh models sorting` — focused groups pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQnovWx6zRpBiE4jatdk8Q)_