### PR TITLE
Move learned-sort + eval train-and-score to background jobs

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject, timer, Subscription, pairwise } from 'rxjs';
-import { takeUntil, switchMap } from 'rxjs/operators';
+import { takeUntil, switchMap, filter, take } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -19,7 +19,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { DetectorRegistryEntry } from '../../models/api.models';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
-import { LabelingStatusResponse } from '../../models/api.models';
+import { LabelingStatusResponse, LearnedSortJobResponse } from '../../models/api.models';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
@@ -395,14 +395,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortState.setSortStatus('Training...');
     this.sortingApi.learnedSort().pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
-        this.sortState.setSortResults(
-          response.results.map((r) => ({ id: r.id, score: r.score, bestRegion: r.best_region })),
-          response.threshold,
-        );
-        this.sortState.setSortBusy(false);
-        this.sortState.setSortStatus('');
-        if (autoSelect) {
-          this.autoSelectNext();
+        if (response.status === 'done') {
+          this.applyLearnedSortResult(response, autoSelect);
+        } else if (response.status === 'running') {
+          this.pollLearnedSortJob(response.job_id, autoSelect);
+        } else {
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus(response.error || 'Training failed');
         }
       },
       error: () => {
@@ -410,6 +409,44 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         this.sortState.setSortStatus('Training failed');
       },
     });
+  }
+
+  private pollLearnedSortJob(jobId: string, autoSelect: boolean): void {
+    timer(200, 500)
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap(() => this.sortingApi.getLearnedSortResult(jobId)),
+        filter((res) => res.status !== 'running'),
+        take(1),
+      )
+      .subscribe({
+        next: (res) => {
+          if (res.status === 'done') {
+            this.applyLearnedSortResult(res, autoSelect);
+          } else {
+            this.sortState.setSortBusy(false);
+            this.sortState.setSortStatus(res.error || 'Training failed');
+          }
+        },
+        error: () => {
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus('Training failed');
+        },
+      });
+  }
+
+  private applyLearnedSortResult(response: LearnedSortJobResponse, autoSelect: boolean): void {
+    const results = response.results ?? [];
+    const threshold = response.threshold ?? 0;
+    this.sortState.setSortResults(
+      results.map((r) => ({ id: r.id, score: r.score, bestRegion: r.best_region })),
+      threshold,
+    );
+    this.sortState.setSortBusy(false);
+    this.sortState.setSortStatus('');
+    if (autoSelect) {
+      this.autoSelectNext();
+    }
   }
 
   onLoadSort(): void {

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -48,9 +48,15 @@ describe('ProgressModalComponent', () => {
     const iterReq = httpMock.expectOne('/api/eval/voting-iterations');
     iterReq.flush({ progress: 0, total: 10, done: false });
 
-    // Flush train-and-score
+    // Flush train-and-score — the endpoint now returns a job envelope
+    // and the component returns the data inline on cache hit (status=done).
     const trainReq = httpMock.expectOne('/api/eval/train-and-score');
-    trainReq.flush({ error_cost: [{ num_labels: 5, error_cost: 0.5 }] });
+    trainReq.flush({
+      job_id: 'abc',
+      status: 'done',
+      metric: 'smart',
+      error_cost: [{ num_labels: 5, error_cost: 0.5 }],
+    });
 
     tick(50);
     expect(component.analyzing).toBeFalse();

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject, takeUntil, timer, switchMap } from 'rxjs';
+import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
+import { EvalTrainAndScoreJobResponse } from '../../../models/api.models';
 import { ModalComponent } from '../../modal/modal.component';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -104,23 +105,55 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
         },
       });
 
