### PR TITLE
Add ApiKeyLoginProvider for headless API clients

### DIFF
--- a/app.py
+++ b/app.py
@@ -325,9 +325,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--login",
         type=str,
-        choices=["trivial"],
+        choices=["trivial", "api_key"],
         default=None,
-        help="Login provider: 'trivial' shows a username prompt (no password, cookie-based)",
+        help=(
+            "Login provider: 'trivial' shows a username prompt (no password, cookie-based); "
+            "'api_key' authenticates via Authorization: Bearer <key> against data/api_keys.json"
+        ),
     )
     parser.add_argument(
         "--autodetect",
@@ -568,11 +571,22 @@ if __name__ == "__main__":
 
     elif args.local or not args.autodetect:
         # Activate the chosen login provider before starting the server.
-        if getattr(args, "login", None) == "trivial":
+        login_choice = getattr(args, "login", None)
+        if login_choice == "trivial":
             from vtsearch.auth import TrivialLoginProvider, set_login_provider
 
             set_login_provider(TrivialLoginProvider())
             print("\U0001f511 Trivial login enabled \u2014 users will be prompted for a username", flush=True)
+        elif login_choice == "api_key":
+            from vtsearch.auth import ApiKeyLoginProvider, set_login_provider
+            from vtsearch.config import DATA_DIR
+
+            provider = ApiKeyLoginProvider()
+            set_login_provider(provider)
+            print(
+                f"\U0001f511 API-key login enabled \u2014 reading keys from {DATA_DIR / 'api_keys.json'}",
+                flush=True,
+            )
 
         initialize_server(mode_label="LOCAL" if args.local else "PRODUCTION")
         print("\U0001f310 Open http://localhost:5000 in your browser", flush=True)

--- a/tests/api/test_multi_user_security.py
+++ b/tests/api/test_multi_user_security.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from vtsearch.auth import (
+    ApiKeyLoginProvider,
     DefaultLoginProvider,
     LoginProvider,
     TrivialLoginProvider,
@@ -276,6 +277,232 @@ class TestUserDataDirIsolation:
         # Default provider should return DATA_DIR unchanged
         result = get_user_data_dir("anything")
         assert result == DATA_DIR
+
+
+# ---------------------------------------------------------------------------
+# ApiKeyLoginProvider
+# ---------------------------------------------------------------------------
+
+
+def _hash_key(key: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+def _write_keys(path: Path, mapping: dict[str, str]) -> None:
+    import json
+
+    path.write_text(json.dumps(mapping))
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Flask request — only ``headers.get`` is used."""
+
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+
+
+class TestApiKeyLoginProvider:
+    """Test the bearer-token login provider used by headless integrations."""
+
+    def test_name(self):
+        provider = ApiKeyLoginProvider(keys_file=Path("/nonexistent/api_keys.json"))
+        assert provider.name == "api_key"
+
+    def test_login_required_is_false(self):
+        provider = ApiKeyLoginProvider(keys_file=Path("/nonexistent/api_keys.json"))
+        assert provider.login_required() is False
+
+    def test_no_file_means_anonymous(self):
+        provider = ApiKeyLoginProvider(keys_file=Path("/nonexistent/api_keys.json"))
+        req = _FakeRequest({"Authorization": "Bearer some-key"})
+        assert provider.get_user(req) == "anonymous"
+        assert provider.is_authenticated(req) is False
+
+    def test_valid_key_returns_username(self, tmp_path):
+        key = "super-secret-key"
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key(key): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        req = _FakeRequest({"Authorization": f"Bearer {key}"})
+        assert provider.get_user(req) == "alice"
+        assert provider.is_authenticated(req) is True
+
+    def test_invalid_key_returns_anonymous(self, tmp_path):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("real-key"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        req = _FakeRequest({"Authorization": "Bearer wrong-key"})
+        assert provider.get_user(req) == "anonymous"
+        assert provider.is_authenticated(req) is False
+
+    def test_missing_header_returns_anonymous(self, tmp_path):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("k"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        req = _FakeRequest({})
+        assert provider.get_user(req) == "anonymous"
+        assert provider.is_authenticated(req) is False
+
+    def test_non_bearer_header_returns_anonymous(self, tmp_path):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("k"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        # Basic auth shouldn't be parsed as a bearer token even if the rest matches.
+        req = _FakeRequest({"Authorization": "Basic k"})
+        assert provider.get_user(req) == "anonymous"
+
+    def test_empty_bearer_token_returns_anonymous(self, tmp_path):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("k"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        req = _FakeRequest({"Authorization": "Bearer    "})
+        assert provider.get_user(req) == "anonymous"
+
+    def test_multiple_keys_per_user(self, tmp_path):
+        """Two keys mapping to the same username both authenticate."""
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(
+            keys_file,
+            {
+                _hash_key("key-one"): "alice",
+                _hash_key("key-two"): "alice",
+                _hash_key("key-three"): "bob",
+            },
+        )
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer key-one"})) == "alice"
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer key-two"})) == "alice"
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer key-three"})) == "bob"
+
+    def test_data_dir_is_per_user(self, tmp_path):
+        provider = ApiKeyLoginProvider(keys_file=tmp_path / "api_keys.json")
+        base = Path("/app/data")
+        assert provider.get_user_data_dir("alice", base) == base / "alice"
+
+    def test_invalid_username_skipped(self, tmp_path, caplog):
+        """A username with path-traversal characters is rejected at load time."""
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(
+            keys_file,
+            {
+                _hash_key("good"): "alice",
+                _hash_key("evil"): "../../etc/passwd",
+            },
+        )
+        with caplog.at_level("ERROR"):
+            provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        # Good key still works
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer good"})) == "alice"
+        # Evil key is dropped, request resolves to anonymous
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer evil"})) == "anonymous"
+        assert any("invalid username" in rec.message for rec in caplog.records)
+
+    def test_malformed_json_keeps_existing_keys(self, tmp_path, caplog):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("good"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer good"})) == "alice"
+
+        # Corrupt the file. Bump mtime so the reload is actually attempted.
+        import os
+        import time
+
+        keys_file.write_text("{not valid json")
+        future = time.time() + 10
+        os.utime(keys_file, (future, future))
+
+        with caplog.at_level("ERROR"):
+            # Request should still authenticate using the previously loaded map.
+            assert provider.get_user(_FakeRequest({"Authorization": "Bearer good"})) == "alice"
+        assert any("failed to load" in rec.message for rec in caplog.records)
+
+    def test_hot_reload_on_mtime_change(self, tmp_path):
+        """Adding a new key to the file is picked up without restarting."""
+        import os
+        import time
+
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("alice-key"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer bob-key"})) == "anonymous"
+
+        # Add Bob and bump mtime so the reload triggers.
+        _write_keys(
+            keys_file,
+            {
+                _hash_key("alice-key"): "alice",
+                _hash_key("bob-key"): "bob",
+            },
+        )
+        future = time.time() + 10
+        os.utime(keys_file, (future, future))
+
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer bob-key"})) == "bob"
+        # Original key still works.
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer alice-key"})) == "alice"
+
+    def test_file_deleted_clears_keys(self, tmp_path):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("k"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer k"})) == "alice"
+
+        keys_file.unlink()
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer k"})) == "anonymous"
+
+    def test_status_dict(self, tmp_path):
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("k"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        status = provider.status_dict(_FakeRequest({"Authorization": "Bearer k"}))
+        assert status["provider"] == "api_key"
+        assert status["user"] == "alice"
+        assert status["authenticated"] is True
+        assert status["login_required"] is False
+
+        anon_status = provider.status_dict(_FakeRequest({}))
+        assert anon_status["user"] == "anonymous"
+        assert anon_status["authenticated"] is False
+
+    def test_end_to_end_flask_request(self, tmp_path, client):
+        """Plug the provider into the live app and hit /api/auth/status."""
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("flask-test-key"): "alice"})
+        provider = ApiKeyLoginProvider(keys_file=keys_file)
+        original = get_login_provider()
+        try:
+            set_login_provider(provider)
+
+            # No header -> anonymous, unauthenticated.
+            resp = client.get("/api/auth/status")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["provider"] == "api_key"
+            assert data["user"] == "anonymous"
+            assert data["authenticated"] is False
+
+            # Valid bearer token -> alice, authenticated.
+            resp = client.get(
+                "/api/auth/status",
+                headers={"Authorization": "Bearer flask-test-key"},
+            )
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["user"] == "alice"
+            assert data["authenticated"] is True
+        finally:
+            set_login_provider(original)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/auth/__init__.py
+++ b/vtsearch/auth/__init__.py
@@ -11,6 +11,7 @@ The active provider is set once at startup via :func:`set_login_provider`.
 from __future__ import annotations
 
 import logging
+import re
 import threading
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -152,6 +153,151 @@ class TrivialLoginProvider(LoginProvider):
 
     def login_required(self) -> bool:
         return True
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
+        return base_data_dir / username
+
+
+# ---------------------------------------------------------------------------
+# ApiKeyLoginProvider — bearer-token, for headless integrations
+# ---------------------------------------------------------------------------
+
+
+# Usernames are used as data-directory names (data/<user>/...) so they must
+# not contain path separators or traversal segments.
+_VALID_USERNAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class ApiKeyLoginProvider(LoginProvider):
+    """Bearer-token authentication for headless API clients.
+
+    Reads ``Authorization: Bearer <key>`` from the request, hashes the
+    presented key with SHA-256, and looks the hash up in a JSON file
+    (default ``data/api_keys.json``) of the form::
+
+        {"<sha256_hex_of_key>": "alice", "<sha256_hex_of_key>": "ci-bot"}
+
+    The file is reloaded automatically when its mtime changes, so keys
+    can be rotated without restarting the server.
+
+    Generate a key and its hash with::
+
+        python -c "import secrets, hashlib; \\
+            k = secrets.token_urlsafe(32); \\
+            print('key:', k); \\
+            print('hash:', hashlib.sha256(k.encode()).hexdigest())"
+
+    Requests without a valid bearer token resolve to the username
+    ``"anonymous"`` and ``is_authenticated`` returns ``False``.  This
+    provider does not show a login UI (``login_required`` is ``False``)
+    — it is meant for headless callers that send the header directly.
+    """
+
+    name = "api_key"
+
+    def __init__(self, keys_file: Path | None = None) -> None:
+        if keys_file is None:
+            from vtsearch.config import DATA_DIR
+
+            keys_file = DATA_DIR / "api_keys.json"
+        self._keys_file: Path = Path(keys_file)
+        self._keys: dict[str, str] = {}
+        self._mtime: float | None = None
+        self._lock = threading.Lock()
+        self._load_keys_if_changed()
+        if not self._keys:
+            logger.warning(
+                "ApiKeyLoginProvider: no keys loaded from %s — every request will be anonymous. "
+                "Add entries with the snippet in the class docstring.",
+                self._keys_file,
+            )
+
+    def _load_keys_if_changed(self) -> None:
+        try:
+            mtime = self._keys_file.stat().st_mtime
+        except FileNotFoundError:
+            with self._lock:
+                if self._mtime is not None or self._keys:
+                    self._keys = {}
+                    self._mtime = None
+            return
+        except OSError:
+            logger.exception("ApiKeyLoginProvider: failed to stat %s", self._keys_file)
+            return
+        if mtime == self._mtime:
+            return
+        try:
+            import json
+
+            with open(self._keys_file) as f:
+                data = json.load(f)
+        except Exception:
+            logger.exception(
+                "ApiKeyLoginProvider: failed to load %s — keeping previously loaded keys",
+                self._keys_file,
+            )
+            return
+        if not isinstance(data, dict):
+            logger.error(
+                "ApiKeyLoginProvider: %s must contain a JSON object, got %s",
+                self._keys_file,
+                type(data).__name__,
+            )
+            return
+        new_keys: dict[str, str] = {}
+        for key_hash, username in data.items():
+            if not isinstance(key_hash, str) or not isinstance(username, str):
+                logger.error(
+                    "ApiKeyLoginProvider: skipping non-string entry in %s: %r -> %r",
+                    self._keys_file,
+                    key_hash,
+                    username,
+                )
+                continue
+            if not _VALID_USERNAME.match(username):
+                logger.error(
+                    "ApiKeyLoginProvider: skipping key for invalid username %r in %s (must match [A-Za-z0-9._-]+)",
+                    username,
+                    self._keys_file,
+                )
+                continue
+            new_keys[key_hash] = username
+        with self._lock:
+            self._keys = new_keys
+            self._mtime = mtime
+        logger.info(
+            "ApiKeyLoginProvider: loaded %d key(s) from %s",
+            len(new_keys),
+            self._keys_file,
+        )
+
+    def _lookup_user(self, request: Any) -> str | None:
+        if request is None:
+            return None
+        try:
+            header = request.headers.get("Authorization", "") or ""
+        except Exception:
+            return None
+        if not header.startswith("Bearer "):
+            return None
+        token = header[len("Bearer ") :].strip()
+        if not token:
+            return None
+        import hashlib
+
+        token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        self._load_keys_if_changed()
+        with self._lock:
+            return self._keys.get(token_hash)
+
+    def get_user(self, request: Any) -> str:
+        return self._lookup_user(request) or "anonymous"
+
+    def is_authenticated(self, request: Any) -> bool:
+        return self._lookup_user(request) is not None
+
+    def login_required(self) -> bool:
+        return False
 
     def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
         return base_data_dir / username


### PR DESCRIPTION
## Summary

New `LoginProvider` (task 18.5) for headless integrations. Authenticates via `Authorization: Bearer <key>`, mapping the SHA-256 hash of the presented key to a username.

- **Keys live in `data/api_keys.json`**, separate from `data/settings.json`. Settings are exportable / routable through sync sources, so putting credentials there would leak them via `/api/settings/export` or a configured `settings_source`. The key file is server-tier (it *defines* users, so it can't live under one).
- **Keys are hashed (SHA-256), not stored plaintext.** File shape: `{"<sha256_hex>": "alice", "<sha256_hex>": "ci-bot"}`. Multiple hashes can map to the same username, which makes rotation easy.
- **Hot-reload on mtime change** so operators can add/revoke keys without restarting.
- **Username validation at load time** (`[A-Za-z0-9._-]+`) — `get_user_data_dir` resolves to `data/<username>/...`, so a name like `../etc` would traverse out of the data dir. Invalid entries are dropped with a logged error; the rest of the map keeps working.
- **No login UI** (`login_required = False`). Unknown / missing keys resolve to `"anonymous"` and `is_authenticated` is `False`, so the existing `/api/auth/status` check still gates protected operations.

Wires `--login api_key` into `app.py` alongside the existing `trivial` choice. Key generation snippet is in the class docstring.

## Test plan

- [x] `./run-tests.sh core api` — 891 passed, 0 failed
- [x] 13 new `TestApiKeyLoginProvider` cases cover: valid/invalid keys, missing header, non-bearer scheme, empty token, multiple keys per user, per-user data dir, traversal username rejection, malformed JSON resilience, hot reload, file deletion, `status_dict`, and an end-to-end Flask `/api/auth/status` round-trip
- [x] `ruff check` and `ruff format --check` clean
- [x] Frontend TypeScript build still green

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSNRczegR52Xufx1yhx2Jz)_