### PR TITLE
GPU batched embedding for image + text embedders

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -16,6 +16,7 @@ or [ARCHITECTURE.md](../ARCHITECTURE.md), the plan file is deleted.
 | [patch-embedder.md](patch-embedder.md) | **In progress** | Six image embedders (DINOv2 / DINOv3 / EUPE × single+patch). Single-vector variants shipped via PR #1250; patch-region variants and hierarchical region search are the open work. |
 | [RCDatasetImporter.md](RCDatasetImporter.md) | **Scaffolds in place; awaiting client code** | ReCaller / DataWrest / PullWrest / Holder plugin scaffolds exist (`hidden_from_picker = True`); the API client stubs need real implementations. |
 | [extract-library.md](extract-library.md) | **Proposed** | Split VTSearch into a `vtscore` Python library plus the Flask/Angular app, gated on a CI job that runs the test suite without Flask installed. |
+| [gpu-batched-embedding.md](gpu-batched-embedding.md) | **In progress** | Override `_embed_media_bulk_impl` on image + text embedders to batch the GPU forward pass; add `patch_forward_bulk` for the DINO/EUPE patch variants. Targets feature-brainstorm §12.2. |
 | [feature-brainstorm.md](feature-brainstorm.md) | **Backlog** | Wide-ranging idea backlog — new media types, converters, clippers, demo datasets, experiments. Items graduate into their own plan doc as they mature. |
 
 ## Recently completed (removed)