-    // Request train-and-score
+    // Request train-and-score; the new endpoint returns a job envelope.
     this.sortingApi.trainAndScore(this.metric).subscribe({
       next: (res) => {
-        this.analyzing = false;
-        if (this.metric === 'smart') {
-          this.chartData = res.error_cost || [];
-        } else if (this.metric === 'stable') {
-          this.chartData = res.stability || [];
+        if (res.status === 'done') {
+          this.applyEvalResult(res);
+        } else if (res.status === 'running') {
+          this.pollEvalJob(res.job_id);
         } else {
-          this.chartData = res.diversity || [];
+          this.analyzing = false;
         }
-        setTimeout(() => this.renderChart(), 50);
       },
       error: () => {
         this.analyzing = false;
       },
     });
+  }
+
+  private pollEvalJob(jobId: string): void {
+    timer(200, 500)
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap(() => this.sortingApi.getEvalTrainAndScoreResult(jobId)),
+        filter((res) => res.status !== 'running'),
+        take(1),
+      )
+      .subscribe({
+        next: (res) => {
+          if (res.status === 'done') {
+            this.applyEvalResult(res);
+          } else {
+            this.analyzing = false;
+          }
+        },
+        error: () => {
+          this.analyzing = false;
+        },
+      });
+  }
+
+  private applyEvalResult(res: EvalTrainAndScoreJobResponse): void {
+    this.analyzing = false;
+    if (this.metric === 'smart') {
+      this.chartData = res.error_cost || [];
+    } else if (this.metric === 'stable') {
+      this.chartData = res.stability || [];
+    } else {
+      this.chartData = res.diversity || [];
+    }
+    setTimeout(() => this.renderChart(), 50);
   }
 
   private renderChart(): void {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -56,6 +56,20 @@ export interface LearnedSortResponse {
   threshold: number;
 }
 
+/** Initial response to ``POST /api/learned-sort`` and shape returned by the
+ *  result-polling endpoint.  ``status: "done"`` carries the full result;
+ *  ``status: "running"`` means the client should poll
+ *  ``GET /api/learned-sort/result?job_id=…`` until done. */
+export interface LearnedSortJobResponse {
+  job_id: string;
+  status: 'running' | 'done' | 'error' | 'cancelled' | 'missing';
+  results?: LearnedSortResult[];
+  threshold?: number;
+  current?: number;
+  total?: number;
+  error?: string;
+}
+
 export interface VotesResponse {
   good: number[];
   bad: number[];
@@ -528,6 +542,20 @@ export interface TrainAndScoreResponse {
   stability?: StabilityDataPoint[];
   diversity?: DiversityDataPoint[];
   [key: string]: unknown;
+}
+
+/** Job envelope for ``/api/eval/train-and-score``.  Mirrors
+ *  :class:`LearnedSortJobResponse`. */
+export interface EvalTrainAndScoreJobResponse {
+  job_id: string;
+  status: 'running' | 'done' | 'error' | 'cancelled' | 'missing';
+  metric?: 'smart' | 'stable' | 'diverse';
+  error_cost?: ErrorCostDataPoint[];
+  stability?: StabilityDataPoint[];
+  diversity?: DiversityDataPoint[];
+  current?: number;
+  total?: number;
+  error?: string;
 }
 
 export interface IndicatorScoreHistoryResponse {

--- a/frontend/src/app/services/sorting-api.service.spec.ts
+++ b/frontend/src/app/services/sorting-api.service.spec.ts
@@ -39,11 +39,23 @@ describe('SortingApiService', () => {
     req.flush({});
   });
 
-  it('learnedSort should POST', () => {
-    service.learnedSort().subscribe(data => expect(data.results).toBeDefined());
+  it('learnedSort should POST and return a job envelope', () => {
+    service.learnedSort().subscribe(data => {
+      expect(data.job_id).toBeDefined();
+      expect(data.status).toBe('done');
+      expect(data.results).toBeDefined();
+    });
     const req = httpMock.expectOne('/api/learned-sort');
     expect(req.request.method).toBe('POST');
-    req.flush({ results: [], threshold: 0.5 });
+    req.flush({ job_id: 'xyz', status: 'done', results: [], threshold: 0.5 });
+  });
+
+  it('getLearnedSortResult should GET the result endpoint with the job_id', () => {
+    service.getLearnedSortResult('xyz').subscribe();
+    const req = httpMock.expectOne((r) => r.url === '/api/learned-sort/result');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('job_id')).toBe('xyz');
+    req.flush({ job_id: 'xyz', status: 'done', results: [], threshold: 0.5 });
   });
 
   it('getVotes should GET', () => {

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import {
   SortResponse,
   LearnedSortResponse,
+  LearnedSortJobResponse,
   VotesResponse,
   InclusionResponse,
   SafeThresholdsResponse,
@@ -18,7 +19,7 @@ import {
   LabelingStatusResponse,
   DiversityTreeNextResponse,
   ServerMediaFilesResponse,
-  TrainAndScoreResponse,
+  EvalTrainAndScoreJobResponse,
   VotingIterationsResponse,
   IndicatorScoreHistoryResponse,
 } from '../models/api.models';
@@ -35,8 +36,18 @@ export class SortingApiService {
     return this.http.get<SortProgressResponse>('/api/sort/progress');
   }
 
-  learnedSort(): Observable<LearnedSortResponse> {
-    return this.http.post<LearnedSortResponse>('/api/learned-sort', {});
+  /** Kick off a learned-sort training job.  The response will be ``done``
+   *  immediately when the cached signature matches; otherwise the caller
+   *  must poll {@link getLearnedSortResult} with the returned ``job_id``. */
+  learnedSort(): Observable<LearnedSortJobResponse> {
+    return this.http.post<LearnedSortJobResponse>('/api/learned-sort', {});
+  }
+
+  /** Poll for a learned-sort job's completion. */
+  getLearnedSortResult(jobId: string): Observable<LearnedSortJobResponse> {
+    return this.http.get<LearnedSortJobResponse>('/api/learned-sort/result', {
+      params: { job_id: jobId },
+    });
   }
 
   getVotes(): Observable<VotesResponse> {
@@ -158,8 +169,17 @@ export class SortingApiService {
     return this.http.get<DiversityTreeNextResponse>('/api/diversity-tree/next');
   }
 
-  trainAndScore(metric: string): Observable<TrainAndScoreResponse> {
-    return this.http.post<TrainAndScoreResponse>('/api/eval/train-and-score', { metric });
+  /** Kick off an eval train-and-score job.  Like {@link learnedSort}, the
+   *  response will be ``done`` immediately on a cache hit; otherwise poll
+   *  {@link getEvalTrainAndScoreResult}. */
+  trainAndScore(metric: string): Observable<EvalTrainAndScoreJobResponse> {
+    return this.http.post<EvalTrainAndScoreJobResponse>('/api/eval/train-and-score', { metric });
+  }
+
+  getEvalTrainAndScoreResult(jobId: string): Observable<EvalTrainAndScoreJobResponse> {
+    return this.http.get<EvalTrainAndScoreJobResponse>('/api/eval/train-and-score/result', {
+      params: { job_id: jobId },
+    });
   }
 
   getVotingIterations(): Observable<VotingIterationsResponse> {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,6 +351,10 @@ def reset_state():
     _loading_tasks.reset_for_tests()
     _model_loading_tasks.reset_for_tests()
 
+    from vtsearch.utils.async_jobs import reset_all_async_jobs_for_tests
+
+    reset_all_async_jobs_for_tests()
+
     _set_login_provider(_DefaultLoginProvider())
 
     _reset_ds_reg()
@@ -396,6 +400,25 @@ def client():
     app_module.app.config["TESTING"] = True
     with app_module.app.test_client() as c:
         yield c
+
+
+def _wait_for_job(job_manager, *, timeout: float = 30.0) -> None:
+    """Block until the current job in *job_manager* (if any) is done.
+
+    Test helper that the route-level ``wait=true`` flag relies on so tests
+    can call the async endpoints synchronously without sprinkling poll
+    loops everywhere.
+    """
+    import time as _time
+
+    job = job_manager.current()
+    if job is None:
+        return
+    deadline = _time.monotonic() + timeout
+    while job.status == "running" and _time.monotonic() < deadline:
+        job.done_event.wait(timeout=0.05)
+    if job.status == "running":
+        raise TimeoutError(f"Job {job.job_id} did not finish within {timeout}s")
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -139,7 +139,7 @@ class TestLearnedSortContract:
     def test_response_has_results_and_threshold(self, client):
         good_votes.update({1: None, 2: None})
         bad_votes.update({3: None, 4: None})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         data = resp.get_json()
         assert "results" in data
@@ -148,7 +148,7 @@ class TestLearnedSortContract:
     def test_each_result_has_id_and_score(self, client):
         good_votes.update({1: None, 2: None})
         bad_votes.update({3: None, 4: None})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         for entry in data["results"]:
             assert "id" in entry
@@ -584,7 +584,7 @@ class TestErrorResponseFormat:
         assert "error" in data
 
     def test_400_learned_sort_no_votes_is_json(self, client):
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
         data = resp.get_json()
         assert "error" in data

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -966,7 +966,7 @@ class TestSeedVotesFromExamples:
         assert len(bad_votes) >= 1
 
         # Learned sort should work — it accesses the embedding from the inserted media
-        res = client.post("/api/learned-sort")
+        res = client.post("/api/learned-sort", json={"wait": True})
         assert res.status_code == 200
         data = res.get_json()
         assert "results" in data

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -335,18 +335,18 @@ class TestEmptyState:
             medias.update(saved)
 
     def test_learned_sort_no_votes(self, client):
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
         assert "need at least" in resp.get_json()["error"]
 
     def test_learned_sort_only_good_votes(self, client):
         good_votes[1] = None
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_learned_sort_only_bad_votes(self, client):
         bad_votes[1] = None
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_labeling_progress_no_votes(self, client):

--- a/tests/test_label_sorting.py
+++ b/tests/test_label_sorting.py
@@ -97,7 +97,7 @@ class TestVotesEndpointEnriched:
         app_module.good_votes.update({1: None, 2: None})
         app_module.bad_votes.update({3: None, 4: None})
         # Trigger learned sort
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         sort_data = resp.get_json()
         assert "results" in sort_data

--- a/tests/test_labelset_elements_api.py
+++ b/tests/test_labelset_elements_api.py
@@ -352,7 +352,7 @@ class TestCrossDatasetMLPTraining:
         detector_id = self._seed_with_resolvable_labelset(tmp_path, monkeypatch)
         _load_detector_and_wait_local(client, detector_id)
 
-        res = client.post("/api/learned-sort", json={})
+        res = client.post("/api/learned-sort", json={"wait": True})
         assert res.status_code == 200, res.get_data(as_text=True)
         data = res.get_json()
         assert "results" in data and len(data["results"]) > 0

--- a/tests/test_multi_detector.py
+++ b/tests/test_multi_detector.py
@@ -397,7 +397,7 @@ class TestMLPCaching:
         bad_votes[19] = None
         bad_votes[20] = None
 
-        res = client.post("/api/learned-sort")
+        res = client.post("/api/learned-sort", json={"wait": True})
         assert res.status_code == 200
 
         det_ctx = get_active_detector_context()
@@ -417,13 +417,13 @@ class TestMLPCaching:
         bad_votes[19] = None
         bad_votes[20] = None
 
-        client.post("/api/learned-sort")
+        client.post("/api/learned-sort", json={"wait": True})
         det_ctx = get_active_detector_context()
         model1 = det_ctx.model
 
         # Add more votes and retrain
         good_votes[4] = None
-        client.post("/api/learned-sort")
+        client.post("/api/learned-sort", json={"wait": True})
 
         # Model should have been updated
         model2 = det_ctx.model

--- a/tests/test_multi_media_coverage.py
+++ b/tests/test_multi_media_coverage.py
@@ -121,7 +121,7 @@ class TestLearnedSortMultiMedia:
                 good_votes[i] = None
             for i in [18, 19, 20]:
                 bad_votes[i] = None
-            resp = client.post("/api/learned-sort")
+            resp = client.post("/api/learned-sort", json={"wait": True})
             assert resp.status_code == 200
             data = resp.get_json()
             assert "results" in data
@@ -143,7 +143,7 @@ class TestLearnedSortMultiMedia:
                 good_votes[i] = None
             for i in [18, 19, 20]:
                 bad_votes[i] = None
-            resp = client.post("/api/learned-sort")
+            resp = client.post("/api/learned-sort", json={"wait": True})
             assert resp.status_code == 200
             data = resp.get_json()
             assert "results" in data

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -398,7 +398,7 @@ class TestLearnedSort:
     def test_returns_all_clips(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         data = resp.get_json()
         assert len(data["results"]) == app_module.NUM_MEDIAS
@@ -407,7 +407,7 @@ class TestLearnedSort:
     def test_result_fields(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         for entry in data["results"]:
             assert "id" in entry
@@ -416,7 +416,7 @@ class TestLearnedSort:
     def test_sorted_descending(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         scores = [e["score"] for e in data["results"]]
         assert scores == sorted(scores, reverse=True)
@@ -424,28 +424,137 @@ class TestLearnedSort:
     def test_all_media_ids_present(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         ids = {e["id"] for e in data["results"]}
         assert ids == set(range(1, app_module.NUM_MEDIAS + 1))
 
     def test_only_good_votes_returns_400(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_only_bad_votes_returns_400(self, client):
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_scores_in_valid_range(self, client):
         app_module.good_votes.update({k: None for k in [1, 2]})
         app_module.bad_votes.update({k: None for k in [3, 4]})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         for entry in data["results"]:
             assert 0.0 <= entry["score"] <= 1.0
+
+
+class TestLearnedSortAsync:
+    """The endpoint now hands the work off to a background thread and the
+    client polls ``/api/learned-sort/result?job_id=...`` until done."""
+
+    def test_async_returns_job_id_then_polling_yields_result(self, client):
+        from tests.conftest import _wait_for_job
+        from vtsearch.utils.async_jobs import learned_sort_jobs
+
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3, 4]})
+
+        resp = client.post("/api/learned-sort", json={})
+        assert resp.status_code == 200
+        envelope = resp.get_json()
+        assert envelope["status"] in ("running", "done")
+        job_id = envelope["job_id"]
+
+        # Wait for the background thread to finish before polling, since the
+        # test client otherwise sees the still-running snapshot.
+        _wait_for_job(learned_sort_jobs)
+
+        result = client.get(f"/api/learned-sort/result?job_id={job_id}").get_json()
+        assert result["status"] == "done"
+        assert result["job_id"] == job_id
+        assert "results" in result and len(result["results"]) > 0
+        assert "threshold" in result
+
+    def test_unchanged_votes_short_circuit_to_cached(self, client):
+        """The signature cache lets re-sorts skip training entirely."""
+        from vtsearch.utils.async_jobs import learned_sort_jobs
+
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3, 4]})
+
+        first = client.post("/api/learned-sort", json={"wait": True}).get_json()
+        assert first["status"] == "done"
+        first_job_id = first["job_id"]
+
+        # Second call with the same signature should reuse the cached result —
+        # job_id is the original job's id and we get back done immediately
+        # without ``wait=true``.
+        second = client.post("/api/learned-sort", json={}).get_json()
+        assert second["status"] == "done"
+        assert second["job_id"] == first_job_id
+
+        # Cache invalidates when votes change.
+        app_module.bad_votes.update({5: None})
+        third = client.post("/api/learned-sort", json={"wait": True}).get_json()
+        assert third["status"] == "done"
+        assert third["job_id"] != first_job_id
+
+        learned_sort_jobs.reset_for_tests()
+
+    def test_polling_unknown_job_returns_404(self, client):
+        resp = client.get("/api/learned-sort/result?job_id=does-not-exist")
+        assert resp.status_code == 404
+        assert resp.get_json()["status"] == "missing"
+
+    def test_polling_without_job_id_returns_400(self, client):
+        resp = client.get("/api/learned-sort/result")
+        assert resp.status_code == 400
+
+
+class TestEvalTrainAndScoreAsync:
+    """The eval train-and-score endpoint mirrors the learned-sort pattern:
+    return a job envelope, poll a result endpoint, short-circuit unchanged
+    runs via the signature cache."""
+
+    def _seed_history(self):
+        from vtsearch.utils import label_history
+
+        # A handful of "good" votes are enough to exercise the smart metric.
+        for cid, lbl in [(1, "good"), (2, "good"), (3, "bad"), (4, "bad")]:
+            if lbl == "good":
+                app_module.good_votes[cid] = None
+            else:
+                app_module.bad_votes[cid] = None
+            label_history.append((cid, lbl, 0.0))
+
+    def test_wait_returns_metric_inline(self, client):
+        self._seed_history()
+        resp = client.post("/api/eval/train-and-score", json={"metric": "smart", "wait": True})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "done"
+        assert data["metric"] == "smart"
+        assert "error_cost" in data
+
+    def test_async_polls_to_done(self, client):
+        from tests.conftest import _wait_for_job
+        from vtsearch.utils.async_jobs import eval_jobs
+
+        self._seed_history()
+        envelope = client.post("/api/eval/train-and-score", json={"metric": "stable"}).get_json()
+        assert envelope["status"] in ("running", "done")
+        job_id = envelope["job_id"]
+
+        _wait_for_job(eval_jobs)
+
+        result = client.get(f"/api/eval/train-and-score/result?job_id={job_id}").get_json()
+        assert result["status"] == "done"
+        assert result["metric"] == "stable"
+        assert "stability" in result
+
+    def test_invalid_metric_rejected(self, client):
+        resp = client.post("/api/eval/train-and-score", json={"metric": "bogus", "wait": True})
+        assert resp.status_code == 400
 
 
 class TestExampleSort:

--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -232,13 +232,13 @@ class TestProgressCacheWithLabelChanges:
         """Learned sort should work after toggling off a vote."""
         client.post("/api/medias/1/vote", json={"vote": "good"})
         client.post("/api/medias/2/vote", json={"vote": "bad"})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
 
         # Toggle off good vote, add a different good vote
         client.post("/api/medias/1/vote", json={"vote": "good"})
         client.post("/api/medias/3/vote", json={"vote": "good"})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
 
     def test_learned_sort_returns_400_after_toggling_all_good(self, client):
@@ -247,7 +247,7 @@ class TestProgressCacheWithLabelChanges:
         client.post("/api/medias/2/vote", json={"vote": "bad"})
         # Toggle off the only good vote
         client.post("/api/medias/1/vote", json={"vote": "good"})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_labeling_status_after_label_change(self, client):
@@ -344,7 +344,7 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
         """Live models from learned-sort should also be cleared on a vote switch."""
         client.post("/api/medias/1/vote", json={"vote": "good"})
         client.post("/api/medias/2/vote", json={"vote": "bad"})
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         assert len(_live_models) > 0
 
@@ -706,7 +706,7 @@ class TestLiveModelReuse:
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
 
-        resp = client.post("/api/learned-sort")
+        resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
 
         # A live model should have been injected for the current vote set

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -97,17 +97,45 @@ def indicator_score_history():
         return jsonify({"error": "Score history computation failed"}), 500
 
 
+_METRIC_KEY = {"smart": "error_cost", "stable": "stability", "diverse": "diversity"}
+
+
+def _eval_done_payload(job) -> dict:
+    """Build the JSON body for a finished eval job, including metric data."""
+    result = job.result or {}
+    metric = result.get("metric")
+    data_key = _METRIC_KEY.get(metric, "data")
+    return {
+        "job_id": job.job_id,
+        "status": "done",
+        "metric": metric,
+        data_key: result.get("data", []),
+    }
+
+
 @eval_bp.route("/api/eval/train-and-score", methods=["POST"])
 def eval_train_and_score():
-    """Compute indicator score history for a given metric.
+    """Start (or short-circuit) an eval train-and-score computation.
 
-    Expects JSON::
+    The work walks the full ``label_history`` retraining a small MLP at
+    every step, which used to block every other request on the gthread
+    pool.  We now run it on a background daemon thread and return a
+    ``job_id``; clients poll ``/api/eval/train-and-score/result`` for the
+    metric data and ``/api/eval/voting-iterations`` for progress.
 
-        {"metric": "smart" | "stable" | "diverse"}
+    A signature cache keyed by ``(metric, history, votes, inclusion,
+    dataset, detector)`` short-circuits identical re-runs.
 
-    Runs the computation in a background thread and returns the result
-    synchronously. Progress can be polled via ``/api/eval/voting-iterations``.
+    Tests can pass ``{"wait": true}`` to block until the job completes.
     """
+    from vtsearch.utils.async_jobs import eval_jobs
+    from vtsearch.utils.state_core import (
+        get_active_context,
+        get_active_detector_context,
+        set_thread_dataset_context,
+        set_thread_detector_context,
+    )
+
     data = get_json_or_400()
     if not isinstance(data, dict):
         return data
@@ -116,32 +144,96 @@ def eval_train_and_score():
     if metric not in ("smart", "stable", "diverse"):
         return jsonify({"error": "metric must be one of: smart, stable, diverse"}), 400
 
+    wait = bool(data.get("wait"))
+
     clips = snapshot_medias()
     inclusion = get_inclusion()
     history = list(label_history)
-    n_total = max(len(history) - 1, 0)
+    good_snap = dict(good_votes)
+    bad_snap = dict(bad_votes)
 
+    ds_ctx = get_active_context()
+    det_ctx = get_active_detector_context()
+
+    signature = (
+        metric,
+        ds_ctx.dataset_id,
+        det_ctx.detector_id,
+        tuple(sorted(clips.keys())),
+        tuple(history),
+        tuple(sorted(good_snap)),
+        tuple(sorted(bad_snap)),
+        inclusion,
+    )
+
+    cached = eval_jobs.cached_for(signature)
+    if cached is not None:
+        return jsonify(_eval_done_payload(cached))
+
+    n_total = max(len(history) - 1, 0)
     update_eval_progress("running", f"Computing {metric}...", 0, n_total)
 
-    try:
-        if metric == "smart":
-            result_data = calculate_error_cost_over_time(clips, history, good_votes, bad_votes, inclusion)
+    def _run(job):
+        set_thread_dataset_context(ds_ctx)
+        set_thread_detector_context(det_ctx)
+        try:
+            if metric == "smart":
+                data = calculate_error_cost_over_time(clips, history, good_snap, bad_snap, inclusion)
+            elif metric == "stable":
+                data = calculate_prediction_stability_over_time(clips, history, inclusion)
+            else:
+                data = calculate_diversity_level_over_time(clips, history, inclusion)
+            job.result = {"metric": metric, "data": data}
             update_eval_progress("idle", "Done", n_total, n_total)
-            return jsonify({"error_cost": result_data})
-        elif metric == "stable":
-            result_data = calculate_prediction_stability_over_time(clips, history, inclusion)
-            update_eval_progress("idle", "Done", n_total, n_total)
-            return jsonify({"stability": result_data})
-        else:
-            result_data = calculate_diversity_level_over_time(clips, history, inclusion)
-            update_eval_progress("idle", "Done", n_total, n_total)
-            return jsonify({"diversity": result_data})
-    except Exception:
-        import logging
+        except Exception:
+            update_eval_progress("idle", "Error", 0, 0)
+            raise
+        finally:
+            set_thread_dataset_context(None)
+            set_thread_detector_context(None)
 
-        logging.getLogger(__name__).exception("eval train-and-score failed")
-        update_eval_progress("idle", "Error", 0, 0)
-        return jsonify({"error": "Evaluation computation failed"}), 500
+    job = eval_jobs.start(signature, _run)
+
+    if wait:
+        job.done_event.wait(timeout=300)
+        if job.status == "error":
+            return jsonify({"error": job.error or "Evaluation computation failed"}), 500
+        if job.status == "done":
+            return jsonify(_eval_done_payload(job))
+
+    return jsonify({"job_id": job.job_id, "status": "running", "current": 0, "total": n_total})
+
+
+@eval_bp.route("/api/eval/train-and-score/result", methods=["GET"])
+def eval_train_and_score_result():
+    """Poll a background eval train-and-score job."""
+    from vtsearch.utils.async_jobs import eval_jobs
+
+    job_id = request.args.get("job_id", "").strip()
+    if not job_id:
+        return jsonify({"error": "job_id is required"}), 400
+
+    job = eval_jobs.get(job_id)
+    if job is None:
+        return jsonify({"status": "missing", "error": "Job not found"}), 404
+
+    if job.status == "running":
+        prog = get_eval_progress()
+        return jsonify({
+            "job_id": job.job_id,
+            "status": "running",
+            "current": prog.get("current", 0),
+            "total": prog.get("total", 0),
+        })
+    if job.status == "error":
+        return jsonify({
+            "job_id": job.job_id,
+            "status": "error",
+            "error": job.error or "Evaluation computation failed",
+        }), 500
+    if job.status == "cancelled":
+        return jsonify({"job_id": job.job_id, "status": "cancelled"})
+    return jsonify(_eval_done_payload(job))
 
 
 @eval_bp.route("/api/eval/voting-iterations", methods=["GET"])

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -177,22 +177,49 @@ def sort_clips():
         return jsonify({"error": "Text sort failed"}), 500
 
 
+def _learned_sort_done_payload(job) -> dict:
+    """Build the JSON body returned when a learned-sort job is finished."""
+    result = job.result or {}
+    return {
+        "job_id": job.job_id,
+        "status": "done",
+        "results": result.get("results", []),
+        "threshold": result.get("threshold", 0.0),
+    }
+
+
 @sorting_bp.route("/api/learned-sort", methods=["POST"])
 def learned_sort():
-    """Train MLP on the active detector's saved labelset (or active votes when
-    no detector is loaded) and return all medias sorted by predicted score.
+    """Kick off (or short-circuit) a learned-sort training job.
 
-    When a detector is active, training uses every label saved on disk —
-    including labels whose underlying media isn't part of the active dataset.
-    Their vectors are pulled from :attr:`DetectorContext.label_embeddings`
-    (populated at load) so the MLP isn't degraded by ignoring cross-dataset
-    labels.
+    Training is GIL-bound and ran inline used to stall every other request
+    served by the small ``gthread`` pool — votes polls, thumbnails, even
+    media bytes.  The endpoint now hands the work off to a background daemon
+    thread and returns immediately with a ``job_id``; clients poll
+    :func:`learned_sort_result` until ``status == "done"``.
+
+    A small signature cache short-circuits the no-op case: when the votes,
+    detector, inclusion and thresholding settings are unchanged from the
+    most recent successful run, the previous result is returned directly.
+
+    Tests can pass ``{"wait": true}`` in the body to block until the job
+    completes and receive the result inline.  The frontend leaves it false.
     """
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.models.detector_registry import get_detector
     from vtsearch.models.detector_store import _detector_path, _read_detector
     from vtsearch.models.labelset_training import labelset_train_and_score
-    from vtsearch.utils.state_core import _empty_detector_context, get_active_detector_context
+    from vtsearch.utils.async_jobs import learned_sort_jobs
+    from vtsearch.utils.state_core import (
+        _empty_detector_context,
+        get_active_context,
+        get_active_detector_context,
+        set_thread_dataset_context,
+        set_thread_detector_context,
+    )
+
+    body = request.get_json(silent=True) or {}
+    wait = bool(body.get("wait"))
 
     snap = snapshot_medias()
 
@@ -200,6 +227,7 @@ def learned_sort():
     # labelset cached on det_ctx by ``ensure_votes_match_active_dataset`` to
     # avoid re-reading the JSON file on every click.
     det_ctx = get_active_detector_context()
+    ds_ctx = get_active_context()
     labelset: LabelSet | None = None
     det_media_type = ""
     if det_ctx is not _empty_detector_context and det_ctx.detector_id:
@@ -214,99 +242,203 @@ def learned_sort():
                     labelset = LabelSet.from_dict(det_data.get("labelset") or {})
                     det_media_type = det_data.get("media_type", "") or ""
 
+    # Early validation so 400s come back before we spin a thread.
     if labelset is not None:
         good_count = sum(1 for el in labelset.elements if el.label == "good")
         bad_count = sum(1 for el in labelset.elements if el.label == "bad")
         if good_count == 0 or bad_count == 0:
             return jsonify({"error": "need at least one good and one bad vote"}), 400
-        results, threshold, model = labelset_train_and_score(
-            det_ctx,
-            labelset,
-            media_type=det_media_type,
-            clips_dict=snap,
-            inclusion_value=get_inclusion(),
-            safe_thresholds=get_safe_thresholds(),
-            calibrate_count=get_calibrate_count(),
-            calibration_fraction=get_calibration_fraction(),
-        )
     else:
         if not good_votes or not bad_votes:
             return jsonify({"error": "need at least one good and one bad vote"}), 400
-        results, threshold, model = train_and_score(
-            snap,
-            good_votes,
-            bad_votes,
-            get_inclusion(),
-            safe_thresholds=get_safe_thresholds(),
-            calibrate_count=get_calibrate_count(),
-            calibration_fraction=get_calibration_fraction(),
-            vote_region_boxes=dict(vote_region_boxes),
-        )
 
-    # Store scores so the /api/votes endpoint can provide confidence info.
-    update_learned_scores({r["id"]: r["score"] for r in results})
+    inclusion_value = get_inclusion()
+    safe_thresholds_value = get_safe_thresholds()
+    calibrate_count_value = get_calibrate_count()
+    calibration_fraction_value = get_calibration_fraction()
+    region_boxes_snapshot = dict(vote_region_boxes)
 
-    # In the labelset path, training used the on-disk labelset (potentially
-    # cross-dataset) — derive the live-cache key and the cached training
-    # snapshot from the labelset itself, not from local cid-keyed votes.
-    labelset_local_good: set[int] | None = None
-    labelset_local_bad: set[int] | None = None
-    labelset_training_medias: dict[int, dict] | None = None
-    labelset_has_cross_dataset = False
+    # Signature: covers everything that changes the training output.  Re-sorts
+    # with the same vote set + settings reuse the cached result.
     if labelset is not None:
-        from vtsearch.utils import build_media_lookup, resolve_media_ids
+        labels_sig = tuple(
+            sorted((el.label, _stable_element_id_for_sig(el)) for el in labelset.elements)
+        )
+    else:
+        labels_sig = (
+            ("good", tuple(sorted(good_votes))),
+            ("bad", tuple(sorted(bad_votes))),
+            ("regions", tuple(sorted(region_boxes_snapshot.items()))),
+        )
+    signature = (
+        det_ctx.detector_id,
+        ds_ctx.dataset_id,
+        tuple(sorted(snap.keys())),
+        labels_sig,
+        inclusion_value,
+        safe_thresholds_value,
+        calibrate_count_value,
+        calibration_fraction_value,
+    )
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
-        labelset_local_good = set()
-        labelset_local_bad = set()
-        labelset_training_medias = {}
-        for el in labelset.elements:
-            if el.label not in ("good", "bad"):
-                continue
-            cids = resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup)
-            if not cids:
-                labelset_has_cross_dataset = True
-                continue
-            target = labelset_local_good if el.label == "good" else labelset_local_bad
-            for cid in cids:
-                target.add(cid)
-                if cid in snap:
-                    labelset_training_medias[cid] = snap[cid]
+    cached = learned_sort_jobs.cached_for(signature)
+    if cached is not None:
+        return jsonify(_learned_sort_done_payload(cached))
 
-    # Inject the live model into the progress cache so indicators and the
-    # progress line-graph use the actual model that guided sorting, rather
-    # than retraining an independent model from scratch.  The cache is keyed
-    # by current-dataset cids, so only inject when the model's training set
-    # is fully representable in that key — otherwise the cache would return
-    # a cross-dataset model when local-cids replay asks for a local-only one.
-    if model is not None:
-        if labelset is None:
-            inject_live_model(good_votes, bad_votes, model, threshold)
-        elif (
-            not labelset_has_cross_dataset
-            and labelset_local_good == set(good_votes)
-            and labelset_local_bad == set(bad_votes)
-        ):
-            inject_live_model(good_votes, bad_votes, model, threshold)
+    def _run(job):
+        # Background thread needs the same dataset/detector context as the
+        # request thread so proxies (good_votes, bad_votes, etc.) resolve
+        # correctly when the training helpers reach for them.
+        set_thread_dataset_context(ds_ctx)
+        set_thread_detector_context(det_ctx)
+        try:
+            if labelset is not None:
+                results, threshold, model = labelset_train_and_score(
+                    det_ctx,
+                    labelset,
+                    media_type=det_media_type,
+                    clips_dict=snap,
+                    inclusion_value=inclusion_value,
+                    safe_thresholds=safe_thresholds_value,
+                    calibrate_count=calibrate_count_value,
+                    calibration_fraction=calibration_fraction_value,
+                )
+            else:
+                results, threshold, model = train_and_score(
+                    snap,
+                    dict(good_votes),
+                    dict(bad_votes),
+                    inclusion_value,
+                    safe_thresholds=safe_thresholds_value,
+                    calibrate_count=calibrate_count_value,
+                    calibration_fraction=calibration_fraction_value,
+                    vote_region_boxes=region_boxes_snapshot,
+                )
 
-    if det_ctx is not _empty_detector_context and model is not None:
-        det_ctx.model = model
-        det_ctx.threshold = threshold
-        # Cache the voted media items with embeddings for cross-embedder scenarios.
-        if labelset is not None:
-            det_ctx.training_medias = labelset_training_medias or {}
-        else:
-            training = {}
-            for cid in list(good_votes) + list(bad_votes):
-                if cid in snap:
-                    training[cid] = snap[cid]
-            det_ctx.training_medias = training
-        if snap:
-            first = next(iter(snap.values()), {})
-            det_ctx.embedder = first.get("embedder", "")
-            det_ctx.media_type = first.get("type", "")
+            # Store scores so the /api/votes endpoint can provide confidence info.
+            update_learned_scores({r["id"]: r["score"] for r in results})
 
-    return jsonify({"results": results, "threshold": round(threshold, 4)})
+            # In the labelset path, training used the on-disk labelset
+            # (potentially cross-dataset) — derive the live-cache key and the
+            # cached training snapshot from the labelset itself, not from
+            # local cid-keyed votes.
+            labelset_local_good: set[int] | None = None
+            labelset_local_bad: set[int] | None = None
+            labelset_training_medias: dict[int, dict] | None = None
+            labelset_has_cross_dataset = False
+            if labelset is not None:
+                from vtsearch.utils import build_media_lookup, resolve_media_ids
+
+                origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+                labelset_local_good = set()
+                labelset_local_bad = set()
+                labelset_training_medias = {}
+                for el in labelset.elements:
+                    if el.label not in ("good", "bad"):
+                        continue
+                    cids = resolve_media_ids(
+                        el.to_dict(), origin_lookup, md5_lookup, name_lookup
+                    )
+                    if not cids:
+                        labelset_has_cross_dataset = True
+                        continue
+                    target = labelset_local_good if el.label == "good" else labelset_local_bad
+                    for cid in cids:
+                        target.add(cid)
+                        if cid in snap:
+                            labelset_training_medias[cid] = snap[cid]
+
+            # Inject the live model into the progress cache so indicators and
+            # the progress line-graph use the actual model that guided
+            # sorting, rather than retraining an independent model from
+            # scratch.  The cache is keyed by current-dataset cids, so only
+            # inject when the model's training set is fully representable in
+            # that key — otherwise the cache would return a cross-dataset
+            # model when local-cids replay asks for a local-only one.
+            if model is not None:
+                if labelset is None:
+                    inject_live_model(good_votes, bad_votes, model, threshold)
+                elif (
+                    not labelset_has_cross_dataset
+                    and labelset_local_good == set(good_votes)
+                    and labelset_local_bad == set(bad_votes)
+                ):
+                    inject_live_model(good_votes, bad_votes, model, threshold)
+
+            if det_ctx is not _empty_detector_context and model is not None:
+                det_ctx.model = model
+                det_ctx.threshold = threshold
+                # Cache the voted media items with embeddings for cross-embedder scenarios.
+                if labelset is not None:
+                    det_ctx.training_medias = labelset_training_medias or {}
+                else:
+                    training = {}
+                    for cid in list(good_votes) + list(bad_votes):
+                        if cid in snap:
+                            training[cid] = snap[cid]
+                    det_ctx.training_medias = training
+                if snap:
+                    first = next(iter(snap.values()), {})
+                    det_ctx.embedder = first.get("embedder", "")
+                    det_ctx.media_type = first.get("type", "")
+
+            job.result = {"results": results, "threshold": round(threshold, 4)}
+        finally:
+            set_thread_dataset_context(None)
+            set_thread_detector_context(None)
+
+    job = learned_sort_jobs.start(signature, _run)
+
+    if wait:
+        job.done_event.wait(timeout=120)
+        if job.status == "error":
+            return jsonify({"error": job.error or "learned-sort failed"}), 500
+        if job.status == "done":
+            return jsonify(_learned_sort_done_payload(job))
+
+    return jsonify({"job_id": job.job_id, "status": "running", "current": 0, "total": 1})
+
+
+def _stable_element_id_for_sig(el) -> str:
+    """Return a stable identifier for a labelset element for signature use."""
+    from vtsearch.models.labelset_elements import stable_element_id
+
+    return stable_element_id(el)
+
+
+@sorting_bp.route("/api/learned-sort/result", methods=["GET"])
+def learned_sort_result():
+    """Poll a learned-sort background job.
+
+    Returns the same shape as the POST endpoint's ``done`` response when the
+    job has finished, or a ``running`` snapshot otherwise.
+    """
+    from vtsearch.utils.async_jobs import learned_sort_jobs
+
+    job_id = request.args.get("job_id", "").strip()
+    if not job_id:
+        return jsonify({"error": "job_id is required"}), 400
+
+    job = learned_sort_jobs.get(job_id)
+    if job is None:
+        return jsonify({"status": "missing", "error": "Job not found"}), 404
+
+    if job.status == "running":
+        return jsonify({
+            "job_id": job.job_id,
+            "status": "running",
+            "current": job.current,
+            "total": job.total,
+        })
+    if job.status == "error":
+        return jsonify({
+            "job_id": job.job_id,
+            "status": "error",
+            "error": job.error or "learned-sort failed",
+        }), 500
+    if job.status == "cancelled":
+        return jsonify({"job_id": job.job_id, "status": "cancelled"})
+    return jsonify(_learned_sort_done_payload(job))
 
 
 @sorting_bp.route("/api/votes")

--- a/vtsearch/utils/async_jobs.py
+++ b/vtsearch/utils/async_jobs.py
@@ -1,0 +1,213 @@
+"""Single-slot async job manager for long-running training operations.
+
+The Flask app runs with ``gthread`` workers and a small thread pool.  Endpoints
+that do heavy GIL-bound Python work (training loops, list/array churn) starve
+unrelated requests like ``/api/votes`` polls and thumbnail fetches.  This
+module lets those endpoints push the heavy work onto a background daemon
+thread so the request handler can return immediately with a job id, freeing
+the worker thread to serve other requests while training runs.
+
+Each :class:`JobManager` is a *single-slot* runner: starting a new job
+cancels the in-flight one (callers can re-derive at any time).  Results from
+the most recent successful run are kept in a tiny ring so a follow-up
+request with the same signature can short-circuit and return immediately —
+the "re-sort without new votes is free" fast path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+
+@dataclass
+class AsyncJob:
+    """State container for a single background training job."""
+
+    job_id: str
+    signature: Any = None
+    status: str = "running"  # "running" | "done" | "error" | "cancelled"
+    result: Any = None
+    error: str | None = None
+    current: int = 0
+    total: int = 0
+    message: str = ""
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    done_event: threading.Event = field(default_factory=threading.Event)
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.cancel_event.is_set()
+
+    def cancel(self) -> None:
+        self.cancel_event.set()
+
+    def update_progress(self, current: int, total: int, message: str = "") -> None:
+        """Update progress counters atomically (single writer per job)."""
+        self.current = current
+        self.total = total
+        if message:
+            self.message = message
+
+
+class JobManager:
+    """Single-slot, signature-keyed background job runner.
+
+    Starting a new job cancels any in-flight one.  Results from the most
+    recently completed job are cached by *signature* so that a follow-up
+    call with an unchanged signature reuses the previous result instead of
+    re-running.
+    """
+
+    def __init__(self, name: str, max_history: int = 8) -> None:
+        self._name = name
+        self._lock = threading.RLock()
+        self._jobs: dict[str, AsyncJob] = {}
+        self._current_id: str | None = None
+        self._last_done: AsyncJob | None = None
+        self._max_history = max_history
+
+    # ------------------------------------------------------------------ #
+    # Lookups
+    # ------------------------------------------------------------------ #
+
+    def get(self, job_id: str) -> Optional[AsyncJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def current(self) -> Optional[AsyncJob]:
+        with self._lock:
+            if self._current_id is None:
+                return None
+            return self._jobs.get(self._current_id)
+
+    def cached_for(self, signature: Any) -> Optional[AsyncJob]:
+        """Return the most-recent completed job iff its signature matches."""
+        with self._lock:
+            j = self._last_done
+            if j is not None and j.status == "done" and j.signature == signature:
+                return j
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def start(
+        self,
+        signature: Any,
+        target: Callable[[AsyncJob], Any],
+    ) -> AsyncJob:
+        """Start a new job.  Cancels the in-flight one if any.
+
+        *target* receives the :class:`AsyncJob` and should assign
+        ``job.result`` before returning.  Raising propagates as
+        ``status = "error"``.
+        """
+        with self._lock:
+            prev = self._jobs.get(self._current_id) if self._current_id else None
+            if prev is not None and prev.status == "running":
+                prev.cancel()
+            job = AsyncJob(
+                job_id=uuid.uuid4().hex,
+                signature=signature,
+                status="running",
+                started_at=time.time(),
+            )
+            self._jobs[job.job_id] = job
+            self._current_id = job.job_id
+            self._prune_locked()
+
+        threading.Thread(
+            target=self._run,
+            args=(job, target),
+            name=f"{self._name}-{job.job_id[:8]}",
+            daemon=True,
+        ).start()
+        return job
+
+    def _run(self, job: AsyncJob, target: Callable[[AsyncJob], Any]) -> None:
+        try:
+            target(job)
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger(__name__).exception("%s job failed", self._name)
+            with self._lock:
+                job.status = "error"
+                job.error = str(exc) or exc.__class__.__name__
+            return
+        finally:
+            job.finished_at = time.time()
+
+        with self._lock:
+            if job.is_cancelled and job.status == "running":
+                job.status = "cancelled"
+            elif job.status == "running":
+                job.status = "done"
+                self._last_done = job
+            job.done_event.set()
+
+    def _prune_locked(self) -> None:
+        if len(self._jobs) <= self._max_history:
+            return
+        keep: set[str] = set()
+        if self._current_id:
+            keep.add(self._current_id)
+        if self._last_done is not None:
+            keep.add(self._last_done.job_id)
+        # Keep the most recent N by start time
+        ordered = sorted(self._jobs.values(), key=lambda j: j.started_at, reverse=True)
+        for j in ordered[: self._max_history]:
+            keep.add(j.job_id)
+        self._jobs = {jid: j for jid, j in self._jobs.items() if jid in keep}
+
+    # ------------------------------------------------------------------ #
+    # Test helpers
+    # ------------------------------------------------------------------ #
+
+    def reset_for_tests(self) -> None:
+        """Cancel any running job and clear all stored state."""
+        with self._lock:
+            for j in self._jobs.values():
+                if j.status == "running":
+                    j.cancel()
+            self._jobs.clear()
+            self._current_id = None
+            self._last_done = None
+
+
+# ---------------------------------------------------------------------- #
+# Application-wide singletons
+# ---------------------------------------------------------------------- #
+
+#: Background runner for ``/api/learned-sort``.
+learned_sort_jobs = JobManager("learned-sort")
+
+#: Background runner for ``/api/eval/train-and-score``.
+eval_jobs = JobManager("eval-train-score")
+
+
+def reset_all_async_jobs_for_tests() -> None:
+    """Reset every singleton job manager.  Called from the autouse fixture."""
+    learned_sort_jobs.reset_for_tests()
+    eval_jobs.reset_for_tests()
+
+
+def serialize_job(job: AsyncJob) -> dict[str, Any]:
+    """Return a JSON-safe snapshot of *job* (without ``result``).
+
+    The result payload differs per endpoint and is added by the route.
+    """
+    return {
+        "job_id": job.job_id,
+        "status": job.status,
+        "current": job.current,
+        "total": job.total,
+        "message": job.message,
+        "error": job.error,
+    }


### PR DESCRIPTION
## Summary

- `/api/learned-sort` and `/api/eval/train-and-score` no longer run their 600-epoch MLP loop / per-history-step retrain on the request thread. They now hand the work off to a single-slot daemon thread (`JobManager` in `vtsearch/utils/async_jobs.py`) and return a `{job_id, status}` envelope immediately. Clients poll the matching `/result` endpoint until `status == "done"`.
- A signature cache (votes + inclusion + thresholding settings + dataset/detector id) short-circuits identical re-runs, so re-sorting without new votes is free.
- Both endpoints accept `{"wait": true}` to block until the job finishes — used by tests so they stay synchronous. The Angular frontend uses the async + polling flow.

This unblocks unrelated requests (thumbnails, `/api/votes` polls) that were starving while training held the gthread worker slot and the GIL.

## Breaking change

`/api/learned-sort` and `/api/eval/train-and-score` no longer return `{results, threshold}` / `{error_cost, ...}` inline by default. They return a job envelope and the client must poll the new `/result` endpoint, or pass `{"wait": true}` to opt back into synchronous behaviour.

## Test plan

- [x] `./run-tests.sh` — 3218 passed, 1 skipped
- [x] New tests in `tests/test_sorting.py`:
  - `TestLearnedSortAsync`: async job envelope + polling, signature-cache short-circuit, 404 / 400 polling error paths
  - `TestEvalTrainAndScoreAsync`: `wait=true` inline path, async polling to done, invalid-metric rejection
- [x] `ruff check` clean on touched files
- [x] Frontend `npm run build:prod` clean
- [ ] Manual: spin up the app, vote rapidly, confirm thumbnails + `/api/votes` stay responsive while learned-sort retrains in the background

https://claude.ai/code/session_01MmuD1cUJCFYLx1PkQxWVMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmuD1cUJCFYLx1PkQxWVMH)_