### PR TITLE
Close PIL file handles in image embedders

### DIFF
--- a/vtsearch/media/image/_dinov2_shared.py
+++ b/vtsearch/media/image/_dinov2_shared.py
@@ -91,7 +91,8 @@ class _Dinov2Base(MediaEmbedder):
         try:
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             return self.embed_pil_image(image)
         except Exception:
             logging.getLogger(__name__).exception("Error embedding %s", file_path)
@@ -137,7 +138,8 @@ class _Dinov2Base(MediaEmbedder):
             import torch  # noqa: PLC0415
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             inputs = self._processor(images=image, return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}

--- a/vtsearch/media/image/_dinov3_shared.py
+++ b/vtsearch/media/image/_dinov3_shared.py
@@ -102,7 +102,8 @@ class _Dinov3Base(MediaEmbedder):
         try:
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             return self.embed_pil_image(image)
         except Exception:
             logging.getLogger(__name__).exception("Error embedding %s", file_path)
@@ -148,7 +149,8 @@ class _Dinov3Base(MediaEmbedder):
             import torch  # noqa: PLC0415
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             inputs = self._processor(images=image, return_tensors="pt")
             device = next(self._model.parameters()).device
             inputs = {k: v.to(device) for k, v in inputs.items()}

--- a/vtsearch/media/image/_eupe_shared.py
+++ b/vtsearch/media/image/_eupe_shared.py
@@ -165,7 +165,8 @@ class _EupeBase(MediaEmbedder):
             import torch  # noqa: PLC0415
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             tensor = self._preprocess(image).unsqueeze(0)
             device = next(self._model.parameters()).device
             tensor = tensor.to(device)

--- a/vtsearch/media/image/embedder_clip.py
+++ b/vtsearch/media/image/embedder_clip.py
@@ -88,7 +88,8 @@ class ImageClipEmbedder(MediaEmbedder):
         try:
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             return self.embed_pil_image(image)
         except Exception:
             logging.getLogger(__name__).exception("Error embedding %s", file_path)

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -112,7 +112,8 @@ class ImageSiglipEmbedder(MediaEmbedder):
         try:
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             return self.embed_pil_image(image)
         except Exception:
             logging.getLogger(__name__).exception("Error embedding %s", file_path)

--- a/vtsearch/media/image/embedder_siglip2.py
+++ b/vtsearch/media/image/embedder_siglip2.py
@@ -93,7 +93,8 @@ class ImageSiglip2Embedder(MediaEmbedder):
         try:
             from PIL import Image  # noqa: PLC0415
 
-            image = Image.open(file_path).convert("RGB")
+            with Image.open(file_path) as _img:
+                image = _img.convert("RGB")
             return self.embed_pil_image(image)
         except Exception:
             logging.getLogger(__name__).exception("Error embedding %s", file_path)

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -1279,8 +1279,8 @@ class ImageMediaType(MediaType):
                 with open(img_path, "rb") as f:
                     image_bytes = f.read()
                 try:
-                    img = Image.open(img_path)
-                    width, height = img.width, img.height
+                    with Image.open(img_path) as img:
+                        width, height = img.width, img.height
                 except Exception:
                     width, height = None, None
                 clips[clip_id] = {
@@ -1609,8 +1609,8 @@ class ImageMediaType(MediaType):
         with open(file_path, "rb") as f:
             media_bytes = f.read()
         try:
-            img = Image.open(file_path)
-            width, height = img.width, img.height
+            with Image.open(file_path) as img:
+                width, height = img.width, img.height
         except Exception:
             width, height = None, None
         return {

--- a/vtsearch/models/resolver.py
+++ b/vtsearch/models/resolver.py
@@ -488,10 +488,10 @@ def _apply_clip_and_embed(
             from PIL import Image
 
             box_values = [int(float(v)) for v in clip_box.split(",")]
-            img = Image.open(file_path)
-            cropped = img.crop(tuple(box_values))
-            buf = _io.BytesIO()
-            cropped.save(buf, format=img.format or "PNG")
+            with Image.open(file_path) as img:
+                cropped = img.crop(tuple(box_values))
+                buf = _io.BytesIO()
+                cropped.save(buf, format=img.format or "PNG")
             crop_bytes = buf.getvalue()
             fd, tmp = tempfile.mkstemp(suffix=".png")
             try:


### PR DESCRIPTION
## Summary

`Image.open(path)` returns a lazy PIL `Image` that keeps the underlying file handle open until the image is garbage-collected. Even when followed by `.convert("RGB")`, the original `Image` (with its `fp`) lingers, so at 100k+ images the file-descriptor count rides the GC and can blow through the process ulimit.

Wrapped every file-path `Image.open` call in a `with` block so the descriptor is released as soon as the data we need is read:

- `vtsearch/media/image/embedder_clip.py`
- `vtsearch/media/image/embedder_siglip.py`, `embedder_siglip2.py`
- `vtsearch/media/image/_dinov2_shared.py` (both embed + patch paths)
- `vtsearch/media/image/_dinov3_shared.py` (both embed + patch paths)
- `vtsearch/media/image/_eupe_shared.py`
- `vtsearch/media/image/media_type.py` (folder import metadata + `load_media_data`)
- `vtsearch/models/resolver.py` (image clip crop path)

In-memory `Image.open(io.BytesIO(...))` call sites were left alone — they don't leak fds.

## Test plan

- [x] `./run-tests.sh core models` — 408 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01VzCBY9fGbPYdEULzvZz5wQ)_