### PR TITLE
Skip session-start rebase when local diverges from origin/&lt;branch&gt;

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,6 +17,9 @@ elif [ "$current_branch" = "dev" ] || [ "$current_branch" = "main" ]; then
   echo "ℹ session-start: on $current_branch; skipping dev rebase." >&2
 elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
   echo "‼ session-start: working tree dirty; skipping dev rebase to avoid clobbering changes." >&2
+elif git rev-parse --verify --quiet "refs/remotes/origin/$current_branch" >/dev/null \
+    && [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$current_branch")" ]; then
+  echo "‼ session-start: local $current_branch differs from origin/$current_branch (pushed work would be orphaned); skipping dev rebase." >&2
 else
   echo "ℹ session-start: fetching and rebasing $current_branch onto origin/dev..." >&2
   if git fetch origin --prune 2>&1 | sed 's/^/  /' >&2 \


### PR DESCRIPTION
## Summary
Follow-up to #1351. SessionStart hooks fire on session resume, not just on fresh containers — so if a session is resumed after a push and `dev` has advanced, the previous version of the hook would silently rebase the local branch onto the new `dev`, orphaning the already-pushed commit on `origin/<branch>` and forcing a force-push to land the same change again. (This actually happened immediately after #1351 merged: a resume rebased a9966ac onto a newer dev, diverging from the just-pushed remote.)

Add a guard that skips the rebase when `origin/<current_branch>` exists and differs from HEAD. Fresh containers (no remote branch yet) and resumed-but-clean sessions still rebase as before.

## Test plan
- [x] `bash -n .claude/hooks/session-start.sh` — syntax check passes.
- [x] Dry-run with a dirty tree — hits the existing "working tree dirty; skipping" branch.
- [ ] Verify on a fresh remote session that the rebase still runs when `origin/<branch>` doesn't exist yet.
- [ ] Verify on a resumed session with pushed work + advanced dev that the new guard fires and skips with the divergence message.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp4pg4tqySg8NrqeYvi1fr)_