### PR TITLE
Add ruff-format CI gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .

--- a/app.py
+++ b/app.py
@@ -315,10 +315,7 @@ if __name__ == "__main__":
         type=str,
         default=None,
         dest="import_labels_into",
-        help=(
-            "Detector name to merge labels into before scoring. "
-            "Used with --autodetect plus --label-importer-file."
-        ),
+        help=("Detector name to merge labels into before scoring. Used with --autodetect plus --label-importer-file."),
     )
     parser.add_argument(
         "--label-importer",

--- a/scripts/inspect_hac_duplicates.py
+++ b/scripts/inspect_hac_duplicates.py
@@ -73,9 +73,7 @@ def _assign_cells_to_leaves(saliency: np.ndarray, k: int) -> list[set[tuple[int,
 
 def analyse_one(rng: np.random.Generator, grid: int, k: int, dim: int) -> TreeStats:
     patch_grid = rng.standard_normal((grid, grid, dim)).astype(np.float32)
-    patch_grid = patch_grid / np.maximum(
-        np.linalg.norm(patch_grid, axis=-1, keepdims=True), 1e-12
-    )
+    patch_grid = patch_grid / np.maximum(np.linalg.norm(patch_grid, axis=-1, keepdims=True), 1e-12)
     raw_sal = rng.random((grid, grid)).astype(np.float32)
     saliency = raw_sal / raw_sal.sum()
     cls_vec = rng.standard_normal(dim).astype(np.float32)
@@ -179,12 +177,18 @@ def main() -> None:
     print(f"# internal HAC nodes (per image):          {T // args.n} (K-1={args.k - 1})")
     print(f"# internals total:                         {T}")
     print()
-    print(f"box == one of own children's box:          {totals['box_eq_child']:>6} "
-          f"({100 * totals['box_eq_child'] / T:.1f}%)")
-    print(f"box == some earlier region's box:          {totals['box_eq_any_earlier']:>6} "
-          f"({100 * totals['box_eq_any_earlier'] / T:.1f}%)")
-    print(f"underlying cell set == earlier region's:   {totals['cells_eq_earlier']:>6} "
-          f"({100 * totals['cells_eq_earlier'] / T:.1f}%)")
+    print(
+        f"box == one of own children's box:          {totals['box_eq_child']:>6} "
+        f"({100 * totals['box_eq_child'] / T:.1f}%)"
+    )
+    print(
+        f"box == some earlier region's box:          {totals['box_eq_any_earlier']:>6} "
+        f"({100 * totals['box_eq_any_earlier'] / T:.1f}%)"
+    )
+    print(
+        f"underlying cell set == earlier region's:   {totals['cells_eq_earlier']:>6} "
+        f"({100 * totals['cells_eq_earlier'] / T:.1f}%)"
+    )
     print()
     print("of the box-equal pairs:")
     print(f"  cells also equal (true duplicates):      {totals['cells_eq_box_eq']}")

--- a/scripts/run_hac_tree_sweep.py
+++ b/scripts/run_hac_tree_sweep.py
@@ -209,8 +209,7 @@ def _render_cell_thumb(
     for r in range(h_grid):
         for c in range(w_grid):
             if cell_mask[r, c]:
-                full_mask[row_edges[r] : row_edges[r + 1],
-                          col_edges[c] : col_edges[c + 1]] = True
+                full_mask[row_edges[r] : row_edges[r + 1], col_edges[c] : col_edges[c + 1]] = True
 
     if not full_mask.any():
         canvas = Image.new("RGB", size, pad)
@@ -243,9 +242,7 @@ def _render_cell_thumb(
     return cell
 
 
-def _layout_tree(
-    regions: list[RegionVector], k: int
-) -> tuple[list[float], list[int], int]:
+def _layout_tree(regions: list[RegionVector], k: int) -> tuple[list[float], list[int], int]:
     """Assign each HAC node a (column, row) position — planar.
 
     Strategy: in-order DFS from the root.  Every binary tree admits a
@@ -264,9 +261,7 @@ def _layout_tree(
 
     # Leaf centroid x (image coords) — used only to decide left vs right
     # at each merge, never to override the tree structure.
-    leaf_cx: dict[int, float] = {
-        i: (hac[i].box[0] + hac[i].box[2]) / 2.0 for i in range(k)
-    }
+    leaf_cx: dict[int, float] = {i: (hac[i].box[0] + hac[i].box[2]) / 2.0 for i in range(k)}
     # min(leaf_cx) over each subtree, computed bottom-up over the HAC build
     # order (children always precede their parent).
     min_cx: dict[int, float] = dict(leaf_cx)
@@ -394,8 +389,7 @@ def render_config_tree(
         full = full_orig.resize((new_w, new_h), Image.LANCZOS)
         canvas.paste(full, (img_origin_x, img_origin_y))
         draw.rectangle(
-            (img_origin_x - 1, img_origin_y - 1,
-             img_origin_x + new_w, img_origin_y + new_h),
+            (img_origin_x - 1, img_origin_y - 1, img_origin_x + new_w, img_origin_y + new_h),
             outline=(60, 60, 60),
             width=1,
         )
@@ -548,7 +542,7 @@ def measure_config(regions: list[RegionVector], k: int) -> dict[str, float]:
     # Compute "subtree leaf count" for each node so we can score balance.
     leaf_count = [1] * len(leaves) + [0] * len(internals)
     flat = regions[1:]  # leaves + internals as a flat list (children indices
-                       # in `regions` are 1-based because of the CLS node).
+    # in `regions` are 1-based because of the CLS node).
     balances: list[float] = []
     growths: list[float] = []
     n_cell_noop = 0
@@ -607,9 +601,7 @@ def diversity_tree_clusters(
     from sklearn.cluster import AgglomerativeClustering
 
     cls_l2 = cls_vectors / (np.linalg.norm(cls_vectors, axis=1, keepdims=True) + 1e-12)
-    model = AgglomerativeClustering(
-        n_clusters=n_clusters, metric="cosine", linkage="average"
-    )
+    model = AgglomerativeClustering(n_clusters=n_clusters, metric="cosine", linkage="average")
     assign = model.fit_predict(cls_l2)
     clusters: dict[int, list[str]] = {i: [] for i in range(n_clusters)}
     for lab, c in zip(labels, assign):
@@ -624,20 +616,22 @@ def diversity_tree_clusters(
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--places-dir", type=Path,
-                    default=Path("data/places365"))
-    ap.add_argument("--out-dir", type=Path,
-                    default=Path("docs/experiments/hac-tree-sweep"))
+    ap.add_argument("--places-dir", type=Path, default=Path("data/places365"))
+    ap.add_argument("--out-dir", type=Path, default=Path("docs/experiments/hac-tree-sweep"))
     ap.add_argument("--num-images", type=int, default=30)
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--k-values", type=int, nargs="+", default=list(DEFAULT_K_VALUES))
     ap.add_argument("--alpha-values", type=float, nargs="+", default=list(DEFAULT_ALPHA_VALUES))
     ap.add_argument(
-        "--default-k", type=int, default=12,
+        "--default-k",
+        type=int,
+        default=12,
         help="K used for the single per-image tree render (the design's default).",
     )
     ap.add_argument(
-        "--default-alpha", type=float, default=0.5,
+        "--default-alpha",
+        type=float,
+        default=0.5,
         help="α used for the single per-image tree render.",
     )
     args = ap.parse_args()
@@ -651,6 +645,7 @@ def main() -> None:
     # Download Places365 val_256 (501 MB) + label file on first run.
     if not (args.places_dir / "val_256").is_dir() or not (args.places_dir / "places365_val.txt").is_file():
         from vtsearch.datasets.downloader import download_places365
+
         print(f"downloading Places365 to {args.places_dir.parent}…")
         download_places365()
 
@@ -703,9 +698,7 @@ def main() -> None:
         tree_path = args.out_dir / "trees" / f"{idx:02d}_{category}_{path.stem}.jpg"
         tree.save(tree_path, quality=88, optimize=True)
         print(
-            f"  [{idx}] {image_label}: "
-            f"{'cache' if cached else 'forward'} {timings[-1]:.2f}s, "
-            f"tree -> {tree_path.name}"
+            f"  [{idx}] {image_label}: {'cache' if cached else 'forward'} {timings[-1]:.2f}s, tree -> {tree_path.name}"
         )
 
     # ----- aggregate metrics ------------------------------------------------
@@ -814,7 +807,7 @@ def write_report(
         "scratch.  By construction every merge strictly grows the cell "
         "set (leaves are non-empty and disjoint, so the union always "
         "contains new patches relative to either child), so there are "
-        "no \"duplicate\" merges to flag — the loose bounding "
+        'no "duplicate" merges to flag — the loose bounding '
         "rectangle occasionally lands on a child's rectangle, but "
         "that's a rectangle artifact, not something the model sees."
     )
@@ -857,7 +850,7 @@ def write_report(
         "space); "
         "`cell_noop_rate` ≈ fraction of internal merges whose "
         "**patch-cell union** equals one of its children's cell set — "
-        "i.e. \"did the merge actually grow the region the MLP sees?\""
+        'i.e. "did the merge actually grow the region the MLP sees?"'
         "  Always 0 by construction (leaves are non-empty and disjoint, "
         "so the union strictly contains either child).  Published "
         "as a sanity invariant — if it ever drifts above 0 the "
@@ -934,7 +927,7 @@ def write_report(
         "binary tree); K=16 drops to ~0.62 (more chain-like).  This "
         "is the expected trade-off: with more leaves, the affinity "
         "matrix gets noisier and HAC can fall into a long chain when "
-        "one leaf keeps being the \"closest neighbour.\""
+        'one leaf keeps being the "closest neighbour."'
     )
     lines.append(
         "- **`root_area` is always 1.0** — every config recovers the "

--- a/tests/api/test_error_recovery.py
+++ b/tests/api/test_error_recovery.py
@@ -169,6 +169,7 @@ class TestMissingRequiredFields:
         resp = client.post("/api/textsort-suggestions", json={"text": "   "})
         assert resp.status_code == 400
 
+
 class TestTypeMismatches:
     """Routes should reject wrong-typed values."""
 
@@ -542,7 +543,6 @@ class TestSettingsEdgeCases:
         assert resp.status_code == 200
 
 
-
 class TestVoteEdgeCases:
     """Edge cases in voting behavior."""
 
@@ -614,4 +614,3 @@ class TestPathTraversalPrevention:
             content_type="multipart/form-data",
         )
         assert resp.status_code == 400
-

--- a/tests/api/test_file_browser.py
+++ b/tests/api/test_file_browser.py
@@ -421,5 +421,3 @@ class TestMultiUserServerMediaFiles:
             assert resp.status_code == 400
         finally:
             set_login_provider(original)
-
-

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -719,7 +719,9 @@ class TestFolderImporterWithConverters:
 
         mock_converter_medias = {1: {"id": 1, "type": "image"}}
 
-        def _fake_run_converters(folder, output_type, specs, medias, thin=False, recursive=True, folder_path_for_origin=""):
+        def _fake_run_converters(
+            folder, output_type, specs, medias, thin=False, recursive=True, folder_path_for_origin=""
+        ):
             if specs:
                 medias.update(mock_converter_medias)
 
@@ -728,9 +730,7 @@ class TestFolderImporterWithConverters:
                 "vtsearch.datasets.importers.server_folder.load_dataset_from_folder",
                 side_effect=ValueError("No images files found"),
             ),
-            patch(
-                "vtsearch.datasets.importers.server_folder._run_converter_specs", side_effect=_fake_run_converters
-            ),
+            patch("vtsearch.datasets.importers.server_folder._run_converter_specs", side_effect=_fake_run_converters),
         ):
             medias: dict = {}
             IMPORTER.run(
@@ -822,18 +822,14 @@ class TestLegacyEffectiveSourceSpecs:
     def test_legacy_with_converters_csv(self):
         from vtsearch.datasets.importers.http_archive import IMPORTER
 
-        specs = IMPORTER.effective_source_specs(
-            {"media_type": "image", "converters": "video2image,document2image"}
-        )
+        specs = IMPORTER.effective_source_specs({"media_type": "image", "converters": "video2image,document2image"})
         assert [s.converter for s in specs] == [None, "video2image", "document2image"]
         assert [s.source_type for s in specs] == ["image", "video", "document"]
 
     def test_legacy_unknown_converter_is_skipped(self):
         from vtsearch.datasets.importers.http_archive import IMPORTER
 
-        specs = IMPORTER.effective_source_specs(
-            {"media_type": "image", "converters": "video2image,bogus"}
-        )
+        specs = IMPORTER.effective_source_specs({"media_type": "image", "converters": "video2image,bogus"})
         assert [s.converter for s in specs] == [None, "video2image"]
 
 

--- a/tests/core/test_dockerfile_syntax.py
+++ b/tests/core/test_dockerfile_syntax.py
@@ -78,11 +78,7 @@ def test_parser_finds_simple_block() -> None:
 
 
 def test_parser_joins_backslash_continuations() -> None:
-    text = (
-        'RUN python -u -c "import os; \\\n'
-        "from sys import path; \\\n"
-        'print(path)"\n'
-    )
+    text = 'RUN python -u -c "import os; \\\nfrom sys import path; \\\nprint(path)"\n'
     snippets = _find_python_c_snippets(text)
     assert len(snippets) == 1
     assert "import os" in snippets[0]
@@ -92,13 +88,7 @@ def test_parser_joins_backslash_continuations() -> None:
 
 def test_parser_catches_inline_try_except_syntax_error() -> None:
     """Regression for the bug fixed in PR #1282."""
-    text = (
-        'RUN python -u -c "import os; \\\n'
-        "try: \\\n"
-        "    do_thing(); \\\n"
-        "except Exception: \\\n"
-        '    pass"\n'
-    )
+    text = 'RUN python -u -c "import os; \\\ntry: \\\n    do_thing(); \\\nexcept Exception: \\\n    pass"\n'
     snippets = _find_python_c_snippets(text)
     assert len(snippets) == 1
     with pytest.raises(SyntaxError):
@@ -107,10 +97,7 @@ def test_parser_catches_inline_try_except_syntax_error() -> None:
 
 def test_parser_skips_non_dash_c_python_invocations() -> None:
     """Real script files (``python scripts/foo.py``) are out of scope."""
-    text = (
-        "RUN python -u scripts/preload_siglip.py\n"
-        'RUN python -c "print(1)"\n'
-    )
+    text = 'RUN python -u scripts/preload_siglip.py\nRUN python -c "print(1)"\n'
     assert _find_python_c_snippets(text) == ["print(1)"]
 
 

--- a/tests/datasets/test_extension_scaffolds.py
+++ b/tests/datasets/test_extension_scaffolds.py
@@ -427,9 +427,9 @@ class TestEnrichedExportOriginParams:
     def test_origin_params_in_enriched_export(self, client):
         """Origin params like contentID appear in custom_metadata and available_columns."""
         from vtsearch.state import (
-    medias,
-    good_votes,
-)
+            medias,
+            good_votes,
+        )
 
         saved = dict(medias)
         medias.clear()
@@ -482,9 +482,9 @@ class TestEnrichedExportOriginParams:
     def test_custom_metadata_overrides_origin_params(self, client):
         """custom_metadata values take precedence over same-named origin params."""
         from vtsearch.state import (
-    medias,
-    good_votes,
-)
+            medias,
+            good_votes,
+        )
 
         saved = dict(medias)
         medias.clear()

--- a/tests/datasets/test_multi_dataset.py
+++ b/tests/datasets/test_multi_dataset.py
@@ -243,10 +243,10 @@ class TestMultiDatasetSwitching:
 
     def test_switch_preserves_medias(self):
         from vtsearch.state import (
-    medias,
-    register_context,
-    set_thread_dataset_context,
-)
+            medias,
+            register_context,
+            set_thread_dataset_context,
+        )
 
         # Setup context A with medias
         ctx_a = DatasetContext("switch_a")
@@ -272,11 +272,11 @@ class TestMultiDatasetSwitching:
     def test_switch_detectors_preserves_votes(self):
         """Votes are per-detector: switching detectors preserves each one's votes."""
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-    register_detector_context,
-    set_thread_detector_context,
-)
+            good_votes,
+            bad_votes,
+            register_detector_context,
+            set_thread_detector_context,
+        )
 
         det_a = DetectorContext("det_a")
         register_detector_context(det_a)
@@ -303,11 +303,11 @@ class TestMultiDatasetSwitching:
 
     def test_switch_detectors_preserves_label_history(self):
         from vtsearch.state import (
-    label_history,
-    register_detector_context,
-    set_thread_detector_context,
-    toggle_vote,
-)
+            label_history,
+            register_detector_context,
+            set_thread_detector_context,
+            toggle_vote,
+        )
 
         det_a = DetectorContext("hist_det_a")
         register_detector_context(det_a)
