### PR TITLE
Halve calibrate_count default and cache thresholds across no-op resorts

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -131,7 +131,7 @@ class TestSettingsModule:
         assert settings_mod.get_calibrate_count() == 1
 
     def test_calibrate_count_default(self):
-        assert settings_mod.get_calibrate_count() == 2
+        assert settings_mod.get_calibrate_count() == 1
 
     def test_calibrate_count_persists_across_reset(self, isolated_settings):
         settings_mod.set_calibrate_count(10)
@@ -467,7 +467,7 @@ class TestSettingsModule:
         defaults = settings_mod.get_defaults()
         assert defaults["volume"] == 1.0
         assert defaults["theme"] == "dark"
-        assert defaults["calibrate_count"] == 2
+        assert defaults["calibrate_count"] == 1
         assert defaults["calibration_fraction"] == 0.5
         assert defaults["safe_thresholds"] is False
         assert defaults["show_metadata"] is True

--- a/tests/test_settings_api_routes.py
+++ b/tests/test_settings_api_routes.py
@@ -117,7 +117,7 @@ class TestSettingsAPI:
         data = res.get_json()
         assert data["volume"] == 1.0
         assert data["theme"] == "dark"
-        assert data["calibrate_count"] == 2
+        assert data["calibrate_count"] == 1
         assert data["calibration_fraction"] == 0.5
         assert data["safe_thresholds"] is False
         assert isinstance(data["focus_mode_left"], dict)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -388,6 +388,152 @@ class TestCalibrateCountEnvDefault:
         assert isinstance(config.DEFAULT_CALIBRATE_COUNT, int)
         assert config.DEFAULT_CALIBRATE_COUNT >= 1
 
+
+class TestCalibrationCache:
+    """When the same labels are passed twice in a row with the same settings,
+    the cross-calibration trainings should be skipped on the second call."""
+
+    def _det_ctx(self):
+        from vtsearch.utils.state_core import DetectorContext
+
+        return DetectorContext("test-det")
+
+    def _seed_six_labels(self):
+        # Six labels puts us above the ``< 6`` skip floor so calibration
+        # actually runs (and can therefore be cached).
+        app_module.good_votes.update({k: None for k in [1, 2, 3]})
+        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+
+    def test_second_call_with_same_inputs_skips_calibration(self):
+        from vtsearch.models import training
+
+        self._seed_six_labels()
+        det_ctx = self._det_ctx()
+
+        training.train_and_score(
+            app_module.medias,
+            app_module.good_votes,
+            app_module.bad_votes,
+            det_ctx=det_ctx,
+        )
+        assert det_ctx.calibration_cache is not None
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            side_effect=AssertionError("calibration should be cached on repeat call"),
+        ) as patched:
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+                det_ctx=det_ctx,
+            )
+        patched.assert_not_called()
+
+    def test_second_call_returns_same_threshold(self):
+        from vtsearch.models import training
+
+        self._seed_six_labels()
+        det_ctx = self._det_ctx()
+
+        _, t1, _ = training.train_and_score(
+            app_module.medias,
+            app_module.good_votes,
+            app_module.bad_votes,
+            det_ctx=det_ctx,
+        )
+        _, t2, _ = training.train_and_score(
+            app_module.medias,
+            app_module.good_votes,
+            app_module.bad_votes,
+            det_ctx=det_ctx,
+        )
+        assert t1 == t2
+
+    def test_label_change_invalidates_cache(self):
+        from vtsearch.models import training
+
+        self._seed_six_labels()
+        det_ctx = self._det_ctx()
+
+        training.train_and_score(
+            app_module.medias,
+            app_module.good_votes,
+            app_module.bad_votes,
+            det_ctx=det_ctx,
+        )
+        first_key = det_ctx.calibration_cache[0]
+
+        # Flip one media's label — calibration must recompute.
+        app_module.good_votes.pop(3)
+        app_module.bad_votes[3] = None
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            wraps=training.calculate_cross_calibration_threshold,
+        ) as patched:
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+                det_ctx=det_ctx,
+            )
+        assert patched.call_count == 1
+        assert det_ctx.calibration_cache[0] != first_key
+
+    def test_inclusion_change_invalidates_cache(self):
+        from vtsearch.models import training
+
+        self._seed_six_labels()
+        det_ctx = self._det_ctx()
+
+        training.train_and_score(
+            app_module.medias,
+            app_module.good_votes,
+            app_module.bad_votes,
+            inclusion_value=0,
+            det_ctx=det_ctx,
+        )
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            wraps=training.calculate_cross_calibration_threshold,
+        ) as patched:
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+                inclusion_value=2,
+                det_ctx=det_ctx,
+            )
+        assert patched.call_count == 1
+
+    def test_no_cache_when_det_ctx_missing(self):
+        """Without a det_ctx, every call must recompute calibration."""
+        from vtsearch.models import training
+
+        self._seed_six_labels()
+
+        with unittest.mock.patch.object(
+            training,
+            "calculate_cross_calibration_threshold",
+            wraps=training.calculate_cross_calibration_threshold,
+        ) as patched:
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+            )
+            training.train_and_score(
+                app_module.medias,
+                app_module.good_votes,
+                app_module.bad_votes,
+            )
+        assert patched.call_count == 2
+
     def test_settings_default_matches_config(self):
         from vtsearch import config, settings
 

