### PR TITLE
Track true embedding provenance in folder loader

### DIFF
--- a/tests/test_importer_loading.py
+++ b/tests/test_importer_loading.py
@@ -161,6 +161,41 @@ class TestLoadDatasetContentVectors:
         np.testing.assert_array_equal(medias[1]["embedding"], model_vector)
         mt._mock_embedder.embed_media.assert_called_once()
 
+    def test_content_vector_file_has_empty_embedder_id(self, tmp_path):
+        """Files whose vectors came from content_vectors should not be stamped
+        with the active embedder's name — the external vector may be a different
+        dimension, and downstream re-embedding for queries would dimension-mismatch.
+        """
+        import numpy as np
+
+        from vtsearch.datasets.loader import load_dataset_from_folder
+
+        wav_pre = tmp_path / "pre.wav"
+        wav_model = tmp_path / "model.wav"
+        self._write_wav(wav_pre)
+        self._write_wav(wav_model)
+
+        # External vector with a different dimension than the model would produce
+        # — simulates an NPZ from a higher-dim embedder (e.g. SigLIP-so400m 1152d).
+        external_vector = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        model_vector = np.array([1.0, 2.0, 3.0])
+        mt = self._make_fake_media_type(embed_return=model_vector)
+
+        medias: dict = {}
+
+        with self._patch_media_registry(mt):
+            load_dataset_from_folder(
+                tmp_path,
+                "audio",
+                medias,
+                content_vectors={"pre.wav": external_vector},
+                on_progress=lambda *a: None,
+            )
+
+        by_name = {m["filename"]: m for m in medias.values()}
+        assert by_name["pre.wav"]["embedder"] == ""
+        assert by_name["model.wav"]["embedder"] == "clap"
+
     def test_content_vector_file_skips_none_embed_check(self, tmp_path):
         """A file with a content vector is included even if embed_media would return None."""
         import unittest.mock as mock

--- a/vtsearch/datasets/loader_folder.py
+++ b/vtsearch/datasets/loader_folder.py
@@ -394,24 +394,29 @@ def load_dataset_from_folder(
                 elif file_path.name in custom_metadata_map:
                     file_cm = custom_metadata_map[file_path.name]
 
-            # Resolve embedding: custom_metadata > content_vectors > model
+            # Externally-supplied vectors (custom_metadata / content_vectors)
+            # may come from a different model than ``emb`` — leave embedder_id
+            # blank so downstream query re-embedding doesn't dimension-mismatch.
             cm_embedding = _get_embedding_value(file_cm) if file_cm else None
             if cm_embedding is not None:
                 embedding = cm_embedding
+                embedder_id = ""
             elif content_vectors and rel_path in content_vectors:
                 embedding = content_vectors[rel_path]
+                embedder_id = ""
             elif content_vectors and file_path.name in content_vectors:
                 embedding = content_vectors[file_path.name]
+                embedder_id = ""
             elif skip_embedding:
                 embedding = None
+                embedder_id = ""
             else:
                 if emb is None:
                     continue
                 embedding = bulk_embeddings.get(file_path)
                 if embedding is None:
                     continue
-
-            embedder_id = emb.name if emb else ""
+                embedder_id = emb.name
 
             # Resolve MD5: custom_metadata > content_md5s > computed
             cm_md5 = _get_md5_value(file_cm) if file_cm else ""
@@ -619,7 +624,6 @@ def load_dataset_from_folder_chunked(
         raise ValueError(f"No {media_type} files found in folder")
 
     total_files = len(media_files)
-    embedder_id = emb.name if emb else ""
 
     # Process in groups of chunk_size
     for start in range(0, total_files, chunk_size):
@@ -676,22 +680,27 @@ def load_dataset_from_folder_chunked(
                 elif file_path.name in custom_metadata_map:
                     file_cm = custom_metadata_map[file_path.name]
 
-            # Resolve embedding: custom_metadata > content_vectors > model
+            # External vectors keep embedder_id blank — see non-chunked path.
             cm_embedding = _get_embedding_value(file_cm) if file_cm else None
             if cm_embedding is not None:
                 embedding = cm_embedding
+                embedder_id = ""
             elif content_vectors and rel_path in content_vectors:
                 embedding = content_vectors[rel_path]
+                embedder_id = ""
             elif content_vectors and file_path.name in content_vectors:
                 embedding = content_vectors[file_path.name]
+                embedder_id = ""
             elif skip_embedding:
                 embedding = None
+                embedder_id = ""
             else:
                 if emb is None:
                     continue
                 embedding = chunk_bulk_embeddings.get(file_path)
                 if embedding is None:
                     continue
+                embedder_id = emb.name
 
             cm_md5 = _get_md5_value(file_cm) if file_cm else ""
 


### PR DESCRIPTION
## Summary

When a file's vector came from `custom_metadata` or `content_vectors` (e.g. an external SigLIP-so400m 1152-d NPZ paired with the default 768-d SigLIP embedder), `loader_folder.py` was stamping it with the active embedder's name. Downstream code that re-embeds a query "in the same embedder" then produced a dimension mismatch.

Fix: set `embedder_id` per-branch in the embedding-resolution ladder. Vectors actually produced by `emb` keep `emb.name`; externally-supplied vectors (custom_metadata / content_vectors) get `""` so query re-embedding doesn't pick a misleadingly-labelled model. Applied to both the non-chunked and chunked code paths.

## Test plan

- [x] `./run-tests.sh io datasets` (1013 passed)
- [x] `./run-tests.sh` full suite (3212 passed)
- [x] New `test_content_vector_file_has_empty_embedder_id` asserts a mixed load stamps the externally-supplied media with `embedder = ""` and the embedder-produced media with `embedder = "clap"`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg5k71xqXdothx3c66cvuF)_