### PR TITLE
Keyboard shortcut help overlay (press ? to open)

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -62,6 +62,16 @@
   <span class="top-bar-field" title="The currently active detector used for scoring and sorting"><strong>Detector:</strong> <span class="top-bar-value">{{ modelDisplayName }}</span></span>
   <span class="top-bar-spacer"></span>
   <button
+    class="help-btn"
+    aria-label="Keyboard shortcuts"
+    title="Keyboard shortcuts (?)"
+    (click)="showKeyboardHelp = true"
+  ><svg aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.2"/>
+      <path d="M5.8 6.2a2.2 2.2 0 014.4 0c0 1.1-.8 1.5-1.5 2-.5.3-.7.7-.7 1.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+      <circle cx="8" cy="12" r="0.7" fill="currentColor"/>
+    </svg></button>
+  <button
     class="settings-btn"
     aria-label="Settings"
     title="Settings"
@@ -78,6 +88,9 @@
 </div>
 @if (showSettings) {
   <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="onSettingsClosed()" />
+}
+@if (showKeyboardHelp) {
+  <vt-keyboard-help-modal (closed)="onKeyboardHelpClosed()" />
 }
 <vt-dialog-host />
 <vt-achievement-unlock-host />

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -160,6 +160,34 @@ header {
   flex: 1;
 }
 
+.help-btn {
+  background: transparent;
+  border: 1px solid var(--header-btn-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  padding: var(--space-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  flex-shrink: 0;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--header-text-dim);
+  }
+
+  &:hover {
+    background: var(--header-btn-hover-bg);
+    border-color: var(--header-btn-hover-border);
+
+    svg {
+      color: var(--header-text);
+    }
+  }
+}
+
 .settings-btn {
   background: transparent;
   border: 1px solid var(--header-btn-border);

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
 import { AchievementUnlockHostComponent } from './components/achievement-unlock-host/achievement-unlock-host.component';
 import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
+import { KeyboardHelpModalComponent } from './components/modals/keyboard-help-modal/keyboard-help-modal.component';
 import { LoginComponent } from './components/login/login.component';
 import { MediaStateService } from './services/media-state.service';
 import { DatasetStateService } from './services/dataset-state.service';
@@ -15,7 +16,7 @@ import { AchievementsService } from './services/achievements.service';
 import { ThemeService } from './services/theme.service';
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, RouterOutlet, DialogHostComponent, AchievementUnlockHostComponent, SettingsModalComponent, LoginComponent],
+  imports: [CommonModule, RouterOutlet, DialogHostComponent, AchievementUnlockHostComponent, SettingsModalComponent, KeyboardHelpModalComponent, LoginComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
@@ -23,6 +24,7 @@ export class AppComponent {
   title = 'VTSearch';
   menuOpen = false;
   showSettings = false;
+  showKeyboardHelp = false;
   gearClosing = false;
   isOnLabelView = false;
   settingsViewTab = '';
@@ -81,6 +83,32 @@ export class AppComponent {
     if (this.menuOpen) {
       this.menuOpen = false;
     }
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onDocumentKeydown(event: KeyboardEvent): void {
+    if (event.key !== '?') return;
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (this.isTypingTarget(event.target)) return;
+    event.preventDefault();
+    this.showKeyboardHelp = !this.showKeyboardHelp;
+  }
+
+  private isTypingTarget(target: EventTarget | null): boolean {
+    const el = target as HTMLElement | null;
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === 'INPUT') {
+      const type = (el as HTMLInputElement).type;
+      if (type !== 'checkbox' && type !== 'radio' && type !== 'range') return true;
+    }
+    if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (el.isContentEditable) return true;
+    return false;
+  }
+
+  onKeyboardHelpClosed(): void {
+    this.showKeyboardHelp = false;
   }
 
   onMenuKeydown(event: KeyboardEvent): void {

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
@@ -1,0 +1,25 @@
+<vt-modal title="Keyboard shortcuts" [open]="true" (closed)="close()">
+  <div class="kbd-help">
+    @for (group of groups; track group.title) {
+      <section class="kbd-group">
+        <h3 class="kbd-group-title">{{ group.title }}</h3>
+        <ul class="kbd-list">
+          @for (sc of group.shortcuts; track sc.description) {
+            <li class="kbd-row">
+              <span class="kbd-keys">
+                @for (k of sc.keys; track k; let last = $last) {
+                  <kbd class="kbd-key">{{ k }}</kbd>
+                  @if (!last) {
+                    <span class="kbd-plus">+</span>
+                  }
+                }
+              </span>
+              <span class="kbd-desc">{{ sc.description }}</span>
+            </li>
+          }
+        </ul>
+      </section>
+    }
+    <p class="kbd-hint">Press <kbd class="kbd-key">?</kbd> any time to open this sheet.</p>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -1,0 +1,70 @@
+.kbd-help {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+  min-width: 360px;
+  max-width: 560px;
+}
+
+.kbd-group-title {
+  margin: 0 0 var(--space-sm);
+  font-size: var(--font-lg);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-xs);
+}
+
+.kbd-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.kbd-row {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) 1fr;
+  align-items: center;
+  gap: var(--space-lg);
+  padding: var(--space-xs) 0;
+}
+
+.kbd-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.kbd-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0.1rem 0.4rem;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--font-sm);
+  color: var(--text-primary);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-sm, 4px);
+  line-height: 1.2;
+}
+
+.kbd-plus {
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}
+
+.kbd-desc {
+  color: var(--text-secondary, var(--text-primary));
+}
+
+.kbd-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -1,0 +1,64 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalComponent } from '../../modal/modal.component';
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: Shortcut[];
+}
+
+@Component({
+  selector: 'vt-keyboard-help-modal',
+  standalone: true,
+  imports: [CommonModule, ModalComponent],
+  templateUrl: './keyboard-help-modal.component.html',
+  styleUrl: './keyboard-help-modal.component.scss',
+})
+export class KeyboardHelpModalComponent {
+  @Output() closed = new EventEmitter<void>();
+
+  readonly groups: ShortcutGroup[] = [
+    {
+      title: 'Voting',
+      shortcuts: [
+        { keys: ['→'], description: 'Vote good (👍)' },
+        { keys: ['←'], description: 'Vote bad (👎)' },
+      ],
+    },
+    {
+      title: 'Playback',
+      shortcuts: [
+        { keys: ['Space'], description: 'Play / pause audio or video' },
+        { keys: ['↑'], description: 'Volume up' },
+        { keys: ['↓'], description: 'Volume down' },
+      ],
+    },
+    {
+      title: 'Image viewer',
+      shortcuts: [
+        { keys: ['+'], description: 'Zoom in' },
+        { keys: ['-'], description: 'Zoom out' },
+        { keys: ['['], description: 'Rotate left' },
+        { keys: [']'], description: 'Rotate right' },
+        { keys: ['Shift', 'drag'], description: 'Draw region box (patch embedder)' },
+        { keys: ['Esc'], description: 'Cancel armed vote / clear region box' },
+      ],
+    },
+    {
+      title: 'General',
+      shortcuts: [
+        { keys: ['?'], description: 'Show this help' },
+        { keys: ['Esc'], description: 'Close modal or dropdown' },
+      ],
+    },
+  ];
+
+  close(): void {
+    this.closed.emit();
+  }
+}


