### PR TITLE
Migrate auth/achievements/main blueprints to flask-smorest

### DIFF
--- a/app.py
+++ b/app.py
@@ -240,13 +240,18 @@ def _echo_request_id(response):
 # Register Blueprints
 # ---------------------------------------------------------------------------
 
-app.register_blueprint(achievements_bp)
-app.register_blueprint(auth_bp)
+# achievements_bp, auth_bp, and main_bp are flask-smorest Blueprints
+# (OpenAPI migration); register them via the Api so their decorated
+# routes appear in /api/openapi.json. Their undecorated routes (e.g.
+# main_bp's SPA-serving paths, achievements_bp's raw-markdown stream)
+# attach to Flask normally and are simply absent from the spec.
+api.register_blueprint(achievements_bp)
+api.register_blueprint(auth_bp)
 app.register_blueprint(eval_bp)
 app.register_blueprint(file_browser_bp)
 app.register_blueprint(labels_bp)
 app.register_blueprint(media_server_bp)
-app.register_blueprint(main_bp)
+api.register_blueprint(main_bp)
 app.register_blueprint(medias_bp)
 app.register_blueprint(sorting_bp)
 app.register_blueprint(processors_bp)

--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -248,6 +248,11 @@ request/response gates getting in the way during their migration.
       `/api/docs` serve the spec / Swagger UI
 - [x] `vtsearch/schemas/` package created
 - [x] Pilot: `settings/api.py` migrated to flask-smorest
+- [x] `auth.py`, `achievements.py`, `main.py` (`/api/version`) migrated
+      to flask-smorest. Raw-markdown + SPA-serving routes stay
+      undecorated on the same `flask_smorest.Blueprint` (regular Flask
+      routing, simply absent from the spec since they don't return
+      JSON).
 - [ ] Frontend `SettingsApiService` rewired to generated client
 - [ ] `frontend/src/app/models/api.models.ts` settings section deleted
 - [ ] Remaining blueprints (see Order above)

--- a/tests/api/test_multi_user_security.py
+++ b/tests/api/test_multi_user_security.py
@@ -375,7 +375,9 @@ class TestTrivialLoginEndpoints:
         """Login endpoint returns 400 when the trivial provider is not active."""
         resp = client.post("/api/auth/login", json={"username": "alice"})
         assert resp.status_code == 400
-        assert "not supported" in resp.get_json()["error"]
+        # flask-smorest emits its standard error envelope with the
+        # message under "message", not "error".
+        assert "not supported" in resp.get_json()["message"]
 
     def test_logout_rejected_with_default_provider(self, client):
         """Logout endpoint returns 400 when the trivial provider is not active."""
@@ -423,7 +425,8 @@ class TestTrivialLoginEndpoints:
         try:
             set_login_provider(TrivialLoginProvider())
             resp = client.post("/api/auth/login", json={"username": ""})
-            assert resp.status_code == 400
+            # Schema-level validation failure → 422 (flask-smorest).
+            assert resp.status_code == 422
         finally:
             set_login_provider(original)
 
@@ -432,7 +435,7 @@ class TestTrivialLoginEndpoints:
         try:
             set_login_provider(TrivialLoginProvider())
             resp = client.post("/api/auth/login", json={"username": "alice bob"})
-            assert resp.status_code == 400
+            assert resp.status_code == 422
         finally:
             set_login_provider(original)
 
@@ -441,7 +444,7 @@ class TestTrivialLoginEndpoints:
         try:
             set_login_provider(TrivialLoginProvider())
             resp = client.post("/api/auth/login", json={"username": "../etc"})
-            assert resp.status_code == 400
+            assert resp.status_code == 422
         finally:
             set_login_provider(original)
 

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -454,11 +454,13 @@ class TestReadmeReaderApi:
 
     def test_check_phrase_missing_body(self, client):
         resp = client.post("/api/achievements/check-phrase", json={})
-        assert resp.status_code == 400
+        # Schema validation: missing required "phrase" → 422.
+        assert resp.status_code == 422
 
     def test_check_phrase_non_string(self, client):
         resp = client.post("/api/achievements/check-phrase", json={"phrase": 42})
-        assert resp.status_code == 400
+        # Schema validation: "phrase" must be a string → 422.
+        assert resp.status_code == 422
 
     def test_docs_raw_returns_markdown(self, client):
         resp = client.get("/api/achievements/docs/readme/raw")