@@ -330,11 +330,11 @@ class TestMultiDatasetSwitching:
 
     def test_switch_detectors_preserves_learned_scores(self):
         from vtsearch.state import (
-    get_learned_scores,
-    register_detector_context,
-    set_thread_detector_context,
-    update_learned_scores,
-)
+            get_learned_scores,
+            register_detector_context,
+            set_thread_detector_context,
+            update_learned_scores,
+        )
 
         det_a = DetectorContext("scores_det_a")
         register_detector_context(det_a)
@@ -353,11 +353,11 @@ class TestMultiDatasetSwitching:
 
     def test_unload_frees_context(self):
         from vtsearch.state import (
-    medias,
-    register_context,
-    set_thread_dataset_context,
-    unregister_context,
-)
+            medias,
+            register_context,
+            set_thread_dataset_context,
+            unregister_context,
+        )
 
         ctx = DatasetContext("unload_me")
         ctx.medias[100] = self._make_test_media(100)
@@ -598,11 +598,11 @@ class TestSyncLabelsAcrossDatasets:
         from vtsearch.detectors.store import _read_detector, _write_detector
         from vtsearch.settings import get_detectors_dir, set_detectors_dir
         from vtsearch.state import (
-    bad_votes,
-    good_votes,
-    set_thread_detector_context,
-    snapshot_medias,
-)
+            bad_votes,
+            good_votes,
+            set_thread_detector_context,
+            snapshot_medias,
+        )
         from vtsearch.state.core import DetectorContext, register_detector_context
 
         reset_for_tests()
