### PR TITLE
Add --dry-run mode for autodetect CLI (plan 17.5)

### DIFF
--- a/app.py
+++ b/app.py
@@ -496,6 +496,17 @@ if __name__ == "__main__":
         dest="label_importer_file",
         help=("Path passed to the label importer's ``filepath`` field. Used with --import-labels-into."),
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help=(
+            "Print what --autodetect would embed, score, and export without "
+            "doing it. Validates importer/exporter names, settings file, and "
+            "any --import-labels-into request, but loads no media and trains "
+            "no models."
+        ),
+    )
 
     # Two-pass parsing: first pass gets --importer and --exporter names;
     # second pass adds their plugin-specific arguments and re-parses.
@@ -571,6 +582,8 @@ if __name__ == "__main__":
 
         chunk_size = getattr(args, "chunk_size", None)
 
+        dry_run = bool(getattr(args, "dry_run", False))
+
         # Optional one-shot label import into a detector before scoring.
         # The merged labelset is picked up by the autodetect pipeline below.
         if args.import_labels_into:
@@ -581,22 +594,31 @@ if __name__ == "__main__":
                 from vtsearch.settings import set_settings_path
 
                 set_settings_path(settings_path)
-            from vtsearch.cli import import_labels_into_detector_from_file
-
-            try:
-                applied, skipped = import_labels_into_detector_from_file(
-                    args.import_labels_into,
-                    args.label_importer,
-                    args.label_importer_file,
-                )
+            if dry_run:
                 print(
-                    f"Imported {applied} label(s) into detector "
-                    f"'{args.import_labels_into}' (skipped {skipped} duplicate/invalid).",
+                    f"DRY RUN — would import labels from {args.label_importer_file!r} "
+                    f"via importer {args.label_importer!r} into detector "
+                    f"{args.import_labels_into!r}.",
                     flush=True,
                 )
-            except (FileNotFoundError, ValueError) as exc:
-                print(f"Error importing labels: {exc}", file=sys.stderr)
-                sys.exit(1)
+                print("", flush=True)
+            else:
+                from vtsearch.cli import import_labels_into_detector_from_file
+
+                try:
+                    applied, skipped = import_labels_into_detector_from_file(
+                        args.import_labels_into,
+                        args.label_importer,
+                        args.label_importer_file,
+                    )
+                    print(
+                        f"Imported {applied} label(s) into detector "
+                        f"'{args.import_labels_into}' (skipped {skipped} duplicate/invalid).",
+                        flush=True,
+                    )
+                except (FileNotFoundError, ValueError) as exc:
+                    print(f"Error importing labels: {exc}", file=sys.stderr)
+                    sys.exit(1)
 
         if args.importer:
             # Importer-based path
@@ -606,13 +628,24 @@ if __name__ == "__main__":
                 from vtsearch.cli import autodetect_importer_main_chunked
 
                 autodetect_importer_main_chunked(
-                    args.importer, field_values, chunk_size, settings_path, args.exporter, exporter_field_values
+                    args.importer,
+                    field_values,
+                    chunk_size,
+                    settings_path,
+                    args.exporter,
+                    exporter_field_values,
+                    dry_run=dry_run,
                 )
             else:
                 from vtsearch.cli import autodetect_importer_main
 
                 autodetect_importer_main(
-                    args.importer, field_values, settings_path, args.exporter, exporter_field_values
+                    args.importer,
+                    field_values,
+                    settings_path,
+                    args.exporter,
+                    exporter_field_values,
+                    dry_run=dry_run,
                 )
 
         elif args.dataset:
@@ -620,11 +653,24 @@ if __name__ == "__main__":
             if chunk_size:
                 from vtsearch.cli import autodetect_main_chunked
 
-                autodetect_main_chunked(args.dataset, chunk_size, settings_path, args.exporter, exporter_field_values)
+                autodetect_main_chunked(
+                    args.dataset,
+                    chunk_size,
+                    settings_path,
+                    args.exporter,
+                    exporter_field_values,
+                    dry_run=dry_run,
+                )
             else:
                 from vtsearch.cli import autodetect_main
 
