### PR TITLE
Cheaply peek staged pkl uploads to count medias

### DIFF
--- a/vtsearch/datasets/pickle_security.py
+++ b/vtsearch/datasets/pickle_security.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import pickle
+import struct
 from typing import Any
 
 
@@ -60,3 +61,81 @@ def safe_pickle_load(f: io.BufferedIOBase, **kwargs: Any) -> Any:
     forwarded to the underlying ``Unpickler``.
     """
     return RestrictedUnpickler(f, **kwargs).load()
+
+
+class _PeekUnpickler(pickle._Unpickler):
+    """Pure-Python unpickler that preserves dict/key structure but stubs out
+    heavy leaf values.
+
+    Used by :func:`peek_pickle_dataset_summary` to extract a dataset's media
+    count and first-entry media type from a ``.pkl`` upload without paying
+    the cost of materialising per-media embedding lists (millions of Python
+    floats) or inline media bytes (audio/image/video blobs).
+
+    Safety: ``find_class`` enforces the same allowlist as
+    :class:`RestrictedUnpickler`, so an RCE payload is still rejected.
+    """
+
+    dispatch = pickle._Unpickler.dispatch.copy()
+
+    def find_class(self, module: str, name: str) -> Any:
+        if (module, name) in _PICKLE_SAFE_CLASSES:
+            return pickle._Unpickler.find_class(self, module, name)
+        raise pickle.UnpicklingError(
+            f"Forbidden pickle class: {module}.{name}. Only plain Python types and numpy arrays are allowed."
+        )
+
+    def load_binfloat(self) -> None:
+        self.read(8)
+        self.append(None)
+
+    dispatch[pickle.BINFLOAT[0]] = load_binfloat
+
+    def load_binbytes(self) -> None:
+        (size,) = struct.unpack("<I", self.read(4))
+        self.read(size)
+        self.append(b"")
+
+    dispatch[pickle.BINBYTES[0]] = load_binbytes
+
+    def load_binbytes8(self) -> None:
+        (size,) = struct.unpack("<Q", self.read(8))
+        self.read(size)
+        self.append(b"")
+
+    dispatch[pickle.BINBYTES8[0]] = load_binbytes8
+
+    def load_short_binbytes(self) -> None:
+        size = self.read(1)[0]
+        self.read(size)
+        self.append(b"")
+
+    dispatch[pickle.SHORT_BINBYTES[0]] = load_short_binbytes
+
+    def load_append(self) -> None:
+        # Discard the value instead of appending to the list below it.
+        self.stack.pop()
+
+    dispatch[pickle.APPEND[0]] = load_append
+
+    def load_appends(self) -> None:
+        # Drop everything between the mark and the top; the list below the
+        # mark stays empty.
+        self.pop_mark()
+
+    dispatch[pickle.APPENDS[0]] = load_appends
+
+
+def peek_pickle_dataset_summary(f: io.BufferedIOBase) -> Any:
+    """Cheaply summarise a dataset pickle without instantiating embeddings.
+
+    Returns the same top-level structure ``pickle.load`` would, but with
+    embedding lists left empty and inline media-byte blobs replaced by
+    ``b""``. Sufficient for reading the media count and the first entry's
+    ``"type"`` field; not suitable for any operation that needs the
+    underlying vectors or bytes.
+
+    Rejects non-allowlisted classes the same way :func:`safe_pickle_load`
+    does, so an RCE payload still raises ``UnpicklingError``.
+    """
+    return _PeekUnpickler(f).load()

--- a/vtsearch/routes/datasets.py
+++ b/vtsearch/routes/datasets.py
@@ -21,7 +21,7 @@ from flask import Blueprint, jsonify, request, send_file
 from vtsearch.config import DATA_DIR, EMBEDDINGS_DIR
 from vtsearch.routes.helpers import get_json_or_400, get_json_safe, get_plugin_or_404, get_request_field
 from vtsearch.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
-from vtsearch.datasets.loader import safe_pickle_load
+from vtsearch.datasets.pickle_security import peek_pickle_dataset_summary
 from vtsearch.datasets.registry import (
     list_datasets as _reg_list_all,
     remove_loaded_id as _reg_remove_loaded,
@@ -333,23 +333,24 @@ def stage_file():
     staging_path = STAGING_DIR / f"stage_{uuid4().hex}.pkl"
     file.save(staging_path)
 
-    # Peek inside the pkl to get count and media type.
+    # Peek the pkl's dict structure cheaply — embeddings and inline media
+    # bytes are skipped, so this stays light even on multi-GB uploads.
     try:
         with open(staging_path, "rb") as f:
-            data = safe_pickle_load(f)
-        if isinstance(data, dict) and "medias" in data:
-            media_dict = data["medias"]
-        elif isinstance(data, dict):
-            media_dict = data
+            peeked = peek_pickle_dataset_summary(f)
+        if isinstance(peeked, dict) and "medias" in peeked:
+            media_dict = peeked["medias"]
+        elif isinstance(peeked, dict):
+            media_dict = peeked
         else:
             media_dict = {}
-        count = len(media_dict)
-        if media_dict:
+        count = len(media_dict) if isinstance(media_dict, dict) else 0
+        media_type = "unknown"
+        if isinstance(media_dict, dict) and media_dict:
             first = next(iter(media_dict.values()))
-            media_type = first.get("type", "audio")
-        else:
-            media_type = "unknown"
-        del data, media_dict
+            if isinstance(first, dict):
+                media_type = first.get("type", "audio") or "unknown"
+        del peeked, media_dict
     except Exception:
         count = 0
         media_type = "unknown"


### PR DESCRIPTION
## Summary

`stage_file` (`vtsearch/routes/datasets.py:336-356`) used to call `safe_pickle_load` on every uploaded `.pkl` purely to read two scalars (entry count + first media's `type`). For real datasets the dominant cost there is materialising per-media embedding lists (millions of Python floats) and inline media-byte blobs — work that's thrown away immediately after the count is read.

This PR adds `peek_pickle_dataset_summary` in `vtsearch/datasets/pickle_security.py`, a pure-Python unpickler that keeps the same allowlist enforced by `RestrictedUnpickler` but stubs out the heavy leaf opcodes:

- `BINFLOAT` reads the 8 bytes and pushes `None` — embedding floats are never allocated.
- `BINBYTES` / `SHORT_BINBYTES` / `BINBYTES8` read past the payload and push `b""` — inline audio/image/video bytes are discarded.
- `APPEND` / `APPENDS` drop the appended values, so embedding lists end up empty.

Dict structure (and therefore `len(medias)` and the first entry's `"type"`) is preserved. `stage_file` switches to this helper.

## Test plan
- [x] `python -m pytest tests/test_pickle_safety.py tests/test_combine_datasets.py` — 60/60 pass, including `test_stage_file_rejects_rce` (allowlist still enforced) and the existing `count` / `media_type` assertions in `TestStageFileEndpoint`.
- [x] `./run-tests.sh` — 3211 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_0167ffPnPwg4DxKqH7Tb2cXn)_