### PR TITLE
Replace REST progress polling with SSE /api/events

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ from vtsearch.routes import (  # noqa: E402
     detectors_registry_bp,
     embed_bp,
     eval_bp,
+    events_bp,
     file_browser_bp,
     labels_bp,
     media_server_bp,
@@ -223,6 +224,7 @@ app.register_blueprint(detectors_registry_bp)
 app.register_blueprint(detector_scoring_bp)
 app.register_blueprint(detector_find_bp)
 app.register_blueprint(embed_bp)
+app.register_blueprint(events_bp)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ unless otherwise noted. File uploads use `multipart/form-data`.
 | **Body** | JSON request body (Content-Type `application/json`) |
 | **Form** | `multipart/form-data` |
 | `→` | Response body |
-| Async endpoints | Return immediately; poll `GET /api/dataset/progress` |
+| Async endpoints | Return immediately; subscribe to the `dataset` channel on `GET /api/events` (SSE) for progress |
 
 **Common error shape:**
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -453,7 +453,8 @@ errors directly to the user.
    daemon thread.
 3. `POST /api/dataset/import/<name>/options` invokes `get_field_options()`
    to populate dynamic-options dropdowns (see above).
-4. `GET /api/dataset/progress` provides progress bar data.
+4. The `dataset` channel on `GET /api/events` (SSE) streams progress
+   bar data.
 
 ### Progress reporting
 

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -86,17 +86,16 @@ POST /api/find
 }
 ```
 
-### Find progress
+### Find progress (SSE)
 
-```
-GET /api/find/progress
-```
+Find progress streams on the `find` channel of
+[`/api/events`](events.md):
 
-→ ```json
+```json
 {
   "status": "running",
   "message": "Scoring with \"ModelName\" on \"DatasetName\"...",
-  "cur": 150,
+  "current": 150,
   "total": 300,
   "step": 2,
   "total_steps": 3,

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -126,29 +126,28 @@ GET /api/dataset/status
 
 → `{"loaded": true, "num_medias": 500, "has_votes": true, "media_type": "audio", "display_name": "ESC-50", "num_dupes": 3}`
 
-### Dataset progress
+### Dataset progress (SSE)
 
-```
-GET /api/dataset/progress
-```
+Progress for dataset operations is streamed through the unified
+[`/api/events`](events.md) Server-Sent Events endpoint. Two channels
+carry dataset state:
 
-→ Progress object for long-running operations (loading, embedding, etc.):
+- `dataset` — the singleton dataset progress tracker (used by staging,
+  embedding, and other one-at-a-time operations):
 
-```json
-{"status": "loading", "message": "Embedding medias…", "cur": 50, "total": 500}
-```
+  ```json
+  {"status": "loading", "message": "Embedding medias…", "current": 50, "total": 500}
+  ```
 
-### Loading tasks
+- `loading-tasks` — array of all active dataset loading tasks:
 
-```
-GET /api/dataset/loading-tasks
-```
+  ```json
+  [{"task_id": "task_abc", "name": "ESC-50", "status": "loading", "message": "...", "current": 50, "total": 500}]
+  ```
 
-→ All active dataset loading tasks with their progress:
-
-```json
-{"tasks": [{"id": "task_abc", "name": "ESC-50", "status": "loading", "message": "...", "cur": 50, "total": 500}]}
-```
+Connect with `new EventSource('/api/events')` and listen for the
+`dataset` and `loading-tasks` events. The first frame on each channel
+is the current snapshot — no separate bootstrap call is needed.
 
 ### Cancel loading
 
@@ -254,7 +253,8 @@ POST /api/dataset/load-source
 
 → `{"ok": true, "message": "Loading started"}`
 
-All load endpoints are async — poll `GET /api/dataset/progress`.
+All load endpoints are async — subscribe to the `dataset` and
+`loading-tasks` channels on [`/api/events`](events.md) (SSE) for progress.
 
 ### Demo datasets
 

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,0 +1,99 @@
+# Progress events (SSE)
+
+VTSearch streams progress for every long-running operation through a
+single [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+endpoint. Replaces the per-tracker REST polling endpoints
+(`/api/dataset/progress`, `/api/sort/progress`, `/api/find/progress`,
+`/api/dataset/loading-tasks`, `/api/detectors/loading-tasks`,
+`/api/eval/voting-iterations`).
+
+## Endpoint
+
+```
+GET /api/events
+```
+
+`Content-Type: text/event-stream`. Connect with `new EventSource('/api/events')`.
+
+The first frame on every channel is the **current snapshot** of that
+tracker, so clients do not need a separate REST bootstrap call.
+
+## Channels
+
+| Event name | Payload | Source |
+|---|---|---|
+| `dataset` | progress object | singleton `dataset_progress` tracker (staging, embedding) |
+| `loading-tasks` | array of task objects | `loading_tasks` (parallel dataset loads) |
+| `detector-loading-tasks` | array of task objects | `detector_loading_tasks` |
+| `sort` | progress object | `sort_progress` (text sort) |
+| `find` | progress object | `find_progress` (multi-dataset Find) |
+| `eval` | progress object | `eval_progress` (train-and-score) |
+
+### Progress object shape
+
+```json
+{
+  "status": "loading",
+  "message": "Embedding medias…",
+  "current": 50,
+  "total": 500,
+  "step": 1,
+  "total_steps": 3,
+  "error": null
+}
+```
+
+Optional fields (`step`, `total_steps`, `error`, `staging_result`) are
+included only for trackers that declare them.
+
+### Task object shape (`loading-tasks` / `detector-loading-tasks`)
+
+```json
+{
+  "task_id": "task_abc",
+  "name": "ESC-50",
+  "status": "loading",
+  "message": "Embedding…",
+  "current": 50,
+  "total": 500,
+  "error": null,
+  "created_at": 1731000000.123,
+  "dataset_id": "esc50",
+  "media_type": "audio",
+  "embedder": "clap"
+}
+```
+
+`dataset_id`, `detector_id`, `media_type`, `embedder` are only present
+when the task carries that information.
+
+## Frame format
+
+```
+event: dataset
+data: {"status":"loading",...}
+
+```
+
+Comment lines (`: heartbeat`) arrive every ~5 seconds so connections
+survive idle proxies. They also re-emit the `loading-tasks` and
+`detector-loading-tasks` channels so finished tasks vanish from the UI
+once they pass their stale-prune window without a server-side timer.
+
+## Example
+
+```ts
+const es = new EventSource('/api/events');
+es.addEventListener('dataset', (e) => {
+  const { current, total, message } = JSON.parse(e.data);
+  setProgress(current / total, message);
+});
+es.addEventListener('loading-tasks', (e) => {
+  setActiveTasks(JSON.parse(e.data));
+});
+```
+
+The browser's `EventSource` reconnects automatically on transient
+network failures. The Angular client (`ProgressEventsService`) also
+schedules a manual reconnect 2 s after `readyState === CLOSED` for the
+rare case the server explicitly closes the stream.

--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -95,13 +95,17 @@ POST /api/eval/train-and-score
 → `{"error_cost": [...]}` (smart), `{"stability": [...]}` (stable), or
 `{"diversity": [...]}` (diverse).
 
-### Evaluation progress
+### Evaluation progress (SSE)
 
-```
-GET /api/eval/voting-iterations
+Eval progress streams on the `eval` channel of
+[`/api/events`](events.md):
+
+```json
+{"status": "running", "message": "Computing smart...", "current": 5, "total": 10}
 ```
 
-→ `{"progress": 5, "total": 10, "done": false}`
+`status` is `"idle"` or `"running"`; the operation is done once `status`
+is back to `"idle"` and `current >= total`.
 
 ---
 

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -174,13 +174,14 @@ the frontend.
 Returns HTTP 400 + `{"supports_text": false, ...}` when the dataset's
 embedder doesn't support text queries.
 
-### Text sort progress
+### Text sort progress (SSE)
 
-```
-GET /api/sort/progress
-```
+Text-sort progress streams on the `sort` channel of
+[`/api/events`](events.md):
 
-→ `{"status": "sorting", "message": "Computing similarities…", "cur": 50, "total": 100}`
+```json
+{"status": "sorting", "message": "Computing similarities…", "current": 50, "total": 100}
+```
 
 Status is `"idle"` or `"sorting"`.
 

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -168,8 +168,8 @@ POST /api/detectors/registry/load
 
 → `{"ok": true, "message": "Loading started", "task_id": "..."}`
 