@@ -669,11 +669,11 @@ class TestSyncLabelsAcrossDatasets:
         from vtsearch.detectors.store import _read_detector, _write_detector
         from vtsearch.settings import get_detectors_dir, set_detectors_dir
         from vtsearch.state import (
-    bad_votes,
-    good_votes,
-    set_thread_detector_context,
-    snapshot_medias,
-)
+            bad_votes,
+            good_votes,
+            set_thread_detector_context,
+            snapshot_medias,
+        )
         from vtsearch.state.core import DetectorContext, register_detector_context
 
         reset_for_tests()

--- a/tests/datasets/test_synthetic_importer.py
+++ b/tests/datasets/test_synthetic_importer.py
@@ -78,9 +78,7 @@ class TestSyntheticImporterValidation:
 
     def test_user_dataset_name_overrides_default(self):
         imp = SyntheticDatasetImporter()
-        out = imp.resolve_display_name(
-            {"media_type": "audio", "size": "7", "dataset_name": "My Tones"}
-        )
+        out = imp.resolve_display_name({"media_type": "audio", "size": "7", "dataset_name": "My Tones"})
         assert out == "My Tones"
 
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -354,10 +354,10 @@ class TestLabelVoteIsolation:
         labels.  Without the clear, votes from a prior session leak in.
         """
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-    medias,
-)
+            good_votes,
+            bad_votes,
+            medias,
+        )
 
         ids = list(medias.keys())
         if len(ids) < 4:
@@ -388,10 +388,10 @@ class TestLabelVoteIsolation:
     def test_import_after_clear_only_has_model_labels(self, client):
         """After clearing + importing, only the target model's labels are active."""
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-    medias,
-)
+            good_votes,
+            bad_votes,
+            medias,
+        )
 
         ids = list(medias.keys())
         if len(ids) < 4:
@@ -513,10 +513,10 @@ class TestLoadModelEndpoint:
     def test_load_clears_previous_labels(self, client):
         """Loading model B must not carry over labels from model A."""
         from vtsearch.state import (
-    bad_votes,
-    good_votes,
-    medias,
-)
+            bad_votes,
+            good_votes,
+            medias,
+        )
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -555,9 +555,9 @@ class TestLoadModelEndpoint:
     def test_load_restores_saved_labels(self, client):
         """Loading a model that has a saved labelset should restore its labels."""
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -599,13 +599,13 @@ class TestLoadModelEndpoint:
 
         from vtsearch.detectors.dataset_sync import ensure_votes_match_active_dataset
         from vtsearch.state import (
-    DatasetContext,
-    bad_votes,
-    good_votes,
-    medias,
-    register_context,
-    set_thread_dataset_context,
-)
+            DatasetContext,
+            bad_votes,
+            good_votes,
+            medias,
+            register_context,
+            set_thread_dataset_context,
+        )
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -659,12 +659,8 @@ class TestLoadModelEndpoint:
         # dataset is now B.
         ensure_votes_match_active_dataset()
 
-        assert a_good not in good_votes, (
-            "good cid from dataset A leaked into dataset B's id-space"
-        )
-        assert a_bad not in bad_votes, (
-            "bad cid from dataset A leaked into dataset B's id-space"
-        )
+        assert a_good not in good_votes, "good cid from dataset A leaked into dataset B's id-space"
+        assert a_bad not in bad_votes, "bad cid from dataset A leaked into dataset B's id-space"
 
 
 class TestVoteSyncsToLoadedModel:
@@ -819,9 +815,9 @@ class TestSeedVotesFromExamples:
     def test_seed_endpoint_adds_good_votes(self, client):
         """Media examples whose MD5 matches a loaded media should become good votes."""
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -867,9 +863,9 @@ class TestSeedVotesFromExamples:
     def test_seed_unmatched_inserts_new_media(self, client):
         """A media example not in the dataset should be embedded and inserted as a new media."""
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         original_count = len(medias)
 
@@ -966,10 +962,10 @@ class TestSeedVotesFromExamples:
     def test_new_example_usable_in_training(self, client):
         """Inserted examples should have embeddings usable by learned-sort."""
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-    medias,
-)
+            good_votes,
+            bad_votes,
+            medias,
+        )
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -1002,9 +998,9 @@ class TestSeedVotesFromExamples:
     def test_load_model_seeds_from_media_examples(self, client):
         """Loading a model with media examples should auto-seed good votes."""
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -1028,7 +1024,6 @@ class TestSeedVotesFromExamples:
             json={
                 "name": "AutoSeed",
                 "media_type": "audio",
-
                 "text_query": "",
                 "media_example": fname,
             },
@@ -1057,7 +1052,6 @@ class TestSeedVotesFromExamples:
             json={
                 "name": "TextOnly",
                 "media_type": "audio",
-
                 "text_query": "dogs",
             },
         )
