### PR TITLE
Add env-tunable runtime config: TORCH_THREADS, DEVICE, SERVER_ROOTS, MAX_UPLOAD_MB

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,15 @@ import os
 import sys
 import warnings
 
-# Limit threads to reduce memory overhead in constrained environments
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
+# Limit threads to reduce memory overhead in constrained environments.  Native
+# math libraries read these env vars during *their* import, which happens the
+# moment torch / numpy / scipy are imported — so they have to be set before
+# anything triggers that.  Mirrors ``vtsearch.config.TORCH_THREADS`` but
+# resolved inline to avoid importing ``vtsearch.config`` (and therefore
+# everything it transitively imports) this early.
+_torch_threads = str(max(1, int(os.environ.get("VTSEARCH_TORCH_THREADS", "1"))))
+os.environ["OMP_NUM_THREADS"] = _torch_threads
+os.environ["MKL_NUM_THREADS"] = _torch_threads
 
 # Configure logging — respects VTSEARCH_LOG_LEVEL env var.
 # Default is WARNING.  Set to INFO or DEBUG for resolver diagnostics:
@@ -79,6 +85,14 @@ app = Flask(__name__)
 # if set; otherwise fall back to a dev-only default.  Production
 # deployments should always set the env var.
 app.secret_key = os.environ.get("VTSEARCH_SECRET_KEY", "vtsearch-dev-key-change-in-production")
+
+# Optional cap on request body size (uploads).  ``MAX_UPLOAD_MB == 0`` leaves
+# Flask's default of no limit in place; a positive value rejects oversized
+# requests with HTTP 413 before they consume disk.
+from vtsearch.config import MAX_UPLOAD_MB as _MAX_UPLOAD_MB  # noqa: E402
+
+if _MAX_UPLOAD_MB > 0:
+    app.config["MAX_CONTENT_LENGTH"] = _MAX_UPLOAD_MB * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -15,6 +15,83 @@ MODELS_CACHE_DIR = (
     Path(os.environ["VTSEARCH_MODELS_DIR"]) if "VTSEARCH_MODELS_DIR" in os.environ else DATA_DIR / "models"
 )
 