-Loading is async — poll `GET /api/detectors/loading-tasks` for progress.
-404 if model not found.
+Loading is async — subscribe to the `detector-loading-tasks` channel
+on [`/api/events`](events.md) (SSE) for progress. 404 if model not found.
 
 ### Unload model
 
@@ -179,13 +179,14 @@ POST /api/detectors/registry/{model_id}/unload
 
 → `{"ok": true}`
 
-### Model loading tasks
+### Model loading tasks (SSE)
 
-```
-GET /api/detectors/loading-tasks
-```
+Active model loading tasks are streamed on the `detector-loading-tasks`
+channel of [`/api/events`](events.md):
 
-→ `{"tasks": [{"id": "...", "name": "...", "status": "loading", "message": "...", "cur": 50, "total": 100}]}`
+```json
+[{"task_id": "...", "name": "...", "status": "loading", "message": "...", "current": 50, "total": 100}]
+```
 
 ### Cancel model loading
 

--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -438,8 +438,32 @@ Currently many embedders embed one-at-a-time. Batch within a converter run + wit
 ### 12.4 Model preload manager ★★ S
 Setting exists; could be smarter — predict which embedder is needed next from active dataset metadata.
 
-### 12.5 WebSocket for live progress ★★ M
-Today progress is polled via REST. WebSocket = lower latency, less server load, smoother UI.
+### 12.5 ~~WebSocket~~ SSE for live progress ★★ M — **DONE**
+Was: progress polled via REST (`/api/dataset/progress`, `/api/sort/progress`,
+`/api/find/progress`, `/api/dataset/loading-tasks`,
+`/api/detectors/loading-tasks`, `/api/eval/voting-iterations`).
+
+Replaced by a single Server-Sent Events stream at **`GET /api/events`**
+(see [`docs/api/events.md`](../api/events.md)). Channels: `dataset`,
+`sort`, `find`, `eval`, `loading-tasks`, `detector-loading-tasks`. The
+first frame on every channel is the current snapshot, so clients don't
+need a bootstrap REST call.
+
+**Why SSE over WebSocket:**
+- Progress is one-way (server → client), text-only — exactly SSE's
+  sweet spot, where WebSocket's bidirectionality is wasted.
+- Flask is sync/WSGI — SSE works as a plain streaming response, no
+  `flask-sock` / ASGI / Upgrade-handshake surface area.
+- Auth, per-request context, and proxy compatibility come for free
+  because it's still an HTTP GET.
+- `EventSource` reconnects automatically; we don't have to build
+  heartbeat / resume / backoff.
+
+WebSocket can be revisited later if a genuinely bidirectional feature
+(live multi-user voting, presence) lands.
+
+The old §18.9 ("SSE event stream") is subsumed by this item — they
+referred to the same idea.
 
 ### 12.6 Background prefetch of next likely media ★ S
 For speed-labelling, preload the next 3 items' previews.
@@ -667,8 +691,11 @@ Apple Silicon + Graviton tier deployments.
 ### 18.8 Model-cache warmer init container ★ S
 Compose pattern that pulls model weights once, sidecar reuses.
 
-### 18.9 SSE event stream ★ M
-`/api/events?since=...` for the progress + activity feed (§16.5) without WebSocket.
+### 18.9 ~~SSE event stream~~ — **subsumed by §12.5 (DONE)**
+The progress feed shipped as `GET /api/events` — see §12.5 and
+[`docs/api/events.md`](../api/events.md). An "activity feed" channel
+(votes, label changes, etc.) for §16.5 can be added as another event
+name on the same endpoint when needed.
 
 ---
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -2,9 +2,10 @@ import { Component, HostListener, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { EMPTY, Subject, timer } from 'rxjs';
-import { catchError, filter, take, takeUntil, switchMap } from 'rxjs/operators';
+import { catchError, filter, switchMap, take, takeUntil } from 'rxjs/operators';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
+import { ProgressEventsService } from '../../services/progress-events.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { FindSessionService } from '../../services/find-session.service';
@@ -13,7 +14,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
 import { AchievementsService } from '../../services/achievements.service';
-import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, LoadingTasksResponse, DetectorRegistryEntry } from '../../models/api.models';
+import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, DetectorRegistryEntry } from '../../models/api.models';
 import { formatProgressFraction } from '../../utils/format-progress';
 import { ColMeta, ManagedColumns } from '../../utils/managed-columns';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
@@ -190,6 +191,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private topBarState: TopBarStateService,
     private achievements: AchievementsService,
+    private progressEvents: ProgressEventsService,
   ) {}
 
   ngOnInit(): void {
@@ -282,24 +284,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
   }
 
-  /** Check for in-progress loading tasks (e.g. after a page reload) and resume polling. */
+  /** Check for in-progress loading tasks (e.g. after a page reload) and start watching. */
   private resumeActivePolling(): void {
-    this.datasetsApi
-      .getLoadingTasks()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((tasks) => {
-        if (tasks.some((t) => t.status !== 'idle')) {
-          this.startProgressPolling();
-        }
-      });
-    this.detectorsApi
-      .getDetectorLoadingTasks()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((resp) => {
-        if ((resp.tasks ?? []).some((t: LoadingTask) => t.status !== 'idle')) {
-          this.startDetectorProgressPolling();
-        }
-      });
+    // SSE pushes the initial snapshot the moment we connect, so the first
+    // event on each channel tells us whether there's anything in flight.
+    this.progressEvents.loadingTasks$
+      .pipe(filter((tasks) => tasks.some((t) => t.status !== 'idle')), take(1), takeUntil(this.destroy$))
+      .subscribe(() => this.startProgressPolling());
+    this.progressEvents.detectorLoadingTasks$
+      .pipe(filter((tasks) => tasks.some((t) => t.status !== 'idle')), take(1), takeUntil(this.destroy$))
+      .subscribe(() => this.startDetectorProgressPolling());
   }
 
   // --- Column resize / drag-reorder ---
@@ -968,14 +962,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetPollingActive = true;
     this.completedTaskIds.clear();
 
