### PR TITLE
Structured JSON logging with per-request context (request_id / dataset_id / detector_id / user)

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,22 +13,13 @@ _torch_threads = str(max(1, int(os.environ.get("VTSEARCH_TORCH_THREADS", "1"))))
 os.environ["OMP_NUM_THREADS"] = _torch_threads
 os.environ["MKL_NUM_THREADS"] = _torch_threads
 
-# Configure logging — respects VTSEARCH_LOG_LEVEL env var.
-# Default is WARNING.  Set to INFO or DEBUG for resolver diagnostics:
-#   VTSEARCH_LOG_LEVEL=INFO python app.py
-#   VTSEARCH_LOG_LEVEL=DEBUG python app.py
-_log_level = os.environ.get("VTSEARCH_LOG_LEVEL", "WARNING").upper()
-logging.basicConfig(
-    level=getattr(logging, _log_level, logging.WARNING),
-    format="%(levelname)s %(name)s: %(message)s",
-)
+# Configure structured logging — JSON lines by default with per-record
+# request_id / dataset_id / detector_id / user fields. Override via:
+#   VTSEARCH_LOG_LEVEL=INFO   (default WARNING)
+#   VTSEARCH_LOG_FORMAT=text  (default json — switch to text for local dev)
+from vtsearch.logging_config import new_request_id, setup_logging  # noqa: E402
 
-# Suppress Werkzeug request logging (GET/POST lines) — only show errors
-logging.getLogger("werkzeug").setLevel(logging.ERROR)
-# Suppress huggingface_hub "unauthenticated requests" console warning —
-# all models we use are public, so no token is needed.
-logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
-logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
+setup_logging()
 
 # All HF models we use are public — no token needed.  Each from_pretrained()
 # call passes token=False to signal this explicitly.  The env var + warnings
@@ -101,6 +92,24 @@ if _MAX_UPLOAD_MB > 0:
 # ---------------------------------------------------------------------------
 # Per-request user context
 # ---------------------------------------------------------------------------
+
+
+@app.before_request
+def _set_request_id():
+    """Assign a unique request id to every request.
+
+    The id is exposed on ``g.request_id`` so log records produced during
+    the request automatically carry it (via the structured-logging
+    ContextFilter), and echoed back in the ``X-Request-Id`` response
+    header so clients can quote it in bug reports. If the caller supplied
+    their own ``X-Request-Id`` header we trust it (truncated to 64 chars
+    to bound log line size), which lets gateways/load balancers propagate
+    end-to-end trace ids.
+    """
+    from flask import request
+
+    inbound = request.headers.get("X-Request-Id")
+    g.request_id = inbound[:64] if inbound else new_request_id()
 
 
 @app.before_request
@@ -190,6 +199,15 @@ def _no_cache_api(response):
 
     if request.path.startswith("/api/"):
         response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.after_request
+def _echo_request_id(response):
+    """Surface the per-request id on every response so clients can quote it."""
+    rid = getattr(g, "request_id", None)
+    if rid:
+        response.headers["X-Request-Id"] = rid
     return response
 
 

--- a/tests/core/test_structured_logging.py
+++ b/tests/core/test_structured_logging.py
@@ -54,6 +54,31 @@ def _emit(stream: io.StringIO, fmt: str, fn) -> list[dict]:
     return lines  # type: ignore[return-value]
 
 
+def _emit_with_empty_context(stream: io.StringIO, fmt: str, fn):
+    """Like ``_emit`` but clears the test-default dataset/detector thread-locals
+    for the duration of the call. The autouse ``reset_state`` fixture installs
+    ``_test_default`` contexts; tests that assert *absence* of context need
+    those out of the way."""
+    from vtsearch.auth import set_thread_user
+    from vtsearch.state.core import (
+        get_thread_dataset_context,
+        get_thread_detector_context,
+        set_thread_dataset_context,
+        set_thread_detector_context,
+    )
+
+    prior_ds = get_thread_dataset_context()
+    prior_det = get_thread_detector_context()
+    set_thread_dataset_context(None)
+    set_thread_detector_context(None)
+    set_thread_user(None)
+    try:
+        return _emit(stream, fmt, fn)
+    finally:
+        set_thread_dataset_context(prior_ds)
+        set_thread_detector_context(prior_det)
+
+
 # ---------------------------------------------------------------------------
 # Formatter unit tests
 # ---------------------------------------------------------------------------