@@ -1075,9 +1069,9 @@ class TestSeedVotesFromExamples:
         good_votes that ``goodCount >= autopilot_top_greens``.
         """
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         ids = list(medias.keys())
         if len(ids) < 4:
@@ -1099,7 +1093,6 @@ class TestSeedVotesFromExamples:
             json={
                 "name": "SkipGood",
                 "media_type": "audio",
-
                 "text_query": "",
             },
         )
@@ -1114,9 +1107,9 @@ class TestSeedVotesFromExamples:
     def test_load_model_seeds_novel_example(self, client):
         """Loading a model with a non-dataset example should embed and insert it."""
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         original_count = len(medias)
         fname = self._create_example_file(b"novel-load-bytes", "novel_load.wav")
@@ -1134,7 +1127,6 @@ class TestSeedVotesFromExamples:
             json={
                 "name": "NovelSeed",
                 "media_type": "audio",
-
                 "text_query": "",
             },
         )
@@ -1182,10 +1174,10 @@ class TestLoadModelCrossDatasetResolution:
         from vtsearch.detectors.store import _write_detector
         from vtsearch.settings import get_detectors_dir, set_detectors_dir
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-    medias,
-)
+            good_votes,
+            bad_votes,
+            medias,
+        )
 
         reset_for_tests()
 
@@ -1297,9 +1289,9 @@ class TestLoadModelCrossDatasetResolution:
         from vtsearch.detectors.store import _write_detector
         from vtsearch.settings import get_detectors_dir, set_detectors_dir
         from vtsearch.state import (
-    good_votes,
-    medias,
-)
+            good_votes,
+            medias,
+        )
 
         reset_for_tests()
 
@@ -1537,9 +1529,9 @@ class TestRegisterModelFromLabelset:
         """Loading the newly-created model resolves labels into the active dataset."""
         import app as app_module
         from vtsearch.state import (
-    bad_votes,
-    good_votes,
-)
+            bad_votes,
+            good_votes,
+        )
 
         md5_good = app_module.medias[1]["md5"]
         md5_bad = app_module.medias[2]["md5"]

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -422,10 +422,7 @@ class TestImageEupeSingleEmbedder:
         """
         from vtsearch.config import EUPE_MODEL_ID
 
-        assert (
-            EUPE_MODEL_ID
-            == "https://huggingface.co/facebook/EUPE-ViT-B/resolve/main/EUPE-ViT-B.pt"
-        )
+        assert EUPE_MODEL_ID == "https://huggingface.co/facebook/EUPE-ViT-B/resolve/main/EUPE-ViT-B.pt"
 
     def test_embed_media_returns_none_when_not_loaded(self):
         from vtsearch.media.image.embedder_eupe_single import ImageEupeSingleEmbedder

--- a/tests/detectors/test_label_curve.py
+++ b/tests/detectors/test_label_curve.py
@@ -250,10 +250,19 @@ class TestRunLabelCurveEval:
         # trainers x label_counts x seeds = 2 * 2 * 2 = 8 per category → 16 rows total.
         assert len(df) == 2 * 2 * 2 * 2
         assert set(df.columns) >= {
-            "dataset", "category", "trainer", "n_labels", "seed",
-            "auroc", "average_precision", "best_f1",
-            "xcal_threshold", "f1_at_xcal", "train_seconds",
-            "brier", "f1_at_0.5",
+            "dataset",
+            "category",
+            "trainer",
+            "n_labels",
+            "seed",
+            "auroc",
+            "average_precision",
+            "best_f1",
+            "xcal_threshold",
+            "f1_at_xcal",
+            "train_seconds",
+            "brier",
+            "f1_at_0.5",
         }
         assert set(df["trainer"]) == {"svm_linear", "mlp"}
         assert set(df["dataset"]) == {"synth"}

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -228,9 +228,7 @@ class TestLabelElementThumbnail:
         _seed_cross_dataset_model()
         detail = client.get("/api/detectors/cross-ds-model/labels-detail").get_json()
         target = detail["good"][0]
-        res = client.get(
-            f"/api/detectors/cross-ds-model/labels/{target['id']}/thumbnail"
-        )
+        res = client.get(f"/api/detectors/cross-ds-model/labels/{target['id']}/thumbnail")
         assert res.status_code == 404
 
 

--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -153,9 +153,9 @@ class TestVoteIsolation:
 
     def test_votes_isolated_between_detectors(self):
         from vtsearch.state import (
-    bad_votes,
-    good_votes,
-)
+            bad_votes,
+            good_votes,
+        )
         from vtsearch.state.core import (
             DetectorContext,
             register_detector_context,
@@ -184,9 +184,9 @@ class TestVoteIsolation:
 
     def test_toggle_vote_goes_to_active_detector(self):
         from vtsearch.state import (
-    good_votes,
-    toggle_vote,
-)
+            good_votes,
+            toggle_vote,
+        )
         from vtsearch.state.core import (
             DetectorContext,
             register_detector_context,
@@ -203,9 +203,9 @@ class TestVoteIsolation:
 
     def test_clear_votes_only_clears_active_detector(self):
         from vtsearch.state import (
-    clear_votes,
-    good_votes,
-)
+            clear_votes,
+            good_votes,
+        )
         from vtsearch.state.core import (
             DetectorContext,
             register_detector_context,
@@ -393,9 +393,9 @@ class TestMLPCaching:
 
     def test_learned_sort_caches_model(self, client):
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-)
+            good_votes,
+            bad_votes,
+        )
         from vtsearch.state.core import get_active_detector_context, _empty_detector_context
 
         # Vote to enable training
@@ -417,9 +417,9 @@ class TestMLPCaching:
 
     def test_cached_model_updates_on_retrain(self, client):
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-)
+            good_votes,
+            bad_votes,
+        )
         from vtsearch.state.core import get_active_detector_context
 
         good_votes[1] = None
@@ -463,10 +463,10 @@ class TestLabelingStatusResetOnDetectorSwitch:
         a fresh detector B must NOT return green smart/stable status."""
         from vtsearch.detectors.labeling_progress import _cached_steps, _progress_lock
         from vtsearch.state import (
-    good_votes,
-    bad_votes,
-    label_history,
-)
+            good_votes,
+            bad_votes,
+            label_history,
+        )
         from vtsearch.state.core import (
             DetectorContext,
             register_detector_context,

--- a/tests/downloads/test_arxiv_download.py
+++ b/tests/downloads/test_arxiv_download.py
@@ -17,9 +17,7 @@ _ENTRY_TEMPLATE = """<entry>
 
 
 def _make_atom_feed(entries: list[tuple[str, str]]) -> bytes:
-    body = "\n".join(
-        _ENTRY_TEMPLATE.format(title=t, summary=s) for t, s in entries
-    )
+    body = "\n".join(_ENTRY_TEMPLATE.format(title=t, summary=s) for t, s in entries)
     return _ATOM_TEMPLATE.format(entries=body).encode("utf-8")
 
 

--- a/tests/downloads/test_dbpedia_download.py
+++ b/tests/downloads/test_dbpedia_download.py
@@ -25,6 +25,7 @@ def _make_dbpedia_tgz(tmp_path: Path, articles_per_class: int = 3) -> Path:
 
     archive_path = tmp_path / "dbpedia_csv.tgz"
     with tarfile.open(archive_path, "w:gz") as tar:
+
         def _add_text(name: str, body: str) -> None:
             data = body.encode("utf-8")
             info = tarfile.TarInfo(name=name)
@@ -95,9 +96,7 @@ class TestDownloadDbpedia:
         extract_dir = tmp_path / "dbpedia_csv"
         extract_dir.mkdir()
         (extract_dir / "classes.txt").write_text("Alpha\nBeta\n", encoding="utf-8")
-        (extract_dir / "train.csv").write_text(
-            '"1","First","Hello."\n"2","Second","World."\n', encoding="utf-8"
-        )
+        (extract_dir / "train.csv").write_text('"1","First","Hello."\n"2","Second","World."\n', encoding="utf-8")
 
         with patch.object(dl_module.core, "DATA_DIR", tmp_path):
             result = dl_module.download_dbpedia(on_progress=lambda *a: None)

--- a/tests/integration/test_async_jobs.py
+++ b/tests/integration/test_async_jobs.py
@@ -156,9 +156,7 @@ class TestCoalescing:
 
         second_release = threading.Event()
         second_release.set()
