### PR TITLE
Add SVM trainer prototype and label-curve sweep

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,8 @@ _TEST_GROUPS = {
         "test_eval",
         "test_eval_visualize",
         "test_eval_voting_iterations",
+        "test_label_curve",
+        "test_svm_training",
         "test_resolver",
         "test_new_embedders",
         "test_labelset_elements_api",

--- a/tests/test_label_curve.py
+++ b/tests/test_label_curve.py
@@ -1,0 +1,360 @@
+"""Tests for the label-curve sweep (vtsearch.eval.label_curve)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtsearch.eval.label_curve import (
+    TRAINERS,
+    _auroc,
+    _average_precision,
+    _best_f1,
+    _brier,
+    _build_split_pool,
+    _cross_calibrated_threshold,
+    _f1_at,
+    _sample_labels,
+    evaluate_one,
+    run_label_curve_eval,
+    summarise,
+)
+
+
+def _synth_dataset(
+    n_pos: int = 30,
+    n_neg: int = 30,
+    dim: int = 8,
+    seed: int = 0,
+    category: str = "target",
+) -> dict[int, dict]:
+    """Build a tiny synthetic medias dict with two clearly-separable categories.
+
+    Mirrors the shape of a real VTSearch medias dict: each entry has an
+    ``embedding`` (np.ndarray) and a ``category`` (str), keyed by an
+    integer media ID.
+    """
+    rng = np.random.default_rng(seed)
+    clips: dict[int, dict] = {}
+    next_id = 1
+    pos = rng.standard_normal((n_pos, dim)).astype(np.float32) * 0.2
+    pos[:, 0] += 1.0
+    neg = rng.standard_normal((n_neg, dim)).astype(np.float32) * 0.2
+    neg[:, 0] -= 1.0
+    for vec in pos:
+        clips[next_id] = {"embedding": vec, "category": category}
+        next_id += 1
+    for vec in neg:
+        clips[next_id] = {"embedding": vec, "category": "other"}
+        next_id += 1
+    return clips
+
+
+class TestMetricHelpers:
+    def test_auroc_perfect_separation(self):
+        scores = np.array([0.9, 0.8, 0.1, 0.2])
+        labels = np.array([1, 1, 0, 0])
+        assert _auroc(scores, labels) == pytest.approx(1.0)
+
+    def test_auroc_reversed_predictions(self):
+        scores = np.array([0.1, 0.2, 0.9, 0.8])
+        labels = np.array([1, 1, 0, 0])
+        assert _auroc(scores, labels) == pytest.approx(0.0)
+
+    def test_auroc_random_is_half(self):
+        # Constant scores → AUROC should average to 0.5 over ties.
+        scores = np.array([0.5, 0.5, 0.5, 0.5])
+        labels = np.array([1, 0, 1, 0])
+        assert _auroc(scores, labels) == pytest.approx(0.5)
+
+    def test_average_precision_perfect_ranking(self):
+        scores = np.array([0.9, 0.8, 0.1])
+        labels = np.array([1, 1, 0])
+        assert _average_precision(scores, labels) == pytest.approx(1.0)
+
+    def test_brier_zero_for_perfect_calibration(self):
+        scores = np.array([1.0, 0.0, 1.0])
+        labels = np.array([1, 0, 1])
+        assert _brier(scores, labels) == pytest.approx(0.0)
+
+    def test_brier_max_for_inverted_predictions(self):
+        scores = np.array([0.0, 1.0])
+        labels = np.array([1, 0])
+        assert _brier(scores, labels) == pytest.approx(1.0)
+
+    def test_f1_at_threshold(self):
+        scores = np.array([0.9, 0.6, 0.4, 0.1])
+        labels = np.array([1, 1, 0, 0])
+        assert _f1_at(scores, labels, 0.5) == pytest.approx(1.0)
+        # Threshold too high → all predicted negative → recall=0, F1=0
+        assert _f1_at(scores, labels, 0.95) == pytest.approx(0.0)
+
+    def test_best_f1_finds_optimum(self):
+        scores = np.array([0.9, 0.6, 0.4, 0.1])
+        labels = np.array([1, 1, 0, 0])
+        assert _best_f1(scores, labels) == pytest.approx(1.0)
+
+
+class TestSplitPool:
+    def test_partitions_categories(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        assert pool.sim_pos.shape[0] == 10
+        assert pool.sim_neg.shape[0] == 10
+        # Test set holds the remaining 10 positives + 10 negatives.
+        assert pool.test_X.shape[0] == 20
+        assert int(pool.test_y.sum()) == 10
+
+    def test_returns_none_when_too_small(self):
+        clips = _synth_dataset(n_pos=1, n_neg=10)
+        assert _build_split_pool(clips, "target", seed=0, sim_fraction=0.5) is None
+
+    def test_returns_none_when_unknown_category(self):
+        clips = _synth_dataset(n_pos=10, n_neg=10)
+        assert _build_split_pool(clips, "missing", seed=0, sim_fraction=0.5) is None
+
+    def test_seed_is_reproducible(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool_a = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        pool_b = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool_a is not None and pool_b is not None
+        np.testing.assert_array_equal(pool_a.sim_pos, pool_b.sim_pos)
+        np.testing.assert_array_equal(pool_a.test_y, pool_b.test_y)
+
+
+class TestSampleLabels:
+    def test_balanced_split(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        X, y = _sample_labels(pool, n_labels=10, seed=0)  # type: ignore[misc]
+        assert X.shape == (10, 8)
+        assert int(y.sum()) == 5  # n_labels // 2
+
+    def test_caps_to_pool_size_when_imbalanced(self):
+        # Pool with only 3 positives in sim — asking for 50 labels should
+        # cap at 3 positives.
+        clips = _synth_dataset(n_pos=6, n_neg=200)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        out = _sample_labels(pool, n_labels=50, seed=0)
+        assert out is not None
+        X, y = out
+        assert int(y.sum()) <= pool.sim_pos.shape[0]
+        assert int((y == 0).sum()) <= pool.sim_neg.shape[0]
+
+    def test_returns_none_when_pool_is_single_class(self):
+        # An empty positive sim pool can't satisfy any balanced request.
+        clips = _synth_dataset(n_pos=2, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        # Hand-strip the positive pool to force the corner case.
+        bare = pool.__class__(
+            sim_pos=np.empty((0, pool.sim_pos.shape[1]), dtype=np.float32),
+            sim_neg=pool.sim_neg,
+            test_X=pool.test_X,
+            test_y=pool.test_y,
+        )
+        assert _sample_labels(bare, n_labels=4, seed=0) is None
+
+
+class TestCrossCalibratedThreshold:
+    def test_returns_finite_threshold_with_balanced_labels(self):
+        # 10 labels, balanced — every fold should produce a valid threshold.
+        from vtsearch.eval.label_curve import TRAINERS as T
+
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((20, 4)).astype(np.float32)
+        X[:10, 0] += 1.5  # positives in upper half
+        X[10:, 0] -= 1.5
+        y = np.array([1] * 10 + [0] * 10, dtype=np.int32)
+        t = _cross_calibrated_threshold(X, y, T["svm_linear"], seed=0)
+        assert np.isfinite(t)
+
+    def test_too_few_labels_returns_default(self):
+        from vtsearch.eval.label_curve import TRAINERS as T
+
+        X = np.zeros((3, 4), dtype=np.float32)
+        y = np.array([1, 0, 1], dtype=np.int32)
+        # n=3 hits the n < 4 guard → returns 0.5 fallback.
+        assert _cross_calibrated_threshold(X, y, T["svm_linear"], seed=0) == 0.5
+
+
+class TestEvaluateOne:
+    _EXPECTED_KEYS = (
+        "trainer",
+        "n_labels",
+        "n_pos",
+        "n_neg",
+        "seed",
+        "auroc",
+        "average_precision",
+        "best_f1",
+        "xcal_threshold",
+        "f1_at_xcal",
+        "train_seconds",
+        "brier",
+        "f1_at_0.5",
+        "predict_seconds",
+    )
+
+    def test_returns_row_schema_for_svm(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        row = evaluate_one(pool, trainer_name="svm_linear", n_labels=10, seed=0)
+        assert row is not None
+        for key in self._EXPECTED_KEYS:
+            assert key in row, f"missing key {key!r}"
+        assert row["trainer"] == "svm_linear"
+        # Trivially-separable synthetic data should score high.
+        assert row["auroc"] > 0.85
+        # Cross-calibrated threshold is a finite float.
+        assert np.isfinite(row["xcal_threshold"])
+        # f1_at_xcal should be high too on this trivially-separable data.
+        assert row["f1_at_xcal"] > 0.7
+
+    def test_returns_row_schema_for_mlp(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        row = evaluate_one(pool, trainer_name="mlp", n_labels=10, seed=0)
+        assert row is not None
+        assert row["trainer"] == "mlp"
+        assert 0.0 <= row["auroc"] <= 1.0
+        for key in self._EXPECTED_KEYS:
+            assert key in row, f"missing key {key!r}"
+
+    def test_unknown_trainer_raises(self):
+        clips = _synth_dataset()
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        with pytest.raises(KeyError):
+            evaluate_one(pool, trainer_name="random_forest", n_labels=10, seed=0)
+
+
+class TestRunLabelCurveEval:
+    def test_full_sweep_schema(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20, seed=1)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("svm_linear", "mlp"),
+            label_counts=(6, 10),
+            seeds=(0, 1),
+            progress=False,
+        )
+        # 1 dataset * 1 category (sim_fraction filters out 'other' as target? no —
+        # 'other' has 20 entries too so it's also a valid target).
+        # Categories: {target, other} → 2 categories.
+        # trainers x label_counts x seeds = 2 * 2 * 2 = 8 per category → 16 rows total.
+        assert len(df) == 2 * 2 * 2 * 2
+        assert set(df.columns) >= {
+            "dataset", "category", "trainer", "n_labels", "seed",
+            "auroc", "average_precision", "best_f1",
+            "xcal_threshold", "f1_at_xcal", "train_seconds",
+            "brier", "f1_at_0.5",
+        }
+        assert set(df["trainer"]) == {"svm_linear", "mlp"}
+        assert set(df["dataset"]) == {"synth"}
+
+    def test_category_filter(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("svm_linear",),
+            label_counts=(10,),
+            seeds=(0,),
+            categories={"synth": ["target"]},
+            progress=False,
+        )
+        assert set(df["category"]) == {"target"}
+
+    def test_unknown_trainer_raises(self):
+        clips = _synth_dataset(n_pos=10, n_neg=10)
+        with pytest.raises(KeyError):
+            run_label_curve_eval(
+                dataset_clips={"synth": clips},
+                trainers=("does_not_exist",),
+            )
+
+    def test_empty_when_dataset_too_small(self):
+        clips = _synth_dataset(n_pos=1, n_neg=1)
+        df = run_label_curve_eval(
+            dataset_clips={"tiny": clips},
+            trainers=("svm_linear",),
+            label_counts=(10,),
+            seeds=(0,),
+            progress=False,
+        )
+        assert df.empty
+        assert set(df.columns) >= {"dataset", "trainer", "auroc"}
+
+
+class TestSummarise:
+    def test_summary_collapses_seeds(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("svm_linear",),
+            label_counts=(10,),
+            seeds=(0, 1, 2),
+            categories={"synth": ["target"]},
+            progress=False,
+        )
+        summary = summarise(df)
+        # 1 dataset x 1 category x 1 trainer x 1 n_labels = 1 row
+        assert len(summary) == 1
+        for col in ("auroc_mean", "auroc_std", "f1_at_xcal_mean", "xcal_threshold_mean"):
+            assert col in summary.columns, f"missing summary column {col!r}"
+
+    def test_default_summary_drops_diagnostics(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("svm_linear",),
+            label_counts=(10,),
+            seeds=(0,),
+            categories={"synth": ["target"]},
+            progress=False,
+        )
+        summary = summarise(df)
+        # Brier and F1@0.5 are diagnostics — excluded from the default
+        # summary because neither is meaningful for an uncalibrated
+        # ranking model with a learnable threshold.
+        for col in summary.columns:
+            assert "brier" not in col, f"unexpected diagnostic column {col!r}"
+            assert "f1_at_0.5" not in col, f"unexpected diagnostic column {col!r}"
+
+    def test_include_diagnostics_brings_them_back(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("svm_linear",),
+            label_counts=(10,),
+            seeds=(0,),
+            categories={"synth": ["target"]},
+            progress=False,
+        )
+        summary = summarise(df, include_diagnostics=True)
+        assert "brier_mean" in summary.columns
+        assert "f1_at_0.5_mean" in summary.columns
+
+    def test_summary_handles_empty(self):
+        clips = _synth_dataset(n_pos=1, n_neg=1)
+        df = run_label_curve_eval(
+            dataset_clips={"tiny": clips},
+            trainers=("svm_linear",),
+            label_counts=(10,),
+            seeds=(0,),
+            progress=False,
+        )
+        # summarise on empty df just returns it unchanged
+        assert summarise(df).empty
+
+
+class TestRegistryIntrospection:
+    def test_mlp_and_svm_trainers_registered(self):
+        assert "mlp" in TRAINERS
+        assert "svm_linear" in TRAINERS
+        assert "svm_rbf" in TRAINERS

--- a/tests/test_svm_training.py
+++ b/tests/test_svm_training.py
@@ -1,0 +1,255 @@
+"""Tests for the SVM trainer prototype (vtsearch.models.svm_training)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtsearch.models.svm_training import (
+    SVMClassifier,
+    _effective_calibration,
+    train_svm,
+)
+
+
+def _separable(n_per_class: int = 30, dim: int = 8, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    """Build two linearly separable Gaussian blobs.
+
+    Positives sit near ``+1`` along the first axis, negatives near ``-1``.
+    Returns ``(X, y)`` already shuffled so callers can pass straight to
+    ``train_svm``.
+    """
+    rng = np.random.default_rng(seed)
+    pos = rng.standard_normal((n_per_class, dim)).astype(np.float32) * 0.2
+    pos[:, 0] += 1.0
+    neg = rng.standard_normal((n_per_class, dim)).astype(np.float32) * 0.2
+    neg[:, 0] -= 1.0
+    X = np.concatenate([pos, neg])
+    y = np.concatenate([np.ones(n_per_class, dtype=np.int32), np.zeros(n_per_class, dtype=np.int32)])
+    order = rng.permutation(X.shape[0])
+    return X[order], y[order]
+
+
+class TestEffectiveCalibration:
+    def test_auto_picks_decision_sigmoid_when_one_class_lt_2(self):
+        assert _effective_calibration("auto", n_pos=1, n_neg=10) == "decision_sigmoid"
+        assert _effective_calibration("auto", n_pos=10, n_neg=1) == "decision_sigmoid"
+
+    def test_auto_picks_sigmoid_for_small_balanced(self):
+        # 2 <= min < 10 → Platt
+        assert _effective_calibration("auto", n_pos=3, n_neg=3) == "sigmoid"
+        assert _effective_calibration("auto", n_pos=9, n_neg=9) == "sigmoid"
+
+    def test_auto_picks_isotonic_for_larger_balanced(self):
+        assert _effective_calibration("auto", n_pos=20, n_neg=20) == "isotonic"
+
+    def test_explicit_mode_downgrades_when_unfittable(self):
+        # User asked for isotonic with only 1 positive — must downgrade.
+        assert _effective_calibration("isotonic", n_pos=1, n_neg=10) == "decision_sigmoid"
+
+    def test_explicit_mode_honoured_when_fittable(self):
+        assert _effective_calibration("sigmoid", n_pos=3, n_neg=3) == "sigmoid"
+        assert _effective_calibration("isotonic", n_pos=3, n_neg=3) == "isotonic"
+
+
+class TestTrainSVMShapeContracts:
+    def test_returns_svm_classifier(self):
+        X, y = _separable(n_per_class=20)
+        clf = train_svm(X, y)
+        assert isinstance(clf, SVMClassifier)
+
+    def test_predict_proba_returns_1d_floats_in_range(self):
+        X, y = _separable(n_per_class=20)
+        clf = train_svm(X, y)
+        probs = clf.predict_proba(X)
+        assert probs.shape == (X.shape[0],)
+        assert probs.dtype.kind == "f"
+        assert float(probs.min()) >= 0.0
+        assert float(probs.max()) <= 1.0
+
+    def test_rejects_single_class(self):
+        X = np.random.default_rng(0).standard_normal((10, 4)).astype(np.float32)
+        with pytest.raises(ValueError, match="both classes"):
+            train_svm(X, np.ones(10, dtype=np.int32))
+
+    def test_rejects_size_one(self):
+        with pytest.raises(ValueError):
+            train_svm(np.zeros((1, 4), dtype=np.float32), np.array([1], dtype=np.int32))
+
+    def test_rejects_mismatched_xy(self):
+        X = np.zeros((5, 4), dtype=np.float32)
+        with pytest.raises(ValueError, match="rows"):
+            train_svm(X, np.array([0, 1, 0], dtype=np.int32))
+
+    def test_rejects_non_2d(self):
+        with pytest.raises(ValueError, match="2-D"):
+            train_svm(np.zeros(10, dtype=np.float32), np.zeros(10, dtype=np.int32))
+
+
+class TestSeparableData:
+    def test_linear_kernel_separates_blobs(self):
+        X, y = _separable(n_per_class=40, seed=1)
+        clf = train_svm(X, y, kernel="linear")
+        probs = clf.predict_proba(X)
+        # Trivially separable → near-perfect AUROC
+        pos = probs[y == 1]
+        neg = probs[y == 0]
+        assert pos.mean() > neg.mean() + 0.5
+
+    def test_rbf_kernel_separates_blobs(self):
+        X, y = _separable(n_per_class=40, seed=2)
+        clf = train_svm(X, y, kernel="rbf")
+        probs = clf.predict_proba(X)
+        pos = probs[y == 1]
+        neg = probs[y == 0]
+        assert pos.mean() > neg.mean() + 0.5
+
+    def test_unknown_kernel_raises(self):
+        X, y = _separable()
+        with pytest.raises(ValueError, match="kernel"):
+            train_svm(X, y, kernel="polynomial")  # type: ignore[arg-type]
+
+
+class TestDeterminism:
+    def test_same_seed_same_predictions(self):
+        X, y = _separable(n_per_class=30, seed=7)
+        a = train_svm(X, y, seed=42).predict_proba(X)
+        b = train_svm(X, y, seed=42).predict_proba(X)
+        np.testing.assert_allclose(a, b, atol=1e-6)
+
+
+class TestDefaultCalibration:
+    """The default is ``decision_sigmoid`` — no CV calibration."""
+
+    def test_default_is_decision_sigmoid(self):
+        X, y = _separable(n_per_class=20)
+        clf = train_svm(X, y)
+        assert clf.calibration == "decision_sigmoid"
+        assert clf.calibrator is None
+
+    def test_default_emits_monotone_scores_in_unit_interval(self):
+        # The wrapper is still sigmoid-over-decision_function, so scores
+        # stay in [0, 1] and downstream threshold-finders see a familiar
+        # range.  But ordering is what actually matters.
+        X, y = _separable(n_per_class=20)
+        clf = train_svm(X, y)
+        probs = clf.predict_proba(X)
+        assert ((probs >= 0.0) & (probs <= 1.0)).all()
+
+    def test_explicit_isotonic_uses_cv_calibration(self):
+        X, y = _separable(n_per_class=30)
+        clf = train_svm(X, y, calibration="isotonic")
+        assert clf.calibration == "isotonic"
+        assert clf.calibrator is not None
+
+    def test_explicit_sigmoid_uses_cv_calibration(self):
+        X, y = _separable(n_per_class=20)
+        clf = train_svm(X, y, calibration="sigmoid")
+        assert clf.calibration == "sigmoid"
+        assert clf.calibrator is not None
+
+    def test_auto_picks_isotonic_when_data_supports_it(self):
+        X, y = _separable(n_per_class=20)
+        clf = train_svm(X, y, calibration="auto")
+        # 20 per class → smallest >= 10 → isotonic
+        assert clf.calibration == "isotonic"
+        assert clf.calibrator is not None
+
+    def test_unfittable_cv_calibration_falls_back(self):
+        # 1 pos + 5 neg can't fit even cv=2 calibrator, must fall back.
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((6, 4)).astype(np.float32)
+        y = np.array([1, 0, 0, 0, 0, 0], dtype=np.int32)
+        clf = train_svm(X, y, calibration="isotonic")
+        assert clf.calibration == "decision_sigmoid"
+        assert clf.calibrator is None
+        probs = clf.predict_proba(X)
+        assert probs.shape == (6,)
+        assert ((probs >= 0.0) & (probs <= 1.0)).all()
+
+
+def _overlapping(n_per_class: int = 40, dim: int = 8, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    """Build two Gaussian blobs with substantial overlap.
+
+    Class weights have to actually move the decision boundary for the
+    inclusion tests to be observable, which means the trainer needs to
+    face genuine ambiguity.  ``_separable`` is too easy — both inclusion
+    values learn essentially the same boundary.
+    """
+    rng = np.random.default_rng(seed)
+    pos = rng.standard_normal((n_per_class, dim)).astype(np.float32)
+    pos[:, 0] += 0.6
+    neg = rng.standard_normal((n_per_class, dim)).astype(np.float32)
+    neg[:, 0] -= 0.6
+    X = np.concatenate([pos, neg])
+    y = np.concatenate([np.ones(n_per_class, dtype=np.int32), np.zeros(n_per_class, dtype=np.int32)])
+    order = rng.permutation(X.shape[0])
+    return X[order], y[order]
+
+
+class TestInclusionWeights:
+    """``inclusion_value`` becomes a class-weight multiplier on the SVM.
+
+    Note that with CV-based probability calibration (Platt / isotonic) the
+    effect of class weights is largely cancelled out at the probability
+    layer — the calibrator maps decision scores back to the true base
+    rate of the training data.  Inclusion bias only shows up if the
+    caller picks a non-default threshold (analogous to the MLP path
+    where ``find_optimal_threshold`` consumes the same inclusion value).
+    So here we verify the trainer accepts and applies the bias, without
+    asserting a post-calibration probability shift that's intentionally
+    flattened by the calibrator.
+    """
+
+    @staticmethod
+    def _class_weight_for(inclusion_value: int) -> dict[int, float]:
+        X, y = _overlapping(n_per_class=20, seed=11)
+        clf = train_svm(X, y, inclusion_value=inclusion_value, calibration="decision_sigmoid")
+        cw = clf.base.get_params().get("class_weight")
+        if isinstance(cw, dict):
+            return {int(k): float(v) for k, v in cw.items()}
+        # ``"balanced"`` for inclusion_value == 0 — represent as ratio 1.0.
+        return {0: 1.0, 1: 1.0}
+
+    def test_positive_inclusion_upweights_positives(self):
+        balanced = self._class_weight_for(0)
+        biased = self._class_weight_for(5)
+        # Positive class weight grows; negative stays at 1.
+        ratio_balanced = balanced[1] / balanced[0]
+        ratio_biased = biased[1] / biased[0]
+        assert ratio_biased > ratio_balanced
+
+    def test_negative_inclusion_upweights_negatives(self):
+        balanced = self._class_weight_for(0)
+        biased = self._class_weight_for(-5)
+        ratio_balanced = balanced[1] / balanced[0]
+        ratio_biased = biased[1] / biased[0]
+        assert ratio_biased < ratio_balanced
+
+    def test_decision_sigmoid_bias_visible_in_probabilities(self):
+        """Without CV calibration, inclusion bias propagates through to scores.
+
+        ``decision_sigmoid`` is the small-data fallback path; here the
+        sigmoid is applied to the raw decision function so a shifted
+        boundary directly shifts the output probabilities.
+        """
+        X, y = _overlapping(n_per_class=40, seed=12)
+        balanced = train_svm(X, y, inclusion_value=0, calibration="decision_sigmoid")
+        positive = train_svm(X, y, inclusion_value=5, calibration="decision_sigmoid")
+        negative = train_svm(X, y, inclusion_value=-5, calibration="decision_sigmoid")
+        # Positive bias raises mean P; negative bias lowers it.
+        assert positive.predict_proba(X).mean() > balanced.predict_proba(X).mean()
+        assert negative.predict_proba(X).mean() < balanced.predict_proba(X).mean()
+
+
+class TestStandardize:
+    def test_standardize_path_runs(self):
+        X, y = _separable(n_per_class=20)
+        # Scale wildly to force StandardScaler to do something.
+        X = X * 100.0
+        clf = train_svm(X, y, standardize=True)
+        assert clf.scaler is not None
+        probs = clf.predict_proba(X)
+        assert probs.shape == (X.shape[0],)
+        # Probabilities still well-behaved.
+        assert ((probs >= 0.0) & (probs <= 1.0)).all()

--- a/vtsearch/eval/label_curve.py
+++ b/vtsearch/eval/label_curve.py
@@ -1,0 +1,582 @@
+"""Label-curve sweep: MLP vs SVM as a function of training-set size.
+
+Answers the question "should we switch from MLPs to SVMs?" by training
+each candidate classifier on a growing number of labels (5, 10, 20, ...)
+drawn from a demo dataset's simulation split, scoring a held-out test
+split, and reporting rank-based metrics plus a production-path F1
+across seeds.
+
+The headline metrics are rank-based on purpose: VTSearch never trusts
+the model's raw score as a probability — it derives the operating
+threshold via :func:`vtsearch.models.training.calculate_cross_calibration_threshold`
+and then applies it at inference.  So the relevant comparison is "how
+good is the ranking" (AUROC, AP, best-F1) plus "what F1 does the
+production cross-calibration path actually achieve" (``f1_at_xcal``,
+which uses :func:`vtsearch.models.training.find_optimal_threshold` on a
+held-out cal slice of the training labels).  Brier score and F1@0.5 are
+kept on every row as diagnostics but excluded from the default
+summary.
+
+The sweep iterates over::
+
+    dataset x target_category x trainer x label_count x seed
+
+and writes one row per cell to a tidy DataFrame, mirroring the layout
+of :mod:`vtsearch.eval.voting_iterations` so the results compose with
+existing tooling.
+
+Example::
+
+    from vtsearch.eval.label_curve import run_label_curve_eval
+    df = run_label_curve_eval(
+        dataset_clips={"esc50_s": medias},
+        trainers=("mlp", "svm_linear"),
+        label_counts=(5, 10, 20, 50, 100),
+        seeds=(0, 1, 2, 3, 4),
+    )
+
+See ``python -m vtsearch.eval.label_curve --help`` for the CLI.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Sequence
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Trainer plugin registry
+# ---------------------------------------------------------------------------
+
+
+PredictFn = Callable[[np.ndarray], np.ndarray]
+"""Callable returning P(positive) in [0, 1] for each row of X."""
+
+TrainerFn = Callable[[np.ndarray, np.ndarray, int], PredictFn]
+"""Trainer signature: ``(X_train, y_train, seed) -> predict_fn``."""
+
+
+def _train_mlp(X: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
+    """Adapt :func:`vtsearch.models.training.train_model` to the sweep API."""
+    import torch  # noqa: PLC0415
+
+    from vtsearch.models.training import train_model
+
+    X_t = torch.from_numpy(np.asarray(X, dtype=np.float32))
+    y_t = torch.from_numpy(np.asarray(y, dtype=np.float32)).unsqueeze(1)
+    model = train_model(X_t, y_t, input_dim=X.shape[1], seed=seed)
+
+    def predict(X_test: np.ndarray) -> np.ndarray:
+        X_arr = np.asarray(X_test, dtype=np.float32)
+        with torch.no_grad():
+            t = torch.from_numpy(X_arr).to(next(model.parameters()).device)
+            return torch.sigmoid(model(t)).squeeze(1).cpu().numpy()
+
+    return predict
+
+
+def _train_svm_factory(kernel: str) -> TrainerFn:
+    """Build a sweep-shaped trainer that fits an SVM with the given kernel."""
+
+    def trainer(X: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
+        from vtsearch.models.svm_training import train_svm
+
+        clf = train_svm(X, y, kernel=kernel, seed=seed)  # type: ignore[arg-type]
+        return clf.predict_proba
+
+    return trainer
+
+
+# Registry of available trainers.  Keep this dict tight — adding a new
+# entry here is the only place a new candidate model needs to be plugged
+# in for the sweep.
+TRAINERS: dict[str, TrainerFn] = {
+    "mlp": _train_mlp,
+    "svm_linear": _train_svm_factory("linear"),
+    "svm_rbf": _train_svm_factory("rbf"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Metric helpers
+# ---------------------------------------------------------------------------
+
+
+def _auroc(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Area under the ROC curve via the Mann-Whitney U formulation.
+
+    Returns ``nan`` if either class is empty (undefined).
+    """
+    pos = scores[labels == 1]
+    neg = scores[labels == 0]
+    if pos.size == 0 or neg.size == 0:
+        return float("nan")
+    # Average over ties: rank all scores, sum of positive ranks, etc.
+    order = np.argsort(scores, kind="mergesort")
+    ranks = np.empty_like(order, dtype=np.float64)
+    ranks[order] = np.arange(1, len(scores) + 1)
+    # Average ranks for ties so AUROC handles flat predictions correctly.
+    s_sorted = scores[order]
+    i = 0
+    while i < len(s_sorted):
+        j = i + 1
+        while j < len(s_sorted) and s_sorted[j] == s_sorted[i]:
+            j += 1
+        if j - i > 1:
+            avg = ranks[order[i:j]].mean()
+            ranks[order[i:j]] = avg
+        i = j
+    pos_rank_sum = ranks[labels == 1].sum()
+    n_pos = float(pos.size)
+    n_neg = float(neg.size)
+    u = pos_rank_sum - n_pos * (n_pos + 1) / 2.0
+    return float(u / (n_pos * n_neg))
+
+
+def _average_precision(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Average precision (area under PR curve), matching sklearn semantics."""
+    if labels.sum() == 0:
+        return float("nan")
+    order = np.argsort(-scores, kind="mergesort")
+    sorted_labels = labels[order]
+    cum_tp = np.cumsum(sorted_labels == 1)
+    precisions = cum_tp / np.arange(1, len(sorted_labels) + 1)
+    # AP = mean precision over positive positions.
+    pos_mask = sorted_labels == 1
+    return float(precisions[pos_mask].mean())
+
+
+def _brier(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Brier score: mean squared error between probabilities and 0/1 labels."""
+    return float(((scores - labels) ** 2).mean())
+
+
+def _f1_at(scores: np.ndarray, labels: np.ndarray, threshold: float) -> float:
+    preds = (scores >= threshold).astype(np.int32)
+    tp = int(((preds == 1) & (labels == 1)).sum())
+    fp = int(((preds == 1) & (labels == 0)).sum())
+    fn = int(((preds == 0) & (labels == 1)).sum())
+    denom = 2 * tp + fp + fn
+    return 0.0 if denom == 0 else 2.0 * tp / denom
+
+
+def _best_f1(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Maximum F1 achievable over any threshold on these scores."""
+    if labels.sum() == 0:
+        return float("nan")
+    order = np.argsort(-scores, kind="mergesort")
+    sorted_labels = labels[order].astype(np.int64)
+    cum_tp = np.cumsum(sorted_labels == 1)
+    positions = np.arange(1, len(sorted_labels) + 1)
+    total_pos = int(sorted_labels.sum())
+    precisions = cum_tp / positions
+    recalls = cum_tp / total_pos
+    denom = precisions + recalls
+    f1 = np.divide(
+        2 * precisions * recalls,
+        denom,
+        out=np.zeros_like(denom, dtype=np.float64),
+        where=denom > 0,
+    )
+    return float(f1.max())
+
+
+# ---------------------------------------------------------------------------
+# Sampling
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SplitPool:
+    """Pre-built positive/negative pools for one (dataset, category, seed).
+
+    Decoupling the split from the label-count loop ensures every label
+    count under a fixed seed draws from the *same* sim pool, so the curve
+    measures "what changes as we add labels" rather than "what changes as
+    we reshuffle".
+    """
+
+    sim_pos: np.ndarray
+    sim_neg: np.ndarray
+    test_X: np.ndarray
+    test_y: np.ndarray
+
+
+def _build_split_pool(
+    clips: dict[int, dict[str, Any]],
+    target_category: str,
+    seed: int,
+    sim_fraction: float,
+) -> _SplitPool | None:
+    """Partition medias into sim/test pools, separated by ground-truth class.
+
+    Returns ``None`` when the dataset is too small to form a usable test
+    set with at least one positive and one negative example.
+    """
+    rng = np.random.default_rng(seed)
+    pos_ids = np.array(
+        [cid for cid, m in clips.items() if m.get("category") == target_category],
+        dtype=np.int64,
+    )
+    neg_ids = np.array(
+        [cid for cid, m in clips.items() if m.get("category") != target_category],
+        dtype=np.int64,
+    )
+    if pos_ids.size < 2 or neg_ids.size < 2:
+        return None
+    rng.shuffle(pos_ids)
+    rng.shuffle(neg_ids)
+
+    n_pos_sim = max(1, int(pos_ids.size * sim_fraction))
+    n_neg_sim = max(1, int(neg_ids.size * sim_fraction))
+    sim_pos_ids = pos_ids[:n_pos_sim]
+    sim_neg_ids = neg_ids[:n_neg_sim]
+    test_pos_ids = pos_ids[n_pos_sim:]
+    test_neg_ids = neg_ids[n_neg_sim:]
+    if test_pos_ids.size == 0 or test_neg_ids.size == 0:
+        return None
+
+    def _stack(ids: np.ndarray) -> np.ndarray:
+        return np.stack([np.asarray(clips[int(cid)]["embedding"], dtype=np.float32) for cid in ids])
+
+    sim_pos = _stack(sim_pos_ids)
+    sim_neg = _stack(sim_neg_ids)
+    test_X = np.concatenate([_stack(test_pos_ids), _stack(test_neg_ids)], axis=0)
+    test_y = np.concatenate(
+        [np.ones(test_pos_ids.size, dtype=np.int32), np.zeros(test_neg_ids.size, dtype=np.int32)]
+    )
+    return _SplitPool(sim_pos=sim_pos, sim_neg=sim_neg, test_X=test_X, test_y=test_y)
+
+
+def _sample_labels(
+    pool: _SplitPool,
+    n_labels: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Draw a balanced label budget from the sim pools.
+
+    Splits the label budget roughly 50/50 across classes; clips to the
+    pool size when one class is smaller than ``n_labels // 2``.  Returns
+    ``None`` when the request can't be satisfied with at least one of
+    each class.
+    """
+    rng = np.random.default_rng(seed)
+    n_pos_want = n_labels // 2
+    n_neg_want = n_labels - n_pos_want
+    n_pos = min(n_pos_want, pool.sim_pos.shape[0])
+    n_neg = min(n_neg_want, pool.sim_neg.shape[0])
+    if n_pos < 1 or n_neg < 1:
+        return None
+    pos_idx = rng.choice(pool.sim_pos.shape[0], size=n_pos, replace=False)
+    neg_idx = rng.choice(pool.sim_neg.shape[0], size=n_neg, replace=False)
+    X = np.concatenate([pool.sim_pos[pos_idx], pool.sim_neg[neg_idx]], axis=0)
+    y = np.concatenate([np.ones(n_pos, dtype=np.int32), np.zeros(n_neg, dtype=np.int32)])
+    # Shuffle so trainers can't exploit ordering.
+    order = rng.permutation(X.shape[0])
+    return X[order], y[order]
+
+
+# ---------------------------------------------------------------------------
+# Sweep driver
+# ---------------------------------------------------------------------------
+
+
+_HEADLINE_METRICS: tuple[str, ...] = (
+    "auroc",
+    "average_precision",
+    "best_f1",
+    "xcal_threshold",
+    "f1_at_xcal",
+    "train_seconds",
+)
+"""Rank-based metrics plus the production-path threshold metric.
+
+These are the columns ``summarise()`` aggregates by default and the CLI
+leads its summary with.  ``best_f1`` represents "what F1 is achievable
+with the right threshold" and ``f1_at_xcal`` represents "what F1
+production would actually get, using cross-calibration to pick that
+threshold from the labels alone."
+"""
+
+_DIAGNOSTIC_METRICS: tuple[str, ...] = (
+    "brier",
+    "f1_at_0.5",
+    "predict_seconds",
+)
+"""Kept on every row but excluded from the default summary.
+
+Brier and F1@0.5 only mean something if the score is a calibrated
+probability with 0.5 as the operating point — neither holds in VTSearch
+(the MLP's sigmoid is uncalibrated and the operating point is the
+cross-calibrated threshold).  They stay available for anyone debugging
+score-distribution shapes.
+"""
+
+_ROW_COLUMNS: tuple[str, ...] = (
+    "dataset",
+    "category",
+    "trainer",
+    "n_labels",
+    "n_pos",
+    "n_neg",
+    "seed",
+    *_HEADLINE_METRICS,
+    *_DIAGNOSTIC_METRICS,
+)
+
+
+def _cross_calibrated_threshold(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    trainer_fn: TrainerFn,
+    seed: int,
+    *,
+    inclusion_value: int = 0,
+    calibrate_count: int = 2,
+    cal_fraction: float = 0.5,
+) -> float:
+    """Trainer-agnostic port of ``calculate_cross_calibration_threshold``.
+
+    Mirrors what production does at vote time: split the labels k ways
+    into train/cal halves, retrain on each half, find the
+    inclusion-weighted optimal threshold on the cal half, average the
+    thresholds.  This is the threshold ``f1_at_xcal`` is measured at, so
+    a trainer that ranks well but doesn't admit a stable cross-validated
+    threshold pays the price here.
+
+    Returns ``0.5`` when the label budget is too small to form valid
+    splits (mirrors the production fallback).
+    """
+    from vtsearch.models.training import find_optimal_threshold
+
+    n = int(y_train.size)
+    if n < 4:
+        return 0.5
+    n_cal = max(1, round(n * cal_fraction))
+    n_tr = n - n_cal
+    if n_tr < 2 or n_cal < 1:
+        return 0.5
+
+    rng = np.random.default_rng(seed)
+    thresholds: list[float] = []
+    for k in range(max(1, calibrate_count)):
+        order = rng.permutation(n)
+        tr_idx = order[:n_tr]
+        cal_idx = order[n_tr:]
+        # Single-class splits would crash the trainer or short-circuit
+        # the threshold finder; just skip this fold.
+        if len({int(v) for v in y_train[tr_idx]}) < 2:
+            continue
+        if len({int(v) for v in y_train[cal_idx]}) < 2:
+            continue
+        try:
+            predict = trainer_fn(X_train[tr_idx], y_train[tr_idx], seed + k)
+        except ValueError:
+            continue
+        cal_scores = np.asarray(predict(X_train[cal_idx]), dtype=np.float64).tolist()
+        cal_labels = [float(v) for v in y_train[cal_idx]]
+        t = find_optimal_threshold(cal_scores, cal_labels, inclusion_value)
+        # ``find_optimal_threshold`` can return +/-inf on degenerate
+        # splits; only count finite thresholds toward the mean.
+        if np.isfinite(t):
+            thresholds.append(float(t))
+
+    if not thresholds:
+        return 0.5
+    return float(np.mean(thresholds))
+
+
+def evaluate_one(
+    pool: _SplitPool,
+    trainer_name: str,
+    n_labels: int,
+    seed: int,
+    *,
+    inclusion_value: int = 0,
+    calibrate_count: int = 2,
+    cal_fraction: float = 0.5,
+) -> dict[str, Any] | None:
+    """Run a single cell of the sweep, returning a result row or ``None``.
+
+    ``None`` means the cell was skipped (not enough labels in the pool to
+    satisfy the request with both classes present).
+    """
+    if trainer_name not in TRAINERS:
+        raise KeyError(f"Unknown trainer {trainer_name!r}; choices: {sorted(TRAINERS)}")
+    sample = _sample_labels(pool, n_labels, seed)
+    if sample is None:
+        return None
+    X_train, y_train = sample
+
+    trainer_fn = TRAINERS[trainer_name]
+    t0 = time.monotonic()
+    try:
+        predict = trainer_fn(X_train, y_train, seed)
+    except ValueError:
+        # SVM trainer raises on single-class data — guard already covered
+        # by the balanced sampler, but the trainer also defends itself so
+        # we treat unexpected refusals as skipped cells.
+        return None
+    train_seconds = time.monotonic() - t0
+
+    t0 = time.monotonic()
+    scores = predict(pool.test_X)
+    predict_seconds = time.monotonic() - t0
+
+    labels = pool.test_y
+
+    # Cross-calibrated threshold mirrors the production path: split the
+    # *training* labels (no test info leaks in), find the optimal
+    # threshold on the cal halves, average.  ``f1_at_xcal`` then measures
+    # the F1 we'd actually achieve at inference time, given only the
+    # labels the model was trained on.
+    xcal_thr = _cross_calibrated_threshold(
+        X_train,
+        y_train,
+        trainer_fn,
+        seed,
+        inclusion_value=inclusion_value,
+        calibrate_count=calibrate_count,
+        cal_fraction=cal_fraction,
+    )
+    return {
+        "trainer": trainer_name,
+        "n_labels": int(y_train.size),
+        "n_pos": int((y_train == 1).sum()),
+        "n_neg": int((y_train == 0).sum()),
+        "seed": int(seed),
+        "auroc": _auroc(scores, labels),
+        "average_precision": _average_precision(scores, labels),
+        "best_f1": _best_f1(scores, labels),
+        "xcal_threshold": float(xcal_thr),
+        "f1_at_xcal": _f1_at(scores, labels, xcal_thr),
+        "train_seconds": round(train_seconds, 4),
+        "brier": _brier(np.clip(scores, 0.0, 1.0), labels),
+        "f1_at_0.5": _f1_at(scores, labels, 0.5),
+        "predict_seconds": round(predict_seconds, 4),
+    }
+
+
+def run_label_curve_eval(
+    dataset_clips: dict[str, dict[int, dict[str, Any]]],
+    trainers: Sequence[str] = ("mlp", "svm_linear"),
+    label_counts: Sequence[int] = (5, 10, 20, 50, 100),
+    seeds: Sequence[int] = (0, 1, 2, 3, 4),
+    categories: dict[str, Sequence[str]] | None = None,
+    sim_fraction: float = 0.5,
+    inclusion_value: int = 0,
+    calibrate_count: int = 2,
+    cal_fraction: float = 0.5,
+    progress: bool = False,
+) -> pd.DataFrame:
+    """Sweep trainers × label counts × seeds × (dataset, category).
+
+    Args:
+        dataset_clips: Mapping of dataset name to a preloaded medias dict.
+            Each media must carry an ``"embedding"`` (np.ndarray) and a
+            ``"category"`` (str).
+        trainers: Trainer names to compare (keys of :data:`TRAINERS`).
+        label_counts: How many training labels to feed each trainer.
+        seeds: Random seeds.  The split/sample is fully determined by the
+            (dataset, category, seed) triple, so different trainers see
+            identical training data at each (n_labels, seed).
+        categories: Optional restriction of target categories per dataset.
+            ``None`` means "every unique category in the dataset".
+        sim_fraction: Fraction of medias placed in the sim pool (the rest
+            become the held-out test pool).
+        inclusion_value: Passed to the cross-calibration threshold finder
+            (FPR/FNR tradeoff).  Doesn't affect the trainer's ranking; only
+            the ``xcal_threshold`` / ``f1_at_xcal`` columns.
+        calibrate_count: Number of train/cal folds for cross-calibration
+            (mirrors the production default of 2).
+        cal_fraction: Fraction of training labels held out as the cal
+            portion within each fold.
+        progress: When ``True``, print a one-line status update at the
+            start of each (dataset, category, seed) outer cell.
+
+    Returns:
+        A tidy :class:`pandas.DataFrame` with one row per evaluated cell.
+        Columns: ``dataset, category, trainer, n_labels, n_pos, n_neg,
+        seed, auroc, average_precision, brier, f1_at_0.5, best_f1,
+        train_seconds, predict_seconds``.
+    """
+    import pandas as pd  # noqa: PLC0415
+
+    for name in trainers:
+        if name not in TRAINERS:
+            raise KeyError(f"Unknown trainer {name!r}; choices: {sorted(TRAINERS)}")
+
+    rows: list[dict[str, Any]] = []
+    for ds_name, clips in dataset_clips.items():
+        if categories and ds_name in categories:
+            target_cats: Sequence[str] = list(categories[ds_name])
+        else:
+            target_cats = sorted({m["category"] for m in clips.values() if m.get("category")})
+
+        for cat in target_cats:
+            for seed in seeds:
+                pool = _build_split_pool(clips, cat, int(seed), sim_fraction)
+                if pool is None:
+                    continue
+                if progress:
+                    print(
+                        f"[{ds_name}] category={cat!r} seed={seed} "
+                        f"sim_pos={pool.sim_pos.shape[0]} sim_neg={pool.sim_neg.shape[0]} "
+                        f"test={pool.test_y.size}",
+                        flush=True,
+                    )
+                for n in label_counts:
+                    for trainer in trainers:
+                        row = evaluate_one(
+                            pool,
+                            trainer,
+                            int(n),
+                            int(seed),
+                            inclusion_value=inclusion_value,
+                            calibrate_count=calibrate_count,
+                            cal_fraction=cal_fraction,
+                        )
+                        if row is None:
+                            continue
+                        row["dataset"] = ds_name
+                        row["category"] = cat
+                        rows.append(row)
+
+    return pd.DataFrame(rows, columns=list(_ROW_COLUMNS))
+
+
+def summarise(df: pd.DataFrame, *, include_diagnostics: bool = False) -> pd.DataFrame:
+    """Collapse seeds into per-(dataset, category, trainer, n_labels) means.
+
+    Useful when you just want the headline numbers for a plot.  Returns
+    mean and stddev for each metric so error bars are still computable.
+
+    By default only the rank-based metrics, ``best_f1``, the cross-
+    calibrated threshold, and ``f1_at_xcal`` are aggregated — those are
+    the columns that matter when downstream consumes ranks and learns
+    its own threshold.  Pass ``include_diagnostics=True`` to also get
+    Brier and F1@0.5 (useful if you specifically want to inspect score
+    distribution shapes).
+    """
+    if df.empty:
+        return df
+    metric_cols = list(_HEADLINE_METRICS)
+    if include_diagnostics:
+        metric_cols += list(_DIAGNOSTIC_METRICS)
+    # Keep only the metrics that are actually present in *df* — lets older
+    # callers / cached frames flow through ``summarise()`` without crashing.
+    metric_cols = [c for c in metric_cols if c in df.columns]
+    grouped = df.groupby(["dataset", "category", "trainer", "n_labels"], sort=False)
+    agg = grouped[metric_cols].agg(["mean", "std"]).reset_index()
+    # Flatten MultiIndex columns: ("auroc", "mean") -> "auroc_mean".
+    agg.columns = [
+        f"{a}_{b}" if isinstance(b, str) and b else a
+        for a, b in agg.columns.to_flat_index()
+    ]
+    return agg

--- a/vtsearch/eval/label_curve_main.py
+++ b/vtsearch/eval/label_curve_main.py
@@ -1,0 +1,201 @@
+"""CLI entry point for the MLP-vs-SVM label-curve sweep.
+
+Usage::
+
+    # Quick smoke test on the smallest demo dataset
+    python -m vtsearch.eval.label_curve_main --datasets esc50_s \
+        --label-counts 5 10 20 --seeds 0 1 2
+
+    # Full sweep, writing a tidy CSV
+    python -m vtsearch.eval.label_curve_main \
+        --datasets esc50_s flowers102_s \
+        --trainers mlp svm_linear svm_rbf \
+        --label-counts 5 10 20 50 100 200 \
+        --seeds 0 1 2 3 4 \
+        --output label_curve.csv
+
+The CLI loads one demo dataset at a time (via ``load_demo_dataset``) so
+embedding downloads only happen for the datasets you actually ask for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TYPE_CHECKING, Any
+
+from vtsearch.eval.label_curve import TRAINERS, run_label_curve_eval, summarise
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def _load_dataset(demo_id: str) -> dict[int, dict[str, Any]]:
+    """Load one demo dataset into a fresh medias dict."""
+    from vtsearch.datasets.loader import load_demo_dataset
+
+    medias: dict[int, dict[str, Any]] = {}
+    load_demo_dataset(demo_id, medias)
+    return medias
+
+
+def _print_summary(summary: pd.DataFrame) -> None:
+    """Print one row per (dataset, category, trainer, n_labels) cell.
+
+    Leads with rank-based metrics (AUROC, AP) and the production-path F1
+    (``f1_at_xcal``), since VTSearch never trusts the raw score as a
+    probability — it always picks a threshold via cross-calibration.
+    """
+    if summary.empty:
+        print("(no rows — every cell was skipped)")
+        return
+    for _, row in summary.iterrows():
+        print(
+            f"  {row['dataset']:>14s} | {row['category']:>20s} | "
+            f"{row['trainer']:>10s} | N={int(row['n_labels']):>3d} | "
+            f"AUROC={row['auroc_mean']:.3f}±{row['auroc_std']:.3f}  "
+            f"AP={row['average_precision_mean']:.3f}±{row['average_precision_std']:.3f}  "
+            f"bestF1={row['best_f1_mean']:.3f}  "
+            f"F1@xcal={row['f1_at_xcal_mean']:.3f}±{row['f1_at_xcal_std']:.3f}  "
+            f"train={row['train_seconds_mean']:.3f}s"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m vtsearch.eval.label_curve_main",
+        description="MLP vs SVM label-curve sweep on demo datasets.",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        required=True,
+        metavar="DEMO_ID",
+        help="Demo dataset IDs to load (e.g. esc50_s, flowers102_s).",
+    )
+    parser.add_argument(
+        "--trainers",
+        nargs="+",
+        default=["mlp", "svm_linear"],
+        choices=sorted(TRAINERS),
+        help="Which trainers to compare (default: mlp svm_linear).",
+    )
+    parser.add_argument(
+        "--label-counts",
+        nargs="+",
+        type=int,
+        default=[5, 10, 20, 50, 100],
+        metavar="N",
+        help="Training-set sizes to sweep (default: 5 10 20 50 100).",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=[0, 1, 2, 3, 4],
+        metavar="SEED",
+        help="Random seeds (default: 0 1 2 3 4).",
+    )
+    parser.add_argument(
+        "--categories",
+        nargs="+",
+        default=None,
+        metavar="CAT",
+        help="Restrict evaluation to these target categories (applies to "
+        "every dataset).  Default: every unique category per dataset.",
+    )
+    parser.add_argument(
+        "--sim-fraction",
+        type=float,
+        default=0.5,
+        help="Fraction of medias in the sim pool (default: 0.5).",
+    )
+    parser.add_argument(
+        "--inclusion-value",
+        type=int,
+        default=0,
+        metavar="V",
+        help="Inclusion bias passed to find_optimal_threshold (default: 0).",
+    )
+    parser.add_argument(
+        "--calibrate-count",
+        type=int,
+        default=2,
+        metavar="K",
+        help="Number of train/cal folds for cross-calibration (default: 2).",
+    )
+    parser.add_argument(
+        "--cal-fraction",
+        type=float,
+        default=0.5,
+        help="Fraction of training labels held out as the cal portion (default: 0.5).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        metavar="FILE",
+        help="Write the tidy result table to FILE (.csv or .json by extension).",
+    )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Suppress per-cell progress lines.",
+    )
+    args = parser.parse_args(argv)
+
+    # Lazy-init models so the eval script doesn't pay the startup cost
+    # when the user just runs --help.
+    from vtsearch.models import initialize_models
+
+    initialize_models()
+
+    dataset_clips: dict[str, dict[int, dict[str, Any]]] = {}
+    for demo_id in args.datasets:
+        print(f"Loading {demo_id} ...", flush=True)
+        try:
+            dataset_clips[demo_id] = _load_dataset(demo_id)
+        except Exception as e:  # pragma: no cover - exercised via CLI
+            print(f"  ERROR loading {demo_id}: {e}", file=sys.stderr)
+            continue
+
+    if not dataset_clips:
+        print("No datasets loaded — aborting.", file=sys.stderr)
+        return 2
+
+    categories = None
+    if args.categories:
+        categories = {ds: args.categories for ds in dataset_clips}
+
+    df = run_label_curve_eval(
+        dataset_clips=dataset_clips,
+        trainers=args.trainers,
+        label_counts=args.label_counts,
+        seeds=args.seeds,
+        categories=categories,
+        sim_fraction=args.sim_fraction,
+        inclusion_value=args.inclusion_value,
+        calibrate_count=args.calibrate_count,
+        cal_fraction=args.cal_fraction,
+        progress=not args.no_progress,
+    )
+
+    print(f"\nCollected {len(df)} rows.\n")
+    print("=" * 78)
+    print("SUMMARY (mean ± stddev across seeds)")
+    print("=" * 78)
+    _print_summary(summarise(df))
+
+    if args.output:
+        out = args.output
+        if out.endswith(".json"):
+            df.to_json(out, orient="records", indent=2)
+        else:
+            df.to_csv(out, index=False)
+        print(f"\nResults written to {out}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/vtsearch/models/svm_training.py
+++ b/vtsearch/models/svm_training.py
@@ -1,0 +1,261 @@
+"""SVM trainer prototype for the learned-sort comparison study.
+
+This module is intentionally standalone — it does NOT wire into
+``DetectorContext`` or the ``train_and_score`` production path.  Its job
+is to expose a trainer with the same input/output contract as the MLP
+(features in, calibrated [0, 1] probabilities out) so the label-curve
+sweep in :mod:`vtsearch.eval.label_curve` can compare them head-to-head.
+
+If the sweep shows the SVM is competitive, the next step is to add a
+trainer-selection field on detectors and route through this module from
+``train_and_score``.  Until then, treat everything here as experimental.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+
+
+SVMKernel = Literal["linear", "rbf"]
+CalibrationMode = Literal["sigmoid", "isotonic", "decision_sigmoid", "auto"]
+
+
+@dataclass
+class SVMClassifier:
+    """Trained SVM wrapped with a probability source.
+
+    ``calibrator`` is either a sklearn ``CalibratedClassifierCV`` (when CV
+    calibration was feasible) or ``None`` (small-data fallback — we sigmoid
+    the raw decision function instead).
+    """
+
+    base: Any
+    """Underlying sklearn estimator (``LinearSVC`` or ``SVC``)."""
+
+    calibrator: Any | None
+    """``CalibratedClassifierCV`` fit on the same data, or ``None``."""
+
+    scaler: Any | None
+    """Optional ``StandardScaler`` applied before any predict call."""
+
+    kernel: SVMKernel = "linear"
+    calibration: CalibrationMode = "auto"
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """Return P(positive) for each row of *X* as a 1-D float array in [0, 1]."""
+        X = np.asarray(X, dtype=np.float32)
+        if self.scaler is not None:
+            X = self.scaler.transform(X)
+        if self.calibrator is not None:
+            return self.calibrator.predict_proba(X)[:, 1].astype(np.float32)
+        # Fallback: sigmoid over decision function.  Not a true probability
+        # but monotone in the SVM score, which is what the ranker cares
+        # about; thresholding on 0.5 corresponds to decision_function >= 0.
+        d = self.base.decision_function(X)
+        d = np.clip(d, -30.0, 30.0)  # avoid overflow in exp
+        return (1.0 / (1.0 + np.exp(-d))).astype(np.float32)
+
+
+def _make_base_estimator(
+    kernel: SVMKernel,
+    C: float,
+    seed: int,
+    class_weight: str | dict[int, float] | None,
+) -> Any:
+    """Construct the underlying SVM (no calibration yet)."""
+    if kernel == "linear":
+        from sklearn.svm import LinearSVC  # noqa: PLC0415
+
+        # ``dual='auto'`` lets sklearn pick the better solver based on
+        # n_samples vs. n_features.  This is the sklearn-recommended default
+        # on >=1.3 and avoids the FutureWarning about the previous default.
+        return LinearSVC(
+            C=C,
+            class_weight=class_weight,
+            dual="auto",
+            max_iter=5000,
+            random_state=seed,
+        )
+    if kernel == "rbf":
+        from sklearn.svm import SVC  # noqa: PLC0415
+
+        # ``probability=False`` here — we attach our own calibrator outside
+        # so the calibration mode is uniform across kernels.
+        return SVC(
+            C=C,
+            kernel="rbf",
+            gamma="scale",
+            class_weight=class_weight,
+            probability=False,
+            random_state=seed,
+        )
+    raise ValueError(f"Unsupported SVM kernel: {kernel!r}")
+
+
+def _effective_calibration(
+    requested: CalibrationMode,
+    n_pos: int,
+    n_neg: int,
+) -> CalibrationMode:
+    """Pick a calibration mode that's actually fittable for the label counts.
+
+    ``CalibratedClassifierCV`` needs at least ``cv`` samples per class
+    (default 5).  We drop to ``cv=2`` when possible and otherwise fall
+    back to ``decision_sigmoid``, which works for any N >= 1 per class.
+
+    ``isotonic`` additionally needs enough distinct decision-function
+    values to be useful; below ~10 calibration points it overfits, so we
+    downgrade to ``sigmoid`` (Platt) in that regime.
+    """
+    if requested != "auto":
+        # Caller asked for a specific mode — try to honour it; fall back
+        # only if the data literally can't support CV calibration.
+        if requested in ("sigmoid", "isotonic") and min(n_pos, n_neg) < 2:
+            return "decision_sigmoid"
+        return requested
+
+    smallest = min(n_pos, n_neg)
+    if smallest < 2:
+        return "decision_sigmoid"
+    if smallest < 5:
+        return "sigmoid"  # Platt is the right tool when calibration set is tiny
+    if smallest < 10:
+        return "sigmoid"
+    return "isotonic"
+
+
+def train_svm(
+    X: np.ndarray,
+    y: np.ndarray,
+    *,
+    kernel: SVMKernel = "linear",
+    C: float = 1.0,
+    calibration: CalibrationMode = "decision_sigmoid",
+    inclusion_value: int = 0,
+    seed: int = 42,
+    standardize: bool = False,
+) -> SVMClassifier:
+    """Fit an SVM classifier and return a score-emitting wrapper.
+
+    Mirrors the call shape of :func:`vtsearch.models.training.train_model`
+    (features, labels, inclusion bias, seed) and returns an object whose
+    ``predict_proba`` produces a monotone score directly comparable to
+    ``torch.sigmoid(mlp(X))`` for ranking and threshold-finding purposes.
+
+    The default is ``"decision_sigmoid"``: a sigmoid wrapper over the raw
+    ``decision_function``.  This is deliberate.  Production VTSearch
+    treats the MLP's sigmoid output as an *uncalibrated score* and picks
+    a threshold via cross-calibration (see
+    :func:`vtsearch.models.training.calculate_cross_calibration_threshold`)
+    rather than trusting it as a probability.  Wrapping the SVM in
+    ``CalibratedClassifierCV`` would burn training data on k-fold CV
+    (strictly less data per fold than fitting once on all of it) and
+    invert the effect of ``inclusion_value`` by mapping decision scores
+    back to the empirical base rate — both of which are undesirable
+    when only the ranking and a learnable threshold matter.  Pass
+    ``calibration="isotonic"`` or ``"sigmoid"`` (Platt) if you do
+    explicitly want calibrated probabilities for some downstream task,
+    or ``"auto"`` to let the data size pick (legacy behaviour).
+
+    Args:
+        X: ``(N, D)`` float array of training embeddings.
+        y: ``(N,)`` array of 0/1 labels (1 = good, 0 = bad).
+        kernel: ``"linear"`` (LinearSVC, fast) or ``"rbf"`` (SVC).
+        C: Inverse regularisation strength.  Defaults to 1.0; bump up for
+            noisy embeddings, down for very small N.
+        calibration: How to map the SVM decision function to scores.
+            Default ``"decision_sigmoid"`` (no CV calibration, just a
+            sigmoid over ``decision_function``).  ``"auto"`` picks based
+            on label counts; ``"sigmoid"`` forces Platt scaling;
+            ``"isotonic"`` forces isotonic regression.  See
+            :func:`_effective_calibration` for the auto rules and the
+            fall-back behaviour when the data can't support CV
+            calibration.
+        inclusion_value: ``[-10, 10]`` bias toward including (positive) or
+            excluding (negative) — translated to ``class_weight``.
+        seed: Random seed for the SVM solver and the calibrator's CV splits.
+        standardize: When ``True``, fit a ``StandardScaler`` first.  Most
+            embedders (CLAP/CLIP/SigLIP/E5) emit L2-normalised vectors so
+            this is off by default; turn on if you're feeding raw or
+            unnormalised features.
+
+    Returns:
+        A fitted :class:`SVMClassifier`.
+
+    Raises:
+        ValueError: when the training data has fewer than 2 samples or is
+            single-class.  The MLP path silently returns ``None`` in that
+            case; here we surface the error so the caller (the eval
+            harness) can record it as a skip.
+    """
+    X = np.asarray(X, dtype=np.float32)
+    y = np.asarray(y).astype(np.int32).ravel()
+    if X.ndim != 2:
+        raise ValueError(f"X must be 2-D, got shape {X.shape}")
+    if X.shape[0] != y.shape[0]:
+        raise ValueError(f"X has {X.shape[0]} rows but y has {y.shape[0]}")
+
+    n_pos = int((y == 1).sum())
+    n_neg = int((y == 0).sum())
+    if n_pos == 0 or n_neg == 0:
+        raise ValueError(f"train_svm needs both classes (got n_pos={n_pos}, n_neg={n_neg})")
+    if n_pos + n_neg < 2:
+        raise ValueError("train_svm needs at least 2 training samples")
+
+    scaler = None
+    if standardize:
+        from sklearn.preprocessing import StandardScaler  # noqa: PLC0415
+
+        scaler = StandardScaler().fit(X)
+        X_fit = scaler.transform(X)
+    else:
+        X_fit = X
+
+    # Translate inclusion into a class weight.  Mirrors the MLP path:
+    # the "balanced" baseline divides by class frequency, then we apply
+    # an exponential multiplier in the requested direction.
+    if inclusion_value == 0:
+        class_weight: str | dict[int, float] = "balanced"
+    elif inclusion_value > 0:
+        base_pos = n_neg / max(n_pos, 1)
+        class_weight = {0: 1.0, 1: float(base_pos * (2.0**inclusion_value))}
+    else:
+        base_neg = n_pos / max(n_neg, 1)
+        class_weight = {0: float(base_neg * (2.0 ** (-inclusion_value))), 1: 1.0}
+
+    base = _make_base_estimator(kernel, C, seed, class_weight)
+
+    mode = _effective_calibration(calibration, n_pos, n_neg)
+
+    calibrator: Any | None
+    if mode == "decision_sigmoid":
+        base.fit(X_fit, y)
+        calibrator = None
+    else:
+        from sklearn.calibration import CalibratedClassifierCV  # noqa: PLC0415
+        from sklearn.model_selection import StratifiedKFold  # noqa: PLC0415
+
+        # cv must be <= min(n_pos, n_neg).  We already guaranteed >= 2 above.
+        cv_n = min(5, min(n_pos, n_neg))
+        cv_splitter = StratifiedKFold(n_splits=cv_n, shuffle=True, random_state=seed)
+        calibrator = CalibratedClassifierCV(
+            estimator=base,
+            method=mode,  # "sigmoid" (Platt) or "isotonic"
+            cv=cv_splitter,
+        )
+        calibrator.fit(X_fit, y)
+        # ``calibrator`` holds its own fitted copy of the base estimator
+        # via cross-validation; ``base`` itself is left unfit.  That's
+        # fine because predict_proba only ever consults ``calibrator``
+        # when one is present.
+
+    return SVMClassifier(
+        base=base,
+        calibrator=calibrator,
+        scaler=scaler,
+        kernel=kernel,
+        calibration=mode,
+    )


### PR DESCRIPTION
## Summary

Adds an experimental SVM trainer alongside the production MLP path, plus a head-to-head sweep harness so we can answer **"should we switch from MLPs to SVMs?"** empirically before committing to any production wiring.

Production VTSearch never trusts the model's raw score as a probability — it derives the operating threshold via cross-calibration (`calculate_cross_calibration_threshold` → `find_optimal_threshold`) and then applies it at inference. So the sweep leads with rank-based metrics (AUROC, AP, best-F1) plus a production-path metric (F1 at the cross-calibrated threshold). Brier score and F1@0.5 are kept on every row as diagnostics but excluded from the default summary.

This is research scaffolding — the SVM is **not** routed through `DetectorContext.model` or `train_and_score` yet. Production behaviour is unchanged.

## What's added

**`vtsearch/models/svm_training.py`** — standalone trainer
- `train_svm(X, y, *, kernel, C, calibration, inclusion_value, seed, standardize)` → `SVMClassifier`
- Wraps `LinearSVC` (default) or `SVC(kernel='rbf')` with an optional `CalibratedClassifierCV`
- **Default calibration is `decision_sigmoid`** (sigmoid over `decision_function`, no CV calibration). CV calibration burns training data on k-fold splits (strictly less per fold than fitting once on all of it) and inverts `inclusion_value` semantics by mapping decision scores back to the empirical base rate — both undesirable when downstream only needs ranking and a learnable threshold.
- Explicit `"sigmoid"` (Platt), `"isotonic"`, and `"auto"` modes remain available for callers that genuinely want calibrated probabilities.

**`vtsearch/eval/label_curve.py`** — sweep driver
- Iterates `dataset × category × trainer × label_count × seed`
- Each cell trains once on N labels, plus k extra times for cross-calibration (mirroring `calibrate_count=2` from production)
- Headline metrics: `auroc`, `average_precision`, `best_f1`, `xcal_threshold`, `f1_at_xcal`, `train_seconds`
- Diagnostic metrics (still present on every row, excluded from default summary): `brier`, `f1_at_0.5`, `predict_seconds`
- `summarise(df, include_diagnostics=True)` brings the diagnostics back into the summary if you specifically want them
- Trainers register via the `TRAINERS` dict — one entry per candidate

**`vtsearch/eval/label_curve_main.py`** — CLI
```bash
python -m vtsearch.eval.label_curve_main \
    --datasets esc50_s flowers102_s \
    --trainers mlp svm_linear svm_rbf \
    --label-counts 5 10 20 50 100 200 \
    --seeds 0 1 2 3 4 \
    --inclusion-value 0 \
    --calibrate-count 2 \
    --cal-fraction 0.5 \
    --output label_curve.csv
```

**`tests/test_svm_training.py`, `tests/test_label_curve.py`** — 54 new tests covering shape contracts, calibration-mode selection (default, explicit, fallback), separable-blob AUROC, determinism, inclusion-bias-as-class-weight semantics, ranking metric correctness, the cross-calibrated threshold helper, and end-to-end sweep schema including diagnostic / non-diagnostic summary modes.

## Why standalone (not wired into `DetectorContext.model`)

The MLP path serializes via `state_dict → nested lists` (`build_model_from_weights`) and the model registry assumes an `nn.Sequential` shape. Replicating that for sklearn estimators is a real refactor and not worth doing until the sweep shows SVMs actually win in some regime. The prototype is enough to run the experiments described in the discussion thread.

## Test plan

- [x] `./run-tests.sh` — 3282 passed, 1 skipped (full suite green)
- [x] `python -m pytest tests/test_svm_training.py tests/test_label_curve.py` — 54 passed
- [x] `ruff check` clean on all new files
- [ ] Run sweep against `esc50_s` + an image demo dataset (follow-up — needs dataset download)

https://claude.ai/code/session_01ATtnrSkicGsJH2WTqEwkWa