-                autodetect_main(args.dataset, settings_path, args.exporter, exporter_field_values)
+                autodetect_main(
+                    args.dataset,
+                    settings_path,
+                    args.exporter,
+                    exporter_field_values,
+                    dry_run=dry_run,
+                )
 
         else:
             parser.error("--autodetect requires either --dataset <file.pkl> or --importer <name>")

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -74,6 +74,49 @@ Predicted Good (5 items):
 
 Items with origin information include the origin display string before the filename.
 
+### Dry-run mode
+
+Add `--dry-run` to any `--autodetect` invocation to print the plan
+without loading media, training detectors, scoring, or exporting:
+
+```bash
+python app.py --autodetect --dataset data.pkl --settings settings.json --dry-run
+python app.py --autodetect --importer server_folder --path /data/sounds \
+    --media-type audio --settings settings.json --exporter server_json_file \
+    --filepath out.json --dry-run
+```
+
+The output names the source (pickle file or importer + params), the
+settings file, every detector listed under `autorun_detectors` (with its
+media type and label count), and the exporter + its field values:
+
+```
+DRY RUN — no media will be loaded, embedded, scored, or exported.
+
+Source:
+  Importer: server_folder
+  Params:
+    path: /data/sounds
+    media_type: audio
+  Chunk size: whole dataset
+
+Settings: settings.json
+Autorun detectors (2):
+  - Dog Barks  [media_type=audio, labels=12, file=data/detectors/Dog Barks.json]
+  - Cat Meows  [media_type=audio, labels=8, file=data/detectors/Cat Meows.json]
+
+Exporter: server_json_file
+  filepath: out.json
+```
+
+`--dry-run` validates importer and exporter names, checks that the
+dataset pickle (if given) exists, verifies required CLI fields are
+populated, and reports any detector JSON files that are missing — so
+typos in a cron-style invocation fail immediately instead of after a
+multi-minute embedding pass. `--import-labels-into ... --label-importer-file ...`
+is announced as part of the plan but skipped (no detector JSON is
+modified).
+
 ## Web server modes
 
 **Development (Flask dev server)** — bind to `0.0.0.0:5000`:

--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -685,8 +685,8 @@ Already designed in `docs/design/cli-detector-converter.md`; ship it.
 ### 17.4 Watch mode ★ S
 `--watch /path/to/inbox` re-runs autodetect whenever new files appear.
 