@@ -73,10 +98,11 @@ class TestJsonFormatter:
     def test_no_context_outside_request(self):
         """Context fields should be absent (not null) when no context exists."""
         stream = io.StringIO()
-        records = _emit(stream, "json", lambda: logging.getLogger("vtsearch.test").info("no ctx"))
+        records = _emit_with_empty_context(stream, "json", lambda: logging.getLogger("vtsearch.test").info("no ctx"))
         assert "request_id" not in records[0]
         assert "dataset_id" not in records[0]
         assert "detector_id" not in records[0]
+        assert "user" not in records[0]
 
     def test_extra_fields_included(self):
         stream = io.StringIO()
@@ -116,10 +142,32 @@ class TestJsonFormatter:
 
 
 class TestTextFormatter:
-    def test_basic_line(self):
+    def test_basic_line_no_context(self):
         stream = io.StringIO()
-        lines = _emit(stream, "text", lambda: logging.getLogger("vtsearch.test").warning("hi"))
+        lines = _emit_with_empty_context(stream, "text", lambda: logging.getLogger("vtsearch.test").warning("hi"))
         assert lines == ["WARNING vtsearch.test: hi"]
+
+    def test_basic_line_with_thread_local_context(self):
+        """When thread-local context is set, the bracketed tags appear."""
+        from vtsearch.state.core import (
+            DatasetContext,
+            get_thread_dataset_context,
+            get_thread_detector_context,
+            set_thread_dataset_context,
+            set_thread_detector_context,
+        )
+
+        prior_ds = get_thread_dataset_context()
+        prior_det = get_thread_detector_context()
+        try:
+            set_thread_dataset_context(DatasetContext("my-ds"))
+            set_thread_detector_context(None)
+            stream = io.StringIO()
+            lines = _emit(stream, "text", lambda: logging.getLogger("vtsearch.test").warning("hi"))
+            assert lines == ["WARNING vtsearch.test [ds=my-ds]: hi"]
+        finally:
+            set_thread_dataset_context(prior_ds)
+            set_thread_detector_context(prior_det)
 
 
 # ---------------------------------------------------------------------------
@@ -130,45 +178,24 @@ class TestTextFormatter:
 class TestRequestContext:
     """When inside a Flask request, log records inherit g.* fields."""
 
-    def test_request_id_and_user_on_record(self, client):
-        # The /api/auth/status endpoint is a safe always-available GET.
-        # We swap in a handler and emit a log line from within a request.
+    def test_request_id_and_user_on_record(self):
+        """A log line emitted inside a Flask request context carries
+        request_id and user pulled from ``g``."""
         import app as app_module
+        from flask import g
 
         stream = io.StringIO()
-        captured: list[dict] = []
+        with app_module.app.test_request_context("/api/auth/status"):
+            g.request_id = new_request_id()
+            g.user = "alice"
+            expected_rid = g.request_id
+            records = _emit(stream, "json", lambda: logging.getLogger("vtsearch.test.probe").warning("inside request"))
 
