### PR TITLE
Drop dead http_archive_resolve cache path

### DIFF
--- a/tests/test_media_sources.py
+++ b/tests/test_media_sources.py
@@ -153,26 +153,6 @@ class TestHttpArchiveSource:
         # Before any access, _inner should be None
         assert source._inner is None
 
-    def test_uses_cached_dir(self, tmp_path):
-        """When a cached extraction directory exists, it's reused."""
-        from vtsearch.config import DATA_DIR
-        from vtsearch.datasets.sources.http_archive import HttpArchiveSource
-
-        # Create a fake cached extraction dir
-        cached = DATA_DIR / "http_archive_resolve_test.zip"
-        cached.mkdir(parents=True, exist_ok=True)
-        (cached / "clip.wav").write_bytes(b"audio")
-
-        try:
-            source = HttpArchiveSource("https://example.com/test.zip")
-            result = source.resolve_path(origin_name="clip.wav")
-            assert result is not None
-            assert result.name == "clip.wav"
-        finally:
-            import shutil
-
-            shutil.rmtree(cached, ignore_errors=True)
-
     def test_delegates_to_local_folder(self, tmp_path):
         """After extraction, fetch_item delegates to LocalFolderSource."""
         from vtsearch.datasets.sources.http_archive import HttpArchiveSource
@@ -204,8 +184,8 @@ class TestHttpArchiveSource:
         assert any(i.key == "audio/clip.wav" for i in items)
         assert all(i.source_name == "http_archive" for i in items)
 
-    def test_cleanup_removes_source_dir(self, tmp_path):
-        """cleanup() removes directories named http_archive_source_*."""
+    def test_cleanup_removes_extract_dir(self, tmp_path):
+        """cleanup() removes the extraction directory."""
         from vtsearch.datasets.sources.http_archive import HttpArchiveSource
 
         source = HttpArchiveSource("https://example.com/test.zip")
@@ -221,24 +201,6 @@ class TestHttpArchiveSource:
         source.cleanup()
         assert not source_dir.exists()
         assert source._inner is None
-
-    def test_cleanup_preserves_cached_dir(self, tmp_path):
-        """cleanup() does NOT remove http_archive_resolve_* (cached) dirs."""
-        from vtsearch.datasets.sources.http_archive import HttpArchiveSource
-
-        source = HttpArchiveSource("https://example.com/test.zip")
-        cached_dir = tmp_path / "http_archive_resolve_test.zip"
-        cached_dir.mkdir()
-        (cached_dir / "file.wav").write_bytes(b"data")
-
-        from vtsearch.datasets.sources.local_folder import LocalFolderSource
-
-        source._extract_dir = cached_dir
-        source._inner = LocalFolderSource(cached_dir)
-
-        source.cleanup()
-        # Cached dir should still exist
-        assert cached_dir.exists()
 
 
 # ── get_source_for_origin ─────────────────────────────────────────────

--- a/vtsearch/datasets/sources/http_archive.py
+++ b/vtsearch/datasets/sources/http_archive.py
@@ -59,22 +59,10 @@ class HttpArchiveSource(MediaSource):
 
         from vtsearch.datasets.sources.local_folder import LocalFolderSource
 
-        url_filename = self._url.split("?")[0].rstrip("/").rsplit("/", 1)[-1] or "archive"
-        cached_dir = DATA_DIR / f"http_archive_resolve_{url_filename}"
-
-        # Serialise cache checks so concurrent requests don't both download.
         with _extract_lock:
-            # Re-check after acquiring the lock (another thread may have finished).
             if self._inner is not None:
                 return self._inner
 
-            # Check for a previously-cached extraction for this URL.
-            if cached_dir.is_dir():
-                self._extract_dir = cached_dir
-                self._inner = LocalFolderSource(cached_dir)
-                return self._inner
-
-            # Download and extract to a unique temp directory.
             from vtsearch.datasets.downloader import download_file_with_progress
             from vtsearch.datasets.importers.http_archive import _extract_archive
             from vtsearch.utils.url_validation import validate_url
@@ -82,6 +70,7 @@ class HttpArchiveSource(MediaSource):
             validate_url(self._url)
             DATA_DIR.mkdir(exist_ok=True)
 
+            url_filename = self._url.split("?")[0].rstrip("/").rsplit("/", 1)[-1] or "archive"
             run_id = uuid4().hex[:12]
             archive_path = DATA_DIR / f"http_archive_download_{run_id}_{url_filename}"
             extract_dir = DATA_DIR / f"http_archive_source_{run_id}"
@@ -122,9 +111,7 @@ class HttpArchiveSource(MediaSource):
     def cleanup(self) -> None:
         """Remove the temporary extraction directory."""
         if self._extract_dir is not None and self._extract_dir.is_dir():
-            # Only clean up directories we created (not cached ones).
-            if "http_archive_source_" in self._extract_dir.name:
-                shutil.rmtree(self._extract_dir, ignore_errors=True)
+            shutil.rmtree(self._extract_dir, ignore_errors=True)
         self._extract_dir = None
         self._inner = None
 


### PR DESCRIPTION
Closing: PR #1304 (race-fix for HttpArchiveSource) landed on `dev` in the meantime and actually wires up the `http_archive_resolve_*` cache (extract_dir is renamed to the resolve_ name after extraction). This PR's premise — that the cache branch was dead code — no longer holds.

The "grow forever" concern is real on current dev (resolve_ dirs are never evicted), but treating those as an intentional cross-run cache is the design `dev` now reflects. If unbounded growth becomes a problem in practice, the follow-up is an eviction policy on resolve_ dirs (size/age cap), not removing the cache.