### PR TITLE
Replace unpaginated GET /api/medias with lightweight /api/medias/ids

### DIFF
--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -6,13 +6,39 @@
 
 ## Medias
 
-### List medias
+### List media IDs
 
 ```
-GET /api/medias
+GET /api/medias/ids
 ```
 
-→ JSON array of media metadata objects:
+→ Lightweight JSON array of stubs, one per media in the loaded dataset:
+
+```json
+[
+  { "id": 0, "type": "audio", "embedder": "clap-fused" },
+  { "id": 1, "type": "audio", "embedder": "clap-fused" }
+]
+```
+
+Every stub carries `id` and `type`; `embedder` is included when the media
+has one.  Display-worthy metadata (`filename`, `md5`, `custom_metadata`,
+`origin_name`, `description`, `clip_*`) is fetched on demand for the IDs
+the client actually needs via [Batch fetch](#batch-fetch-metadata) — this
+keeps the listing payload bounded even for datasets with tens of
+thousands of items.
+
+### Batch fetch metadata
+
+```
+POST /api/medias/batch
+Content-Type: application/json
+
+{ "ids": [0, 1, 2] }
+```
+
+→ JSON array of full metadata objects for the requested IDs (unknown IDs
+are silently omitted):
 
 ```json
 [
@@ -33,10 +59,11 @@ GET /api/medias
 ]
 ```
 
-Every item contains `id`, `type`, `filename`, `md5`, and `custom_metadata`.
-The `custom_metadata` dict holds media-type-specific display fields (e.g.
-`duration`/`frequency` for audio, `width`/`height` for images, `word_count`
-for text). `origin_name` and `description` are included when present.
+Every returned item contains `id`, `type`, `filename`, `md5`, and
+`custom_metadata`.  The `custom_metadata` dict holds media-type-specific
+display fields (e.g.  `duration`/`frequency` for audio, `width`/`height`
+for images, `word_count` for text).  `origin_name`, `description`,
+`embedder`, and `clip_*` keys are included when present.
 
 ### Stream audio
 
@@ -243,18 +270,6 @@ POST /api/votes/seed-from-examples
 Seeds good votes from the active model's media examples.
 
 → `{"ok": true, "seeded": 5}`
-
-### Batch media metadata
-
-```
-POST /api/medias/batch
-```
-
-**Body:** `{"ids": [0, 1, 2], "offset": 0, "limit": 50}`
-
-Paginated media metadata retrieval.
-
-→ `{"medias": [...], "total": 500}`
 
 ### Label-file sort
 

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -32,9 +32,9 @@ describe('LabelViewComponent', () => {
   function flushInitialRequests(): void {
     fixture.detectChanges();
     // Flush /api/medias
-    httpMock.expectOne('/api/medias').flush([
-      { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
-      { id: 2, type: 'audio', filename: 'b.wav', md5: 'b2', custom_metadata: {} },
+    httpMock.expectOne('/api/medias/ids').flush([
+      { id: 1, type: 'audio' },
+      { id: 2, type: 'audio' },
     ]);
     // Flush /api/votes (label-view + right-panel both poll)
     httpMock.match('/api/votes').forEach(req =>
@@ -264,8 +264,8 @@ describe('LabelViewComponent', () => {
 
     // Now trigger init which loads medias
     fixture.detectChanges();
-    httpMock.expectOne('/api/medias').flush([
-      { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
+    httpMock.expectOne('/api/medias/ids').flush([
+      { id: 1, type: 'audio' },
     ]);
     httpMock.match('/api/votes').forEach(req =>
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -8,6 +8,7 @@ import {
   AfterViewChecked,
   OnChanges,
   OnDestroy,
+  OnInit,
   SimpleChanges,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -34,7 +35,7 @@ const PREFETCH_BUFFER = 50;
   templateUrl: './media-list.component.html',
   styleUrl: './media-list.component.scss',
 })
-export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestroy {
+export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
   @Input() medias: MediaItem[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
@@ -62,6 +63,14 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
   private scrollSubscribed = false;
 
   constructor(private metadataCache: MediaMetadataCacheService) {}
+
+  ngOnInit(): void {
+    // When the cache hydrates new items, re-enrich the displayed rows so
+    // visible items show their filename / score / metadata.
+    this.metadataCache.version$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.rebuildOrderedItems());
+  }
 
   ngOnDestroy(): void {
     this.destroy$.next();
@@ -98,13 +107,20 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
   }
 
   private rebuildOrderedItems(): void {
-    const mediaMap = new Map(this.medias.map((m) => [m.id, m]));
+    // ``this.medias`` carries stubs (``{id, type, embedder?}``) from
+    // ``/api/medias/ids``.  Look up the cached full metadata for visible
+    // rows; fall back to the stub so the row renders immediately and gets
+    // upgraded once the batch fetch lands.
+    const stubMap = new Map(this.medias.map((m) => [m.id, m]));
+    const enrich = (id: number): MediaItem | undefined =>
+      this.metadataCache.get(id) ?? stubMap.get(id);
+
     const items: { media: MediaItem; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
 
     if (this.sortOrder && this.sortOrder.length > 0) {
       let thresholdInserted = false;
       for (const sorted of this.sortOrder) {
-        const media = mediaMap.get(sorted.id);
+        const media = enrich(sorted.id);
         if (!media) continue;
 
         let showThreshold = false;
@@ -121,7 +137,8 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
         });
       }
     } else {
-      for (const media of this.medias) {
+      for (const stub of this.medias) {
+        const media = this.metadataCache.get(stub.id) ?? stub;
         items.push({ media, score: null, showThreshold: false, bestRegion: null });
       }
     }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,8 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { MediaItem } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 
 export interface LabelEntry {
   id: number;
@@ -19,7 +22,7 @@ export interface LabelEntry {
   templateUrl: './label-list.component.html',
   styleUrl: './label-list.component.scss',
 })
-export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
+export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
   @Input() medias: MediaItem[] = [];
@@ -36,14 +39,25 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
 
   sortedEntries: LabelEntry[] = [];
   private pendingScrollPct: number | null = null;
-  /** Pre-built Map for O(1) media lookups by id (rebuilt when medias input changes). */
+  /** Pre-built Map for O(1) media stub lookups by id (rebuilt when medias input changes). */
   private mediaMap = new Map<number, MediaItem>();
+  private readonly destroy$ = new Subject<void>();
 
-  constructor(private activeContext: ActiveContextService) {}
+  constructor(
+    private activeContext: ActiveContextService,
+    private metadataCache: MediaMetadataCacheService,
+  ) {}
 
   ngOnInit(): void {
     this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
+    this.metadataCache.ensureLoaded(this.ids);
     this.sortedEntries = this.buildSortedEntries();
+    // Re-render entry names when the cache hydrates voted items.
+    this.metadataCache.version$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.sortedEntries = this.buildSortedEntries();
+      });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -55,7 +69,19 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
     if (changes['medias']) {
       this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
     }
+    if (changes['ids']) {
+      this.metadataCache.ensureLoaded(this.ids);
+    }
     this.sortedEntries = this.buildSortedEntries();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private lookup(id: number): MediaItem | undefined {
+    return this.metadataCache.get(id) ?? this.mediaMap.get(id);
   }
 
   ngAfterViewChecked(): void {
@@ -74,7 +100,7 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   }
 
   private buildEntry(id: number): LabelEntry {
-    const media = this.mediaMap.get(id);
+    const media = this.lookup(id);
     const name = media ? (media.filename || `Clip #${id}`) : `Clip #${id}`;
     const time = this.clickTimes[String(id)] ?? -1;
     const score = this.learnedScores[String(id)] ?? -1;
@@ -123,12 +149,12 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   hasThumbnailUrl(id: number): boolean {
     const url = this.thumbnailUrl(id);
     if (url && this.thumbnailFailedUrls.has(url)) return false;
-    const media = this.mediaMap.get(id);
+    const media = this.lookup(id);
     return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document' || media.type === 'audio');
   }
 
   thumbnailUrl(id: number): string {
-    const media = this.mediaMap.get(id);
+    const media = this.lookup(id);
     if (!media) return '';
     return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
   }
@@ -139,7 +165,7 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
 
   placeholderIcon(id: number): string | null {
     if (this.hasThumbnailUrl(id)) return null;
-    const media = this.mediaMap.get(id);
+    const media = this.lookup(id);
     if (!media) return null;
     if (media.type === 'audio') return '\u266B';
     if (media.type === 'text') return '\u00B6';

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -2,12 +2,21 @@
 
 // --- Medias ---
 
+/**
+ * One media item.
+ *
+ * Only ``id`` and ``type`` are guaranteed — the dataset listing
+ * (``GET /api/medias/ids``) returns just those plus an optional
+ * ``embedder``.  The remaining display-worthy fields are populated on
+ * demand for items currently in the viewport via the metadata cache
+ * (``POST /api/medias/batch``).
+ */
 export interface MediaItem {
   id: number;
   type: string;
-  filename: string;
-  md5: string;
-  custom_metadata: Record<string, unknown>;
+  filename?: string;
+  md5?: string;
+  custom_metadata?: Record<string, unknown>;
   origin_name?: string;
   description?: string;
   clip_start?: number;

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -11,16 +11,18 @@ import { MediasApiService } from './medias-api.service';
 const BATCH_SIZE = 200;
 
 /**
- * Caches media metadata (id, type, filename, md5, etc.) and loads it lazily in
- * batches via `POST /api/medias/batch`.
+ * Caches full media metadata (`filename`, `md5`, `custom_metadata`, …)
+ * loaded lazily in batches via `POST /api/medias/batch`.
  *
- * The full `/api/medias` response can be hundreds of megabytes for large
- * datasets.  This cache fetches only the metadata the UI actually needs —
- * typically the items currently visible in the virtual-scrolling viewport.
+ * The dataset-wide listing comes from `GET /api/medias/ids` and only
+ * carries `id`, `type`, and (optionally) `embedder`.  This cache fills in
+ * the rest on demand — typically for the items currently in a
+ * virtual-scrolling viewport.
  *
  * Usage:
  *   1. Call `ensureLoaded(ids)` with the IDs the viewport needs.
- *   2. Subscribe to `medias$` or call `get(id)` for cached items.
+ *   2. Subscribe to `version$` to re-render when new items arrive, or call
+ *      `get(id)` to read a single cached item.
  *   3. `toMediaItems(ids)` returns MediaItem[] for already-cached IDs (skips
  *      unknown ones so the template can render immediately).
  */
@@ -56,14 +58,6 @@ export class MediaMetadataCacheService implements OnDestroy {
   /** Current cache size. */
   get size(): number {
     return this.cache.size;
-  }
-
-  /** Bulk-insert items (e.g. from the initial full `/api/medias` load for small datasets). */
-  populate(items: MediaItem[]): void {
-    for (const item of items) {
-      this.cache.set(item.id, item);
-    }
-    this.versionSubject.next(this.versionSubject.value + 1);
   }
 
   /** Clear all cached metadata. */

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -35,14 +35,14 @@ describe('MediaStateService', () => {
 
   it('loadMedias should fetch and store medias', () => {
     service.loadMedias();
-    const req = httpMock.expectOne('/api/medias');
+    const req = httpMock.expectOne('/api/medias/ids');
     req.flush(mockMedias);
     expect(service.medias).toEqual(mockMedias);
   });
 
   it('selectMedia should update selectedId', () => {
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
 
     service.selectMedia(2);
     expect(service.selectedId).toBe(2);
@@ -51,7 +51,7 @@ describe('MediaStateService', () => {
 
   it('selectedMedia should return null for unknown id', () => {
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
 
     service.selectMedia(999);
     expect(service.selectedMedia).toBeNull();
@@ -59,7 +59,7 @@ describe('MediaStateService', () => {
 
   it('clear should reset all state', () => {
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
     service.selectMedia(1);
 
     service.clear();
@@ -72,7 +72,7 @@ describe('MediaStateService', () => {
     service.medias$.subscribe((m) => emissions.push(m));
 
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockMedias);
 
     setTimeout(() => {
       expect(emissions.length).toBeGreaterThanOrEqual(2); // initial [] + loaded

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -6,11 +6,15 @@ import { MediasApiService } from './medias-api.service';
 import { MediaMetadataCacheService } from './media-metadata-cache.service';
 
 /**
- * Threshold: datasets with more items than this use lazy metadata loading
- * instead of fetching everything in a single /api/medias call.
+ * Tracks the dataset-wide list of media stubs (``{id, type, embedder?}``)
+ * and the current selection.
+ *
+ * Each stub is the minimum the UI needs to build the virtual scroller, the
+ * stripe overview, and the media-type / embedder gates.  Full per-item
+ * metadata (``filename``, ``md5``, ``custom_metadata``, …) is fetched on
+ * demand for whatever is currently in the viewport via
+ * {@link MediaMetadataCacheService}.
  */
-const LAZY_THRESHOLD = 500;
-
 @Injectable({ providedIn: 'root' })
 export class MediaStateService implements OnDestroy {
   private readonly mediasSubject = new BehaviorSubject<MediaItem[]>([]);
@@ -41,7 +45,6 @@ export class MediaStateService implements OnDestroy {
   get selectedMedia(): MediaItem | null {
     const id = this.selectedIdSubject.value;
     if (id === null) return null;
-    // Try cache first (works for both large and small datasets).
     const cached = this.metadataCache.get(id);
     if (cached) return cached;
     return this.mediasSubject.value.find((m) => m.id === id) ?? null;
@@ -49,18 +52,15 @@ export class MediaStateService implements OnDestroy {
 
   selectMedia(id: number): void {
     this.selectedIdSubject.next(id);
-    // Ensure the selected item's metadata is loaded for the center panel.
     this.metadataCache.ensureLoaded([id]);
   }
 
   loadMedias(): void {
     this.mediasApi
-      .getMedias()
+      .getMediaIds()
       .pipe(takeUntil(this.destroy$))
-      .subscribe((medias) => {
-        // Populate the metadata cache so batch lookups work for any ID.
-        this.metadataCache.populate(medias);
-        this.mediasSubject.next(medias);
+      .subscribe((stubs) => {
+        this.mediasSubject.next(stubs);
       });
   }
 

--- a/frontend/src/app/services/medias-api.service.spec.ts
+++ b/frontend/src/app/services/medias-api.service.spec.ts
@@ -21,11 +21,20 @@ describe('MediasApiService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('getMedias should GET /api/medias', () => {
-    const mock = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} }];
-    service.getMedias().subscribe(data => expect(data).toEqual(mock));
-    const req = httpMock.expectOne('/api/medias');
+  it('getMediaIds should GET /api/medias/ids', () => {
+    const mock = [{ id: 1, type: 'audio' }, { id: 2, type: 'audio', embedder: 'clap' }];
+    service.getMediaIds().subscribe(data => expect(data).toEqual(mock));
+    const req = httpMock.expectOne('/api/medias/ids');
     expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('getMediasBatch should POST /api/medias/batch with ids', () => {
+    const mock = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} }];
+    service.getMediasBatch([1]).subscribe(data => expect(data).toEqual(mock));
+    const req = httpMock.expectOne('/api/medias/batch');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ ids: [1] });
     req.flush(mock);
   });
 

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -11,8 +11,13 @@ import {
 export class MediasApiService {
   constructor(private http: HttpClient) {}
 
-  getMedias(): Observable<MediaItem[]> {
-    return this.http.get<MediaItem[]>('/api/medias');
+  /**
+   * Lightweight listing of every media in the loaded dataset.  Returns
+   * only ``id``, ``type``, and ``embedder`` — the rest of the metadata is
+   * fetched on demand via {@link getMediasBatch}.
+   */
+  getMediaIds(): Observable<MediaItem[]> {
+    return this.http.get<MediaItem[]>('/api/medias/ids');
   }
 
   getMediasBatch(ids: number[]): Observable<MediaItem[]> {

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -607,7 +607,7 @@ class TestAchievementsApi:
 class TestActionHooks:
     def test_vote_endpoint_increments_counter(self, client):
         # Find any media id from the test fixture.
-        listing = client.get("/api/medias").get_json()
+        listing = client.get("/api/medias/ids").get_json()
         media_id = listing[0]["id"]
         resp = client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})
         assert resp.status_code == 200
@@ -615,7 +615,7 @@ class TestActionHooks:
         assert _by_id(state, "votes_cast")["counter"] == 1
 
     def test_unvote_does_not_decrement(self, client):
-        listing = client.get("/api/medias").get_json()
+        listing = client.get("/api/medias/ids").get_json()
         media_id = listing[0]["id"]
         client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})
         client.post(f"/api/medias/{media_id}/vote", json={"vote": "good"})  # toggle off

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -16,53 +16,51 @@ from vtsearch.utils import good_votes, bad_votes
 
 
 class TestMediasContract:
-    """GET /api/medias response shape."""
+    """GET /api/medias/ids and POST /api/medias/batch response shapes."""
 
-    def test_returns_json_array(self, client):
-        resp = client.get("/api/medias")
+    def _all_ids(self, client) -> list[int]:
+        return [m["id"] for m in client.get("/api/medias/ids").get_json()]
+
+    def _batch(self, client) -> list[dict]:
+        ids = self._all_ids(client)
+        return client.post("/api/medias/batch", json={"ids": ids}).get_json()
+
+    def test_ids_returns_json_array(self, client):
+        resp = client.get("/api/medias/ids")
         assert resp.status_code == 200
         assert resp.content_type.startswith("application/json")
         data = resp.get_json()
         assert isinstance(data, list)
-
-    def test_each_media_has_required_fields(self, client):
-        resp = client.get("/api/medias")
-        data = resp.get_json()
-        required = {"id", "type", "filename", "md5", "custom_metadata"}
-        for item in data:
-            assert required.issubset(item.keys()), f"Missing keys: {required - item.keys()}"
-
-    def test_custom_metadata_is_dict(self, client):
-        resp = client.get("/api/medias")
-        data = resp.get_json()
-        for item in data:
-            assert isinstance(item["custom_metadata"], dict)
-
-    def test_id_is_integer(self, client):
-        resp = client.get("/api/medias")
-        data = resp.get_json()
         for item in data:
             assert isinstance(item["id"], int)
+            assert isinstance(item["type"], str)
 
-    def test_file_size_in_custom_metadata(self, client):
-        resp = client.get("/api/medias")
-        data = resp.get_json()
-        for item in data:
+    def test_batch_each_media_has_required_fields(self, client):
+        required = {"id", "type", "filename", "md5", "custom_metadata"}
+        for item in self._batch(client):
+            assert required.issubset(item.keys()), f"Missing keys: {required - item.keys()}"
+
+    def test_batch_custom_metadata_is_dict(self, client):
+        for item in self._batch(client):
+            assert isinstance(item["custom_metadata"], dict)
+
+    def test_batch_id_is_integer(self, client):
+        for item in self._batch(client):
+            assert isinstance(item["id"], int)
+
+    def test_batch_file_size_in_custom_metadata(self, client):
+        for item in self._batch(client):
             assert "File Size" in item["custom_metadata"]
             assert isinstance(item["custom_metadata"]["File Size"], int)
             assert item["custom_metadata"]["File Size"] > 0
 
-    def test_md5_is_32_char_hex_string(self, client):
-        resp = client.get("/api/medias")
-        data = resp.get_json()
-        for item in data:
+    def test_batch_md5_is_32_char_hex_string(self, client):
+        for item in self._batch(client):
             assert isinstance(item["md5"], str)
             assert len(item["md5"]) == 32
 
-    def test_excludes_embedding_and_media_bytes(self, client):
-        resp = client.get("/api/medias")
-        data = resp.get_json()
-        for item in data:
+    def test_batch_excludes_embedding_and_media_bytes(self, client):
+        for item in self._batch(client):
             assert "embedding" not in item
             assert "media_bytes" not in item
             assert "media_string" not in item
@@ -623,5 +621,5 @@ class TestApiCacheControl:
         assert resp.headers.get("Cache-Control") == "no-store"
 
     def test_medias_no_store(self, client):
-        resp = client.get("/api/medias")
+        resp = client.get("/api/medias/ids")
         assert resp.headers.get("Cache-Control") == "no-store"

--- a/tests/test_clipper_workflow.py
+++ b/tests/test_clipper_workflow.py
@@ -562,30 +562,6 @@ class TestCrossDatasetClipEmbedding:
 class TestAPIClipMetadata:
     """The /api/medias endpoint should include clip metadata."""
 
-    def test_list_medias_includes_clip_fields(self, client):
-        saved = dict(medias)
-        medias.clear()
-        try:
-            from vtsearch.datasets.load_pipeline import _apply_clipper
-
-            clips_dict = {1: _make_audio_media(1, duration=5.0)}
-            _apply_clipper(clips_dict, "sound_tiling", {"duration": 2.0})
-            for cid, clip in clips_dict.items():
-                medias[cid] = clip
-
-            resp = client.get("/api/medias")
-            assert resp.status_code == 200
-            data = resp.get_json()
-            assert len(data) > 1
-
-            for item in data:
-                assert "clip_start" in item
-                assert "clip_end" in item
-                assert "clip_index" in item
-        finally:
-            medias.clear()
-            medias.update(saved)
-
     def test_batch_medias_includes_clip_fields(self, client):
         saved = dict(medias)
         medias.clear()
@@ -597,7 +573,7 @@ class TestAPIClipMetadata:
             for cid, clip in clips_dict.items():
                 medias[cid] = clip
 
-            ids = list(clips_dict.keys())
+            ids = list(medias.keys())
             resp = client.post("/api/medias/batch", json={"ids": ids})
             assert resp.status_code == 200
             data = resp.get_json()
@@ -621,7 +597,8 @@ class TestAPIClipMetadata:
             for cid, clip in clips_dict.items():
                 medias[cid] = clip
 
-            resp = client.get("/api/medias")
+            ids = list(medias.keys())
+            resp = client.post("/api/medias/batch", json={"ids": ids})
             assert resp.status_code == 200
             data = resp.get_json()
             for item in data:

--- a/tests/test_converter_selection.py
+++ b/tests/test_converter_selection.py
@@ -1082,11 +1082,7 @@ class TestImportLocalFolderRouteForwardsSourceSpecs:
     reach the importer."""
 
     def test_source_specs_form_field_is_forwarded(self, client, tmp_path):
-        import io
         import json
-
-        # Send a single dummy file so the upload doesn't 400 on empty.
-        files = [("files", ("a.png", io.BytesIO(b"\x89PNG\r\n\x1a\n"), "image/png"))]
 
         specs_json = json.dumps(
             [

--- a/tests/test_dataset_importer_media.py
+++ b/tests/test_dataset_importer_media.py
@@ -799,7 +799,7 @@ class TestImporterMediasInSorting:
         assert scores == sorted(scores, reverse=True)
 
     def test_api_medias_shows_importer_md5(self, client, tmp_path):
-        """GET /api/medias should expose the importer-supplied MD5."""
+        """POST /api/medias/batch should expose the importer-supplied MD5."""
         from vtsearch.utils import medias as app_medias
 
         loaded, _, md5s = self._load_importer_medias_into_app(tmp_path, num_files=3)
@@ -808,9 +808,12 @@ class TestImporterMediasInSorting:
         app_medias.clear()
         try:
             app_medias.update(loaded)
-            resp = client.get("/api/medias")
-            assert resp.status_code == 200
-            data = resp.get_json()
+            ids_resp = client.get("/api/medias/ids")
+            assert ids_resp.status_code == 200
+            ids = [m["id"] for m in ids_resp.get_json()]
+            batch_resp = client.post("/api/medias/batch", json={"ids": ids})
+            assert batch_resp.status_code == 200
+            data = batch_resp.get_json()
             api_md5s = {m["filename"]: m["md5"] for m in data}
             for fname, expected_md5 in md5s.items():
                 assert api_md5s[fname] == expected_md5

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -318,7 +318,7 @@ class TestEmptyState:
         saved = dict(medias)
         medias.clear()
         try:
-            resp = client.get("/api/medias")
+            resp = client.get("/api/medias/ids")
             assert resp.status_code == 200
             assert resp.get_json() == []
         finally:

--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -296,38 +296,51 @@ class TestCustomMetadataMapInLoader:
         assert media["custom_metadata"]["source"] == "external_db"
 
 
-class TestListMedias:
+class TestListMediaIds:
+    """Tests for the lightweight ``GET /api/medias/ids`` listing.
+
+    This endpoint replaced the previous unpaginated ``GET /api/medias`` —
+    full per-item metadata now comes from ``POST /api/medias/batch`` for
+    just the IDs the viewport needs.
+    """
+
     def test_returns_all_medias(self, client):
-        resp = client.get("/api/medias")
+        resp = client.get("/api/medias/ids")
         assert resp.status_code == 200
         data = resp.get_json()
         assert len(data) == app_module.NUM_MEDIAS
 
-    def test_media_fields(self, client):
-        resp = client.get("/api/medias")
+    def test_stub_fields_only(self, client):
+        """Each stub carries id + type and (optionally) embedder — nothing else."""
+        resp = client.get("/api/medias/ids")
         data = resp.get_json()
+        allowed = {"id", "type", "embedder"}
         for media in data:
             assert "id" in media
-            assert "md5" in media
-            assert "filename" in media
-            assert "custom_metadata" in media
-            # Type-specific fields appear in custom_metadata
-            cm = media["custom_metadata"]
-            assert "Frequency" in cm
-            assert "Duration" in cm
-            assert "File Size" in cm
+            assert "type" in media
+            extra = set(media.keys()) - allowed
+            assert not extra, f"unexpected heavy fields in /ids response: {extra}"
 
-    def test_does_not_expose_media_bytes(self, client):
-        resp = client.get("/api/medias")
+    def test_does_not_expose_heavy_fields(self, client):
+        resp = client.get("/api/medias/ids")
         data = resp.get_json()
         for media in data:
-            assert "media_bytes" not in media
+            for heavy in (
+                "media_bytes",
+                "embedding",
+                "filename",
+                "md5",
+                "custom_metadata",
+                "thumbnail_bytes",
+                "description",
+                "origin_name",
+            ):
+                assert heavy not in media
 
-    def test_does_not_expose_embedding(self, client):
+    def test_unpaginated_endpoint_is_gone(self, client):
+        """The old ``GET /api/medias`` route no longer exists."""
         resp = client.get("/api/medias")
-        data = resp.get_json()
-        for media in data:
-            assert "embedding" not in media
+        assert resp.status_code == 404
 
 
 class TestBatchMedias:
@@ -339,7 +352,7 @@ class TestBatchMedias:
         returned_ids = {m["id"] for m in data}
         assert returned_ids == {1, 2}
 
-    def test_same_fields_as_list_medias(self, client):
+    def test_returns_full_metadata(self, client):
         resp = client.post("/api/medias/batch", json={"ids": [1]})
         data = resp.get_json()
         assert len(data) == 1
@@ -387,7 +400,7 @@ class TestMediaThumbnailBytes:
         assert thumb[:8] == b"\x89PNG\r\n\x1a\n"
 
     def test_thumbnail_bytes_not_exposed_in_api(self, client):
-        resp = client.get("/api/medias")
+        resp = client.post("/api/medias/batch", json={"ids": list(range(1, app_module.NUM_MEDIAS + 1))})
         data = resp.get_json()
         for media in data:
             assert "thumbnail_bytes" not in media

--- a/tests/test_multi_media_coverage.py
+++ b/tests/test_multi_media_coverage.py
@@ -197,7 +197,7 @@ class TestMediasListingMultiMedia:
         try:
             for i in range(1, 4):
                 medias[i] = make_image_media(i)
-            resp = client.get("/api/medias")
+            resp = client.get("/api/medias/ids")
             assert resp.status_code == 200
             data = resp.get_json()
             assert len(data) == 3
@@ -215,7 +215,7 @@ class TestMediasListingMultiMedia:
         try:
             for i in range(1, 4):
                 medias[i] = make_text_media(i)
-            resp = client.get("/api/medias")
+            resp = client.get("/api/medias/ids")
             assert resp.status_code == 200
             data = resp.get_json()
             assert len(data) == 3
@@ -232,7 +232,7 @@ class TestMediasListingMultiMedia:
         try:
             for i in range(1, 4):
                 medias[i] = make_video_media(i)
-            resp = client.get("/api/medias")
+            resp = client.get("/api/medias/ids")
             assert resp.status_code == 200
             data = resp.get_json()
             assert len(data) == 3

--- a/tests/test_multi_user_security.py
+++ b/tests/test_multi_user_security.py
@@ -179,7 +179,7 @@ class TestFlaskAuthMiddleware:
     def test_g_user_set_on_api_requests(self, client):
         """Verify g.user is set via the before_request middleware."""
         # Any API call should work without errors — the middleware sets g.user
-        resp = client.get("/api/medias")
+        resp = client.get("/api/medias/ids")
         assert resp.status_code == 200
 
 
@@ -326,7 +326,7 @@ class TestProviderSwapSafety:
         set_login_provider(AnotherProvider())
 
         # These should all return 200 regardless of provider
-        resp = client.get("/api/medias")
+        resp = client.get("/api/medias/ids")
         assert resp.status_code == 200
 
         resp = client.get("/api/auth/status")

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -224,69 +224,48 @@ def _flask_response(mr: MediaResponse) -> Response:
     return send_file(io.BytesIO(mr.data), mimetype=mr.mimetype, download_name=mr.download_name)
 
 
-@medias_bp.route("/api/medias")
-def list_medias() -> Response:
-    """Return metadata for all loaded medias as a JSON array.
+@medias_bp.route("/api/medias/ids")
+def list_media_ids() -> Response:
+    """Return a lightweight listing of all loaded medias.
 
-    Excludes heavyweight fields (``embedding``, ``media_bytes``,
-    ``media_string``) from the response.
+    Each item contains only the fields the frontend needs to build virtual
+    scrollers and to inspect the dataset's media type / embedder *before*
+    any item becomes visible: ``id``, ``type``, and ``embedder`` (when set).
+    Display-worthy metadata (``filename``, ``md5``, ``custom_metadata``,
+    ``origin_name``, ``description``, ``clip_*``) is fetched on demand for
+    the items currently in the viewport via ``POST /api/medias/batch``.
 
-    Each item contains the required fields ``id``, ``type``, ``filename``,
-    ``md5``, and a ``custom_metadata`` dict of display-worthy key/value
-    pairs contributed by the media type and/or importer.
-
-    Returns:
-        A JSON array of media metadata dicts.
+    This replaces the previous unpaginated ``GET /api/medias`` endpoint,
+    which serialised the full metadata for every media in the dataset on
+    every call — a 10-20× larger payload that the cache + batch pattern
+    makes unnecessary.
     """
-    from vtsearch.media import get as get_media_type  # noqa: PLC0415
-
     result: list[dict[str, Any]] = []
     for c in snapshot_medias().values():
-        media_type_id = c.get("type", "audio")
-        media_data: dict[str, Any] = {
-            "id": c["id"],
-            "type": media_type_id,
-            "filename": c.get("filename", f"media_{c['id']}.wav"),
-            "md5": c["md5"],
-        }
-        # Build custom_metadata from media type + any importer-supplied fields
-        try:
-            mt = get_media_type(media_type_id)
-            custom: dict[str, Any] = mt.display_metadata(c)
-        except KeyError:
-            custom = {}
-        importer_custom = c.get("custom_metadata")
-        if importer_custom:
-            custom.update(importer_custom)
-        media_data["custom_metadata"] = custom
-        if "origin_name" in c:
-            media_data["origin_name"] = c["origin_name"]
-        if "description" in c:
-            media_data["description"] = c["description"]
-        if c.get("embedder"):
-            media_data["embedder"] = c["embedder"]
-        # Include clip metadata so the frontend can trim playback / display.
-        for clip_key in ("clip_start", "clip_end", "clip_index", "clip_box"):
-            if clip_key in c:
-                media_data[clip_key] = c[clip_key]
-        result.append(media_data)
+        item: dict[str, Any] = {"id": c["id"], "type": c.get("type", "audio")}
+        embedder = c.get("embedder")
+        if embedder:
+            item["embedder"] = embedder
+        result.append(item)
     return jsonify(result)
 
 
 @medias_bp.route("/api/medias/batch", methods=["POST"])
 def batch_medias() -> tuple[Response, int] | Response:
-    """Return metadata for a specific set of media IDs.
+    """Return full metadata for a specific set of media IDs.
 
-    This is the paginated counterpart of ``GET /api/medias`` — callers
-    request only the IDs they need (e.g. the ones currently visible in a
-    virtual-scrolling viewport), keeping payload size bounded.
+    Callers request only the IDs they need (e.g. the ones currently visible
+    in a virtual-scrolling viewport), keeping payload size bounded.  Use
+    :func:`list_media_ids` (``GET /api/medias/ids``) to discover which
+    media IDs exist in the loaded dataset.
 
     Request body (JSON):
         ``{"ids": [1, 2, 3, ...]}`` — list of integer media IDs.
 
     Returns:
-        A JSON array of media metadata dicts (same shape as the full
-        ``/api/medias`` response) for the requested IDs that exist.
+        A JSON array of media metadata dicts containing ``id``, ``type``,
+        ``filename``, ``md5``, ``custom_metadata``, and optional
+        ``origin_name`` / ``description`` / ``embedder`` / ``clip_*`` keys.
         Unknown IDs are silently omitted.
     """
     from vtsearch.media import get as get_media_type  # noqa: PLC0415


### PR DESCRIPTION
## Summary

- The unpaginated `GET /api/medias` was serialising the full metadata for every media in the loaded dataset on every call — ~5 MB / 10k items.  `POST /api/medias/batch` already provided per-id hydration, so the heavy listing is redundant.
- This PR removes the route and replaces it with a lightweight `GET /api/medias/ids` that returns just `{id, type, embedder?}` per media (≈10–20× smaller payload).  Full per-item metadata is hydrated on demand for visible IDs via the existing `/batch` endpoint and `MediaMetadataCacheService`.

### Backend
- `vtsearch/routes/medias.py` — `list_medias()` deleted; new `list_media_ids()` mounted at `GET /api/medias/ids`.

### Frontend
- `MediasApiService.getMedias()` → `getMediaIds()` hitting `/ids`.
- `MediaStateService.medias$` now carries stubs from `/ids` (no longer pre-fills the metadata cache).
- `MediaListComponent` / `LabelListComponent` enrich rendered rows from the cache (falling back to the stub) and subscribe to `version$` so each row upgrades to its full metadata when the batch fetch lands.
- `MediaItem.filename` / `md5` / `custom_metadata` are now optional on the type — they're populated by `/batch`, not the listing.
- `media-metadata-cache.service.ts` — dropped the now-unused `populate()` method.

### Docs
- `docs/api/medias.md` — replaced the `GET /api/medias` section with documentation for `GET /api/medias/ids` and `POST /api/medias/batch` (the old hand-written `/batch` description was stale and contradicted the implementation).

### Tests
- New `TestListMediaIds` covers the `/ids` shape and asserts `GET /api/medias` now returns 404.
- Tests that hit `/api/medias` purely as an "app is up" check now hit `/ids`; tests that asserted `filename` / `md5` / `clip_*` fields switched to `/batch`.
- Updated Angular specs (`MediasApiService`, `MediaStateService`, `LabelViewComponent`) to expect `/ids`.
- Drive-by: removed an unused `files` local in `tests/test_converter_selection.py` that ruff F841 flagged.

## Breaking changes

- `GET /api/medias` is gone — external API clients must migrate to `GET /api/medias/ids` + `POST /api/medias/batch`.

## Test plan

- [x] `./run-tests.sh` — 3210 passed, 1 skipped, 2 xpassed (full suite, ~51 s)
- [x] `./run-tests.sh core api` — 762 passed (~16 s)
- [x] `ruff check .` — clean
- [x] `npm run build:prod` — frontend builds without errors (run as part of `./run-tests.sh`)
- [ ] Manual UI smoke (browser): label-view and find-view load, virtual-scrolled rows lazily fill in their filenames from `/batch` — *not run; no Chrome available in this sandbox*


---
_Generated by [Claude Code](https://claude.ai/code/session_013o7SZbXkU8MjXjdcJpRqW3)_