-        second = mgr.start(
-            "sig-B", _make_target(second_release, threading.Event(), ran)
-        )
+        second = mgr.start("sig-B", _make_target(second_release, threading.Event(), ran))
         assert second.status == "pending"
 
         first_release.set()

--- a/tests/io/test_dataset_importer_media.py
+++ b/tests/io/test_dataset_importer_media.py
@@ -824,9 +824,9 @@ class TestImporterMediasInSorting:
     def test_label_export_uses_importer_md5(self, client, tmp_path):
         """Label export should include the importer-supplied MD5 in the labelset."""
         from vtsearch.state import (
-    good_votes,
-    medias as app_medias,
-)
+            good_votes,
+            medias as app_medias,
+        )
 
         loaded, _, md5s = self._load_importer_medias_into_app(tmp_path, num_files=3)
 

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -267,9 +267,9 @@ class TestCliScoringNegativeHits:
         from vtsearch.models import build_model_from_weights
         from vtsearch.detectors.training import serialize_weights, train_and_threshold
         from vtsearch.state import (
-    medias,
-    snapshot_medias,
-)
+            medias,
+            snapshot_medias,
+        )
 
         snap = snapshot_medias()
         good_ids = [1, 2, 3]

--- a/tests/io/test_importers.py
+++ b/tests/io/test_importers.py
@@ -400,10 +400,7 @@ class TestImporterDatasetName:
 
     def test_resolve_display_name_prefers_user_value(self):
         imp = self._make_importer()
-        assert (
-            imp.resolve_display_name({"dataset_name": "My Pictures", "flavour": "blue"})
-            == "My Pictures"
-        )
+        assert imp.resolve_display_name({"dataset_name": "My Pictures", "flavour": "blue"}) == "My Pictures"
 
     def test_resolve_display_name_falls_back_to_default(self):
         imp = self._make_importer()
@@ -437,10 +434,7 @@ class TestImporterDefaultDisplayName:
         from vtsearch.datasets.importers.demo import IMPORTER
 
         first_name = next(iter(DEMO_DATASETS.keys()))
-        assert (
-            IMPORTER.resolve_display_name({"name": first_name, "dataset_name": "Override"})
-            == "Override"
-        )
+        assert IMPORTER.resolve_display_name({"name": first_name, "dataset_name": "Override"}) == "Override"
 
     def test_synthetic_default_name_matches_size_and_type(self):
         from vtsearch.datasets.importers.synthetic import IMPORTER
@@ -458,14 +452,8 @@ class TestImporterDefaultDisplayName:
     def test_http_archive_strips_archive_extension(self):
         from vtsearch.datasets.importers.http_archive import IMPORTER
 
-        assert (
-            IMPORTER.default_display_name({"url": "https://example.org/data/genres.tar.gz"})
-            == "genres"
-        )
-        assert (
-            IMPORTER.default_display_name({"url": "https://example.org/data/photos.zip"})
-            == "photos"
-        )
+        assert IMPORTER.default_display_name({"url": "https://example.org/data/genres.tar.gz"}) == "genres"
+        assert IMPORTER.default_display_name({"url": "https://example.org/data/photos.zip"}) == "photos"
         # No URL → falls back to display_name
         assert IMPORTER.default_display_name({}) == IMPORTER.display_name
 
@@ -484,9 +472,7 @@ class TestImporterDefaultDisplayName:
         it must NOT leak into origin params (which feed Detector reload)."""
         from vtsearch.datasets.importers.server_folder import IMPORTER
 
-        origin = IMPORTER.build_origin(
-            {"path": "/data/x", "media_type": "audio", "dataset_name": "My Set"}
-        )
+        origin = IMPORTER.build_origin({"path": "/data/x", "media_type": "audio", "dataset_name": "My Set"})
         assert "dataset_name" not in origin["params"]
 
 
@@ -715,14 +701,9 @@ class TestImporterBulkHooks:
 
         def fetch_bulk(records, _fv, _thin):
             # Pretend we did one batched call.
-            return [
-                {"type": "audio", "filename": f"bulk:{r}", "embedding": None}
-                for r in records
-            ]
+            return [{"type": "audio", "filename": f"bulk:{r}", "embedding": None} for r in records]
 
-        imp = self._make_importer(
-            records=["a", "b"], fetch_one=fetch_one, fetch_bulk=fetch_bulk
-        )
+        imp = self._make_importer(records=["a", "b"], fetch_one=fetch_one, fetch_bulk=fetch_bulk)
         medias: dict = {}
         imp.run({}, medias)
 
@@ -757,8 +738,13 @@ class TestReCallerBulkOverride:
         from vtsearch.datasets.importers import recaller as rc
 
         results = [
-            {"contentID": f"C{i}", "mediaID": f"M{i}", "media_url": f"http://pw/{i}",
-             "media_type": "audio", "md5": f"md5_{i}"}
+            {
+                "contentID": f"C{i}",
+                "mediaID": f"M{i}",
+                "media_url": f"http://pw/{i}",
+                "media_type": "audio",
+                "md5": f"md5_{i}",
+            }
             for i in range(3)
         ]
         monkeypatch.setattr(rc, "_rc_fetch_results", lambda _q: list(results))

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -258,9 +258,9 @@ class TestResolveClipIdsUnion:
 
     def test_md5_match_only(self):
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         # Entry with only md5, no origin — should match by md5
         md5 = app_module.medias[1]["md5"]
@@ -271,9 +271,9 @@ class TestResolveClipIdsUnion:
 
     def test_origin_match_only(self):
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         media = app_module.medias[1]
@@ -284,9 +284,9 @@ class TestResolveClipIdsUnion:
     def test_union_of_origin_and_md5(self):
         """When origin matches media A and md5 matches media B, both are returned."""
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         # Give media 2 the same md5 as media 1 (simulate content-duplicate under different origin)
         orig_md5 = app_module.medias[2]["md5"]
@@ -309,9 +309,9 @@ class TestResolveClipIdsUnion:
 
     def test_no_match_returns_empty(self):
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entry = {
@@ -326,9 +326,9 @@ class TestResolveClipIdsUnion:
     def test_name_fallback_matches_by_origin_name(self):
         """Bare entry (no md5, no origin) matches by origin_name via name_lookup."""
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
         origin_name = app_module.medias[1].get("origin_name", "")
@@ -344,9 +344,9 @@ class TestResolveClipIdsUnion:
     def test_name_fallback_uses_filename_when_no_origin_name(self):
         """name_lookup falls back to 'filename' key when origin_name is absent."""
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
         origin_name = app_module.medias[1].get("origin_name", "")
@@ -358,9 +358,9 @@ class TestResolveClipIdsUnion:
     def test_name_fallback_skipped_when_md5_matches(self):
         """Name fallback is NOT used when md5 already matches (avoids false positives)."""
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
         md5 = app_module.medias[1]["md5"]
@@ -376,9 +376,9 @@ class TestResolveClipIdsUnion:
         mislabel any C file with a colliding basename.
         """
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
         origin_name = app_module.medias[1].get("origin_name", "")
