### PR TITLE
Gate cross-calibration on n_labels >= 6 at every call site

### DIFF
--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -307,8 +307,12 @@ class TestTrainModelEpochs:
 
 
 class TestCalibrationSkippedForTinyLabels:
-    """``train_and_score`` should skip cross-calibration when safe_thresholds
-    is on and there are too few labels for the blend to use the xcal output."""
+    """``train_and_score`` should skip cross-calibration when there are
+    too few labels for the result to be useful — regardless of
+    ``safe_thresholds``.  Calibration costs two 200-epoch trainings per
+    call, and below the blend's ramp floor those trainings are either
+    discarded (safe_thresholds=True) or trained on too little data to
+    be reliable (safe_thresholds=False)."""
 
     def test_skips_calibration_when_safe_and_under_six_labels(self):
         """With safe_thresholds=True and n_labels<6, calculate_cross_calibration_threshold
@@ -332,8 +336,10 @@ class TestCalibrationSkippedForTinyLabels:
         patched.assert_not_called()
         assert 0.0 <= threshold <= 1.0
 
-    def test_still_calibrates_when_safe_off(self):
-        """With safe_thresholds=False, the xcal threshold is always required."""
+    def test_skips_calibration_when_safe_off_and_under_six_labels(self):
+        """With safe_thresholds=False and n_labels<6, calibration is still
+        skipped — fold trainings are unreliable with so few labels, and the
+        gate is purely a function of n_labels."""
         from vtsearch.models import training
 
         app_module.good_votes.update({k: None for k in [1, 2]})
@@ -342,7 +348,7 @@ class TestCalibrationSkippedForTinyLabels:
         with unittest.mock.patch.object(
             training,
             "calculate_cross_calibration_threshold",
-            wraps=training.calculate_cross_calibration_threshold,
+            side_effect=AssertionError("calibration should be skipped for tiny label sets"),
         ) as patched:
             training.train_and_score(
                 app_module.medias,
@@ -350,7 +356,7 @@ class TestCalibrationSkippedForTinyLabels:
                 app_module.bad_votes,
                 safe_thresholds=False,
             )
-        assert patched.call_count == 1
+        patched.assert_not_called()
 
     def test_still_calibrates_when_enough_labels(self):
         """With safe_thresholds=True and n_labels>=6, calibration still runs."""

--- a/vtsearch/models/labelset_training.py
+++ b/vtsearch/models/labelset_training.py
@@ -250,17 +250,23 @@ def labelset_train_and_score(
     input_dim = X.shape[1]
     hidden_dim = _auto_hidden_dim(len(X_list))
 
-    cal_rng = np.random.RandomState(42)
-    threshold = calculate_cross_calibration_threshold(
-        X_list,
-        y_list,
-        input_dim,
-        inclusion_value,
-        rng=cal_rng,
-        calibrate_count=calibrate_count,
-        calibration_fraction=calibration_fraction,
-        hidden_dim=hidden_dim,
-    )
+    # Skip cross-cal trainings below the ``calculate_safe_threshold`` ramp
+    # floor — they're expensive and the result is discarded by the blend
+    # (label_weight=0 → pure GMM) or unreliable with so few labels.
+    if len(X_list) < 6:
+        threshold = 0.5
+    else:
+        cal_rng = np.random.RandomState(42)
+        threshold = calculate_cross_calibration_threshold(
+            X_list,
+            y_list,
+            input_dim,
+            inclusion_value,
+            rng=cal_rng,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+            hidden_dim=hidden_dim,
+        )
 
     model = train_model(X, y, input_dim, inclusion_value, hidden_dim=hidden_dim)
 

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -576,16 +576,15 @@ def train_and_score(
     # scores (same capacity, same score distribution shape).
     hidden_dim = _auto_hidden_dim(len(X_list))
 
-    # Calculate threshold using k-fold calibration.
-    # Use a seeded RNG so that train/calibrate splits are deterministic —
-    # without this, the global np.random state makes results non-reproducible.
-    # When ``safe_thresholds`` is on and the label count is below the
-    # ``calculate_safe_threshold`` ramp floor, the blended weight on the
-    # cross-cal threshold is exactly 0 (pure GMM), so the calibration
-    # trainings would be discarded.  Skip them and pass ``inf`` to signal
-    # "use the GMM threshold" downstream.
-    if safe_thresholds and len(X_list) < 6:
-        threshold = float("inf")
+    # Calculate threshold using k-fold calibration.  Skip when the label
+    # count is below the ``calculate_safe_threshold`` ramp floor: the
+    # calibration trainings would be expensive (two 200-epoch fits) and
+    # the result is either discarded (safe_thresholds=True blends with
+    # label_weight=0 → pure GMM) or unreliable (safe_thresholds=False with
+    # so few labels).  Use 0.5 as the neutral default; it blends to pure
+    # GMM under safe_thresholds and is a sensible mid-point otherwise.
+    if len(X_list) < 6:
+        threshold = 0.5
     else:
         cal_rng = np.random.RandomState(42)
         threshold = calculate_cross_calibration_threshold(
@@ -770,14 +769,17 @@ def train_detector_from_origins(
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 
-    threshold = calculate_cross_calibration_threshold(
-        X_list,
-        y_list,
-        input_dim,
-        inclusion,
-        calibrate_count=calibrate_count,
-        calibration_fraction=calibration_fraction,
-    )
+    if len(X_list) < 6:
+        threshold = 0.5
+    else:
+        threshold = calculate_cross_calibration_threshold(
+            X_list,
+            y_list,
+            input_dim,
+            inclusion,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+        )
     model = train_model(X, y, input_dim, inclusion)
 
     state_dict = model.state_dict()


### PR DESCRIPTION
## Summary

Cross-calibration runs two 200-epoch MLP trainings per call. Below 6 labels its result is either entirely discarded by the GMM blend (`safe_thresholds=True` → `label_weight=0`) or trained on too little data to trust (`safe_thresholds=False`). The gate already existed in `train_and_score` but only under `safe_thresholds`; `labelset_train_and_score` and `train_detector_from_origins` had no gate at all and paid the full calibration cost only to have the result thrown away by the blend.

- Apply `if len(X_list) < 6: threshold = 0.5` uniformly at all three call sites
- 0.5 is the neutral default — under `safe_thresholds` it still resolves to pure GMM because `label_weight = 0` for `n < 6`
- Update the sorting test to assert that `safe_thresholds=False` also skips below the floor (the gate is now purely a function of `n_labels`)

## Test plan

- [x] `./run-tests.sh sorting models` (223 passed)
- [x] `./run-tests.sh` full suite (3211 passed, 1 skipped)


---
_Generated by [Claude Code](https://claude.ai/code/session_017qEruR6TDgN3x2XcQViQP8)_