+# ---------------------------------------------------------------------------
+# Runtime tunables
+# ---------------------------------------------------------------------------
+
+# Thread count for native math libraries (OpenMP / MKL) and ``torch``.  The
+# default of 1 keeps memory overhead low in constrained environments — each
+# additional thread allocates its own scratch buffers.  Override with
+# ``VTSEARCH_TORCH_THREADS`` on bigger boxes where embedding throughput
+# matters more than RSS.  Consumed by ``app.py`` (OMP/MKL env vars set
+# before torch import) and ``vtsearch.models.loader.ensure_torch_configured``
+# (``torch.set_num_threads``).
+TORCH_THREADS = max(1, int(os.environ.get("VTSEARCH_TORCH_THREADS", "1")))
+
+# Preferred compute device for embedding and training.  ``"auto"`` resolves
+# to ``"cuda"`` when a GPU is visible to PyTorch and ``"cpu"`` otherwise;
+# explicit values like ``"cuda"``, ``"cuda:0"``, ``"cpu"``, or ``"mps"`` are
+# passed through unchanged.  Resolution is lazy — the env var stores the
+# user's intent, ``resolve_device()`` actually imports torch when called.
+# Currently advisory: every embedder still loads on CPU.  Reserved for the
+# upcoming device-aware embedder refactor.
+DEVICE = os.environ.get("VTSEARCH_DEVICE", "auto").lower()
+
+
+def resolve_device() -> str:
+    """Resolve :data:`DEVICE` to a concrete ``torch.device`` string.
+
+    Imports torch lazily so that simply importing this module does not pull
+    torch in.  Returns ``"cpu"`` if torch is unavailable.
+    """
+    if DEVICE != "auto":
+        return DEVICE
+    try:
+        import torch  # noqa: PLC0415
+
+        if torch.cuda.is_available():
+            return "cuda"
+        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+    except ImportError:
+        return "cpu"
+
+
+def _parse_server_roots(value: str | None) -> tuple[Path, ...]:
+    """Parse ``VTSEARCH_SERVER_ROOTS`` into a tuple of resolved Paths.
+
+    Splits on :data:`os.pathsep` (``:`` on Unix, ``;`` on Windows).  Empty
+    segments are ignored.  When the env var is unset or empty the tuple
+    contains a single entry — ``Path.cwd()`` at import time — which
+    reproduces the historical "anything under CWD" behaviour exactly.
+    """
+    if not value:
+        return (Path.cwd().resolve(),)
+    roots: list[Path] = []
+    for segment in value.split(os.pathsep):
+        segment = segment.strip()
+        if segment:
+            roots.append(Path(segment).resolve())
+    return tuple(roots) if roots else (Path.cwd().resolve(),)
+
+
+# Allowed roots for the server file browser and server-path importers/exporters.
+# In single-user mode these define the directories the user is permitted to
+# read from and write to via the API.  The first entry is the default browse
+# root (what ``/api/browse`` shows when no ``path`` parameter is provided).
+# Multi-user mode is unaffected — each user is still confined to their own
+# ``data/<username>/`` subtree regardless of this setting.
+SERVER_ROOTS: tuple[Path, ...] = _parse_server_roots(os.environ.get("VTSEARCH_SERVER_ROOTS"))
+
+# Maximum size (in megabytes) accepted for a single HTTP request body.  Wired
+# into Flask's ``MAX_CONTENT_LENGTH`` config in ``app.py``.  ``0`` (the
+# default) disables the cap, preserving Flask's out-of-the-box "no limit"
+# behaviour so existing large-archive uploads keep working.  Set
+# ``VTSEARCH_MAX_UPLOAD_MB`` to a positive integer to reject oversized
+# uploads with HTTP 413 before they consume disk.
+MAX_UPLOAD_MB = max(0, int(os.environ.get("VTSEARCH_MAX_UPLOAD_MB", "0")))
+
 # Training
 #
 # ``TRAIN_EPOCHS`` is an *upper bound* — :func:`vtsearch.models.training.train_model`

--- a/vtsearch/models/loader.py
+++ b/vtsearch/models/loader.py
@@ -13,14 +13,14 @@ to work unchanged.
 import gc
 import sys
 
-from vtsearch.config import MODELS_CACHE_DIR
+from vtsearch.config import MODELS_CACHE_DIR, TORCH_THREADS
 
 
 _torch_configured = False
 
 
 def ensure_torch_configured() -> None:
-    """Set ``torch.set_num_threads(1)`` once, the first time torch is used.
+    """Set ``torch.set_num_threads(TORCH_THREADS)`` the first time torch is used.
 
     Safe to call multiple times — the configuration is applied only once.
     Call this from any code path that imports torch before doing work
@@ -33,7 +33,7 @@ def ensure_torch_configured() -> None:
         return
     import torch  # noqa: PLC0415
 
-    torch.set_num_threads(1)
+    torch.set_num_threads(TORCH_THREADS)
     _torch_configured = True
 
 

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -26,12 +26,16 @@ file_browser_bp = Blueprint("file_browser", __name__)
 def _get_browse_root() -> Path:
     """Return the root directory users are allowed to browse.
 
-    In single-user mode this is ``Path.cwd()``; in multi-user mode it is
+    In single-user mode this is the first entry of
+    :data:`vtsearch.config.SERVER_ROOTS` (which defaults to
+    ``Path.cwd()`` when the env var is unset).  In multi-user mode it is
     the current user's data directory.
     """
     base = _paths.get_file_access_base_dir()
     if base is None:
-        return Path.cwd()
+        from vtsearch.config import SERVER_ROOTS  # noqa: PLC0415
+
+        return SERVER_ROOTS[0]
     return base
 
 

