### PR TITLE
Add --list-plugins CLI, OpenAPI schema, and entry-point plugin discovery

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,6 +280,45 @@ if __name__ == "__main__":
         action="store_true",
         help="Run a detector on a dataset from the command line and print predicted-Good items",
     )
+    parser.add_argument(
+        "--list-plugins",
+        action="store_true",
+        dest="list_plugins",
+        help=(
+            "List every auto-discovered plugin (importers, exporters, embedders, "
+            "converters, clippers, …) and exit. Useful for shell completion."
+        ),
+    )
+    parser.add_argument(
+        "--plugin-family",
+        type=str,
+        default=None,
+        dest="plugin_family",
+        help=(
+            "When given with --list-plugins, restrict output to this family "
+            "(e.g. importers, exporters). Combine with --format=names for "
+            "completion-friendly output."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        default="plain",
+        choices=["plain", "json", "names"],
+        dest="output_format",
+        help=(
+            "Output format for --list-plugins / --openapi-schema. 'plain' is "
+            "human-readable, 'json' is machine-readable, 'names' emits bare "
+            "plugin names one per line (shell-completion friendly). "
+            "--openapi-schema only honours 'json' (default for that flag)."
+        ),
+    )
+    parser.add_argument(
+        "--openapi-schema",
+        action="store_true",
+        dest="openapi_schema",
+        help="Print the auto-generated OpenAPI 3.0 spec for the HTTP API and exit.",
+    )
     parser.add_argument("--dataset", type=str, help="Path to a dataset pickle file (used with --autodetect)")
     parser.add_argument(
         "--settings",
@@ -338,6 +377,39 @@ if __name__ == "__main__":
     # Two-pass parsing: first pass gets --importer and --exporter names;
     # second pass adds their plugin-specific arguments and re-parses.
     args, remaining = parser.parse_known_args()
+
+    # ---- Early-exit informational flags --------------------------------
+    # These run before the autodetect / server paths so they don't trigger
+    # model loading or the full Flask app boot.
+    if args.list_plugins:
+        from vtsearch.plugins.inventory import format_json, format_names, format_plain, gather_plugins
+
+        inventory = gather_plugins()
+        if args.plugin_family:
+            if args.plugin_family not in inventory:
+                parser.error(
+                    f"Unknown plugin family: {args.plugin_family}. "
+                    f"Available: {', '.join(inventory)}"
+                )
+            inventory = {args.plugin_family: inventory[args.plugin_family]}
+        if args.output_format == "json":
+            sys.stdout.write(format_json(inventory))
+            sys.stdout.write("\n")
+        elif args.output_format == "names":
+            sys.stdout.write(format_names(inventory, family=args.plugin_family))
+        else:
+            sys.stdout.write(format_plain(inventory))
+        sys.exit(0)
+
+    if args.openapi_schema:
+        import json as _json
+
+        from vtsearch.openapi import generate_openapi_spec
+
+        spec = generate_openapi_spec(app)
+        sys.stdout.write(_json.dumps(spec, indent=2))
+        sys.stdout.write("\n")
+        sys.exit(0)
 
     importer = None
     exporter = None

--- a/app.py
+++ b/app.py
@@ -354,10 +354,7 @@ if __name__ == "__main__":
         type=str,
         default=None,
         dest="import_labels_into",
-        help=(
-            "Detector name to merge labels into before scoring. "
-            "Used with --autodetect plus --label-importer-file."
-        ),
+        help=("Detector name to merge labels into before scoring. Used with --autodetect plus --label-importer-file."),
     )
     parser.add_argument(
         "--label-importer",
@@ -387,10 +384,7 @@ if __name__ == "__main__":
         inventory = gather_plugins()
         if args.plugin_family:
             if args.plugin_family not in inventory:
-                parser.error(
-                    f"Unknown plugin family: {args.plugin_family}. "
-                    f"Available: {', '.join(inventory)}"
-                )
+                parser.error(f"Unknown plugin family: {args.plugin_family}. Available: {', '.join(inventory)}")
             inventory = {args.plugin_family: inventory[args.plugin_family]}
         if args.output_format == "json":
             sys.stdout.write(format_json(inventory))

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,6 +38,27 @@ Status codes follow standard HTTP semantics: 200 OK, 201 Created, 204 No
 Content, 400 Bad Request, 404 Not Found, 409 Conflict, 500 Internal Server
 Error.
 
+## Machine-readable schema
+
+`GET /openapi.json` returns an auto-generated OpenAPI 3.0 document
+describing every route on the running app — every URL, HTTP method, path
+parameter, and the view function's docstring. It's regenerated on each
+request, so it always matches the running code. Use it to:
+
+- Point a Swagger UI / Redoc instance at the running server.
+- Generate a TypeScript / Python client.
+- Diff against a snapshot in CI to catch unintended API surface changes.
+
+You can also dump the spec without starting the server:
+
+```bash
+python app.py --openapi-schema > openapi.json
+```
+
+The spec intentionally keeps request/response **schemas** permissive —
+this page is still the canonical reference for body shapes. The OpenAPI
+doc's job is to keep the *route inventory* honest.
+
 ---
 
 *Readme Reader code phrase:* `json all the way down`

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,6 +109,35 @@ python app.py --login trivial    # multi-user mode with simple username auth
 
 Without `--login`, the app uses `DefaultLoginProvider` (single-user, always authenticated).
 
+## Inspecting plugins and the API schema
+
+`python app.py --list-plugins` enumerates every auto-discovered plugin —
+dataset importers, exporters, label importers/sources, settings I/O,
+media converters/types/embedders/clippers, and media sources — and
+exits without starting the server. Three output formats:
+
+```bash
+python app.py --list-plugins                          # human-readable
+python app.py --list-plugins --format json            # machine-readable
+python app.py --list-plugins --format names           # one "family:name" per line
+python app.py --list-plugins --plugin-family importers --format names
+                                                      # one bare name per line — completion-friendly
+```
+
+Use `--format names --plugin-family <family>` from a shell-completion
+script to suggest valid values for `--importer`, `--exporter`, etc.
+
+`python app.py --openapi-schema` prints an OpenAPI 3.0 document for the
+HTTP API to stdout and exits — same content as `GET /openapi.json` on
+the running server:
+
+```bash
+python app.py --openapi-schema > openapi.json
+```
+
+See [API.md § Machine-readable schema](API.md#machine-readable-schema)
+for what's covered and what's intentionally left permissive.
+
 ---
 
 *Readme Reader code phrase:* `command palette unlocked`

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -100,21 +100,64 @@ Most plugin families use sub-packages, which pair well with per-plugin
 (`vtsearch.datasets.sources`), which use flat `.py` modules
 (`local_folder.py`, `http_archive.py`, `pullwrest.py`).
 
-| Plugin Family       | Package                            | Sentinel              | Base Class          |
-|---------------------|------------------------------------|-----------------------|---------------------|
-| Data Importers      | `vtsearch.datasets.importers`      | `IMPORTER`            | `DatasetImporter`   |
-| Results Exporters   | `vtsearch.exporters`               | `EXPORTER`            | `LabelsetExporter`  |
-| Label Importers     | `vtsearch.labels.importers`        | `LABEL_IMPORTER`      | `LabelImporter`     |
-| Processor Importers | `vtsearch.processors.importers`    | `PROCESSOR_IMPORTER`  | `ProcessorImporter` |
-| Settings Importers  | `vtsearch.settings_io.importers`   | `SETTINGS_IMPORTER`   | `SettingsImporter`  |
-| Settings Exporters  | `vtsearch.settings_io.exporters`   | `SETTINGS_EXPORTER`   | `SettingsExporter`  |
-| Settings Sources    | `vtsearch.settings_io.sources`     | `SETTINGS_SOURCE`     | `SettingsSource`    |
-| Labelset Sources    | `vtsearch.labels.sources`          | `LABELSET_SOURCE`     | `LabelsetSource`    |
-| Media Converters    | `vtsearch.converters`              | `CONVERTER`           | `MediaConverter`    |
-| Media Sources       | `vtsearch.datasets.sources`        | `SOURCE`              | `MediaSource`       |
+| Plugin Family       | Package                            | Sentinel              | Base Class          | Entry-point group              |
+|---------------------|------------------------------------|-----------------------|---------------------|--------------------------------|
+| Data Importers      | `vtsearch.datasets.importers`      | `IMPORTER`            | `DatasetImporter`   | `vtsearch.importers`           |
+| Results Exporters   | `vtsearch.exporters`               | `EXPORTER`            | `LabelsetExporter`  | `vtsearch.exporters`           |
+| Label Importers     | `vtsearch.labels.importers`        | `LABEL_IMPORTER`      | `LabelImporter`     | `vtsearch.label_importers`     |
+| Processor Importers | `vtsearch.processors.importers`    | `PROCESSOR_IMPORTER`  | `ProcessorImporter` | —                              |
+| Settings Importers  | `vtsearch.settings_io.importers`   | `SETTINGS_IMPORTER`   | `SettingsImporter`  | `vtsearch.settings_importers`  |
+| Settings Exporters  | `vtsearch.settings_io.exporters`   | `SETTINGS_EXPORTER`   | `SettingsExporter`  | `vtsearch.settings_exporters`  |
+| Settings Sources    | `vtsearch.settings_io.sources`     | `SETTINGS_SOURCE`     | `SettingsSource`    | `vtsearch.settings_sources`    |
+| Labelset Sources    | `vtsearch.labels.sources`          | `LABELSET_SOURCE`     | `LabelsetSource`    | `vtsearch.labelset_sources`    |
+| Media Converters    | `vtsearch.converters`              | `CONVERTER`           | `MediaConverter`    | `vtsearch.converters`          |
+| Media Sources       | `vtsearch.datasets.sources`        | `SOURCE`              | `MediaSource`       | `vtsearch.media_sources`       |
 
 Failed imports emit a warning but do not break the application — a missing
 optional dependency gracefully disables that plugin.
+
+### Third-party plugins via `importlib.metadata` entry points
+
+Plugins don't have to live inside the `vtsearch` source tree. Any installed
+Python distribution can register a plugin by declaring an entry point in
+the family's group (see the rightmost column above). For example, a
+third-party importer would add this to its `pyproject.toml`:
+
+```toml
+[project.entry-points."vtsearch.importers"]
+my_importer = "my_pkg.importer:IMPORTER"
+```
+
+The value (`my_pkg.importer:IMPORTER`) must resolve to an already-instantiated
+plugin object — the same shape that the in-tree sentinel attribute holds.
+After `pip install` of the third-party package, the plugin appears in
+`list_importers()`, the relevant `/api/...` endpoint, and `python app.py
+--list-plugins` without any changes to the core repo.
+
+Built-in plugins take precedence: if an entry point's `name` clashes with
+a name already registered by the package scan, it is skipped and a warning
+is emitted. A broken entry point (import error, missing `name` attribute)
+warns and is skipped — it cannot block discovery of other plugins.
+
+### Listing every registered plugin
+
+`python app.py --list-plugins` prints every auto-discovered plugin
+across all families — useful both for humans (`--format plain`, the
+default) and for shell completion scripts (`--format names`). Add
+`--plugin-family <name>` to scope the output, e.g.
+`python app.py --list-plugins --plugin-family importers --format names`
+emits one importer name per line.
+
+Output formats:
+
+| Flag value      | Use case                                                |
+|-----------------|---------------------------------------------------------|
+| `plain` (default) | Human-readable grouped table                          |
+| `json`          | Machine-readable; full `{name, display_name, description}` for each plugin |
+| `names`         | One name per line; with a family, bare names — without one, `family:name` pairs |
+
+The same inventory is also available programmatically as
+`vtsearch.plugins.inventory.gather_plugins()`.
 
 ---
 

--- a/docs/plans/extract-library.md
+++ b/docs/plans/extract-library.md
@@ -78,7 +78,7 @@ The sentinel-based registry (`IMPORTER`, `EXPORTER`, `SETTINGS_SOURCE`, `LABELSE
 - [ ] Library exposes `vtscore.utils.registry.PluginRegistry` (already generic).
 - [ ] Library auto-discovers its own plugins (importers, exporters, label sources, etc.) at registry creation.
 - [ ] App registers app-only plugins (`settings_io/`, settings sources) on top of the library's registries at startup.
-- [ ] Add an `importlib.metadata` entry-point hook so third-party packages can register plugins without monkey-patching. (Stretch goal.)
+- [x] Add an `importlib.metadata` entry-point hook so third-party packages can register plugins without monkey-patching. (Landed ahead of the library split as feature-brainstorm §12.11 — `PluginRegistry(entry_point_group=…)` scans `vtsearch.<family>` groups. Built-ins win on name clashes; broken entry points warn and are skipped.)
 
 ## Phase 6 — Pickle compatibility
 

--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -447,17 +447,17 @@ For speed-labelling, preload the next 3 items' previews.
 ### 12.7 Resume interrupted training ★ S
 Checkpoint MLP state every N epochs.
 
-### 12.8 Centralised plugin registry CLI ★ S
-`python app.py --list-plugins` showing every importer/exporter/embedder/converter/clipper. Useful for auto-completion in shell.
+### 12.8 Centralised plugin registry CLI ★ S — **shipped**
+`python app.py --list-plugins` shows every importer/exporter/embedder/converter/clipper across all auto-discovered plugin families. Supports `--format plain|json|names` and `--plugin-family <name>` for shell-completion scripts. Backed by `vtsearch.plugins.inventory.gather_plugins()`. See [CLI.md § Inspecting plugins and the API schema](../CLI.md#inspecting-plugins-and-the-api-schema).
 
-### 12.9 OpenAPI schema ★★ M
-Auto-generate from Flask routes (apispec/flask-smorest). Powers Swagger UI and a generated TS client. The frontend already manually maintains DTOs — generating them would prevent drift.
+### 12.9 OpenAPI schema ★★ M — **shipped (minimal)**
+`GET /openapi.json` and `python app.py --openapi-schema` return an OpenAPI 3.0 doc generated from Flask's `url_map` — every route, method, path parameter, and view docstring. Request/response schemas are intentionally left permissive (`{type: object}`); the route inventory alone is enough to power Swagger UI and a generated TS client and to gate API surface changes in CI. See [API.md § Machine-readable schema](../API.md#machine-readable-schema). Open question: do we want to add per-route Pydantic / `apispec` decorators later to fill in body schemas? Deferred until a real consumer needs them.
 
 ### 12.10 Python client library ★★ M
 `pip install vtsearch-client` so notebooks can drive the same endpoints headlessly.
 
-### 12.11 Plugin discovery via importlib.metadata ★★ M
-Already on the `vtscore` extraction roadmap; pull this forward — it's independently useful.
+### 12.11 Plugin discovery via importlib.metadata ★★ M — **shipped**
+Every `PluginRegistry` now also scans an `importlib.metadata` entry-point group (`vtsearch.importers`, `vtsearch.exporters`, …). Third-party packages can register plugins from their own `pyproject.toml` without monkey-patching `vtsearch`. Built-ins still win on name clashes; broken entry points warn and are skipped. See [EXTENDING-plugins.md § Third-party plugins via importlib.metadata entry points](../EXTENDING-plugins.md#third-party-plugins-via-importlibmetadata-entry-points).
 
 ### 12.12 Ruff → Ruff format CI gate ★ XS
 We have ruff; add a CI step that fails on unformatted code.

--- a/tests/api/test_openapi_schema.py
+++ b/tests/api/test_openapi_schema.py
@@ -1,0 +1,90 @@
+"""Tests for the auto-generated OpenAPI 3.0 schema.
+
+Covers both the generator (`vtsearch.openapi.generate_openapi_spec`) and
+the ``/openapi.json`` endpoint that serves it.
+"""
+
+from __future__ import annotations
+
+from vtsearch.openapi import _flask_rule_to_openapi_path, generate_openapi_spec
+
+
+class TestRuleConversion:
+    def test_plain_path_passes_through(self):
+        path, params = _flask_rule_to_openapi_path("/api/version")
+        assert path == "/api/version"
+        assert params == []
+
+    def test_int_parameter(self):
+        path, params = _flask_rule_to_openapi_path("/api/foo/<int:id>")
+        assert path == "/api/foo/{id}"
+        assert len(params) == 1
+        assert params[0]["name"] == "id"
+        assert params[0]["in"] == "path"
+        assert params[0]["required"] is True
+        assert params[0]["schema"]["type"] == "integer"
+
+    def test_string_default(self):
+        path, params = _flask_rule_to_openapi_path("/api/foo/<name>")
+        assert path == "/api/foo/{name}"
+        assert params[0]["schema"]["type"] == "string"
+
+    def test_multiple_parameters(self):
+        path, params = _flask_rule_to_openapi_path("/api/<int:x>/<string:y>")
+        assert path == "/api/{x}/{y}"
+        assert [p["name"] for p in params] == ["x", "y"]
+
+
+class TestSpecGeneration:
+    def test_openapi_version(self, client):
+        spec = generate_openapi_spec(client.application)
+        assert spec["openapi"].startswith("3.0")
+
+    def test_info_block(self, client):
+        spec = generate_openapi_spec(client.application, title="X", version="9.9")
+        assert spec["info"]["title"] == "X"
+        assert spec["info"]["version"] == "9.9"
+
+    def test_includes_known_routes(self, client):
+        spec = generate_openapi_spec(client.application)
+        paths = spec["paths"]
+        assert "/api/version" in paths
+        # Detector endpoints are namespaced under /api/detectors/...
+        assert any(p.startswith("/api/detectors") for p in paths), "detector routes missing"
+
+    def test_skips_static_route(self, client):
+        spec = generate_openapi_spec(client.application)
+        # Flask's static rule (/static/<path:filename>) is skipped.
+        assert "/static/{filename}" not in spec["paths"]
+
+    def test_tags_are_emitted(self, client):
+        spec = generate_openapi_spec(client.application)
+        assert "tags" in spec
+        tag_names = {t["name"] for t in spec["tags"]}
+        # At least the datasets tag should be present.
+        assert "datasets" in tag_names
+
+    def test_post_routes_have_request_body(self, client):
+        spec = generate_openapi_spec(client.application)
+        # Find a known POST route and check it carries a requestBody.
+        found_post_with_body = False
+        for path, methods in spec["paths"].items():
+            if "post" in methods and "requestBody" in methods["post"]:
+                found_post_with_body = True
+                break
+        assert found_post_with_body, "no POST operation declared a requestBody"
+
+
+class TestOpenApiEndpoint:
+    def test_endpoint_returns_spec(self, client):
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["openapi"].startswith("3.0")
+        assert "/api/version" in data["paths"]
+
+    def test_endpoint_self_describes(self, client):
+        """The /openapi.json route should itself appear in the spec it serves."""
+        resp = client.get("/openapi.json")
+        data = resp.get_json()
+        assert "/openapi.json" in data["paths"]

--- a/tests/core/test_plugin_entry_points.py
+++ b/tests/core/test_plugin_entry_points.py
@@ -164,8 +164,11 @@ def test_built_in_registries_declare_entry_point_groups(module_path, registry_va
     import importlib
 
     mod = importlib.import_module(module_path)
-    # The registry is private but the closure on `list_*` keeps a reference.
     list_fn = getattr(mod, registry_var)
-    # ``list_fn`` is ``registry.list`` — pull the bound registry off it.
-    registry = list_fn.__self__
+    # ``list_*`` is either a bound method on the registry (from
+    # ``make_plugin_registry``) or a free function that delegates to a
+    # private module-level ``_registry``.
+    registry = getattr(list_fn, "__self__", None)
+    if registry is None:
+        registry = mod._registry
     assert registry._entry_point_group == expected_group

--- a/tests/core/test_plugin_entry_points.py
+++ b/tests/core/test_plugin_entry_points.py
@@ -1,0 +1,171 @@
+"""Tests for ``importlib.metadata`` entry-point discovery in :class:`PluginRegistry`.
+
+Third-party packages can register a plugin by declaring an entry point in
+the ``vtsearch.<family>`` group; this test stubs ``importlib.metadata``
+and verifies the registry picks up entry-point plugins, surfaces failures
+via warnings, and never lets an entry point silently shadow a built-in.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import warnings
+
+import pytest
+
+from vtsearch.plugins import PluginRegistry
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for :class:`importlib.metadata.EntryPoint`."""
+
+    def __init__(self, name: str, value: str, target) -> None:
+        self.name = name
+        self.value = value
+        self.group = "vtsearch.test_family"
+        self._target = target
+
+    def load(self):
+        if isinstance(self._target, Exception):
+            raise self._target
+        return self._target
+
+
+class _DummyPlugin:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.display_name = name.title()
+        self.description = "test"
+
+
+def _patch_entry_points(monkeypatch, entries: list[_FakeEntryPoint]) -> None:
+    def fake_entry_points(*, group: str):
+        return [e for e in entries if e.group == group]
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+
+
+class TestEntryPointDiscovery:
+    def test_loads_entry_point_plugin(self, monkeypatch):
+        plugin = _DummyPlugin("from_entry_point")
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("my_plugin", "pkg.mod:OBJ", plugin)])
+
+        registry: PluginRegistry = PluginRegistry(
+            # Use an existing package whose own scan turns up nothing matching
+            # the test sentinel, so the only registration comes from the entry
+            # point.
+            package="vtsearch.plugins",
+            sentinel="TEST_SENTINEL_NEVER_PRESENT",
+            label="test plugin",
+            entry_point_group="vtsearch.test_family",
+        )
+        assert registry.get("from_entry_point") is plugin
+        assert plugin in registry.list()
+
+    def test_built_in_wins_over_entry_point_name_clash(self, monkeypatch):
+        from vtsearch.datasets.importers import list_importers
+
+        # server_folder is an established built-in importer.
+        built_in_names = {imp.name for imp in list_importers()}
+        assert "server_folder" in built_in_names
+
+        rogue = _DummyPlugin("server_folder")
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("rogue", "rogue:OBJ", rogue)])
+
+        registry: PluginRegistry = PluginRegistry(
+            package="vtsearch.datasets.importers",
+            sentinel="IMPORTER",
+            label="dataset importer",
+            entry_point_group="vtsearch.test_family",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            entry = registry.get("server_folder")
+        # The built-in is returned, not the rogue stub.
+        assert entry is not rogue
+        # And a warning was emitted explaining the skip.
+        assert any("clashes with built-in" in str(w.message) for w in caught)
+
+    def test_failed_load_warns_and_continues(self, monkeypatch):
+        good = _DummyPlugin("good_plugin")
+        boom = _FakeEntryPoint("broken", "pkg:OBJ", RuntimeError("nope"))
+        ok = _FakeEntryPoint("good", "pkg:OBJ", good)
+        _patch_entry_points(monkeypatch, [boom, ok])
+
+        registry: PluginRegistry = PluginRegistry(
+            package="vtsearch.plugins",
+            sentinel="TEST_SENTINEL_NEVER_PRESENT",
+            label="test plugin",
+            entry_point_group="vtsearch.test_family",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert registry.get("good_plugin") is good
+        assert registry.get("broken") is None
+        # A warning was raised for the failure.
+        assert any("Failed to load" in str(w.message) for w in caught)
+
+    def test_entry_point_without_name_is_skipped(self, monkeypatch):
+        class _NoName:
+            display_name = "Bad"
+            description = ""
+
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("noname", "pkg:OBJ", _NoName())])
+
+        registry: PluginRegistry = PluginRegistry(
+            package="vtsearch.plugins",
+            sentinel="TEST_SENTINEL_NEVER_PRESENT",
+            label="test plugin",
+            entry_point_group="vtsearch.test_family",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert registry.list() == []
+        assert any("no 'name' attribute" in str(w.message) for w in caught)
+
+    def test_no_group_means_no_entry_point_scan(self, monkeypatch):
+        # If a registry has no entry_point_group, importlib.metadata is never
+        # consulted — even if our patched version would have happily loaded
+        # something.
+        called = {"count": 0}
+
+        def fake_entry_points(*, group: str):
+            called["count"] += 1
+            return []
+
+        monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+
+        registry: PluginRegistry = PluginRegistry(
+            package="vtsearch.plugins",
+            sentinel="TEST_SENTINEL_NEVER_PRESENT",
+            label="test plugin",
+            entry_point_group=None,
+        )
+        registry.list()
+        assert called["count"] == 0
+
+
+@pytest.mark.parametrize(
+    "module_path,registry_var,expected_group",
+    [
+        ("vtsearch.datasets.importers", "list_importers", "vtsearch.importers"),
+        ("vtsearch.exporters", "list_exporters", "vtsearch.exporters"),
+        ("vtsearch.labels.importers", "list_label_importers", "vtsearch.label_importers"),
+        ("vtsearch.labels.sources", "list_labelset_sources", "vtsearch.labelset_sources"),
+        ("vtsearch.settings_io.importers", "list_settings_importers", "vtsearch.settings_importers"),
+        ("vtsearch.settings_io.exporters", "list_settings_exporters", "vtsearch.settings_exporters"),
+        ("vtsearch.settings_io.sources", "list_settings_sources", "vtsearch.settings_sources"),
+        ("vtsearch.converters", "list_converters", "vtsearch.converters"),
+        ("vtsearch.datasets.sources", "list_media_sources", "vtsearch.media_sources"),
+    ],
+)
+def test_built_in_registries_declare_entry_point_groups(module_path, registry_var, expected_group):
+    """Each plugin family must expose a stable entry-point group name."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    # The registry is private but the closure on `list_*` keeps a reference.
+    list_fn = getattr(mod, registry_var)
+    # ``list_fn`` is ``registry.list`` — pull the bound registry off it.
+    registry = list_fn.__self__
+    assert registry._entry_point_group == expected_group

--- a/tests/core/test_plugin_inventory.py
+++ b/tests/core/test_plugin_inventory.py
@@ -1,0 +1,92 @@
+"""Tests for the centralised plugin inventory (`vtsearch.plugins.inventory`).
+
+Backs the ``python app.py --list-plugins`` CLI: every plugin family must
+show up with at least one entry (since the codebase ships built-ins for
+each one), and the three output formats must round-trip cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vtsearch.plugins.inventory import (
+    FAMILIES,
+    format_json,
+    format_names,
+    format_plain,
+    gather_plugins,
+)
+
+
+class TestGatherPlugins:
+    def test_returns_all_known_families(self):
+        inv = gather_plugins()
+        assert set(inv.keys()) == set(FAMILIES)
+
+    def test_each_family_has_entries(self):
+        # The codebase ships built-ins for every family — if one comes back
+        # empty something has broken auto-discovery.
+        inv = gather_plugins()
+        for family in FAMILIES:
+            assert inv[family], f"family {family!r} is empty — discovery regressed?"
+
+    def test_importers_include_server_folder(self):
+        inv = gather_plugins()
+        names = {entry.name for entry in inv["importers"]}
+        assert "server_folder" in names
+
+    def test_exporters_include_server_json_file(self):
+        inv = gather_plugins()
+        names = {entry.name for entry in inv["exporters"]}
+        assert "server_json_file" in names
+
+    def test_converters_carry_source_and_target_types(self):
+        inv = gather_plugins()
+        for entry in inv["converters"]:
+            assert "source_type" in entry.extra
+            assert "target_type" in entry.extra
+
+    def test_embedders_carry_media_type(self):
+        inv = gather_plugins()
+        assert inv["embedders"], "no embedders discovered"
+        for entry in inv["embedders"]:
+            assert "media_type" in entry.extra
+
+
+class TestFormatters:
+    @pytest.fixture
+    def inventory(self):
+        return gather_plugins()
+
+    def test_format_plain_is_human_readable(self, inventory):
+        out = format_plain(inventory)
+        # Every family label appears as a header line.
+        assert "Dataset importers" in out
+        assert "Results exporters" in out
+        # And at least one known built-in name shows up.
+        assert "server_folder" in out
+
+    def test_format_json_is_valid_json(self, inventory):
+        out = format_json(inventory)
+        parsed = json.loads(out)
+        assert set(parsed.keys()) == set(FAMILIES)
+        # Each entry round-trips name + display_name + description.
+        for entry in parsed["importers"]:
+            assert "name" in entry and "display_name" in entry
+
+    def test_format_names_global_uses_family_prefix(self, inventory):
+        out = format_names(inventory)
+        lines = [ln for ln in out.splitlines() if ln]
+        assert all(":" in ln for ln in lines)
+        assert "importers:server_folder" in lines
+
+    def test_format_names_with_family_strips_prefix(self, inventory):
+        out = format_names(inventory, family="importers")
+        lines = [ln for ln in out.splitlines() if ln]
+        assert all(":" not in ln for ln in lines)
+        assert "server_folder" in lines
+
+    def test_format_names_unknown_family_is_empty(self, inventory):
+        assert format_names(inventory, family="not_a_family") == ""

--- a/vtsearch/converters/__init__.py
+++ b/vtsearch/converters/__init__.py
@@ -26,6 +26,7 @@ _registry: PluginRegistry[MediaConverter] = PluginRegistry(
     sentinel="CONVERTER",
     label="media converter",
     discover_modules=True,
+    entry_point_group="vtsearch.converters",
 )
 
 

--- a/vtsearch/datasets/importers/__init__.py
+++ b/vtsearch/datasets/importers/__init__.py
@@ -19,6 +19,7 @@ get_importer, list_importers = make_plugin_registry(
     package=__name__,
     sentinel="IMPORTER",
     label="dataset importer",
+    entry_point_group="vtsearch.importers",
 )
 
 __all__ = ["get_importer", "list_importers"]

--- a/vtsearch/datasets/sources/__init__.py
+++ b/vtsearch/datasets/sources/__init__.py
@@ -22,14 +22,20 @@ from typing import Any
 from vtsearch.datasets.sources.base import MediaItem, MediaSource
 from vtsearch.plugins import PluginRegistry
 
-__all__ = ["MediaItem", "MediaSource", "get_source_for_origin"]
+__all__ = ["MediaItem", "MediaSource", "get_source_for_origin", "list_media_sources"]
 
 _registry: PluginRegistry = PluginRegistry(
     package="vtsearch.datasets.sources",
     sentinel="SOURCE",
     label="media source",
     discover_modules=True,
+    entry_point_group="vtsearch.media_sources",
 )
+
+
+def list_media_sources() -> list:
+    """Return all registered media source factories."""
+    return _registry.list()
 
 
 def get_source_for_origin(origin: dict[str, Any] | None) -> MediaSource | None:

--- a/vtsearch/exporters/__init__.py
+++ b/vtsearch/exporters/__init__.py
@@ -19,6 +19,7 @@ get_exporter, list_exporters = make_plugin_registry(
     package=__name__,
     sentinel="EXPORTER",
     label="labelset exporter",
+    entry_point_group="vtsearch.exporters",
 )
 
 __all__ = ["get_exporter", "list_exporters"]

--- a/vtsearch/labels/importers/__init__.py
+++ b/vtsearch/labels/importers/__init__.py
@@ -19,6 +19,7 @@ get_label_importer, list_label_importers = make_plugin_registry(
     package=__name__,
     sentinel="LABEL_IMPORTER",
     label="label importer",
+    entry_point_group="vtsearch.label_importers",
 )
 
 __all__ = ["get_label_importer", "list_label_importers"]

--- a/vtsearch/labels/sources/__init__.py
+++ b/vtsearch/labels/sources/__init__.py
@@ -19,6 +19,7 @@ get_labelset_source, list_labelset_sources = make_plugin_registry(
     package=__name__,
     sentinel="LABELSET_SOURCE",
     label="labelset source",
+    entry_point_group="vtsearch.labelset_sources",
 )
 
 __all__ = ["get_labelset_source", "list_labelset_sources"]

--- a/vtsearch/openapi.py
+++ b/vtsearch/openapi.py
@@ -1,0 +1,161 @@
+"""OpenAPI 3.0 schema generation for VTSearch's Flask routes.
+
+VTSearch's HTTP API today is documented manually in ``docs/API.md`` and
+duplicated in the Angular frontend's DTOs.  This module walks Flask's
+``url_map`` and produces a minimal OpenAPI 3.0 document — enough for a
+Swagger UI and an auto-generated TS client to stop drifting from the
+backend.
+
+Limitations
+-----------
+
+We don't introspect handler bodies, so request/response *schemas* are
+left empty (``content`` defaults to JSON with no shape).  Path
+parameters declared in the rule (``<int:id>``) are surfaced; query and
+JSON body parameters would need either decorators or runtime
+introspection — both deferred.  Even so, the route inventory + methods +
+docstrings already prevents the most common kind of drift (a route exists
+or it doesn't).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from flask import Flask
+
+#: HTTP methods Flask adds to every route, which aren't real verbs.
+_INTERNAL_METHODS: frozenset[str] = frozenset({"OPTIONS", "HEAD"})
+
+#: Maps Werkzeug rule converters to OpenAPI ``schema.type`` values.
+_TYPE_MAP: dict[str, dict[str, str]] = {
+    "int": {"type": "integer"},
+    "float": {"type": "number"},
+    "uuid": {"type": "string", "format": "uuid"},
+    "path": {"type": "string"},
+    "string": {"type": "string"},
+    "default": {"type": "string"},
+}
+
+_RULE_PARAM_RE = re.compile(r"<(?:(?P<converter>[^:>]+):)?(?P<name>[^>]+)>")
+
+
+def _flask_rule_to_openapi_path(rule: str) -> tuple[str, list[dict[str, Any]]]:
+    """Convert a Flask rule like ``/foo/<int:id>`` to OpenAPI path + params.
+
+    Returns ``(openapi_path, [parameter_dict, ...])`` where each parameter
+    dict is an OpenAPI Parameter Object with ``in: path``.
+    """
+    params: list[dict[str, Any]] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        converter = match.group("converter") or "default"
+        name = match.group("name")
+        params.append(
+            {
+                "name": name,
+                "in": "path",
+                "required": True,
+                "schema": _TYPE_MAP.get(converter, _TYPE_MAP["default"]),
+            }
+        )
+        return "{" + name + "}"
+
+    return _RULE_PARAM_RE.sub(_replace, rule), params
+
+
+def _operation_for(view: Any, methods: list[str], path: str) -> dict[str, Any]:
+    """Build an OpenAPI Operation Object from a Flask view function."""
+    doc = (getattr(view, "__doc__", "") or "").strip()
+    summary = doc.splitlines()[0] if doc else ""
+    description = doc
+
+    op: dict[str, Any] = {
+        "operationId": getattr(view, "__name__", "unknown"),
+        "responses": {
+            "200": {"description": "Successful response"},
+        },
+    }
+    if summary:
+        op["summary"] = summary
+    if description:
+        op["description"] = description
+
+    # Tag operations by URL family ("/api/datasets/..." → "datasets").
+    tag = _infer_tag(path)
+    if tag:
+        op["tags"] = [tag]
+
+    if any(m in methods for m in ("POST", "PUT", "PATCH")):
+        op["requestBody"] = {
+            "required": False,
+            "content": {"application/json": {"schema": {"type": "object"}}},
+        }
+
+    return op
+
+
+def _infer_tag(path: str) -> str:
+    """Pick an OpenAPI tag from a URL path.
+
+    Uses the segment after ``/api/`` when present, otherwise the first
+    non-empty segment.  Returns ``""`` for paths like ``/``.
+    """
+    parts = [p for p in path.strip("/").split("/") if p]
+    if not parts:
+        return ""
+    if parts[0] == "api" and len(parts) > 1:
+        return parts[1]
+    return parts[0]
+
+
+def generate_openapi_spec(app: Flask, *, title: str = "VTSearch API", version: str = "1.0.0") -> dict[str, Any]:
+    """Return an OpenAPI 3.0 dict describing every Flask route on *app*.
+
+    The result is JSON-serialisable and ready to be served from a route or
+    written to a file.
+    """
+    paths: dict[str, dict[str, Any]] = {}
+    tags: dict[str, bool] = {}
+
+    for rule in sorted(app.url_map.iter_rules(), key=lambda r: r.rule):
+        # Skip Flask's static file serving rule — it has no useful API surface.
+        if rule.endpoint == "static":
+            continue
+
+        view = app.view_functions.get(rule.endpoint)
+        if view is None:
+            continue
+
+        openapi_path, path_params = _flask_rule_to_openapi_path(rule.rule)
+        path_entry = paths.setdefault(openapi_path, {})
+        if path_params and "parameters" not in path_entry:
+            path_entry["parameters"] = path_params
+
+        methods = sorted(m for m in (rule.methods or set()) if m not in _INTERNAL_METHODS)
+        for method in methods:
+            op = _operation_for(view, methods, openapi_path)
+            path_entry[method.lower()] = op
+            for tag in op.get("tags", []):
+                tags[tag] = True
+
+    spec: dict[str, Any] = {
+        "openapi": "3.0.3",
+        "info": {
+            "title": title,
+            "version": version,
+            "description": (
+                "Auto-generated from VTSearch's Flask routes. "
+                "Request/response schemas are intentionally permissive — "
+                "see docs/API.md for the canonical reference."
+            ),
+        },
+        "paths": paths,
+    }
+    if tags:
+        spec["tags"] = [{"name": t} for t in sorted(tags)]
+    return spec
+
+
+__all__ = ["generate_openapi_spec"]

--- a/vtsearch/plugins/__init__.py
+++ b/vtsearch/plugins/__init__.py
@@ -343,16 +343,14 @@ class PluginRegistry(Generic[T]):
                 plugin = ep.load()
             except Exception as exc:
                 warnings.warn(
-                    f"Failed to load {self._label} entry point "
-                    f"{ep.name!r} from {ep.value!r}: {exc}",
+                    f"Failed to load {self._label} entry point {ep.name!r} from {ep.value!r}: {exc}",
                     stacklevel=2,
                 )
                 continue
             plugin_name = getattr(plugin, "name", None)
             if not plugin_name:
                 warnings.warn(
-                    f"{self._label} entry point {ep.name!r} from "
-                    f"{ep.value!r} has no 'name' attribute; skipped",
+                    f"{self._label} entry point {ep.name!r} from {ep.value!r} has no 'name' attribute; skipped",
                     stacklevel=2,
                 )
                 continue

--- a/vtsearch/plugins/__init__.py
+++ b/vtsearch/plugins/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import importlib.metadata
 import importlib.util
 import sys
 import threading
@@ -243,13 +244,34 @@ class PluginRegistry(Generic[T]):
         When ``True``, also scan flat ``.py`` files (not just sub-packages)
         for the sentinel.  Useful for plugin families where each plugin is
         a single module rather than a sub-package (e.g. converters, sources).
+    entry_point_group:
+        Optional :mod:`importlib.metadata` entry-point group to scan after
+        the local package scan, e.g. ``"vtsearch.importers"``.  Third-party
+        packages can register a plugin by adding an entry to this group in
+        their own ``pyproject.toml`` / ``setup.cfg``::
+
+            [project.entry-points."vtsearch.importers"]
+            my_importer = "my_pkg.my_module:IMPORTER"
+
+        The entry point must resolve to an already-instantiated plugin
+        object (same shape as a sentinel attribute) — typically you point
+        directly at the module's ``IMPORTER`` / ``EXPORTER`` / ... sentinel.
     """
 
-    def __init__(self, package: str, sentinel: str, label: str, *, discover_modules: bool = False) -> None:
+    def __init__(
+        self,
+        package: str,
+        sentinel: str,
+        label: str,
+        *,
+        discover_modules: bool = False,
+        entry_point_group: str | None = None,
+    ) -> None:
         self._package = package
         self._sentinel = sentinel
         self._label = label
         self._discover_modules = discover_modules
+        self._entry_point_group = entry_point_group
         self._items: dict[str, T] = {}
         self._discovered = False
         self._discovering = False
@@ -291,6 +313,58 @@ class PluginRegistry(Generic[T]):
                 if entry.name in ("__init__.py", "base.py"):
                     continue
                 self._try_load(entry.stem, file_path=entry if entry.is_symlink() else None)
+
+        if self._entry_point_group:
+            self._discover_entry_points()
+
+    def _discover_entry_points(self) -> None:
+        """Load third-party plugins registered via :mod:`importlib.metadata`.
+
+        Each entry point in :attr:`_entry_point_group` is resolved to an
+        object that's treated like a sentinel value — its ``.name`` is the
+        registry key.  Failures are surfaced as warnings so a single bad
+        third-party plugin can't break the rest of the registry.
+
+        Built-in plugins (discovered by the package scan above) take
+        precedence: an entry point whose name clashes with a built-in is
+        skipped.  This prevents an installed third-party package from
+        accidentally shadowing a core plugin.
+        """
+        try:
+            eps = importlib.metadata.entry_points(group=self._entry_point_group)
+        except Exception as exc:  # pragma: no cover
+            warnings.warn(
+                f"Failed to read entry-point group {self._entry_point_group!r}: {exc}",
+                stacklevel=2,
+            )
+            return
+        for ep in eps:
+            try:
+                plugin = ep.load()
+            except Exception as exc:
+                warnings.warn(
+                    f"Failed to load {self._label} entry point "
+                    f"{ep.name!r} from {ep.value!r}: {exc}",
+                    stacklevel=2,
+                )
+                continue
+            plugin_name = getattr(plugin, "name", None)
+            if not plugin_name:
+                warnings.warn(
+                    f"{self._label} entry point {ep.name!r} from "
+                    f"{ep.value!r} has no 'name' attribute; skipped",
+                    stacklevel=2,
+                )
+                continue
+            if plugin_name in self._items:
+                warnings.warn(
+                    f"{self._label} entry point {ep.name!r} from "
+                    f"{ep.value!r} clashes with built-in plugin "
+                    f"{plugin_name!r}; skipped",
+                    stacklevel=2,
+                )
+                continue
+            self._items[plugin_name] = plugin
 
     def _try_load(self, module_name: str, *, file_path: Path | None = None) -> None:
         """Import *module_name* under this registry's package and register its sentinel.
@@ -373,6 +447,7 @@ def make_plugin_registry(
     label: str,
     *,
     discover_modules: bool = False,
+    entry_point_group: str | None = None,
 ) -> tuple[Callable[[str], Any], Callable[[], list[Any]]]:
     """Create a :class:`PluginRegistry` and return its ``(get, list)`` accessors.
 
@@ -384,6 +459,7 @@ def make_plugin_registry(
             package=__name__,
             sentinel="IMPORTER",
             label="dataset importer",
+            entry_point_group="vtsearch.importers",
         )
 
     Parameters are forwarded to :class:`PluginRegistry`.
@@ -393,5 +469,6 @@ def make_plugin_registry(
         sentinel=sentinel,
         label=label,
         discover_modules=discover_modules,
+        entry_point_group=entry_point_group,
     )
     return registry.get, registry.list

--- a/vtsearch/plugins/inventory.py
+++ b/vtsearch/plugins/inventory.py
@@ -1,0 +1,216 @@
+"""Centralised plugin inventory.
+
+Gathers every plugin family auto-discovered by VTSearch into a single
+data structure for the ``python app.py --list-plugins`` CLI and any other
+tooling that wants a cross-family view of what's installed.
+
+The inventory covers both ``PluginRegistry``-backed families (importers,
+exporters, label sources, settings I/O, converters, media sources) and
+the embedder / clipper / media-type registries that live directly on
+:mod:`vtsearch.media`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class PluginEntry:
+    """A single plugin's identity for inventory purposes."""
+
+    name: str
+    display_name: str
+    description: str
+    extra: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "display_name": self.display_name,
+            "description": self.description,
+        }
+        if self.extra:
+            out.update(self.extra)
+        return out
+
+
+def _entry_from_plugin(plugin: Any, *, extra: dict[str, Any] | None = None) -> PluginEntry:
+    return PluginEntry(
+        name=getattr(plugin, "name", repr(plugin)),
+        display_name=getattr(plugin, "display_name", "") or "",
+        description=getattr(plugin, "description", "") or "",
+        extra=extra or {},
+    )
+
+
+def _safe_list(loader: Callable[[], list[Any]]) -> list[Any]:
+    """Run *loader* and swallow ImportError-class failures.
+
+    A missing optional dependency in one plugin shouldn't block inventory
+    of every other family.  Anything more serious is left to bubble up so
+    the caller sees the real bug.
+    """
+    try:
+        return list(loader())
+    except (ImportError, ModuleNotFoundError):
+        return []
+
+
+def gather_plugins() -> dict[str, list[PluginEntry]]:
+    """Return ``{family: [PluginEntry, ...]}`` for every registered plugin.
+
+    Family keys are stable, snake-cased identifiers suitable for shell
+    completion scripts; ordering matches discovery order within a family
+    (alphabetical by file name for built-ins, then entry-point order).
+    """
+    # Importers are looked up lazily so that ``python app.py --list-plugins``
+    # doesn't pay the full app startup cost — Flask blueprints, model
+    # registries, etc. only get imported when their family is asked for.
+    from vtsearch.converters import list_converters
+    from vtsearch.datasets.importers import list_importers
+    from vtsearch.datasets.sources import list_media_sources
+    from vtsearch.exporters import list_exporters
+    from vtsearch.labels.importers import list_label_importers
+    from vtsearch.labels.sources import list_labelset_sources
+    from vtsearch.media import all_clippers, all_embedders, all_types
+    from vtsearch.settings_io.exporters import list_settings_exporters
+    from vtsearch.settings_io.importers import list_settings_importers
+    from vtsearch.settings_io.sources import list_settings_sources
+
+    inventory: dict[str, list[PluginEntry]] = {}
+
+    inventory["importers"] = [_entry_from_plugin(p) for p in _safe_list(list_importers)]
+    inventory["exporters"] = [_entry_from_plugin(p) for p in _safe_list(list_exporters)]
+    inventory["label_importers"] = [_entry_from_plugin(p) for p in _safe_list(list_label_importers)]
+    inventory["labelset_sources"] = [_entry_from_plugin(p) for p in _safe_list(list_labelset_sources)]
+    inventory["settings_importers"] = [_entry_from_plugin(p) for p in _safe_list(list_settings_importers)]
+    inventory["settings_exporters"] = [_entry_from_plugin(p) for p in _safe_list(list_settings_exporters)]
+    inventory["settings_sources"] = [_entry_from_plugin(p) for p in _safe_list(list_settings_sources)]
+    inventory["converters"] = [
+        _entry_from_plugin(
+            c,
+            extra={
+                "source_type": getattr(c, "source_type", ""),
+                "target_type": getattr(c, "target_type", ""),
+            },
+        )
+        for c in _safe_list(list_converters)
+    ]
+    inventory["media_sources"] = [_entry_from_plugin(p) for p in _safe_list(list_media_sources)]
+
+    # Media-side registries — embedders / clippers / media types don't
+    # use PluginBase, so build entries from their attribute surface.
+    inventory["media_types"] = [
+        PluginEntry(
+            name=getattr(mt, "type_id", ""),
+            display_name=getattr(mt, "display_name", "") or getattr(mt, "type_id", ""),
+            description=getattr(mt, "description", "") or "",
+            extra={"folder_import_name": getattr(mt, "folder_import_name", "")},
+        )
+        for mt in _safe_list(all_types)
+    ]
+    inventory["embedders"] = [
+        PluginEntry(
+            name=getattr(emb, "name", ""),
+            display_name=getattr(emb, "display_name", "") or getattr(emb, "name", ""),
+            description=getattr(emb, "description", "") or "",
+            extra={
+                "media_type": getattr(emb, "media_type_id", ""),
+                "is_default": bool(getattr(emb, "is_default", False)),
+            },
+        )
+        for emb in _safe_list(all_embedders)
+    ]
+    inventory["clippers"] = [
+        PluginEntry(
+            name=getattr(clip, "name", ""),
+            display_name=getattr(clip, "display_name", "") or getattr(clip, "name", ""),
+            description=getattr(clip, "description", "") or "",
+            extra={"media_type": getattr(clip, "media_type", "")},
+        )
+        for clip in _safe_list(all_clippers)
+    ]
+
+    return inventory
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+_FAMILY_LABELS: dict[str, str] = {
+    "importers": "Dataset importers",
+    "exporters": "Results exporters",
+    "label_importers": "Label importers",
+    "labelset_sources": "Labelset sources",
+    "settings_importers": "Settings importers",
+    "settings_exporters": "Settings exporters",
+    "settings_sources": "Settings sources",
+    "converters": "Media converters",
+    "media_sources": "Media sources",
+    "media_types": "Media types",
+    "embedders": "Media embedders",
+    "clippers": "Media clippers",
+}
+
+
+def format_plain(inventory: dict[str, list[PluginEntry]]) -> str:
+    """Render *inventory* as a human-readable plain-text listing."""
+    out: list[str] = []
+    for family, entries in inventory.items():
+        label = _FAMILY_LABELS.get(family, family)
+        out.append(f"{label} ({len(entries)}):")
+        if not entries:
+            out.append("  (none)")
+        else:
+            width = max(len(e.name) for e in entries)
+            for entry in entries:
+                line = f"  {entry.name.ljust(width)}"
+                if entry.display_name and entry.display_name != entry.name:
+                    line += f"  {entry.display_name}"
+                out.append(line)
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def format_names(inventory: dict[str, list[PluginEntry]], family: str | None = None) -> str:
+    """Render plugin *names* one per line — designed for shell completion.
+
+    When *family* is given, only that family's names are emitted; otherwise
+    every family is emitted as ``<family>:<name>`` so a completion script
+    can split on the first colon.
+    """
+    if family is not None:
+        entries = inventory.get(family, [])
+        return "\n".join(e.name for e in entries) + ("\n" if entries else "")
+    lines: list[str] = []
+    for fam, entries in inventory.items():
+        for entry in entries:
+            lines.append(f"{fam}:{entry.name}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def format_json(inventory: dict[str, list[PluginEntry]]) -> str:
+    """Render *inventory* as a JSON object."""
+    import json
+
+    return json.dumps(
+        {family: [entry.to_dict() for entry in entries] for family, entries in inventory.items()},
+        indent=2,
+        sort_keys=False,
+    )
+
+
+FAMILIES: tuple[str, ...] = tuple(_FAMILY_LABELS.keys())
+
+__all__ = [
+    "FAMILIES",
+    "PluginEntry",
+    "gather_plugins",
+    "format_plain",
+    "format_names",
+    "format_json",
+]

--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -17,6 +17,15 @@ def version() -> Response:
     return jsonify({"version": __version__})
 
 
+@main_bp.route("/openapi.json")
+def openapi_json() -> Response:
+    """Return the auto-generated OpenAPI 3.0 spec for this Flask app."""
+    from vtsearch.openapi import generate_openapi_spec
+
+    spec = generate_openapi_spec(current_app, version=__version__)
+    return jsonify(spec)
+
+
 def _static_dir() -> Path:
     """Return the static directory path."""
     return Path(current_app.root_path) / "static"

--- a/vtsearch/settings_io/exporters/__init__.py
+++ b/vtsearch/settings_io/exporters/__init__.py
@@ -19,6 +19,7 @@ get_settings_exporter, list_settings_exporters = make_plugin_registry(
     package=__name__,
     sentinel="SETTINGS_EXPORTER",
     label="settings exporter",
+    entry_point_group="vtsearch.settings_exporters",
 )
 
 __all__ = ["get_settings_exporter", "list_settings_exporters"]

--- a/vtsearch/settings_io/importers/__init__.py
+++ b/vtsearch/settings_io/importers/__init__.py
@@ -19,6 +19,7 @@ get_settings_importer, list_settings_importers = make_plugin_registry(
     package=__name__,
     sentinel="SETTINGS_IMPORTER",
     label="settings importer",
+    entry_point_group="vtsearch.settings_importers",
 )
 
 __all__ = ["get_settings_importer", "list_settings_importers"]

--- a/vtsearch/settings_io/sources/__init__.py
+++ b/vtsearch/settings_io/sources/__init__.py
@@ -19,6 +19,7 @@ get_settings_source, list_settings_sources = make_plugin_registry(
     package=__name__,
     sentinel="SETTINGS_SOURCE",
     label="settings source",
+    entry_point_group="vtsearch.settings_sources",
 )
 
 __all__ = ["get_settings_source", "list_settings_sources"]


### PR DESCRIPTION
Ships three related items from `docs/plans/feature-brainstorm.md`:

## 12.8 — Centralised plugin registry CLI

`python app.py --list-plugins` enumerates every auto-discovered plugin across all families:

- importers, exporters, label importers/sources, settings importers/exporters/sources
- media converters, media sources, media types, embedders, clippers

Three output formats:

| `--format` | Use case |
|------------|----------|
| `plain` (default) | Human-readable grouped table |
| `json`     | Machine-readable; full `{name, display_name, description, …}` per plugin |
| `names`    | One name per line — with `--plugin-family`, bare names (shell-completion friendly); without it, `family:name` pairs |

Backed by `vtsearch.plugins.inventory.gather_plugins()` for programmatic use.

## 12.9 — OpenAPI 3.0 schema

`vtsearch.openapi.generate_openapi_spec(app)` walks Flask's `url_map` and produces a minimal OpenAPI 3.0 doc — every route, HTTP method, path parameter (with Werkzeug-converter-aware types), and the view function's docstring as `summary`/`description`. Routes are tagged by URL family (`/api/datasets/...` → tag `datasets`).

Two delivery channels:

- `GET /openapi.json` on the running server.
- `python app.py --openapi-schema > openapi.json` without booting the server.

Request/response **schemas** are intentionally permissive (`{type: object}` for JSON bodies). The route inventory alone is enough to power Swagger UI, generate a TS/Python client, and CI-gate API surface changes. Per-route Pydantic / `apispec` decorators can be added later when a real consumer needs body shapes.

## 12.11 — `importlib.metadata` entry-point plugin discovery

`PluginRegistry` now takes an optional `entry_point_group=` kwarg. After the in-tree package scan, it iterates `importlib.metadata.entry_points(group=…)` and registers each loaded plugin. Each family declares a stable group name:

| Family | Group |
|--------|-------|
| Data importers     | `vtsearch.importers` |
| Results exporters  | `vtsearch.exporters` |
| Label importers    | `vtsearch.label_importers` |
| Labelset sources   | `vtsearch.labelset_sources` |
| Settings importers | `vtsearch.settings_importers` |
| Settings exporters | `vtsearch.settings_exporters` |
| Settings sources   | `vtsearch.settings_sources` |
| Media converters   | `vtsearch.converters` |
| Media sources      | `vtsearch.media_sources` |

Third-party packages register a plugin from their own `pyproject.toml`:

```toml
[project.entry-points."vtsearch.importers"]
my_importer = "my_pkg.importer:IMPORTER"
```

Safety:

- Built-ins win on name clash — an entry point whose `name` collides with an in-tree plugin is skipped with a warning.
- A broken entry point (import error, missing `name`, etc.) warns and is skipped — it can't block discovery of other plugins.
- Registries without an `entry_point_group` never touch `importlib.metadata`.

Pulls forward the stretch item in `docs/plans/extract-library.md` (Phase 5) since it's independently useful.

## Docs

- `docs/CLI.md` — `--list-plugins` and `--openapi-schema` sections.
- `docs/API.md` — "Machine-readable schema" section pointing at `/openapi.json`.
- `docs/EXTENDING-plugins.md` — entry-point group table column + a "Third-party plugins via importlib.metadata entry points" section.
- `docs/plans/feature-brainstorm.md` — 12.8/12.9/12.11 marked **shipped**.
- `docs/plans/extract-library.md` — Phase 5 entry-point checkbox ticked with a back-reference.

## Tests

37 new tests, all under fast CPU markers:

- `tests/core/test_plugin_inventory.py` — `gather_plugins` shape, family contents (`server_folder`, `server_json_file`, etc.), all three formatters round-trip.
- `tests/core/test_plugin_entry_points.py` — entry-point loading, built-in-wins precedence with warning, failure isolation, missing-`name` skip, no scan when `entry_point_group=None`, plus a parametrised check that every built-in registry declares its expected group.
- `tests/api/test_openapi_schema.py` — rule→OpenAPI path conversion (int/string/multi-param), spec shape (version, info, tags, requestBody on POST), self-describing `/openapi.json` endpoint, static-route skip.

Full suite: `ALL 3391 TESTS PASSED (1 skipped, total: 3392)`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mccoz2sWQM8cFhfqWqJUQX)_