@@ -596,7 +598,8 @@ class TestAchievementsApi:
 
     def test_acknowledge_requires_tier_idx(self, client):
         resp = client.post("/api/achievements/votes_cast/acknowledge", json={})
-        assert resp.status_code == 400
+        # Schema validation: missing required "tier_idx" → 422.
+        assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/achievements.py
+++ b/vtsearch/routes/achievements.py
@@ -15,17 +15,35 @@ POST /api/achievements/check-phrase
 GET  /api/achievements/docs/<doc_id>/raw
     Stream the raw markdown of a Readme Reader doc, so the frontend can link
     to it directly without requiring internet access to GitHub.
+
+Migrated to ``flask_smorest`` so the JSON routes are described in
+``/api/openapi.json``. The raw-markdown route stays undecorated (it
+serves ``text/plain``, not JSON) — it's still attached to the same
+``Blueprint`` and Flask routes it normally, just absent from the spec.
+See ``docs/plans/openapi-schema.md``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Response
+from flask_smorest import Blueprint, abort
 
 from vtsearch import achievements
+from vtsearch.schemas.achievements import (
+    AchievementStateSchema,
+    AcknowledgeRequestSchema,
+    AcknowledgeResponseSchema,
+    CheckPhraseRequestSchema,
+    CheckPhraseResponseSchema,
+)
 
-achievements_bp = Blueprint("achievements", __name__)
+achievements_bp = Blueprint(
+    "achievements",
+    __name__,
+    description="Counters, tiers, and the Readme Reader doc set.",
+)
 
 #: Repo root resolved at import time.  ``vtsearch/routes/achievements.py``
 #: lives two levels under the repo root.
@@ -33,42 +51,42 @@ _REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 
 
 @achievements_bp.route("/api/achievements", methods=["GET"])
+@achievements_bp.response(200, AchievementStateSchema)
 def get_achievements():
     """Return the full achievement state."""
-    return jsonify(achievements.get_full_state())
+    return achievements.get_full_state()
 
 
 @achievements_bp.route("/api/achievements/<category_id>/acknowledge", methods=["POST"])
-def acknowledge_achievement(category_id: str):
+@achievements_bp.arguments(AcknowledgeRequestSchema)
+@achievements_bp.response(200, AcknowledgeResponseSchema)
+def acknowledge_achievement(body: dict, category_id: str):
     """Mark *category_id*'s tier as announced."""
-    body = request.get_json(force=True, silent=True) or {}
-    tier_idx = body.get("tier_idx")
-    if not isinstance(tier_idx, int):
-        return jsonify({"error": "tier_idx (int) is required"}), 400
-    changed = achievements.acknowledge(category_id, tier_idx)
-    return jsonify({"ok": True, "changed": changed})
+    changed = achievements.acknowledge(category_id, body["tier_idx"])
+    return {"ok": True, "changed": changed}
 
 
 @achievements_bp.route("/api/achievements/check-phrase", methods=["POST"])
-def check_phrase():
+@achievements_bp.arguments(CheckPhraseRequestSchema)
+@achievements_bp.response(200, CheckPhraseResponseSchema)
+def check_phrase(body: dict):
     """Check a user-submitted phrase against the Readme Reader docs."""
-    body = request.get_json(force=True, silent=True) or {}
-    phrase = body.get("phrase")
-    if not isinstance(phrase, str):
-        return jsonify({"error": "phrase (string) is required"}), 400
-    result = achievements.record_doc_phrase(phrase)
-    return jsonify(result)
+    return achievements.record_doc_phrase(body["phrase"])
 
 
 @achievements_bp.route("/api/achievements/docs/<doc_id>/raw", methods=["GET"])
 def get_doc_raw(doc_id: str):
-    """Return the raw markdown for a Readme Reader doc."""
+    """Return the raw markdown for a Readme Reader doc.
+
+    Plain-text response — intentionally undecorated so it stays out of
+    the OpenAPI spec (the spec is for JSON APIs).
+    """
     doc = next((d for d in achievements.DOCS if d["id"] == doc_id), None)
     if doc is None:
-        return jsonify({"error": "unknown doc id"}), 404
+        abort(404, message="unknown doc id")
     abs_path = (_REPO_ROOT / doc["path"]).resolve()
     if _REPO_ROOT not in abs_path.parents and abs_path != _REPO_ROOT:
-        return jsonify({"error": "doc resolved outside repo"}), 500
+        abort(500, message="doc resolved outside repo")
     if not abs_path.is_file():