### PR DESCRIPTION
## Summary

Implements Feature-brainstorm #11.2 — a keyboard-shortcut help sheet that opens when you press `?`. Fixes onboarding fragility by making every binding discoverable in one click.

- New `KeyboardHelpModalComponent` listing every shortcut, grouped: Voting, Playback, Image viewer, General.
- Global `?` keybinding (works on dashboard, label view, and find view) via a `document:keydown` `HostListener` on `AppComponent`. Skips when typing in inputs/textareas/contenteditable, and ignores modifier-key combinations.
- Help button in the top bar (next to the gear) with a `?`-mark icon, tooltip `Keyboard shortcuts (?)`.
- The existing `KeyboardService` already gates its bindings on `.modal-backdrop` not being present, so the label-view arrow/space shortcuts cleanly stand down while the overlay is open.
- No backend changes; no settings persistence (the overlay is ephemeral).

## Test plan

- [x] `cd frontend && npm run build:prod` — clean, zero warnings, all bundles within budget.
- [x] `./run-tests.sh core` — 426/426 passing.
- [ ] Manually open the app, press `?` from dashboard and from label view; verify the modal appears and that arrow keys don't cast votes while it's open.
- [ ] Press `?` again (or Esc, or the close button, or backdrop click) to dismiss.
- [ ] Press `?` while focus is inside a text input — verify the input receives the `?` character and the modal does NOT open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01452fPPEnRjM18AyYQLVUVc)_