-        # Register a one-shot before_request that logs and records what gets
-        # attached to the record. We can't simply emit from the test thread
-        # since g doesn't exist there.
-        seen: dict = {}
-
-        @app_module.app.before_request
-        def _log_probe():  # type: ignore[unused-ignore]
-            handler = _build_handler(stream, fmt="json")
-            root = logging.getLogger()
-            root.addHandler(handler)
-            try:
-                logging.getLogger("vtsearch.test.probe").warning("inside request")
-            finally:
-                root.removeHandler(handler)
-            seen["lines"] = [json.loads(ln) for ln in stream.getvalue().splitlines() if ln.strip()]
-
-        try:
-            resp = client.get("/api/auth/status")
-            assert resp.status_code == 200
-        finally:
-            # Remove the one-shot hook so subsequent tests aren't affected.
-            funcs = app_module.app.before_request_funcs.get(None, [])
-            if _log_probe in funcs:
-                funcs.remove(_log_probe)
-
-        captured = seen["lines"]
-        assert len(captured) == 1
-        rec = captured[0]
-        assert "request_id" in rec and len(rec["request_id"]) >= 8
-        # DefaultLoginProvider returns "default"
-        assert rec["user"] == "default"
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["request_id"] == expected_rid
+        assert len(rec["request_id"]) == 12
+        assert rec["user"] == "alice"
 
     def test_response_carries_x_request_id_header(self, client):
         resp = client.get("/api/auth/status")
@@ -188,6 +215,12 @@ class TestRequestContext:
         # Bounded to <= 64 chars.
         assert len(resp.headers["X-Request-Id"]) <= 64
         assert resp.headers["X-Request-Id"] == huge[:64]
+
+    def test_unknown_api_route_still_gets_request_id_header(self, client):
+        """Even 404s should carry X-Request-Id so clients can quote it in bug reports."""
+        resp = client.get("/api/no-such-endpoint-asdf")
+        assert resp.status_code == 404
+        assert resp.headers.get("X-Request-Id") is not None
 
 
 class TestThreadLocalContext:

