### PR TITLE
Disable gunicorn worker timeout by default

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -34,7 +34,7 @@ installation and getting started, see [SETUP.md](SETUP.md).
 | `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn — triggers model init / autoload / settings-source sync at import time (the Flask `__main__` block is skipped under WSGI). Set automatically in the Dockerfiles. |
 | `VTSEARCH_BIND` | `0.0.0.0:5000` | Gunicorn bind address (`host:port`) |
 | `VTSEARCH_THREADS` | `8` | Threads per gunicorn worker |
-| `VTSEARCH_TIMEOUT` | `120` | Worker request timeout in seconds; `0` disables |
+| `VTSEARCH_TIMEOUT` | `0` | Worker request timeout in seconds; `0` (default) disables. Long imports, training, and evaluation runs routinely exceed any short timeout — overriding to anything below ~1800 risks SIGKILL mid-operation. |
 
 ### HuggingFace / PyTorch
 
@@ -87,7 +87,7 @@ The bundled config pins a single worker with 8 gthread threads:
 workers = 1
 worker_class = "gthread"
 threads = 8
-timeout = 120
+timeout = 0  # disabled; long imports / training would otherwise SIGKILL the worker
 ```
 
 **Why one worker?** VTSearch keeps all dataset/model state in-process
@@ -105,7 +105,7 @@ Override the relevant config via environment variables:
 |---------|---------|-------|
 | `VTSEARCH_BIND` | `0.0.0.0:5000` | `host:port` |
 | `VTSEARCH_THREADS` | `8` | Threads per worker — raise for more concurrent requests |
-| `VTSEARCH_TIMEOUT` | `120` | Worker timeout in seconds; `0` disables |
+| `VTSEARCH_TIMEOUT` | `0` | Worker timeout in seconds; `0` (default) disables. Long imports / training routinely exceed short timeouts. |
 | `VTSEARCH_LOG_LEVEL` | `warning` | Gunicorn log level |
 
 For larger tuning changes, edit `gunicorn.conf.py` directly.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -379,7 +379,7 @@ VTSearch reads several optional environment variables:
 | `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn — triggers model init / settings sync at import time |
 | `VTSEARCH_BIND` | `0.0.0.0:5000` | Gunicorn bind address (`host:port`) |
 | `VTSEARCH_THREADS` | `8` | Threads per gunicorn worker |
-| `VTSEARCH_TIMEOUT` | `120` | Gunicorn worker timeout in seconds |
+| `VTSEARCH_TIMEOUT` | `0` | Gunicorn worker timeout in seconds (`0` = disabled; long imports / training would otherwise SIGKILL the worker) |
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for additional deployment-specific configuration, including the full env-var reference and gunicorn tuning.
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -9,7 +9,16 @@ worker and rely on threads for concurrency — matching the Flask dev server's
 Environment overrides:
   VTSEARCH_BIND          — host:port (default 0.0.0.0:5000)
   VTSEARCH_THREADS       — threads per worker (default 8)
-  VTSEARCH_TIMEOUT       — worker timeout in seconds, 0 disables (default 120)
+  VTSEARCH_TIMEOUT       — worker timeout in seconds, 0 disables (default 0)
+
+The worker timeout defaults to 0 (disabled). VTSearch routinely runs
+long-lived in-process work — importing 100k-element datasets, training
+detectors, evaluating sort iterations — and gunicorn's default 30 s (or
+even a 120 s cap) would SIGKILL the worker mid-operation, losing the
+dataset/model state held by the single worker. If you front gunicorn
+with a reverse proxy that needs request-level deadlines, override
+VTSEARCH_TIMEOUT explicitly; values shorter than ~1800 s are likely to
+truncate normal workloads.
 """
 
 import os
@@ -20,7 +29,7 @@ workers = 1
 worker_class = "gthread"
 threads = int(os.environ.get("VTSEARCH_THREADS", "8"))
 
-timeout = int(os.environ.get("VTSEARCH_TIMEOUT", "120"))
+timeout = int(os.environ.get("VTSEARCH_TIMEOUT", "0"))
 graceful_timeout = 30
 keepalive = 5
 


### PR DESCRIPTION
## Summary
- `gunicorn.conf.py` defaulted `VTSEARCH_TIMEOUT` to 120 s, which SIGKILLs the single worker mid-operation for any non-trivial dataset (100k-element imports, `eval_train_and_score`, autopilot resorts, etc.) and loses all in-process dataset/model state — there is no second worker to take over.
- Defaults `VTSEARCH_TIMEOUT` to `0` (disabled). Operators who front gunicorn with a reverse proxy that needs request-level deadlines can override explicitly; the docs and the config comment now note that values below ~1800 s are likely to truncate normal workloads.
- Updates `gunicorn.conf.py` docstring, `docs/DEPLOYMENT.md`, and `docs/SETUP.md` so the env-var tables and the example config snippet match the new default and explain *why*.

## Test plan
- [ ] `grep -n VTSEARCH_TIMEOUT gunicorn.conf.py docs/DEPLOYMENT.md docs/SETUP.md` shows the new default consistently.
- [ ] `VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app` starts and a long-running import (>120 s) completes without the worker being killed.
- [ ] `VTSEARCH_TIMEOUT=30 gunicorn -c gunicorn.conf.py app:app` still honours the override.

## Backwards compatibility
Behaviour change: requests that previously hit the 120 s wall are no longer interrupted by gunicorn. There is no API or schema change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHKkcxVNaxTinqj4sftREr)_