### PR TITLE
Cmd/Ctrl-Z undo (and Shift-Z redo) for votes

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -89,6 +89,10 @@
       </div>
     }
 
+    @if (undoToastText) {
+      <div class="undo-toast" role="status" aria-live="polite">{{ undoToastText }}</div>
+    }
+
     <vt-voting-overlay
       [isGood]="isGood"
       [isBad]="isBad"

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -202,3 +202,23 @@
   font-size: 0.8rem;
   text-align: center;
 }
+
+.undo-toast {
+  flex-shrink: 0;
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.15));
+  border-radius: 4px;
+  background: var(--bg-subtle, rgba(0, 0, 0, 0.4));
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  text-align: center;
+  animation: undo-toast-fade 2s ease-out;
+}
+
+@keyframes undo-toast-fade {
+  0% { opacity: 0; }
+  10% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -46,6 +46,10 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   swipeClass = '';
   spinningVote: 'good' | 'bad' | null = null;
 
+  /** Transient text shown after Cmd/Ctrl-Z; auto-cleared after a short delay. */
+  undoToastText: string | null = null;
+  private undoToastTimer: ReturnType<typeof setTimeout> | null = null;
+
   // Bad-vote-with-box state: drawing a box is real work, so a stray ← shouldn't
   // throw it away. The first ← arms a sticky discard-confirm state (no timeout);
   // the second ← throws the box away and votes no. Esc, a mousedown on the box,
@@ -83,6 +87,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.keyboard.stop();
     this.subs.forEach((s) => s.unsubscribe());
     if (this.spinTimer) clearTimeout(this.spinTimer);
+    if (this.undoToastTimer) clearTimeout(this.undoToastTimer);
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
   }
 
@@ -133,9 +138,26 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
               else this.imageViewer.rotateRight();
             }
             break;
+          case 'undo':
+            if (!this.disabled && !this.isVoting) this.voteState.undo();
+            break;
+          case 'redo':
+            if (!this.disabled && !this.isVoting) this.voteState.redo();
+            break;
         }
       }),
+      this.voteState.toast$.subscribe((t) => this.showUndoToast(t.action, t.mediaName)),
     );
