### PR TITLE
Pyright Stage 3: gate datasets/detectors/eval/embedding/training

### DIFF
--- a/docs/plans/pyright-type-checking.md
+++ b/docs/plans/pyright-type-checking.md
@@ -12,8 +12,10 @@ package. Rolled out in stages so each PR stays reviewable.
   count to the GitHub step summary.
 - **Stage 2:** ✅ shipped. Adds `settings.py`, `settings_factory.py`,
   `state/`, `security/` to the gated scope (31 real errors fixed).
-- **Stage 3:** ⏳ next — `datasets/`, `detectors/`, `eval/`, `models/`.
-- **Stages 4–6:** 📋 not started.
+- **Stage 3:** ✅ shipped. Adds `datasets/`, `detectors/`, `eval/`,
+  `embedding/`, `training/` to the gated scope (38 real errors fixed).
+- **Stage 4:** ⏳ next — `routes/`, `converters/`.
+- **Stages 5–6:** 📋 not started.
 - **Stage 7 (`tests/`):** 📋 optional, deferred.
 
 ## Goal
@@ -84,6 +86,21 @@ After Stage 2 shipped, `pyright vtsearch/` with deps installed reports
 (`models/` no longer exists — its contents were redistributed into
 `detectors/`, `training/`, and `embedding/` during a separate reorg.)
 