-### 17.5 Dry-run mode ★ XS
-`--dry-run` prints what would be embedded/scored/exported without doing it.
+### 17.5 Dry-run mode ★ XS ✅ shipped
+`--dry-run` prints what would be embedded/scored/exported without doing it. Validates importer/exporter names, settings file, dataset pickle existence, and required CLI field values, but loads no media and trains no models. See [CLI.md § Dry-run mode](../CLI.md#dry-run-mode).
 
 ### 17.6 Progress JSON output ★ S
 `--progress-format json` for scripted callers / CI integration.

--- a/tests/cli/test_cli_dry_run.py
+++ b/tests/cli/test_cli_dry_run.py
@@ -1,0 +1,260 @@
+"""Tests for the ``--dry-run`` autodetect mode.
+
+The dry-run path must print the plan derived from the command-line
+arguments + the settings file and return immediately — without consuming
+the media-source iterator, training any detectors, or invoking the
+exporter. It must still validate importer/exporter names, the dataset
+pickle's existence, and any required CLI fields so misconfiguration
+fails fast.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+import app as app_module
+from helpers import make_dataset_file as _make_dataset_file
+from vtsearch.settings import get_detectors_dir
+
+
+@pytest.fixture(autouse=True)
+def _clean_tm_dir():
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+    yield
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+
+
+def _write_trainable_model(name: str, labelset: dict, media_type: str = "audio") -> Path:
+    from vtsearch.detectors.store import _detector_path, _write_detector
+
+    path = _detector_path(name)
+    _write_detector(
+        path,
+        {
+            "name": name,
+            "text_query": "",
+            "media_type": media_type,
+            "examples": [],
+            "labelset": labelset,
+        },
+    )
+    return path
+
+
+def _settings_file_with_detectors(tmp_path: Path, tm_names: list[str]) -> Path:
+    settings = {
+        "autorun_detectors": list(tm_names),
+        "detectors_dir": str(get_detectors_dir()),
+    }
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps(settings))
+    return settings_path
+
+
+def _make_labelset_with_two_audio_labels() -> dict:
+    return {
+        "labels": [
+            {
+                "md5": "a" * 32,
+                "label": "good",
+                "origin": {"importer": "ds_a", "params": {}},
+                "origin_name": "alpha.wav",
+            },
+            {
+                "md5": "b" * 32,
+                "label": "bad",
+                "origin": {"importer": "ds_a", "params": {}},
+                "origin_name": "beta.wav",
+            },
+        ]
+    }
+
+
+class TestDryRunPickle:
+    def test_dry_run_pickle_prints_plan_and_writes_nothing(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+        out_path = tmp_path / "results.json"
+
+        from vtsearch.cli import autodetect_main
+
+        autodetect_main(
+            str(dataset_path),
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(out_path)},
+            dry_run=True,
+        )
+
+        captured = capsys.readouterr()
+        out = captured.out
+        assert "DRY RUN" in out
+        assert "Dataset pickle:" in out
+        assert str(dataset_path) in out
+        assert "Autorun detectors (1)" in out
+        assert "dry-tm" in out
+        assert "media_type=audio" in out
+        assert "labels=2" in out
+        assert "Exporter: server_json_file" in out
+        assert str(out_path) in out
+        # Critical: no exporter ran.
+        assert not out_path.exists()
+
+    def test_dry_run_pickle_reports_chunk_size(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtsearch.cli import autodetect_main_chunked
+
+        autodetect_main_chunked(
+            str(dataset_path),
+            chunk_size=250,
+            settings_path=str(settings_path),
+            dry_run=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Chunk size: 250" in out
+
+    def test_dry_run_missing_dataset_file_errors(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+        bogus = tmp_path / "does-not-exist.pkl"
+
+        from vtsearch.cli import autodetect_main
+
+        with pytest.raises(SystemExit):
+            autodetect_main(str(bogus), settings_path=str(settings_path), dry_run=True)
+
+        err = capsys.readouterr().err
+        assert "does-not-exist.pkl" in err
+
+    def test_dry_run_missing_detector_flagged(self, client, tmp_path, capsys):
+        # No detector JSON written for "ghost-tm".
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["ghost-tm"])
+
+        from vtsearch.cli import autodetect_main
+
+        autodetect_main(str(dataset_path), settings_path=str(settings_path), dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "ghost-tm" in out
+        assert "MISSING" in out
+
+    def test_dry_run_empty_autorun_list_calls_it_out(self, client, tmp_path, capsys):
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, [])
+
+        from vtsearch.cli import autodetect_main
+
+        autodetect_main(str(dataset_path), settings_path=str(settings_path), dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Autorun detectors: (none" in out
+
+
+class TestDryRunImporter:
+    def test_dry_run_importer_prints_params(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtsearch.cli import autodetect_importer_main
+
+        autodetect_importer_main(
+            "server_folder",
+            {"path": "/data/sounds", "media_type": "audio"},
+            settings_path=str(settings_path),
+            dry_run=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Importer: server_folder" in out
+        assert "path: /data/sounds" in out
+        assert "media_type: audio" in out
+
+    def test_dry_run_importer_validates_required_fields(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtsearch.cli import autodetect_importer_main
+
+        # server_folder requires "path" — empty value should error during dry-run.
+        with pytest.raises(SystemExit):
+            autodetect_importer_main(
+                "server_folder",
+                {"path": "", "media_type": "audio"},
+                settings_path=str(settings_path),
+                dry_run=True,
+            )
+
+        err = capsys.readouterr().err
+        assert "--path" in err or "Missing required" in err
+
+    def test_dry_run_unknown_importer_errors(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtsearch.cli import autodetect_importer_main
+
+        with pytest.raises(SystemExit):
+            autodetect_importer_main(
+                "no_such_importer",
+                {},
+                settings_path=str(settings_path),
+                dry_run=True,
+            )
+
+        err = capsys.readouterr().err
+        assert "no_such_importer" in err
+
+
+class TestDryRunExporterValidation:
+    def test_dry_run_unknown_exporter_errors(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtsearch.cli import autodetect_main
+
+        with pytest.raises(SystemExit):
+            autodetect_main(
+                str(dataset_path),
+                settings_path=str(settings_path),
+                exporter_name="no_such_exporter",
+                exporter_field_values={},
+                dry_run=True,
+            )
+
+        err = capsys.readouterr().err
+        assert "no_such_exporter" in err
+
+    def test_dry_run_missing_required_exporter_field_errors(self, client, tmp_path, capsys):
+        _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
+
+        from vtsearch.cli import autodetect_main
+
+        # server_json_file requires "filepath".
+        with pytest.raises(SystemExit):
+            autodetect_main(
+                str(dataset_path),
+                settings_path=str(settings_path),
+                exporter_name="server_json_file",
+                exporter_field_values={},
+                dry_run=True,
+            )
+
+        err = capsys.readouterr().err
+        assert "--filepath" in err or "Missing required" in err

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -24,6 +24,87 @@ def _list_importer_names() -> list[str]:
     return [imp.name for imp in list_importers()]
 
 
+def _summarize_autorun_detectors(detector_names: list[str]) -> list[dict[str, Any]]:
+    """Read each named detector's on-disk JSON and return a small summary.
+
+    Used by ``--dry-run`` to describe which detectors would be trained and
+    scored without actually loading models or embedding any media.
+    """
+    from vtsearch.detectors.store import _detector_path, _read_detector
+
+    summaries: list[dict[str, Any]] = []
+    for name in detector_names:
+        path = _detector_path(name)
+        data = _read_detector(path)
+        if data is None:
+            summaries.append({"name": name, "path": str(path), "missing": True})
+            continue
+        labelset = data.get("labelset") or {}
+        labels = labelset.get("labels") if isinstance(labelset, dict) else None
+        n_labels = len(labels) if isinstance(labels, list) else 0
+        summaries.append(
+            {
+                "name": name,
+                "path": str(path),
+                "media_type": data.get("media_type", "") or "",
+                "labels": n_labels,
+                "missing": False,
+            }
+        )
+    return summaries
+
+
+def _print_dry_run_plan(
+    *,
+    source_description: dict[str, Any],
+    settings_path: str | None,
+    autorun_detectors: list[str],
+    exporter_name: str | None,
+    exporter_field_values: dict[str, Any] | None,
+) -> None:
+    """Print the autodetect plan that ``--dry-run`` would otherwise execute."""
+    print("DRY RUN — no media will be loaded, embedded, scored, or exported.", flush=True)
+    print("", flush=True)
+
+    print("Source:", flush=True)
+    kind = source_description.get("kind", "")
+    if kind == "pickle":
+        print(f"  Dataset pickle: {source_description.get('dataset', '')}", flush=True)
+    elif kind == "importer":
+        print(f"  Importer: {source_description.get('importer', '')}", flush=True)
+        params = source_description.get("params") or {}
+        if params:
+            print("  Params:", flush=True)
+            for k, v in params.items():
+                print(f"    {k}: {v if v != '' else '(empty)'}", flush=True)
+        else:
+            print("  Params: (none)", flush=True)
+    chunk_size = source_description.get("chunk_size")
+    print(f"  Chunk size: {chunk_size if chunk_size else 'whole dataset'}", flush=True)
+    print("", flush=True)
+
+    print(f"Settings: {settings_path or '(default: data/settings.json)'}", flush=True)
+    if not autorun_detectors:
+        print("Autorun detectors: (none — pipeline would abort with an error)", flush=True)
+    else:
+        summaries = _summarize_autorun_detectors(autorun_detectors)
+        print(f"Autorun detectors ({len(summaries)}):", flush=True)
+        for s in summaries:
+            if s.get("missing"):
+                print(f"  - {s['name']}  [MISSING — {s['path']}]", flush=True)
+            else:
+                print(
+                    f"  - {s['name']}  [media_type={s['media_type'] or '?'}, labels={s['labels']}, file={s['path']}]",
+                    flush=True,
+                )
+    print("", flush=True)
+
+    print(f"Exporter: {exporter_name or 'gui (default — print to console)'}", flush=True)
+    if exporter_field_values:
+        for k, v in exporter_field_values.items():
+            print(f"  {k}: {v if v != '' else '(empty)'}", flush=True)
+
+
 def _list_exporter_names() -> list[str]:
     """Return the names of all registered exporters."""
     from vtsearch.exporters import list_exporters
@@ -308,12 +389,18 @@ def _run_pipeline(
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
     empty_error: str = "No medias loaded",
+    dry_run: bool = False,
+    source_description: dict[str, Any] | None = None,
 ) -> None:
     """Shared pipeline: read settings, iterate media chunks, score, export.
 
     All four CLI entry points (pickle / importer, whole / chunked) delegate
     to this single function, differing only in the *media_source* iterator
     they supply.
+
+    When *dry_run* is True the function prints the plan derived from
+    *source_description* + the settings file and returns without consuming
+    the iterator, so no importer runs and no embedding or scoring occurs.
     """
     if settings_path:
         from vtsearch.settings import set_settings_path
@@ -321,6 +408,39 @@ def _run_pipeline(
         set_settings_path(settings_path)
 
     from vtsearch.settings import get_autorun_detectors
+
+    if dry_run:
+        sd = source_description or {}
+        if sd.get("kind") == "pickle":
+            dataset = sd.get("dataset", "")
+            if dataset and not Path(dataset).exists():
+                raise FileNotFoundError(f"Dataset file not found: {dataset}")
+        elif sd.get("kind") == "importer":
+            from vtsearch.datasets.importers import get_importer
+
+            importer_name = sd.get("importer", "")
+            importer = get_importer(importer_name)
+            if importer is None:
+                available = _list_importer_names()
+                raise ValueError(f"Unknown importer: {importer_name}. Available: {', '.join(available)}")
+            importer.validate_cli_field_values(sd.get("params") or {})
+
+        if exporter_name:
+            from vtsearch.exporters import get_exporter
+
+            exporter = get_exporter(exporter_name)
+            if exporter is None:
+                available = _list_exporter_names()
+                raise ValueError(f"Unknown exporter: {exporter_name}. Available: {', '.join(available)}")
+            exporter.validate_cli_field_values(exporter_field_values or {})
+        _print_dry_run_plan(
+            source_description=source_description or {},
+            settings_path=settings_path,
+            autorun_detectors=get_autorun_detectors(),
+            exporter_name=exporter_name,
+            exporter_field_values=exporter_field_values,
+        )
+        return
 
     merged_results: dict[str, dict[str, Any]] = {}
     media_type: str | None = None
@@ -375,15 +495,19 @@ def autodetect_main(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
+    *,
+    dry_run: bool = False,
 ) -> None:
     """CLI entry point: run autodetect with all autorun detectors."""
     try:
         _run_pipeline(
-            _load_pickle_whole(dataset_path),
+            _load_pickle_whole(dataset_path) if not dry_run else iter(()),
             settings_path=settings_path,
             exporter_name=exporter_name,
             exporter_field_values=exporter_field_values,
             empty_error=f"No medias loaded from dataset: {dataset_path}",
+            dry_run=dry_run,
+            source_description={"kind": "pickle", "dataset": dataset_path, "chunk_size": None},
         )
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -396,15 +520,24 @@ def autodetect_importer_main(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
+    *,
+    dry_run: bool = False,
 ) -> None:
     """CLI entry point: run autodetect with a named importer and output results."""
     try:
         _run_pipeline(
-            _load_importer_whole(importer_name, field_values),
+            _load_importer_whole(importer_name, field_values) if not dry_run else iter(()),
             settings_path=settings_path,
             exporter_name=exporter_name,
             exporter_field_values=exporter_field_values,
             empty_error=f"No medias loaded by importer '{importer_name}'",
+            dry_run=dry_run,
+            source_description={
+                "kind": "importer",
+                "importer": importer_name,
+                "params": field_values,
+                "chunk_size": None,
+            },
         )
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -417,15 +550,19 @@ def autodetect_main_chunked(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
+    *,
+    dry_run: bool = False,
 ) -> None:
     """CLI entry point: chunked autodetect on a pickle dataset."""
     try:
         _run_pipeline(
-            _load_pickle_chunked(dataset_path, chunk_size),
+            _load_pickle_chunked(dataset_path, chunk_size) if not dry_run else iter(()),
             settings_path=settings_path,
             exporter_name=exporter_name,
             exporter_field_values=exporter_field_values,
             empty_error=f"No medias loaded from dataset: {dataset_path}",
+            dry_run=dry_run,
+            source_description={"kind": "pickle", "dataset": dataset_path, "chunk_size": chunk_size},
         )
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -439,15 +576,24 @@ def autodetect_importer_main_chunked(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
+    *,
+    dry_run: bool = False,
 ) -> None:
     """CLI entry point: chunked autodetect with a named importer."""
     try:
         _run_pipeline(
-            _load_importer_chunked(importer_name, field_values, chunk_size),
+            _load_importer_chunked(importer_name, field_values, chunk_size) if not dry_run else iter(()),
             settings_path=settings_path,
             exporter_name=exporter_name,
             exporter_field_values=exporter_field_values,
             empty_error=f"No medias loaded by importer '{importer_name}'",
+            dry_run=dry_run,
+            source_description={
+                "kind": "importer",
+                "importer": importer_name,
+                "params": field_values,
+                "chunk_size": chunk_size,
+            },
         )
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Implements **17.5 Dry-run mode** from `docs/plans/feature-brainstorm.md`.

`python app.py --autodetect ... --dry-run` prints the plan (source, settings file, autorun detectors, exporter + field values) and returns without loading any media, training MLPs, scoring, or invoking the exporter. Validates importer/exporter names, dataset pickle existence, and required CLI fields so misconfigured cron-style invocations fail fast instead of after a multi-minute embedding pass.

- `vtsearch/cli.py` — `_print_dry_run_plan()` + `_summarize_autorun_detectors()`; `_run_pipeline()` takes `dry_run` / `source_description` and short-circuits; all four `autodetect_*_main` entry points expose `dry_run=False`.
- `app.py` — `--dry-run` flag; threaded to the four entry points; `--import-labels-into` is announced as part of the plan but skipped (no detector JSON written).
- `docs/CLI.md` — new "Dry-run mode" subsection with example output.
- `docs/plans/feature-brainstorm.md` — 17.5 marked shipped, links to the CLI doc.
- `tests/cli/test_cli_dry_run.py` — 10 new tests covering pickle / importer / chunked paths, plus validation failures for missing pickle, missing detector JSON, unknown importer/exporter, and missing required fields.

Example output (importer path):

```
DRY RUN — no media will be loaded, embedded, scored, or exported.

Source:
  Importer: server_folder
  Params:
    path: /data/sounds
    media_type: audio
  Chunk size: whole dataset

Settings: settings.json
Autorun detectors (2):
  - Dog Barks  [media_type=audio, labels=12, file=data/detectors/Dog Barks.json]
  - Cat Meows  [media_type=audio, labels=8, file=data/detectors/Cat Meows.json]

Exporter: server_json_file
  filepath: out.json
```

## Test plan

- [x] `./run-tests.sh cli` — 99 passed
- [x] `./run-tests.sh` — 3491 passed, 1 skipped
- [x] `ruff check .` / `ruff format --check .`
- [x] End-to-end smoke: `python app.py --autodetect --importer server_folder --path /data/sounds --media-type audio --settings ... --exporter server_json_file --filepath ... --dry-run` prints the plan, writes nothing
- [x] End-to-end smoke: missing pickle errors via `--dry-run` with exit code 1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGa4U3hb9nq2eTXT5vU1X4)_