--- a/vtsearch/config.py
+++ b/vtsearch/config.py
@@ -105,8 +105,11 @@ TRAIN_PATIENCE = int(os.environ.get("VTSEARCH_TRAIN_PATIENCE", "10"))
 # Default ``calibrate_count`` baked into ``data/settings.json`` on first run.
 # Each unit adds one full fold-training pass per learned-sort; lower it to
 # trade calibration quality for latency.  Min 1 (clamped in
-# :mod:`vtsearch.settings`).
-DEFAULT_CALIBRATE_COUNT = max(1, int(os.environ.get("VTSEARCH_CALIBRATE_COUNT", "2")))
+# :mod:`vtsearch.settings`).  The default is 1: with
+# ``calibration_fraction=0.5`` a single fold already trains on half the
+# labels, and a second fold mostly averages out per-split noise — bumping
+# back up is a one-setting change when the noise actually matters.
+DEFAULT_CALIBRATE_COUNT = max(1, int(os.environ.get("VTSEARCH_CALIBRATE_COUNT", "1")))
 MLP_HIDDEN_MIN = 4
 MLP_HIDDEN_MAX = 32
 MLP_DROPOUT = 0.5

--- a/vtsearch/models/labelset_training.py
+++ b/vtsearch/models/labelset_training.py
@@ -231,11 +231,13 @@ def labelset_train_and_score(
     import torch
 
     from vtsearch.models import (
-        calculate_cross_calibration_threshold,
         calculate_safe_threshold,
         train_model,
     )
-    from vtsearch.models.training import _auto_hidden_dim
+    from vtsearch.models.training import (
+        _auto_hidden_dim,
+        cross_calibration_threshold_cached,
+    )
 
     populate_label_embeddings(det_ctx, labelset, media_type=media_type, snap=clips_dict)
     X_list, y_list = build_xy_from_labelset(det_ctx, labelset)
@@ -256,16 +258,15 @@ def labelset_train_and_score(
     if len(X_list) < 6:
         threshold = 0.5
     else:
-        cal_rng = np.random.RandomState(42)
-        threshold = calculate_cross_calibration_threshold(
+        threshold = cross_calibration_threshold_cached(
             X_list,
             y_list,
             input_dim,
             inclusion_value,
-            rng=cal_rng,
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
+            det_ctx=det_ctx,
         )
 
     model = train_model(X, y, input_dim, inclusion_value, hidden_dim=hidden_dim)

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -84,6 +84,86 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         return float(np.median(scores))
 
 
+def _calibration_cache_key(
+    X_list: list,
+    y_list: list[float],
+    inclusion_value: int,
+    calibrate_count: int,
+    calibration_fraction: float,
+    hidden_dim: int,
+) -> tuple:
+    """Build a deterministic cache key for cross-calibration inputs.
+
+    ``calculate_cross_calibration_threshold`` is a deterministic function of
+    these inputs (the RNG is seeded with 42 at every call site that uses the
+    cache), so two calls with matching keys must produce the same threshold.
+    The key encodes the raw training vectors (not just the label IDs) so that
+    a labelset re-resolved to different embeddings — e.g. after the embedder
+    changes — invalidates the cache automatically.
+    """
+    X_bytes = np.stack(X_list).astype(np.float32, copy=False).tobytes()
+    y_bytes = np.asarray(y_list, dtype=np.float32).tobytes()
+    return (
+        X_bytes,
+        y_bytes,
+        int(inclusion_value),
+        int(calibrate_count),
+        float(calibration_fraction),
+        int(hidden_dim),
+    )
+
+
+def cross_calibration_threshold_cached(
+    X_list: list,
+    y_list: list[float],
+    input_dim: int,
+    inclusion_value: int,
+    *,
+    calibrate_count: int,
+    calibration_fraction: float,
+    hidden_dim: int,
+    det_ctx: Any = None,
+) -> float:
+    """Memoized wrapper around :func:`calculate_cross_calibration_threshold`.
+
+    When *det_ctx* is provided, stores the last computed threshold on
+    ``det_ctx.calibration_cache`` and reuses it on the next call when every
+    input matches.  This is the common case during interactive sorting: the
+    user toggles ``inclusion`` or loads a new media item, the labels stay
+    the same, and recomputing two ~200-epoch fold fits would produce the
+    same number we computed last time.
+
+    A real label change produces a different cache key and falls through
+    to a fresh calibration — no explicit invalidation needed.
+    """
+    if det_ctx is not None:
+        key = _calibration_cache_key(
+            X_list, y_list, inclusion_value, calibrate_count, calibration_fraction, hidden_dim,
+        )
+        cached = getattr(det_ctx, "calibration_cache", None)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+    else:
+        key = None
+
+    rng = np.random.RandomState(42)
+    threshold = calculate_cross_calibration_threshold(
+        X_list,
+        y_list,
+        input_dim,
+        inclusion_value,
+        rng=rng,
+        calibrate_count=calibrate_count,
+        calibration_fraction=calibration_fraction,
+        hidden_dim=hidden_dim,
+    )
+
+    if det_ctx is not None and key is not None:
+        det_ctx.calibration_cache = (key, threshold)
+
+    return threshold
+
+
 def _auto_hidden_dim(n_train: int) -> int:
     """Choose hidden-layer width based on training-set size.
 
@@ -508,6 +588,7 @@ def train_and_score(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     vote_region_boxes: dict[int, tuple[float, float, float, float]] | None = None,
+    det_ctx: Any = None,
 ) -> tuple[list[dict[str, Any]], float, nn.Sequential | None]:
     """Train a small MLP on voted media embeddings and score every media.
 
@@ -591,16 +672,15 @@ def train_and_score(
     if len(X_list) < 6:
         threshold = 0.5
     else:
-        cal_rng = np.random.RandomState(42)
-        threshold = calculate_cross_calibration_threshold(
+        threshold = cross_calibration_threshold_cached(
             X_list,
             y_list,
             input_dim,
             inclusion_value,
-            rng=cal_rng,
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
+            det_ctx=det_ctx,
         )
 
     # Train final model on all data.  Training is image-level in v1 — the

--- a/vtsearch/models/training_workflow.py
+++ b/vtsearch/models/training_workflow.py
@@ -82,6 +82,7 @@ def apply_and_retrain(
                 calibrate_count=get_calibrate_count(),
                 calibration_fraction=get_calibration_fraction(),
                 vote_region_boxes=dict(vote_region_boxes),
+                det_ctx=det_ctx,
             )
             if model is not None:
                 det_ctx.model = model

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -317,6 +317,7 @@ def learned_sort():
                     calibrate_count=calibrate_count_value,
                     calibration_fraction=calibration_fraction_value,
                     vote_region_boxes=region_boxes_snapshot,
+                    det_ctx=det_ctx,
                 )
 
             # Store scores so the /api/votes endpoint can provide confidence info.

--- a/vtsearch/utils/state_core.py
+++ b/vtsearch/utils/state_core.py
@@ -160,6 +160,15 @@ class DetectorContext:
         "cached_labelset_media_type",  # str
         # Sync source
         "labelset_source",  # dict | None — {"source_name": "...", "field_values": {...}}
+        # Calibration threshold cache.  Holds ``(key, threshold)`` where *key*
+        # is a deterministic fingerprint of the inputs to
+        # :func:`calculate_cross_calibration_threshold` (training vectors,
+        # labels, inclusion, calibrate_count, calibration_fraction,
+        # hidden_dim).  Reusing the cached threshold is safe iff *key*
+        # matches — calibration is a deterministic function of these inputs
+        # (seeded RNG), so a hit is a pure memoization, not a stale carry-
+        # over from a previously trained model.
+        "calibration_cache",  # tuple[Any, float] | None
     )
 
     def __init__(self, detector_id: str = "", *, name: str = "", media_type: str = "", embedder: str = "") -> None:
@@ -200,6 +209,7 @@ class DetectorContext:
         self.cached_labelset_media_type: str = ""
         # Sync source
         self.labelset_source: dict[str, Any] | None = None
+        self.calibration_cache: tuple[Any, float] | None = None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two speedups for learned-sort latency, neither of which crosses the "threshold from MLP#N doesn't apply to MLP#N+1" hazard line.

### #1: Default `calibrate_count` 2 → 1

`DEFAULT_CALIBRATE_COUNT` was 2: every learned-sort ran two ~200-epoch fold trainings on half-the-labels each, then averaged the two thresholds. With `calibration_fraction=0.5` a single fold already trains on half the labels, so the second fold was mostly smoothing per-split noise. Cuts the calibration cost in half. Users who want the smoothing back can bump `calibrate_count` in settings.

### #2: Calibration-threshold cache on `DetectorContext`

`calculate_cross_calibration_threshold` is a deterministic function of `(X, y, inclusion, calibrate_count, calibration_fraction, hidden_dim)` — the RNG is seeded at every call site — so memoizing the result across calls with matching inputs is safe.

Common case: the user toggles a view setting or new media loads, but the labels themselves don't change → cached threshold returned, both fold fits skipped.

Important non-claim: this is **not** a cross-model carry-over. The cache key encodes the raw `X`/`y` bytes, not a model fingerprint. A real label change produces a different key and triggers a fresh calibration automatically — no explicit invalidation needed. The threshold is never reused against a model trained on different labels.

### Why not also cache across label changes

A previous draft suggested reusing the threshold across adjacent fits (one new vote, same threshold). That's unsafe: each fit starts from a fresh Kaiming init and follows a different optimizer trajectory, so the sigmoid output scale can shift. The whole reason cross-calibration exists is to re-anchor the threshold to the *current* model's score distribution. This PR keeps that invariant.

## Test plan

- [x] `./run-tests.sh` — 3233 passed, 1 skipped
- [x] `ruff check` — clean
- [x] New `TestCalibrationCache` covers: hit on identical inputs, threshold equality, invalidation on label change, invalidation on inclusion change, no caching without `det_ctx`
- [x] Existing `TestCalibrationSkippedForTinyLabels` still passes — the `< 6` skip floor takes precedence over the cache

https://claude.ai/code/session_01KYZH21rZT6Q3yoiKzeuqT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYZH21rZT6Q3yoiKzeuqT3)_