### PR TITLE
Log staging-cleanup failures in server_files importer

### DIFF
--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -25,6 +25,7 @@ that :meth:`resolve_file` can find the original file on disk.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import tempfile
@@ -35,6 +36,22 @@ from typing import Any
 from vtsearch.datasets.importers._npz_vectors import read_npz_filenames_and_vectors
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtsearch.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
+
+logger = logging.getLogger(__name__)
+
+
+def _cleanup_staging(staging: Path) -> None:
+    """Remove the staging symlink farm, logging (not raising) failures.
+
+    Cleanup runs in ``finally`` blocks where re-raising would mask the
+    real error; but silently swallowing leaves a symlink farm behind on
+    e.g. a permission error, so log every per-path failure.
+    """
+
+    def _onerror(func, path, exc_info):
+        logger.warning("Failed to remove staging entry %s: %s", path, exc_info[1])
+
+    shutil.rmtree(staging, onerror=_onerror)
 
 
 def _read_text_paths_file(paths_file: Path) -> list[Path]:
@@ -256,7 +273,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         staging = Path(tempfile.mkdtemp(prefix="server_files_"))
         name_to_source = _symlink_paths(paths, staging)
         if not name_to_source:
-            shutil.rmtree(staging, ignore_errors=True)
+            _cleanup_staging(staging)
             raise ValueError(f"None of the paths in {paths_file} resolved to existing files")
 
         # Rekey npz vectors from the original absolute path to the
@@ -355,7 +372,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
             if not had_direct and not medias:
                 raise ValueError(f"No {output_type} files found in listed paths")
         finally:
-            shutil.rmtree(staging, ignore_errors=True)
+            _cleanup_staging(staging)
 
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         paths_file = Path(field_values["paths_file"])
@@ -428,7 +445,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
                     # file).
                     yield converter_chunk
         finally:
-            shutil.rmtree(staging, ignore_errors=True)
+            _cleanup_staging(staging)
 
     def run_chunked_cli(
         self,


### PR DESCRIPTION
## Summary

The three `shutil.rmtree(staging, ignore_errors=True)` calls in
`vtsearch/datasets/importers/server_files/__init__.py` (the early-return
path in `_stage_paths`, the `run` finally, and the `run_chunked` finally)
silently dropped permission errors and other cleanup failures, leaving a
stale symlink farm behind under `/tmp` with no trace in the logs.

This routes all three through a small `_cleanup_staging` helper that
uses `shutil.rmtree`'s `onerror` callback to log each per-path failure
as a warning while still letting the import finish — so we get the same
non-fatal behaviour we had before, but the next operator sees *why* the
temp directory is still around.

## Test plan

- [x] `ruff check vtsearch/datasets/importers/server_files/` passes
- [x] `python -m py_compile vtsearch/datasets/importers/server_files/__init__.py` passes
- [ ] Existing `tests/test_server_files_importer.py` continues to pass


---
_Generated by [Claude Code](https://claude.ai/code/session_017XNtYndjp3jEYXz2zjcEtK)_