--- a/docs/plans/gpu-batched-embedding.md
+++ b/docs/plans/gpu-batched-embedding.md
@@ -1,0 +1,129 @@
+# GPU batched embedding
+
+Status: **In progress** (Phase A landing first).
+Tracks: feature-brainstorm.md §12.2.
+
+Today the dataset loader already routes embedding through
+`MediaEmbedder.embed_media_bulk()` (see `vtsearch/datasets/loader_folder.py`),
+but **no embedder overrides the bulk hook** — every concrete embedder
+inherits the default `_embed_media_bulk_impl` that just loops
+`embed_media()` per item under the global `_embed_lock`. On GPU that
+leaves a 5–10× speedup on the table for any folder/HF import.
+
+This plan adds real batched forward passes to the embedders that benefit
+most, without changing any caller. The hook + plumbing already exist;
+this is purely a per-embedder override on top.
+
+## Goals
+
+- 5–10× faster folder/HF imports on GPU for image and video datasets.
+- Batched patch-forward for the DINOv2 / DINOv3 / EUPE patch variants,
+  fusing the two-passes-per-image situation called out in
+  `loader_folder.py:_bulk_patch_forward_files`.
+- No change to the embedder ABC for callers: `embed_media_bulk()` and
+  `patch_forward_bulk()` are the only entry points the loader uses.
+
+## Non-goals
+
+- **Clip re-embed batching** (`_fixup_clip_md5_and_embeddings` in
+  `vtsearch/datasets/load_pipeline.py`) — currently writes each clip
+  to a tempfile and goes through `embed_file()` one at a time. The win
+  is real but the refactor touches audio decode / text / image PIL
+  paths and wants its own follow-up PR.
+- A unified concurrency story across datasets — `_embed_lock` still
+  serialises GPU forwards across embedder instances. Orthogonal.
+- New tunables for the user; batch size is an internal knob with one
+  env override.
+
+## Phase A — Bulk image + text embedders
+
+Override `_embed_media_bulk_impl` on:
+
+- `ImageSiglipEmbedder` (`embedder_siglip.py`)
+- `ImageSiglip2Embedder` (`embedder_siglip2.py`)
+- `ImageClipEmbedder` (`embedder_clip.py`)
+- `_Dinov2Base`, `_Dinov3Base` (shared bases — covers single+patch CLS)
+- `_EupeBase`
+- `TextE5Embedder`, `TextBgeEmbedder` (sentence-transformers natively batches)
+- Audio CLAP + video X-CLIP / LanguageBind: deferred to a follow-up
+  (decode is the bottleneck; smaller win, more I/O complexity).
+
+**Shape**: each image embedder grows a `_forward_pil_batch(images,
+batch_size)` helper that runs the processor + model on a list of PIL
+images and returns an `(N, D)` numpy array. `_embed_media_bulk_impl`
+decodes images one-by-one (PIL decode is cheap and inherently
+per-file), then calls the batched forward in chunks. Failures are
+isolated to the offending image (we drop it from the batch with `None`
+in its position).
+
+**Batch size**: read once at first use from
+`VTSEARCH_EMBED_BATCH_SIZE` (default 32). Lives on `MediaEmbedder` as
+`embed_batch_size` property; subclasses may override. No per-user
+setting yet.
+
+**Progress**: emitted once per *batch*, not per item, with
+`(i+1)*batch_size / total` so the bar still ticks. Matches existing
+"Embedding N/M..." status string for compatibility.
+
+## Phase B — Bulk patch_forward
+
+`MediaEmbedder` gains:
+
+```python
+def patch_forward_bulk(self, medias: list[dict]) -> list[Optional[PatchEmbedOutput]]:
+    ...
+def _patch_forward_bulk_impl(self, medias) -> list[Optional[PatchEmbedOutput]]:
+    # default: loop per-item, emit progress
+```
+
+Override on `_Dinov2Base._compute_patch_output_bulk`,
+`_Dinov3Base._compute_patch_output_bulk`, `_EupeBase._compute_patch_output_bulk`.
+Update `_bulk_patch_forward_files` in `loader_folder.py` to call the
+new bulk hook.
+
+Single-vector and patch passes still happen separately for now — fusing
+them into a single forward (so DINOv3 doesn't run 2× per image) is a
+nice-to-have but requires changing the loader's `embed_media_bulk →
+patch_forward_bulk` ordering. Scoped out of Phase B; revisit if
+profiling shows it's the dominant cost.
+
+## Phase C (deferred) — Clip re-embed
+
+`_fixup_clip_md5_and_embeddings` in `vtsearch/datasets/load_pipeline.py`
+loops per clip, writes to a tempfile, and calls `embed_file()`. For
+audio/image clips this is the worst remaining single-call hot spot.
+
+The refactor is:
+1. Group clips by media_type.
+2. For each group, decode `content_bytes` into in-memory PIL / wav /
+   text inputs without touching disk.
+3. Call the appropriate bulk surface on the embedder.
+
+Punted because each media type needs its own "bytes → embedder input"
+path and audio decoders aren't trivial. Will land as a follow-up plan
+doc once Phase A/B are in.
+
+## Risks
+
+- **VRAM**: 32 × 224×224 ViT-B is ~80 MB of activations — fine on 8 GB.
+  X-CLIP at batch 32 with 8 frames each is ~640 MB and could OOM on
+  small cards; leaving video to a follow-up sidesteps it.
+- **Determinism**: per-batch vs per-item forwards can differ at the
+  last-bit level due to kernel choice. Tests assert near-equal
+  (`np.allclose(..., atol=1e-5)`), not exact equality.
+- **Per-image failures**: one bad PIL decode shouldn't fail the whole
+  batch. The decode loop catches per image and replaces the spot with
+  `None`; the GPU forward sees a smaller batch.
+
+## Acceptance
+
+1. Each new bulk impl produces vectors `np.allclose` to the per-item
+   path for the same inputs. Covered by a single shared parametrised
+   test in `tests/io/test_bulk_embedding.py`.
+2. `_bulk_patch_forward_files` calls `patch_forward_bulk` exactly once
+   per folder load (assertion in tests/detectors).
+3. `./run-tests.sh` green (existing bulk tests still pass — the
+   default-loop contract is preserved for embedders that don't
+   override).
+4. Hand-timed on GPU (out-of-band, not CI): SigLIP folder of 200
+   images < 1/5 of pre-PR wall time.

--- a/tests/detectors/test_image_bulk_embedding.py
+++ b/tests/detectors/test_image_bulk_embedding.py
@@ -238,9 +238,7 @@ def _stub_image_embedder(emb, dim: int = 3):
     # Replace the per-class _forward_pil_batch so we never touch torch.
     def fake_forward(images):
         # Position-based vectors so we can assert slot alignment.
-        return np.stack(
-            [np.full(dim, float(i), dtype=np.float32) for i in range(len(images))]
-        )
+        return np.stack([np.full(dim, float(i), dtype=np.float32) for i in range(len(images))])
 
     emb._forward_pil_batch = fake_forward
 
@@ -361,9 +359,7 @@ class TestEupeBulkOverride:
         # EUPE's bulk goes through _forward_pil_batch as well — same shortcut.
 
         def fake_forward(images):
-            return np.stack(
-                [np.full(3, float(i), dtype=np.float32) for i in range(len(images))]
-            )
+            return np.stack([np.full(3, float(i), dtype=np.float32) for i in range(len(images))])
 
         emb._forward_pil_batch = fake_forward
 
@@ -531,7 +527,5 @@ class TestLoaderRoutesToPatchForwardBulk:
 
         assert emb.patch_forward_bulk.call_count == 1
         sent = emb.patch_forward_bulk.call_args.args[0]
-        assert sorted(Path(m["media_path"]).name for m in sent) == sorted(
-            p.name for p in paths
-        )
+        assert sorted(Path(m["media_path"]).name for m in sent) == sorted(p.name for p in paths)
         assert set(out.keys()) == set(paths)

--- a/tests/detectors/test_image_bulk_embedding.py
+++ b/tests/detectors/test_image_bulk_embedding.py
@@ -1,0 +1,537 @@
+"""Tests for the batched ``_embed_media_bulk_impl`` overrides on image embedders.
+
+The overrides themselves are model-free — they delegate to the shared
+helper in ``vtsearch.media.image._image_bulk`` and a per-embedder
+``_forward_pil_batch`` callable.  These tests stub the model + processor
+so we can assert:
+
+* The bulk path decodes each file path to a PIL image and batches the
+  GPU forward in chunks of ``embed_batch_size``.
+* Per-image PIL-decode failures don't kill the batch.
+* The returned list aligns position-for-position with the input list.
+* The same plumbing works for ``patch_forward_bulk`` on the patch
+  embedders.
+
+No model weights are loaded — these tests run on CPU in milliseconds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_image(path: Path, color: tuple[int, int, int] = (255, 0, 0)) -> None:
+    Image.new("RGB", (8, 8), color=color).save(path)
+
+
+def _media(path: Path) -> dict:
+    return {"media_path": str(path), "origin": None, "origin_name": path.name}
+
+
+# ---------------------------------------------------------------------------
+# resolve_embed_batch_size
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEmbedBatchSize:
+    def test_default(self, monkeypatch):
+        from vtsearch.media.embedder import (
+            DEFAULT_EMBED_BATCH_SIZE,
+            resolve_embed_batch_size,
+        )
+
+        monkeypatch.delenv("VTSEARCH_EMBED_BATCH_SIZE", raising=False)
+        assert resolve_embed_batch_size() == DEFAULT_EMBED_BATCH_SIZE
+
+    def test_env_override(self, monkeypatch):
+        from vtsearch.media.embedder import resolve_embed_batch_size
+
+        monkeypatch.setenv("VTSEARCH_EMBED_BATCH_SIZE", "7")
+        assert resolve_embed_batch_size() == 7
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        from vtsearch.media.embedder import (
+            DEFAULT_EMBED_BATCH_SIZE,
+            resolve_embed_batch_size,
+        )
+
+        monkeypatch.setenv("VTSEARCH_EMBED_BATCH_SIZE", "abc")
+        assert resolve_embed_batch_size() == DEFAULT_EMBED_BATCH_SIZE
+
+    def test_nonpositive_env_falls_back(self, monkeypatch):
+        from vtsearch.media.embedder import (
+            DEFAULT_EMBED_BATCH_SIZE,
+            resolve_embed_batch_size,
+        )
+
+        monkeypatch.setenv("VTSEARCH_EMBED_BATCH_SIZE", "0")
+        assert resolve_embed_batch_size() == DEFAULT_EMBED_BATCH_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Shared bulk_embed_image_files helper
+# ---------------------------------------------------------------------------
+
+
+class TestBulkEmbedImageFilesHelper:
+    """The shared helper in ``vtsearch.media.image._image_bulk``."""
+
+    def test_chunks_into_batch_size_groups(self, tmp_path):
+        from vtsearch.media.image._image_bulk import bulk_embed_image_files
+
+        paths = []
+        for i in range(5):
+            p = tmp_path / f"img_{i}.png"
+            _write_image(p)
+            paths.append(p)
+
+        medias = [_media(p) for p in paths]
+
+        seen_batch_sizes: list[int] = []
+
+        def fake_forward(images: list[Image.Image]) -> np.ndarray:
+            seen_batch_sizes.append(len(images))
+            # 1-d "embedding" = batch position so we can verify slot alignment
+            return np.arange(len(images), dtype=np.float32).reshape(-1, 1)
+
+        out = bulk_embed_image_files(
+            medias,
+            forward_pil_batch=fake_forward,
+            batch_size=2,
+            on_progress=lambda *a, **kw: None,
+            label="test",
+        )
+
+        # 5 items at batch_size=2 → 3 chunks (2, 2, 1).
+        assert seen_batch_sizes == [2, 2, 1]
+        assert len(out) == 5
+        assert all(v is not None for v in out)
+
+    def test_pil_decode_failure_keeps_others_in_batch(self, tmp_path):
+        from vtsearch.media.image._image_bulk import bulk_embed_image_files
+
+        good = tmp_path / "good.png"
+        _write_image(good)
+        bad = tmp_path / "bad.png"
+        bad.write_bytes(b"not a real image")
+
+        medias = [_media(good), _media(bad), _media(good)]
+
+        def fake_forward(images: list[Image.Image]) -> np.ndarray:
+            # Only the two good images should reach the forward.
+            assert len(images) == 2
+            return np.ones((len(images), 3), dtype=np.float32)
+
+        out = bulk_embed_image_files(
+            medias,
+            forward_pil_batch=fake_forward,
+            batch_size=10,
+            on_progress=lambda *a, **kw: None,
+            label="test",
+        )
+
+        assert out[0] is not None
+        assert out[1] is None  # decode failed
+        assert out[2] is not None
+
+    def test_forward_exception_drops_batch_but_continues(self, tmp_path):
+        from vtsearch.media.image._image_bulk import bulk_embed_image_files
+
+        # 4 images, batch_size=2 → 2 chunks; first chunk's forward raises.
+        paths = []
+        for i in range(4):
+            p = tmp_path / f"img_{i}.png"
+            _write_image(p)
+            paths.append(p)
+        medias = [_media(p) for p in paths]
+
+        calls = {"n": 0}
+
+        def fake_forward(images: list[Image.Image]) -> np.ndarray:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("simulated OOM")
+            return np.ones((len(images), 2), dtype=np.float32)
+
+        out = bulk_embed_image_files(
+            medias,
+            forward_pil_batch=fake_forward,
+            batch_size=2,
+            on_progress=lambda *a, **kw: None,
+            label="test",
+        )
+
+        assert out[0] is None
+        assert out[1] is None
+        assert out[2] is not None
+        assert out[3] is not None
+
+    def test_empty_input(self):
+        from vtsearch.media.image._image_bulk import bulk_embed_image_files
+
+        out = bulk_embed_image_files(
+            [],
+            forward_pil_batch=lambda _imgs: np.zeros((0, 1), dtype=np.float32),
+            batch_size=4,
+            on_progress=lambda *a, **kw: None,
+            label="test",
+        )
+        assert out == []
+
+    def test_progress_emitted_per_batch(self, tmp_path):
+        from vtsearch.media.image._image_bulk import bulk_embed_image_files
+
+        paths = []
+        for i in range(3):
+            p = tmp_path / f"img_{i}.png"
+            _write_image(p)
+            paths.append(p)
+        medias = [_media(p) for p in paths]
+
+        events: list[tuple[str, int, int]] = []
+
+        def on_progress(status, msg, cur, tot):
+            events.append((status, cur, tot))
+
+        def fake_forward(images: list[Image.Image]) -> np.ndarray:
+            return np.zeros((len(images), 1), dtype=np.float32)
+
+        bulk_embed_image_files(
+            medias,
+            forward_pil_batch=fake_forward,
+            batch_size=2,
+            on_progress=on_progress,
+            label="test",
+        )
+
+        # batch_size=2 over 3 items → 2 batches → 2 progress ticks.
+        assert events == [("embedding", 2, 3), ("embedding", 3, 3)]
+
+
+# ---------------------------------------------------------------------------
+# Concrete embedder overrides — wired up but model-free.
+# ---------------------------------------------------------------------------
+
+
+def _stub_image_embedder(emb, dim: int = 3):
+    """Install minimal mocks so the bulk override can run end-to-end."""
+
+    fake_processor = mock.MagicMock()
+    # Processor return type just needs `.items()` returning (name, tensor) pairs;
+    # we replace the forward callable in the embedder so the processor output
+    # doesn't actually flow into a model.
+    fake_processor.return_value = {}
+    emb._processor = fake_processor
+
+    fake_model = mock.MagicMock()
+    emb._model = fake_model
+
+    # Replace the per-class _forward_pil_batch so we never touch torch.
+    def fake_forward(images):
+        # Position-based vectors so we can assert slot alignment.
+        return np.stack(
+            [np.full(dim, float(i), dtype=np.float32) for i in range(len(images))]
+        )
+
+    emb._forward_pil_batch = fake_forward
+
+
+class TestSiglipBulkOverride:
+    def test_bulk_returns_per_input_vector(self, tmp_path):
+        from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
+
+        emb = ImageSiglipEmbedder()
+        _stub_image_embedder(emb)
+
+        paths = [tmp_path / f"img_{i}.png" for i in range(3)]
+        for p in paths:
+            _write_image(p)
+
+        out = emb.embed_media_bulk([_media(p) for p in paths])
+
+        assert len(out) == 3
+        assert all(v is not None for v in out)
+        # Position-based vectors confirm slot alignment.
+        assert out[0][0] == 0.0
+        assert out[1][0] == 1.0
+        assert out[2][0] == 2.0
+
+    def test_routes_through_bulk_helper(self, tmp_path):
+        from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
+
+        emb = ImageSiglipEmbedder()
+        _stub_image_embedder(emb)
+
+        p = tmp_path / "img.png"
+        _write_image(p)
+
+        with mock.patch(
+            "vtsearch.media.image.embedder_siglip.bulk_embed_image_files",
+            wraps=__import__(
+                "vtsearch.media.image._image_bulk", fromlist=["bulk_embed_image_files"]
+            ).bulk_embed_image_files,
+        ) as wrapped:
+            emb.embed_media_bulk([_media(p)])
+
+        assert wrapped.call_count == 1
+        kwargs = wrapped.call_args.kwargs
+        assert kwargs["label"] == "SigLIP"
+
+
+class TestClipBulkOverride:
+    def test_bulk_returns_per_input_vector(self, tmp_path):
+        from vtsearch.media.image.embedder_clip import ImageClipEmbedder
+
+        emb = ImageClipEmbedder()
+        _stub_image_embedder(emb)
+
+        paths = [tmp_path / f"img_{i}.png" for i in range(4)]
+        for p in paths:
+            _write_image(p)
+
+        out = emb.embed_media_bulk([_media(p) for p in paths])
+
+        assert len(out) == 4
+        assert all(v is not None for v in out)
+
+
+class TestSiglip2BulkOverride:
+    def test_bulk_returns_per_input_vector(self, tmp_path):
+        from vtsearch.media.image.embedder_siglip2 import ImageSiglip2Embedder
+
+        emb = ImageSiglip2Embedder()
+        _stub_image_embedder(emb)
+
+        p = tmp_path / "img.png"
+        _write_image(p)
+        out = emb.embed_media_bulk([_media(p)])
+        assert len(out) == 1 and out[0] is not None
+
+
+class TestDinov2BulkOverride:
+    def test_bulk_returns_per_input_vector(self, tmp_path):
+        from vtsearch.media.image.embedder_dinov2_single import (
+            ImageDinov2SingleEmbedder,
+        )
+
+        emb = ImageDinov2SingleEmbedder()
+        _stub_image_embedder(emb)
+
+        paths = [tmp_path / f"img_{i}.png" for i in range(2)]
+        for p in paths:
+            _write_image(p)
+
+        out = emb.embed_media_bulk([_media(p) for p in paths])
+        assert [v[0] for v in out] == [0.0, 1.0]
+
+
+class TestDinov3BulkOverride:
+    def test_bulk_returns_per_input_vector(self, tmp_path):
+        from vtsearch.media.image.embedder_dinov3_single import (
+            ImageDinov3SingleEmbedder,
+        )
+
+        emb = ImageDinov3SingleEmbedder()
+        _stub_image_embedder(emb)
+
+        paths = [tmp_path / f"img_{i}.png" for i in range(2)]
+        for p in paths:
+            _write_image(p)
+
+        out = emb.embed_media_bulk([_media(p) for p in paths])
+        assert len(out) == 2 and all(v is not None for v in out)
+
+
+class TestEupeBulkOverride:
+    def test_bulk_returns_per_input_vector(self, tmp_path):
+        from vtsearch.media.image.embedder_eupe_single import ImageEupeSingleEmbedder
+
+        emb = ImageEupeSingleEmbedder()
+        emb._model = mock.MagicMock()
+        emb._preprocess = mock.MagicMock()
+        # EUPE's bulk goes through _forward_pil_batch as well — same shortcut.
+
+        def fake_forward(images):
+            return np.stack(
+                [np.full(3, float(i), dtype=np.float32) for i in range(len(images))]
+            )
+
+        emb._forward_pil_batch = fake_forward
+
+        paths = [tmp_path / f"img_{i}.png" for i in range(3)]
+        for p in paths:
+            _write_image(p)
+
+        out = emb.embed_media_bulk([_media(p) for p in paths])
+        assert [v[0] for v in out] == [0.0, 1.0, 2.0]
+
+
+# ---------------------------------------------------------------------------
+# patch_forward_bulk
+# ---------------------------------------------------------------------------
+
+
+class TestPatchForwardBulkDefault:
+    """The ABC's default impl loops :meth:`patch_forward` per item."""
+
+    def test_default_loops_per_item(self):
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "image"
+
+            @property
+            def supports_patch_regions(self):
+                return True
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                return None
+
+            def _patch_forward_impl(self, media):
+                return {"id": media["id"]}
+
+        emb = _Stub()
+        emb._model = True
+        out = emb.patch_forward_bulk([{"id": 1}, {"id": 2}, {"id": 3}])
+        assert out == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+    def test_default_emits_progress(self):
+        from vtsearch.media.embedder import MediaEmbedder
+
+        class _Stub(MediaEmbedder):
+            @property
+            def name(self):
+                return "stub"
+
+            @property
+            def media_type_id(self):
+                return "image"
+
+            @property
+            def supports_patch_regions(self):
+                return True
+
+            def _load_models_impl(self):
+                self._model = True
+
+            def _embed_media_impl(self, media):
+                return None
+
+            def _patch_forward_impl(self, media):
+                return None
+
+        emb = _Stub()
+        emb._model = True
+        events: list[tuple] = []
+        emb._on_progress = lambda s, m, c, t: events.append((s, c, t))
+        emb.patch_forward_bulk([{}, {}])
+
+        assert events == [("embedding", 1, 2), ("embedding", 2, 2)]
+
+
+class TestPatchForwardBulkOverrides:
+    """The DINOv2/v3 + EUPE patch embedders override the bulk hook."""
+
+    def test_dinov3_patch_routes_through_helper(self, tmp_path):
+        from vtsearch.media.image.embedder_dinov3_patch import (
+            ImageDinov3PatchEmbedder,
+        )
+
+        emb = ImageDinov3PatchEmbedder()
+        emb._model = mock.MagicMock()
+        emb._processor = mock.MagicMock()
+
+        seen: list[int] = []
+
+        def fake_patch_forward(images):
+            seen.append(len(images))
+            return [{"i": i} for i, _ in enumerate(images)]
+
+        emb._patch_forward_pil_batch = fake_patch_forward
+
+        paths = [tmp_path / f"img_{i}.png" for i in range(3)]
+        for p in paths:
+            _write_image(p)
+
+        out = emb.patch_forward_bulk([_media(p) for p in paths])
+        assert seen == [3]  # one batch, all three
+        assert len(out) == 3
+        assert all(o is not None for o in out)
+
+    def test_dinov2_patch_routes_through_helper(self, tmp_path):
+        from vtsearch.media.image.embedder_dinov2_patch import (
+            ImageDinov2PatchEmbedder,
+        )
+
+        emb = ImageDinov2PatchEmbedder()
+        emb._model = mock.MagicMock()
+        emb._processor = mock.MagicMock()
+
+        def fake_patch_forward(images):
+            return [{"i": i} for i, _ in enumerate(images)]
+
+        emb._patch_forward_pil_batch = fake_patch_forward
+
+        p = tmp_path / "img.png"
+        _write_image(p)
+        out = emb.patch_forward_bulk([_media(p)])
+        assert len(out) == 1
+        assert out[0] == {"i": 0}
+
+
+# ---------------------------------------------------------------------------
+# Loader integration: _bulk_patch_forward_files goes through patch_forward_bulk
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderRoutesToPatchForwardBulk:
+    def test_loader_calls_patch_forward_bulk_once(self, tmp_path):
+        from vtsearch.datasets.loader_folder import _bulk_patch_forward_files
+
+        # Build a mock embedder that mimics the new bulk surface.
+        emb = mock.MagicMock()
+        emb._on_progress = lambda *a, **kw: None
+
+        def fake_bulk(medias):
+            return [{"i": i} for i, _ in enumerate(medias)]
+
+        emb.patch_forward_bulk.side_effect = fake_bulk
+
+        paths = []
+        for i in range(3):
+            p = tmp_path / f"img_{i}.png"
+            _write_image(p)
+            paths.append(p)
+
+        out = _bulk_patch_forward_files(
+            emb,
+            paths,
+            folder_path=tmp_path,
+            on_progress=lambda *a, **kw: None,
+            media_type="image",
+        )
+
+        assert emb.patch_forward_bulk.call_count == 1
+        sent = emb.patch_forward_bulk.call_args.args[0]
+        assert sorted(Path(m["media_path"]).name for m in sent) == sorted(
+            p.name for p in paths
+        )
+        assert set(out.keys()) == set(paths)

--- a/vtsearch/datasets/loader_folder.py
+++ b/vtsearch/datasets/loader_folder.py
@@ -140,45 +140,35 @@ def _bulk_patch_forward_files(
     origin: dict[str, Any] | None = None,
     custom_metadata_map: dict[str, dict[str, Any]] | None = None,
 ) -> dict[Path, Any]:
-    """Run :meth:`MediaEmbedder.patch_forward` on every file in *media_files*.
+    """Run :meth:`MediaEmbedder.patch_forward_bulk` on every file in *media_files*.
 
     Only called when the active embedder reports
     ``supports_patch_regions == True``.  Returns a ``Path → PatchEmbedOutput``
     mapping; files whose patch forward returned ``None`` are omitted.
 
-    Per-image, not bulk-batched — there is no patch-forward batch API on
-    the embedder yet.  For v1 this means patch-capable embedders run two
-    forward passes per image (one in ``embed_media_bulk`` for the CLS
-    vector, one here for the full patch grid).  Acceptable for v1; a
-    follow-up can fuse the two passes when latency matters.
+    The embedder may batch the forward internally (DINOv2 / DINOv3 / EUPE
+    patch variants do) or fall back to per-item via the default loop
+    contract on :class:`MediaEmbedder`.
     """
-    pending: list[tuple[Path, dict[str, Any]]] = []
+    pending_paths: list[Path] = []
+    pending_medias: list[dict[str, Any]] = []
     for file_path in media_files:
-        pending.append((file_path, _make_embed_input(file_path, folder_path, origin, custom_metadata_map)))
+        pending_paths.append(file_path)
+        pending_medias.append(_make_embed_input(file_path, folder_path, origin, custom_metadata_map))
 
-    if not pending:
+    if not pending_paths:
         return {}
 
-    on_progress("embedding", f"Patch-embedding {len(pending)} {media_type} files...", 0, len(pending))
+    on_progress("embedding", f"Patch-embedding {len(pending_paths)} {media_type} files...", 0, len(pending_paths))
 
-    out: dict[Path, Any] = {}
     original_cb = emb._on_progress
     emb._on_progress = on_progress
     try:
-        for i, (file_path, media_dict) in enumerate(pending):
-            patch_out = emb.patch_forward(media_dict)
-            if patch_out is not None:
-                out[file_path] = patch_out
-            on_progress(
-                "embedding",
-                f"Patch-embedding {i + 1}/{len(pending)} {media_type} files...",
-                i + 1,
-                len(pending),
-            )
+        outputs = emb.patch_forward_bulk(pending_medias)
     finally:
         emb._on_progress = original_cb
 
-    return out
+    return {fp: out for fp, out in zip(pending_paths, outputs) if out is not None}
 
 
 def _attach_patch_regions(media_data: dict[str, Any], patch_out: Any) -> None:

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import io
 import logging
+import os
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -15,6 +16,7 @@ import numpy as np
 from vtsearch.media.base import ProgressCallback, _noop_progress
 
 __all__ = [
+    "DEFAULT_EMBED_BATCH_SIZE",
     "MediaEmbedder",
     "embedder_load_setup",
     "extract_tensor",
@@ -22,8 +24,30 @@ __all__ = [
     "intercept_weight_loading_progress",
     "load_pretrained_local_first",
     "media_from_path",
+    "resolve_embed_batch_size",
     "timed_progress",
 ]
+
+
+DEFAULT_EMBED_BATCH_SIZE = 32
+
+
+def resolve_embed_batch_size(default: int = DEFAULT_EMBED_BATCH_SIZE) -> int:
+    """Return the configured GPU embed batch size.
+
+    Reads ``VTSEARCH_EMBED_BATCH_SIZE`` from the environment; non-positive
+    or unparseable values fall back to *default*.  Subclasses with tighter
+    VRAM constraints (e.g. video models with per-clip frame stacks) can
+    pass a smaller *default* without touching the env var.
+    """
+    raw = os.environ.get("VTSEARCH_EMBED_BATCH_SIZE", "").strip()
+    if not raw:
+        return max(1, default)
+    try:
+        val = int(raw)
+    except ValueError:
+        return max(1, default)
+    return val if val > 0 else max(1, default)
 
 
 def media_from_path(file_path: Any, origin: dict | None = None) -> dict:
@@ -448,6 +472,18 @@ class MediaEmbedder(ABC):
         return False
 
     @property
+    def embed_batch_size(self) -> int:
+        """How many items to forward through the model in one GPU call.
+
+        Default reads :envvar:`VTSEARCH_EMBED_BATCH_SIZE` (falling back to
+        :data:`DEFAULT_EMBED_BATCH_SIZE`).  Subclasses with tighter VRAM
+        budgets — typically video models that stack frames per clip —
+        should override to pass a smaller default to
+        :func:`resolve_embed_batch_size`.
+        """
+        return resolve_embed_batch_size()
+
+    @property
     def license_notice(self) -> Optional[str]:
         """User-facing licence warning shown before a user selects this embedder.
 
@@ -616,6 +652,38 @@ class MediaEmbedder(ABC):
         Default returns ``None``.  Patch-capable embedders override this.
         """
         return None
+
+    def patch_forward_bulk(self, medias: list[dict]) -> list[Optional["PatchEmbedOutput"]]:  # noqa: F821
+        """Return per-patch features for every image in *medias*.
+
+        Patch-capable embedders override :meth:`_patch_forward_bulk_impl`
+        to batch the forward pass through their backbone. The default
+        loops :meth:`patch_forward` per item and emits per-item progress
+        via :attr:`_on_progress` — matching the contract of
+        :meth:`embed_media_bulk`.
+
+        Positions where patch-forward returned ``None`` (failed decode,
+        unsupported, etc.) contain ``None``.
+        """
+        if not medias:
+            return []
+        return self._patch_forward_bulk_impl(medias)
+
+    def _patch_forward_bulk_impl(
+        self, medias: list[dict]
+    ) -> list[Optional["PatchEmbedOutput"]]:  # noqa: F821
+        """Subclass hook: bulk patch-forward.
+
+        Default: loop over :meth:`patch_forward`, emitting per-item
+        progress.  Override to fuse the per-image forward into a single
+        batched GPU call.
+        """
+        total = len(medias)
+        results: list[Optional["PatchEmbedOutput"]] = []  # noqa: F821
+        for i, m in enumerate(medias):
+            self._on_progress("embedding", f"Patch-embedding {i + 1}/{total}...", i + 1, total)
+            results.append(self.patch_forward(m))
+        return results
 
     @property
     def description_wrappers(self) -> list[str]:

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -669,9 +669,7 @@ class MediaEmbedder(ABC):
             return []
         return self._patch_forward_bulk_impl(medias)
 
-    def _patch_forward_bulk_impl(
-        self, medias: list[dict]
-    ) -> list[Optional["PatchEmbedOutput"]]:  # noqa: F821
+    def _patch_forward_bulk_impl(self, medias: list[dict]) -> list[Optional["PatchEmbedOutput"]]:  # noqa: F821
         """Subclass hook: bulk patch-forward.
 
         Default: loop over :meth:`patch_forward`, emitting per-item

--- a/vtsearch/media/image/_dinov2_shared.py
+++ b/vtsearch/media/image/_dinov2_shared.py
@@ -148,9 +148,7 @@ class _Dinov2Base(MediaEmbedder):
                 label="DINOv2",
             )
 
-    def _patch_forward_pil_batch(
-        self, images: list["Image.Image"]
-    ) -> list[Optional[PatchEmbedOutput]]:
+    def _patch_forward_pil_batch(self, images: list["Image.Image"]) -> list[Optional[PatchEmbedOutput]]:
         import torch  # noqa: PLC0415
 
         rgb = [im.convert("RGB") for im in images]
@@ -159,10 +157,7 @@ class _Dinov2Base(MediaEmbedder):
         inputs = {k: v.to(device) for k, v in inputs.items()}
         with torch.no_grad():
             outputs = self._model(**inputs, output_attentions=True)
-        return [
-            hf_vit_to_patch_output(outputs, num_register_tokens=0, batch_index=i)
-            for i in range(len(images))
-        ]
+        return [hf_vit_to_patch_output(outputs, num_register_tokens=0, batch_index=i) for i in range(len(images))]
 
     def _compute_patch_output(self, media: dict) -> Optional[PatchEmbedOutput]:
         """Return CLS + per-patch grid + CLS→patch attention saliency.

--- a/vtsearch/media/image/_dinov2_shared.py
+++ b/vtsearch/media/image/_dinov2_shared.py
@@ -31,6 +31,7 @@ from vtsearch.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtsearch.media.image._image_bulk import bulk_embed_image_files
 from vtsearch.media.patch_embed import PatchEmbedOutput, hf_vit_to_patch_output
 
 if TYPE_CHECKING:
@@ -120,6 +121,48 @@ class _Dinov2Base(MediaEmbedder):
         except Exception:
             logging.getLogger(__name__).exception("Error embedding PIL image (DINOv2)")
             return None
+
+    def _forward_pil_batch(self, images: list["Image.Image"]) -> np.ndarray:
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model(**inputs)
+            cls = outputs.last_hidden_state[:, 0]
+            return cls.detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="DINOv2",
+            )
+
+    def _patch_forward_pil_batch(
+        self, images: list["Image.Image"]
+    ) -> list[Optional[PatchEmbedOutput]]:
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model(**inputs, output_attentions=True)
+        return [
+            hf_vit_to_patch_output(outputs, num_register_tokens=0, batch_index=i)
+            for i in range(len(images))
+        ]
 
     def _compute_patch_output(self, media: dict) -> Optional[PatchEmbedOutput]:
         """Return CLS + per-patch grid + CLS→patch attention saliency.

--- a/vtsearch/media/image/_dinov3_shared.py
+++ b/vtsearch/media/image/_dinov3_shared.py
@@ -161,9 +161,7 @@ class _Dinov3Base(MediaEmbedder):
                 label="DINOv3",
             )
 
-    def _patch_forward_pil_batch(
-        self, images: list["Image.Image"]
-    ) -> list[Optional[PatchEmbedOutput]]:
+    def _patch_forward_pil_batch(self, images: list["Image.Image"]) -> list[Optional[PatchEmbedOutput]]:
         """Return per-image :class:`PatchEmbedOutput` for *images*."""
         import torch  # noqa: PLC0415
 
@@ -205,9 +203,7 @@ class _Dinov3Base(MediaEmbedder):
             inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 outputs = self._model(**inputs, output_attentions=True)
-            return hf_vit_to_patch_output(
-                outputs, num_register_tokens=_DINOV3_NUM_REGISTER_TOKENS
-            )
+            return hf_vit_to_patch_output(outputs, num_register_tokens=_DINOV3_NUM_REGISTER_TOKENS)
         except Exception:
             logging.getLogger(__name__).exception("Error patch-embedding %s (DINOv3)", file_path)
             return None

--- a/vtsearch/media/image/_dinov3_shared.py
+++ b/vtsearch/media/image/_dinov3_shared.py
@@ -32,6 +32,7 @@ from vtsearch.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtsearch.media.image._image_bulk import bulk_embed_image_files
 from vtsearch.media.patch_embed import PatchEmbedOutput, hf_vit_to_patch_output
 
 if TYPE_CHECKING:
@@ -132,6 +133,54 @@ class _Dinov3Base(MediaEmbedder):
         except Exception:
             logging.getLogger(__name__).exception("Error embedding PIL image (DINOv3)")
             return None
+
+    def _forward_pil_batch(self, images: list["Image.Image"]) -> np.ndarray:
+        """Return CLS vectors as ``(N, 768)`` for *images*."""
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model(**inputs)
+            cls = outputs.last_hidden_state[:, 0]
+            return cls.detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="DINOv3",
+            )
+
+    def _patch_forward_pil_batch(
+        self, images: list["Image.Image"]
+    ) -> list[Optional[PatchEmbedOutput]]:
+        """Return per-image :class:`PatchEmbedOutput` for *images*."""
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model(**inputs, output_attentions=True)
+        return [
+            hf_vit_to_patch_output(
+                outputs,
+                num_register_tokens=_DINOV3_NUM_REGISTER_TOKENS,
+                batch_index=i,
+            )
+            for i in range(len(images))
+        ]
 
     def _compute_patch_output(self, media: dict) -> Optional[PatchEmbedOutput]:
         """Return CLS + per-patch grid + CLS→patch attention saliency.

--- a/vtsearch/media/image/_eupe_shared.py
+++ b/vtsearch/media/image/_eupe_shared.py
@@ -41,6 +41,7 @@ from vtsearch.media.embedder import (
     intercept_tqdm_progress,
     timed_progress,
 )
+from vtsearch.media.image._image_bulk import bulk_embed_image_files
 from vtsearch.media.patch_embed import PatchEmbedOutput, eupe_features_to_patch_output
 
 
@@ -147,6 +148,63 @@ class _EupeBase(MediaEmbedder):
         if features is None:
             return None
         return eupe_features_to_patch_output(features)
+
+    def _forward_pil_batch(self, images: list) -> np.ndarray:
+        """Run EUPE on a batch of PIL images, returning ``(N, D)`` CLS vectors."""
+        features = self._forward_features_batch(images)
+        if features is None:
+            raise RuntimeError("EUPE bulk forward returned no features")
+        cls = features["x_norm_clstoken"]  # (N, D)
+        arr = cls.detach().cpu().float().numpy()
+        norms = np.linalg.norm(arr, axis=-1, keepdims=True)
+        return (arr / np.maximum(norms, 1e-12)).astype(np.float32)
+
+    def _patch_forward_pil_batch(self, images: list) -> list[Optional[PatchEmbedOutput]]:
+        features = self._forward_features_batch(images)
+        if features is None:
+            raise RuntimeError("EUPE bulk forward returned no features")
+        return [
+            eupe_features_to_patch_output(features, batch_index=i)
+            for i in range(len(images))
+        ]
+
+    def _forward_features_batch(self, images: list):
+        """Run ``model.forward_features`` on a list of PIL images.
+
+        Returns the raw EUPE feature dict (with a leading batch dim) or
+        ``None`` on any failure.
+        """
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._preprocess is None:
+            return None
+        try:
+            import torch  # noqa: PLC0415
+
+            tensors = [self._preprocess(im.convert("RGB")) for im in images]
+            batch = torch.stack(tensors, dim=0)
+            device = next(self._model.parameters()).device
+            batch = batch.to(device)
+            with torch.no_grad():
+                features = self._model.forward_features(batch)
+            return features
+        except Exception:
+            logging.getLogger(__name__).exception("Error running EUPE bulk forward")
+            return None
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._preprocess is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="EUPE",
+            )
 
     def _forward_features(self, media: dict):
         """Run one ``model.forward_features`` pass on the media's image file.

--- a/vtsearch/media/image/_eupe_shared.py
+++ b/vtsearch/media/image/_eupe_shared.py
@@ -120,9 +120,7 @@ class _EupeBase(MediaEmbedder):
         # standard ImageNet eval transform inline.
         self._preprocess = transforms.Compose(
             [
-                transforms.Resize(
-                    256, interpolation=transforms.InterpolationMode.BICUBIC
-                ),
+                transforms.Resize(256, interpolation=transforms.InterpolationMode.BICUBIC),
                 transforms.CenterCrop(224),
                 transforms.ToTensor(),
                 transforms.Normalize(mean=list(_IMAGENET_MEAN), std=list(_IMAGENET_STD)),
@@ -163,10 +161,7 @@ class _EupeBase(MediaEmbedder):
         features = self._forward_features_batch(images)
         if features is None:
             raise RuntimeError("EUPE bulk forward returned no features")
-        return [
-            eupe_features_to_patch_output(features, batch_index=i)
-            for i in range(len(images))
-        ]
+        return [eupe_features_to_patch_output(features, batch_index=i) for i in range(len(images))]
 
     def _forward_features_batch(self, images: list):
         """Run ``model.forward_features`` on a list of PIL images.

--- a/vtsearch/media/image/_image_bulk.py
+++ b/vtsearch/media/image/_image_bulk.py
@@ -1,0 +1,173 @@
+"""Shared bulk helpers for image embedders.
+
+Every image embedder shares the same input pipeline — PIL-load each
+file, convert to RGB, pass a list of PIL images through the model's
+processor, run the forward in chunks, then split the resulting tensor
+back per-item.  This module factors that out so each concrete embedder
+only supplies its model-specific forward callable.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional, TYPE_CHECKING
+
+import numpy as np
+
+from vtsearch.media.base import ProgressCallback
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+_log = logging.getLogger(__name__)
+
+
+def _load_pil(path: Path) -> Optional["Image.Image"]:
+    """Open *path* and return an RGB PIL Image, or ``None`` on failure."""
+    try:
+        from PIL import Image  # noqa: PLC0415
+
+        with Image.open(path) as img:
+            return img.convert("RGB")
+    except Exception:
+        _log.exception("Error decoding image %s", path)
+        return None
+
+
+def bulk_embed_image_files(
+    medias: list[dict],
+    forward_pil_batch: Callable[[list["Image.Image"]], np.ndarray],
+    batch_size: int,
+    on_progress: ProgressCallback,
+    label: str,
+) -> list[Optional[np.ndarray]]:
+    """Embed images from media dicts in chunks of *batch_size*.
+
+    *forward_pil_batch* is a callable that runs the model's preprocess +
+    forward pass on a list of PIL images and returns an ``(N, D)``
+    :class:`numpy.ndarray`.
+
+    Files that fail to decode are reported as ``None`` in the output at
+    the matching index.  A failing GPU forward fails the whole batch
+    (those positions are filled with ``None``) but does not abort the
+    overall call — subsequent batches still run.
+    """
+    total = len(medias)
+    results: list[Optional[np.ndarray]] = [None] * total
+    if total == 0:
+        return results
+
+    batch_size = max(1, int(batch_size))
+    start = 0
+    while start < total:
+        end = min(start + batch_size, total)
+        chunk_indices: list[int] = []
+        chunk_images: list[Image.Image] = []
+        for idx in range(start, end):
+            media = medias[idx]
+            path_str = media.get("media_path")
+            if not path_str:
+                continue
+            img = _load_pil(Path(path_str))
+            if img is None:
+                continue
+            chunk_indices.append(idx)
+            chunk_images.append(img)
+
+        on_progress("embedding", f"Embedding {label} {end}/{total}...", end, total)
+
+        if not chunk_images:
+            start = end
+            continue
+
+        try:
+            vectors = forward_pil_batch(chunk_images)
+        except Exception:
+            _log.exception("Bulk %s forward failed for indices %s", label, chunk_indices)
+            start = end
+            continue
+
+        if vectors is None or len(vectors) != len(chunk_indices):
+            _log.warning(
+                "Bulk %s forward returned %d vectors for %d inputs — skipping batch",
+                label,
+                0 if vectors is None else len(vectors),
+                len(chunk_indices),
+            )
+            start = end
+            continue
+
+        for slot, vec in zip(chunk_indices, vectors):
+            results[slot] = np.asarray(vec)
+
+        start = end
+
+    return results
+
+
+def bulk_patch_forward_image_files(
+    medias: list[dict],
+    forward_pil_batch: Callable[[list["Image.Image"]], list[Any]],
+    batch_size: int,
+    on_progress: ProgressCallback,
+    label: str,
+) -> list[Optional[Any]]:
+    """Run a batched patch-forward over PIL-decoded images.
+
+    Same per-file decode + per-batch GPU call shape as
+    :func:`bulk_embed_image_files`, but *forward_pil_batch* returns a
+    list of :class:`PatchEmbedOutput`-typed objects (one per input image)
+    so callers can attach side-channel state per-image.
+    """
+    total = len(medias)
+    results: list[Optional[Any]] = [None] * total
+    if total == 0:
+        return results
+
+    batch_size = max(1, int(batch_size))
+    start = 0
+    while start < total:
+        end = min(start + batch_size, total)
+        chunk_indices: list[int] = []
+        chunk_images: list[Image.Image] = []
+        for idx in range(start, end):
+            media = medias[idx]
+            path_str = media.get("media_path")
+            if not path_str:
+                continue
+            img = _load_pil(Path(path_str))
+            if img is None:
+                continue
+            chunk_indices.append(idx)
+            chunk_images.append(img)
+
+        on_progress("embedding", f"Patch-embedding {label} {end}/{total}...", end, total)
+
+        if not chunk_images:
+            start = end
+            continue
+
+        try:
+            outputs = forward_pil_batch(chunk_images)
+        except Exception:
+            _log.exception("Bulk %s patch-forward failed for indices %s", label, chunk_indices)
+            start = end
+            continue
+
+        if outputs is None or len(outputs) != len(chunk_indices):
+            _log.warning(
+                "Bulk %s patch-forward returned %d outputs for %d inputs — skipping batch",
+                label,
+                0 if outputs is None else len(outputs),
+                len(chunk_indices),
+            )
+            start = end
+            continue
+
+        for slot, out in zip(chunk_indices, outputs):
+            results[slot] = out
+
+        start = end
+
+    return results

--- a/vtsearch/media/image/embedder_clip.py
+++ b/vtsearch/media/image/embedder_clip.py
@@ -18,6 +18,7 @@ from vtsearch.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtsearch.media.image._image_bulk import bulk_embed_image_files
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -114,6 +115,31 @@ class ImageClipEmbedder(MediaEmbedder):
         except Exception:
             logging.getLogger(__name__).exception("Error embedding PIL image (CLIP)")
             return None
+
+    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model.get_image_features(**inputs)
+            return _extract_tensor(outputs).detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="CLIP",
+            )
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/image/embedder_dinov2_patch.py
+++ b/vtsearch/media/image/embedder_dinov2_patch.py
@@ -42,9 +42,7 @@ class ImageDinov2PatchEmbedder(_Dinov2Base):
     def _patch_forward_impl(self, media: dict) -> Optional[PatchEmbedOutput]:
         return self._compute_patch_output(media)
 
-    def _patch_forward_bulk_impl(
-        self, medias: list[dict]
-    ) -> list[Optional[PatchEmbedOutput]]:
+    def _patch_forward_bulk_impl(self, medias: list[dict]) -> list[Optional[PatchEmbedOutput]]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtsearch/media/image/embedder_dinov2_patch.py
+++ b/vtsearch/media/image/embedder_dinov2_patch.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Optional
 
 from vtsearch.media.image._dinov2_shared import _Dinov2Base
+from vtsearch.media.image._image_bulk import bulk_patch_forward_image_files
 from vtsearch.media.patch_embed import PatchEmbedOutput
 
 
@@ -40,6 +41,22 @@ class ImageDinov2PatchEmbedder(_Dinov2Base):
 
     def _patch_forward_impl(self, media: dict) -> Optional[PatchEmbedOutput]:
         return self._compute_patch_output(media)
+
+    def _patch_forward_bulk_impl(
+        self, medias: list[dict]
+    ) -> list[Optional[PatchEmbedOutput]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_patch_forward_image_files(
+                medias,
+                forward_pil_batch=self._patch_forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="DINOv2 patch",
+            )
 
 
 EMBEDDER = ImageDinov2PatchEmbedder()

--- a/vtsearch/media/image/embedder_dinov3_patch.py
+++ b/vtsearch/media/image/embedder_dinov3_patch.py
@@ -48,9 +48,7 @@ class ImageDinov3PatchEmbedder(_Dinov3Base):
     def _patch_forward_impl(self, media: dict) -> Optional[PatchEmbedOutput]:
         return self._compute_patch_output(media)
 
-    def _patch_forward_bulk_impl(
-        self, medias: list[dict]
-    ) -> list[Optional[PatchEmbedOutput]]:
+    def _patch_forward_bulk_impl(self, medias: list[dict]) -> list[Optional[PatchEmbedOutput]]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._processor is None:

--- a/vtsearch/media/image/embedder_dinov3_patch.py
+++ b/vtsearch/media/image/embedder_dinov3_patch.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Optional
 
 from vtsearch.media.image._dinov3_shared import _Dinov3Base
+from vtsearch.media.image._image_bulk import bulk_patch_forward_image_files
 from vtsearch.media.patch_embed import PatchEmbedOutput
 
 
@@ -46,6 +47,22 @@ class ImageDinov3PatchEmbedder(_Dinov3Base):
 
     def _patch_forward_impl(self, media: dict) -> Optional[PatchEmbedOutput]:
         return self._compute_patch_output(media)
+
+    def _patch_forward_bulk_impl(
+        self, medias: list[dict]
+    ) -> list[Optional[PatchEmbedOutput]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_patch_forward_image_files(
+                medias,
+                forward_pil_batch=self._patch_forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="DINOv3 patch",
+            )
 
 
 EMBEDDER = ImageDinov3PatchEmbedder()

--- a/vtsearch/media/image/embedder_eupe_patch.py
+++ b/vtsearch/media/image/embedder_eupe_patch.py
@@ -43,9 +43,7 @@ class ImageEupePatchEmbedder(_EupeBase):
     def _patch_forward_impl(self, media: dict) -> Optional[PatchEmbedOutput]:
         return self._compute_patch_output(media)
 
-    def _patch_forward_bulk_impl(
-        self, medias: list[dict]
-    ) -> list[Optional[PatchEmbedOutput]]:
+    def _patch_forward_bulk_impl(self, medias: list[dict]) -> list[Optional[PatchEmbedOutput]]:
         if self._model is None:
             self.load_models()
         if self._model is None or self._preprocess is None:

--- a/vtsearch/media/image/embedder_eupe_patch.py
+++ b/vtsearch/media/image/embedder_eupe_patch.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Optional
 
 from vtsearch.media.image._eupe_shared import _EupeBase
+from vtsearch.media.image._image_bulk import bulk_patch_forward_image_files
 from vtsearch.media.patch_embed import PatchEmbedOutput
 
 
@@ -41,6 +42,22 @@ class ImageEupePatchEmbedder(_EupeBase):
 
     def _patch_forward_impl(self, media: dict) -> Optional[PatchEmbedOutput]:
         return self._compute_patch_output(media)
+
+    def _patch_forward_bulk_impl(
+        self, medias: list[dict]
+    ) -> list[Optional[PatchEmbedOutput]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._preprocess is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_patch_forward_image_files(
+                medias,
+                forward_pil_batch=self._patch_forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="EUPE patch",
+            )
 
 
 EMBEDDER = ImageEupePatchEmbedder()

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -18,6 +18,7 @@ from vtsearch.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtsearch.media.image._image_bulk import bulk_embed_image_files
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -139,6 +140,36 @@ class ImageSiglipEmbedder(MediaEmbedder):
         except Exception:
             logging.getLogger(__name__).exception("Error embedding PIL image")
             return None
+
+    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
+        """Run SigLIP's vision encoder on a list of PIL images.
+
+        Returns an ``(N, 768)`` array.  Caller is responsible for batch
+        sizing — this runs the whole list in one forward pass.
+        """
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model.get_image_features(**inputs)
+            return _extract_tensor(outputs).detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="SigLIP",
+            )
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/image/embedder_siglip2.py
+++ b/vtsearch/media/image/embedder_siglip2.py
@@ -23,6 +23,7 @@ from vtsearch.media.embedder import (
     load_pretrained_local_first,
     timed_progress,
 )
+from vtsearch.media.image._image_bulk import bulk_embed_image_files
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -119,6 +120,31 @@ class ImageSiglip2Embedder(MediaEmbedder):
         except Exception:
             logging.getLogger(__name__).exception("Error embedding PIL image (SigLIP 2)")
             return None
+
+    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model.get_image_features(**inputs)
+            return _extract_tensor(outputs).detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="SigLIP 2",
+            )
 
     def embed_text(self, text: str) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtsearch/media/patch_embed.py
+++ b/vtsearch/media/patch_embed.py
@@ -158,6 +158,7 @@ def hf_vit_to_patch_output(
     outputs,
     *,
     num_register_tokens: int = 0,
+    batch_index: int = 0,
 ) -> Optional[PatchEmbedOutput]:
     """Turn a HuggingFace ViT ``ModelOutput`` into a :class:`PatchEmbedOutput`.
 
@@ -168,13 +169,16 @@ def hf_vit_to_patch_output(
     ``outputs`` must have ``last_hidden_state`` and ``attentions`` set —
     pass ``output_attentions=True`` to the model forward call.
 
+    *batch_index* selects which image in a batched forward to extract
+    (default 0 preserves the single-image call sites).
+
     Returns ``None`` if the patch grid isn't square (the loader treats
     that as "no regions for this image", same as a forward-pass failure).
     """
     import torch  # noqa: PLC0415
 
-    hidden = outputs.last_hidden_state[0]  # (T, D)
-    attn = outputs.attentions[-1][0]  # (heads, T, T) — last block
+    hidden = outputs.last_hidden_state[batch_index]  # (T, D)
+    attn = outputs.attentions[-1][batch_index]  # (heads, T, T) — last block
     skip = 1 + num_register_tokens
     cls_vec = hidden[0]
     patch_tokens = hidden[skip:]
@@ -200,7 +204,11 @@ def _norm_torch(t: "torch.Tensor") -> np.ndarray:
     return v / np.maximum(n, 1e-12)
 
 
-def eupe_features_to_patch_output(features: dict) -> Optional[PatchEmbedOutput]:
+def eupe_features_to_patch_output(
+    features: dict,
+    *,
+    batch_index: int = 0,
+) -> Optional[PatchEmbedOutput]:
     """Turn a :func:`facebookresearch/EUPE`-style ``forward_features`` dict
     into a :class:`PatchEmbedOutput`.
 
@@ -208,6 +216,9 @@ def eupe_features_to_patch_output(features: dict) -> Optional[PatchEmbedOutput]:
     into named keys (``x_norm_clstoken``, ``x_storage_tokens``,
     ``x_norm_patchtokens``), so we don't need a register-token slice — the
     storage tokens are already absent from ``x_norm_patchtokens``.
+
+    *batch_index* selects which image in a batched forward to extract
+    (default 0 preserves the single-image call sites).
 
     Saliency is the **CLS-cosine-similarity proxy**: each patch's softmaxed
     cosine similarity to the CLS vector.  EUPE's attention path uses
@@ -221,8 +232,8 @@ def eupe_features_to_patch_output(features: dict) -> Optional[PatchEmbedOutput]:
     """
     import torch  # noqa: PLC0415
 
-    cls = features["x_norm_clstoken"][0]  # (D,)
-    patches = features["x_norm_patchtokens"][0]  # (N, D)
+    cls = features["x_norm_clstoken"][batch_index]  # (D,)
+    patches = features["x_norm_patchtokens"][batch_index]  # (N, D)
     num_patches = patches.shape[0]
     side = int(round(num_patches**0.5))
     if side * side != num_patches:

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -104,6 +104,51 @@ class TextBGEEmbedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", file_path)
             return None
 
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        """Batch-encode every text file through sentence-transformers in one call."""
+        if self._model is None:
+            self.load_models()
+        if self._model is None:
+            return [None] * len(medias)
+
+        passages: list[Optional[str]] = []
+        for media in medias:
+            file_path = media.get("media_path")
+            if not file_path:
+                passages.append(None)
+                continue
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    text = f.read().strip()
+            except Exception:
+                logging.getLogger(__name__).exception("Error reading %s", file_path)
+                passages.append(None)
+                continue
+            passages.append(text if text else None)
+
+        ready_indices = [i for i, p in enumerate(passages) if p is not None]
+        if not ready_indices:
+            return [None] * len(medias)
+
+        total = len(medias)
+        self._on_progress("embedding", f"Embedding BGE {len(ready_indices)}/{total}...", 0, total)
+        with self._embed_lock:
+            try:
+                vectors = self._model.encode(
+                    [passages[i] for i in ready_indices],
+                    normalize_embeddings=True,
+                    batch_size=self.embed_batch_size,
+                )
+            except Exception:
+                logging.getLogger(__name__).exception("BGE bulk encode failed")
+                return [None] * len(medias)
+
+        results: list[Optional[np.ndarray]] = [None] * len(medias)
+        for slot, vec in zip(ready_indices, vectors):
+            results[slot] = np.asarray(vec)
+        self._on_progress("embedding", f"Embedding BGE {total}/{total}...", total, total)
+        return results
+
     def embed_text_passage(self, text: str) -> Optional[np.ndarray]:
         """Embed *text* as a passage (used when loading demo datasets in-memory)."""
         if self._model is None:

--- a/vtsearch/media/text/embedder_e5.py
+++ b/vtsearch/media/text/embedder_e5.py
@@ -108,6 +108,56 @@ class TextE5Embedder(MediaEmbedder):
             logging.getLogger(__name__).exception("Error embedding %s", file_path)
             return None
 
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        """Batch-encode every text file through sentence-transformers in one call.
+
+        Sentence-Transformers' ``encode`` natively chunks long input lists
+        through the model in ``batch_size`` groups — we feed the whole
+        ready set in at once and let it do the GPU batching.
+        """
+        if self._model is None:
+            self.load_models()
+        if self._model is None:
+            return [None] * len(medias)
+
+        passages: list[Optional[str]] = []
+        for media in medias:
+            file_path = media.get("media_path")
+            if not file_path:
+                passages.append(None)
+                continue
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    text = f.read().strip()
+            except Exception:
+                logging.getLogger(__name__).exception("Error reading %s", file_path)
+                passages.append(None)
+                continue
+            passages.append(f"passage: {text}" if text else None)
+
+        ready_indices = [i for i, p in enumerate(passages) if p is not None]
+        if not ready_indices:
+            return [None] * len(medias)
+
+        total = len(medias)
+        self._on_progress("embedding", f"Embedding E5 {len(ready_indices)}/{total}...", 0, total)
+        with self._embed_lock:
+            try:
+                vectors = self._model.encode(
+                    [passages[i] for i in ready_indices],
+                    normalize_embeddings=True,
+                    batch_size=self.embed_batch_size,
+                )
+            except Exception:
+                logging.getLogger(__name__).exception("E5 bulk encode failed")
+                return [None] * len(medias)
+
+        results: list[Optional[np.ndarray]] = [None] * len(medias)
+        for slot, vec in zip(ready_indices, vectors):
+            results[slot] = np.asarray(vec)
+        self._on_progress("embedding", f"Embedding E5 {total}/{total}...", total, total)
+        return results
+
     def embed_text_passage(self, text: str) -> Optional[np.ndarray]:
         """Embed *text* as a passage (used when loading demo datasets in-memory)."""
         if self._model is None:


### PR DESCRIPTION
Implements Phase A + B of [`docs/plans/gpu-batched-embedding.md`](docs/plans/gpu-batched-embedding.md) (= feature-brainstorm §12.2).

## What changed

`MediaEmbedder.embed_media_bulk()` has existed for a while — the loader already routes folder/HF imports through it — but **no embedder overrode the bulk hook**, so every model was running one image per forward pass. This PR fills in the override on the image + text embedders that benefit most, plus adds the same plumbing for the patch-forward path.

- **Image embedders** (SigLIP, SigLIP 2, CLIP, DINOv2, DINOv3, EUPE) now PIL-decode per file but run the GPU forward in chunks via a shared `vtsearch/media/image/_image_bulk.py` helper.
- **`patch_forward_bulk` API** added to `MediaEmbedder` (default loops per-item, preserving the existing contract). DINOv2 / DINOv3 / EUPE patch variants override it, fusing the per-image attention forwards into batched calls.
- **Text embedders** (E5, BGE) hand the whole ready set into `sentence-transformers`' `encode(list, batch_size=...)` instead of one string at a time.
- **Loader** (`_bulk_patch_forward_files`) now calls `patch_forward_bulk` once instead of looping `patch_forward` per image.
- **Batch size**: 32 by default, overridable via `VTSEARCH_EMBED_BATCH_SIZE`. Lives on `MediaEmbedder.embed_batch_size` so video / large-VRAM models can override.

## Out of scope (Phase C, deferred)

`_fixup_clip_md5_and_embeddings` still writes each clip to a tempfile and calls `embed_file()` per clip. That refactor needs per-media-type bytes-to-embedder-input paths and is queued as a follow-up; see the plan doc.

Audio CLAP and video X-CLIP / LanguageBind are also deferred — decode is the bottleneck there, and X-CLIP's 8-frame stacks risk OOM at the same batch size.

## Test plan

- [x] `./run-tests.sh detectors io` — 1419 passed
- [x] `./run-tests.sh` — 3375 passed, 1 skipped, 2 xpassed
- [x] `ruff check .` clean
- [ ] Hand-timed GPU run on a 200-image SigLIP folder (out-of-band; not blocking merge)

New test file `tests/detectors/test_image_bulk_embedding.py` covers:
- The shared `bulk_embed_image_files` helper: chunking, per-image PIL decode failures, forward-pass exceptions, progress emission.
- Per-embedder bulk overrides (SigLIP, SigLIP 2, CLIP, DINOv2, DINOv3, EUPE) with model + processor stubbed out.
- The new `patch_forward_bulk` default loop and the DINOv2/v3 + EUPE overrides.
- Loader routing: `_bulk_patch_forward_files` calls `patch_forward_bulk` exactly once.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L4G72DGVoWBkafWoXoDe)_