### PR TITLE
Coalesce rapid learned-sort requests into a pending slot

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,22 +405,30 @@ def client():
 
 
 def _wait_for_job(job_manager, *, timeout: float = 30.0) -> None:
-    """Block until the current job in *job_manager* (if any) is done.
+    """Block until the running job (and any coalesced pending follow-up) finish.
 
-    Test helper that the route-level ``wait=true`` flag relies on so tests
-    can call the async endpoints synchronously without sprinkling poll
-    loops everywhere.
+    With the coalescing job manager, a ``start()`` issued while a job is
+    running ends up in the pending slot and gets promoted automatically
+    when the runner finishes.  Tests that issue several requests need to
+    wait for the whole chain to drain, not just the first job.
     """
     import time as _time
 
-    job = job_manager.current()
-    if job is None:
-        return
     deadline = _time.monotonic() + timeout
-    while job.status == "running" and _time.monotonic() < deadline:
-        job.done_event.wait(timeout=0.05)
-    if job.status == "running":
-        raise TimeoutError(f"Job {job.job_id} did not finish within {timeout}s")
+    while _time.monotonic() < deadline:
+        job = job_manager.current()
+        if job is None:
+            return
+        if job.status in ("running", "pending"):
+            job.done_event.wait(timeout=0.05)
+            continue
+        # Current is finished.  Yield briefly so any pending promotion
+        # spawned from _run can replace current before we re-check.
+        _time.sleep(0.01)
+        follow = job_manager.current()
+        if follow is None or follow.job_id == job.job_id:
+            return
+    raise TimeoutError(f"Job manager did not drain within {timeout}s")
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests/test_async_jobs.py
+++ b/tests/test_async_jobs.py
@@ -1,0 +1,245 @@
+"""Tests for the coalescing single-runner JobManager.
+
+The manager must guarantee:
+
+* Only one job runs at a time (no parallel training threads).
+* A ``start()`` issued while a job is running enqueues a single pending
+  job; further ``start()`` calls update the same pending in place and
+  return the same ``AsyncJob`` (latest signature wins).
+* When the running job finishes, the pending job is promoted and
+  spawned automatically.
+* When the running job raises, the pending is still promoted (the error
+  path must hand off).
+* The signature cache continues to short-circuit identical re-runs.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from vtsearch.utils.async_jobs import AsyncJob, JobManager
+
+
+def _make_target(release: threading.Event, started: threading.Event, marker: list):
+    """Return a target that records its signature, then waits to be released."""
+
+    def target(job: AsyncJob) -> None:
+        started.set()
+        marker.append(job.signature)
+        # Block until the test releases us so we can interleave more start() calls.
+        release.wait(timeout=5)
+        job.result = {"signature": job.signature}
+
+    return target
+
+
+class TestCoalescing:
+    def test_single_start_runs_immediately(self):
+        mgr = JobManager("test")
+        release = threading.Event()
+        started = threading.Event()
+        ran: list = []
+        release.set()  # let it run through immediately
+
+        job = mgr.start("sig-A", _make_target(release, started, ran))
+        assert job.status in ("running", "done")
+        assert job.done_event.wait(timeout=5)
+        assert job.status == "done"
+        assert ran == ["sig-A"]
+
+    def test_second_start_while_running_pends(self):
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        first = mgr.start("sig-A", _make_target(first_release, first_started, ran))
+        assert first_started.wait(timeout=5)
+        assert first.status == "running"
+
+        # Second start while first is running — must enqueue, not spawn.
+        second_release = threading.Event()
+        second_started = threading.Event()
+        second_release.set()
+        second = mgr.start("sig-B", _make_target(second_release, second_started, ran))
+        assert second.status == "pending"
+        assert second.job_id != first.job_id
+
+        # Second's target must NOT have run yet — only first is on a thread.
+        assert ran == ["sig-A"]
+        assert not second_started.is_set()
+
+        # Release first; second should be promoted automatically.
+        first_release.set()
+        assert second.done_event.wait(timeout=5)
+        assert ran == ["sig-A", "sig-B"]
+        assert second.status == "done"
+        assert first.status == "done"
+
+    def test_third_start_coalesces_into_pending(self):
+        """Rapid #100, #101, #102 → run #100, then run #102 (skip #101)."""
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        first = mgr.start("sig-A", _make_target(first_release, first_started, ran))
+        assert first_started.wait(timeout=5)
+
+        # Two more starts while first is running.
+        release_bc = threading.Event()
+        release_bc.set()
+        started_b = threading.Event()
+        started_c = threading.Event()
+        second = mgr.start("sig-B", _make_target(release_bc, started_b, ran))
+        third = mgr.start("sig-C", _make_target(release_bc, started_c, ran))
+
+        # Same pending object reused — latest signature wins.
+        assert second.job_id == third.job_id
+        assert third.signature == "sig-C"
+        assert second.signature == "sig-C"  # second was mutated in place
+        assert third.status == "pending"
+
+        first_release.set()
+        assert third.done_event.wait(timeout=5)
+        # Only sig-A and sig-C ran; sig-B was coalesced away.
+        assert ran == ["sig-A", "sig-C"]
+        assert not started_b.is_set(), "sig-B target should never have executed"
+        assert started_c.is_set(), "sig-C target should have executed as the coalesced pending"
+        # Both callers (#101 and #102) get the same job's result.
+        assert second.result == {"signature": "sig-C"}
+        assert third.result == {"signature": "sig-C"}
+
+    def test_no_parallel_threads_under_burst(self):
+        """N rapid starts must produce at most 2 actually-run targets:
+        the one that started first, plus the coalesced latest."""
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        first = mgr.start("sig-0", _make_target(first_release, first_started, ran))
+        assert first_started.wait(timeout=5)
+
+        followups_release = threading.Event()
+        followups_release.set()
+        followup = None
+        for i in range(1, 50):
+            followup = mgr.start(
+                f"sig-{i}",
+                _make_target(followups_release, threading.Event(), ran),
+            )
+            # Every one of them should land in the same pending slot.
+            assert followup.status == "pending"
+        assert followup is not None
+        assert followup.signature == "sig-49"
+
+        first_release.set()
+        assert followup.done_event.wait(timeout=5)
+        # Only two targets actually executed: sig-0 and sig-49.
+        assert ran == ["sig-0", "sig-49"]
+
+    def test_pending_promoted_after_running_job_raises(self):
+        """Even if the running job blows up, the pending must still run."""
+        mgr = JobManager("test")
+        first_release = threading.Event()
+        first_started = threading.Event()
+        ran: list = []
+
+        def boom(job: AsyncJob) -> None:
+            first_started.set()
+            first_release.wait(timeout=5)
+            raise RuntimeError("kaboom")
+
+        first = mgr.start("sig-A", boom)
+        assert first_started.wait(timeout=5)
+
+        second_release = threading.Event()
+        second_release.set()
+        second = mgr.start(
+            "sig-B", _make_target(second_release, threading.Event(), ran)
+        )
+        assert second.status == "pending"
+
+        first_release.set()
+        # Wait for first to finish (with error).
+        assert first.done_event.wait(timeout=5)
+        assert first.status == "error"
+        assert "kaboom" in (first.error or "")
+
+        # Pending must have been promoted regardless.
+        assert second.done_event.wait(timeout=5)
+        assert second.status == "done"
+        assert ran == ["sig-B"]
+
+    def test_signature_cache_works_across_coalesced_runs(self):
+        """After a coalesced run completes, an identical-signature start()
+        short-circuits via cached_for()."""
+        mgr = JobManager("test")
+        release = threading.Event()
+        release.set()
+        ran: list = []
+
+        job1 = mgr.start("sig-X", _make_target(release, threading.Event(), ran))
+        assert job1.done_event.wait(timeout=5)
+        assert job1.status == "done"
+
+        # Same signature → cached_for hits.
+        cached = mgr.cached_for("sig-X")
+        assert cached is not None
+        assert cached.job_id == job1.job_id
+
+        # Different signature misses the cache.
+        assert mgr.cached_for("sig-Y") is None
+
+    def test_serial_starts_after_idle_do_not_enqueue(self):
+        """When nothing is running, start() should spawn immediately, not
+        pend — the pending slot is only used while a job is in flight."""
+        mgr = JobManager("test")
+        release = threading.Event()
+        release.set()
+        ran: list = []
+
+        job1 = mgr.start("sig-A", _make_target(release, threading.Event(), ran))
+        assert job1.done_event.wait(timeout=5)
+
+        job2 = mgr.start("sig-B", _make_target(release, threading.Event(), ran))
+        assert job2.status in ("running", "done")  # not pending
+        assert job2.done_event.wait(timeout=5)
+        assert ran == ["sig-A", "sig-B"]
+
+    def test_only_one_thread_runs_at_a_time(self):
+        """Sanity: even with overlapping starts, no two targets execute
+        concurrently.  Track concurrency with a counter."""
+        mgr = JobManager("test")
+        active = 0
+        max_active = 0
+        active_lock = threading.Lock()
+        gate = threading.Event()
+
+        def target(job: AsyncJob) -> None:
+            nonlocal active, max_active
+            with active_lock:
+                active += 1
+                max_active = max(max_active, active)
+            gate.wait(timeout=2)
+            with active_lock:
+                active -= 1
+            job.result = job.signature
+
+        first = mgr.start("sig-A", target)
+        # Pile on while first is running.
+        _ = [mgr.start(f"sig-{i}", target) for i in range(20)]
+
+        gate.set()
+        assert first.done_event.wait(timeout=5)
+        # Drain any promoted pending.
+        for _ in range(10):
+            cur = mgr.current()
+            if cur is None or cur.status == "done":
+                break
+            cur.done_event.wait(timeout=2)
+        assert max_active == 1