-        return jsonify({"error": "doc file missing"}), 500
+        abort(500, message="doc file missing")
     return Response(abs_path.read_text(encoding="utf-8"), mimetype="text/plain; charset=utf-8")

--- a/vtsearch/routes/auth.py
+++ b/vtsearch/routes/auth.py
@@ -1,62 +1,56 @@
-"""Authentication status and login/logout routes."""
+"""Authentication status and login/logout routes.
+
+Migrated to ``flask_smorest`` so the routes are described in
+``/api/openapi.json``. See ``docs/plans/openapi-schema.md``.
+"""
 
 from __future__ import annotations
 
-import re
-
-from flask import Blueprint, jsonify, request, session
+from flask import request, session
+from flask_smorest import Blueprint, abort
 
 from vtsearch.auth import TrivialLoginProvider, get_login_provider
+from vtsearch.schemas.auth import AuthStatusSchema, LoginRequestSchema
 
-auth_bp = Blueprint("auth", __name__)
+auth_bp = Blueprint(
+    "auth",
+    __name__,
+    description="Authentication status, login, and logout.",
+)
 
-# Username constraints for the trivial provider.
-_USERNAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+def _trivial_or_400() -> TrivialLoginProvider:
+    """Return the active provider if it's the trivial one, else 400."""
+    provider = get_login_provider()
+    if not isinstance(provider, TrivialLoginProvider):
+        abort(400, message="Login/logout not supported by the active provider")
+    return provider
 
 
 @auth_bp.route("/api/auth/status", methods=["GET"])
+@auth_bp.response(200, AuthStatusSchema)
 def auth_status():
-    """Return the current authentication state.
-
-    Response shape::
-
-        {
-            "provider": "default",
-            "user": "default",
-            "authenticated": true,
-            "login_required": false
-        }
-    """
+    """Return the current authentication state."""
     provider = get_login_provider()
-    return jsonify(provider.status_dict(request))
+    return provider.status_dict(request)
 
 
 @auth_bp.route("/api/auth/login", methods=["POST"])
-def auth_login():
-    """Set the session username (trivial provider only).
-
-    Expects JSON ``{"username": "alice"}``.  Returns the updated auth
-    status dict on success.
-    """
-    provider = get_login_provider()
-    if not isinstance(provider, TrivialLoginProvider):
-        return jsonify({"error": "Login not supported by the active provider"}), 400
-
-    body = request.get_json(silent=True) or {}
-    username = (body.get("username") or "").strip()
-    if not username or not _USERNAME_RE.match(username):
-        return jsonify({"error": "Username must be 1-64 alphanumeric/dash/underscore characters"}), 400
-
-    session[TrivialLoginProvider._COOKIE_KEY] = username
-    return jsonify(provider.status_dict(request))
+@auth_bp.arguments(LoginRequestSchema)
+@auth_bp.response(200, AuthStatusSchema)
+@auth_bp.alt_response(400, description="Active login provider does not support login.")
+def auth_login(body: dict):
+    """Set the session username (trivial provider only)."""
+    provider = _trivial_or_400()
+    session[TrivialLoginProvider._COOKIE_KEY] = body["username"]
+    return provider.status_dict(request)
 
 
 @auth_bp.route("/api/auth/logout", methods=["POST"])
+@auth_bp.response(200, AuthStatusSchema)
+@auth_bp.alt_response(400, description="Active login provider does not support logout.")
 def auth_logout():
     """Clear the session username (trivial provider only)."""
-    provider = get_login_provider()
-    if not isinstance(provider, TrivialLoginProvider):
-        return jsonify({"error": "Logout not supported by the active provider"}), 400
-
+    provider = _trivial_or_400()
     session.pop(TrivialLoginProvider._COOKIE_KEY, None)
-    return jsonify(provider.status_dict(request))
+    return provider.status_dict(request)

