### PR TITLE
Mark Backup CLI (18.2) as not necessary in plan

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -701,7 +701,7 @@ Already designed in `docs/design/cli-detector-converter.md`; ship it.
 ### 18.1 `/healthz` and `/readyz` ★★ S
 Distinguish "process is up" from "models are loaded and DB is reachable".
 
-### 18.2 Backup CLI ★★ S
+### 18.2 Backup CLI ★★ S — NOT NECESSARY
 `python app.py --backup data-snapshot.tar.gz` and `--restore`. Includes datasets-pkl, settings, detectors.
 
 ### 18.3 Audit log ★ M


### PR DESCRIPTION
## Summary
- Annotates plan item 18.2 (Backup CLI) in `docs/plans/feature-brainstorm.md` as "NOT NECESSARY" so it isn't picked up as future work.

## Test plan
- [ ] Docs-only change; no code paths affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp5pib3r4wFmpmfoN5oNa3)_