--- a/tests/test_async_jobs.py
+++ b/tests/test_async_jobs.py
@@ -16,9 +16,6 @@ The manager must guarantee:
 from __future__ import annotations
 
 import threading
-import time
-
-import pytest
 
 from vtsearch.utils.async_jobs import AsyncJob, JobManager
 
@@ -86,7 +83,7 @@ class TestCoalescing:
         first_started = threading.Event()
         ran: list = []
 
-        first = mgr.start("sig-A", _make_target(first_release, first_started, ran))
+        mgr.start("sig-A", _make_target(first_release, first_started, ran))
         assert first_started.wait(timeout=5)
 
         # Two more starts while first is running.
@@ -121,7 +118,7 @@ class TestCoalescing:
         first_started = threading.Event()
         ran: list = []
 
-        first = mgr.start("sig-0", _make_target(first_release, first_started, ran))
+        mgr.start("sig-0", _make_target(first_release, first_started, ran))
         assert first_started.wait(timeout=5)
 
         followups_release = threading.Event()

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -217,7 +217,7 @@ def eval_train_and_score_result():
     if job is None:
         return jsonify({"status": "missing", "error": "Job not found"}), 404
 
-    if job.status == "running":
+    if job.status in ("running", "pending"):
         prog = get_eval_progress()
         return jsonify({
             "job_id": job.job_id,

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -428,7 +428,7 @@ def learned_sort_result():
     if job is None:
         return jsonify({"status": "missing", "error": "Job not found"}), 404
 
-    if job.status == "running":
+    if job.status in ("running", "pending"):
         return jsonify({
             "job_id": job.job_id,
             "status": "running",

--- a/vtsearch/utils/async_jobs.py
+++ b/vtsearch/utils/async_jobs.py
@@ -7,11 +7,20 @@ module lets those endpoints push the heavy work onto a background daemon
 thread so the request handler can return immediately with a job id, freeing
 the worker thread to serve other requests while training runs.
 
-Each :class:`JobManager` is a *single-slot* runner: starting a new job
-cancels the in-flight one (callers can re-derive at any time).  Results from
-the most recent successful run are kept in a tiny ring so a follow-up
-request with the same signature can short-circuit and return immediately —
-the "re-sort without new votes is free" fast path.
+Each :class:`JobManager` runs **one** background job at a time and keeps a
+single coalescing pending slot.  When a new ``start()`` arrives while a job
+is running, its target+signature are stashed as *pending*; if another
+``start()`` arrives before the runner picks the pending slot up, the
+pending slot is updated in place (latest wins) and the same job object is
+returned.  When the running job finishes, the pending job is promoted and
+spawned automatically.  This avoids the previous design's failure mode
+where rapid-fire requests spawned parallel training threads that fought
+for CPU/GPU — cancellation was cooperative-only and never honoured inside
+the training loop.
+
+Results from the most recent successful run are kept by *signature* so a
+follow-up request with an unchanged signature can short-circuit and return
+the previous result — the "re-sort without new votes is free" fast path.
 """
 
 from __future__ import annotations
@@ -30,7 +39,7 @@ class AsyncJob:
 
     job_id: str
     signature: Any = None
-    status: str = "running"  # "running" | "done" | "error" | "cancelled"
+    status: str = "running"  # "pending" | "running" | "done" | "error" | "cancelled"
     result: Any = None
     error: str | None = None
     current: int = 0
@@ -57,12 +66,17 @@ class AsyncJob:
 
 
 class JobManager:
-    """Single-slot, signature-keyed background job runner.
+    """Single-runner, signature-keyed background job manager with one pending slot.
 
-    Starting a new job cancels any in-flight one.  Results from the most
-    recently completed job are cached by *signature* so that a follow-up
-    call with an unchanged signature reuses the previous result instead of
-    re-running.
+    Only one job runs at a time.  A second ``start()`` while a job is in
+    flight stashes the new target+signature in a pending slot; further
+    ``start()`` calls update the pending slot in place (latest wins) and
+    return the same pending job object.  When the running job finishes,
+    the pending job is promoted and spawned.
+
+    Results from the most recently completed job are cached by *signature*
+    so a follow-up call with an unchanged signature reuses the previous
+    result instead of re-running.
     """
 
     def __init__(self, name: str, max_history: int = 8) -> None:
@@ -70,6 +84,8 @@ class JobManager:
         self._lock = threading.RLock()
         self._jobs: dict[str, AsyncJob] = {}
         self._current_id: str | None = None
+        self._pending: AsyncJob | None = None
+        self._pending_target: Callable[[AsyncJob], Any] | None = None
         self._last_done: AsyncJob | None = None
         self._max_history = max_history
 
@@ -104,16 +120,40 @@ class JobManager:
         signature: Any,
         target: Callable[[AsyncJob], Any],
     ) -> AsyncJob:
-        """Start a new job.  Cancels the in-flight one if any.
+        """Start (or coalesce into pending) a job.
+
+        If no job is running, *target* spawns immediately on a daemon
+        thread.  If a job is already running, the new (signature, target)
+        is stashed in the pending slot — overwriting any existing pending
+        — and the same pending :class:`AsyncJob` is returned on every
+        subsequent call until the runner picks it up.
 
         *target* receives the :class:`AsyncJob` and should assign
         ``job.result`` before returning.  Raising propagates as
         ``status = "error"``.
         """
+        spawn_job: AsyncJob | None = None
         with self._lock:
             prev = self._jobs.get(self._current_id) if self._current_id else None
             if prev is not None and prev.status == "running":
-                prev.cancel()
+                if self._pending is not None:
+                    # Coalesce: update the existing pending in place so all
+                    # callers waiting on this job_id receive the latest run.
+                    self._pending.signature = signature
+                    self._pending_target = target
+                    return self._pending
+                job = AsyncJob(
+                    job_id=uuid.uuid4().hex,
+                    signature=signature,
+                    status="pending",
+                    started_at=time.time(),
+                )
+                self._jobs[job.job_id] = job
+                self._pending = job
+                self._pending_target = target
+                self._prune_locked()
+                return job
+
             job = AsyncJob(
                 job_id=uuid.uuid4().hex,
                 signature=signature,
@@ -123,14 +163,18 @@ class JobManager:
             self._jobs[job.job_id] = job
             self._current_id = job.job_id
             self._prune_locked()
+            spawn_job = job
 
+        self._spawn_thread(spawn_job, target)
+        return job
+
+    def _spawn_thread(self, job: AsyncJob, target: Callable[[AsyncJob], Any]) -> None:
         threading.Thread(
             target=self._run,
             args=(job, target),
             name=f"{self._name}-{job.job_id[:8]}",
             daemon=True,
         ).start()
-        return job
 
     def _run(self, job: AsyncJob, target: Callable[[AsyncJob], Any]) -> None:
         try:
@@ -140,11 +184,15 @@ class JobManager:
             with self._lock:
                 job.status = "error"
                 job.error = str(exc) or exc.__class__.__name__
+                job.finished_at = time.time()
+                job.done_event.set()
+            self._promote_pending_if_any()
             return
-        finally:
-            job.finished_at = time.time()
 
+        next_job: AsyncJob | None = None
+        next_target: Callable[[AsyncJob], Any] | None = None
         with self._lock:
+            job.finished_at = time.time()
             if job.is_cancelled and job.status == "running":
                 job.status = "cancelled"
             elif job.status == "running":
@@ -152,12 +200,46 @@ class JobManager:
                 self._last_done = job
             job.done_event.set()
 
+            if self._pending is not None:
+                next_job = self._pending
+                next_target = self._pending_target
+                self._pending = None
+                self._pending_target = None
+                next_job.status = "running"
+                next_job.started_at = time.time()
+                self._current_id = next_job.job_id
+
+        if next_job is not None and next_target is not None:
+            self._spawn_thread(next_job, next_target)
+
+    def _promote_pending_if_any(self) -> None:
+        """Promote the pending slot to running and spawn it, if present.
+
+        Called from the error path so a failed job still hands off to the
+        coalesced next request.
+        """
+        next_job: AsyncJob | None = None
+        next_target: Callable[[AsyncJob], Any] | None = None
+        with self._lock:
+            if self._pending is not None:
+                next_job = self._pending
+                next_target = self._pending_target
+                self._pending = None
+                self._pending_target = None
+                next_job.status = "running"
+                next_job.started_at = time.time()
+                self._current_id = next_job.job_id
+        if next_job is not None and next_target is not None:
+            self._spawn_thread(next_job, next_target)
+
     def _prune_locked(self) -> None:
         if len(self._jobs) <= self._max_history:
             return
         keep: set[str] = set()
         if self._current_id:
             keep.add(self._current_id)
+        if self._pending is not None:
+            keep.add(self._pending.job_id)
         if self._last_done is not None:
             keep.add(self._last_done.job_id)
         # Keep the most recent N by start time
@@ -174,10 +256,12 @@ class JobManager:
         """Cancel any running job and clear all stored state."""
         with self._lock:
             for j in self._jobs.values():
-                if j.status == "running":
+                if j.status in ("running", "pending"):
                     j.cancel()
             self._jobs.clear()
             self._current_id = None
+            self._pending = None
+            self._pending_target = None
             self._last_done = None
 
 


### PR DESCRIPTION
## Problem

The single-slot `JobManager` used to call `cancel()` on the in-flight job whenever a new `start()` arrived.  Cancellation is cooperative-only, and the training loop in `vtsearch/models/training.py` never checks `is_cancelled()` — so a rapid burst of votes during a 1.5s training actually spawned **N parallel training threads** that fought for the same CPU/GPU and made every individual training slower.  Under that load, the user could click forever and never see a fresh sort.

Worse, this also burned compute that nobody waited for: every cancelled job ran to completion in the background just to have its result thrown away by the `is_cancelled` check at the very end.

## Fix

Switch `JobManager` from "cancel-and-restart" to "one runner + one pending slot":

- A `start()` while a job is running stashes the new `(signature, target)` as **pending** and returns a new `AsyncJob` with `status="pending"`.
- A second `start()` before the pending is picked up **updates the pending in place** (latest signature wins) and returns the *same* job object — so every caller that polled the pending job_id sees the same eventual result.
- When the running job finishes (success **or** error), the pending is promoted to running and spawned automatically.

This guarantees forward progress: each training completes, every completed live MLP donates to `_live_models` for the Smart/Stable metrics worker, and resource contention disappears.

## Impact on Smart/Stable metrics

None on correctness.  The metrics worker walks `label_history` and trains its own MLP at every step where `_live_models` has no donation — coalesced trainings just mean the worker fills a few more gaps itself in the background.  Curve completeness is unchanged.

## Test plan

- [x] New `tests/test_async_jobs.py` covers: single start runs immediately, second start while running pends, third start coalesces into existing pending (verifies sig-B target never executes), 50-rapid-start burst produces exactly 2 actual runs, pending promotes even after the running job raises, signature cache hits across coalesced runs, no-op when nothing is running, concurrency counter never exceeds 1.
- [x] Existing `tests/test_sorting.py` async tests still pass (polling endpoints, signature cache short-circuit).
- [x] Full `./run-tests.sh` suite: 3295 passed.
- [x] `ruff check` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SZDafSD21j4RsKAL9WGCBH)_