--- a/tests/core/test_structured_logging.py
+++ b/tests/core/test_structured_logging.py
@@ -1,0 +1,344 @@
+"""Tests for structured logging + request-id middleware."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import threading
+
+from vtsearch.logging_config import (
+    ContextFilter,
+    JsonFormatter,
+    TextFormatter,
+    new_request_id,
+    setup_logging,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_handler(stream: io.StringIO, fmt: str = "json") -> logging.Handler:
+    """Build a handler with the same wiring setup_logging() uses, but
+    pointed at an in-memory stream so the test can read what was written."""
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(JsonFormatter() if fmt == "json" else TextFormatter())
+    handler.addFilter(ContextFilter())
+    return handler
+
+
+def _emit(stream: io.StringIO, fmt: str, fn) -> list[dict]:
+    """Install a fresh handler, run ``fn`` (which calls a logger), then
+    return the parsed JSON lines (or raw text lines if fmt == 'text')."""
+    root = logging.getLogger()
+    prior_level = root.level
+    prior_handlers = list(root.handlers)
+    for h in prior_handlers:
+        root.removeHandler(h)
+    handler = _build_handler(stream, fmt=fmt)
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    try:
+        fn()
+    finally:
+        root.removeHandler(handler)
+        for h in prior_handlers:
+            root.addHandler(h)
+        root.setLevel(prior_level)
+    lines = [line for line in stream.getvalue().splitlines() if line.strip()]
+    if fmt == "json":
+        return [json.loads(line) for line in lines]
+    return lines  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Formatter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestJsonFormatter:
+    def test_basic_fields(self):
+        stream = io.StringIO()
+        records = _emit(stream, "json", lambda: logging.getLogger("vtsearch.test").warning("hello %s", "world"))
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["level"] == "WARNING"
+        assert rec["logger"] == "vtsearch.test"
+        assert rec["msg"] == "hello world"
+        assert "ts" in rec and rec["ts"].endswith("Z")
+
+    def test_no_context_outside_request(self):
+        """Context fields should be absent (not null) when no context exists."""
+        stream = io.StringIO()
+        records = _emit(stream, "json", lambda: logging.getLogger("vtsearch.test").info("no ctx"))
+        assert "request_id" not in records[0]
+        assert "dataset_id" not in records[0]
+        assert "detector_id" not in records[0]
+
+    def test_extra_fields_included(self):
+        stream = io.StringIO()
+        records = _emit(
+            stream,
+            "json",
+            lambda: logging.getLogger("vtsearch.test").info("job done", extra={"job_id": "abc", "count": 3}),
+        )
+        assert records[0]["job_id"] == "abc"
+        assert records[0]["count"] == 3
+
+    def test_non_json_extras_repr_fallback(self):
+        class Weird:
+            def __repr__(self):
+                return "<weird>"
+
+        stream = io.StringIO()
+        records = _emit(
+            stream,
+            "json",
+            lambda: logging.getLogger("vtsearch.test").info("x", extra={"obj": Weird()}),
+        )
+        assert records[0]["obj"] == "<weird>"
+
+    def test_exception_included(self):
+        stream = io.StringIO()
+
+        def go():
+            try:
+                raise ValueError("boom")
+            except ValueError:
+                logging.getLogger("vtsearch.test").exception("caught")
+
+        records = _emit(stream, "json", go)
+        assert records[0]["msg"] == "caught"
+        assert "ValueError: boom" in records[0]["exc"]
+
+
+class TestTextFormatter:
+    def test_basic_line(self):
+        stream = io.StringIO()
+        lines = _emit(stream, "text", lambda: logging.getLogger("vtsearch.test").warning("hi"))
+        assert lines == ["WARNING vtsearch.test: hi"]
+
+
+# ---------------------------------------------------------------------------
+# Context resolution
+# ---------------------------------------------------------------------------
+
+
+class TestRequestContext:
+    """When inside a Flask request, log records inherit g.* fields."""
+
+    def test_request_id_and_user_on_record(self, client):
+        # The /api/auth/status endpoint is a safe always-available GET.
+        # We swap in a handler and emit a log line from within a request.
+        import app as app_module
+
+        stream = io.StringIO()
+        captured: list[dict] = []
+
+        # Register a one-shot before_request that logs and records what gets
+        # attached to the record. We can't simply emit from the test thread
+        # since g doesn't exist there.
+        seen: dict = {}
+
+        @app_module.app.before_request
+        def _log_probe():  # type: ignore[unused-ignore]
+            handler = _build_handler(stream, fmt="json")
+            root = logging.getLogger()
+            root.addHandler(handler)
+            try:
+                logging.getLogger("vtsearch.test.probe").warning("inside request")
+            finally:
+                root.removeHandler(handler)
+            seen["lines"] = [json.loads(ln) for ln in stream.getvalue().splitlines() if ln.strip()]
+
+        try:
+            resp = client.get("/api/auth/status")
+            assert resp.status_code == 200
+        finally:
+            # Remove the one-shot hook so subsequent tests aren't affected.
+            funcs = app_module.app.before_request_funcs.get(None, [])
+            if _log_probe in funcs:
+                funcs.remove(_log_probe)
+
+        captured = seen["lines"]
+        assert len(captured) == 1
+        rec = captured[0]
+        assert "request_id" in rec and len(rec["request_id"]) >= 8
+        # DefaultLoginProvider returns "default"
+        assert rec["user"] == "default"
+
+    def test_response_carries_x_request_id_header(self, client):
+        resp = client.get("/api/auth/status")
+        assert resp.status_code == 200
+        rid = resp.headers.get("X-Request-Id")
+        assert rid is not None
+        assert len(rid) >= 8
+
+    def test_inbound_request_id_is_honoured(self, client):
+        resp = client.get("/api/auth/status", headers={"X-Request-Id": "trace-xyz-123"})
+        assert resp.headers["X-Request-Id"] == "trace-xyz-123"
+
+    def test_inbound_request_id_is_truncated(self, client):
+        """A malicious caller can't blow up log lines by sending a 10 MB header."""
+        huge = "z" * 5000
+        resp = client.get("/api/auth/status", headers={"X-Request-Id": huge})
+        # Bounded to <= 64 chars.
+        assert len(resp.headers["X-Request-Id"]) <= 64
+        assert resp.headers["X-Request-Id"] == huge[:64]
+
+
+class TestThreadLocalContext:
+    """In a background thread, records inherit set_thread_* values."""
+
+    def test_thread_local_user_on_record(self):
+        from vtsearch.auth import set_thread_user
+
+        stream = io.StringIO()
+        captured: list[dict] = []
+        ready = threading.Event()
+
+        def target():
+            set_thread_user("alice")
+            try:
+                handler = _build_handler(stream, fmt="json")
+                root = logging.getLogger()
+                prior = list(root.handlers)
+                for h in prior:
+                    root.removeHandler(h)
+                root.addHandler(handler)
+                root.setLevel(logging.DEBUG)
+                try:
+                    logging.getLogger("vtsearch.test.bg").info("from-thread")
+                finally:
+                    root.removeHandler(handler)
+                    for h in prior:
+                        root.addHandler(h)
+                lines = [json.loads(ln) for ln in stream.getvalue().splitlines() if ln.strip()]
+                captured.extend(lines)
+            finally:
+                set_thread_user(None)
+                ready.set()
+
+        t = threading.Thread(target=target)
+        t.start()
+        ready.wait(timeout=5)
+        t.join(timeout=5)
+
+        assert len(captured) == 1
+        assert captured[0]["user"] == "alice"
+
+    def test_thread_local_dataset_and_detector_id(self):
+        from vtsearch.state.core import (
+            DatasetContext,
+            DetectorContext,
+            set_thread_dataset_context,
+            set_thread_detector_context,
+        )
+
+        stream = io.StringIO()
+        captured: list[dict] = []
+        ready = threading.Event()
+
+        def target():
+            ds = DatasetContext("my-dataset-42")
+            det = DetectorContext("my-detector-7")
+            set_thread_dataset_context(ds)
+            set_thread_detector_context(det)
+            try:
+                handler = _build_handler(stream, fmt="json")
+                root = logging.getLogger()
+                prior = list(root.handlers)
+                for h in prior:
+                    root.removeHandler(h)
+                root.addHandler(handler)
+                root.setLevel(logging.DEBUG)
+                try:
+                    logging.getLogger("vtsearch.test.bg").info("with-ctx")
+                finally:
+                    root.removeHandler(handler)
+                    for h in prior:
+                        root.addHandler(h)
+                lines = [json.loads(ln) for ln in stream.getvalue().splitlines() if ln.strip()]
+                captured.extend(lines)
+            finally:
+                set_thread_dataset_context(None)
+                set_thread_detector_context(None)
+                ready.set()
+
+        t = threading.Thread(target=target)
+        t.start()
+        ready.wait(timeout=5)
+        t.join(timeout=5)
+
+        assert len(captured) == 1
+        assert captured[0]["dataset_id"] == "my-dataset-42"
+        assert captured[0]["detector_id"] == "my-detector-7"
+
+
+# ---------------------------------------------------------------------------
+# setup_logging idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSetupLogging:
+    def test_idempotent_no_duplicate_handlers(self):
+        """Calling setup_logging twice should not double up log output."""
+        try:
+            setup_logging(level="DEBUG", fmt="json")
+            count_first = len(logging.getLogger().handlers)
+            setup_logging(level="DEBUG", fmt="json")
+            count_second = len(logging.getLogger().handlers)
+            assert count_first == count_second == 1
+        finally:
+            # Restore defaults so subsequent tests use the env-driven config.
+            setup_logging()
+
+    def test_format_env_var_selects_text(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_LOG_FORMAT", "text")
+        try:
+            setup_logging()
+            handler = logging.getLogger().handlers[0]
+            assert isinstance(handler.formatter, TextFormatter)
+        finally:
+            monkeypatch.delenv("VTSEARCH_LOG_FORMAT", raising=False)
+            setup_logging()
+
+    def test_unknown_level_falls_back_to_warning(self):
+        try:
+            setup_logging(level="NOSUCHLEVEL")
+            assert logging.getLogger().level == logging.WARNING
+        finally:
+            setup_logging()
+
+
+class TestRequestIdHelper:
+    def test_new_request_id_is_unique(self):
+        ids = {new_request_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_new_request_id_length(self):
+        rid = new_request_id()
+        assert len(rid) == 12
+        # Hex characters only.
+        int(rid, 16)
+
+
+# ---------------------------------------------------------------------------
+# ContextFilter does not overwrite caller-supplied extras
+# ---------------------------------------------------------------------------
+
+
+class TestExtraOverride:
+    def test_caller_supplied_extras_win(self):
+        """If a caller passes extra={"dataset_id": "X"}, don't clobber it
+        with the resolved context (which may be None outside a request)."""
+        stream = io.StringIO()
+
+        def go():
+            logging.getLogger("vtsearch.test").info("explicit", extra={"dataset_id": "explicit-ds"})
+
+        records = _emit(stream, "json", go)
+        assert records[0]["dataset_id"] == "explicit-ds"

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -1,0 +1,273 @@
+"""Structured logging with contextual VTSearch request fields.
+
+Every ``LogRecord`` is tagged with the user, ``dataset_id``, ``detector_id``,
+and ``request_id`` active when the record was created. Inside a Flask
+request handler the values come from ``flask.g`` (populated by the
+``before_request`` middleware in :mod:`app`); inside a background thread
+they come from the thread-locals already maintained by
+:mod:`vtsearch.auth` and :mod:`vtsearch.state.core`
+(``set_thread_user``, ``set_thread_dataset_context``,
+``set_thread_detector_context``).
+
+Two output formats are supported, selected by the
+``VTSEARCH_LOG_FORMAT`` env var:
+
+* ``json`` (default) — one JSON object per line, suitable for log aggregators.
+* ``text`` — human-readable bracketed-tag form, suitable for local dev.
+
+The level is controlled by ``VTSEARCH_LOG_LEVEL`` (default ``WARNING``).
+
+Existing ``logging.getLogger(__name__)`` call sites scattered throughout
+the codebase inherit the context automatically — no per-call ``extra=``
+dict is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from typing import Any, TextIO
+
+_DEFAULT_LEVEL = "WARNING"
+_DEFAULT_FORMAT = "json"
+
+# Order matters: the JsonFormatter emits these in this order, and the
+# TextFormatter walks them in this order to build the bracketed tag list.
+_CONTEXT_FIELDS: tuple[str, ...] = ("request_id", "user", "dataset_id", "detector_id")
+
+# Built-in LogRecord attributes — used to filter the record's __dict__
+# down to caller-supplied ``extra=`` keys when emitting JSON.
+_STD_RECORD_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+        "asctime",
+        "taskName",
+    }
+)
+
+
+def _resolve_context() -> dict[str, Any]:
+    """Pull the active VTSearch context from Flask ``g`` or thread-locals.
+
+    Returns a dict with whatever subset of (``request_id``, ``user``,
+    ``dataset_id``, ``detector_id``) is available; missing values are
+    omitted (not set to ``None``) so the JSON output stays compact.
+
+    Defensive: any exception while resolving is swallowed so a misconfigured
+    Flask app or a half-initialised thread context can never take down
+    logging. Logging that crashes is worse than logging that's missing a
+    field.
+    """
+    out: dict[str, Any] = {}
+
+    try:
+        from flask import g, has_request_context  # local import — Flask may not be loaded yet
+    except Exception:
+        has_request_context = lambda: False  # noqa: E731
+        g = None  # type: ignore[assignment]
+
+    in_request = False
+    try:
+        in_request = bool(has_request_context())
+    except Exception:
+        in_request = False
+
+    ds_ctx = None
+    det_ctx = None
+    if in_request and g is not None:
+        try:
+            rid = getattr(g, "request_id", None)
+            if rid:
+                out["request_id"] = rid
+            user = getattr(g, "user", None)
+            if user:
+                out["user"] = user
+            ds_ctx = getattr(g, "_dataset_context", None)
+            det_ctx = getattr(g, "_detector_context", None)
+        except Exception:
+            pass
+
+    # Thread-local fallbacks (background jobs propagate these via
+    # set_thread_user / set_thread_dataset_context / set_thread_detector_context).
+    if "user" not in out:
+        try:
+            from vtsearch.auth import get_thread_user
+
+            tl_user = get_thread_user()
+            if tl_user:
+                out["user"] = tl_user
+        except Exception:
+            pass
+
+    if ds_ctx is None or det_ctx is None:
+        try:
+            from vtsearch.state.core import (
+                get_thread_dataset_context,
+                get_thread_detector_context,
+            )
+
+            if ds_ctx is None:
+                ds_ctx = get_thread_dataset_context()
+            if det_ctx is None:
+                det_ctx = get_thread_detector_context()
+        except Exception:
+            pass
+
+    ds_id = getattr(ds_ctx, "dataset_id", None) if ds_ctx is not None else None
+    if ds_id:
+        out["dataset_id"] = ds_id
+    det_id = getattr(det_ctx, "detector_id", None) if det_ctx is not None else None
+    if det_id:
+        out["detector_id"] = det_id
+
+    return out
+
+
+class ContextFilter(logging.Filter):
+    """Attach VTSearch context fields to every ``LogRecord``.
+
+    Installed on the root logger's stream handler so every record routed
+    through it gets the fields, regardless of which module produced it.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        ctx = _resolve_context()
+        for field in _CONTEXT_FIELDS:
+            # Don't overwrite an explicit ``extra={"dataset_id": "..."}``
+            # value passed by the caller — they know what they're doing.
+            if not hasattr(record, field):
+                setattr(record, field, ctx.get(field))
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    """One JSON object per ``LogRecord``, on a single line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts_struct = time.gmtime(record.created)
+        ts = time.strftime("%Y-%m-%dT%H:%M:%S", ts_struct) + f".{int(record.msecs):03d}Z"
+        payload: dict[str, Any] = {
+            "ts": ts,
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        for field in _CONTEXT_FIELDS:
+            value = getattr(record, field, None)
+            if value is not None:
+                payload[field] = value
+
+        # Caller-supplied extras (``logger.info("...", extra={"job_id": x})``).
+        for key, value in record.__dict__.items():
+            if key in _STD_RECORD_ATTRS or key in payload or key.startswith("_"):
+                continue
+            if key in _CONTEXT_FIELDS:
+                continue
+            try:
+                json.dumps(value)
+                payload[key] = value
+            except (TypeError, ValueError):
+                payload[key] = repr(value)
+
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, default=str)
+
+
+class TextFormatter(logging.Formatter):
+    """Plain-text formatter with bracketed context tags.
+
+    Example::
+
+        WARNING vtsearch.routes.datasets [req=abc123 ds=my-dataset]: Foo
+    """
+
+    _SHORT = {
+        "request_id": "req",
+        "user": "user",
+        "dataset_id": "ds",
+        "detector_id": "det",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        tags: list[str] = []
+        for field in _CONTEXT_FIELDS:
+            value = getattr(record, field, None)
+            if not value:
+                continue
+            short_val = str(value)[:8] if field == "request_id" else str(value)
+            tags.append(f"{self._SHORT[field]}={short_val}")
+        ctx = f" [{' '.join(tags)}]" if tags else ""
+        base = f"{record.levelname} {record.name}{ctx}: {record.getMessage()}"
+        if record.exc_info:
+            base += "\n" + self.formatException(record.exc_info)
+        return base
+
+
+def setup_logging(
+    level: str | None = None,
+    fmt: str | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Configure root logging for VTSearch.
+
+    Resolution order for each parameter:
+
+    1. Explicit keyword argument.
+    2. Environment variable (``VTSEARCH_LOG_LEVEL`` / ``VTSEARCH_LOG_FORMAT``).
+    3. Built-in default (``WARNING`` / ``json``).
+
+    Idempotent: safe to call multiple times. Replaces any handlers added
+    by a previous call (or by an earlier ``logging.basicConfig``) so log
+    lines aren't emitted twice.
+    """
+    level_str = (level or os.environ.get("VTSEARCH_LOG_LEVEL") or _DEFAULT_LEVEL).upper()
+    level_value = getattr(logging, level_str, logging.WARNING)
+
+    fmt_kind = (fmt or os.environ.get("VTSEARCH_LOG_FORMAT") or _DEFAULT_FORMAT).lower()
+    formatter: logging.Formatter = JsonFormatter() if fmt_kind == "json" else TextFormatter()
+
+    handler = logging.StreamHandler(stream or sys.stderr)
+    handler.setFormatter(formatter)
+    handler.addFilter(ContextFilter())
+
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    root.addHandler(handler)
+    root.setLevel(level_value)
+
+    # Quiet down chatty libraries — preserved from app.py's old basicConfig.
+    logging.getLogger("werkzeug").setLevel(logging.ERROR)
+    logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+    logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
+
+
+def new_request_id() -> str:
+    """Generate a short request id (12 hex chars from a uuid4)."""
+    return uuid.uuid4().hex[:12]


### PR DESCRIPTION
Implements feature 12.15 from `docs/plans/feature-brainstorm.md` — "Structured logging + request IDs ★★ S":

> Today logs are print-style. JSON logs with `dataset_id`/`detector_id`/`request_id` make production debugging tractable.

## Summary

- New module `vtsearch/logging_config.py` with:
  - `JsonFormatter` — one JSON object per line (`ts`, `level`, `logger`, `msg`, context fields, exception traceback, any caller-supplied `extra=` keys).
  - `TextFormatter` — human-readable bracketed-tag form for local dev (`WARNING vtsearch.routes.datasets [req=abc12345 ds=my-dataset]: …`).
  - `ContextFilter` — installed on the root handler; resolves the active `request_id` / `user` / `dataset_id` / `detector_id` per record. Inside a Flask request it reads from `flask.g`; in background threads it falls back to the existing `vtsearch.auth` / `vtsearch.state.core` thread-locals (`set_thread_user`, `set_thread_dataset_context`, `set_thread_detector_context`). Caller-supplied `extra={…}` values win over the resolved context.
  - `setup_logging()` — idempotent root configuration. Replaces the old `logging.basicConfig` site in `app.py`. Configurable via `VTSEARCH_LOG_LEVEL` (default `WARNING`) and `VTSEARCH_LOG_FORMAT` (default `json`, set to `text` for local dev).
  - `new_request_id()` — 12-hex-char id derived from `uuid4()`.

- `app.py` middleware:
  - `before_request` mints a fresh `g.request_id`, or honours an inbound `X-Request-Id` header (truncated to 64 chars so a malicious caller can't blow up log lines).
  - `after_request` echoes `X-Request-Id` on every response, including 404s, so clients can quote it in bug reports.

- 19 new tests in `tests/core/test_structured_logging.py` covering: JSON shape, `extra=` propagation, non-JSON value `repr()` fallback, exception emission, text-format tags, in-request `g`-derived context, background-thread context, inbound header honour/truncation, 404 still gets the header, idempotent `setup_logging`, `VTSEARCH_LOG_FORMAT` env-var selection, and unknown-level fallback.

Existing `logging.getLogger(__name__).foo(…)` call sites scattered throughout the codebase automatically inherit the new context — no per-call `extra=` dict is needed. The 100ish `print()` calls (mostly CLI banners and autodetect-result output) are deliberately left alone; they're user-facing terminal UX, not logs.

## Test plan

- [x] `python -m pytest tests/core/test_structured_logging.py` → 19/19 pass
- [x] `./run-tests.sh core` → 471/471 pass
- [x] `./run-tests.sh` (full default suite) → 3436 passed, 1 skipped, 2 xpassed
- [x] `ruff check` / `ruff format --check` clean on all new/modified files
- [ ] Manual: hit `/api/auth/status` and verify `X-Request-Id` shows up in response headers
- [ ] Manual: set `VTSEARCH_LOG_LEVEL=INFO` and verify JSON log lines include `request_id`, `dataset_id`, `detector_id`, `user`


---
_Generated by [Claude Code](https://claude.ai/code/session_011PXTwStdqR4fx9ErJkxmco)_