### PR TITLE
Surface exception type + first line in generic 500 responses

### DIFF
--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -19,7 +19,13 @@ from uuid import uuid4
 from flask import Blueprint, jsonify, request, send_file
 
 from vtsearch.config import DATA_DIR, EMBEDDINGS_DIR
-from vtsearch.routes.helpers import get_json_or_400, get_json_safe, get_plugin_or_404, get_request_field
+from vtsearch.routes.helpers import (
+    format_exception_detail,
+    get_json_or_400,
+    get_json_safe,
+    get_plugin_or_404,
+    get_request_field,
+)
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtsearch.datasets.loader import safe_pickle_load
 from vtsearch.datasets.registry import (
@@ -880,11 +886,11 @@ def export_dataset():
             download_name="vtsearch_dataset.pkl",
             as_attachment=True,
         )
-    except Exception:
+    except Exception as exc:
         import logging
 
         logging.getLogger(__name__).exception("Dataset export failed")
-        return jsonify({"error": "Dataset export failed"}), 500
+        return jsonify({"error": f"Dataset export failed: {format_exception_detail(exc)}"}), 500
 
 
 @datasets_bp.route("/api/dataset/clear", methods=["POST"])

--- a/vtsearch/routes/helpers.py
+++ b/vtsearch/routes/helpers.py
@@ -183,6 +183,18 @@ def get_request_field(key: str, has_file_fields: bool) -> str:
     return get_json_safe().get(key, "")
 
 
+def format_exception_detail(exc: BaseException) -> str:
+    """Return ``"ExcType: first line"`` (or ``"ExcType"`` when the message is empty).
+
+    Used in 500 response bodies so the UI can distinguish failure kinds
+    (e.g. ``MemoryError`` from ``RuntimeError: embedder X not loaded``)
+    without exposing a multi-line traceback.
+    """
+    text = str(exc)
+    first = text.splitlines()[0].strip() if text else ""
+    return f"{type(exc).__name__}: {first}" if first else type(exc).__name__
+
+
 def format_mtime(entry) -> str:
     """Return the file/directory modification time as an ISO-8601 string.
 

--- a/vtsearch/routes/media_server.py
+++ b/vtsearch/routes/media_server.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from flask import Blueprint, jsonify, request, send_file
 
 from vtsearch.config import DATA_DIR
-from vtsearch.routes.helpers import get_json_or_400
+from vtsearch.routes.helpers import format_exception_detail, get_json_or_400
 from vtsearch.utils import snapshot_medias
 
 media_server_bp = Blueprint("media_server", __name__)
@@ -231,11 +231,11 @@ def example_sort_server():
         else:
             results, thresh = _example_sort_from_path(file_path)
         return jsonify({"results": results, "threshold": thresh})
-    except Exception:
+    except Exception as exc:
         import logging
 
         logging.getLogger(__name__).exception("example-sort-server failed")
-        return jsonify({"error": "Example sort failed"}), 500
+        return jsonify({"error": f"Example sort failed: {format_exception_detail(exc)}"}), 500
 
 
 @media_server_bp.route("/api/example-sort-origin", methods=["POST"])
@@ -300,10 +300,10 @@ def example_sort_origin():
         else:
             results, thresh = _example_sort_from_path(file_path)
         return jsonify({"results": results, "threshold": thresh})
-    except Exception:
+    except Exception as exc:
         import logging
 
         logging.getLogger(__name__).exception("example-sort-origin failed")
-        return jsonify({"error": "Example sort failed"}), 500
+        return jsonify({"error": f"Example sort failed: {format_exception_detail(exc)}"}), 500
     finally:
         source.cleanup()

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import numpy as np
 from flask import Blueprint, jsonify, request
 
-from vtsearch.routes.helpers import get_embedder_for_medias, get_json_or_400, get_json_safe
+from vtsearch.routes.helpers import (
+    format_exception_detail,
+    get_embedder_for_medias,
+    get_json_or_400,
+    get_json_safe,
+)
 
 from vtsearch.config import DATA_DIR
 import vtsearch.utils.paths as _paths
@@ -171,10 +176,10 @@ def sort_clips():
         results, threshold = _cosine_sort(text_vec)
         update_sort_progress("idle")
         return jsonify({"results": results, "threshold": threshold})
-    except Exception:
+    except Exception as exc:
         logging.getLogger(__name__).exception("text sort failed")
         update_sort_progress("idle")
-        return jsonify({"error": "Text sort failed"}), 500
+        return jsonify({"error": f"Text sort failed: {format_exception_detail(exc)}"}), 500
 
 
 @sorting_bp.route("/api/learned-sort", methods=["POST"])
@@ -515,11 +520,11 @@ def example_sort():
 
         return jsonify({"results": results, "threshold": thresh})
 
-    except Exception:
+    except Exception as exc:
         import logging
 
         logging.getLogger(__name__).exception("example-sort failed")
-        return jsonify({"error": "Example sort failed"}), 500
+        return jsonify({"error": f"Example sort failed: {format_exception_detail(exc)}"}), 500
 
 
 @sorting_bp.route("/api/label-file-sort", methods=["POST"])


### PR DESCRIPTION
## Summary

Several broad `except Exception` handlers returned a flat error string
("Text sort failed", "Example sort failed", "Dataset export failed")
with no information about the underlying failure. The UI couldn't
distinguish e.g. a missing embedder from `MemoryError`.

- New shared helper `format_exception_detail(exc)` in
  `vtsearch/routes/helpers.py` returns `"ExcType: first line"` (or just
  `"ExcType"` when the message is blank).
- Applied to the three spots called out in the task —
  `routes/sorting.py` `/api/text-sort` (was L174-177),
  `routes/media_server.py` `/api/example-sort-server` (was L234-238),
  `routes/datasets.py` `/api/dataset/export` (was L880-884) — plus the
  two sibling handlers that shared the same anti-pattern:
  `sorting.py` `/api/example-sort` (form variant) and
  `media_server.py` `/api/example-sort-origin`.
- The traceback still goes to the logger via `.exception()`; only the
  exception class + first line of `str(exc)` is surfaced to the client,
  so multi-line tracebacks don't leak.

## Test plan

- [x] `python -m pytest tests/test_api_contracts.py tests/test_error_recovery.py tests/test_sorting.py tests/test_datasets.py -q -m 'not gpu and not slow'` — 255 passed, 2 skipped
- [x] `ruff check` on the four touched files — clean
- [ ] Manual: trigger a failing text-sort (e.g. missing embedder) and confirm the response body includes the exception class name

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2vWiFEP3H4Z8piCZjBWNb)_