### PR TITLE
Add pyright CI gate (Stage 1: foundation packages)

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -29,7 +29,20 @@ jobs:
         run: npm install -g pyright@1.1.408
 
       - name: Pyright (gated scope)
-        run: pyright
+        run: |
+          set +e
+          pyright 2>&1 | tee /tmp/pyright-gated.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Pyright gated scope"
+            echo ""
+            echo "Exit status: \`$status\`"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/pyright-gated.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
 
   # Advisory: full vtsearch/ package. Does not fail the build — its job
   # is to surface the residual error count so the next stage can size

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -23,7 +23,18 @@ jobs:
           node-version: "20"
 
       - name: Install vtsearch + deps (CPU)
-        run: bash scripts/install-cpu.sh
+        run: |
+          set +e
+          bash scripts/install-cpu.sh 2>&1 | tee /tmp/install.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Install step (exit=$status)"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/install.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
 
       - name: Install pyright
         run: npm install -g pyright@1.1.408
@@ -62,7 +73,18 @@ jobs:
           node-version: "20"
 
       - name: Install vtsearch + deps (CPU)
-        run: bash scripts/install-cpu.sh
+        run: |
+          set +e
+          bash scripts/install-cpu.sh 2>&1 | tee /tmp/install.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Install step (exit=$status)"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/install.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
 
       - name: Install pyright
         run: npm install -g pyright@1.1.408

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,68 @@
+name: Pyright
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  # Hard gate: must pass for the PR to merge.
+  # Covers the directories listed in pyrightconfig.json `include`.
+  # Scope expands stage-by-stage per docs/plans/pyright-type-checking.md.
+  gated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install vtsearch + deps (CPU)
+        run: bash scripts/install-cpu.sh
+
+      - name: Install pyright
+        run: npm install -g pyright@1.1.408
+
+      - name: Pyright (gated scope)
+        run: pyright
+
+  # Advisory: full vtsearch/ package. Does not fail the build — its job
+  # is to surface the residual error count so the next stage can size
+  # the work. Removed in Stage 6 of docs/plans/pyright-type-checking.md.
+  advisory:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install vtsearch + deps (CPU)
+        run: bash scripts/install-cpu.sh
+
+      - name: Install pyright
+        run: npm install -g pyright@1.1.408
+
+      - name: Pyright (full vtsearch/ — advisory)
+        run: |
+          set +e
+          pyright --outputjson vtsearch > pyright-full.json
+          status=$?
+          python -c "
+          import json
+          d = json.load(open('pyright-full.json'))
+          s = d['summary']
+          print(f\"errors: {s['errorCount']}  warnings: {s['warningCount']}  files: {s['filesAnalyzed']}\")
+          " | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,14 +62,14 @@ This applies to:
 - TypeScript errors from `tsc` / `npm run build:prod` (including in `*.spec.ts` files, even though specs do not currently run — they must still typecheck).
 - Angular build warnings of any kind, including `anyComponentStyle` budget warnings (e.g. `▲ [WARNING] ... exceeded maximum budget`). `run-tests.sh` treats every `▲ [WARNING]` line from `build:prod` as a hard test failure, so do not just bump budgets to silence them — fix the underlying bloat (split the component, extract shared styles, or remove dead rules). Bumping a budget is only acceptable when the size is genuinely justified, and requires the user's explicit approval.
 - Python test failures from `./run-tests.sh` and `pytest` runs.
-- Linter errors from `ruff`.
+- Linter errors from `ruff check` and formatting drift from `ruff format --check`. Both run as the first step of `./run-tests.sh`, so the test loop catches them before pytest — but if you're tempted to skip the test loop, run `ruff check . && ruff format --check .` at minimum before pushing. CI (`.github/workflows/lint.yml`) is the backstop.
 - Any other diagnostics surfaced by tooling you invoke.
 
 If a failure is genuinely outside the scope of the current task (e.g. a flaky network test, a failure in unrelated infrastructure you cannot reproduce), explicitly call it out in your end-of-turn summary with one sentence explaining why you did not fix it. The default is **fix it**; skipping requires justification.
 
 ## Commands
-- **Run tests (CPU, fast)**: `./run-tests.sh` (also checks frontend TypeScript build)
-- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; `core` includes frontend build check)
+- **Run tests (CPU, fast)**: `./run-tests.sh` (also runs `ruff check`, `ruff format --check`, and the frontend TypeScript build)
+- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; every invocation runs ruff first; `core` additionally runs the frontend build check)
 - **Run multiple groups**: `./run-tests.sh core sorting api`
 - **Run tests with extra args**: `./run-tests.sh core -- -x --tb=long` (args after `--` go to pytest)
 - **Run tests (CPU, full)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -q --tb=short -m 'not gpu'`

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,6 +18,7 @@ or [ARCHITECTURE.md](../ARCHITECTURE.md), the plan file is deleted.
 | [extract-library.md](extract-library.md) | **Proposed** | Split VTSearch into a `vtscore` Python library plus the Flask/Angular app, gated on a CI job that runs the test suite without Flask installed. |
 | [gpu-batched-embedding.md](gpu-batched-embedding.md) | **In progress** | Override `_embed_media_bulk_impl` on image + text embedders to batch the GPU forward pass; add `patch_forward_bulk` for the DINO/EUPE patch variants. Targets feature-brainstorm §12.2. |
 | [openapi-schema.md](openapi-schema.md) | **In progress** | Replace hand-maintained frontend DTOs with an OpenAPI schema generated from Flask routes via flask-smorest. Settings blueprint migrated as the pilot; remaining blueprints follow. |
+| [pyright-type-checking.md](pyright-type-checking.md) | **In progress** | Adopt pyright basic mode as a hard CI gate, rolled out one package at a time. Targets feature-brainstorm §12.13. Stage 1 (foundation: utils, auth, plugins, sync, concurrency, exporters, labels, settings_io, cli, config) lands with the plan. |
 | [feature-brainstorm.md](feature-brainstorm.md) | **Backlog** | Wide-ranging idea backlog — new media types, converters, clippers, demo datasets, experiments. Items graduate into their own plan doc as they mature. |
 
 ## Recently completed (removed)

--- a/docs/plans/pyright-type-checking.md
+++ b/docs/plans/pyright-type-checking.md
@@ -1,0 +1,130 @@
+# Pyright Type-Checking
+
+Adopt **pyright in basic mode** as a hard CI gate across the `vtsearch/`
+package. Rolled out in stages so each PR stays reviewable.
+
+## Goal
+
+- `pyrightconfig.json` at repo root with `typeCheckingMode: "basic"`.
+- A CI job (`.github/workflows/pyright.yml`) that fails the build on any
+  pyright error in the **gated** scope.
+- An **advisory** CI step that runs pyright over the entire `vtsearch/`
+  package on every PR (does not fail the build) so we always know the
+  residual error count for the next stage.
+- Each stage expands the gated scope by editing `include` in
+  `pyrightconfig.json`. Once stage 6 lands, the gated scope == the
+  advisory scope and the advisory job goes away.
+
+## Why pyright, why basic mode
+
+- **Pyright over mypy**: faster, better inference, fewer plugins
+  required to handle Flask/numpy/torch idioms.
+- **Basic mode over strict**: basic flags real bugs (None-attribute
+  access, wrong arg counts, undefined names, override mismatches)
+  without forcing exhaustive annotations on a 49k-line codebase.
+  Strict can come later if we want it.
+
+## Baseline (2026-05-15)
+
+`pyright vtsearch/` from a clean working tree reports **482 errors** and
+1 warning, broken down by directory:
+
+| Dir | Total | Non-import |
+|---|---:|---:|
+| `media/` | 211 | 68 |
+| `routes/` | 96 | 57 |
+| `security/` | 20 | 20 |
+| `models/` | 33 | 9 |
+| `eval/` | 29 | 1 |
+| `datasets/` | 26 | 13 |
+| `detectors/` | 18 | 7 |
+| `converters/` | 15 | 1 |
+| `state/` | 13 | 9 |
+| `utils/` | 6 | 0 |
+| `settings.py` | 5 | 5 |
+| `auth/` | 3 | 0 |
+| `labels/` | 2 | 2 |
+| other | ~5 | ~2 |
+
+The 288 `reportMissingImports` errors come from heavy third-party
+packages (`torch`, `transformers`, ...) that aren't installed in a bare
+shell. CI installs them via `requirements/base.txt`, so import errors
+will resolve there. **Local dev needs `bash scripts/install-cpu.sh`
+for clean reports.**
+
+## Stages
+
+Each stage is a separate PR. The "errors to fix" column counts real
+(non-import) errors at the start of the stage.
+
+| # | Scope added to `include` | Errors to fix |
+|---|---|---:|
+| 0 | (no scope; config + advisory CI only) | 0 |
+| **1** | `utils/`, `auth/`, `plugins/`, `sync/`, `concurrency/`, `exporters/`, `labels/`, `settings_io/`, `cli.py`, `config.py` | 4 |
+| 2 | `settings.py`, `settings_factory.py`, `state/`, `security/` | ~27 |
+| 3 | `datasets/`, `detectors/`, `eval/`, `models/` | ~30 |
+| 4 | `routes/`, `converters/` | ~58 |
+| 5 | `media/` (heaviest — may need `.pyi` stubs or per-file `# pyright: ignore`) | ~68 |
+| 6 | Whole `vtsearch/` — advisory job removed | 0 |
+| 7 *(optional)* | `tests/` | TBD |
+
+**Stage 0 + Stage 1 land in the same PR** (the one that introduces this
+plan). Subsequent stages are separate PRs.
+
+## Configuration choices
+
+`pyrightconfig.json`:
+
+```json
+{
+  "include": ["..."],
+  "exclude": ["**/__pycache__", "**/node_modules", "tests", "frontend"],
+  "pythonVersion": "3.10",
+  "typeCheckingMode": "basic",
+  "useLibraryCodeForTypes": true,
+  "reportMissingImports": "error",
+  "reportMissingTypeStubs": "none"
+}
+```
+
+- `useLibraryCodeForTypes: true` lets pyright infer from installed
+  package code when stubs are missing — important for `torch`,
+  `transformers`, `laion_clap`.
+- `reportMissingTypeStubs` is silenced; we don't ship stubs.
+- `tests/` is excluded for now (Stage 7).
+
+## CI shape
+
+Single workflow `.github/workflows/pyright.yml`:
+
+1. **`gated` job** — installs deps, runs `pyright` (uses
+   `pyrightconfig.json` `include`). Hard gate.
+2. **`advisory` job** — installs deps, runs
+   `pyright vtsearch/ || true`. Posts the error count in the job
+   summary. Does not fail the build.
+
+The advisory job is deleted in Stage 6.
+
+## Non-goals (now)
+
+- Strict mode.
+- Annotating every public function.
+- Type-checking `tests/`, `frontend/`, or `scripts/`.
+- Wiring pyright into `./run-tests.sh` (CI-only — keeps the local
+  test loop fast since pyright on a fresh repo takes ~30 s).
+
+## Local usage
+
+```bash
+pip install pyright              # or use pre-built CI binary
+bash scripts/install-cpu.sh      # so reportMissingImports passes
+pyright                          # gated scope (matches CI hard gate)
+pyright vtsearch/                # full-package check (matches advisory job)
+```
+
+## Backwards compatibility
+
+This is additive — no runtime behavior changes. Type-only fixes
+applied during each stage may change function signatures (e.g.
+parameter renames to match base classes); those are noted in each
+stage's PR description.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,27 @@
+{
+  "include": [
+    "vtsearch/auth",
+    "vtsearch/cli.py",
+    "vtsearch/concurrency",
+    "vtsearch/config.py",
+    "vtsearch/exporters",
+    "vtsearch/labels",
+    "vtsearch/plugins",
+    "vtsearch/settings_io",
+    "vtsearch/sync",
+    "vtsearch/utils"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "**/node_modules",
+    "tests",
+    "frontend",
+    "scripts",
+    "data"
+  ],
+  "pythonVersion": "3.10",
+  "typeCheckingMode": "basic",
+  "useLibraryCodeForTypes": true,
+  "reportMissingImports": "error",
+  "reportMissingTypeStubs": "none"
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,6 +22,27 @@ cd "$(dirname "$0")"
 # Install deps if needed
 bash .claude/hooks/ensure-test-deps.sh
 
+# Ruff lint + format check (matches .github/workflows/lint.yml).
+# Runs early because it's fast (~1s) and catches mistakes the pytest /
+# frontend stages can't see, e.g. F401 unused-import on TYPE_CHECKING
+# imports whose only "use" is inside a string-form forward reference.
+echo "Running ruff check..."
+if ! ruff check . ; then
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: ruff check failed"
+    echo "============================================================"
+    exit 1
+fi
+echo "Running ruff format --check..."
+if ! ruff format --check . ; then
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: ruff format --check failed (run 'ruff format .')"
+    echo "============================================================"
+    exit 1
+fi
+
 # Split arguments into groups and extra pytest args
 TEST_GROUPS=()
 EXTRA_ARGS=()

--- a/vtsearch/labels/sources/base.py
+++ b/vtsearch/labels/sources/base.py
@@ -17,7 +17,7 @@ from vtsearch.plugins import PluginField
 from vtsearch.sync import SyncSource
 
 if TYPE_CHECKING:
-    pass
+    from vtsearch.datasets.labelset import LabelSet
 
 LabelsetSourceField = PluginField
 

--- a/vtsearch/labels/sources/base.py
+++ b/vtsearch/labels/sources/base.py
@@ -17,7 +17,10 @@ from vtsearch.plugins import PluginField
 from vtsearch.sync import SyncSource
 
 if TYPE_CHECKING:
-    from vtsearch.datasets.labelset import LabelSet
+    # Imported for the `"LabelSet"` forward reference in the generic
+    # subscription below. Ruff can't see string-based references, so the
+    # noqa suppresses an otherwise-correct F401.
+    from vtsearch.datasets.labelset import LabelSet  # noqa: F401
 
 LabelsetSourceField = PluginField
 

--- a/vtsearch/plugins/__init__.py
+++ b/vtsearch/plugins/__init__.py
@@ -332,8 +332,11 @@ class PluginRegistry(Generic[T]):
         skipped.  This prevents an installed third-party package from
         accidentally shadowing a core plugin.
         """
+        group = self._entry_point_group
+        if group is None:
+            return
         try:
-            eps = importlib.metadata.entry_points(group=self._entry_point_group)
+            eps = importlib.metadata.entry_points(group=group)
         except Exception as exc:  # pragma: no cover
             warnings.warn(
                 f"Failed to read entry-point group {self._entry_point_group!r}: {exc}",

--- a/vtsearch/plugins/__init__.py
+++ b/vtsearch/plugins/__init__.py
@@ -290,6 +290,8 @@ class PluginRegistry(Generic[T]):
         (excluding ``__init__.py`` and ``base.py``) for the sentinel.
         """
         parent = importlib.import_module(self._package)
+        if parent.__file__ is None:
+            raise RuntimeError(f"Cannot discover plugins under namespace package {self._package!r}")
         package_dir = Path(parent.__file__).parent
         for entry in sorted(package_dir.iterdir()):
             if entry.name.startswith((".", "_")):

--- a/vtsearch/sync/__init__.py
+++ b/vtsearch/sync/__init__.py
@@ -42,8 +42,12 @@ class SyncSource(PluginBase, Generic[LoadT, SaveT]):
         """
         raise NotImplementedError(f"{type(self).__name__}.load() is not implemented")
 
-    def save(self, data: SaveT, field_values: dict[str, Any]) -> None:
+    def save(self, data: SaveT, /, field_values: dict[str, Any]) -> None:
         """Export *data* to the source.
+
+        The first parameter is positional-only so subclasses can name it
+        according to what they save (``labelset``, ``settings``, ...) without
+        breaking the override contract.
 
         Raises:
             NotImplementedError: If the subclass has not implemented this.


### PR DESCRIPTION
## Summary

Adopts **pyright in basic mode** as a hard CI gate, rolled out package-by-package per [`docs/plans/pyright-type-checking.md`](https://github.com/samggreenberg/vtsearch/blob/claude/add-type-checking-bVopx/docs/plans/pyright-type-checking.md). Targets feature-brainstorm §12.13.

### Why staged

Baseline `pyright vtsearch/` reports **482 errors** (288 of them `reportMissingImports` that resolve once CI installs full deps, leaving ~194 real errors). A single PR that types the whole package would be unreviewable; each stage is a separate PR.

### What lands in this PR

**Stage 0 (config + advisory CI):**
- `pyrightconfig.json` — basic mode, py3.10, `useLibraryCodeForTypes: true`, `reportMissingImports: "error"`.
- `.github/workflows/pyright.yml` with two jobs:
  - **`gated`** (hard fail) — runs `pyright` over the `include` scope.
  - **`advisory`** (`continue-on-error: true`) — runs `pyright vtsearch/` and prints the residual error count in the job summary. Removed in Stage 6.

**Stage 1 (foundation in `include`):** `vtsearch/auth`, `vtsearch/cli.py`, `vtsearch/concurrency`, `vtsearch/config.py`, `vtsearch/exporters`, `vtsearch/labels`, `vtsearch/plugins`, `vtsearch/settings_io`, `vtsearch/sync`, `vtsearch/utils`.

### Bug-fix-shaped type fixes

The 4 real errors in the Stage-1 scope:

- **`labels/sources/base.py`** — `LabelsetSource(SyncSource[..., "LabelSet"])` referenced a forward type that was never imported. Added the import under `TYPE_CHECKING`.
- **`sync/__init__.py`** — `SyncSource.save(self, data, field_values)` is overridden by `SettingsSource.save(..., settings, ...)` and `LabelsetSource.save(..., labelset, ...)`. The parameter rename violated pyright's override-LSP check. Made the first arg **positional-only** in the base (`/`) so subclasses can pick a domain-specific name without breaking the contract. All existing call sites (`vtsearch/labels/sync.py:69`, `vtsearch/settings.py:890`) already pass positionally.
- **`plugins/__init__.py`** — `Path(parent.__file__).parent` crashed on namespace packages where `__file__ is None`. Now raises a clear `RuntimeError` explaining the constraint.

No runtime behavior changes — these are tightening / clarifying fixes.

### Local usage

```bash
pip install pyright
bash scripts/install-cpu.sh   # so reportMissingImports resolves locally
pyright                       # gated scope (matches CI hard gate)
pyright vtsearch/             # full-package check (matches advisory job)
```

## Roadmap (in the plan doc)

| Stage | Scope | Real errors |
|---|---|---:|
| **1** (this PR) | foundation | **4 → 0** |
| 2 | `settings.py`, `settings_factory.py`, `state/`, `security/` | ~27 |
| 3 | `datasets/`, `detectors/`, `eval/`, `models/` | ~30 |
| 4 | `routes/`, `converters/` | ~58 |
| 5 | `media/` | ~68 |
| 6 | whole `vtsearch/` — advisory job removed | 0 |
| 7 *(optional)* | `tests/` | TBD |

## Test plan

- [x] `pyright` (gated scope) passes locally with full deps installed.
- [x] `./run-tests.sh` — 3375 passed, 1 skipped.
- [ ] CI: both jobs green; `advisory` posts residual count to job summary.

https://claude.ai/code/session_01VMrp7NtMs4JX9cqh7J9Z6q

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMrp7NtMs4JX9cqh7J9Z6q)_