--- a/vtsearch/routes/main.py
+++ b/vtsearch/routes/main.py
@@ -1,25 +1,48 @@
-"""Blueprint for main application routes."""
+"""Blueprint for main application routes.
+
+``/api/version`` is the only JSON API exposed here and is described via
+``flask_smorest`` decorators so it appears in ``/api/openapi.json``.
+The other routes serve static files / the Angular SPA shell and stay
+plain Flask routes (no schema, no spec presence) — they share the same
+``flask_smorest.Blueprint`` object since that class is a regular Flask
+``Blueprint`` subclass and only decorated routes contribute to the
+spec.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from flask import Blueprint, Response, current_app, jsonify, send_from_directory
+from flask import Response, current_app, jsonify, send_from_directory
+from flask_smorest import Blueprint
 
 from vtsearch import __version__
+from vtsearch.schemas.main import VersionSchema
 
-main_bp = Blueprint("main", __name__)
+main_bp = Blueprint(
+    "main",
+    __name__,
+    description="App version and SPA / static-file serving.",
+)
 
 
 @main_bp.route("/api/version")
-def version() -> Response:
+@main_bp.response(200, VersionSchema)
+def version() -> dict:
     """Return the app version (UTC timestamp of the last dev->main merge)."""
-    return jsonify({"version": __version__})
+    return {"version": __version__}
 
 
 @main_bp.route("/openapi.json")
 def openapi_json() -> Response:
-    """Return the auto-generated OpenAPI 3.0 spec for this Flask app."""
+    """Return the auto-generated OpenAPI 3.0 spec for this Flask app.
+
+    Served by the pre-existing permissive walker in
+    :mod:`vtsearch.openapi`; the richer flask-smorest spec lives at
+    ``/api/openapi.json``. Both coexist until the migration in
+    ``docs/plans/openapi-schema.md`` completes — at which point this
+    route is deleted along with the walker.
+    """
     from vtsearch.openapi import generate_openapi_spec
 
     spec = generate_openapi_spec(current_app, version=__version__)

--- a/vtsearch/schemas/achievements.py
+++ b/vtsearch/schemas/achievements.py
@@ -1,0 +1,80 @@
+"""Schemas for the achievements API (``/api/achievements/*``).
+
+Models the shape returned by :func:`vtsearch.achievements.get_full_state`
+and the small request bodies accepted by the acknowledge / check-phrase
+endpoints. See ``vtsearch/achievements.py`` for the source-of-truth
+shape these schemas mirror.
+"""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+
+class _AchievementEntrySchema(Schema):
+    id = fields.String(required=True)
+    name = fields.String(required=True)
+    description = fields.String(required=True)
+    icon = fields.String(required=True)
+    tiers = fields.List(fields.Integer(), required=True)
+    counter = fields.Integer(required=True)
+    tier_idx = fields.Integer(required=True, metadata={"description": "Current tier index; -1 = locked."})
+    next_threshold = fields.Integer(
+        allow_none=True,
+        required=True,
+        metadata={"description": "Counter value needed to reach the next tier, or null at max tier."},
+    )
+
+
+class _PendingAnnouncementSchema(Schema):
+    id = fields.String(required=True)
+    name = fields.String(required=True)
+    icon = fields.String(required=True)
+    tier_idx = fields.Integer(required=True)
+    tier_name = fields.String(required=True)
+    threshold = fields.Integer(required=True)
+
+
+class _DocEntrySchema(Schema):
+    id = fields.String(required=True)
+    name = fields.String(required=True)
+    path = fields.String(required=True)
+    read = fields.Boolean(required=True)
+
+
+class AchievementStateSchema(Schema):
+    """Response for ``GET /api/achievements``."""
+
+    tier_names = fields.List(fields.String(), required=True)
+    achievements = fields.List(fields.Nested(_AchievementEntrySchema), required=True)
+    pending_announcements = fields.List(fields.Nested(_PendingAnnouncementSchema), required=True)
+    docs = fields.List(fields.Nested(_DocEntrySchema), required=True)
+
+
+class AcknowledgeRequestSchema(Schema):
+    tier_idx = fields.Integer(required=True, strict=True)
+
+
+class AcknowledgeResponseSchema(Schema):
+    ok = fields.Boolean(required=True)
+    changed = fields.Boolean(required=True)
+
+
+class CheckPhraseRequestSchema(Schema):
+    phrase = fields.String(required=True)
+
+
+class CheckPhraseResponseSchema(Schema):
+    matched = fields.Boolean(required=True)
+    doc_id = fields.String(allow_none=True, required=True)
+    doc_name = fields.String(allow_none=True, required=True)
+    already_read = fields.Boolean(required=True)
+
+
+__all__ = [
+    "AchievementStateSchema",
+    "AcknowledgeRequestSchema",
+    "AcknowledgeResponseSchema",
+    "CheckPhraseRequestSchema",
+    "CheckPhraseResponseSchema",
+]

--- a/vtsearch/schemas/auth.py
+++ b/vtsearch/schemas/auth.py
@@ -1,0 +1,59 @@
+"""Schemas for the auth API (``/api/auth/*``).
+
+Models the response shape of ``LoginProvider.status_dict()`` and the
+request body accepted by ``POST /api/auth/login``. Provider
+implementations may add extra fields to ``status_dict``, so the
+response schema is open (``unknown = "include"``).
+"""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields, pre_load, validate
+
+
+class AuthStatusSchema(Schema):
+    """Response for ``GET /api/auth/status`` and ``POST /api/auth/{login,logout}``.
+
+    The four fields below are the contract every ``LoginProvider`` must
+    fulfil; custom providers may add extra keys and they pass through
+    untouched (``unknown = "include"``).
+    """
+
+    provider = fields.String(required=True, metadata={"description": "Active login provider name."})
+    user = fields.String(
+        required=True,
+        metadata={"description": "Current user, or 'anonymous' when not logged in."},
+    )
+    authenticated = fields.Boolean(required=True)
+    login_required = fields.Boolean(required=True)
+
+    class Meta:
+        unknown = "include"
+
+
+class LoginRequestSchema(Schema):
+    """Body for ``POST /api/auth/login`` (trivial provider only).
+
+    Mirrors the historical ``^[A-Za-z0-9_-]{1,64}$`` validation from
+    the legacy hand-rolled route. Surrounding whitespace is stripped
+    before the regex runs, matching the legacy ``.strip()`` behavior.
+    """
+
+    username = fields.String(
+        required=True,
+        validate=validate.Regexp(
+            r"^[A-Za-z0-9_-]{1,64}$",
+            error="Username must be 1-64 alphanumeric/dash/underscore characters",
+        ),
+    )
+
+    @pre_load
+    def _strip_username(self, data, **_kwargs):
+        if isinstance(data, dict):
+            raw = data.get("username")
+            if isinstance(raw, str):
+                data = {**data, "username": raw.strip()}
+        return data
+
+
+__all__ = ["AuthStatusSchema", "LoginRequestSchema"]

--- a/vtsearch/schemas/main.py
+++ b/vtsearch/schemas/main.py
@@ -1,0 +1,22 @@
+"""Schemas for the small ``main`` blueprint (``/api/version``).
+
+The static-file / SPA-serving routes in :mod:`vtsearch.routes.main` are
+not JSON APIs and do not have schemas; only ``GET /api/version`` is
+modelled here.
+"""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+
+class VersionSchema(Schema):
+    """Response for ``GET /api/version``."""
+
+    version = fields.String(
+        required=True,
+        metadata={"description": "UTC timestamp of HEAD's commit (ISO 8601, Z-terminated)."},
+    )
+
+
+__all__ = ["VersionSchema"]


### PR DESCRIPTION
## Summary

Continues the OpenAPI migration in `docs/plans/openapi-schema.md`. After
the `settings/api.py` pilot landed, this PR migrates the next blueprint
group in the plan's order (`auth.py`, `achievements.py`, `main.py`) so
their JSON routes appear in `/api/openapi.json` with real
request/response schemas.

- New marshmallow schemas under `vtsearch/schemas/`:
  `auth.py`, `achievements.py`, `main.py`.
- `vtsearch.routes.{auth,achievements,main}` swap `flask.Blueprint` →
  `flask_smorest.Blueprint`. JSON routes get `@blp.arguments` /
  `@blp.response` decorators; static-file (SPA), raw-markdown, and the
  legacy `/openapi.json` passthrough stay undecorated on the same
  blueprint object (regular Flask routing, simply absent from the
  spec).
- `app.py` registers the three blueprints via `api.register_blueprint`.
- Tests updated for the standard flask-smorest envelope already
  adopted in the settings pilot:
  - Schema-level body validation failures now return **422** instead
    of the legacy 400 (e.g. missing `tier_idx`, non-string `phrase`,
    invalid `username` regex).
  - The login-provider-mismatch message moved from `{"error": ...}` to
    `{"message": ...}` (flask-smorest's standard `abort()` envelope).

After: 7 freshly-typed paths appear in `/api/openapi.json` alongside
the existing settings routes (18 total).

## Test plan
- [x] `./run-tests.sh core api` — 860 passed
- [x] `./run-tests.sh` (full default suite) — 3447 passed, 1 skipped, 2 xpassed
- [x] Smoke-check `/api/openapi.json` lists all 7 new paths
- [ ] Manual Swagger UI sanity check at `/api/docs` (reviewer)

https://claude.ai/code/session_01WV81WEMswg6Ty7m4tRNwQn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV81WEMswg6Ty7m4tRNwQn)_