### PR TITLE
Auto-rebase onto origin/dev in SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,6 +6,28 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Rebase the working branch onto origin/dev. The harness cuts new branches
+# off `main` (the GitHub default), so without this the session starts
+# without commits already merged to `dev`. See CLAUDE.md "Branch Policy".
+cd "$CLAUDE_PROJECT_DIR"
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ -z "$current_branch" ] || [ "$current_branch" = "HEAD" ]; then
+  echo "‼ session-start: detached HEAD or no branch; skipping dev rebase." >&2
+elif [ "$current_branch" = "dev" ] || [ "$current_branch" = "main" ]; then
+  echo "ℹ session-start: on $current_branch; skipping dev rebase." >&2
+elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
+  echo "‼ session-start: working tree dirty; skipping dev rebase to avoid clobbering changes." >&2
+else
+  echo "ℹ session-start: fetching and rebasing $current_branch onto origin/dev..." >&2
+  if git fetch origin --prune 2>&1 | sed 's/^/  /' >&2 \
+      && git rebase origin/dev 2>&1 | sed 's/^/  /' >&2; then
+    echo "✓ session-start: rebased $current_branch onto origin/dev." >&2
+  else
+    echo "‼ session-start: rebase failed; aborting and leaving branch as-is." >&2
+    git rebase --abort 2>/dev/null || true
+  fi
+fi
+
 # Install lightweight dev tools only — linter and formatter.
 # Heavy dependencies (PyTorch, transformers, etc.) are installed lazily
 # by ensure-test-deps.sh the first time tests or the app are run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Media explorer web app for browsing/voting on audio, images, text, video, or doc
 
 ## Branch Policy (CRITICAL)
 
-- **Always base work on `dev`.** At the start of every session, before making any changes, run `git fetch origin --prune && git rebase origin/dev`. The harness cuts the working branch off `main` (the GitHub default), so this rebase is required to pick up work already merged to `dev`. The GitHub default stays `main` so new users land on the stable branch — `dev` is Claude's starting point, not the public default.
+- **Always base work on `dev`.** The `.claude/hooks/session-start.sh` SessionStart hook runs `git fetch origin --prune && git rebase origin/dev` automatically in remote sessions, so a fresh container lands rebased onto `dev`. If the hook reports "skipping" (dirty tree, detached HEAD) or "rebase failed", run the fetch+rebase yourself before making any changes. The harness cuts the working branch off `main` (the GitHub default), so this rebase is required to pick up work already merged to `dev`. The GitHub default stays `main` so new users land on the stable branch — `dev` is Claude's starting point, not the public default.
 - **All pull requests MUST target `dev`**, never `main`.
 - **Claude must NEVER open a PR that merges into `main`.** The `main` branch is protected and only updated by human maintainers.
 - When creating a PR, always use `--base dev` (e.g., `gh pr create --base dev ...` or the equivalent MCP tool parameter).


### PR DESCRIPTION
## Summary
- CLAUDE.md's Branch Policy requires every session to start with `git fetch origin --prune && git rebase origin/dev` (the harness cuts new branches off `main`, so without this they miss work already merged to `dev`). Relying on Claude to remember this is fragile.
- Extend `.claude/hooks/session-start.sh` to do the fetch+rebase automatically in remote sessions, with guards for detached HEAD, dirty working tree, and rebase failure — each surfaces a loud `‼`/`ℹ` message instead of silently clobbering work.
- Update the CLAUDE.md Branch Policy bullet to point at the hook and tell future Claudes what to do when it reports a skip.

## Test plan
- [x] `bash -n .claude/hooks/session-start.sh` — syntax check passes.
- [x] Dry-run with `CLAUDE_CODE_REMOTE=true` and a dirty tree — correctly hits the "working tree dirty; skipping" branch instead of attempting a rebase.
- [ ] Verify on the next fresh remote session that the hook fetches and rebases cleanly (will show `✓ session-start: rebased <branch> onto origin/dev.` in the session-start log).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp4pg4tqySg8NrqeYvi1fr)_