+### Post-Stage-3 advisory count
+
+After Stage 3 shipped, `pyright vtsearch/` with deps installed reports
+**137 errors** across the remaining out-of-gate scopes:
+
+| Dir | Errors |
+|---|---:|
+| `media/` | 97 |
+| `routes/` | 37 |
+| `converters/` | 3 |
+
+(`media/` ticked up by one against the Stage-2 snapshot because of an
+unrelated refactor between the two stages — not new regression from
+Stage 3's fixes.)
+
 ## Stages
 
 Each stage is a separate PR. The "errors to fix" column counts real
@@ -94,8 +111,8 @@ Each stage is a separate PR. The "errors to fix" column counts real
 | 0 | (no scope; config + advisory CI only) | 0 | ✅ shipped (PR #1349) |
 | 1 | `utils/`, `auth/`, `plugins/`, `sync/`, `concurrency/`, `exporters/`, `labels/`, `settings_io/`, `cli.py`, `config.py` | 4 | ✅ shipped (PR #1349) |
 | 2 | `settings.py`, `settings_factory.py`, `state/`, `security/` | 31 | ✅ shipped |
-| **3** | `datasets/`, `detectors/`, `eval/`, `embedding/`, `training/` | ~38 | ⏳ next |
-| 4 | `routes/`, `converters/` | ~40 | 📋 |
+| 3 | `datasets/`, `detectors/`, `eval/`, `embedding/`, `training/` | 38 | ✅ shipped |
+| **4** | `routes/`, `converters/` | ~40 | ⏳ next |
 | 5 | `media/` (heaviest — may need `.pyi` stubs or per-file `# pyright: ignore`) | ~96 | 📋 |
 | 6 | Whole `vtsearch/` (incl. `achievements.py`, `logging_config.py`, `openapi.py`, `schemas/`) — advisory job removed | 0 | 📋 |
 | 7 *(optional)* | `tests/` | TBD | 📋 |
@@ -162,6 +179,62 @@ Patterns that recurred enough to document:
    `# pyright: ignore[reportArgumentType]` rather than `int -> str`
    gymnastics. `KMeans.inertia_` is typed `Optional[float]`; assign to
    a local and narrow before comparing.
+
+### Stage 3 fixes (shipped)
+
+Patterns that recurred enough to document:
+
+1. **Methods only on a subclass, not the ABC.** `embed_pil_image` lives
+   on every image-embedder subclass but not on `MediaEmbedder`; same
+   for `_get_model_and_processor` / `_get_model` on the audio/video/text
+   subclasses. Callers know their embedder is the right kind by
+   construction (`embedders_for_type("image")[0]`, `get_embedder("clap")`).
+   Fix at the call site: `cast(Any, emb).embed_pil_image(...)`. Lifting
+   the method onto the ABC isn't right either — it isn't part of the
+   contract for non-image embedders.
+2. **`Optional` ABC params losing all attribute info.** A
+   `det_ctx: object` parameter blocks `det_ctx.model = ...` assignments
+   because `object` has no `model`. Use a `TYPE_CHECKING`-guarded
+   import of the real class (`DetectorContext`) and annotate with the
+   forward reference; avoids a runtime import cycle while restoring
+   attribute access for the checker.
+3. **`elem.origin or {}` does not narrow `elem.origin` for downstream
+   code.** Pyright narrows the expression itself, not the original
+   attribute. Bind to a local first
+   (`origin = elem.origin or {}; ... call(origin)`) so the narrow
+   applies to the value flowing into the call.
+4. **`ProgressCallback` is `Callable[[str, str, int, int], None]` — pass
+   all four args.** Several loader call sites passed only two
+   (`on_progress("idle", "Done")`), which pyright caught as missing
+   positional arguments. Pass `0, 0` for the count/total of a no-op
+   completion message.
+5. **sklearn return-type unions driven by overloads.** `fetch_20newsgroups`
+   has a `return_X_y` overload that widens the return type to
+   `Bunch | tuple`, so `.data` / `.target` / `.target_names` access
+   fails. With `return_X_y` defaulted to `False` (the only mode we use)
+   the runtime value is always a Bunch. `cast(Any, fetch_20newsgroups(...))`
+   is the pragmatic fix.
+6. **sklearn `GaussianMixture.means_` is `Optional[ndarray]`.** It's
+   always set after `.fit()`. `assert gmm.means_ is not None` before
+   use; pyright narrows from there.
+7. **Pillow `Image.frombytes(mode, size, data)` expects
+   `tuple[int, int]`, not `list[int]`.** `[pix.width, pix.height]` →
+   `(pix.width, pix.height)`.
+8. **Pillow `Image.crop(box)` expects
+   `tuple[float, float, float, float]`.** `tuple(some_list)` is
+   `tuple[int, ...]` with indeterminate length — too loose. Build the
+   tuple from indexed elements (`(parts[0], parts[1], parts[2], parts[3])`)
+   after a length check.
+9. **Optional dict args called with `None` from a sibling helper.**
+   `_load_embedder_with_progress(media_dict: dict, ...)` was called by
+   `_load_embedder_for_clips()` as `(None, ...)`. The body already
+   handles `None`; widen the param type to `dict | None`.
+10. **Pandas `Series` row scalars confuse builtin coercions.**
+    `int(row["n_labels"])` errors because pandas stubs widen the
+    cell type to `ndarray | Series | Any`. The value is a scalar at
+    runtime; a localized `# pyright: ignore[reportArgumentType]` is
+    the right escape hatch rather than wrapping every cell access in
+    `cast`.
 
 ### Operational notes from Stage 1
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -4,6 +4,10 @@
     "vtsearch/cli.py",
     "vtsearch/concurrency",
     "vtsearch/config.py",
+    "vtsearch/datasets",
+    "vtsearch/detectors",
+    "vtsearch/embedding",
+    "vtsearch/eval",
     "vtsearch/exporters",
     "vtsearch/labels",
     "vtsearch/plugins",
@@ -13,6 +17,7 @@
     "vtsearch/settings_io",
     "vtsearch/state",
     "vtsearch/sync",
+    "vtsearch/training",
     "vtsearch/utils"
   ],
   "exclude": [

--- a/vtsearch/datasets/downloader/text.py
+++ b/vtsearch/datasets/downloader/text.py
@@ -9,7 +9,7 @@ import time
 import uuid
 import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, cast
 from urllib.parse import urlencode
 
 import requests
@@ -89,13 +89,20 @@ def download_20newsgroups(
     # Get the actual newsgroup categories to download
     newsgroup_categories = [category_mapping.get(cat, cat) for cat in categories]
 
-    # Download the dataset (sklearn handles caching automatically)
-    newsgroups = fetch_20newsgroups(
-        subset="train",
-        categories=newsgroup_categories,
-        remove=("headers", "footers", "quotes"),
-        shuffle=True,
-        random_state=42,
+    # Download the dataset (sklearn handles caching automatically).
+    # cast(Any) because the stubs widen the return type to a
+    # `Bunch | tuple` union driven by the `return_X_y` overload; with the
+    # default `return_X_y=False` we always get a Bunch with `.data`,
+    # `.target`, `.target_names`.
+    newsgroups = cast(
+        Any,
+        fetch_20newsgroups(
+            subset="train",
+            categories=newsgroup_categories,
+            remove=("headers", "footers", "quotes"),
+            shuffle=True,
+            random_state=42,
+        ),
     )
 
     # Map back to our category names

--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -84,7 +84,7 @@ def _extract_archive(
 
     elif name.endswith(".rar"):
         try:
-            import rarfile  # optional dependency
+            import rarfile  # optional dependency  # pyright: ignore[reportMissingImports]
         except ImportError as exc:
             raise RuntimeError(
                 "RAR extraction requires the 'rarfile' package. Install it with: pip install rarfile"

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -91,7 +91,9 @@ class PickleDatasetImporter(DatasetImporter):
     def default_display_name(self, field_values: dict[str, Any]) -> str:
         file_obj = field_values.get("file")
         candidate = ""
-        if hasattr(file_obj, "filename") and file_obj.filename:
+        if file_obj is None:
+            pass
+        elif hasattr(file_obj, "filename") and file_obj.filename:
             candidate = file_obj.filename
         elif hasattr(file_obj, "name") and file_obj.name:
             candidate = file_obj.name

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import hashlib
 import io
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 from vtsearch.datasets.importers.base import DatasetImporter, ImporterField, SourceSpec
 from vtsearch.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
@@ -89,7 +89,9 @@ def _load_pdf_images(
         pdf_rel = pdf_path.relative_to(folder).as_posix()
 
         for page_name, pil_image in pages:
-            embedding = emb.embed_pil_image(pil_image)
+            # Image-type embedders all implement embed_pil_image, but
+            # it's not declared on the MediaEmbedder ABC.
+            embedding = cast(Any, emb).embed_pil_image(pil_image)
             if embedding is None:
                 continue
 

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -144,7 +144,7 @@ def _get_embedder_for_clips():
 
 
 def _load_embedder_with_progress(
-    media_dict: dict,
+    media_dict: dict | None,
     progress_fn,
     step: int | None = None,
     total_steps: int | None = None,

--- a/vtsearch/datasets/loader_demo.py
+++ b/vtsearch/datasets/loader_demo.py
@@ -130,7 +130,7 @@ def load_demo_dataset(
                 # Old pickles (created before origin stamping) may have empty
                 # params — this ensures they are corrected on load.
                 _stamp_demo_origin(medias, dataset_name, converter_name)
-                on_progress("idle", f"Loaded {dataset_name} dataset")
+                on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)
                 return
 
     # Resolve the embedder
@@ -222,4 +222,4 @@ def load_demo_dataset(
     # Write a clipper sidecar so the demo list can check readiness.
     _loader._write_clipper_sidecar(pkl_file, clipper_name)
 
-    on_progress("idle", f"Loaded {dataset_name} dataset")
+    on_progress("idle", f"Loaded {dataset_name} dataset", 0, 0)

--- a/vtsearch/datasets/loader_folder.py
+++ b/vtsearch/datasets/loader_folder.py
@@ -512,7 +512,7 @@ def load_dataset_from_folder(
             "Try a smaller dataset or free up system RAM."
         )
 
-    on_progress("idle", f"Loaded {len(medias)} {media_type} medias from folder")
+    on_progress("idle", f"Loaded {len(medias)} {media_type} medias from folder", 0, 0)
 
 
 def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
@@ -797,4 +797,4 @@ def load_dataset_from_folder_chunked(
         if chunk_medias:
             yield chunk_medias
 
-    on_progress("idle", f"Finished chunked loading of {total_files} {media_type} files")
+    on_progress("idle", f"Finished chunked loading of {total_files} {media_type} files", 0, 0)

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import gc
 import hashlib
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator, Optional, cast
 
 import numpy as np
 from PIL import Image
@@ -396,7 +396,9 @@ def embed_image_file_from_pil(image: Image.Image, embedder_name: str = "") -> Op
         if not avail:
             return None
         emb = avail[0]
-    return emb.embed_pil_image(image)
+    # Image-type embedders all implement embed_pil_image, but the method
+    # is not on the MediaEmbedder ABC (only image subclasses define it).
+    return cast(Any, emb).embed_pil_image(image)
 
 
 def _write_embedder_sidecar(pkl_path: Path, embedder_name: str) -> None:

--- a/vtsearch/datasets/pdf.py
+++ b/vtsearch/datasets/pdf.py
@@ -37,7 +37,7 @@ def render_pdf_pages(pdf_path: Path, dpi: int = 150) -> list[tuple[str, "Image.I
         for page_num in range(len(doc)):
             page = doc[page_num]
             pix = page.get_pixmap(matrix=matrix)
-            img = PILImage.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            img = PILImage.frombytes("RGB", (pix.width, pix.height), pix.samples)
             page_name = f"{pdf_path.name}-{page_num + 1}"
             pages.append((page_name, img))
     finally:

--- a/vtsearch/detectors/label_restoration.py
+++ b/vtsearch/detectors/label_restoration.py
@@ -24,7 +24,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
 
     Returns the number of labels successfully restored.
     """
-    from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.datasets.labelset import LabeledElement, LabelSet
     from vtsearch.state import (
         apply_label,
         build_media_lookup,
@@ -47,7 +47,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
     origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
 
     restored = 0
-    unresolved: list[tuple] = []  # (elem, label) pairs needing origin resolution
+    unresolved: list[LabeledElement] = []  # elements needing origin resolution
     for elem in labelset.elements:
         if elem.label not in ("good", "bad"):
             continue

--- a/vtsearch/detectors/labelset_elements.py
+++ b/vtsearch/detectors/labelset_elements.py
@@ -14,7 +14,7 @@ import hashlib
 import json as _json
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Mapping
 
 from vtsearch.datasets.labelset import LabeledElement, LabelSet, element_key
 
@@ -88,8 +88,8 @@ def build_element_view(
     elem: LabeledElement,
     *,
     media_type: str,
-    click_times: dict[int, float],
-    learned_scores: dict[int, float],
+    click_times: Mapping[int, float | int],
+    learned_scores: Mapping[int, float],
 ) -> dict[str, Any]:
     """Build the JSON-serialisable dict the frontend consumes for *elem*.
 

--- a/vtsearch/detectors/labelset_training.py
+++ b/vtsearch/detectors/labelset_training.py
@@ -49,9 +49,10 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
         if file_path is None:
             return None
 
-        params = (elem.origin or {}).get("params", {}) if elem.origin else {}
+        origin = elem.origin or {}
+        params = origin.get("params", {})
         if isinstance(params, dict) and params.get("clipper"):
-            return _apply_clip_and_embed(file_path, media_type, elem.origin, embedder_name)
+            return _apply_clip_and_embed(file_path, media_type, origin, embedder_name)
         return embed_file(file_path, media_type, embedder_name)
 
 

--- a/vtsearch/detectors/resolver.py
+++ b/vtsearch/detectors/resolver.py
@@ -487,9 +487,12 @@ def _apply_clip_and_embed(
 
             from PIL import Image
 
-            box_values = [int(float(v)) for v in clip_box.split(",")]
+            parts = [int(float(v)) for v in clip_box.split(",")]
+            if len(parts) != 4:
+                raise ValueError(f"clip_box must have 4 values, got {len(parts)}")
+            box_values: tuple[int, int, int, int] = (parts[0], parts[1], parts[2], parts[3])
             with Image.open(file_path) as img:
-                cropped = img.crop(tuple(box_values))
+                cropped = img.crop(box_values)
                 buf = _io.BytesIO()
                 cropped.save(buf, format=img.format or "PNG")
             crop_bytes = buf.getvalue()

--- a/vtsearch/detectors/training.py
+++ b/vtsearch/detectors/training.py
@@ -95,6 +95,9 @@ def train_and_threshold(
     if safe:
         from vtsearch.embedding.matrix import get_embedding_matrix_for_snap
 
+        # `safe` is only True when `snap` is truthy (see assignment above),
+        # so the narrowing is real even though pyright can't track it.
+        assert snap is not None
         _all_ids, all_embs = get_embedding_matrix_for_snap(snap)
         X_all = torch.from_numpy(all_embs)
         with torch.no_grad():

--- a/vtsearch/detectors/workflow.py
+++ b/vtsearch/detectors/workflow.py
@@ -7,10 +7,15 @@ cross-validated threshold.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vtsearch.state.core import DetectorContext
+
 
 def apply_and_retrain(
     detector_id: str,
-    det_ctx: object,
+    det_ctx: "DetectorContext",
     new_entries: list[dict],
     detector_name: str,
 ) -> tuple[int, bool]:

--- a/vtsearch/embedding/loader.py
+++ b/vtsearch/embedding/loader.py
@@ -12,6 +12,7 @@ to work unchanged.
 
 import gc
 import sys
+from typing import Any, cast
 
 from vtsearch.config import MODELS_CACHE_DIR, resolve_device
 from vtsearch.media.torch_setup import ensure_torch_configured
@@ -199,7 +200,8 @@ def get_clap_model():
     from vtsearch.media import get_embedder
 
     emb = get_embedder("clap")
-    return emb._get_model_and_processor()
+    # _get_model_and_processor is defined on the CLAP subclass, not the ABC.
+    return cast(Any, emb)._get_model_and_processor()
 
 
 def get_xclip_model():
@@ -207,7 +209,7 @@ def get_xclip_model():
     from vtsearch.media import get_embedder
 
     emb = get_embedder("xclip")
-    return emb._get_model_and_processor()
+    return cast(Any, emb)._get_model_and_processor()
 
 
 def get_e5_model():
@@ -215,4 +217,4 @@ def get_e5_model():
     from vtsearch.media import get_embedder
 
     emb = get_embedder("e5")
-    return emb._get_model()
+    return cast(Any, emb)._get_model()

--- a/vtsearch/eval/label_curve.py
+++ b/vtsearch/eval/label_curve.py
@@ -546,7 +546,7 @@ def run_label_curve_eval(
                         row["category"] = cat
                         rows.append(row)
 
-    return pd.DataFrame(rows, columns=list(_ROW_COLUMNS))
+    return pd.DataFrame(rows, columns=pd.Index(list(_ROW_COLUMNS)))
 
 
 def summarise(df: pd.DataFrame, *, include_diagnostics: bool = False) -> pd.DataFrame:

--- a/vtsearch/eval/label_curve_main.py
+++ b/vtsearch/eval/label_curve_main.py
@@ -50,9 +50,11 @@ def _print_summary(summary: pd.DataFrame) -> None:
         print("(no rows — every cell was skipped)")
         return
     for _, row in summary.iterrows():
+        # row['n_labels'] is a scalar at runtime but pandas stubs widen it.
+        n_labels = int(row["n_labels"])  # pyright: ignore[reportArgumentType]
         print(
             f"  {row['dataset']:>14s} | {row['category']:>20s} | "
-            f"{row['trainer']:>10s} | N={int(row['n_labels']):>3d} | "
+            f"{row['trainer']:>10s} | N={n_labels:>3d} | "
             f"AUROC={row['auroc_mean']:.3f}±{row['auroc_std']:.3f}  "
             f"AP={row['average_precision_mean']:.3f}±{row['average_precision_std']:.3f}  "
             f"bestF1={row['best_f1_mean']:.3f}  "

--- a/vtsearch/eval/voting_iterations.py
+++ b/vtsearch/eval/voting_iterations.py
@@ -306,7 +306,10 @@ def run_voting_iterations_eval(
                 )
                 all_rows.extend(rows)
 
-    return pd.DataFrame(all_rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"])
+    return pd.DataFrame(
+        all_rows,
+        columns=pd.Index(["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"]),
+    )
 
 
 def run_voting_iterations_eval_from_pickles(

--- a/vtsearch/training/thresholds.py
+++ b/vtsearch/training/thresholds.py
@@ -42,7 +42,9 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         gmm: GaussianMixture = GaussianMixture(n_components=2, random_state=42)
         gmm.fit(X)
 
-        # Get the means of the two components
+        # Get the means of the two components.  The stub types `means_`
+        # as `np.ndarray | None`; after `fit` it's always set.
+        assert gmm.means_ is not None
         means = np.ravel(gmm.means_)
 
         # Identify which component is "low" (Bad) and which is "high" (Good)


### PR DESCRIPTION
## Summary

Stage 3 of `docs/plans/pyright-type-checking.md` — expands the pyright hard
gate to cover `vtsearch/datasets`, `vtsearch/detectors`, `vtsearch/eval`,
`vtsearch/embedding`, and `vtsearch/training`. Fixes the 38 real errors
the gate surfaced and documents the recurring patterns in the plan.

After this lands, the full-package advisory check reports **137 errors**
remaining (97 in `media/`, 37 in `routes/`, 3 in `converters/`) for the
next two stages.

## What changed (by recurring pattern)

- **Methods only on a subclass, not the ABC** — `embed_pil_image` on
  image embedders, `_get_model_and_processor` / `_get_model` on the
  audio/video/text subclasses. Callers know their embedder is the right
  kind by construction; `cast(Any, emb).method(...)` at the call site.
- **`Optional` ABC params losing all attribute info** —
  `apply_and_retrain(det_ctx: object, ...)` → typed via a
  `TYPE_CHECKING`-guarded `DetectorContext` import so attribute
  assignments check.
- **`elem.origin or {}` doesn't narrow `elem.origin` downstream** — bind
  to a local first.
- **`ProgressCallback` is `Callable[[str, str, int, int], None]`** — four
  loader call sites passed only two args; pass `0, 0` for no-op
  completions.
- **sklearn return-type unions driven by overloads** — `fetch_20newsgroups`
  defaults to a Bunch but stubs widen to `Bunch | tuple`; `cast(Any, ...)`.
- **`GaussianMixture.means_` is `Optional[ndarray]` after fit** — assert.
- **Pillow tuples** — `Image.frombytes` size and `Image.crop` box both
  need fixed-size tuples, not `tuple(some_list)` (loses arity).
- **Optional dict args called with `None` from a sibling** — widen the
  param type to `dict | None` rather than guarding the call site.
- **Pandas `Series` row scalars confuse `int(...)`** — localized
  `# pyright: ignore[reportArgumentType]` is the right escape.

Full per-pattern recipes are in the Stage 3 fixes section of
`docs/plans/pyright-type-checking.md`.

## Test plan

- [x] `pyright` (gated scope) — 0 errors
- [x] `pyright vtsearch/` (advisory) — 137 errors (down from 174)
- [x] `ruff check .` and `ruff format --check .` — clean
- [x] `./run-tests.sh` — 3459 passed, 1 skipped, 2 xpassed

https://claude.ai/code/session_01XQGtzXzksPjW5tute1sgEt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQGtzXzksPjW5tute1sgEt)_