### PR TITLE
Mark feature-brainstorm 17.4 (watch mode) as unnecessary

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -682,8 +682,10 @@ Already designed in `docs/design/cli-detector-converter.md`; ship it.
 ### 17.3 Pipeline file ★ M
 `python app.py --pipeline pipeline.yaml` runs an importer → clipper → embedder → detector → exporter sequence declared in YAML. Replaces N CLI flags with one config file. Repeatable for cron.
 
-### 17.4 Watch mode ★ S
-`--watch /path/to/inbox` re-runs autodetect whenever new files appear.
+### ~~17.4 Watch mode ★ S~~ — unnecessary
+~~`--watch /path/to/inbox` re-runs autodetect whenever new files appear.~~
+
+Dropped: not worth building. External schedulers (cron, systemd timers, file-watcher daemons like `inotifywait` / `entr`) can re-invoke `--autodetect` on new files without bloating the CLI surface or adding a long-running-process code path to maintain.
 
 ### 17.5 Dry-run mode ★ XS
 `--dry-run` prints what would be embedded/scored/exported without doing it.


### PR DESCRIPTION
## Summary

- Strikethroughs the §17.4 "Watch mode" entry in `docs/plans/feature-brainstorm.md` and adds a one-line rationale.
- External schedulers (cron, systemd timers, `inotifywait` / `entr`) can already re-invoke `--autodetect` on new files, so a long-running `--watch` mode would add a maintenance burden without enabling anything those tools can't already do.

## Test plan

- [x] Docs-only change; no code paths affected, no tests required.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PnKBx4j3cUodHGGCRNicb)_