### PR TITLE
Cap auto-detect / auto-process scoring workers by memory budget

### DIFF
--- a/vtsearch/routes/detector_scoring.py
+++ b/vtsearch/routes/detector_scoring.py
@@ -15,6 +15,7 @@ from flask import Blueprint, jsonify, request
 
 from vtsearch.routes.helpers import get_json_safe
 from vtsearch.utils import snapshot_medias
+from vtsearch.utils.memory_budget import cap_workers_by_memory
 from vtsearch.utils.progress import update_find_progress
 
 logger = logging.getLogger(__name__)
@@ -460,8 +461,14 @@ def auto_detect():
             logger.exception("Auto-detect failed for detector %s", name)
             return None
 
+    embed_dim = int(all_embs.shape[1]) if all_embs.ndim > 1 else 0
+    worker_cap = cap_workers_by_memory(
+        len(all_ids),
+        embed_dim,
+        max_workers=min(len(detectors_to_run), 8),
+    )
     results: dict[str, dict] = {}
-    with ThreadPoolExecutor(max_workers=min(len(detectors_to_run), 8)) as pool:
+    with ThreadPoolExecutor(max_workers=worker_cap) as pool:
         futures = [pool.submit(_run_single, name, data, entry) for name, data, entry in detectors_to_run]
         for future in futures:
             outcome = future.result()

--- a/vtsearch/routes/processors_scoring.py
+++ b/vtsearch/routes/processors_scoring.py
@@ -13,6 +13,7 @@ from vtsearch.utils import (
     get_autorun_localizers_by_media,
     snapshot_medias,
 )
+from vtsearch.utils.memory_budget import cap_workers_by_memory
 
 processors_scoring_bp = Blueprint("processors_scoring", __name__)
 
@@ -74,8 +75,20 @@ def _auto_run_processors(
             "results": hits,
         }
 
+    n_items = len(snap)
+    first = next(iter(snap.values()), {}) if snap else {}
+    embedding = first.get("embedding")
+    try:
+        embed_dim = int(len(embedding)) if embedding is not None else 0
+    except TypeError:
+        embed_dim = 0
+    worker_cap = cap_workers_by_memory(
+        n_items,
+        embed_dim,
+        max_workers=min(len(processors), 8),
+    )
     results = {}
-    with ThreadPoolExecutor(max_workers=min(len(processors), 8)) as pool:
+    with ThreadPoolExecutor(max_workers=worker_cap) as pool:
         futures = [pool.submit(_run_single, name, data) for name, data in processors.items()]
         for future in futures:
             outcome = future.result()

--- a/vtsearch/utils/memory_budget.py
+++ b/vtsearch/utils/memory_budget.py
@@ -1,0 +1,64 @@
+"""Helpers for capping concurrency by a memory budget.
+
+The auto-detect and auto-process endpoints fan out across all medias inside a
+``ThreadPoolExecutor``.  Each worker materialises an ``N x D`` fp32 tensor of
+embeddings (plus activations of the same order), which at ``N=100k, D=1152``
+is roughly 450 MB per worker.  Eight unconstrained workers can therefore push
+multi-GB transient allocations through the process; this module lets the
+callers cap the worker count so peak memory stays inside a configured budget.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Default share of available system memory we are willing to hand to the
+# scoring fan-out.  The rest must stay free for embeddings, the loaded
+# datasets, the model weights, and OS / framework overhead.
+_DEFAULT_BUDGET_FRACTION = 0.25
+
+# Floor for the per-process budget when we cannot read system memory: 1 GiB.
+_FALLBACK_BUDGET_BYTES = 1 * 1024 * 1024 * 1024
+
+
+def _available_memory_bytes() -> int:
+    """Best-effort estimate of currently-available physical memory in bytes."""
+    try:
+        with open("/proc/meminfo", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    try:
+        pages = os.sysconf("SC_AVPHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return pages * page_size
+    except (OSError, ValueError):
+        pass
+    return _FALLBACK_BUDGET_BYTES
+
+
+def cap_workers_by_memory(
+    n_items: int,
+    embed_dim: int,
+    *,
+    max_workers: int,
+    bytes_per_element: int = 4,
+    budget_fraction: float = _DEFAULT_BUDGET_FRACTION,
+) -> int:
+    """Cap *max_workers* so peak per-worker memory fits in the budget.
+
+    Each worker is assumed to allocate ``n_items * embed_dim *
+    bytes_per_element`` bytes for its score-all-medias pass.  We allow it to
+    consume up to ``budget_fraction`` of currently-available memory, divided
+    across the concurrent workers.  Always returns at least 1.
+    """
+    if max_workers <= 1 or n_items <= 0 or embed_dim <= 0:
+        return max(1, max_workers)
+    per_worker = n_items * embed_dim * bytes_per_element
+    if per_worker <= 0:
+        return max(1, max_workers)
+    budget = int(_available_memory_bytes() * budget_fraction)
+    return max(1, min(max_workers, budget // per_worker))


### PR DESCRIPTION
## Summary

`/api/auto-detect` (`vtsearch/routes/detector_scoring.py:464`) and `/api/auto-extract|localize` (`vtsearch/routes/processors_scoring.py:78`) fan out scoring over a `ThreadPoolExecutor(max_workers=min(len(...), 8))`. Each worker materialises an `N x D` fp32 tensor of embeddings (and similarly-sized intermediate activations) over the snapshot. At `N=100k, D=1152` that is roughly **460 MB per worker**, so eight unconstrained workers can push multi-GB transient allocations through the process.

This PR adds a small helper, `vtsearch/utils/memory_budget.cap_workers_by_memory()`, and wires it into both call sites so the executor never spawns more workers than the budget allows.

## Approach

- `_available_memory_bytes()` reads `MemAvailable:` from `/proc/meminfo`, falls back to `sysconf("SC_AVPHYS_PAGES") * SC_PAGE_SIZE`, and finally to a **1 GiB floor** so the helper still does something sensible in containers without `/proc` access.
- `cap_workers_by_memory(n_items, embed_dim, *, max_workers, bytes_per_element=4, budget_fraction=0.25)`:
  - Reserves 25% of currently-available memory for the scoring fan-out (the rest must stay free for embeddings, datasets, model weights, OS / framework overhead).
  - Caps to `max(1, budget // (n_items * embed_dim * bytes_per_element))`, clamped to `max_workers`.
  - Always returns at least 1.
- `detector_scoring.py` passes `len(all_ids)` and the actual `embed_dim` from `all_embs.shape[1]`.
- `processors_scoring._auto_run_processors` reads `embed_dim` from the first media's `embedding` field (length-based, with a `TypeError` guard for the rare case the field is absent or not sized).

## Scaling sanity check

With ~16 GB MemAvailable (this dev box → 4 GB budget):

| N | D | Per worker | Cap |
|---|---|---|---|
| 100k | 1152 | 460 MB | 8 |
| 200k | 1152 | 921 MB | 4 |
| 500k | 1152 | 2.3 GB | 1 |
| 1M | 1152 | 4.6 GB | 1 |

## Test plan

- [x] `./run-tests.sh api models` → 354 passed (after rebuilding the Angular bundle; dashboard failures pre-existed and were due to a stale `static/` dir).
- [x] `python -m pytest tests/test_detectors.py tests/test_find_label.py tests/test_processors.py tests/test_multi_detector.py` → 140 passed.
- [x] `ruff check` clean on the three touched files.
- [ ] Manual: confirm peak RSS on `/api/auto-detect` against a 100k+ media dataset stays inside the budget instead of fanning to 8 x 460 MB.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VxVqNy9ErFfrKyvBDG4J7K)_