### PR TITLE
Make email_smtp sender address configurable

### DIFF
--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -373,19 +373,26 @@ class TestEmailLabelsetExporter:
         keys = {f.key for f in exp.fields}
         assert "to" in keys
 
-    def test_only_to_field_required(self):
+    def test_fields_are_from_and_to(self):
         from vtsearch.exporters import get_exporter
 
         exp = get_exporter("email_smtp")
         keys = {f.key for f in exp.fields}
-        assert keys == {"to"}
+        assert keys == {"from", "to"}
 
     def test_export_raises_on_missing_to(self):
         from vtsearch.exporters import get_exporter
 
         exp = get_exporter("email_smtp")
         with pytest.raises(ValueError, match="Recipient"):
-            exp.export(SAMPLE_RESULTS, {"to": ""})
+            exp.export(SAMPLE_RESULTS, {"from": "me@example.com", "to": ""})
+
+    def test_export_raises_on_missing_from(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        with pytest.raises(ValueError, match="Sender"):
+            exp.export(SAMPLE_RESULTS, {"from": "", "to": "you@example.com"})
 
     def test_export_calls_smtp_via_mx(self):
         from vtsearch.exporters import get_exporter
@@ -401,17 +408,18 @@ class TestEmailLabelsetExporter:
             patch("vtsearch.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
             patch("vtsearch.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
         ):
-            result = exp.export(SAMPLE_RESULTS, {"to": "you@example.com"})
+            result = exp.export(
+                SAMPLE_RESULTS,
+                {"from": "me@my-domain.example", "to": "you@example.com"},
+            )
 
         mock_smtp_cls.assert_called_once_with("mx.example.com", 25, timeout=30)
         mock_server.sendmail.assert_called_once()
+        sender, recipients, _ = mock_server.sendmail.call_args.args
+        assert sender == "me@my-domain.example"
+        assert recipients == ["you@example.com"]
         assert "message" in result
         assert "you@example.com" in result["message"]
-
-    def test_from_address_is_vtsearch(self):
-        from vtsearch.exporters.email_smtp import FROM_ADDRESS
-
-        assert FROM_ADDRESS == "VTSearch@fake.ai"
 
     def test_plain_text_builder(self):
         from vtsearch.exporters.email_smtp import _build_plain_text
@@ -560,7 +568,7 @@ class TestExportEndpoint:
                 "/api/exporters/export",
                 json={
                     "exporter_name": "email_smtp",
-                    "field_values": {"to": "you@example.com"},
+                    "field_values": {"from": "me@my-domain.example", "to": "you@example.com"},
                     "results": SAMPLE_RESULTS,
                 },
             )

--- a/vtsearch/exporters/email_smtp/__init__.py
+++ b/vtsearch/exporters/email_smtp/__init__.py
@@ -2,7 +2,8 @@
 
 Connects directly to the recipient's mail server (via DNS MX record lookup)
 so no SMTP credentials or server configuration are needed.  The sender
-address is always ``VTSearch@fake.ai``.
+address is supplied by the caller — a real domain you control is required,
+because most MX hosts reject mail whose sender domain has no DNS records.
 
 Requires the ``dnspython`` package for MX record resolution.
 """
@@ -15,8 +16,6 @@ from email.mime.text import MIMEText
 from typing import Any
 
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
-
-FROM_ADDRESS = "VTSearch@fake.ai"
 
 
 def _build_plain_text(results: dict[str, Any]) -> str:
@@ -86,8 +85,9 @@ class EmailLabelsetExporter(LabelsetExporter):
     """Send auto-detect results by e-mail via direct MX delivery.
 
     Looks up the recipient domain's MX record and connects directly — no
-    SMTP credentials or server configuration required.  The sender address
-    is always ``VTSearch@fake.ai``.
+    SMTP credentials or server configuration required.  The caller must
+    supply a sender address on a domain they control; receiving MX hosts
+    reject mail whose sender domain has no DNS records.
     """
 
     name = "email_smtp"
@@ -95,6 +95,16 @@ class EmailLabelsetExporter(LabelsetExporter):
     description = "Email the results summary to any address."
     icon = "📧"
     fields = [
+        ExporterField(
+            key="from",
+            label="Sender Email",
+            field_type="email",
+            description=(
+                "The email address to send from. Must be on a domain you control — "
+                "MX hosts reject mail from non-existent domains."
+            ),
+            placeholder="vtsearch@your-domain.example",
+        ),
         ExporterField(
             key="to",
             label="Recipient Email",
@@ -105,11 +115,16 @@ class EmailLabelsetExporter(LabelsetExporter):
     ]
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        from_addr = field_values.get("from", "").strip()
         to_addr = field_values.get("to", "").strip()
+
+        if not from_addr:
+            raise ValueError("Sender email address is required.")
+        if "@" not in from_addr:
+            raise ValueError("Sender email address is invalid.")
 
         if not to_addr:
             raise ValueError("Recipient email address is required.")
-
         if "@" not in to_addr:
             raise ValueError("Recipient email address is invalid.")
 
@@ -122,7 +137,7 @@ class EmailLabelsetExporter(LabelsetExporter):
 
         msg = MIMEMultipart("alternative")
         msg["Subject"] = subject
-        msg["From"] = FROM_ADDRESS
+        msg["From"] = from_addr
         msg["To"] = to_addr
 
         plain = _build_plain_text(results)
@@ -132,7 +147,7 @@ class EmailLabelsetExporter(LabelsetExporter):
 
         with smtplib.SMTP(mx_host, 25, timeout=30) as server:
             server.ehlo()
-            server.sendmail(FROM_ADDRESS, [to_addr], msg.as_string())
+            server.sendmail(from_addr, [to_addr], msg.as_string())
 
         return {
             "message": (f"Email with {total_hits} hit(s) sent to {to_addr} via {mx_host}."),


### PR DESCRIPTION
## Summary

- The email_smtp exporter hardcoded `VTSearch@fake.ai` as the `From:` address. Most MX hosts reject mail whose sender domain has no DNS records, so the exporter was effectively broken outside lab SMTP setups.
- Replace the hardcoded sender with a required `from` ExporterField so callers supply a real address on a domain they control. The address is used for both the `From:` header and the SMTP envelope sender.
- Update tests: drop the assertion that pinned the constant to `VTSearch@fake.ai`, verify the new field is required and rejects empty values, and assert the sender propagates to `sendmail`.

## Breaking change

The email_smtp exporter now requires a `from` field — callers that previously only supplied `to` will get a `ValueError: Sender email address is required.` until they pass a sender too.

## Test plan

- [x] `./run-tests.sh io` — 532 passed

https://claude.ai/code/session_01NrkVRn154nPH75taiNZBJu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrkVRn154nPH75taiNZBJu)_