--- a/vtsearch/utils/paths.py
+++ b/vtsearch/utils/paths.py
@@ -17,8 +17,8 @@ def get_file_access_base_dir() -> Path | None:
 
     In single-user mode (:class:`~vtsearch.auth.DefaultLoginProvider`) this
     returns ``None``, which causes :func:`validate_server_filepath` to fall
-    back to ``Path.cwd()`` — giving the single user full access to any path
-    under the working directory.
+    back to :data:`vtsearch.config.SERVER_ROOTS[0]` (``Path.cwd()`` by
+    default).
 
     In multi-user mode (any non-default provider) this returns the current
     user's data directory so that each user is confined to their own
@@ -41,7 +41,9 @@ def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) ->
         User-supplied file path (absolute or relative).
     base_dir:
         The directory the resolved path must reside in.
-        Defaults to ``Path.cwd()``.
+        Defaults to :data:`vtsearch.config.SERVER_ROOTS[0]` (which itself
+        falls back to ``Path.cwd()`` when ``VTSEARCH_SERVER_ROOTS`` is
+        unset).
 
     Returns
     -------
@@ -54,7 +56,9 @@ def validate_server_filepath(filepath_str: str, base_dir: Path | None = None) ->
         If the resolved path is outside *base_dir*.
     """
     if base_dir is None:
-        base_dir = Path.cwd()
+        from vtsearch.config import SERVER_ROOTS  # noqa: PLC0415
+
+        base_dir = SERVER_ROOTS[0]
 
     path = Path(filepath_str)
 


### PR DESCRIPTION
## Summary
Replaces a handful of hard-coded operational values in the runtime with env-driven knobs so the same image works in constrained dev containers and on bigger boxes without code edits.

- **`TORCH_THREADS`** (`VTSEARCH_TORCH_THREADS`, default `1`) — drives the `OMP_NUM_THREADS` / `MKL_NUM_THREADS` env vars set in `app.py` *and* `torch.set_num_threads()` in `vtsearch.models.loader`, so all three knobs move together.
- **`DEVICE`** (`VTSEARCH_DEVICE`, default `"auto"`) — advisory constant plus a lazy `resolve_device()` helper that returns `"cuda"` / `"mps"` / `"cpu"`. Reserved for the upcoming device-aware embedder refactor; every embedder still loads on CPU today, so this is a constant-only addition (no embedder changes in this PR).
- **`SERVER_ROOTS`** (`VTSEARCH_SERVER_ROOTS`, `os.pathsep`-separated list, default `(Path.cwd(),)`) — replaces the `Path.cwd()` fallbacks in `routes/file_browser._get_browse_root` and `utils/paths.validate_server_filepath`. First entry is the default browse root in single-user mode. Multi-user mode is unchanged (each user is still confined to their own `data/<username>/` subtree).
- **`MAX_UPLOAD_MB`** (`VTSEARCH_MAX_UPLOAD_MB`, default `0` = unlimited) — when `> 0`, sets Flask `MAX_CONTENT_LENGTH` so oversized uploads get HTTP 413 before consuming disk. Default `0` preserves Flask's out-of-the-box no-limit behaviour exactly.

`TRAIN_EPOCHS` and `CALIBRATE_COUNT` were already env-tunable (`VTSEARCH_TRAIN_EPOCHS`, `VTSEARCH_CALIBRATE_COUNT`) and were left as-is.

## Test plan
- [x] `./run-tests.sh` — full suite, 3211 passed / 1 skipped / 2 xpassed
- [x] `ruff check` on the five changed files — all checks passed
- [ ] Manual: set `VTSEARCH_TORCH_THREADS=4` and confirm `torch.get_num_threads()` reports 4 after first model load
- [ ] Manual: set `VTSEARCH_SERVER_ROOTS=/tmp` and confirm `/api/browse` lists `/tmp` and rejects paths outside it
- [ ] Manual: set `VTSEARCH_MAX_UPLOAD_MB=10` and confirm an 11 MB upload is rejected with 413

https://claude.ai/code/session_01MRxoMEaRXxWUZwaKcYsk8z

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRxoMEaRXxWUZwaKcYsk8z)_