### PR TITLE
Add /healthz and /readyz probes

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,7 @@ from vtsearch.routes import (  # noqa: E402
     eval_bp,
     events_bp,
     file_browser_bp,
+    health_bp,
     labels_bp,
     media_server_bp,
     medias_bp,
@@ -250,6 +251,7 @@ api.register_blueprint(achievements_bp)
 api.register_blueprint(auth_bp)
 app.register_blueprint(eval_bp)
 app.register_blueprint(file_browser_bp)
+api.register_blueprint(health_bp)
 api.register_blueprint(labels_bp)
 app.register_blueprint(media_server_bp)
 api.register_blueprint(main_bp)

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,93 @@
+"""Tests for the ``/healthz`` (liveness) and ``/readyz`` (readiness) probes."""
+
+from unittest.mock import patch
+
+import app as app_module  # noqa: F401 — triggers conftest side effects
+
+
+class TestLiveness:
+    """``GET /healthz`` is always 200 while the process is up."""
+
+    def test_returns_ok(self, client):
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"status": "ok"}
+
+    def test_does_not_touch_models(self, client):
+        """Liveness must not trigger embedder loading."""
+        with patch("vtsearch.routes.health.predict_embedders_to_preload") as m:
+            resp = client.get("/healthz")
+        assert resp.status_code == 200
+        m.assert_not_called()
+
+
+class TestReadiness:
+    """``GET /readyz`` returns 200 only when every sub-check passes."""
+
+    def test_ready_with_empty_registry(self, client):
+        """An empty dataset/detector registry implies no embedders are required.
+
+        ``conftest.reset_state`` clears both registries before each test, so
+        ``predict_embedders_to_preload()`` returns ``[]`` and the models
+        check passes trivially.
+        """
+        resp = client.get("/readyz")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "ready"
+        assert body["checks"]["data_dir"]["ok"] is True
+        assert body["checks"]["models"]["ok"] is True
+
+    def test_not_ready_when_embedder_pending(self, client):
+        """If an embedder is expected but not loaded, return 503."""
+        with patch(
+            "vtsearch.routes.health.predict_embedders_to_preload",
+            return_value=["clap"],
+        ):
+            # In the test session embedders' load_models is stubbed, so _model
+            # remains None — exactly the "still loading" condition we want.
+            resp = client.get("/readyz")
+        assert resp.status_code == 503
+        body = resp.get_json()
+        assert body["status"] == "not_ready"
+        assert body["checks"]["models"]["ok"] is False
+        assert "clap" in body["checks"]["models"]["detail"]
+
+    def test_not_ready_when_data_dir_unwritable(self, client, tmp_path):
+        """If the data dir is not writable, return 503.
+
+        ``os.access`` is patched directly because the test container often
+        runs as root, where chmod bits are bypassed and the natural
+        approach of ``chmod 0o500`` doesn't actually make a dir unwritable.
+        """
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        with (
+            patch("vtsearch.routes.health.DATA_DIR", ro_dir),
+            patch("vtsearch.routes.health.os.access", return_value=False),
+        ):
+            resp = client.get("/readyz")
+        assert resp.status_code == 503
+        body = resp.get_json()
+        assert body["status"] == "not_ready"
+        assert body["checks"]["data_dir"]["ok"] is False
+        assert "not writable" in body["checks"]["data_dir"]["detail"]
+
+    def test_reports_loaded_embedder_as_ok(self, client):
+        """When the expected embedder has a non-None ``_model``, models check passes."""
+        from vtsearch.media import get_embedder
+
+        emb = get_embedder("clap")
+        sentinel = object()
+        with (
+            patch(
+                "vtsearch.routes.health.predict_embedders_to_preload",
+                return_value=["clap"],
+            ),
+            patch.object(emb, "_model", sentinel, create=True),
+        ):
+            resp = client.get("/readyz")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["checks"]["models"]["ok"] is True
+        assert "clap" in body["checks"]["models"]["detail"]

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -20,6 +20,7 @@ from vtsearch.routes.detectors import (
 from vtsearch.routes.eval import eval_bp
 from vtsearch.routes.events import events_bp
 from vtsearch.routes.file_browser import file_browser_bp
+from vtsearch.routes.health import health_bp
 from vtsearch.routes.labels import exporters_bp, label_importers_bp, labels_bp
 from vtsearch.routes.main import main_bp
 from vtsearch.routes.media import embed_bp, media_server_bp, medias_bp
@@ -46,6 +47,7 @@ __all__ = [
     "events_bp",
     "exporters_bp",
     "file_browser_bp",
+    "health_bp",
     "label_importers_bp",
     "labels_bp",
     "main_bp",

--- a/vtsearch/routes/health.py
+++ b/vtsearch/routes/health.py
@@ -1,0 +1,114 @@
+"""Liveness (``/healthz``) and readiness (``/readyz``) probes.
+
+These are the standard two-endpoint pattern popularised by Kubernetes:
+
+* ``/healthz`` answers *"is the process up?"* — cheap, dependency-free,
+  always 200 while Flask is serving. A failure means the orchestrator
+  should restart the container.
+* ``/readyz`` answers *"can this process actually serve traffic right now?"*
+  It returns 200 when every readiness sub-check passes and 503 otherwise.
+  A failure means the orchestrator should pull this instance out of the
+  load-balancer rotation but leave it running (it may recover on its own,
+  e.g. once embedders finish warming up).
+
+The endpoints live at the root of the URL space (not under ``/api/``) to
+follow the convention orchestrators expect.
+"""
+
+from __future__ import annotations
+
+import os
+
+from flask import jsonify
+from flask_smorest import Blueprint
+
+from vtsearch.config import DATA_DIR
+from vtsearch.embedding.loader import predict_embedders_to_preload
+from vtsearch.media import get_embedder
+from vtsearch.schemas.health import HealthSchema, ReadinessSchema
+
+health_bp = Blueprint(
+    "health",
+    __name__,
+    description="Liveness and readiness probes for orchestrators (Kubernetes, ECS, etc.).",
+)
+
+
+@health_bp.route("/healthz", methods=["GET"])
+@health_bp.response(200, HealthSchema)
+def healthz() -> dict:
+    """Liveness probe — 200 while the Flask process is serving.
+
+    Intentionally does no work beyond returning a constant. Anything more
+    expensive risks turning a slow dependency into a restart loop.
+    """
+    return {"status": "ok"}
+
+
+def _check_data_dir() -> tuple[bool, str]:
+    """Return ``(ok, detail)`` for the data-directory readiness check."""
+    try:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return False, f"cannot create data dir {DATA_DIR}: {exc}"
+    if not os.access(DATA_DIR, os.W_OK):
+        return False, f"data dir {DATA_DIR} is not writable"
+    return True, str(DATA_DIR)
+
+
+def _check_models() -> tuple[bool, str]:
+    """Return ``(ok, detail)`` for the embedder-warmup readiness check.
+
+    "Ready" means every embedder predicted from the registered datasets
+    and detectors has its model in memory. With an empty registry (fresh
+    process, no datasets loaded), nothing is expected and the check
+    passes trivially.
+    """
+    expected = predict_embedders_to_preload()
+    if not expected:
+        return True, "no embedders required (empty registry)"
+
+    pending: list[str] = []
+    for name in expected:
+        try:
+            emb = get_embedder(name)
+        except KeyError:
+            pending.append(name)
+            continue
+        if getattr(emb, "_model", None) is None:
+            pending.append(name)
+
+    if pending:
+        return False, f"loading: {', '.join(pending)}"
+    return True, f"loaded: {', '.join(expected)}"
+
+
+@health_bp.route("/readyz", methods=["GET"])
+@health_bp.response(200, ReadinessSchema)
+@health_bp.alt_response(503, schema=ReadinessSchema, description="One or more readiness checks failed.")
+def readyz():
+    """Readiness probe — 200 when every sub-check passes, 503 otherwise.
+
+    Sub-checks:
+
+    * ``data_dir`` — :data:`vtsearch.config.DATA_DIR` exists and is
+      writable (the app needs this for embeddings, model cache, settings).
+    * ``models`` — every embedder implied by the dataset/detector
+      registries is warm (``_model is not None``).
+    """
+    checks: dict[str, dict] = {}
+
+    data_ok, data_detail = _check_data_dir()
+    checks["data_dir"] = {"ok": data_ok, "detail": data_detail}
+
+    models_ok, models_detail = _check_models()
+    checks["models"] = {"ok": models_ok, "detail": models_detail}
+
+    all_ok = all(c["ok"] for c in checks.values())
+    body = {"status": "ready" if all_ok else "not_ready", "checks": checks}
+    if all_ok:
+        return body
+    return jsonify(body), 503
+
+
+__all__ = ["health_bp"]

--- a/vtsearch/schemas/health.py
+++ b/vtsearch/schemas/health.py
@@ -1,0 +1,50 @@
+"""Schemas for the ``/healthz`` (liveness) and ``/readyz`` (readiness) probes.
+
+Liveness is a fixed-shape ``{"status": "ok"}``; readiness reports per-check
+detail so an operator can tell *why* the pod is not yet receiving traffic.
+"""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+
+class HealthSchema(Schema):
+    """Response for ``GET /healthz`` (always 200 while the process is alive)."""
+
+    status = fields.String(
+        required=True,
+        metadata={"description": "Always 'ok' — the process is running and serving requests."},
+    )
+
+
+class ReadinessCheckSchema(Schema):
+    """One readiness sub-check (data dir, models, etc.)."""
+
+    ok = fields.Boolean(required=True, metadata={"description": "Whether this individual check passed."})
+    detail = fields.String(
+        required=False,
+        metadata={"description": "Optional human-readable note (failure reason or extra info)."},
+    )
+
+
+class ReadinessSchema(Schema):
+    """Response for ``GET /readyz`` (200 when ready, 503 when not).
+
+    The HTTP status carries the verdict; the body lets operators see which
+    sub-check tripped without grepping logs.
+    """
+
+    status = fields.String(
+        required=True,
+        metadata={"description": "'ready' on 200, 'not_ready' on 503."},
+    )
+    checks = fields.Dict(
+        keys=fields.String(),
+        values=fields.Nested(ReadinessCheckSchema),
+        required=True,
+        metadata={"description": "Per-check results keyed by check name (data_dir, models, …)."},
+    )
+
+
+__all__ = ["HealthSchema", "ReadinessCheckSchema", "ReadinessSchema"]


### PR DESCRIPTION
## Summary

Adds the two-endpoint health-probe pattern popularised by Kubernetes:

- **`GET /healthz`** — liveness. Returns `200 {"status":"ok"}` while the Flask process is serving. No dependency checks; a failure means "restart this container."
- **`GET /readyz`** — readiness. Returns `200` only when every sub-check passes, `503` with a per-check breakdown otherwise. A failure means "alive, but don't route traffic here yet."

Readiness sub-checks (chosen to reflect what actually gates serving in VTSearch):

| check | passes when |
|---|---|
| `data_dir` | `DATA_DIR` exists and is writable (where embeddings, model cache, settings live) |
| `models` | every embedder predicted from the dataset/detector registries is warm (`_model is not None`); trivially passes when the registries are empty |

Both endpoints live at the URL root (not under `/api/`) to match the convention orchestrators expect, and are mounted via `flask_smorest` so they appear in `/api/openapi.json`.

### Files

- `vtsearch/routes/health.py` — `health_bp` blueprint
- `vtsearch/schemas/health.py` — `HealthSchema`, `ReadinessSchema`, `ReadinessCheckSchema`
- `vtsearch/routes/__init__.py`, `app.py` — wire up registration
- `tests/api/test_health.py` — liveness + readiness coverage (empty registry, pending embedder, unwritable data dir, loaded embedder)

## Test plan

- [x] `./run-tests.sh` — all 3480 fast tests pass (no regressions)
- [x] `python -m pytest tests/api/test_health.py -v` — 6/6 pass
- [x] Live sanity check via `test_client`:
  - `GET /healthz` → `200 {"status":"ok"}`
  - `GET /readyz` → `200` with `data_dir` and `models` both `ok` on an empty registry
- [x] OpenAPI spec at `/api/openapi.json` documents both endpoints with `200` + `503` responses

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUXdgqsezfHSt6LdkcRsP9)_