### PR TITLE
Fix fd leak in _reembed_clip on os.write failure

### DIFF
--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -464,8 +464,10 @@ def _reembed_clip(clip: dict, content_bytes: bytes, media_type: str) -> None:
 
     fd, tmp_path = tempfile.mkstemp(suffix=ext)
     try:
-        os.write(fd, content_bytes)
-        os.close(fd)
+        try:
+            os.write(fd, content_bytes)
+        finally:
+            os.close(fd)
         embedding = embed_file(Path(tmp_path), media_type)
         if embedding is not None:
             clip["embedding"] = embedding


### PR DESCRIPTION
## Summary
- In `vtsearch/datasets/load_pipeline.py:465-478`, `os.close(fd)` ran after `os.write(fd, content_bytes)` inside the same `try`. If `os.write` raised, `os.close` never ran and the file descriptor was leaked (the outer `finally` only unlinked the path).
- Move `os.close(fd)` into a nested `finally` so the fd is released whether or not the write succeeds. `embed_file` then runs on a fully-closed file, as it should.

## Test plan
- [ ] `./run-tests.sh datasets` still passes (re-embed path is exercised by clipper workflow tests).

https://claude.ai/code/session_01U4CWrgXrRT8oaKwwsk9TVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4CWrgXrRT8oaKwwsk9TVB)_