-    timer(0, 1000)
-      .pipe(
-        takeUntil(this.polling$),
-        takeUntil(this.destroy$),
-        switchMap(() => this.datasetsApi.getLoadingTasks().pipe(
-          catchError(() => EMPTY),
-        )),
-      )
+    this.progressEvents.loadingTasks$
+      .pipe(takeUntil(this.polling$), takeUntil(this.destroy$))
       .subscribe({
         next: (tasks: LoadingTask[]) => {
           // Separate active from finished
@@ -1031,17 +1019,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.detectorPollingActive = true;
     this.completedModelTaskIds.clear();
 
-    timer(0, 1000)
-      .pipe(
-        takeUntil(this.detectorPolling$),
-        takeUntil(this.destroy$),
-        switchMap(() => this.detectorsApi.getDetectorLoadingTasks().pipe(
-          catchError(() => EMPTY),
-        )),
-      )
+    this.progressEvents.detectorLoadingTasks$
+      .pipe(takeUntil(this.detectorPolling$), takeUntil(this.destroy$))
       .subscribe({
-        next: (resp: LoadingTasksResponse) => {
-          const tasks = resp.tasks ?? [];
+        next: (tasks: LoadingTask[]) => {
           const active = tasks.filter((t) => t.status !== 'idle');
           const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
           const failed = errored.filter((t) => t.error !== 'Cancelled');
@@ -1319,14 +1300,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private startFindProgressPolling(): void {
     this.findPolling$.next(); // cancel previous
-    timer(0, 500)
-      .pipe(
-        takeUntil(this.findPolling$),
-        takeUntil(this.destroy$),
-        switchMap(() => this.detectorsApi.getFindProgress().pipe(
-          catchError(() => EMPTY),
-        )),
-      )
+    this.progressEvents.find$
+      .pipe(takeUntil(this.findPolling$), takeUntil(this.destroy$))
       .subscribe({
         next: (progress: any) => {
           if (!progress || progress.status === 'idle') return;

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ElementRef, ViewChild, NgZone, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject, Subscription, timer } from 'rxjs';
-import { finalize, switchMap, takeUntil } from 'rxjs/operators';
+import { Subject, Subscription } from 'rxjs';
+import { finalize, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -13,6 +13,7 @@ import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import { ProgressEventsService } from '../../services/progress-events.service';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
@@ -63,6 +64,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     public voteState: VoteStateService,
     public sortState: SortStateService,
     private settingsState: SettingsStateService,
+    private progressEvents: ProgressEventsService,
   ) {}
 
   ngOnInit(): void {
@@ -117,11 +119,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private startProgressPolling(): void {
     this.stopProgressPolling();
-    this.progressPollSub = timer(200, 500)
-      .pipe(
-        switchMap(() => this.detectorsApi.getFindProgress()),
-        takeUntil(this.destroy$),
-      )
+    this.progressPollSub = this.progressEvents.find$
+      .pipe(takeUntil(this.destroy$))
       .subscribe((prog: any) => {
         if (prog.status === 'running') {
           const msg = prog.message || 'Scoring with detector…';

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -16,6 +16,7 @@ import { SortStateService, SortMode, SelectMode, SortedItem } from '../../servic
 import { SettingsStateService } from '../../services/settings-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
 import { ActiveContextService } from '../../services/active-context.service';
+import { ProgressEventsService } from '../../services/progress-events.service';
 import { DetectorRegistryEntry } from '../../models/api.models';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
@@ -100,6 +101,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private settingsState: SettingsStateService,
     private autopilotStateService: AutopilotStateService,
     private activeContext: ActiveContextService,
+    private progressEvents: ProgressEventsService,
   ) {}
 
   ngOnInit(): void {
@@ -455,11 +457,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private startScoringProgressPoll(): void {
     this.stopScoringProgressPoll();
-    this.scoringProgressPoll$ = timer(200, 500)
-      .pipe(
-        switchMap(() => this.detectorsApi.getFindProgress()),
-        takeUntil(this.destroy$),
-      )
+    this.scoringProgressPoll$ = this.progressEvents.find$
+      .pipe(takeUntil(this.destroy$))
       .subscribe((prog: any) => {
         if (prog.status === 'running') {
           const msg = prog.message || 'Scoring with detector…';

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -7,6 +7,7 @@ import { ProgressBarComponent } from '../../progress-bar/progress-bar.component'
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { ChartsService } from '../../../services/charts.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
+import { ProgressEventsService } from '../../../services/progress-events.service';
 import {
   ErrorCostDataPoint,
   StabilityDataPoint,
@@ -40,6 +41,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     private sortingApi: SortingApiService,
     private chartsService: ChartsService,
     private settingsState: SettingsStateService,
+    private progressEvents: ProgressEventsService,
   ) {}
 
   get title(): string {
@@ -88,19 +90,16 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     this.analyzing = true;
     this.analysisProgress = 0;
 
-    // Poll progress
-    timer(0, 500)
-      .pipe(
-        takeUntil(this.destroy$),
-        switchMap(() => this.sortingApi.getVotingIterations()),
-      )
+    // Progress comes from the `eval` SSE channel on /api/events.
+    this.progressEvents.votingIterations$
+      .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (res) => {
           if (res.total > 0) {
             this.analysisProgress = Math.round((res.progress / res.total) * 100);
           }
           if (res.done) {
-            this.destroy$.next(); // stop polling
+            this.destroy$.next(); // stop watching
           }
         },
       });

--- a/frontend/src/app/services/datasets-api.service.spec.ts
+++ b/frontend/src/app/services/datasets-api.service.spec.ts
@@ -31,13 +31,6 @@ describe('DatasetsApiService', () => {
     req.flush({ loaded: true, num_medias: 10, has_votes: false });
   });
 
-  it('getProgress should GET', () => {
-    service.getProgress().subscribe();
-    const req = httpMock.expectOne('/api/dataset/progress');
-    expect(req.request.method).toBe('GET');
-    req.flush({});
-  });
-
   it('getImporters should GET', () => {
     service.getImporters().subscribe(data => expect(data.importers).toBeDefined());
     const req = httpMock.expectOne('/api/dataset/importers');

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -4,12 +4,9 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
   DatasetStatus,
-  DatasetProgress,
   DatasetStatsResponse,
   ImportersResponse,
   DemoListResponse,
-  LoadingTask,
-  LoadingTasksResponse,
   MediaTypesResponse,
   DatasetRegistryResponse,
   ClipperInfo,
@@ -27,10 +24,6 @@ export class DatasetsApiService {
 
   getStatus(): Observable<DatasetStatus> {
     return this.http.get<DatasetStatus>('/api/dataset/status');
-  }
-
-  getProgress(): Observable<DatasetProgress> {
-    return this.http.get<DatasetProgress>('/api/dataset/progress');
   }
 
   getImporters(): Observable<ImportersResponse> {
@@ -185,12 +178,6 @@ export class DatasetsApiService {
 
   combineDatasets(params: Record<string, unknown>): Observable<unknown> {
     return this.http.post('/api/dataset/combine', params);
-  }
-
-  getLoadingTasks(): Observable<LoadingTask[]> {
-    return this.http.get<LoadingTasksResponse>('/api/dataset/loading-tasks').pipe(
-      map((res) => res.tasks),
-    );
   }
 
   cancelIngest(): Observable<OkResponse> {

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -7,7 +7,6 @@ import {
   DetectorsRegistryResponse,
   DetectorsResponse,
   LabelsDetailResponse,
-  LoadingTasksResponse,
 } from '../models/api.models';
 import { ActiveContextService } from './active-context.service';
 
@@ -141,10 +140,6 @@ export class DetectorsApiService {
     return this.http.post(`/api/detectors/registry/${encodeURIComponent(detectorId)}/unload`, {});
   }
 
-  getDetectorLoadingTasks(): Observable<LoadingTasksResponse> {
-    return this.http.get<LoadingTasksResponse>('/api/detectors/loading-tasks');
-  }
-
   cancelDetectorLoadingTask(taskId: string): Observable<unknown> {
     return this.http.post(`/api/detectors/cancel/${encodeURIComponent(taskId)}`, {});
   }
@@ -219,10 +214,6 @@ export class DetectorsApiService {
 
   find(params: Record<string, unknown>): Observable<unknown> {
     return this.http.post('/api/find', params);
-  }
-
-  getFindProgress(): Observable<unknown> {
-    return this.http.get('/api/find/progress');
   }
 
   findLabel(params: Record<string, unknown>): Observable<unknown> {

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, OnDestroy, NgZone } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import {
+  DatasetProgress,
+  LoadingTask,
+  SortProgressResponse,
+  VotingIterationsResponse,
+} from '../models/api.models';
+
+/**
+ * Single EventSource subscription that fans out progress updates to every
+ * consumer in the app. Replaces the old REST polling (timer(0, 500) +
+ * /api/dataset/progress, etc.) with a server-push stream — see
+ * `docs/plans/feature-brainstorm.md` §12.5.
+ *
+ * Channels carried over `/api/events`:
+ *
+ *  - `dataset` -> DatasetProgress (singleton tracker; staging operations)
+ *  - `loading-tasks` -> LoadingTask[]
+ *  - `detector-loading-tasks` -> LoadingTask[]
+ *  - `sort` -> SortProgressResponse
+ *  - `find` -> generic progress dict (used by /api/find)
+ *  - `eval` -> singleton tracker dict (raw fields, not the
+ *    {progress,total,done} shape the old `/api/eval/voting-iterations`
+ *    endpoint returned — consumers derive `done` themselves)
+ */
+@Injectable({ providedIn: 'root' })
+export class ProgressEventsService implements OnDestroy {
+  private readonly datasetSubject = new BehaviorSubject<DatasetProgress>({});
+  private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
+  private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
+  private readonly sortSubject = new BehaviorSubject<SortProgressResponse>({});
+  private readonly findSubject = new BehaviorSubject<Record<string, unknown>>({});
+  private readonly evalSubject = new BehaviorSubject<Record<string, unknown>>({});
+
+  readonly dataset$ = this.datasetSubject.asObservable();
+  readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
+  readonly detectorLoadingTasks$ = this.detectorLoadingTasksSubject.asObservable();
+  readonly sort$ = this.sortSubject.asObservable();
+  readonly find$ = this.findSubject.asObservable();
+  readonly eval$ = this.evalSubject.asObservable();
+
+  private source: EventSource | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private zone: NgZone) {
+    this.connect();
+  }
+
+  ngOnDestroy(): void {
+    this.disconnect();
+  }
+
+  // -------------------------------------------------------------------------
+  // Latest-value accessors. Components that briefly need a value outside an
+  // RxJS pipeline (e.g. inside an imperative callback after a POST) use
+  // these instead of re-subscribing.
+  // -------------------------------------------------------------------------
+
+  get loadingTasks(): LoadingTask[] {
+    return this.loadingTasksSubject.value;
+  }
+
+  get detectorLoadingTasks(): LoadingTask[] {
+    return this.detectorLoadingTasksSubject.value;
+  }
+
+  get find(): Record<string, unknown> {
+    return this.findSubject.value;
+  }
+
+  /** Derive the {progress,total,done} shape the eval modal cares about. */
+  get votingIterations(): VotingIterationsResponse {
+    const prog = this.evalSubject.value;
+    const current = Number(prog['current'] ?? 0);
+    const total = Number(prog['total'] ?? 0);
+    const status = String(prog['status'] ?? 'idle');
+    const done = status === 'idle' && total > 0 && current >= total;
+    return { progress: current, total, done };
+  }
+
+  readonly votingIterations$ = new Observable<VotingIterationsResponse>((sub) => {
+    const inner = this.eval$.subscribe(() => sub.next(this.votingIterations));
+    return () => inner.unsubscribe();
+  });
+
+  // -------------------------------------------------------------------------
+  // EventSource lifecycle.
+  // -------------------------------------------------------------------------
+
+  private connect(): void {
+    if (this.source) return;
+    // EventSource fires events outside Angular's NgZone, so manually
+    // re-enter the zone for every subject.next() to trigger change
+    // detection on bound templates.
+    const es = new EventSource('/api/events');
+    this.source = es;
+
+    es.addEventListener('dataset', (e) =>
+      this.zone.run(() => this.datasetSubject.next(this.parse<DatasetProgress>(e, {}))),
+    );
+    es.addEventListener('loading-tasks', (e) =>
+      this.zone.run(() => this.loadingTasksSubject.next(this.parse<LoadingTask[]>(e, []))),
+    );
+    es.addEventListener('detector-loading-tasks', (e) =>
+      this.zone.run(() => this.detectorLoadingTasksSubject.next(this.parse<LoadingTask[]>(e, []))),
+    );
+    es.addEventListener('sort', (e) =>
+      this.zone.run(() => this.sortSubject.next(this.parse<SortProgressResponse>(e, {}))),
+    );
+    es.addEventListener('find', (e) =>
+      this.zone.run(() => this.findSubject.next(this.parse<Record<string, unknown>>(e, {}))),
+    );
+    es.addEventListener('eval', (e) =>
+      this.zone.run(() => this.evalSubject.next(this.parse<Record<string, unknown>>(e, {}))),
+    );
+
+    es.onerror = () => {
+      // EventSource reconnects on its own for transient failures, but
+      // schedules an extra reconnect in case the server closed the stream
+      // permanently. Idempotent: if `source` is already non-null the next
+      // connect() call returns immediately.
+      if (es.readyState === EventSource.CLOSED) {
+        this.source = null;
+        this.scheduleReconnect();
+      }
+    };
+  }
+
+  private disconnect(): void {
+    if (this.reconnectTimer != null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.source) {
+      this.source.close();
+      this.source = null;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer != null) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 2000);
+  }
+
+  private parse<T>(e: Event, fallback: T): T {
+    const msg = e as MessageEvent<string>;
+    try {
+      return JSON.parse(msg.data) as T;
+    } catch {
+      return fallback;
+    }
+  }
+}

--- a/frontend/src/app/services/sorting-api.service.spec.ts
+++ b/frontend/src/app/services/sorting-api.service.spec.ts
@@ -32,13 +32,6 @@ describe('SortingApiService', () => {
     req.flush({ results: [{ id: 1, similarity: 0.9 }], threshold: 0.5 });
   });
 
-  it('getSortProgress should GET', () => {
-    service.getSortProgress().subscribe();
-    const req = httpMock.expectOne('/api/sort/progress');
-    expect(req.request.method).toBe('GET');
-    req.flush({});
-  });
-
   it('learnedSort should POST and return a job envelope', () => {
     service.learnedSort().subscribe(data => {
       expect(data.job_id).toBeDefined();

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -15,12 +15,10 @@ import {
   FillFromSortConfirmResponse,
   TextsortSuggestionsResponse,
   OkResponse,
-  SortProgressResponse,
   LabelingStatusResponse,
   DiversityTreeNextResponse,
   ServerMediaFilesResponse,
   EvalTrainAndScoreJobResponse,
-  VotingIterationsResponse,
   IndicatorScoreHistoryResponse,
 } from '../models/api.models';
 
@@ -30,10 +28,6 @@ export class SortingApiService {
 
   sort(params: { text: string }): Observable<SortResponse> {
     return this.http.post<SortResponse>('/api/sort', params);
-  }
-
-  getSortProgress(): Observable<SortProgressResponse> {
-    return this.http.get<SortProgressResponse>('/api/sort/progress');
   }
 
   /** Kick off a learned-sort training job.  The response will be ``done``
@@ -182,7 +176,4 @@ export class SortingApiService {
     });
   }
 
-  getVotingIterations(): Observable<VotingIterationsResponse> {
-    return this.http.get<VotingIterationsResponse>('/api/eval/voting-iterations');
-  }
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,8 @@ def load_detector_and_wait(client, detector_id, timeout=5.0):
     """
     import time
 
+    from vtsearch.concurrency.progress import detector_loading_tasks
+
     res = client.post("/api/detectors/registry/load", json={"detector_id": detector_id})
     if detector_id is None:
         from vtsearch.state.core import set_thread_detector_context
@@ -20,9 +22,7 @@ def load_detector_and_wait(client, detector_id, timeout=5.0):
         return res
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        tasks_res = client.get("/api/detectors/loading-tasks")
-        tasks = tasks_res.get_json().get("tasks", [])
-        active = [t for t in tasks if t.get("status") != "idle"]
+        active = [t for t in detector_loading_tasks.list_tasks() if t.get("status") != "idle"]
         if not active:
             break
         time.sleep(0.05)

--- a/tests/api/test_api_contracts.py
+++ b/tests/api/test_api_contracts.py
@@ -423,16 +423,6 @@ class TestTextsortSuggestionsContract:
         assert "my suggestion" in data["suggestions"]
 
 
-class TestSortProgressContract:
-    """GET /api/sort/progress response shape."""
-
-    def test_returns_json(self, client):
-        resp = client.get("/api/sort/progress")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert isinstance(data, dict)
-
-
 class TestDiversityTreeContract:
     """GET/POST /api/diversity-tree/next response shape."""
 
@@ -613,10 +603,6 @@ class TestApiCacheControl:
 
     def test_datasets_registry_no_store(self, client):
         resp = client.get("/api/datasets/registry")
-        assert resp.headers.get("Cache-Control") == "no-store"
-
-    def test_loading_tasks_no_store(self, client):
-        resp = client.get("/api/dataset/loading-tasks")
         assert resp.headers.get("Cache-Control") == "no-store"
 
     def test_dataset_status_no_store(self, client):

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -722,13 +722,13 @@ class TestFindButtonValidation:
 
 
 class TestFindProgress:
-    """Tests for the /api/find/progress endpoint and progress reporting."""
+    """Tests for the find_progress tracker (streamed via the SSE `find` channel)."""
 
     def test_find_progress_returns_idle_by_default(self, client):
-        """GET /api/find/progress returns idle state when no Find is running."""
-        resp = client.get("/api/find/progress")
-        assert resp.status_code == 200
-        data = resp.get_json()
+        """The find_progress tracker is idle when no Find is running."""
+        from vtsearch.concurrency.progress import find_progress
+
+        data = find_progress.get()
         assert data["status"] == "idle"
         assert data["message"] == ""
         assert data["step"] is None

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -1,0 +1,216 @@
+"""Tests for the /api/events SSE endpoint and ProgressTracker subscriptions."""
+
+import json
+import threading
+import time
+
+from vtsearch.concurrency.events import (
+    _TASK_CHANNELS,
+    _TRACKER_CHANNELS,
+    initial_snapshot,
+    stream_progress_events,
+)
+from vtsearch.concurrency.progress import (
+    LoadingTasksTracker,
+    ProgressTracker,
+    dataset_progress,
+    loading_tasks,
+    sort_progress,
+)
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / notify primitive tests
+# ---------------------------------------------------------------------------
+
+
+class TestProgressTrackerSubscriptions:
+    def test_subscribe_receives_snapshot_on_update(self):
+        tracker = ProgressTracker()
+        received: list[dict] = []
+        tracker.subscribe(received.append)
+
+        tracker.update("loading", "Working", 3, 10)
+
+        assert len(received) == 1
+        assert received[0]["status"] == "loading"
+        assert received[0]["current"] == 3
+        assert received[0]["total"] == 10
+
+    def test_unsubscribe_stops_notifications(self):
+        tracker = ProgressTracker()
+        received: list[dict] = []
+        tracker.subscribe(received.append)
+        tracker.unsubscribe(received.append)
+
+        tracker.update("loading", "", 1, 2)
+        assert received == []
+
+    def test_unsubscribe_missing_is_noop(self):
+        tracker = ProgressTracker()
+        tracker.unsubscribe(lambda _: None)  # never subscribed; should not raise
+
+    def test_subscriber_exception_does_not_break_producer(self):
+        tracker = ProgressTracker()
+        good: list[dict] = []
+
+        def bad(_snapshot):
+            raise RuntimeError("intentional")
+
+        tracker.subscribe(bad)
+        tracker.subscribe(good.append)
+
+        tracker.update("loading", "", 1, 1)
+
+        # The good subscriber still ran even though the bad one raised.
+        assert len(good) == 1
+
+    def test_extra_fields_round_trip_through_subscription(self):
+        tracker = ProgressTracker(extra_fields={"error": None, "step": None})
+        received: list[dict] = []
+        tracker.subscribe(received.append)
+
+        tracker.update("error", "boom", 0, 0, error="kapow", step=2)
+
+        assert received[0]["error"] == "kapow"
+        assert received[0]["step"] == 2
+
+
+class TestLoadingTasksTrackerSubscriptions:
+    def test_create_task_notifies(self):
+        tracker = LoadingTasksTracker()
+        received: list[list[dict]] = []
+        tracker.subscribe(received.append)
+
+        tracker.create_task("t1", name="One")
+        try:
+            assert len(received) == 1
+            assert received[0][0]["task_id"] == "t1"
+        finally:
+            tracker.remove_task("t1")
+
+    def test_inner_tracker_update_propagates_to_outer(self):
+        tracker = LoadingTasksTracker()
+        received: list[list[dict]] = []
+        inner = tracker.create_task("t1", name="One")
+        tracker.subscribe(received.append)
+        try:
+            inner.update("loading", "Working", 5, 10)
+            assert len(received) == 1
+            assert received[0][0]["status"] == "loading"
+            assert received[0][0]["current"] == 5
+        finally:
+            tracker.remove_task("t1")
+
+    def test_remove_notifies(self):
+        tracker = LoadingTasksTracker()
+        tracker.create_task("t1")
+        received: list[list[dict]] = []
+        tracker.subscribe(received.append)
+
+        tracker.remove_task("t1")
+        assert len(received) == 1
+        assert received[0] == []
+
+
+# ---------------------------------------------------------------------------
+# /api/events endpoint
+# ---------------------------------------------------------------------------
+
+
+def _read_sse_event(stream, *, timeout=2.0):
+    """Pull one event:/data: pair from the SSE generator."""
+    deadline = time.monotonic() + timeout
+    buf = ""
+    while time.monotonic() < deadline:
+        chunk = next(stream, None)
+        if chunk is None:
+            break
+        buf += chunk
+        if "\n\n" in buf:
+            frame, _, buf = buf.partition("\n\n")
+            return frame, buf
+    return None, buf
+
+
+class TestEventsRoute:
+    def test_initial_snapshot_includes_every_channel(self):
+        frames = initial_snapshot()
+        # One frame per known channel.
+        names = {f.split("\n", 1)[0].replace("event: ", "") for f in frames}
+        expected = set(_TRACKER_CHANNELS.keys()) | set(_TASK_CHANNELS.keys())
+        assert names == expected
+
+    def test_endpoint_returns_sse_mimetype(self, client):
+        # We can't keep the generator open easily through the test client,
+        # so just hit it with a streaming GET and assert the response shape.
+        resp = client.get("/api/events", buffered=False)
+        try:
+            assert resp.status_code == 200
+            assert resp.mimetype == "text/event-stream"
+            assert resp.headers.get("X-Accel-Buffering") == "no"
+        finally:
+            resp.close()
+
+    def test_stream_yields_update_after_subscribe(self):
+        """Pump the generator directly and assert a live update arrives."""
+        gen = stream_progress_events(heartbeat_seconds=60.0)
+        try:
+            # Drain initial connect comment + the snapshot frames so the
+            # generator is parked on the queue.get() call.
+            seen_channels: set[str] = set()
+            expected = set(_TRACKER_CHANNELS.keys()) | set(_TASK_CHANNELS.keys())
+            deadline = time.monotonic() + 2.0
+            while seen_channels != expected and time.monotonic() < deadline:
+                chunk = next(gen)
+                if chunk.startswith("event: "):
+                    name = chunk.split("\n", 1)[0].removeprefix("event: ")
+                    seen_channels.add(name)
+            assert seen_channels == expected
+
+            # Now publish an update on a fresh tracker and read it back.
+            #
+            # The generator is blocked inside queue.get() in the SSE
+            # thread; we trigger an update from this thread, then pull
+            # the next frame.
+            def push_update():
+                # Small wait so we know the generator has parked on
+                # queue.get(). Without this, the publish can race the
+                # subscribe.
+                time.sleep(0.05)
+                sort_progress.update("running", "tick", 1, 10)
+
+            t = threading.Thread(target=push_update, daemon=True)
+            t.start()
+            frame = next(gen)
+            t.join(timeout=1.0)
+            assert frame.startswith("event: sort\n")
+            data_line = [ln for ln in frame.splitlines() if ln.startswith("data: ")][0]
+            payload = json.loads(data_line.removeprefix("data: "))
+            assert payload["status"] == "running"
+            assert payload["current"] == 1
+        finally:
+            gen.close()
+
+    def test_initial_dataset_snapshot_reflects_current_state(self):
+        dataset_progress.update("loading", "snap", 7, 8)
+        try:
+            frames = initial_snapshot()
+            ds_frame = next(f for f in frames if f.startswith("event: dataset\n"))
+            data_line = [ln for ln in ds_frame.splitlines() if ln.startswith("data: ")][0]
+            payload = json.loads(data_line.removeprefix("data: "))
+            assert payload["current"] == 7
+            assert payload["total"] == 8
+        finally:
+            dataset_progress.update("idle", "", 0, 0)
+
+    def test_initial_loading_tasks_snapshot(self):
+        loading_tasks.create_task("evt_test", name="Evt DS")
+        try:
+            frames = initial_snapshot()
+            lt_frame = next(f for f in frames if f.startswith("event: loading-tasks\n"))
+            data_line = [ln for ln in lt_frame.splitlines() if ln.startswith("data: ")][0]
+            payload = json.loads(data_line.removeprefix("data: "))
+            assert any(t["task_id"] == "evt_test" for t in payload)
+        finally:
+            loading_tasks.remove_task("evt_test")

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -254,7 +254,7 @@ class TestGetProgressWithLoadingTasks:
 # ---------------------------------------------------------------------------
 
 
-class TestLoadingTasksTracker:
+class TestLoadingTasksTrackerEndpoint:
     """Test the loading_tasks tracker (streamed via the SSE `loading-tasks` channel)."""
 
     def test_returns_empty_when_no_tasks(self, client):

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -254,24 +254,19 @@ class TestGetProgressWithLoadingTasks:
 # ---------------------------------------------------------------------------
 
 
-class TestLoadingTasksEndpoint:
-    """Test the /api/dataset/loading-tasks endpoint."""
+class TestLoadingTasksTracker:
+    """Test the loading_tasks tracker (streamed via the SSE `loading-tasks` channel)."""
 
     def test_returns_empty_when_no_tasks(self, client):
-        resp = client.get("/api/dataset/loading-tasks")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["tasks"] == []
+        assert loading_tasks.list_tasks() == []
 
     def test_returns_active_tasks(self, client):
         pt = loading_tasks.create_task("api_test", "API Test DS")
         pt.update("loading", "Processing", 25, 50)
         try:
-            resp = client.get("/api/dataset/loading-tasks")
-            assert resp.status_code == 200
-            data = resp.get_json()
-            assert len(data["tasks"]) == 1
-            task = data["tasks"][0]
+            tasks = loading_tasks.list_tasks()
+            assert len(tasks) == 1
+            task = tasks[0]
             assert task["task_id"] == "api_test"
             assert task["name"] == "API Test DS"
             assert task["status"] == "loading"
@@ -281,26 +276,23 @@ class TestLoadingTasksEndpoint:
 
 
 class TestLoadingTasksMediaType:
-    """Test that /api/dataset/loading-tasks exposes media_type."""
+    """Test that the loading_tasks tracker exposes media_type."""
 
-    def test_api_returns_media_type(self, client):
+    def test_tasks_include_media_type(self, client):
         pt = loading_tasks.create_task("mt_test", "Image DS", media_type="image")
         pt.update("loading", "Working", 10, 100)
         try:
-            resp = client.get("/api/dataset/loading-tasks")
-            assert resp.status_code == 200
-            tasks = resp.get_json()["tasks"]
+            tasks = loading_tasks.list_tasks()
             assert len(tasks) == 1
             assert tasks[0]["media_type"] == "image"
         finally:
             loading_tasks.remove_task("mt_test")
 
-    def test_api_omits_empty_media_type(self, client):
+    def test_tasks_omit_empty_media_type(self, client):
         pt = loading_tasks.create_task("mt_test2", "Unknown DS")
         pt.update("loading", "Working", 10, 100)
         try:
-            resp = client.get("/api/dataset/loading-tasks")
-            tasks = resp.get_json()["tasks"]
+            tasks = loading_tasks.list_tasks()
             assert len(tasks) == 1
             assert "media_type" not in tasks[0]
         finally:
@@ -442,15 +434,14 @@ class TestErrorVisibility:
         tasks = loading_tasks.list_tasks()
         assert len(tasks) == 0
 
-    def test_errored_task_in_api_response(self, client):
-        """GET /api/dataset/loading-tasks returns errored tasks."""
+    def test_errored_task_listed_after_finish(self, client):
+        """list_tasks() returns errored tasks until the stale window elapses."""
         pt = loading_tasks.create_task("api_err", "API Err DS")
         pt.update("idle", "", 0, 0, error="Load failed")
         loading_tasks.mark_finished("api_err")
         try:
-            resp = client.get("/api/dataset/loading-tasks")
-            data = resp.get_json()
-            errored = [t for t in data["tasks"] if t.get("error")]
+            tasks = loading_tasks.list_tasks()
+            errored = [t for t in tasks if t.get("error")]
             assert len(errored) == 1
             assert errored[0]["error"] == "Load failed"
         finally:

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -368,14 +368,15 @@ def _load_detector_and_wait_local(client, detector_id, timeout=5.0):
     """
     import time
 
+    from vtsearch.concurrency.progress import detector_loading_tasks
     from vtsearch.state.core import get_detector_context, set_thread_detector_context
 
     res = client.post("/api/detectors/registry/load", json={"detector_id": detector_id})
     assert res.status_code in (200, 202), res.get_data(as_text=True)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        tasks = client.get("/api/detectors/loading-tasks").get_json().get("tasks", [])
-        if not [t for t in tasks if t.get("status") != "idle"]:
+        active = [t for t in detector_loading_tasks.list_tasks() if t.get("status") != "idle"]
+        if not active:
             break
         time.sleep(0.05)
 

--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -374,9 +374,9 @@ class TestModelLoadingTasks:
     """Test the model loading tasks progress API."""
 
     def test_loading_tasks_empty(self, client):
-        res = client.get("/api/detectors/loading-tasks")
-        assert res.status_code == 200
-        assert res.get_json()["tasks"] == []
+        from vtsearch.concurrency.progress import detector_loading_tasks
+
+        assert detector_loading_tasks.list_tasks() == []
 
     def test_cancel_nonexistent_task(self, client):
         res = client.post("/api/detectors/cancel/nonexistent")

--- a/vtsearch/concurrency/events.py
+++ b/vtsearch/concurrency/events.py
@@ -27,10 +27,11 @@ from vtsearch.concurrency.progress import (
     sort_progress,
 )
 
-#: Snapshot interval used as a fallback when no events arrive — also doubles
-#: as the SSE heartbeat (comment line) cadence so proxies / load balancers
-#: don't drop idle connections.
-HEARTBEAT_SECONDS = 15.0
+#: SSE heartbeat cadence. Also drives the periodic re-emit of task
+#: channels so finished tasks vanish from clients once they pass the
+#: ``LoadingTasksTracker`` stale-prune window without us having to
+#: schedule a background timer for every finish.
+HEARTBEAT_SECONDS = 5.0
 
 #: Single-channel trackers (key = SSE event name).
 _TRACKER_CHANNELS: dict[str, ProgressTracker] = {
@@ -120,6 +121,10 @@ def stream_progress_events(
                 yield _format_sse(name, snapshot)
             except queue.Empty:
                 yield ": heartbeat\n\n"
+                # Re-emit task channels so clients see finished tasks
+                # disappear once their stale-prune window elapses.
+                for name, tasks_tracker in _TASK_CHANNELS.items():
+                    yield _format_sse(name, tasks_tracker.list_tasks())
                 last_heartbeat = time.monotonic()
     finally:
         for subject, handler in subscriptions:

--- a/vtsearch/concurrency/events.py
+++ b/vtsearch/concurrency/events.py
@@ -1,0 +1,126 @@
+"""Server-Sent Events stream for progress channels.
+
+Maintains a registry of named channels (each backed by a
+:class:`ProgressTracker` or :class:`LoadingTasksTracker`) and produces SSE
+event strings that ``/api/events`` streams to connected clients.
+
+Replaces the per-tracker REST polling endpoints (``/api/dataset/progress``,
+``/api/sort/progress``, etc.) with a single push channel — see
+``docs/plans/feature-brainstorm.md`` §12.5.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import time
+from typing import Any, Callable, Iterator
+
+from vtsearch.concurrency.progress import (
+    LoadingTasksTracker,
+    ProgressTracker,
+    dataset_progress,
+    detector_loading_tasks,
+    eval_progress,
+    find_progress,
+    loading_tasks,
+    sort_progress,
+)
+
+#: Snapshot interval used as a fallback when no events arrive — also doubles
+#: as the SSE heartbeat (comment line) cadence so proxies / load balancers
+#: don't drop idle connections.
+HEARTBEAT_SECONDS = 15.0
+
+#: Single-channel trackers (key = SSE event name).
+_TRACKER_CHANNELS: dict[str, ProgressTracker] = {
+    "dataset": dataset_progress,
+    "sort": sort_progress,
+    "find": find_progress,
+    "eval": eval_progress,
+}
+
+#: Task-list trackers (key = SSE event name).
+_TASK_CHANNELS: dict[str, LoadingTasksTracker] = {
+    "loading-tasks": loading_tasks,
+    "detector-loading-tasks": detector_loading_tasks,
+}
+
+
+def _format_sse(event: str, data: Any) -> str:
+    payload = json.dumps(data, default=str)
+    return f"event: {event}\ndata: {payload}\n\n"
+
+
+def initial_snapshot() -> list[str]:
+    """Return the SSE frames a freshly-connected client should receive first."""
+    frames: list[str] = []
+    for name, tracker in _TRACKER_CHANNELS.items():
+        frames.append(_format_sse(name, tracker.get()))
+    for name, tasks_tracker in _TASK_CHANNELS.items():
+        frames.append(_format_sse(name, tasks_tracker.list_tasks()))
+    return frames
+
+
+def stream_progress_events(
+    *, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024
+) -> Iterator[str]:
+    """Yield SSE-formatted strings for every progress channel until disconnect.
+
+    Each connected client gets a private bounded queue; tracker subscriptions
+    push snapshots into the queue, and the generator drains it. On client
+    disconnect (the generator is closed by Flask/Werkzeug) the ``finally``
+    block unsubscribes so we don't leak callbacks.
+    """
+    q: queue.Queue[tuple[str, Any]] = queue.Queue(maxsize=max_queue)
+
+    subscriptions: list[tuple[Any, Callable[..., None]]] = []
+
+    def _make_tracker_handler(channel: str) -> Callable[[dict[str, Any]], None]:
+        def handler(snapshot: dict[str, Any]) -> None:
+            try:
+                q.put_nowait((channel, snapshot))
+            except queue.Full:
+                pass
+
+        return handler
+
+    def _make_tasks_handler(channel: str) -> Callable[[list[dict[str, Any]]], None]:
+        def handler(snapshot: list[dict[str, Any]]) -> None:
+            try:
+                q.put_nowait((channel, snapshot))
+            except queue.Full:
+                pass
+
+        return handler
+
+    for name, tracker in _TRACKER_CHANNELS.items():
+        h = _make_tracker_handler(name)
+        tracker.subscribe(h)
+        subscriptions.append((tracker, h))
+    for name, tasks_tracker in _TASK_CHANNELS.items():
+        h = _make_tasks_handler(name)
+        tasks_tracker.subscribe(h)
+        subscriptions.append((tasks_tracker, h))
+
+    try:
+        # Send the SSE handshake comment immediately so the browser fires
+        # `onopen` before any real event; some proxies buffer until the
+        # first byte arrives.
+        yield ": connected\n\n"
+
+        for frame in initial_snapshot():
+            yield frame
+
+        last_heartbeat = time.monotonic()
+        while True:
+            timeout = max(0.0, heartbeat_seconds - (time.monotonic() - last_heartbeat))
+            try:
+                name, snapshot = q.get(timeout=timeout)
+                yield _format_sse(name, snapshot)
+            except queue.Empty:
+                yield ": heartbeat\n\n"
+                last_heartbeat = time.monotonic()
+    finally:
+        for subject, handler in subscriptions:
+            subject.unsubscribe(handler)

--- a/vtsearch/concurrency/events.py
+++ b/vtsearch/concurrency/events.py
@@ -63,9 +63,7 @@ def initial_snapshot() -> list[str]:
     return frames
 
 
-def stream_progress_events(
-    *, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024
-) -> Iterator[str]:
+def stream_progress_events(*, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024) -> Iterator[str]:
     """Yield SSE-formatted strings for every progress channel until disconnect.
 
     Each connected client gets a private bounded queue; tracker subscriptions

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -2,7 +2,7 @@
 
 import time
 import threading
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 _UNSET = object()  # sentinel for "caller did not provide this argument"
 
@@ -23,6 +23,11 @@ class ProgressTracker:
     the background thread to raise :class:`CancelledError` when the flag is
     set.
 
+    Subscribers (registered via :meth:`subscribe`) are invoked with a
+    snapshot of the data dict on every :meth:`update`. The SSE event
+    endpoint uses this to push progress to connected clients without
+    polling.
+
     Args:
         extra_fields: Mapping of extra field names to their default values.
             These fields can be set via keyword arguments in :meth:`update`
@@ -40,6 +45,8 @@ class ProgressTracker:
             "total": 0,
             **{k: v for k, v in self._extra_defaults.items()},
         }
+        self._subscribers: list[Callable[[dict[str, Any]], None]] = []
+        self._subscribers_lock = threading.Lock()
 
     def update(
         self,
@@ -67,6 +74,36 @@ class ProgressTracker:
             for key in self._extra_defaults:
                 if key in kwargs:
                     self._data[key] = kwargs[key]
+            snapshot = dict(self._data)
+        self._notify(snapshot)
+
+    def subscribe(self, callback: Callable[[dict[str, Any]], None]) -> None:
+        """Register a callback fired with a snapshot after every update.
+
+        The callback runs synchronously on the thread that called
+        :meth:`update`, *outside* the tracker's lock. Subscribers must be
+        non-blocking and exception-safe; any exception they raise is
+        swallowed so a misbehaving subscriber cannot break the producer.
+        """
+        with self._subscribers_lock:
+            self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[dict[str, Any]], None]) -> None:
+        """Remove a previously-registered subscriber. No-op if not present."""
+        with self._subscribers_lock:
+            try:
+                self._subscribers.remove(callback)
+            except ValueError:
+                pass
+
+    def _notify(self, snapshot: dict[str, Any]) -> None:
+        with self._subscribers_lock:
+            subs = list(self._subscribers)
+        for cb in subs:
+            try:
+                cb(snapshot)
+            except Exception:
+                pass
 
     def cancel(self) -> None:
         """Signal the background operation to stop.
@@ -152,6 +189,35 @@ class LoadingTasksTracker:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._tasks: dict[str, dict[str, Any]] = {}
+        self._subscribers: list[Callable[[list[dict[str, Any]]], None]] = []
+        self._subscribers_lock = threading.Lock()
+
+    def subscribe(self, callback: Callable[[list[dict[str, Any]]], None]) -> None:
+        """Register a callback fired with the task list after every change.
+
+        Same semantics as :meth:`ProgressTracker.subscribe`: invoked
+        synchronously, outside locks, exceptions swallowed.
+        """
+        with self._subscribers_lock:
+            self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[list[dict[str, Any]]], None]) -> None:
+        """Remove a previously-registered subscriber. No-op if not present."""
+        with self._subscribers_lock:
+            try:
+                self._subscribers.remove(callback)
+            except ValueError:
+                pass
+
+    def _notify(self) -> None:
+        snapshot = self.list_tasks()
+        with self._subscribers_lock:
+            subs = list(self._subscribers)
+        for cb in subs:
+            try:
+                cb(snapshot)
+            except Exception:
+                pass
 
     def create_task(
         self,
@@ -167,6 +233,7 @@ class LoadingTasksTracker:
         Returns the per-task :class:`ProgressTracker` instance.
         """
         tracker = ProgressTracker(extra_fields={"error": None, "step": None, "total_steps": None})
+        tracker.subscribe(lambda _snapshot: self._notify())
         with self._lock:
             self._tasks[task_id] = {
                 "tracker": tracker,
@@ -178,14 +245,23 @@ class LoadingTasksTracker:
                 "detector_id": detector_id,
                 "embedder": embedder,
             }
+        self._notify()
         return tracker
 
     def mark_finished(self, task_id: str) -> None:
         """Record the time a task finished (for deferred cleanup)."""
+        delay: float | None = None
         with self._lock:
             entry = self._tasks.get(task_id)
             if entry:
                 entry["finished_at"] = time.time()
+                has_error = bool(entry["tracker"].get().get("error"))
+                delay = (30 if has_error else 5) + 0.5
+        self._notify()
+        if delay is not None:
+            t = threading.Timer(delay, self._notify)
+            t.daemon = True
+            t.start()
 
     def get_tracker(self, task_id: str) -> ProgressTracker | None:
         """Return the ProgressTracker for *task_id*, or ``None``."""
@@ -214,11 +290,13 @@ class LoadingTasksTracker:
             entry = self._tasks.get(task_id)
             if entry:
                 entry["dataset_id"] = dataset_id
+        self._notify()
 
     def remove_task(self, task_id: str) -> None:
         """Remove a completed/cancelled task from the tracker."""
         with self._lock:
             self._tasks.pop(task_id, None)
+        self._notify()
 
     def list_tasks(self) -> list[dict[str, Any]]:
         """Return a snapshot of all active loading tasks.

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -249,19 +249,17 @@ class LoadingTasksTracker:
         return tracker
 
     def mark_finished(self, task_id: str) -> None:
-        """Record the time a task finished (for deferred cleanup)."""
-        delay: float | None = None
+        """Record the time a task finished (for deferred cleanup).
+
+        ``list_tasks()`` prunes stale finished entries the next time it is
+        called; SSE streams call it on every heartbeat tick so a
+        background timer here is unnecessary.
+        """
         with self._lock:
             entry = self._tasks.get(task_id)
             if entry:
                 entry["finished_at"] = time.time()
-                has_error = bool(entry["tracker"].get().get("error"))
-                delay = (30 if has_error else 5) + 0.5
         self._notify()
-        if delay is not None:
-            t = threading.Timer(delay, self._notify)
-            t.daemon = True
-            t.start()
 
     def get_tracker(self, task_id: str) -> ProgressTracker | None:
         """Return the ProgressTracker for *task_id*, or ``None``."""

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -17,6 +17,7 @@ from vtsearch.routes.detectors import (
     detectors_registry_bp,
 )
 from vtsearch.routes.eval import eval_bp
+from vtsearch.routes.events import events_bp
 from vtsearch.routes.file_browser import file_browser_bp
 from vtsearch.routes.labels import exporters_bp, label_importers_bp, labels_bp
 from vtsearch.routes.main import main_bp
@@ -40,6 +41,7 @@ __all__ = [
     "detectors_registry_bp",
     "embed_bp",
     "eval_bp",
+    "events_bp",
     "exporters_bp",
     "file_browser_bp",
     "label_importers_bp",

--- a/vtsearch/routes/datasets/status.py
+++ b/vtsearch/routes/datasets/status.py
@@ -1,10 +1,14 @@
-"""Dataset status / progress / cancellation endpoints."""
+"""Dataset status / cancellation endpoints.
+
+Per-operation progress is streamed via the unified ``/api/events`` SSE
+endpoint — see ``feature-brainstorm.md`` §12.5 and
+``vtsearch/routes/events.py``.
+"""
 
 from flask import Blueprint, jsonify
 
 from vtsearch.concurrency.progress import (
     cancel_dataset_progress,
-    get_progress,
     loading_tasks as _loading_tasks,
 )
 from vtsearch.state import (
@@ -35,31 +39,6 @@ def dataset_status():
             "num_dupes": get_dupe_count(),
         }
     )
-
-
-@datasets_status_bp.route("/api/dataset/progress")
-def dataset_progress():
-    """Return the current progress of long-running operations.
-
-    For backward compatibility this returns a single progress dict.
-    Prefers the first active loading task if any, otherwise falls back
-    to the legacy global tracker (used by staging operations).
-    """
-    tasks = _loading_tasks.list_tasks()
-    active = [t for t in tasks if t.get("status") != "idle"]
-    if active:
-        return jsonify(active[0])
-    # Check if any just-finished task has an error to report
-    errored = [t for t in tasks if t.get("error")]
-    if errored:
-        return jsonify(errored[0])
-    return jsonify(get_progress())
-
-
-@datasets_status_bp.route("/api/dataset/loading-tasks")
-def dataset_loading_tasks():
-    """Return all active dataset loading tasks with their progress."""
-    return jsonify({"tasks": _loading_tasks.list_tasks()})
 
 
 @datasets_status_bp.route("/api/dataset/cancel", methods=["POST"])

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -15,7 +15,7 @@ from flask import Blueprint, jsonify
 
 from vtsearch.detectors.training import train_and_threshold
 from vtsearch.routes._shared import get_json_safe
-from vtsearch.concurrency.progress import get_find_progress, update_find_progress
+from vtsearch.concurrency.progress import update_find_progress
 
 detector_find_bp = Blueprint("detector_find", __name__)
 
@@ -114,12 +114,6 @@ def find_check_labels():
             )
 
     return jsonify({"warnings": warnings})
-
-
-@detector_find_bp.route("/api/find/progress")
-def find_progress_endpoint():
-    """Return the current progress of the Find operation."""
-    return jsonify(get_find_progress())
 
 
 @detector_find_bp.route("/api/find", methods=["POST"])

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -485,14 +485,6 @@ def delete_registered_detector(detector_id: str):
     return jsonify({"ok": True})
 
 
-@detectors_registry_bp.route("/api/detectors/loading-tasks")
-def detector_loading_tasks_endpoint():
-    """Return all active detector loading tasks with their progress."""
-    from vtsearch.concurrency.progress import detector_loading_tasks
-
-    return jsonify({"tasks": detector_loading_tasks.list_tasks()})
-
-
 @detectors_registry_bp.route("/api/detectors/cancel/<task_id>", methods=["POST"])
 def cancel_detector_loading_task(task_id: str):
     """Cancel a specific detector loading task."""

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -241,5 +241,3 @@ def eval_train_and_score_result():
     if job.status == "cancelled":
         return jsonify({"job_id": job.job_id, "status": "cancelled"})
     return jsonify(_eval_done_payload(job))
-
-

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -123,7 +123,8 @@ def eval_train_and_score():
     every step, which used to block every other request on the gthread
     pool.  We now run it on a background daemon thread and return a
     ``job_id``; clients poll ``/api/eval/train-and-score/result`` for the
-    metric data and ``/api/eval/voting-iterations`` for progress.
+    metric data; the ``eval`` SSE channel on ``/api/events`` carries
+    live progress.
 
     A signature cache keyed by ``(metric, history, votes, inclusion,
     dataset, detector)`` short-circuits identical re-runs.
@@ -242,20 +243,3 @@ def eval_train_and_score_result():
     return jsonify(_eval_done_payload(job))
 
 
-@eval_bp.route("/api/eval/voting-iterations", methods=["GET"])
-def eval_voting_iterations():
-    """Return progress of the current eval computation.
-
-    Returns::
-
-        {"progress": <int>, "total": <int>, "done": <bool>}
-    """
-    prog = get_eval_progress()
-    done = prog["status"] == "idle" and prog["total"] > 0 and prog["current"] >= prog["total"]
-    return jsonify(
-        {
-            "progress": prog["current"],
-            "total": prog["total"],
-            "done": done,
-        }
-    )

--- a/vtsearch/routes/events.py
+++ b/vtsearch/routes/events.py
@@ -1,0 +1,37 @@
+"""SSE endpoint streaming all progress channels to connected clients.
+
+Replaces per-tracker REST polling (``/api/dataset/progress``,
+``/api/sort/progress``, etc.) with a single push channel — see
+``docs/plans/feature-brainstorm.md`` §12.5.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response, stream_with_context
+
+from vtsearch.concurrency.events import stream_progress_events
+
+events_bp = Blueprint("events", __name__)
+
+
+@events_bp.route("/api/events")
+def progress_events() -> Response:
+    """Stream progress updates for every channel as Server-Sent Events.
+
+    The client connects with ``new EventSource('/api/events')`` and listens
+    for ``dataset``, ``sort``, ``find``, ``eval``, ``loading-tasks``, and
+    ``detector-loading-tasks`` events. The first frame on every channel is
+    the current snapshot — clients do not need a separate REST call to
+    bootstrap state.
+    """
+    response = Response(
+        stream_with_context(stream_progress_events()),
+        mimetype="text/event-stream",
+    )
+    # Long-lived; bypass the @after_request no-store header (already set,
+    # which is fine for SSE) and disable proxy buffering so events flush
+    # immediately instead of pooling behind nginx / gunicorn.
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    response.headers["Connection"] = "keep-alive"
+    return response

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -39,18 +39,9 @@ from vtsearch.state import (
     update_learned_scores,
     vote_region_boxes,
 )
-from vtsearch.concurrency.progress import (
-    get_sort_progress,
-    update_sort_progress,
-)
+from vtsearch.concurrency.progress import update_sort_progress
 
 sorting_bp = Blueprint("sorting", __name__)
-
-
-@sorting_bp.route("/api/sort/progress")
-def sort_progress():
-    """Return the current progress of a text sort operation."""
-    return jsonify(get_sort_progress())
 
 
 def _cosine_sort(query_vec):


### PR DESCRIPTION
## Summary

Closes feature-brainstorm.md §12.5 (and supersedes §18.9). Replaces six polled REST endpoints with a single Server-Sent Events stream at `GET /api/events`.

Discussion in chat settled on **SSE over WebSocket** — progress is one-way, text-only, and Flask is sync/WSGI, so SSE drops in as a plain streaming GET without `flask-sock` / ASGI / Upgrade-handshake surface area. Auth, per-request context, and `EventSource` auto-reconnect all come for free.

## Channels on `/api/events`

| Event | Payload | Replaces |
|---|---|---|
| `dataset` | progress dict | `GET /api/dataset/progress` |
| `loading-tasks` | task array | `GET /api/dataset/loading-tasks` |
| `detector-loading-tasks` | task array | `GET /api/detectors/loading-tasks` |
| `sort` | progress dict | `GET /api/sort/progress` |
| `find` | progress dict | `GET /api/find/progress` |
| `eval` | progress dict | `GET /api/eval/voting-iterations` |

First frame on every channel is the current snapshot, so clients don't need a bootstrap REST call.

## Backend

- `ProgressTracker` / `LoadingTasksTracker` gain `subscribe` / `unsubscribe`; updates fire callbacks outside the lock, exceptions swallowed.
- `vtsearch/concurrency/events.py` drives the SSE generator with a per-connection bounded queue. The heartbeat tick (5 s) doubles as the stale-prune fan-out so finished tasks vanish from the UI without a background timer.
- `/api/events` sets `text/event-stream` + `X-Accel-Buffering: no` for nginx / gunicorn flushing.

## Frontend

- New `ProgressEventsService` owns one `EventSource`, fans out `BehaviorSubject`s per channel, derives `votingIterations$` for the eval modal, and manually reconnects after a permanent close.
- Migrated consumers: `dashboard`, `find-view`, `label-view`, `progress-modal`.
- Dropped `getProgress` / `getLoadingTasks` / `getSortProgress` / `getFindProgress` / `getDetectorLoadingTasks` / `getVotingIterations` (and their specs).

## Tests & docs

- 15 new tests in `tests/api/test_events_sse.py` covering subscribe/unsubscribe, exception isolation, inner-tracker propagation, and the SSE generator's snapshot + live-push behavior.
- New `docs/api/events.md` describes channels and frame format.
- Existing API docs point at the new endpoint; brainstorm doc §12.5 marked **DONE** with the SSE-over-WS rationale.

## Backwards-incompatible

Any external script polling the six removed endpoints needs to switch to `/api/events`. Per CLAUDE.md's "no compatibility shims" rule, the old endpoints are gone rather than kept as fallbacks.

## Test plan

- [x] `./run-tests.sh` — 3365 passed, 1 skipped
- [x] `cd frontend && npm run build:prod` — clean
- [x] `ruff check .` — clean
- [ ] Manual smoke: load a demo dataset and confirm progress streams in the dashboard with no `/api/dataset/loading-tasks` requests in DevTools Network tab
- [ ] Manual smoke: open the eval Progress modal and confirm the progress bar updates from the `eval` SSE channel

https://claude.ai/code/session_016EA88yY9SDK6G4SA3QXhSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016EA88yY9SDK6G4SA3QXhSZ)_