### PR TITLE
Add Prometheus /metrics endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,7 @@ from vtsearch.routes import (  # noqa: E402
     labels_bp,
     media_server_bp,
     medias_bp,
+    metrics_bp,
     datasets_listings_bp,
     datasets_load_bp,
     datasets_registry_bp,
@@ -277,6 +278,7 @@ app.register_blueprint(detector_scoring_bp)
 app.register_blueprint(detector_find_bp)
 app.register_blueprint(embed_bp)
 app.register_blueprint(events_bp)
+app.register_blueprint(metrics_bp)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -526,8 +526,10 @@ Original idea: migrate hot paths (sorting, scoring) to Quart or FastAPI for true
 ### 12.15 Structured logging + request IDs ★★ S
 Today logs are print-style. JSON logs with `dataset_id`/`detector_id`/`request_id` make production debugging tractable.
 
-### 12.16 Prometheus metrics ★★ S
+### 12.16 Prometheus metrics ★★ S — DONE
 `/metrics` endpoint with vote count, embedding latency, training time, RAM usage by dataset.
+
+Shipped: `vtsearch/metrics.py` owns a private `prometheus_client.CollectorRegistry` exposing `vtsearch_votes_total` (counter, labelled by `vote`/`media_type`), `vtsearch_embedding_seconds` (histogram, labelled by `embedder`/`media_type`), `vtsearch_training_seconds` (histogram, labelled by `kind`), `vtsearch_dataset_memory_bytes` (gauge per loaded dataset, computed at scrape time from the cached embedding matrix), plus `vtsearch_datasets_loaded` / `vtsearch_detectors_loaded` / `vtsearch_process_rss_bytes`. Instrumentation hooks live in `state/votes.py` (toggle/apply/bulk-apply paths), `media/embedder.py::embed_media`, and `detectors/training.py` (both `train_and_score` and `train_detector_from_origins`). The Flask blueprint in `routes/metrics.py` renders the registry at `/metrics` in the Prometheus text-exposition format.
 
 ### 12.17 Pydantic models for settings ★ S
 The `_SETTING_SPECS` table is clever but custom; Pydantic v2 would generalise it and produce JSON schemas for free.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,9 @@ pandas
 matplotlib
 scipy
 
+# ── Metrics / observability ─────────────────────────────────────────
+prometheus-client
+
 # ── PyTorch (CPU) ────────────────────────────────────────────────────
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.0.0

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -96,18 +96,29 @@ class TestEmbeddingLatency:
         assert _sample_value(body, count_line) >= 1.0
 
     def test_embedder_embed_media_records_latency(self, client):
-        """MediaEmbedder.embed_media wraps each call with time_embedding."""
+        """MediaEmbedder.embed_media wraps each call with time_embedding.
+
+        The conftest replaces ``embed_media`` on every embedder instance
+        with a Mock, which would mask the wrap. Calling the method off
+        the class (``type(emb).embed_media``) bypasses the instance-level
+        Mock and exercises the real wrapped implementation against a
+        stubbed ``_embed_media_impl``.
+        """
+        from unittest.mock import patch
+
+        import numpy as np
+
         from vtsearch.media import embedders_for_type
-        from vtsearch.state import medias
 
         audio_emb = embedders_for_type("audio")[0]
-        media = next(iter(medias.values()))
 
         before = _sample_value(
             _scrape(client),
             f'vtsearch_embedding_seconds_count{{embedder="{audio_emb.name}",media_type="audio"}}',
         )
-        audio_emb.embed_media(media)
+        with patch.object(audio_emb, "_embed_media_impl", return_value=np.zeros(4, dtype=np.float32)):
+            result = type(audio_emb).embed_media(audio_emb, {"type": "audio"})
+        assert result is not None
         after = _sample_value(
             _scrape(client),
             f'vtsearch_embedding_seconds_count{{embedder="{audio_emb.name}",media_type="audio"}}',
@@ -178,21 +189,27 @@ class TestDatasetMemoryGauge:
 
 
 def _sample_value(body: str, line_prefix: str) -> float:
-    """Return the numeric sample for the first metric line starting with *prefix*.
+    """Return the summed sample value for every metric line starting with *prefix*.
 
-    Returns 0.0 if no matching line is found — useful for "before" reads
-    where the counter may not yet have been initialised. Comment lines
-    (``# HELP`` / ``# TYPE``) are ignored.
+    The Prometheus text format emits one line per label combination, so a
+    bare metric name like ``vtsearch_votes_total`` matches several rows.
+    Tests that want a single label combination should pass the full
+    ``name{label="value"}`` prefix; tests that want the grand total can
+    pass the bare name.
+
+    Returns 0.0 when no line matches.
     """
+    total = 0.0
+    matched = False
     for line in body.splitlines():
         if line.startswith("#"):
             continue
         if line.startswith(line_prefix):
-            # The exposition format is "<series> <value> [<timestamp>]"
             parts = line.rsplit(" ", 1)
             if len(parts) == 2:
                 try:
-                    return float(parts[1])
+                    total += float(parts[1])
+                    matched = True
                 except ValueError:
-                    return 0.0
-    return 0.0
+                    continue
+    return total if matched else 0.0

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -18,7 +18,11 @@ def _scrape(client) -> str:
     response = client.get("/metrics")
     assert response.status_code == 200
     assert response.mimetype == "text/plain"
-    assert "version=0.0.4" in response.headers["Content-Type"]
+    ct = response.headers["Content-Type"]
+    assert "version=0.0.4" in ct
+    # Flask must not duplicate the charset parameter — passing the full
+    # Content-Type via ``content_type=`` keeps it verbatim.
+    assert ct.count("charset=utf-8") == 1
     return response.get_data(as_text=True)
 
 

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -1,0 +1,198 @@
+"""Tests for the Prometheus ``/metrics`` endpoint and the metrics module.
+
+Covers the four signals called out in the 12.16 roadmap entry — vote
+count, embedding latency, training time, RAM by dataset — plus the
+exposition format contract and the no-throw invariants of the recording
+helpers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtsearch import metrics
+from vtsearch.state.core import DatasetContext, _contexts, _state_lock
+
+
+def _scrape(client) -> str:
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert response.mimetype == "text/plain"
+    assert "version=0.0.4" in response.headers["Content-Type"]
+    return response.get_data(as_text=True)
+
+
+class TestMetricsEndpoint:
+    def test_metrics_endpoint_exposes_known_series(self, client):
+        body = _scrape(client)
+
+        # Every metric this module owns must be present in the output —
+        # even before any work has happened — so dashboards can rely on
+        # them appearing in the registry the moment the app is up.
+        assert "vtsearch_votes_total" in body
+        assert "vtsearch_embedding_seconds" in body
+        assert "vtsearch_training_seconds" in body
+        assert "vtsearch_dataset_memory_bytes" in body
+        assert "vtsearch_datasets_loaded" in body
+        assert "vtsearch_detectors_loaded" in body
+
+    def test_help_lines_are_present(self, client):
+        body = _scrape(client)
+        assert "# HELP vtsearch_votes_total" in body
+        assert "# TYPE vtsearch_votes_total counter" in body
+        assert "# HELP vtsearch_embedding_seconds" in body
+        assert "# TYPE vtsearch_embedding_seconds histogram" in body
+        assert "# TYPE vtsearch_training_seconds histogram" in body
+        assert "# TYPE vtsearch_dataset_memory_bytes gauge" in body
+
+
+class TestVoteCounter:
+    def test_record_vote_event_increments_counter(self, client):
+        before = _scrape(client)
+        metrics.record_vote_event("good", media_type="audio")
+        metrics.record_vote_event("good", media_type="audio")
+        metrics.record_vote_event("bad", media_type="audio")
+        after = _scrape(client)
+
+        good_line = 'vtsearch_votes_total{media_type="audio",vote="good"}'
+        bad_line = 'vtsearch_votes_total{media_type="audio",vote="bad"}'
+
+        before_good = _sample_value(before, good_line)
+        after_good = _sample_value(after, good_line)
+        after_bad = _sample_value(after, bad_line)
+
+        assert after_good - before_good == 2.0
+        assert after_bad >= 1.0
+
+    def test_toggle_vote_increments_counter(self, client):
+        from vtsearch.state.votes import toggle_vote
+        from vtsearch.state import medias
+
+        # Pick any media id from the pre-generated test dataset.
+        media_id = next(iter(medias))
+
+        before = _sample_value(_scrape(client), "vtsearch_votes_total")
+        toggle_vote(media_id, "good")
+        toggle_vote(media_id, "good")  # toggle off → records "unlabel"
+        after_body = _scrape(client)
+
+        # Both events must show up: one good + one unlabel.
+        assert _sample_value(after_body, "vtsearch_votes_total") - before >= 2.0
+        assert 'vote="unlabel"' in after_body
+
+    def test_missing_labels_are_replaced_with_unknown(self, client):
+        metrics.record_vote_event("", media_type="")
+        body = _scrape(client)
+        assert 'vote="unknown"' in body
+        assert 'media_type="unknown"' in body
+
+
+class TestEmbeddingLatency:
+    def test_time_embedding_records_observation(self, client):
+        with metrics.time_embedding("test_embedder", "audio"):
+            pass
+        body = _scrape(client)
+        count_line = 'vtsearch_embedding_seconds_count{embedder="test_embedder",media_type="audio"}'
+        assert _sample_value(body, count_line) >= 1.0
+
+    def test_embedder_embed_media_records_latency(self, client):
+        """MediaEmbedder.embed_media wraps each call with time_embedding."""
+        from vtsearch.media import embedders_for_type
+        from vtsearch.state import medias
+
+        audio_emb = embedders_for_type("audio")[0]
+        media = next(iter(medias.values()))
+
+        before = _sample_value(
+            _scrape(client),
+            f'vtsearch_embedding_seconds_count{{embedder="{audio_emb.name}",media_type="audio"}}',
+        )
+        audio_emb.embed_media(media)
+        after = _sample_value(
+            _scrape(client),
+            f'vtsearch_embedding_seconds_count{{embedder="{audio_emb.name}",media_type="audio"}}',
+        )
+        assert after - before == 1.0
+
+
+class TestTrainingTime:
+    def test_time_training_records_observation(self, client):
+        with metrics.time_training("in_memory"):
+            pass
+        body = _scrape(client)
+        assert _sample_value(body, 'vtsearch_training_seconds_count{kind="in_memory"}') >= 1.0
+
+    def test_train_and_score_records_observation(self, client):
+        """The training entry point must increment the histogram on a real fit."""
+        from vtsearch.detectors.training import train_and_score
+        from vtsearch.state import medias
+
+        media_ids = list(medias.keys())
+        assert len(media_ids) >= 4, "Test dataset must have enough medias to train"
+        good = {media_ids[0]: None, media_ids[1]: None}
+        bad = {media_ids[2]: None, media_ids[3]: None}
+
+        before = _sample_value(_scrape(client), 'vtsearch_training_seconds_count{kind="in_memory"}')
+        results, threshold, model = train_and_score(dict(medias), good, bad)
+        assert model is not None  # training must have actually happened
+        after = _sample_value(_scrape(client), 'vtsearch_training_seconds_count{kind="in_memory"}')
+        assert after - before == 1.0
+
+
+class TestDatasetMemoryGauge:
+    def test_loaded_dataset_appears_with_bytes(self, client):
+        ctx = DatasetContext("metrics_test_ds")
+        ctx.dataset_display_name = "Metrics Test"
+        # Seed with a tiny medias dict carrying a real ndarray so the
+        # collector has an embedding-size signal to read.
+        emb = np.zeros(8, dtype=np.float32)
+        ctx.medias[1] = {"embedding": emb}
+
+        with _state_lock:
+            _contexts["metrics_test_ds"] = ctx
+        try:
+            body = _scrape(client)
+            assert "metrics_test_ds" in body
+            # Either the matrix or the per-media estimate must produce a
+            # positive byte count for the seeded context.
+            assert (
+                _sample_value(
+                    body,
+                    'vtsearch_dataset_memory_bytes{dataset_id="metrics_test_ds",name="Metrics Test"}',
+                )
+                > 0.0
+            )
+            assert _sample_value(body, "vtsearch_datasets_loaded") >= 1.0
+        finally:
+            with _state_lock:
+                _contexts.pop("metrics_test_ds", None)
+
+    def test_unregistered_dataset_disappears_from_output(self, client):
+        body = _scrape(client)
+        assert "metrics_test_ds" not in body
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sample_value(body: str, line_prefix: str) -> float:
+    """Return the numeric sample for the first metric line starting with *prefix*.
+
+    Returns 0.0 if no matching line is found — useful for "before" reads
+    where the counter may not yet have been initialised. Comment lines
+    (``# HELP`` / ``# TYPE``) are ignored.
+    """
+    for line in body.splitlines():
+        if line.startswith("#"):
+            continue
+        if line.startswith(line_prefix):
+            # The exposition format is "<series> <value> [<timestamp>]"
+            parts = line.rsplit(" ", 1)
+            if len(parts) == 2:
+                try:
+                    return float(parts[1])
+                except ValueError:
+                    return 0.0
+    return 0.0

--- a/vtsearch/detectors/training.py
+++ b/vtsearch/detectors/training.py
@@ -189,6 +189,7 @@ def train_and_score(
     """
     import torch  # noqa: PLC0415
 
+    from vtsearch.metrics import time_training
     from vtsearch.training.mlp import _auto_hidden_dim, train_model
     from vtsearch.training.thresholds import (
         calculate_safe_threshold,
@@ -251,7 +252,8 @@ def train_and_score(
     # which equals the patch-region full-image vector for patch datasets),
     # mirroring the v1 vote rule of "vote on whole images".  Region-level
     # training examples are a phase-2 concern.
-    model = train_model(X, y, input_dim, inclusion_value, hidden_dim=hidden_dim)
+    with time_training("in_memory"):
+        model = train_model(X, y, input_dim, inclusion_value, hidden_dim=hidden_dim)
 
     # Score every media — region-aware max-pool over regions when the
     # dataset is patch-region-aware, plain single-vector scoring when not.
@@ -386,6 +388,7 @@ def train_detector_from_origins(
     import torch  # noqa: PLC0415
 
     from vtsearch.detectors.resolver import embed_file, resolve_file_context
+    from vtsearch.metrics import time_training
     from vtsearch.training.mlp import train_model
     from vtsearch.training.thresholds import calculate_cross_calibration_threshold
 
@@ -440,7 +443,8 @@ def train_detector_from_origins(
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
         )
-    model = train_model(X, y, input_dim, inclusion)
+    with time_training("from_origins"):
+        model = train_model(X, y, input_dim, inclusion)
 
     state_dict = model.state_dict()
     weights = {k: v.cpu().tolist() for k, v in state_dict.items()}

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -553,7 +553,9 @@ class MediaEmbedder(ABC):
 
         Returns ``None`` if the media cannot be embedded.
         """
-        with self._embed_lock:
+        from vtsearch.metrics import time_embedding
+
+        with self._embed_lock, time_embedding(self.name, self.media_type_id):
             return self._embed_media_impl(media)
 
     @abstractmethod

--- a/vtsearch/metrics.py
+++ b/vtsearch/metrics.py
@@ -1,0 +1,294 @@
+"""Prometheus metrics for VTSearch.
+
+Exposes a small set of counters, histograms, and gauges that cover the
+signals called out in the 12.16 roadmap entry:
+
+- ``vtsearch_votes_total`` — counter of votes recorded (labelled by
+  ``vote`` and ``media_type``).
+- ``vtsearch_embedding_seconds`` — histogram of single-item embedding
+  latency (labelled by ``embedder`` and ``media_type``).
+- ``vtsearch_training_seconds`` — histogram of MLP-training wall time
+  (labelled by ``kind``: ``in_memory`` for the cached-training path,
+  ``from_origins`` for the resolve+embed+train path).
+- ``vtsearch_dataset_memory_bytes`` — per-dataset memory estimate
+  (labelled by ``dataset_id`` and ``name``), computed at scrape time
+  from the cached embedding matrix on each :class:`DatasetContext`.
+- ``vtsearch_datasets_loaded`` / ``vtsearch_detectors_loaded`` — gauges
+  reflecting in-memory registry counts.
+- ``vtsearch_process_rss_bytes`` — best-effort resident-set size for
+  the whole process (falls back silently when ``/proc/self/statm``
+  isn't readable, e.g. on macOS).
+
+The module uses a private :class:`~prometheus_client.CollectorRegistry`
+so it's isolated from the default registry — important for tests, and
+for any user who already exposes their own ``prometheus_client`` metrics
+through the same process. The Flask blueprint in
+``vtsearch.routes.metrics`` renders this registry at ``/metrics``.
+
+Per-dataset memory is exposed as a custom collector so the snapshot is
+fresh on every scrape rather than relying on counter updates at every
+dataset mutation.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.metrics_core import Metric
+
+CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+# A private registry keeps VTSearch metrics independent of any
+# application code that imports ``prometheus_client`` separately.
+registry = CollectorRegistry(auto_describe=True)
+
+
+# ---------------------------------------------------------------------------
+# Static metric instances
+# ---------------------------------------------------------------------------
+
+votes_total = Counter(
+    "vtsearch_votes_total",
+    "Total votes recorded.",
+    ("vote", "media_type"),
+    registry=registry,
+)
+
+# Bucket boundaries chosen for typical single-item embedding latencies:
+# stub embedders return in microseconds, real CLIP/CLAP forward passes are
+# in the 50ms-2s range, document conversion + embedding can spike to 10s+.
+_EMBEDDING_BUCKETS = (
+    0.001,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+)
+
+embedding_seconds = Histogram(
+    "vtsearch_embedding_seconds",
+    "Wall-clock latency of single-item embedding calls.",
+    ("embedder", "media_type"),
+    buckets=_EMBEDDING_BUCKETS,
+    registry=registry,
+)
+
+# Training spans a much wider range — a few hundred ms for tiny vote sets,
+# many seconds for thousands of labels, minutes if origins must be resolved
+# and re-embedded.
+_TRAINING_BUCKETS = (
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+    120.0,
+    300.0,
+)
+
+training_seconds = Histogram(
+    "vtsearch_training_seconds",
+    "Wall-clock duration of detector MLP training.",
+    ("kind",),
+    buckets=_TRAINING_BUCKETS,
+    registry=registry,
+)
+
+datasets_loaded = Gauge(
+    "vtsearch_datasets_loaded",
+    "Number of datasets currently held in memory.",
+    registry=registry,
+)
+
+detectors_loaded = Gauge(
+    "vtsearch_detectors_loaded",
+    "Number of detectors currently held in memory.",
+    registry=registry,
+)
+
+process_rss_bytes = Gauge(
+    "vtsearch_process_rss_bytes",
+    "Resident set size of the VTSearch process in bytes.",
+    registry=registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def record_vote_event(vote: str, media_type: str = "") -> None:
+    """Increment the vote counter.
+
+    Called from the vote-handling paths so ``vtsearch_votes_total`` tracks
+    every label transition the system observes. ``vote`` is one of
+    ``"good"`` / ``"bad"`` / ``"unlabel"``; ``media_type`` is the active
+    detector's media type when known, else the empty string.
+    """
+    try:
+        votes_total.labels(vote=vote or "unknown", media_type=media_type or "unknown").inc()
+    except Exception:
+        # Metrics must never break the request path.
+        pass
+
+
+@contextmanager
+def time_embedding(embedder_name: str, media_type: str = "") -> Iterator[None]:
+    """Context manager that records the duration of an embedding call."""
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        try:
+            embedding_seconds.labels(
+                embedder=embedder_name or "unknown",
+                media_type=media_type or "unknown",
+            ).observe(time.perf_counter() - start)
+        except Exception:
+            pass
+
+
+@contextmanager
+def time_training(kind: str = "in_memory") -> Iterator[None]:
+    """Context manager that records the duration of detector training."""
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        try:
+            training_seconds.labels(kind=kind or "unknown").observe(time.perf_counter() - start)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Per-dataset memory collector (computed at scrape time)
+# ---------------------------------------------------------------------------
+
+
+def _read_rss_bytes() -> int | None:
+    """Return the process resident-set size in bytes, or ``None``.
+
+    Reads ``/proc/self/statm`` on Linux; returns ``None`` on platforms
+    that don't expose it (we deliberately don't depend on ``psutil`` for
+    a single gauge). The first field of ``statm`` is total program size
+    in pages and the second is resident set size in pages.
+    """
+    try:
+        with open("/proc/self/statm", "r", encoding="ascii") as fh:
+            parts = fh.read().split()
+        if len(parts) < 2:
+            return None
+        rss_pages = int(parts[1])
+    except (OSError, ValueError):
+        return None
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError):
+        page_size = 4096
+    return rss_pages * page_size
+
+
+def _estimate_dataset_bytes(ctx) -> int:
+    """Estimate the in-memory footprint of a :class:`DatasetContext`.
+
+    Dominated by the cached embedding matrix when present; falls back to
+    ``num_medias * embedding_dim * 4 bytes`` (fp32) when the matrix
+    hasn't been built yet. Other per-media metadata (path strings,
+    origins, etc.) is small relative to the embedding bytes and is
+    intentionally ignored — this metric is a useful trend, not a precise
+    accounting.
+    """
+    matrix = getattr(ctx, "_emb_matrix", None)
+    if matrix is not None and hasattr(matrix, "nbytes"):
+        return int(matrix.nbytes)
+    medias = getattr(ctx, "medias", None)
+    if not medias:
+        return 0
+    sample = next(iter(medias.values()), None)
+    if sample is None:
+        return 0
+    emb = sample.get("embedding") if isinstance(sample, dict) else None
+    if emb is None or not hasattr(emb, "nbytes"):
+        return 0
+    return int(emb.nbytes) * len(medias)
+
+
+class _DatasetMemoryCollector:
+    """Prometheus collector that emits one sample per loaded dataset.
+
+    Computing this at scrape time (rather than at every mutation) keeps
+    the hot paths free of bookkeeping and guarantees the value reflects
+    the current registry state without any update plumbing.
+    """
+
+    def collect(self) -> Iterator[Metric]:
+        # Late import to avoid a circular import at module load.
+        try:
+            from vtsearch.state.core import _contexts, _state_lock  # type: ignore[attr-defined]
+        except Exception:
+            return
+
+        family = GaugeMetricFamily(
+            "vtsearch_dataset_memory_bytes",
+            "Estimated in-memory size of each loaded dataset, in bytes.",
+            labels=("dataset_id", "name"),
+        )
+        with _state_lock:
+            for dataset_id, ctx in _contexts.items():
+                name = getattr(ctx, "dataset_display_name", None) or dataset_id
+                family.add_metric([dataset_id, name], float(_estimate_dataset_bytes(ctx)))
+        yield family
+
+
+registry.register(_DatasetMemoryCollector())
+
+
+# ---------------------------------------------------------------------------
+# Snapshot rendering
+# ---------------------------------------------------------------------------
+
+
+def _refresh_runtime_gauges() -> None:
+    """Update gauges that mirror runtime state, called at scrape time."""
+    try:
+        from vtsearch.state.core import _contexts, _detector_contexts  # type: ignore[attr-defined]
+
+        datasets_loaded.set(len(_contexts))
+        detectors_loaded.set(len(_detector_contexts))
+    except Exception:
+        pass
+    rss = _read_rss_bytes()
+    if rss is not None:
+        process_rss_bytes.set(rss)
+
+
+def render() -> bytes:
+    """Return the current Prometheus exposition payload as bytes."""
+    _refresh_runtime_gauges()
+    return generate_latest(registry)

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -23,6 +23,7 @@ from vtsearch.routes.file_browser import file_browser_bp
 from vtsearch.routes.labels import exporters_bp, label_importers_bp, labels_bp
 from vtsearch.routes.main import main_bp
 from vtsearch.routes.media import embed_bp, media_server_bp, medias_bp
+from vtsearch.routes.metrics import metrics_bp
 from vtsearch.routes.processors import processors_bp
 from vtsearch.routes.settings import settings_bp, settings_io_bp, sync_sources_bp
 from vtsearch.routes.sorting import sorting_bp
@@ -51,6 +52,7 @@ __all__ = [
     "main_bp",
     "media_server_bp",
     "medias_bp",
+    "metrics_bp",
     "processors_bp",
     "settings_bp",
     "settings_io_bp",

--- a/vtsearch/routes/metrics.py
+++ b/vtsearch/routes/metrics.py
@@ -1,0 +1,26 @@
+"""Prometheus ``/metrics`` endpoint.
+
+Renders the application's metric registry in the standard Prometheus
+text exposition format (``text/plain; version=0.0.4``) so any
+Prometheus server, OpenTelemetry collector, or Grafana Agent can scrape
+it without further configuration.
+
+Metric definitions live in :mod:`vtsearch.metrics`; this module is a
+thin Flask wrapper. ``/metrics`` is registered on the plain ``Flask``
+app — not the ``flask_smorest.Api`` — because the response body is
+opaque to OpenAPI and would only clutter the spec.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response
+
+from vtsearch import metrics
+
+metrics_bp = Blueprint("metrics", __name__)
+
+
+@metrics_bp.route("/metrics")
+def prometheus_metrics() -> Response:
+    """Return the Prometheus exposition payload."""
+    return Response(metrics.render(), mimetype=metrics.CONTENT_TYPE_LATEST)

--- a/vtsearch/routes/metrics.py
+++ b/vtsearch/routes/metrics.py
@@ -22,5 +22,10 @@ metrics_bp = Blueprint("metrics", __name__)
 
 @metrics_bp.route("/metrics")
 def prometheus_metrics() -> Response:
-    """Return the Prometheus exposition payload."""
-    return Response(metrics.render(), mimetype=metrics.CONTENT_TYPE_LATEST)
+    """Return the Prometheus exposition payload.
+
+    Uses ``content_type=`` (not ``mimetype=``) so the ``version=0.0.4``
+    and ``charset=utf-8`` parameters land verbatim — passing them via
+    ``mimetype`` would cause Flask to append a second ``charset=utf-8``.
+    """
+    return Response(metrics.render(), content_type=metrics.CONTENT_TYPE_LATEST)

--- a/vtsearch/state/votes.py
+++ b/vtsearch/state/votes.py
@@ -198,11 +198,17 @@ def toggle_vote(
                     invalidate_progress_cache_from(media_id)
                 added = True
 
+    from vtsearch.metrics import record_vote_event
+
+    det_ctx = get_active_detector_context()
     if added:
         from vtsearch.achievements import record_vote
 
-        det_ctx = get_active_detector_context()
         record_vote(det_ctx.detector_id, media_type=det_ctx.media_type)
+        record_vote_event(vote, media_type=det_ctx.media_type)
+    else:
+        # Toggle-off path: the user undid an existing vote.
+        record_vote_event("unlabel", media_type=det_ctx.media_type)
 
 
 def apply_label(
@@ -250,6 +256,10 @@ def apply_label(
                 add_label_to_history(media_id, "bad")
         if not silent:
             diversity_tree_label(media_id)
+    if not silent:
+        from vtsearch.metrics import record_vote_event
+
+        record_vote_event(label, media_type=get_active_detector_context().media_type)
 
 
 def apply_label_with_click_time(media_id: int, label: str) -> None:
@@ -275,6 +285,9 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
             add_label_to_history(media_id, "bad")
         assign_click_time(media_id)
         diversity_tree_label(media_id)
+    from vtsearch.metrics import record_vote_event
+
+    record_vote_event(label, media_type=get_active_detector_context().media_type)
 
 
 def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all: bool = False) -> None:
@@ -322,3 +335,8 @@ def apply_labels_bulk_with_click_time(labels: list[tuple[int, str]], replace_all
             vote_click_times[media_id] = new_val
             if tree is not None and media_id in tree.vector_to_leaf:
                 tree.label(media_id)
+    from vtsearch.metrics import record_vote_event
+
+    mt = get_active_detector_context().media_type
+    for _media_id, label in labels:
+        record_vote_event(label, media_type=mt)


### PR DESCRIPTION
Closed: after weighing pros/cons, decided not to ship `/metrics` for now. The benefits (real percentiles, standard tooling) only pay off when a scraper exists, and there isn't one in the current single-user deployment. Costs that pushed against shipping: a new dependency, per-worker counter state under gunicorn, label-cardinality footguns, and a non-zero perf cost on every vote / embed / train hot path. Worth revisiting if/when VTSearch gains a multi-tenant or k8s deployment story.

See `docs/plans/feature-brainstorm.md` §12.16 for the captured decision.