### PR TITLE
Enable mixed-precision training on CUDA in train_model

### DIFF
--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -354,15 +354,33 @@ def train_model(
     # without it, float noise drifts the loss down forever and the early-stop
     # never fires.
     min_delta = 1e-4
+    # Mixed-precision: enable autocast + GradScaler only on CUDA, where
+    # tensor cores give a real speedup. CPU/MPS keep the FP32 path so
+    # deterministic training stays bit-for-bit reproducible.
+    from contextlib import nullcontext  # noqa: PLC0415
+
+    use_amp = device.type == "cuda"
+    # Prefer the modern ``torch.amp.GradScaler("cuda", ...)`` API; fall back
+    # to the legacy ``torch.cuda.amp.GradScaler`` on torch <2.3.
+    grad_scaler_cls = getattr(torch.amp, "GradScaler", None)
+    if grad_scaler_cls is not None:
+        scaler = grad_scaler_cls("cuda", enabled=use_amp)
+    else:
+        scaler = torch.cuda.amp.GradScaler(enabled=use_amp)
+    autocast_ctx = (
+        torch.autocast(device_type="cuda") if use_amp else nullcontext()
+    )
     with torch.random.fork_rng(), torch.enable_grad():
         torch.manual_seed(seed)
         for _ in range(epochs):
             optimizer.zero_grad()
-            logits = model(X_train)
-            losses = loss_fn(logits, y_train)
-            weighted_loss = (losses.squeeze() * weights).mean()
-            weighted_loss.backward()
-            optimizer.step()
+            with autocast_ctx:
+                logits = model(X_train)
+                losses = loss_fn(logits, y_train)
+                weighted_loss = (losses.squeeze() * weights).mean()
+            scaler.scale(weighted_loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
             cur = weighted_loss.item()
             if cur < best_loss - min_delta:
                 best_loss = cur


### PR DESCRIPTION
## Summary
- Implements feature-brainstorm §12.3 ("Mixed-precision training ★ XS"): wraps the MLP training loop in `vtsearch/models/training.py:train_model` with `torch.autocast` + `GradScaler` when running on CUDA.
- On CUDA, tensor-core-eligible ops (matmuls) run in FP16 for a speed/memory win; `GradScaler` keeps tiny FP16 gradients from underflowing during backward.
- On CPU/MPS, AMP is bypassed via `nullcontext()` and a disabled `GradScaler`, so the FP32 code path is preserved bit-for-bit. `test_deterministic_training` still passes unchanged.

## Implementation notes
- Guards on `device.type == "cuda"` — no behavior change on the CPU test path or on Apple silicon.
- Uses the modern `torch.amp.GradScaler("cuda", ...)` API with a `getattr` fallback to `torch.cuda.amp.GradScaler` for torch <2.3 (project floor is `>=2.0`); this also silences the deprecation `FutureWarning` that the legacy form emits on modern torch.
- Loss tensor (`BCEWithLogitsLoss` output) stays in FP32 under autocast by PyTorch's standard op-coverage policy, so `weighted_loss.item()` still feeds the early-stop check with the correct unscaled value.
- No persistence implications — purely a runtime tweak inside the training loop, compatible with the "No Persisted Vectors or MLPs" rule.

## Test plan
- [x] `./run-tests.sh sorting detectors` — 1015 passed (covers `train_model` determinism + all detector training paths).
- [x] `./run-tests.sh` — 3354 passed, 1 skipped, 2 xpassed; no GradScaler `FutureWarning` in the warnings summary.
- [ ] GPU-side speedup verification deferred — no CUDA available in the container; on a tensor-core GPU expect ~1.5–2× epoch speedup for larger hidden dims, no measurable effect (and identical results) on CPU.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnVnm41VKu26btEYt6ezht)_