+  }
+
+  private showUndoToast(action: 'undo' | 'redo', mediaName: string): void {
+    const verb = action === 'undo' ? 'Undid vote on' : 'Redid vote on';
+    this.undoToastText = `${verb} ${mediaName}`;
+    if (this.undoToastTimer) clearTimeout(this.undoToastTimer);
+    this.undoToastTimer = setTimeout(() => {
+      this.undoToastText = null;
+      this.undoToastTimer = null;
+    }, 2000);
   }
 
   get mediaType(): string {
@@ -154,6 +176,11 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     if (!this.media) return {};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.media as any)['custom_metadata'] as Record<string, unknown> || {};
+  }
+
+  /** Human-readable label for an item used in undo toasts. */
+  private mediaDisplayName(media: MediaItem): string {
+    return media.filename || media.origin_name || `#${media.id}`;
   }
 
   formatMetadataValue(label: string, value: unknown): string {
@@ -192,6 +219,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     const regionBox = vote === 'good' ? this.currentRegionBox : null;
     this.pendingBadConfirm = false;
     this.isVoting = true;
+    this.voteState.recordVote(this.media.id, vote, this.mediaDisplayName(this.media));
 
     this.mediasApi.vote(this.media.id, vote, regionBox).subscribe({
       next: () => {

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -342,6 +342,9 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
     if (this.sortState.sortBusy) return;
+    const m = this.mediaState.medias.find((x) => x.id === event.id);
+    const name = m?.filename || m?.origin_name || `#${event.id}`;
+    this.voteState.recordVote(event.id, event.vote, name);
     this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.onMediaVoted(event);

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -600,11 +600,17 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
+    this.voteState.recordVote(event.id, event.vote, this.mediaDisplayName(event.id));
     this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.onMediaVoted(event);
       },
     });
+  }
+
+  private mediaDisplayName(id: number): string {
+    const m = this.mediaState.medias.find((x) => x.id === id);
+    return m?.filename || m?.origin_name || `#${id}`;
   }
 
   onMediaVoted(event: { id: number; vote: 'good' | 'bad' }): void {

--- a/frontend/src/app/services/keyboard.service.spec.ts
+++ b/frontend/src/app/services/keyboard.service.spec.ts
@@ -101,6 +101,41 @@ describe('KeyboardService', () => {
     document.body.removeChild(input);
   });
 
+  it('should emit undo on Cmd-Z and Ctrl-Z', () => {
+    service.start();
+    const actions: KeyboardAction[] = [];
+    service.action$.subscribe((a) => actions.push(a));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true }));
+    expect(actions.length).toBe(2);
+    expect(actions[0].type).toBe('undo');
+    expect(actions[1].type).toBe('undo');
+  });
+
+  it('should emit redo on Cmd-Shift-Z', () => {
+    service.start();
+    const actions: KeyboardAction[] = [];
+    service.action$.subscribe((a) => actions.push(a));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Z', metaKey: true, shiftKey: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, shiftKey: true }));
+    expect(actions.length).toBe(2);
+    expect(actions[0].type).toBe('redo');
+    expect(actions[1].type).toBe('redo');
+  });
+
+  it('should not emit undo when typing in an input', () => {
+    service.start();
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.appendChild(input);
+    input.focus();
+    const actions: KeyboardAction[] = [];
+    service.action$.subscribe((a) => actions.push(a));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true }));
+    expect(actions.length).toBe(0);
+    document.body.removeChild(input);
+  });
+
   it('should not listen after stop()', () => {
     service.start();
     service.stop();

--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -6,7 +6,7 @@ export type ZoomDirection = 'in' | 'out';
 export type RotateDirection = 'left' | 'right';
 
 export interface KeyboardAction {
-  type: 'vote' | 'volume' | 'playback' | 'zoom' | 'rotate';
+  type: 'vote' | 'volume' | 'playback' | 'zoom' | 'rotate' | 'undo' | 'redo';
   direction?: VoteDirection;
   volumeDelta?: number;
   zoomDirection?: ZoomDirection;
@@ -49,6 +49,16 @@ export class KeyboardService implements OnDestroy {
 
     // Skip when typing in text fields
     if (this.isTyping()) return;
+
+    // Cmd/Ctrl-Z (undo) and Cmd/Ctrl-Shift-Z (redo) are the only modifier
+    // shortcuts; everything below this point requires no modifiers.
+    if ((e.ctrlKey || e.metaKey) && !e.altKey && (e.key === 'z' || e.key === 'Z')) {
+      e.preventDefault();
+      (document.activeElement as HTMLElement)?.blur();
+      const type = e.shiftKey ? 'redo' : 'undo';
+      this.zone.run(() => this.action$.next({ type }));
+      return;
+    }
 
     // Skip when modifier keys are held
     if (e.ctrlKey || e.metaKey || e.altKey) return;

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -196,6 +196,107 @@ describe('VoteStateService', () => {
     discardPeriodicTasks();
   }));
 
+  describe('undo / redo stack', () => {
+    it('records the previous polarity at click time and POSTs the inverse on undo', () => {
+      service.applyOptimisticVote(5, 'good'); // pretend a vote landed
+      service.recordVote(5, 'good', 'foo.wav'); // capture state BEFORE another click
+      // We just recorded that previously (before next click) it was 'good'.
+      // Simulate the click that would follow: toggle off.
+      service.applyOptimisticVote(5, 'good');
+
+      service.undo();
+      // Inverse direction should be the *previous* polarity, restoring 'good'.
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ vote: 'good' });
+      req.flush({ ok: true });
+      httpMock.expectOne('/api/votes').flush({ good: [5], bad: [], click_times: {}, learned_scores: {} });
+
+      expect(service.canRedo()).toBeTrue();
+      expect(service.canUndo()).toBeFalse();
+    });
+
+    it('redo replays the original clicked direction', () => {
+      service.recordVote(7, 'bad', 'bar.wav'); // previous = null
+      service.applyOptimisticVote(7, 'bad');
+
+      service.undo();
+      httpMock.expectOne('/api/medias/7/vote').flush({ ok: true });
+      httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+
+      service.redo();
+      const req = httpMock.expectOne('/api/medias/7/vote');
+      expect(req.request.body).toEqual({ vote: 'bad' });
+      req.flush({ ok: true });
+      httpMock.expectOne('/api/votes').flush({ good: [], bad: [7], click_times: {}, learned_scores: {} });
+
+      expect(service.canRedo()).toBeFalse();
+      expect(service.canUndo()).toBeTrue();
+    });
+
+    it('a new recordVote clears the redo stack', () => {
+      service.recordVote(1, 'good', 'a');
+      service.applyOptimisticVote(1, 'good');
+      service.undo();
+      httpMock.expectOne('/api/medias/1/vote').flush({ ok: true });
+      httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+      expect(service.canRedo()).toBeTrue();
+
+      service.recordVote(2, 'bad', 'b');
+      expect(service.canRedo()).toBeFalse();
+    });
+
+    it('undo with empty stack is a no-op', () => {
+      service.undo();
+      httpMock.expectNone('/api/medias/0/vote');
+      expect(service.canUndo()).toBeFalse();
+    });
+
+    it('emits a toast on undo and redo', () => {
+      const toasts: { action: string; mediaName: string }[] = [];
+      service.toast$.subscribe((t) => toasts.push(t));
+
+      service.recordVote(9, 'good', 'pic.png');
+      service.applyOptimisticVote(9, 'good');
+      service.undo();
+      httpMock.expectOne('/api/medias/9/vote').flush({ ok: true });
+      httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+
+      service.redo();
+      httpMock.expectOne('/api/medias/9/vote').flush({ ok: true });
+      httpMock.expectOne('/api/votes').flush({ good: [9], bad: [], click_times: {}, learned_scores: {} });
+
+      expect(toasts).toEqual([
+        { action: 'undo', mediaName: 'pic.png' },
+        { action: 'redo', mediaName: 'pic.png' },
+      ]);
+    });
+
+    it('caps the past stack at 20 entries', () => {
+      for (let i = 0; i < 25; i++) {
+        service.recordVote(i, 'good', `m${i}`);
+      }
+      // Undo as many times as the stack should hold. Each pops one and POSTs.
+      let popped = 0;
+      while (service.canUndo()) {
+        service.undo();
+        const req = httpMock.expectOne((r) => r.url.startsWith('/api/medias/') && r.url.endsWith('/vote'));
+        req.flush({ ok: true });
+        httpMock.expectOne('/api/votes').flush({ good: [], bad: [], click_times: {}, learned_scores: {} });
+        popped++;
+        if (popped > 30) throw new Error('runaway');
+      }
+      expect(popped).toBe(20);
+    });
+
+    it('clear() wipes the undo/redo stacks', () => {
+      service.recordVote(1, 'good', 'a');
+      expect(service.canUndo()).toBeTrue();
+      service.clear();
+      expect(service.canUndo()).toBeFalse();
+      expect(service.canRedo()).toBeFalse();
+    });
+  });
+
   it('goodVotes$ should emit on load', (done: DoneFn) => {
     const emissions: Set<number>[] = [];
     service.goodVotes$.subscribe((v) => emissions.push(v));

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -2,7 +2,27 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject, timer } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import { VotesResponse } from '../models/api.models';
+import { MediasApiService } from './medias-api.service';
 import { SortingApiService } from './sorting-api.service';
+
+/**
+ * One vote captured for Cmd/Ctrl-Z undo.  `previousPolarity` is the polarity
+ * the media had *before* the click that produced this entry, so undo can
+ * restore it with a single inverse POST to /api/medias/<id>/vote.
+ */
+export interface UndoEntry {
+  mediaId: number;
+  clickedDirection: 'good' | 'bad';
+  previousPolarity: 'good' | 'bad' | null;
+  mediaName: string;
+}
+
+export interface UndoToast {
+  action: 'undo' | 'redo';
+  mediaName: string;
+}
+
+const UNDO_STACK_MAX = 20;
 
 @Injectable({ providedIn: 'root' })
 export class VoteStateService implements OnDestroy {
@@ -18,14 +38,25 @@ export class VoteStateService implements OnDestroy {
   /** Tracks optimistic votes not yet confirmed by the server. */
   private pendingOptimistic = new Map<number, { vote: 'good' | 'bad'; clickTime: number }>();
 
+  /** Past votes available to undo, most-recent last.  Capped at UNDO_STACK_MAX. */
+  private past: UndoEntry[] = [];
+  /** Votes that have been undone and can be redone via Cmd/Ctrl-Shift-Z. */
+  private future: UndoEntry[] = [];
+  private readonly toastSubject = new Subject<UndoToast>();
+
   readonly goodVotes$ = this.goodVotesSubject.asObservable();
   readonly badVotes$ = this.badVotesSubject.asObservable();
   readonly clickTimes$ = this.clickTimesSubject.asObservable();
   readonly learnedScores$ = this.learnedScoresSubject.asObservable();
   readonly labelsetGoodCount$ = this.labelsetGoodCountSubject.asObservable();
   readonly labelsetBadCount$ = this.labelsetBadCountSubject.asObservable();
+  /** Emits a short message every time an undo or redo executes. */
+  readonly toast$ = this.toastSubject.asObservable();
 
-  constructor(private sortingApi: SortingApiService) {}
+  constructor(
+    private sortingApi: SortingApiService,
+    private mediasApi: MediasApiService,
+  ) {}
 
   ngOnDestroy(): void {
     this.destroy$.next();
@@ -151,6 +182,70 @@ export class VoteStateService implements OnDestroy {
     this.labelsetGoodCountSubject.next(0);
     this.labelsetBadCountSubject.next(0);
     this.pendingOptimistic.clear();
+    this.past = [];
+    this.future = [];
+  }
+
+  /**
+   * Snapshot the polarity *before* a vote click and push it onto the undo
+   * stack.  Must be called BEFORE applyOptimisticVote (otherwise the snapshot
+   * would already reflect the toggle).  Any pending redo entries are dropped,
+   * matching standard editor undo semantics.
+   */
+  recordVote(mediaId: number, clickedDirection: 'good' | 'bad', mediaName: string): void {
+    const previousPolarity: 'good' | 'bad' | null = this.goodVotesSubject.value.has(mediaId)
+      ? 'good'
+      : this.badVotesSubject.value.has(mediaId)
+        ? 'bad'
+        : null;
+    this.past.push({ mediaId, clickedDirection, previousPolarity, mediaName });
+    if (this.past.length > UNDO_STACK_MAX) this.past.shift();
+    this.future = [];
+  }
+
+  canUndo(): boolean {
+    return this.past.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.future.length > 0;
+  }
+
+  /**
+   * Reverse the most recent vote.  The inverse POST is:
+   *   - {@code previousPolarity} if non-null (restores prior state, including
+   *     polarity flips since /vote toggles mutual exclusion server-side), or
+   *   - {@code clickedDirection} if previousPolarity was null (toggles off).
+   *
+   * Side effects that aren't reversible (achievements, label_history append,
+   * click_counter monotonicity) are accepted — the user really did make the
+   * click; we just put the item back where it was.
+   */
+  undo(): void {
+    const entry = this.past.pop();
+    if (!entry) return;
+    this.future.push(entry);
+    const direction: 'good' | 'bad' = entry.previousPolarity ?? entry.clickedDirection;
+    this.applyOptimisticVote(entry.mediaId, direction);
+    this.mediasApi.vote(entry.mediaId, direction).subscribe({
+      next: () => this.loadVotes(),
+      error: () => this.loadVotes(),
+    });
+    this.toastSubject.next({ action: 'undo', mediaName: entry.mediaName });
+  }
+
+  /** Re-apply the most recently undone vote — POST the original direction. */
+  redo(): void {
+    const entry = this.future.pop();
+    if (!entry) return;
+    this.past.push(entry);
+    if (this.past.length > UNDO_STACK_MAX) this.past.shift();
+    this.applyOptimisticVote(entry.mediaId, entry.clickedDirection);
+    this.mediasApi.vote(entry.mediaId, entry.clickedDirection).subscribe({
+      next: () => this.loadVotes(),
+      error: () => this.loadVotes(),
+    });
+    this.toastSubject.next({ action: 'redo', mediaName: entry.mediaName });
   }
 
   private applyVotes(votes: VotesResponse): void {


### PR DESCRIPTION
## Summary
- `VoteStateService` now maintains 20-deep `past` / `future` undo stacks. `recordVote()` snapshots the polarity before each click; `undo()` / `redo()` replay the inverse direction through the existing `/api/medias/<id>/vote` toggle endpoint so all the regular side-effects (diversity tree, labelset sync, etc.) unwind through the same code path that wrote them.
- `KeyboardService` now dispatches `'undo'` on Cmd/Ctrl+Z and `'redo'` on Cmd/Ctrl+Shift+Z (carved out before the existing modifier-skip guard).
- All three vote sites — `center-panel.castVote`, `label-view.onHoverVote`, `find-view.onHoverVote` — call `voteState.recordVote(...)` before posting, so an undo from anywhere in the labeling experience pops the most recent vote regardless of how it was cast.
- Center panel shows a brief 2s toast ("Undid vote on foo.wav") after each undo/redo so the user can confirm the right item was rolled back, especially when it's no longer on screen.
- `click_counter` advances normally on a re-vote — restoring an undone item gets a fresh timeline ordinal (design choice (a) from the brainstorm).

## Test plan
- [x] `npm run build:prod` clean (no errors, no warnings)
- [x] `./run-tests.sh` — 3354 passed
- [x] New `VoteStateService` specs cover: inverse direction on undo, redo replay, redo-stack clear on new vote, no-op on empty stack, toast emission, 20-entry cap, `clear()` wipes both stacks
- [x] New `KeyboardService` specs cover: undo on Cmd-Z and Ctrl-Z, redo on Cmd/Ctrl-Shift-Z, no undo while typing in an input

https://claude.ai/code/session_016N5iCP1niVbsGVAqjEur2v

---
_Generated by [Claude Code](https://claude.ai/code/session_016N5iCP1niVbsGVAqjEur2v)_