### PR TITLE
Cache (N, D) embedding matrix on DatasetContext

### DIFF
--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from collections.abc import Iterator
 from typing import Any
 
-import numpy as np
 
 from vtsearch.datasets.loader import apply_custom_metadata_md5, load_dataset_from_pickle
 from vtsearch.utils.hits import build_media_hit
@@ -104,9 +103,10 @@ def _score_medias_with_detectors(
 
     import torch  # noqa: PLC0415
 
-    all_ids = sorted(medias.keys())
-    all_embs = np.array([medias[cid]["embedding"] for cid in all_ids])
-    X_all = torch.tensor(all_embs, dtype=torch.float32)
+    from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
+
+    all_ids, all_embs = get_embedding_matrix_for_snap(medias)
+    X_all = torch.from_numpy(all_embs)
 
     results: dict[str, dict[str, Any]] = {}
     for det_name, info in detector_mlps.items():

--- a/vtsearch/models/detector_training.py
+++ b/vtsearch/models/detector_training.py
@@ -61,7 +61,7 @@ def train_and_threshold(
         get_safe_thresholds,
     )
 
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 
@@ -83,9 +83,10 @@ def train_and_threshold(
     model = train_model(X, y, input_dim, get_inclusion())
 
     if safe:
-        all_ids = sorted(snap.keys())
-        all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
-        X_all = torch.tensor(all_embs, dtype=torch.float32)
+        from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap
+
+        _all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+        X_all = torch.from_numpy(all_embs)
         with torch.no_grad():
             all_scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
         threshold = calculate_safe_threshold(threshold, all_scores, len(y_list))

--- a/vtsearch/models/embedding_matrix.py
+++ b/vtsearch/models/embedding_matrix.py
@@ -1,0 +1,104 @@
+"""Lazy, cached contiguous embedding matrix on :class:`DatasetContext`.
+
+Building ``np.array([medias[cid]["embedding"] for cid in sorted(...)])``
+per request copies 10k+ arrays twice (once into a list, once into the
+``np.array(...)`` allocation) and another copy when wrapping with
+``torch.tensor(...)``.  The matrix changes only when the set of loaded
+media IDs changes, so we cache one contiguous ``(N, D)`` float32 array
+on the active dataset context and hand callers a ``torch.from_numpy``
+view (zero-copy) when they need a tensor.
+
+Cache invalidation is keyed on ``sorted(ctx.medias.keys())``: when that
+list differs from the cached one, the matrix is rebuilt.  Callers that
+mutate ``ctx.medias`` don't need to do anything — the next access will
+detect the new key set and rebuild.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from vtsearch.utils.state_core import _state_lock
+
+if TYPE_CHECKING:
+    from vtsearch.utils.state_core import DatasetContext
+
+
+def get_embedding_matrix(ctx: "DatasetContext") -> tuple[list[int], np.ndarray]:
+    """Return ``(sorted_ids, (N, D) float32 matrix)`` for *ctx*'s medias.
+
+    The matrix is cached on the context and rebuilt only when the set of
+    media IDs changes.  Convert to a tensor with ``torch.from_numpy(matrix)``
+    for a zero-copy view.
+
+    Returns ``([], np.empty((0, 0), dtype=np.float32))`` when the dataset is
+    empty.
+    """
+    with _state_lock:
+        sorted_ids = sorted(ctx.medias.keys())
+        cached_ids = ctx._emb_matrix_ids
+        cached_matrix = ctx._emb_matrix
+        if cached_matrix is not None and cached_ids == sorted_ids:
+            return list(sorted_ids), cached_matrix
+
+        if not sorted_ids:
+            ctx._emb_matrix_ids = []
+            ctx._emb_matrix = np.empty((0, 0), dtype=np.float32)
+            return [], ctx._emb_matrix
+
+        medias = ctx.medias
+        first_emb = np.asarray(medias[sorted_ids[0]]["embedding"], dtype=np.float32)
+        dim = int(first_emb.shape[-1])
+        matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
+        for i, cid in enumerate(sorted_ids):
+            matrix[i] = medias[cid]["embedding"]
+
+        ctx._emb_matrix_ids = sorted_ids
+        ctx._emb_matrix = matrix
+        return list(sorted_ids), matrix
+
+
+def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
+    """Drop the cached matrix on *ctx*; next access rebuilds it."""
+    with _state_lock:
+        ctx._emb_matrix_ids = None
+        ctx._emb_matrix = None
+
+
+def get_embedding_matrix_for_snap(
+    snap: dict,
+) -> tuple[list[int], np.ndarray]:
+    """Return ``(sorted_ids, matrix)`` for *snap*.
+
+    When *snap*'s key set matches the active :class:`DatasetContext`'s
+    medias, the cached matrix is reused.  Otherwise (a different snapshot
+    or a temp dict from cross-dataset Find) the matrix is built fresh
+    without populating the cache.
+    """
+    from vtsearch.utils.state_core import get_active_context
+
+    sorted_ids = sorted(snap.keys())
+    if not sorted_ids:
+        return [], np.empty((0, 0), dtype=np.float32)
+
+    ctx = get_active_context()
+    with _state_lock:
+        cached_ids = ctx._emb_matrix_ids
+        cached_matrix = ctx._emb_matrix
+    if cached_matrix is not None and cached_ids == sorted_ids:
+        return sorted_ids, cached_matrix
+
+    # Populate the cache when *snap* matches the active dataset's medias
+    # (the common case: `snap = snapshot_medias()`).
+    if sorted_ids == sorted(ctx.medias.keys()):
+        return get_embedding_matrix(ctx)
+
+    # Temp dict / cross-dataset case: build fresh, don't cache.
+    first_emb = np.asarray(snap[sorted_ids[0]]["embedding"], dtype=np.float32)
+    dim = int(first_emb.shape[-1])
+    matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
+    for i, cid in enumerate(sorted_ids):
+        matrix[i] = snap[cid]["embedding"]
+    return sorted_ids, matrix

--- a/vtsearch/models/labelset_training.py
+++ b/vtsearch/models/labelset_training.py
@@ -245,7 +245,7 @@ def labelset_train_and_score(
     if len(X_list) < 2 or num_good == 0 or num_bad == 0:
         return [], 0.5, None
 
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
     hidden_dim = _auto_hidden_dim(len(X_list))
@@ -270,11 +270,12 @@ def labelset_train_and_score(
 
     model = train_model(X, y, input_dim, inclusion_value, hidden_dim=hidden_dim)
 
-    all_ids = sorted(clips_dict.keys())
+    from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap
+
+    all_ids, all_embs = get_embedding_matrix_for_snap(clips_dict)
     if not all_ids:
         return [], threshold, model
-    all_embs = np.array([clips_dict[cid]["embedding"] for cid in all_ids])
-    X_all = torch.tensor(all_embs, dtype=torch.float32)
+    X_all = torch.from_numpy(all_embs)
     with torch.no_grad():
         scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 

--- a/vtsearch/models/region_similarity.py
+++ b/vtsearch/models/region_similarity.py
@@ -127,9 +127,11 @@ def cosine_sort_with_boxes(
 
     # Fast path: pure single-vector cosine — same arithmetic as the
     # original _cosine_sort, retained verbatim so SigLIP / CLIP /
-    # SigLIP2 datasets see zero overhead from this refactor.
-    all_ids = list(snap.keys())
-    all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
+    # SigLIP2 datasets see zero overhead from this refactor.  The matrix
+    # is reused from the active DatasetContext cache when available.
+    from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap
+
+    all_ids, all_embs = get_embedding_matrix_for_snap(snap)
     q_norm = np.linalg.norm(query_vec)
     emb_norms = np.linalg.norm(all_embs, axis=1)
     norm_products = emb_norms * q_norm

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -565,7 +565,7 @@ def train_and_score(
     if len(X_list) < 2 or num_good == 0 or num_bad == 0:
         return [], 0.5, None
 
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
 
     input_dim = X.shape[1]
@@ -609,24 +609,33 @@ def train_and_score(
     # dataset is patch-region-aware, plain single-vector scoring when not.
     # We build one flat tensor of (media, region) rows so the MLP runs
     # in a single forward pass; the per-media max is computed after.
-    all_ids = sorted(clips_dict.keys())
-    flat_vecs: list[np.ndarray] = []
-    media_index_per_row: list[int] = []
-    region_index_per_row: list[int] = []
-    for mi, cid in enumerate(all_ids):
-        media = clips_dict[cid]
-        regions = media.get("patch_regions")
-        if regions:
-            for ri, r in enumerate(regions):
-                flat_vecs.append(np.asarray(r.vec, dtype=np.float32))
+    has_regions = any(clips_dict[cid].get("patch_regions") for cid in clips_dict)
+    if has_regions:
+        all_ids = sorted(clips_dict.keys())
+        flat_vecs: list[np.ndarray] = []
+        media_index_per_row: list[int] = []
+        region_index_per_row: list[int] = []
+        for mi, cid in enumerate(all_ids):
+            media = clips_dict[cid]
+            regions = media.get("patch_regions")
+            if regions:
+                for ri, r in enumerate(regions):
+                    flat_vecs.append(np.asarray(r.vec, dtype=np.float32))
+                    media_index_per_row.append(mi)
+                    region_index_per_row.append(ri)
+            else:
+                flat_vecs.append(np.asarray(media["embedding"], dtype=np.float32))
                 media_index_per_row.append(mi)
-                region_index_per_row.append(ri)
-        else:
-            flat_vecs.append(np.asarray(media["embedding"], dtype=np.float32))
-            media_index_per_row.append(mi)
-            region_index_per_row.append(0)
+                region_index_per_row.append(0)
+        X_all = torch.from_numpy(np.stack(flat_vecs).astype(np.float32, copy=False))
+    else:
+        from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
 
-    X_all = torch.tensor(np.array(flat_vecs), dtype=torch.float32)
+        all_ids, all_embs = get_embedding_matrix_for_snap(clips_dict)
+        X_all = torch.from_numpy(all_embs)
+        n = len(all_ids)
+        media_index_per_row = list(range(n))
+        region_index_per_row = [0] * n
     with torch.no_grad():
         flat_scores = torch.sigmoid(model(X_all)).squeeze(1).cpu().numpy()
 
@@ -765,7 +774,7 @@ def train_detector_from_origins(
     if len(X_list) < 2 or num_good == 0 or num_bad == 0:
         return None, 0.5
 
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 

--- a/vtsearch/routes/detector_find.py
+++ b/vtsearch/routes/detector_find.py
@@ -273,9 +273,10 @@ def multi_find():
             first_media = next(iter(temp_medias.values()), {})
             detected_media_type = first_media.get("type", "")
 
-        all_ids = sorted(temp_medias.keys())
-        all_embs = np.array([temp_medias[cid]["embedding"] for cid in all_ids])
-        X_all = torch.tensor(all_embs, dtype=torch.float32)
+        from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap
+
+        all_ids, all_embs = get_embedding_matrix_for_snap(temp_medias)
+        X_all = torch.from_numpy(all_embs)
 
         total_scoring_units += len(all_ids) * len(detector_configs)
 

--- a/vtsearch/routes/detector_scoring.py
+++ b/vtsearch/routes/detector_scoring.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
-import numpy as np
 from flask import Blueprint, jsonify, request
 
 from vtsearch.routes.helpers import get_json_safe
@@ -281,9 +280,10 @@ def find_label():
         total_steps=_FIND_LABEL_STEPS,
     )
 
-    all_ids = sorted(snap.keys())
-    all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
-    X_all = torch.tensor(all_embs, dtype=torch.float32)
+    from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap
+
+    all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+    X_all = torch.from_numpy(all_embs)
 
     batch_size = max(1, min(500, n_total // 10))
     scores: list[float] = []
@@ -416,9 +416,10 @@ def auto_detect():
     if not detectors_to_run:
         return jsonify({"error": f"No autorun detectors found for media type: {media_type}"}), 400
 
-    all_ids = sorted(snap.keys())
-    all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
-    X_all = torch.tensor(all_embs, dtype=torch.float32)
+    from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap
+
+    all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+    X_all = torch.from_numpy(all_embs)
 
     def _run_single(name: str, det_data: dict, reg_entry: dict | None):
         try:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -5,7 +5,6 @@ import logging
 import threading
 from pathlib import Path
 
-import numpy as np
 from flask import Blueprint, jsonify, request
 
 from vtsearch.routes.helpers import (
@@ -801,9 +800,10 @@ def label_file_sort():
         model, threshold = train_and_threshold(X_list, y_list, snap=snap)
 
         # Score every media in the dataset
-        all_ids = sorted(snap.keys())
-        all_embs = np.array([snap[cid]["embedding"] for cid in all_ids])
-        X_all = torch.tensor(all_embs, dtype=torch.float32)
+        from vtsearch.models.embedding_matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
+
+        all_ids, all_embs = get_embedding_matrix_for_snap(snap)
+        X_all = torch.from_numpy(all_embs)
         with torch.no_grad():
             scores = torch.sigmoid(model(X_all)).squeeze(1).tolist()
 

--- a/vtsearch/utils/state.py
+++ b/vtsearch/utils/state.py
@@ -161,6 +161,12 @@ def clear_medias() -> None:
 
     with _state_lock:
         medias.clear()
+        # Drop the cached embedding matrix so its RAM is released along with
+        # the medias dict.  Lazy rebuild on next access would also handle it,
+        # but releasing now is the friendly thing to do.
+        ctx = _core.get_active_context()
+        ctx._emb_matrix_ids = None
+        ctx._emb_matrix = None
         _core._set_diversity_tree(None)
         _core._set_dataset_display_name(None)
         clear_progress_cache()

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -89,6 +89,13 @@ class DatasetContext:
         "medias",
         "diversity_tree",
         "dataset_display_name",
+        # Cached contiguous (N, D) float32 embedding matrix and the sorted
+        # media-id list it corresponds to.  Built lazily on first access by
+        # ``vtsearch.models.embedding_matrix.get_embedding_matrix`` and reused
+        # across cosine sort, MLP scoring, and diversity-tree construction so
+        # we don't rebuild a 10k-row matrix per call.
+        "_emb_matrix_ids",
+        "_emb_matrix",
     )
 
     def __init__(self, dataset_id: str = "") -> None:
@@ -96,6 +103,8 @@ class DatasetContext:
         self.medias: dict[int, dict[str, Any]] = {}
         self.diversity_tree: Any = None  # DiversityTree | None
         self.dataset_display_name: str | None = None
+        self._emb_matrix_ids: list[int] | None = None
+        self._emb_matrix: Any = None  # np.ndarray | None
 
 
 class DetectorContext:


### PR DESCRIPTION
## Summary

- Every sort / score / training pass was rebuilding the full embedding matrix from scratch: a Python list comprehension over `medias[cid]["embedding"]`, then `np.array(list)` (copy 1), then `torch.tensor(...)` (copy 2). For a 10k-item dataset this is a lot of pointless work — the matrix only changes when the loaded media set changes.
- Cache a contiguous `(N, D)` float32 ndarray on `DatasetContext` keyed by the sorted media-id list. Callers go through `get_embedding_matrix_for_snap(snap)`, which returns the cached matrix when `snap` matches the active dataset and builds fresh otherwise. Tensor conversion uses `torch.from_numpy()` (zero-copy view).
- Updated call sites: `routes/sorting.py` (label-file sort), `routes/detector_scoring.py` (find-label + autorun), `routes/detector_find.py` (cross-dataset Find), `models/training.py` (single-vector scoring path + voted-X stacking), `models/labelset_training.py`, `models/detector_training.py` (safe-thresholds branch), `models/region_similarity.py` (fast path), `cli.py`.
- `clear_medias()` drops the cached matrix so its RAM is released alongside the medias dict.

## Test plan

- [x] `./run-tests.sh sorting models` (216 passed)
- [x] `./run-tests.sh` full suite (3204 passed, 1 skipped, 2 xpassed)
- [x] `ruff check vtsearch/`


---
_Generated by [Claude Code](https://claude.ai/code/session_012SMuvYinkpZz4naaLVY87C)_