@@ -396,9 +396,9 @@ class TestResolveClipIdsUnion:
         to bare-name matching.
         """
         from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+            build_media_lookup,
+            resolve_media_ids,
+        )
 
         origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
         origin_name = app_module.medias[1].get("origin_name", "")
@@ -420,9 +420,9 @@ class TestResolveClipIdsUnion:
 class TestFindMissingEntries:
     def test_all_present_returns_empty(self):
         from vtsearch.state import (
-    build_media_lookup,
-    find_missing_entries,
-)
+            build_media_lookup,
+            find_missing_entries,
+        )
 
         origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entries = [{"md5": app_module.medias[i]["md5"], "label": "good"} for i in [1, 2, 3]]
@@ -431,9 +431,9 @@ class TestFindMissingEntries:
 
     def test_unknown_entries_returned(self):
         from vtsearch.state import (
-    build_media_lookup,
-    find_missing_entries,
-)
+            build_media_lookup,
+            find_missing_entries,
+        )
 
         origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entries = [
@@ -446,9 +446,9 @@ class TestFindMissingEntries:
 
     def test_invalid_labels_excluded(self):
         from vtsearch.state import (
-    build_media_lookup,
-    find_missing_entries,
-)
+            build_media_lookup,
+            find_missing_entries,
+        )
 
         origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
         entries = [

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -265,17 +265,16 @@ class TestLocalUploadVectorsFile:
                 # Return an empty generator for the chunked path.
                 return iter(())
 
-            with patch.object(importer, "run", side_effect=_sniff), patch.object(
-                importer, "run_chunked", side_effect=_sniff
+            with (
+                patch.object(importer, "run", side_effect=_sniff),
+                patch.object(importer, "run_chunked", side_effect=_sniff),
             ):
                 load_fn({})
             return "task-fake-npz"
 
         return _fake_run
 
-    def test_upload_with_vectors_file_populates_importer_content_vectors(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_upload_with_vectors_file_populates_importer_content_vectors(self, client, tmp_path, monkeypatch):
         from vtsearch.datasets.importers import get_importer
 
         monkeypatch.setattr(
@@ -316,9 +315,7 @@ class TestLocalUploadVectorsFile:
         # next upload doesn't inherit stale vectors.
         assert get_importer("server_folder").content_vectors == {}
 
-    def test_upload_without_vectors_file_leaves_importer_unchanged(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_upload_without_vectors_file_leaves_importer_unchanged(self, client, tmp_path, monkeypatch):
         monkeypatch.setattr(
             "vtsearch.routes.datasets.load.LOCAL_UPLOADS_DIR",
             tmp_path / "uploads",

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -34,6 +34,7 @@ def _persist_state() -> None:
     """Persist the current user's settings cache (lock held by caller)."""
     _save_user(get_current_user())
 
+
 logger = logging.getLogger(__name__)
 
 #: Tier display names, indexed 0..3.
@@ -181,9 +182,7 @@ def _hash_phrase(phrase: str) -> str:
 _DOC_HASHES: dict[str, str] = {d["id"]: _hash_phrase(d["phrase"]) for d in _DOCS_RAW}
 
 #: Public, phrase-free copy of the doc list for serialisation.
-DOCS: list[dict[str, str]] = [
-    {"id": d["id"], "name": d["name"], "path": d["path"]} for d in _DOCS_RAW
-]
+DOCS: list[dict[str, str]] = [{"id": d["id"], "name": d["name"], "path": d["path"]} for d in _DOCS_RAW]
 _DOC_BY_ID: dict[str, dict[str, str]] = {d["id"]: d for d in DOCS}
 
 
@@ -436,9 +435,7 @@ def get_full_state() -> dict[str, Any]:
             counter = int(state["counters"].get(cid, 0))
             tier_idx = _current_tier_idx(cid, counter)
             announced_idx = int(state["announced"].get(cid, -1))
-            next_threshold: int | None = (
-                a["tiers"][tier_idx + 1] if tier_idx + 1 < len(a["tiers"]) else None
-            )
+            next_threshold: int | None = a["tiers"][tier_idx + 1] if tier_idx + 1 < len(a["tiers"]) else None
             achievements.append(
                 {
                     "id": cid,
@@ -463,10 +460,7 @@ def get_full_state() -> dict[str, Any]:
                     }
                 )
         read_ids = set(state.get("docs_read_ids", []))
