### PR TITLE
Switch frontend media metadata to lazy /batch fetches

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -145,13 +145,9 @@ export class AppComponent {
   }
 
   private inferMediaType(): string {
-    // From labeling view: use the media type of loaded medias
+    // From labeling view: use the media type of the active dataset.
     if (this.isOnLabelView) {
-      const medias = this.mediaState.medias;
-      if (medias.length > 0) {
-        return medias[0].type;
-      }
-      return '';
+      return this.mediaState.mediaType;
     }
     // From dashboard: if all datasets and models share a single media type, use it
     const datasets = this.datasetState.datasets;

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -1,7 +1,9 @@
 <div class="layout" #layout>
   <div class="panel-left">
     <vt-left-panel
-      [medias]="mediaState.medias"
+      [mediaIds]="mediaState.mediaIds"
+      [mediaType]="mediaState.mediaType"
+      [embedder]="mediaState.embedder"
       [sortOrder]="sortState.sortOrder"
       [threshold]="sortState.threshold"
       [selectedId]="mediaState.selectedId"
@@ -51,7 +53,7 @@
   ></div>
   <div class="panel-right">
     <vt-right-panel
-      [medias]="mediaState.medias"
+      [mediaType]="mediaState.mediaType"
       [focusMode]="focusModeRight"
       [disabled]="sortState.sortBusy"
       mode="find"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -75,20 +75,16 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       next: (status) => { this.datasetName = status.display_name || ''; },
     });
 
-    // When medias arrive, run the find-label scoring
-    this.mediaState.medias$
+    this.mediaState.mediaType$
       .pipe(takeUntil(this.destroy$))
