### PR TITLE
Add --list-&lt;family&gt; CLI shortcuts for plugin discoverability

### DIFF
--- a/app.py
+++ b/app.py
@@ -340,7 +340,9 @@ if __name__ == "__main__":
         dest="list_plugins",
         help=(
             "List every auto-discovered plugin (importers, exporters, embedders, "
-            "converters, clippers, …) and exit. Useful for shell completion."
+            "converters, clippers, …) and exit. Useful for shell completion. "
+            "Per-family shortcuts are also available — see --list-importers, "
+            "--list-exporters, etc."
         ),
     )
     parser.add_argument(
@@ -354,6 +356,13 @@ if __name__ == "__main__":
             "completion-friendly output."
         ),
     )
+
+    # Per-family shortcuts: ``--list-importers`` ≡ ``--list-plugins
+    # --plugin-family importers``, and so on for every family in
+    # vtsearch.plugins.inventory.FAMILIES.
+    from vtsearch.plugins.inventory import register_family_shortcuts
+
+    register_family_shortcuts(parser)
     parser.add_argument(
         "--format",
         type=str,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -124,8 +124,22 @@ python app.py --list-plugins --plugin-family importers --format names
                                                       # one bare name per line — completion-friendly
 ```
 
-Use `--format names --plugin-family <family>` from a shell-completion
-script to suggest valid values for `--importer`, `--exporter`, etc.
+Per-family shortcuts are available for every plugin family — they're
+equivalent to `--list-plugins --plugin-family <family>` and accept the
+same `--format` flag:
+
+```bash
+python app.py --list-importers                        # dataset importers
+python app.py --list-exporters --format names         # results exporters, bare names
+python app.py --list-embedders --format json          # embedders as JSON
+# Also: --list-converters, --list-clippers, --list-media-types,
+# --list-media-sources, --list-label-importers, --list-labelset-sources,
+# --list-settings-importers, --list-settings-exporters, --list-settings-sources.
+```
+
+Use `--format names --plugin-family <family>` (or any `--list-<family>
+--format names` shortcut) from a shell-completion script to suggest
+valid values for `--importer`, `--exporter`, etc.
 
 `python app.py --openapi-schema` prints an OpenAPI 3.0 document for the
 HTTP API to stdout and exits — same content as `GET /openapi.json` on

--- a/tests/core/test_plugin_inventory.py
+++ b/tests/core/test_plugin_inventory.py
@@ -7,16 +7,19 @@ each one), and the three output formats must round-trip cleanly.
 
 from __future__ import annotations
 
+import argparse
 import json
 
 import pytest
 
 from vtsearch.plugins.inventory import (
     FAMILIES,
+    family_flag,
     format_json,
     format_names,
     format_plain,
     gather_plugins,
+    register_family_shortcuts,
 )
 
 
@@ -90,3 +93,40 @@ class TestFormatters:
 
     def test_format_names_unknown_family_is_empty(self, inventory):
         assert format_names(inventory, family="not_a_family") == ""
+
+
+class TestFamilyShortcutFlags:
+    """``--list-<family>`` shortcuts mirror ``--list-plugins --plugin-family <family>``."""
+
+    @pytest.fixture
+    def parser(self):
+        p = argparse.ArgumentParser()
+        # The shortcuts share the ``list_plugins`` / ``plugin_family``
+        # dests with the long-form flags, so the canonical args must be
+        # registered first or the namespace defaults are missing.
+        p.add_argument("--list-plugins", action="store_true", dest="list_plugins")
+        p.add_argument("--plugin-family", default=None, dest="plugin_family")
+        register_family_shortcuts(p)
+        return p
+
+    def test_flag_name_uses_hyphens(self):
+        assert family_flag("importers") == "--list-importers"
+        assert family_flag("label_importers") == "--list-label-importers"
+        assert family_flag("settings_sources") == "--list-settings-sources"
+
+    @pytest.mark.parametrize("family", FAMILIES)
+    def test_each_family_has_a_shortcut(self, parser, family):
+        args = parser.parse_args([family_flag(family)])
+        assert args.list_plugins is True
+        assert args.plugin_family == family
+
+    def test_shortcut_equivalent_to_long_form(self, parser):
+        short = parser.parse_args(["--list-importers"])
+        long = parser.parse_args(["--list-plugins", "--plugin-family", "importers"])
+        assert (short.list_plugins, short.plugin_family) == (long.list_plugins, long.plugin_family)
+
+    def test_help_lists_shortcut(self, parser):
+        # Discoverability is the whole point — `--help` must mention them.
+        help_text = parser.format_help()
+        assert "--list-importers" in help_text
+        assert "--list-exporters" in help_text

--- a/vtsearch/plugins/inventory.py
+++ b/vtsearch/plugins/inventory.py
@@ -12,6 +12,7 @@ the embedder / clipper / media-type registries that live directly on
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -206,6 +207,58 @@ def format_json(inventory: dict[str, list[PluginEntry]]) -> str:
 
 FAMILIES: tuple[str, ...] = tuple(_FAMILY_LABELS.keys())
 
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class _ListFamilyAction(argparse.Action):
+    """Argparse action backing the ``--list-<family>`` shortcuts.
+
+    Sets ``list_plugins=True`` and ``plugin_family=<family>`` on the
+    namespace so the existing ``--list-plugins`` early-exit branch picks
+    them up unchanged.
+    """
+
+    def __init__(self, option_strings, dest, const=None, default=None, required=False, help=None):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            const=const,
+            default=default,
+            required=required,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        namespace.list_plugins = True
+        namespace.plugin_family = self.const
+
+
+def family_flag(family: str) -> str:
+    """Return the CLI flag name for *family* (e.g. ``label_importers`` → ``--list-label-importers``)."""
+    return f"--list-{family.replace('_', '-')}"
+
+
+def register_family_shortcuts(parser: argparse.ArgumentParser) -> None:
+    """Add ``--list-<family>`` shortcut flags to *parser* for every known family.
+
+    Each shortcut is equivalent to ``--list-plugins --plugin-family
+    <family>`` and obeys the same ``--format`` setting.  Generated from
+    :data:`FAMILIES` so a new plugin family automatically gets a shortcut.
+    """
+    for family in FAMILIES:
+        parser.add_argument(
+            family_flag(family),
+            action=_ListFamilyAction,
+            const=family,
+            dest="list_plugins",
+            help=f"Shortcut for --list-plugins --plugin-family {family}.",
+        )
+
+
 __all__ = [
     "FAMILIES",
     "PluginEntry",
@@ -213,4 +266,6 @@ __all__ = [
     "format_plain",
     "format_names",
     "format_json",
+    "family_flag",
+    "register_family_shortcuts",
 ]


### PR DESCRIPTION
## Summary

Implements feature-brainstorm 17.1: per-family CLI shortcuts for plugin discovery.

Each plugin family in `vtsearch.plugins.inventory.FAMILIES` now has a dedicated `--list-<family>` flag, e.g.:

```bash
python app.py --list-importers
python app.py --list-exporters --format names
python app.py --list-embedders --format json
# Also: --list-converters, --list-clippers, --list-media-types,
# --list-media-sources, --list-label-importers, --list-labelset-sources,
# --list-settings-importers, --list-settings-exporters, --list-settings-sources.
```

Each shortcut is equivalent to `--list-plugins --plugin-family <family>` and obeys the same `--format plain|json|names` flag. Shortcuts are generated from `FAMILIES`, so new plugin families pick them up automatically.

## Changes

- `vtsearch/plugins/inventory.py` — new `_ListFamilyAction`, `family_flag()`, and `register_family_shortcuts()` helper.
- `app.py` — registers shortcuts via `register_family_shortcuts(parser)`; updated `--list-plugins` help to point at the shortcuts.
- `docs/CLI.md` — documents the shortcut flags alongside the existing `--list-plugins` examples.
- `tests/core/test_plugin_inventory.py` — new `TestFamilyShortcutFlags` class; parametrised test asserts every family has a working shortcut, plus shortcut-vs-long-form equivalence and a help-text discoverability check.

## Test plan

- [x] `python app.py --help` shows all 12 shortcuts
- [x] `python app.py --list-importers --format names` prints bare importer names
- [x] `python app.py --list-exporters` prints the human-readable exporter list
- [x] `python app.py --list-embedders --format json` returns valid JSON
- [x] `pytest tests/core/test_plugin_inventory.py` — 26 passed
- [x] `./run-tests.sh core` — 486 passed
- [x] `ruff check` and `ruff format --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_019kRahdQ1fAVHsv9QczQeXd)_