-        docs = [
-            {"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids}
-            for d in DOCS
-        ]
+        docs = [{"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids} for d in DOCS]
         return {
             "tier_names": list(TIER_NAMES),
             "achievements": achievements,

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -63,8 +63,7 @@ def _load_and_train_detectors(
         det_media_type = det.get("media_type", "") or ""
         if media_type and det_media_type and det_media_type != media_type:
             print(
-                f"Skipping detector '{det_name}': media_type "
-                f"{det_media_type!r} doesn't match dataset {media_type!r}.",
+                f"Skipping detector '{det_name}': media_type {det_media_type!r} doesn't match dataset {media_type!r}.",
                 flush=True,
             )
             continue

--- a/vtsearch/datasets/downloader/text.py
+++ b/vtsearch/datasets/downloader/text.py
@@ -401,9 +401,7 @@ def download_dbpedia(
     classes_path = extract_dir / "classes.txt"
     class_names: list[str]
     if classes_path.exists():
-        class_names = [
-            line.strip() for line in classes_path.read_text(encoding="utf-8").splitlines() if line.strip()
-        ]
+        class_names = [line.strip() for line in classes_path.read_text(encoding="utf-8").splitlines() if line.strip()]
     else:
         class_names = list(DBPEDIA14_CLASSES)
 
@@ -658,7 +656,9 @@ def download_reuters21578(
             topics_match = _REUTERS_TOPICS_RE.search(block)
             if not topics_match:
                 continue
-            topics = [t.decode("latin-1", errors="replace").strip() for t in _REUTERS_D_RE.findall(topics_match.group(1))]
+            topics = [
+                t.decode("latin-1", errors="replace").strip() for t in _REUTERS_D_RE.findall(topics_match.group(1))
+            ]
             topics = [t for t in topics if t]
             if not topics:
                 continue

--- a/vtsearch/datasets/importers/_npz_vectors.py
+++ b/vtsearch/datasets/importers/_npz_vectors.py
@@ -58,9 +58,7 @@ def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
             names_arr = data[filenames_key]
             vecs_arr = data[vectors_key]
             if names_arr.ndim != 1:
-                raise ValueError(
-                    f"NPZ '{filenames_key}' array must be 1-D, got shape {names_arr.shape}"
-                )
+                raise ValueError(f"NPZ '{filenames_key}' array must be 1-D, got shape {names_arr.shape}")
             if len(vecs_arr) != len(names_arr):
                 raise ValueError(
                     f"NPZ '{filenames_key}' and '{vectors_key}' have mismatched lengths "

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -371,9 +371,7 @@ class DatasetImporter(PluginBase):
         override :meth:`_fetch_records_bulk_impl` instead — the default
         bulk impl loops over this method.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__}.fetch_record() is not implemented"
-        )
+        raise NotImplementedError(f"{type(self).__name__}.fetch_record() is not implemented")
 
     def fetch_records_bulk(
         self,

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -250,9 +250,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         d["available_converters_by_media_type"] = converters_by_target
         return d
 
-    def _stage_paths(
-        self, field_values: dict[str, Any]
-    ) -> tuple[Path, dict[str, Path], dict[str, Any]]:
+    def _stage_paths(self, field_values: dict[str, Any]) -> tuple[Path, dict[str, Path], dict[str, Any]]:
         """Read the paths file and symlink each entry into a fresh temp dir.
 
         Returns ``(staging_dir, name_to_source, content_vectors)`` where:
@@ -364,7 +362,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
                     target_media_type=output_type,
                     medias=medias,
                     thin=thin,
-                    base_origin={"importer": self.name, "params": {"paths_file": str(field_values.get("paths_file", ""))}},
+                    base_origin={
+                        "importer": self.name,
+                        "params": {"paths_file": str(field_values.get("paths_file", ""))},
+                    },
                 )
 
             self._rewrite_origins(medias, name_to_source, self.build_origin(field_values))
@@ -436,7 +437,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
                     target_media_type=output_type,
                     medias=converter_chunk,
                     thin=thin,
-                    base_origin={"importer": self.name, "params": {"paths_file": str(field_values.get("paths_file", ""))}},
+                    base_origin={
+                        "importer": self.name,
+                        "params": {"paths_file": str(field_values.get("paths_file", ""))},
+                    },
                 )
                 if converter_chunk:
                     # Converter-origin medias keep their converter origin

--- a/vtsearch/detectors/label_restoration.py
+++ b/vtsearch/detectors/label_restoration.py
@@ -26,11 +26,11 @@ def restore_labels_from_detector(det_data: dict) -> int:
     """
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.state import (
-    apply_label,
-    build_media_lookup,
-    resolve_media_ids,
-    snapshot_medias,
-)
+        apply_label,
+        build_media_lookup,
+        resolve_media_ids,
+        snapshot_medias,
+    )
 
     labelset_dict = det_data.get("labelset")
     if not labelset_dict:

--- a/vtsearch/detectors/label_sync.py
+++ b/vtsearch/detectors/label_sync.py
@@ -48,11 +48,11 @@ def sync_labels_to_loaded_detector() -> None:
 
     from vtsearch.datasets.labelset import LabelSet, element_key, media_element_key
     from vtsearch.state import (
-    bad_votes,
-    good_votes,
-    snapshot_medias,
-    vote_region_boxes,
-)
+        bad_votes,
+        good_votes,
+        snapshot_medias,
+        vote_region_boxes,
+    )
 
     snap = snapshot_medias()
     current_ls = LabelSet.from_clips_and_votes(

--- a/vtsearch/detectors/labelset_elements.py
+++ b/vtsearch/detectors/labelset_elements.py
@@ -50,10 +50,10 @@ def resolve_current_dataset_cid(elem: LabeledElement) -> int | None:
     snapshot — does not trigger origin-file resolution.
     """
     from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-    snapshot_medias,
-)
+        build_media_lookup,
+        resolve_media_ids,
+        snapshot_medias,
+    )
 
     snap = snapshot_medias()
     if not snap:

--- a/vtsearch/detectors/media_seeding.py
+++ b/vtsearch/detectors/media_seeding.py
@@ -27,13 +27,13 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
 
     from vtsearch.config import DATA_DIR
     from vtsearch.state import (
-    _state_lock,
-    apply_label,
-    build_media_lookup,
-    medias,
-    next_media_id,
-    snapshot_medias,
-)
+        _state_lock,
+        apply_label,
+        build_media_lookup,
+        medias,
+        next_media_id,
+        snapshot_medias,
+    )
 
     media_examples = [
         ex for ex in examples if isinstance(ex, dict) and ex.get("type") == "media" and ex.get("value", "").strip()

--- a/vtsearch/detectors/training.py
+++ b/vtsearch/detectors/training.py
@@ -55,11 +55,11 @@ def train_and_threshold(
         train_model,
     )
     from vtsearch.state import (
-    get_calibrate_count,
-    get_calibration_fraction,
-    get_inclusion,
-    get_safe_thresholds,
-)
+        get_calibrate_count,
+        get_calibration_fraction,
+        get_inclusion,
+        get_safe_thresholds,
+    )
 
     X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)

--- a/vtsearch/eval/label_curve.py
+++ b/vtsearch/eval/label_curve.py
@@ -248,9 +248,7 @@ def _build_split_pool(
     sim_pos = _stack(sim_pos_ids)
     sim_neg = _stack(sim_neg_ids)
     test_X = np.concatenate([_stack(test_pos_ids), _stack(test_neg_ids)], axis=0)
-    test_y = np.concatenate(
-        [np.ones(test_pos_ids.size, dtype=np.int32), np.zeros(test_neg_ids.size, dtype=np.int32)]
-    )
+    test_y = np.concatenate([np.ones(test_pos_ids.size, dtype=np.int32), np.zeros(test_neg_ids.size, dtype=np.int32)])
     return _SplitPool(sim_pos=sim_pos, sim_neg=sim_neg, test_X=test_X, test_y=test_y)
 
 
@@ -575,8 +573,5 @@ def summarise(df: pd.DataFrame, *, include_diagnostics: bool = False) -> pd.Data
     grouped = df.groupby(["dataset", "category", "trainer", "n_labels"], sort=False)
     agg = grouped[metric_cols].agg(["mean", "std"]).reset_index()
     # Flatten MultiIndex columns: ("auroc", "mean") -> "auroc_mean".
-    agg.columns = [
-        f"{a}_{b}" if isinstance(b, str) and b else a
-        for a, b in agg.columns.to_flat_index()
-    ]
+    agg.columns = [f"{a}_{b}" if isinstance(b, str) and b else a for a, b in agg.columns.to_flat_index()]
     return agg

--- a/vtsearch/media/image/_dinov3_shared.py
+++ b/vtsearch/media/image/_dinov3_shared.py
@@ -156,9 +156,7 @@ class _Dinov3Base(MediaEmbedder):
             inputs = {k: v.to(device) for k, v in inputs.items()}
             with torch.no_grad():
                 outputs = self._model(**inputs, output_attentions=True)
-            return hf_vit_to_patch_output(
-                outputs, num_register_tokens=_DINOV3_NUM_REGISTER_TOKENS
-            )
+            return hf_vit_to_patch_output(outputs, num_register_tokens=_DINOV3_NUM_REGISTER_TOKENS)
         except Exception:
             logging.getLogger(__name__).exception("Error patch-embedding %s (DINOv3)", file_path)
             return None

--- a/vtsearch/media/image/_eupe_shared.py
+++ b/vtsearch/media/image/_eupe_shared.py
@@ -119,9 +119,7 @@ class _EupeBase(MediaEmbedder):
         # standard ImageNet eval transform inline.
         self._preprocess = transforms.Compose(
             [
-                transforms.Resize(
-                    256, interpolation=transforms.InterpolationMode.BICUBIC
-                ),
+                transforms.Resize(256, interpolation=transforms.InterpolationMode.BICUBIC),
                 transforms.CenterCrop(224),
                 transforms.ToTensor(),
                 transforms.Normalize(mean=list(_IMAGENET_MEAN), std=list(_IMAGENET_STD)),

--- a/vtsearch/models/region_similarity.py
+++ b/vtsearch/models/region_similarity.py
@@ -139,9 +139,6 @@ def cosine_sort_with_boxes(
     similarities = np.dot(all_embs, query_vec) / safe_norms
     similarities = np.where(norm_products == 0, 0.0, similarities)
     sims_list = similarities.tolist()
-    results = [
-        {"id": cid, "similarity": round(float(sim), 4)}
-        for cid, sim in zip(all_ids, similarities)
-    ]
+    results = [{"id": cid, "similarity": round(float(sim), 4)} for cid, sim in zip(all_ids, similarities)]
     results.sort(key=lambda x: x["similarity"], reverse=True)
     return results, sims_list

--- a/vtsearch/models/training.py
+++ b/vtsearch/models/training.py
@@ -138,7 +138,12 @@ def cross_calibration_threshold_cached(
     """
     if det_ctx is not None:
         key = _calibration_cache_key(
-            X_list, y_list, inclusion_value, calibrate_count, calibration_fraction, hidden_dim,
+            X_list,
+            y_list,
+            inclusion_value,
+            calibrate_count,
+            calibration_fraction,
+            hidden_dim,
         )
         cached = getattr(det_ctx, "calibration_cache", None)
         if cached is not None and cached[0] == key:
@@ -367,9 +372,7 @@ def train_model(
         scaler = grad_scaler_cls("cuda", enabled=use_amp)
     else:
         scaler = torch.cuda.amp.GradScaler(enabled=use_amp)
-    autocast_ctx = (
-        torch.autocast(device_type="cuda") if use_amp else nullcontext()
-    )
+    autocast_ctx = torch.autocast(device_type="cuda") if use_amp else nullcontext()
     with torch.random.fork_rng(), torch.enable_grad():
         torch.manual_seed(seed)
         for _ in range(epochs):

--- a/vtsearch/models/training_workflow.py
+++ b/vtsearch/models/training_workflow.py
@@ -26,11 +26,11 @@ def apply_and_retrain(
 
     from vtsearch.detectors.label_sync import sync_labels_to_loaded_detector
     from vtsearch.state import (
-    apply_label,
-    build_media_lookup,
-    resolve_media_ids,
-    snapshot_medias,
-)
+        apply_label,
+        build_media_lookup,
+        resolve_media_ids,
+        snapshot_medias,
+    )
 
     # Override the request-scoped detector context so vote proxies resolve to
     # this detector's context for the duration of this call.
@@ -62,20 +62,20 @@ def apply_and_retrain(
 
         # Retrain MLP if we have at least one good and one bad vote.
         from vtsearch.state import (
-    bad_votes,
-    good_votes,
-    vote_region_boxes,
-)
+            bad_votes,
+            good_votes,
+            vote_region_boxes,
+        )
 
         trained = False
         if good_votes and bad_votes:
             from vtsearch.models.training import train_and_score
             from vtsearch.state import (
-    get_calibrate_count,
-    get_calibration_fraction,
-    get_inclusion,
-    get_safe_thresholds,
-)
+                get_calibrate_count,
+                get_calibration_fraction,
+                get_inclusion,
+                get_safe_thresholds,
+            )
 
             _, threshold, model = train_and_score(
                 snap,

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -241,12 +241,12 @@ def load_detector_route():
         is_detector_loaded,
     )
     from vtsearch.state import (
-    DetectorContext,
-    bad_votes,
-    get_active_detector_context,
-    good_votes,
-    register_detector_context,
-)
+        DetectorContext,
+        bad_votes,
+        get_active_detector_context,
+        good_votes,
+        register_detector_context,
+    )
 
     data = request.get_json(force=True, silent=True) or {}
     detector_id = data.get("detector_id")
@@ -423,11 +423,11 @@ def unload_detector_route(detector_id: str):
     """Unload a detector from memory (frees its DetectorContext)."""
     from vtsearch.detectors.registry import get_detector, is_detector_loaded, remove_loaded_detector_id
     from vtsearch.state import (
-    bad_votes,
-    get_active_detector_context,
-    good_votes,
-    unregister_detector_context,
-)
+        bad_votes,
+        get_active_detector_context,
+        good_votes,
+        unregister_detector_context,
+    )
 
     entry = get_detector(detector_id)
     if entry is None:

--- a/vtsearch/routes/detectors/store.py
+++ b/vtsearch/routes/detectors/store.py
@@ -281,11 +281,11 @@ def save_detector_labels(name: str):
 
     from vtsearch.datasets.labelset import LabelSet
     from vtsearch.state import (
-    bad_votes,
-    good_votes,
-    snapshot_medias,
-    vote_region_boxes,
-)
+        bad_votes,
+        good_votes,
+        snapshot_medias,
+        vote_region_boxes,
+    )
 
     labelset = LabelSet.from_clips_and_votes(
         snapshot_medias(),
@@ -509,7 +509,9 @@ def combine_detectors():
 
     media_types = {s.get("media_type", "") for s in sources}
     if len(media_types) > 1:
-        return jsonify({"error": f"All source detectors must share the same media_type; got {sorted(media_types)}"}), 400
+        return jsonify(
+            {"error": f"All source detectors must share the same media_type; got {sorted(media_types)}"}
+        ), 400
     media_type = next(iter(media_types))
     if not media_type or media_type == "any":
         return jsonify({"error": "Source detectors must have a specific media_type (not empty or 'any')"}), 400

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -221,18 +221,22 @@ def eval_train_and_score_result():
 
     if job.status in ("running", "pending"):
         prog = get_eval_progress()
-        return jsonify({
-            "job_id": job.job_id,
-            "status": "running",
-            "current": prog.get("current", 0),
-            "total": prog.get("total", 0),
-        })
+        return jsonify(
+            {
+                "job_id": job.job_id,
+                "status": "running",
+                "current": prog.get("current", 0),
+                "total": prog.get("total", 0),
+            }
+        )
     if job.status == "error":
-        return jsonify({
-            "job_id": job.job_id,
-            "status": "error",
-            "error": job.error or "Evaluation computation failed",
-        }), 500
+        return jsonify(
+            {
+                "job_id": job.job_id,
+                "status": "error",
+                "error": job.error or "Evaluation computation failed",
+            }
+        ), 500
     if job.status == "cancelled":
         return jsonify({"job_id": job.job_id, "status": "cancelled"})
     return jsonify(_eval_done_payload(job))

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -159,11 +159,7 @@ def import_labels():
         # already coerces list↔tuple, so we just check shape and pass through.
         rb_raw = entry.get("region_box") if label == "good" else None
         region_box: tuple[float, float, float, float] | None = None
-        if (
-            isinstance(rb_raw, (list, tuple))
-            and len(rb_raw) == 4
-            and all(isinstance(v, (int, float)) for v in rb_raw)
-        ):
+        if isinstance(rb_raw, (list, tuple)) and len(rb_raw) == 4 and all(isinstance(v, (int, float)) for v in rb_raw):
             region_box = (float(rb_raw[0]), float(rb_raw[1]), float(rb_raw[2]), float(rb_raw[3]))
 
         for cid in cids:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -267,9 +267,7 @@ def learned_sort():
     # Signature: covers everything that changes the training output.  Re-sorts
     # with the same vote set + settings reuse the cached result.
     if labelset is not None:
-        labels_sig = tuple(
-            sorted((el.label, _stable_element_id_for_sig(el)) for el in labelset.elements)
-        )
+        labels_sig = tuple(sorted((el.label, _stable_element_id_for_sig(el)) for el in labelset.elements))
     else:
         labels_sig = (
             ("good", tuple(sorted(good_votes))),
@@ -335,9 +333,9 @@ def learned_sort():
             labelset_has_cross_dataset = False
             if labelset is not None:
                 from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+                    build_media_lookup,
+                    resolve_media_ids,
+                )
 
                 origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
                 labelset_local_good = set()
@@ -346,9 +344,7 @@ def learned_sort():
                 for el in labelset.elements:
                     if el.label not in ("good", "bad"):
                         continue
-                    cids = resolve_media_ids(
-                        el.to_dict(), origin_lookup, md5_lookup, name_lookup
-                    )
+                    cids = resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup)
                     if not cids:
                         labelset_has_cross_dataset = True
                         continue
@@ -434,18 +430,22 @@ def learned_sort_result():
         return jsonify({"status": "missing", "error": "Job not found"}), 404
 
     if job.status in ("running", "pending"):
-        return jsonify({
-            "job_id": job.job_id,
-            "status": "running",
-            "current": job.current,
-            "total": job.total,
-        })
+        return jsonify(
+            {
+                "job_id": job.job_id,
+                "status": "running",
+                "current": job.current,
+                "total": job.total,
+            }
+        )
     if job.status == "error":
-        return jsonify({
-            "job_id": job.job_id,
-            "status": "error",
-            "error": job.error or "learned-sort failed",
-        }), 500
+        return jsonify(
+            {
+                "job_id": job.job_id,
+                "status": "error",
+                "error": job.error or "learned-sort failed",
+            }
+        ), 500
     if job.status == "cancelled":
         return jsonify({"job_id": job.job_id, "status": "cancelled"})
     return jsonify(_learned_sort_done_payload(job))


### PR DESCRIPTION
## Summary
Implements brainstorm item **12.12 Ruff → Ruff format CI gate ★ XS**.

- Adds `.github/workflows/lint.yml` that runs on push to `main`/`dev` and on every PR. It installs ruff and runs:
  - `ruff check .` (lint)
  - `ruff format --check .` (format gate — fails on unformatted code)
- Runs `ruff format .` over the 45 files that were not yet formatted so the new gate passes from the start. No logic changes — pure formatting.

## Test plan
- [x] `ruff check .` — `All checks passed!`
- [x] `ruff format --check .` — `348 files already formatted`
- [ ] CI runs the new `Lint` workflow on this PR and both steps pass

https://claude.ai/code/session_01XT1chewXHarUf1ChFLqdWy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT1chewXHarUf1ChFLqdWy)_