-      .subscribe((medias) => {
-        if (medias.length > 0) {
-          const newType = medias[0].type;
-          if (newType !== this.currentMediaType) {
-            this.currentMediaType = newType;
-            this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
-            this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
-            this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
-            this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
-            this.applyPanelPx(newType);
-          }
+      .subscribe((newType) => {
+        if (newType && newType !== this.currentMediaType) {
+          this.currentMediaType = newType;
+          this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
+          this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
+          this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
+          this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
+          this.applyPanelPx(newType);
         }
       });
 

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -1,7 +1,9 @@
 <div class="layout" #layout>
   <div class="panel-left">
     <vt-left-panel
-      [medias]="mediaState.medias"
+      [mediaIds]="mediaState.mediaIds"
+      [mediaType]="mediaState.mediaType"
+      [embedder]="mediaState.embedder"
       [sortOrder]="sortState.sortOrder"
       [threshold]="sortState.threshold"
       [selectedId]="mediaState.selectedId"
@@ -60,7 +62,7 @@
   ></div>
   <div class="panel-right">
     <vt-right-panel
-      [medias]="mediaState.medias"
+      [mediaType]="mediaState.mediaType"
       [focusMode]="focusModeRight"
       [trainableModelName]="trainableModelName"
       (mediaSelected)="onMediaSelect($event)"

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -31,11 +31,13 @@ describe('LabelViewComponent', () => {
 
   function flushInitialRequests(): void {
     fixture.detectChanges();
-    // Flush /api/medias
-    httpMock.expectOne('/api/medias').flush([
-      { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
-      { id: 2, type: 'audio', filename: 'b.wav', md5: 'b2', custom_metadata: {} },
-    ]);
+    // Flush /api/medias/ids (lightweight ID list; full metadata is fetched
+    // on demand via /api/medias/batch).
+    httpMock.expectOne('/api/medias/ids').flush({
+      ids: [1, 2],
+      type: 'audio',
+      embedder: 'laion-clap-large',
+    });
     // Flush /api/votes (label-view + right-panel both poll)
     httpMock.match('/api/votes').forEach(req =>
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
@@ -61,7 +63,8 @@ describe('LabelViewComponent', () => {
 
   it('should load medias on init', () => {
     flushInitialRequests();
-    expect(component.mediaState.medias.length).toBe(2);
+    expect(component.mediaState.mediaIds.length).toBe(2);
+    expect(component.mediaState.mediaType).toBe('audio');
   });
 
   it('should load votes on init', () => {
@@ -264,9 +267,11 @@ describe('LabelViewComponent', () => {
 
     // Now trigger init which loads medias
     fixture.detectChanges();
-    httpMock.expectOne('/api/medias').flush([
-      { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
-    ]);
+    httpMock.expectOne('/api/medias/ids').flush({
+      ids: [1],
+      type: 'audio',
+      embedder: 'laion-clap-large',
+    });
     httpMock.match('/api/votes').forEach(req =>
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
     );

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -120,25 +120,27 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe((modelId) => this.refreshTrainableModelName(modelId));
     this.refreshTrainableModelName(this.activeContext.modelId);
 
-    this.mediaState.medias$
+    this.mediaState.mediaType$
       .pipe(takeUntil(this.destroy$))
-      .subscribe((medias) => {
-        if (medias.length > 0) {
-          const newType = medias[0].type;
-          if (newType !== this.currentMediaType) {
-            this.currentMediaType = newType;
-            this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
-            this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
-            this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
-            this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
-            this.applyPanelPx(newType);
-          }
+      .subscribe((newType) => {
+        if (newType && newType !== this.currentMediaType) {
+          this.currentMediaType = newType;
+          this.viewModeLeft = this.viewModeLeftDict[newType] ?? 'list';
+          this.gridGoalWidthLeft = iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M');
+          this.focusModeLeft = this.focusModeLeftDict[newType] ?? 'click';
+          this.focusModeRight = this.focusModeRightDict[newType] ?? 'click';
+          this.applyPanelPx(newType);
         }
-        if (this.autopilotTextSortPending && medias.length > 0) {
+      });
+
+    this.mediaState.mediaIds$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((ids) => {
+        if (this.autopilotTextSortPending && ids.length > 0) {
           this.autopilotTextSortPending = false;
           this.triggerAutopilotTextSort();
         }
-        if (this.autopilotMediaSortPending && medias.length > 0) {
+        if (this.autopilotMediaSortPending && ids.length > 0) {
           this.autopilotMediaSortPending = false;
           this.triggerAutopilotMediaSort();
         }
@@ -628,13 +630,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       const textQuery = this.labelSession.textQuery;
       const mediaExample = this.labelSession.mediaExample;
       if (textQuery) {
-        if (this.mediaState.medias.length > 0) {
+        if (this.mediaState.mediaIds.length > 0) {
           this.triggerAutopilotTextSort();
         } else {
           this.autopilotTextSortPending = true;
         }
       } else if (mediaExample) {
-        if (this.mediaState.medias.length > 0) {
+        if (this.mediaState.mediaIds.length > 0) {
           this.triggerAutopilotMediaSort();
         } else {
           this.autopilotMediaSortPending = true;

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -7,11 +7,11 @@
     <div class="tab-panel-manual" role="region" aria-label="Find results">
       <div class="images-header">
         <h3 class="images-header-title">
-          {{ mediaTypeName }}s ({{ medias.length | number }})
+          {{ mediaTypeName }}s ({{ mediaIds.length | number }})
         </h3>
         <vt-view-controls
           side="left"
-          [currentMediaType]="medias.length > 0 ? medias[0].type : ''"
+          [currentMediaType]="mediaType"
           class="view-controls-slot" />
 
       </div>
@@ -28,7 +28,7 @@
 
       <div class="media-list-container">
         <vt-media-list
-          [medias]="medias"
+          [mediaIds]="mediaIds"
           [sortOrder]="sortOrder"
           [threshold]="threshold"
           [selectedId]="selectedId"
@@ -47,7 +47,7 @@
           [selectedId]="selectedId"
           [goodVotes]="goodVotes"
           [badVotes]="badVotes"
-          [totalCount]="medias.length"
+          [totalCount]="mediaIds.length"
           (stripeClick)="onStripeClick($event)"
         />
       </div>
@@ -114,17 +114,17 @@
 
         <div class="images-header">
           <h3 class="images-header-title">
-            {{ mediaTypeName }}s ({{ medias.length | number }})
+            {{ mediaTypeName }}s ({{ mediaIds.length | number }})
           </h3>
           <vt-view-controls
             side="left"
-            [currentMediaType]="medias.length > 0 ? medias[0].type : ''"
+            [currentMediaType]="mediaType"
             class="view-controls-slot" />
         </div>
 
         <div class="media-list-container">
           <vt-media-list
-            [medias]="medias"
+            [mediaIds]="mediaIds"
             [sortOrder]="sortOrder"
             [threshold]="threshold"
             [selectedId]="selectedId"
@@ -143,7 +143,7 @@
             [selectedId]="selectedId"
             [goodVotes]="goodVotes"
             [badVotes]="badVotes"
-            [totalCount]="medias.length"
+            [totalCount]="mediaIds.length"
             (stripeClick)="onStripeClick($event)"
           />
         </div>

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -8,7 +8,7 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
-import { MediaItem, LabelingStatusResponse, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import { LabelingStatusResponse, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 
@@ -32,7 +32,11 @@ export type { SortMode, SelectMode, SortedItem };
   styleUrl: './left-panel.component.scss',
 })
 export class LeftPanelComponent implements OnInit, OnChanges {
-  @Input() medias: MediaItem[] = [];
+  @Input() mediaIds: number[] = [];
+  /** Media type of the active dataset (taken from the first item). */
+  @Input() mediaType = '';
+  /** Embedder name of the active dataset (taken from the first item). */
+  @Input() embedder = '';
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
   @Input() selectedId: number | null = null;
@@ -123,14 +127,16 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['medias']) {
+    if (changes['mediaType']) {
       this.updateMediaTypeName();
+    }
+    if (changes['embedder']) {
       this.updateTextSortAvailable();
     }
   }
 
   private updateMediaTypeName(): void {
-    const typeId = this.medias.length > 0 ? this.medias[0].type : '';
+    const typeId = this.mediaType;
     if (typeId && typeId !== this.currentTypeId) {
       this.currentTypeId = typeId;
       const info = this.mediaTypeInfos.find((mt) => mt.type_id === typeId);
@@ -145,12 +151,11 @@ export class LeftPanelComponent implements OnInit, OnChanges {
    * hide a working feature.
    */
   private updateTextSortAvailable(): void {
-    const embedderName = this.medias.length > 0 ? this.medias[0].embedder : '';
-    if (!embedderName || this.embedderInfos.length === 0) {
+    if (!this.embedder || this.embedderInfos.length === 0) {
       this.textSortAvailable = true;
       return;
     }
-    const info = this.embedderInfos.find((e) => e.name === embedderName);
+    const info = this.embedderInfos.find((e) => e.name === this.embedder);
     this.textSortAvailable = info ? info.supports_text !== false : true;
   }
 

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -42,7 +42,7 @@
       />
     }
 
-    @if (medias.length === 0) {
+    @if (mediaIds.length === 0) {
       <div class="empty-list">No media loaded</div>
     }
   </div>

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -1,10 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MediaListComponent } from './media-list.component';
+import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('MediaListComponent', () => {
   let component: MediaListComponent;
   let fixture: ComponentFixture<MediaListComponent>;
+  let cache: MediaMetadataCacheService;
 
   const mockMedias: MediaItem[] = [
     { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
@@ -15,11 +19,17 @@ describe('MediaListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MediaListComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MediaListComponent);
     component = fixture.componentInstance;
-    component.medias = mockMedias;
+    cache = TestBed.inject(MediaMetadataCacheService);
+    // Preload the cache so lookups return real items instead of placeholders.
+    for (const m of mockMedias) {
+      (cache as unknown as { cache: Map<number, MediaItem> }).cache.set(m.id, m);
+    }
+    component.mediaIds = mockMedias.map((m) => m.id);
     fixture.detectChanges();
   });
 
@@ -57,7 +67,6 @@ describe('MediaListComponent', () => {
     component.threshold = 0.4;
     fixture.detectChanges();
     const items = component.cachedOrderedItems;
-    // Threshold is at 0.4, so item with score 0.2 should have showThreshold
     expect(items[0].showThreshold).toBeFalse();
     expect(items[1].showThreshold).toBeFalse();
     expect(items[2].showThreshold).toBeTrue();
@@ -78,7 +87,7 @@ describe('MediaListComponent', () => {
   });
 
   it('should show empty message when no medias', () => {
-    component.medias = [];
+    component.mediaIds = [];
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.empty-list')?.textContent).toContain('No media loaded');
   });

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -8,6 +8,7 @@ import {
   AfterViewChecked,
   OnChanges,
   OnDestroy,
+  OnInit,
   SimpleChanges,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -19,6 +20,11 @@ import { MediaItem } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { SortedItem } from '../left-panel.component';
 import { prefersReducedMotion } from '../../../utils/reduced-motion';
+
+/** Build a placeholder MediaItem for IDs whose metadata is not yet cached. */
+function placeholderMedia(id: number): MediaItem {
+  return { id, type: '', filename: '', md5: '', custom_metadata: {} };
+}
 
 /** Threshold above which we switch from plain DOM to CDK virtual scrolling (list mode only). */
 const VIRTUAL_SCROLL_THRESHOLD = 500;
@@ -34,8 +40,8 @@ const PREFETCH_BUFFER = 50;
   templateUrl: './media-list.component.html',
   styleUrl: './media-list.component.scss',
 })
-export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestroy {
-  @Input() medias: MediaItem[] = [];
+export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
+  @Input() mediaIds: number[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
   @Input() selectedId: number | null = null;
@@ -73,6 +79,14 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
     return this.viewMode === 'list' && this.cachedOrderedItems.length > VIRTUAL_SCROLL_THRESHOLD;
   }
 
+  ngOnInit(): void {
+    // Re-render when the metadata cache has new entries so cached items
+    // replace their placeholders.
+    this.metadataCache.version$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.rebuildOrderedItems());
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['selectedId'] && !changes['selectedId'].firstChange) {
       this.pendingScrollToSelected = true;
@@ -87,7 +101,7 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
 
     // Rebuild cache only when relevant inputs change.
     if (
-      changes['medias'] ||
+      changes['mediaIds'] ||
       changes['sortOrder'] ||
       changes['threshold'] ||
       changes['showScores'] ||
@@ -97,15 +111,18 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
     }
   }
 
+  private lookupMedia(id: number): MediaItem {
+    return this.metadataCache.get(id) ?? placeholderMedia(id);
+  }
+
   private rebuildOrderedItems(): void {
-    const mediaMap = new Map(this.medias.map((m) => [m.id, m]));
     const items: { media: MediaItem; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
 
     if (this.sortOrder && this.sortOrder.length > 0) {
+      const knownIds = new Set(this.mediaIds);
       let thresholdInserted = false;
       for (const sorted of this.sortOrder) {
-        const media = mediaMap.get(sorted.id);
-        if (!media) continue;
+        if (!knownIds.has(sorted.id)) continue;
 
         let showThreshold = false;
         if (!thresholdInserted && this.threshold !== null && sorted.score < this.threshold) {
@@ -114,15 +131,15 @@ export class MediaListComponent implements AfterViewChecked, OnChanges, OnDestro
         }
 
         items.push({
-          media,
+          media: this.lookupMedia(sorted.id),
           score: this.showScores ? sorted.score : null,
           showThreshold,
           bestRegion: sorted.bestRegion ?? null,
         });
       }
     } else {
-      for (const media of this.medias) {
-        items.push({ media, score: null, showThreshold: false, bestRegion: null });
+      for (const id of this.mediaIds) {
+        items.push({ media: this.lookupMedia(id), score: null, showThreshold: false, bestRegion: null });
       }
     }
 

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -1,11 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { LabelListComponent, LabelEntry } from './label-list.component';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { LabelListComponent } from './label-list.component';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { MediaItem } from '../../../models/api.models';
 
 describe('LabelListComponent', () => {
   let component: LabelListComponent;
   let fixture: ComponentFixture<LabelListComponent>;
+  let cache: MediaMetadataCacheService;
 
   const sampleMedias: MediaItem[] = [
     { id: 1, type: 'audio', filename: 'song.wav', md5: 'aaa', custom_metadata: {} },
@@ -13,14 +17,25 @@ describe('LabelListComponent', () => {
     { id: 3, type: 'video', filename: 'clip.mp4', md5: 'ccc', custom_metadata: {} },
   ];
 
+  function seedCache(): void {
+    for (const m of sampleMedias) {
+      (cache as unknown as { cache: Map<number, MediaItem> }).cache.set(m.id, m);
+    }
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LabelListComponent],
-      providers: [ActiveContextService],
+      providers: [
+        ActiveContextService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LabelListComponent);
     component = fixture.componentInstance;
+    cache = TestBed.inject(MediaMetadataCacheService);
   });
 
   it('should create', () => {
@@ -29,9 +44,9 @@ describe('LabelListComponent', () => {
   });
 
   it('should display correct label heading and count', () => {
+    seedCache();
     component.label = 'good';
     component.ids = [1, 2];
-    component.medias = sampleMedias;
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
@@ -42,9 +57,9 @@ describe('LabelListComponent', () => {
   });
 
   it('should display bad label heading', () => {
+    seedCache();
     component.label = 'bad';
     component.ids = [3];
-    component.medias = sampleMedias;
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
@@ -55,9 +70,9 @@ describe('LabelListComponent', () => {
 
   describe('sorting', () => {
     beforeEach(() => {
+      seedCache();
       component.label = 'good';
       component.ids = [1, 2, 3];
-      component.medias = sampleMedias;
       component.clickTimes = { '1': 3, '2': 1, '3': 2 };
       component.learnedScores = { '1': 0.9, '2': 0.5, '3': 0.7 };
     });
@@ -109,9 +124,9 @@ describe('LabelListComponent', () => {
 
   describe('confidence calculation', () => {
     it('should use score directly for good label', () => {
+      seedCache();
       component.label = 'good';
       component.ids = [1];
-      component.medias = sampleMedias;
       component.learnedScores = { '1': 0.8 };
       fixture.detectChanges();
 
@@ -119,9 +134,9 @@ describe('LabelListComponent', () => {
     });
 
     it('should use 1-score for bad label', () => {
+      seedCache();
       component.label = 'bad';
       component.ids = [1];
-      component.medias = sampleMedias;
       component.learnedScores = { '1': 0.3 };
       fixture.detectChanges();
 
@@ -129,9 +144,9 @@ describe('LabelListComponent', () => {
     });
 
     it('should set confidence to -1 when no score', () => {
+      seedCache();
       component.label = 'good';
       component.ids = [1];
-      component.medias = sampleMedias;
       component.learnedScores = {};
       fixture.detectChanges();
 
@@ -141,7 +156,7 @@ describe('LabelListComponent', () => {
 
   describe('view modes and thumbnails', () => {
     beforeEach(() => {
-      component.medias = sampleMedias;
+      seedCache();
     });
 
     it('should have thumbnail URL for images', () => {
@@ -213,23 +228,23 @@ describe('LabelListComponent', () => {
   });
 
   it('should use filename for entry name', () => {
+    seedCache();
     component.ids = [1];
-    component.medias = sampleMedias;
     fixture.detectChanges();
     expect(component.sortedEntries[0].name).toBe('song.wav');
   });
 
   it('should fallback to Clip #ID when no media found', () => {
+    seedCache();
     component.ids = [999];
-    component.medias = sampleMedias;
     fixture.detectChanges();
     expect(component.sortedEntries[0].name).toBe('Clip #999');
   });
 
   it('should render vote entries in the DOM', () => {
+    seedCache();
     component.label = 'good';
     component.ids = [1, 2];
-    component.medias = sampleMedias;
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,8 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, OnChanges, OnDestroy, SimpleChanges, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { MediaItem } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 
 export interface LabelEntry {
   id: number;
@@ -19,10 +22,9 @@ export interface LabelEntry {
   templateUrl: './label-list.component.html',
   styleUrl: './label-list.component.scss',
 })
-export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
+export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
-  @Input() medias: MediaItem[] = [];
   @Input() clickTimes: Record<string, number> = {};
   @Input() learnedScores: Record<string, number> = {};
   @Input() sortMode: LabelSortMode = 'time-desc';
@@ -36,14 +38,23 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
 
   sortedEntries: LabelEntry[] = [];
   private pendingScrollPct: number | null = null;
-  /** Pre-built Map for O(1) media lookups by id (rebuilt when medias input changes). */
-  private mediaMap = new Map<number, MediaItem>();
+  private readonly destroy$ = new Subject<void>();
 
-  constructor(private activeContext: ActiveContextService) {}
+  constructor(
+    private activeContext: ActiveContextService,
+    private metadataCache: MediaMetadataCacheService,
+  ) {}
 
   ngOnInit(): void {
-    this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
+    // Ensure metadata is fetched for the labeled IDs (the list of voted
+    // items is typically small — dozens to hundreds — so this is cheap).
+    this.metadataCache.ensureLoaded(this.ids);
     this.sortedEntries = this.buildSortedEntries();
+    this.metadataCache.version$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.sortedEntries = this.buildSortedEntries();
+      });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -52,10 +63,19 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
       const maxScroll = el.scrollHeight - el.clientHeight;
       this.pendingScrollPct = maxScroll > 0 ? el.scrollTop / maxScroll : 0;
     }
-    if (changes['medias']) {
-      this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
+    if (changes['ids']) {
+      this.metadataCache.ensureLoaded(this.ids);
     }
     this.sortedEntries = this.buildSortedEntries();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private getMedia(id: number): MediaItem | undefined {
+    return this.metadataCache.get(id);
   }
 
   ngAfterViewChecked(): void {
@@ -74,7 +94,7 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   }
 
   private buildEntry(id: number): LabelEntry {
-    const media = this.mediaMap.get(id);
+    const media = this.getMedia(id);
     const name = media ? (media.filename || `Clip #${id}`) : `Clip #${id}`;
     const time = this.clickTimes[String(id)] ?? -1;
     const score = this.learnedScores[String(id)] ?? -1;
@@ -123,12 +143,12 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   hasThumbnailUrl(id: number): boolean {
     const url = this.thumbnailUrl(id);
     if (url && this.thumbnailFailedUrls.has(url)) return false;
-    const media = this.mediaMap.get(id);
+    const media = this.getMedia(id);
     return !!media && (media.type === 'image' || media.type === 'video' || media.type === 'document' || media.type === 'audio');
   }
 
   thumbnailUrl(id: number): string {
-    const media = this.mediaMap.get(id);
+    const media = this.getMedia(id);
     if (!media) return '';
     return this.activeContext.mediaUrl(`/api/medias/${id}/image`);
   }
@@ -139,7 +159,7 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
 
   placeholderIcon(id: number): string | null {
     if (this.hasThumbnailUrl(id)) return null;
-    const media = this.mediaMap.get(id);
+    const media = this.getMedia(id);
     if (!media) return null;
     if (media.type === 'audio') return '\u266B';
     if (media.type === 'text') return '\u00B6';
@@ -147,7 +167,7 @@ export class LabelListComponent implements OnInit, OnChanges, AfterViewChecked {
   }
 
   isMissing(id: number): boolean {
-    return !this.mediaMap.has(id);
+    return !this.metadataCache.has(id);
   }
 
   onEntryClick(id: number): void {

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -55,7 +55,6 @@
     <vt-label-list
       label="good"
       [ids]="goodIds"
-      [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
       [sortMode]="sortMode"
@@ -71,7 +70,6 @@
     <vt-label-list
       label="bad"
       [ids]="badIds"
-      [medias]="medias"
       [clickTimes]="clickTimes"
       [learnedScores]="learnedScores"
       [sortMode]="sortMode"

--- a/frontend/src/app/components/right-panel/right-panel.component.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.spec.ts
@@ -52,13 +52,13 @@ describe('RightPanelComponent', () => {
   }));
 
   it('should load view mode from settings on init', fakeAsync(() => {
-    component.medias = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'x', custom_metadata: {} }];
+    component.mediaType = 'audio';
     fixture.detectChanges();
     tick();
     httpMock.expectOne('/api/settings').flush({ volume: 1, view_mode_right: { audio: 'list', image: 'grid' } });
     httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
-    // Trigger ngOnChanges by setting medias via input
-    component.ngOnChanges({ medias: { currentValue: component.medias, previousValue: [], firstChange: true, isFirstChange: () => true } });
+    // Trigger ngOnChanges by setting mediaType via input
+    component.ngOnChanges({ mediaType: { currentValue: 'audio', previousValue: '', firstChange: true, isFirstChange: () => true } });
     expect(component.viewMode).toBe('list');
     cleanup();
   }));

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DetectorsApiService } from '../../services/detectors-api.service';
-import { LabelElement, MediaItem } from '../../models/api.models';
+import { LabelElement } from '../../models/api.models';
 import { VoteStateService } from '../../services/vote-state.service';
 import { LabelsetStateService } from '../../services/labelset-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
@@ -38,7 +38,8 @@ export interface TrainModeContext {
   styleUrl: './right-panel.component.scss',
 })
 export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() medias: MediaItem[] = [];
+  /** Media type of the active dataset; drives the right-pane view mode. */
+  @Input() mediaType = '';
   @Input() trainMode: TrainModeContext | null = null;
   @Input() focusMode: 'click' | 'hover' = 'click';
   /** 'label' = Labeling mode (detector export allowed), 'find' = Finding mode (no detector export). */
@@ -97,8 +98,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['medias'] && this.medias.length > 0) {
-      const newType = this.medias[0].type;
+    if (changes['mediaType'] && this.mediaType) {
+      const newType = this.mediaType;
       if (newType !== this.currentMediaType) {
         this.currentMediaType = newType;
         this.viewMode = this.viewModeRightDict[newType] ?? 'grid';

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -18,6 +18,19 @@ export interface MediaItem {
   embedder?: string;
 }
 
+/**
+ * Lightweight snapshot returned by ``GET /api/medias/ids``.  Carries just
+ * the ID list plus the first item's ``type`` / ``embedder`` so the UI can
+ * size virtual scrollers and configure type-dependent controls without
+ * fetching full metadata for every item.  Full per-item metadata is
+ * resolved lazily through ``POST /api/medias/batch``.
+ */
+export interface MediaIdsResponse {
+  ids: number[];
+  type: string | null;
+  embedder: string | null;
+}
+
 export interface TextResponse {
   content: string;
   word_count?: number;

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -11,18 +11,15 @@ import { MediasApiService } from './medias-api.service';
 const BATCH_SIZE = 200;
 
 /**
- * Caches media metadata (id, type, filename, md5, etc.) and loads it lazily in
- * batches via `POST /api/medias/batch`.
- *
- * The full `/api/medias` response can be hundreds of megabytes for large
- * datasets.  This cache fetches only the metadata the UI actually needs —
- * typically the items currently visible in the virtual-scrolling viewport.
+ * Caches media metadata (id, type, filename, md5, etc.) and loads it lazily
+ * in batches via `POST /api/medias/batch`.  This is the only path the
+ * frontend uses to fetch per-item metadata — the legacy bulk `GET
+ * /api/medias` endpoint is reserved for tests / CLI tooling.
  *
  * Usage:
  *   1. Call `ensureLoaded(ids)` with the IDs the viewport needs.
- *   2. Subscribe to `medias$` or call `get(id)` for cached items.
- *   3. `toMediaItems(ids)` returns MediaItem[] for already-cached IDs (skips
- *      unknown ones so the template can render immediately).
+ *   2. Subscribe to `version$` to react to cache updates, or call `get(id)`
+ *      directly for cached items.
  */
 @Injectable({ providedIn: 'root' })
 export class MediaMetadataCacheService implements OnDestroy {
@@ -56,14 +53,6 @@ export class MediaMetadataCacheService implements OnDestroy {
   /** Current cache size. */
   get size(): number {
     return this.cache.size;
-  }
-
-  /** Bulk-insert items (e.g. from the initial full `/api/medias` load for small datasets). */
-  populate(items: MediaItem[]): void {
-    for (const item of items) {
-      this.cache.set(item.id, item);
-    }
-    this.versionSubject.next(this.versionSubject.value + 1);
   }
 
   /** Clear all cached metadata. */

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -2,13 +2,18 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { MediaStateService } from './media-state.service';
-import { MediaItem } from '../models/api.models';
+import { MediaIdsResponse, MediaItem } from '../models/api.models';
 
 describe('MediaStateService', () => {
   let service: MediaStateService;
   let httpMock: HttpTestingController;
 
-  const mockMedias: MediaItem[] = [
+  const mockIdsResp: MediaIdsResponse = {
+    ids: [1, 2],
+    type: 'audio',
+    embedder: 'laion-clap-large',
+  };
+  const mockBatch: MediaItem[] = [
     { id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} },
     { id: 2, type: 'image', filename: 'b.png', md5: 'def', custom_metadata: {} },
   ];
@@ -27,56 +32,68 @@ describe('MediaStateService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should start with empty medias', () => {
-    expect(service.medias).toEqual([]);
+  it('should start with empty state', () => {
+    expect(service.mediaIds).toEqual([]);
+    expect(service.mediaType).toBe('');
+    expect(service.embedder).toBe('');
     expect(service.selectedId).toBeNull();
     expect(service.selectedMedia).toBeNull();
   });
 
-  it('loadMedias should fetch and store medias', () => {
+  it('loadMedias should fetch ids and dataset metadata', () => {
     service.loadMedias();
-    const req = httpMock.expectOne('/api/medias');
-    req.flush(mockMedias);
-    expect(service.medias).toEqual(mockMedias);
+    const req = httpMock.expectOne('/api/medias/ids');
+    req.flush(mockIdsResp);
+    expect(service.mediaIds).toEqual([1, 2]);
+    expect(service.mediaType).toBe('audio');
+    expect(service.embedder).toBe('laion-clap-large');
   });
 
-  it('selectMedia should update selectedId', () => {
+  it('selectMedia should update selectedId and trigger metadata fetch', () => {
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockIdsResp);
 
     service.selectMedia(2);
     expect(service.selectedId).toBe(2);
+    // selectMedia triggers a batch fetch via the metadata cache.
+    const batchReq = httpMock.expectOne('/api/medias/batch');
+    batchReq.flush(mockBatch.filter((m) => m.id === 2));
     expect(service.selectedMedia?.filename).toBe('b.png');
   });
 
-  it('selectedMedia should return null for unknown id', () => {
+  it('selectedMedia should return null when metadata not yet cached', () => {
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockIdsResp);
 
     service.selectMedia(999);
+    // Cache flush — even if request errors, selectedMedia stays null until cached.
+    httpMock.expectOne('/api/medias/batch').flush([]);
     expect(service.selectedMedia).toBeNull();
   });
 
   it('clear should reset all state', () => {
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockIdsResp);
     service.selectMedia(1);
+    httpMock.expectOne('/api/medias/batch').flush(mockBatch.filter((m) => m.id === 1));
 
     service.clear();
-    expect(service.medias).toEqual([]);
+    expect(service.mediaIds).toEqual([]);
+    expect(service.mediaType).toBe('');
+    expect(service.embedder).toBe('');
     expect(service.selectedId).toBeNull();
   });
 
-  it('medias$ should emit on load', (done) => {
-    const emissions: MediaItem[][] = [];
-    service.medias$.subscribe((m) => emissions.push(m));
+  it('mediaIds$ should emit on load', (done) => {
+    const emissions: number[][] = [];
+    service.mediaIds$.subscribe((ids) => emissions.push(ids));
 
     service.loadMedias();
-    httpMock.expectOne('/api/medias').flush(mockMedias);
+    httpMock.expectOne('/api/medias/ids').flush(mockIdsResp);
 
     setTimeout(() => {
-      expect(emissions.length).toBeGreaterThanOrEqual(2); // initial [] + loaded
-      expect(emissions[emissions.length - 1]).toEqual(mockMedias);
+      expect(emissions.length).toBeGreaterThanOrEqual(2);
+      expect(emissions[emissions.length - 1]).toEqual([1, 2]);
       done();
     });
   });
@@ -86,6 +103,8 @@ describe('MediaStateService', () => {
     service.selectedId$.subscribe((id) => ids.push(id));
 
     service.selectMedia(5);
+    // selectMedia triggers a batch fetch; flush it so afterEach is satisfied.
+    httpMock.expectOne('/api/medias/batch').flush([]);
 
     setTimeout(() => {
       expect(ids).toContain(5);

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -6,18 +6,25 @@ import { MediasApiService } from './medias-api.service';
 import { MediaMetadataCacheService } from './media-metadata-cache.service';
 
 /**
- * Threshold: datasets with more items than this use lazy metadata loading
- * instead of fetching everything in a single /api/medias call.
+ * Active-dataset media state.
+ *
+ * Holds the ID list for the loaded dataset; full per-item metadata is
+ * fetched on demand through `MediaMetadataCacheService` (which posts to
+ * `/api/medias/batch`).  The legacy `GET /api/medias` endpoint that
+ * returned every media's metadata in one blob is no longer used by the
+ * frontend — it does not scale to 100k-item datasets.
  */
-const LAZY_THRESHOLD = 500;
-
 @Injectable({ providedIn: 'root' })
 export class MediaStateService implements OnDestroy {
-  private readonly mediasSubject = new BehaviorSubject<MediaItem[]>([]);
+  private readonly mediaIdsSubject = new BehaviorSubject<number[]>([]);
+  private readonly mediaTypeSubject = new BehaviorSubject<string>('');
+  private readonly embedderSubject = new BehaviorSubject<string>('');
   private readonly selectedIdSubject = new BehaviorSubject<number | null>(null);
   private readonly destroy$ = new Subject<void>();
 
-  readonly medias$ = this.mediasSubject.asObservable();
+  readonly mediaIds$ = this.mediaIdsSubject.asObservable();
+  readonly mediaType$ = this.mediaTypeSubject.asObservable();
+  readonly embedder$ = this.embedderSubject.asObservable();
   readonly selectedId$ = this.selectedIdSubject.asObservable();
 
   constructor(
@@ -30,8 +37,16 @@ export class MediaStateService implements OnDestroy {
     this.destroy$.complete();
   }
 
-  get medias(): MediaItem[] {
-    return this.mediasSubject.value;
+  get mediaIds(): number[] {
+    return this.mediaIdsSubject.value;
+  }
+
+  get mediaType(): string {
+    return this.mediaTypeSubject.value;
+  }
+
+  get embedder(): string {
+    return this.embedderSubject.value;
   }
 
   get selectedId(): number | null {
@@ -41,31 +56,29 @@ export class MediaStateService implements OnDestroy {
   get selectedMedia(): MediaItem | null {
     const id = this.selectedIdSubject.value;
     if (id === null) return null;
-    // Try cache first (works for both large and small datasets).
-    const cached = this.metadataCache.get(id);
-    if (cached) return cached;
-    return this.mediasSubject.value.find((m) => m.id === id) ?? null;
+    return this.metadataCache.get(id) ?? null;
   }
 
   selectMedia(id: number): void {
     this.selectedIdSubject.next(id);
-    // Ensure the selected item's metadata is loaded for the center panel.
     this.metadataCache.ensureLoaded([id]);
   }
 
   loadMedias(): void {
     this.mediasApi
-      .getMedias()
+      .getMediaIds()
       .pipe(takeUntil(this.destroy$))
-      .subscribe((medias) => {
-        // Populate the metadata cache so batch lookups work for any ID.
-        this.metadataCache.populate(medias);
-        this.mediasSubject.next(medias);
+      .subscribe((resp) => {
+        this.mediaTypeSubject.next(resp.type ?? '');
+        this.embedderSubject.next(resp.embedder ?? '');
+        this.mediaIdsSubject.next(resp.ids);
       });
   }
 
   clear(): void {
-    this.mediasSubject.next([]);
+    this.mediaIdsSubject.next([]);
+    this.mediaTypeSubject.next('');
+    this.embedderSubject.next('');
     this.selectedIdSubject.next(null);
     this.metadataCache.clear();
   }

--- a/frontend/src/app/services/medias-api.service.spec.ts
+++ b/frontend/src/app/services/medias-api.service.spec.ts
@@ -21,11 +21,20 @@ describe('MediasApiService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('getMedias should GET /api/medias', () => {
-    const mock = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} }];
-    service.getMedias().subscribe(data => expect(data).toEqual(mock));
-    const req = httpMock.expectOne('/api/medias');
+  it('getMediaIds should GET /api/medias/ids', () => {
+    const mock = { ids: [1, 2], type: 'audio', embedder: 'laion-clap-large' };
+    service.getMediaIds().subscribe(data => expect(data).toEqual(mock));
+    const req = httpMock.expectOne('/api/medias/ids');
     expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('getMediasBatch should POST ids to /api/medias/batch', () => {
+    const mock = [{ id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} }];
+    service.getMediasBatch([1]).subscribe(data => expect(data).toEqual(mock));
+    const req = httpMock.expectOne('/api/medias/batch');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ ids: [1] });
     req.flush(mock);
   });
 

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
+  MediaIdsResponse,
   MediaItem,
   TextResponse,
   VoteResponse,
@@ -11,8 +12,8 @@ import {
 export class MediasApiService {
   constructor(private http: HttpClient) {}
 
-  getMedias(): Observable<MediaItem[]> {
-    return this.http.get<MediaItem[]>('/api/medias');
+  getMediaIds(): Observable<MediaIdsResponse> {
+    return this.http.get<MediaIdsResponse>('/api/medias/ids');
   }
 
   getMediasBatch(ids: number[]): Observable<MediaItem[]> {

--- a/tests/test_medias.py
+++ b/tests/test_medias.py
@@ -330,6 +330,32 @@ class TestListMedias:
             assert "embedding" not in media
 
 
+class TestListMediaIds:
+    def test_returns_all_ids(self, client):
+        resp = client.get("/api/medias/ids")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, dict)
+        assert "ids" in data
+        assert len(data["ids"]) == app_module.NUM_MEDIAS
+        assert all(isinstance(i, int) for i in data["ids"])
+
+    def test_reports_dataset_type_and_embedder(self, client):
+        resp = client.get("/api/medias/ids")
+        data = resp.get_json()
+        # The test fixture loads audio medias so type should be "audio".
+        assert data["type"] == "audio"
+        assert "embedder" in data
+
+    def test_does_not_expose_metadata(self, client):
+        resp = client.get("/api/medias/ids")
+        data = resp.get_json()
+        # The endpoint must stay lightweight — no per-item metadata, bytes
+        # or embeddings.
+        assert "media_bytes" not in str(data)
+        assert "embedding" not in str(data)
+
+
 class TestBatchMedias:
     def test_returns_requested_ids(self, client):
         resp = client.post("/api/medias/batch", json={"ids": [1, 2]})

--- a/vtsearch/routes/medias.py
+++ b/vtsearch/routes/medias.py
@@ -273,6 +273,32 @@ def list_medias() -> Response:
     return jsonify(result)
 
 
+@medias_bp.route("/api/medias/ids")
+def list_media_ids() -> Response:
+    """Return a lightweight snapshot of media IDs for the active dataset.
+
+    Used by the frontend to drive virtual-scrolling and "any medias loaded?"
+    checks without pulling tens of MB of metadata for large datasets.  Full
+    per-item metadata is fetched lazily via ``POST /api/medias/batch``.
+
+    Returns:
+        JSON object ``{"ids": [int, ...], "type": str|null,
+        "embedder": str|null}``.  ``type`` and ``embedder`` are taken from
+        the first media (or ``null`` when the dataset is empty) so the UI
+        can configure view-mode / text-sort capability without an extra
+        round trip.
+    """
+    snap = snapshot_medias()
+    ids = list(snap.keys())
+    first_type: str | None = None
+    first_embedder: str | None = None
+    if ids:
+        first = snap[ids[0]]
+        first_type = first.get("type", "audio")
+        first_embedder = first.get("embedder") or None
+    return jsonify({"ids": ids, "type": first_type, "embedder": first_embedder})
+
+
 @medias_bp.route("/api/medias/batch", methods=["POST"])
 def batch_medias() -> tuple[Response, int] | Response:
     """Return metadata for a specific set of media IDs.


### PR DESCRIPTION
Superseded — `dev` already contains an equivalent fix that landed while this PR was in flight:

- `GET /api/medias/ids` returns lightweight per-item stubs (`[{id, type, embedder?}, ...]`)
- `GET /api/medias` removed
- Frontend uses `POST /api/medias/batch` exclusively for per-item metadata
- `LabelListComponent` and `MediaListComponent` hydrate names/thumbnails through `MediaMetadataCacheService`

Closing in favour of dev's implementation. The API shape differs slightly from this branch (per-item stubs vs `{ids, type, embedder}` envelope) but accomplishes the same goal.