### PR TITLE
Migrate processors blueprint to flask-smorest

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,7 +63,8 @@ from vtsearch.routes import (  # noqa: E402
     exporters_bp,
     label_importers_bp,
     main_bp,
-    processors_bp,
+    processors_crud_bp,
+    processors_scoring_bp,
     settings_bp,
     settings_io_bp,
     sorting_bp,
@@ -318,7 +319,8 @@ app.register_blueprint(media_server_bp)
 api.register_blueprint(main_bp)
 app.register_blueprint(medias_bp)
 app.register_blueprint(sorting_bp)
-app.register_blueprint(processors_bp)
+api.register_blueprint(processors_crud_bp)
+api.register_blueprint(processors_scoring_bp)
 app.register_blueprint(datasets_listings_bp)
 app.register_blueprint(datasets_status_bp)
 app.register_blueprint(datasets_staging_bp)

--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -311,6 +311,22 @@ request/response gates getting in the way during their migration.
       ``detectors/registry/from-labelset/<imp>``). Labelset-element
       tests in ``tests/detectors/test_labelset_elements_api.py``
       updated to match.
+- [x] `processors/crud.py` and `processors/scoring.py` migrated to
+      flask-smorest (autorun-extractor / autorun-localizer CRUD,
+      pregen-processor list/add, single-shot extract/localize, and
+      auto-extract/auto-localize). Schema-level validation failures
+      (missing required ``name`` / ``media_type`` / ``extractor_type`` /
+      ``localizer_type`` / ``config``) surface as 422 with the standard
+      ``errors`` envelope; handler-level rejects (no medias loaded,
+      media-type mismatch, unbuildable config, rename collisions, no
+      autorun processors for active media type) keep their HTTP codes
+      (400 / 404) with the standard ``message`` envelope. The shared
+      sub-package ``processors_bp`` aggregator is gone — both
+      blueprints are now registered directly with the flask-smorest
+      ``Api`` in ``app.py`` (mirroring the ``detectors/`` layout).
+      Extractor tests in ``tests/detectors/test_extractors.py`` and the
+      cross-cutting checks in ``tests/integration/test_multi_media_coverage.py``
+      updated to match.
 - [ ] Frontend `SettingsApiService` rewired to generated client
 - [ ] `frontend/src/app/models/api.models.ts` settings section deleted
 - [ ] Remaining blueprints (see Order above)

--- a/tests/detectors/test_extractors.py
+++ b/tests/detectors/test_extractors.py
@@ -219,7 +219,7 @@ class TestAutorunExtractors:
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
 
-    def test_add_missing_name_returns_400(self, client):
+    def test_add_missing_name_returns_422(self, client):
         resp = client.post(
             "/api/autorun-extractors",
             json={
@@ -228,9 +228,9 @@ class TestAutorunExtractors:
                 "config": {"target_class": "person"},
             },
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
-    def test_add_missing_extractor_type_returns_400(self, client):
+    def test_add_missing_extractor_type_returns_422(self, client):
         resp = client.post(
             "/api/autorun-extractors",
             json={
@@ -239,9 +239,9 @@ class TestAutorunExtractors:
                 "config": {"target_class": "person"},
             },
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
-    def test_add_missing_media_type_returns_400(self, client):
+    def test_add_missing_media_type_returns_422(self, client):
         resp = client.post(
             "/api/autorun-extractors",
             json={
@@ -250,9 +250,9 @@ class TestAutorunExtractors:
                 "config": {"target_class": "person"},
             },
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
-    def test_add_missing_config_returns_400(self, client):
+    def test_add_missing_config_returns_422(self, client):
         resp = client.post(
             "/api/autorun-extractors",
             json={
@@ -261,7 +261,7 @@ class TestAutorunExtractors:
                 "media_type": "image",
             },
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
     def test_add_multiple(self, client):
         self._post_extractor(client, "ext-a")
@@ -320,13 +320,13 @@ class TestAutorunExtractors:
         )
         assert resp.status_code == 400
 
-    def test_rename_missing_new_name_returns_400(self, client):
+    def test_rename_missing_new_name_returns_422(self, client):
         self._post_extractor(client, "some-ext")
         resp = client.put(
             "/api/autorun-extractors/some-ext/rename",
             json={},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
     # -- stored data --
 
@@ -360,7 +360,7 @@ class TestExtractEndpoint:
                 json={"extractor_type": "image_class", "config": {"target_class": "person"}},
             )
             assert resp.status_code == 400
-            assert "No medias loaded" in resp.get_json()["error"]
+            assert "No medias loaded" in resp.get_json()["message"]
         finally:
             medias.update(saved)
 
@@ -371,15 +371,15 @@ class TestExtractEndpoint:
             json={"extractor_type": "image_class", "config": {"target_class": "person"}},
         )
         assert resp.status_code == 400
-        assert "does not match" in resp.get_json()["error"]
+        assert "does not match" in resp.get_json()["message"]
 
     def test_extract_missing_extractor_type(self, client):
         resp = client.post("/api/extract", json={"config": {"target_class": "person"}})
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
     def test_extract_missing_config(self, client):
         resp = client.post("/api/extract", json={"extractor_type": "image_class"})
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------
@@ -402,7 +402,7 @@ class TestAutoExtract:
     def test_no_extractors_returns_400(self, client):
         resp = client.post("/api/auto-extract")
         assert resp.status_code == 400
-        assert "No autorun extractors" in resp.get_json()["error"]
+        assert "No autorun extractors" in resp.get_json()["message"]
 
     def test_no_matching_media_type_returns_400(self, client):
         # Clips are audio; add an image extractor

--- a/tests/integration/test_multi_media_coverage.py
+++ b/tests/integration/test_multi_media_coverage.py
@@ -370,15 +370,15 @@ class TestExampleSortOrigin:
 class TestExtractEndpoint:
     """POST /api/extract — run a single extractor."""
 
-    def test_missing_extractor_type_returns_400(self, client):
+    def test_missing_extractor_type_returns_422(self, client):
         resp = client.post("/api/extract", json={"name": "test", "config": {"foo": 1}})
-        assert resp.status_code == 400
-        assert "extractor_type" in resp.get_json()["error"].lower()
+        assert resp.status_code == 422
+        assert "extractor_type" in str(resp.get_json()).lower()
 
-    def test_missing_config_returns_400(self, client):
+    def test_missing_config_returns_422(self, client):
         resp = client.post("/api/extract", json={"name": "test", "extractor_type": "image_class"})
-        assert resp.status_code == 400
-        assert "config" in resp.get_json()["error"].lower()
+        assert resp.status_code == 422
+        assert "config" in str(resp.get_json()).lower()
 
     def test_unknown_type_returns_400(self, client):
         resp = client.post(
@@ -398,7 +398,7 @@ class TestExtractEndpoint:
         )
         # Default medias are audio; image_class extractor expects image
         assert resp.status_code == 400
-        assert "media type" in resp.get_json()["error"].lower()
+        assert "media type" in resp.get_json()["message"].lower()
 
     def test_no_medias_returns_400(self, client):
         saved = dict(medias)
@@ -413,7 +413,7 @@ class TestExtractEndpoint:
                 },
             )
             assert resp.status_code == 400
-            assert "No medias" in resp.get_json()["error"]
+            assert "No medias" in resp.get_json()["message"]
         finally:
             medias.clear()
             medias.update(saved)
@@ -428,7 +428,7 @@ class TestAutoExtractEndpoint:
         try:
             resp = client.post("/api/auto-extract")
             assert resp.status_code == 400
-            assert "No medias" in resp.get_json()["error"]
+            assert "No medias" in resp.get_json()["message"]
         finally:
             medias.clear()
             medias.update(saved)
@@ -436,7 +436,7 @@ class TestAutoExtractEndpoint:
     def test_no_autorun_extractors_returns_400(self, client):
         resp = client.post("/api/auto-extract")
         assert resp.status_code == 400
-        assert "No autorun extractors" in resp.get_json()["error"]
+        assert "No autorun extractors" in resp.get_json()["message"]
 
 
 class TestAutoLocalizeEndpoint:
@@ -448,7 +448,7 @@ class TestAutoLocalizeEndpoint:
         try:
             resp = client.post("/api/auto-localize")
             assert resp.status_code == 400
-            assert "No medias" in resp.get_json()["error"]
+            assert "No medias" in resp.get_json()["message"]
         finally:
             medias.clear()
             medias.update(saved)
@@ -456,7 +456,7 @@ class TestAutoLocalizeEndpoint:
     def test_no_autorun_localizers_returns_400(self, client):
         resp = client.post("/api/auto-localize")
         assert resp.status_code == 400
-        assert "No autorun localizers" in resp.get_json()["error"]
+        assert "No autorun localizers" in resp.get_json()["message"]
 
 
 # ===================================================================

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -23,7 +23,7 @@ from vtsearch.routes.file_browser import file_browser_bp
 from vtsearch.routes.labels import exporters_bp, label_importers_bp, labels_bp
 from vtsearch.routes.main import main_bp
 from vtsearch.routes.media import embed_bp, media_server_bp, medias_bp
-from vtsearch.routes.processors import processors_bp
+from vtsearch.routes.processors import processors_crud_bp, processors_scoring_bp
 from vtsearch.routes.settings import settings_bp, settings_io_bp, sync_sources_bp
 from vtsearch.routes.sorting import sorting_bp
 
@@ -51,7 +51,8 @@ __all__ = [
     "main_bp",
     "media_server_bp",
     "medias_bp",
-    "processors_bp",
+    "processors_crud_bp",
+    "processors_scoring_bp",
     "settings_bp",
     "settings_io_bp",
     "sorting_bp",

--- a/vtsearch/routes/processors/__init__.py
+++ b/vtsearch/routes/processors/__init__.py
@@ -1,8 +1,6 @@
-"""Blueprint for extractor, localizer, and pregen-processor routes."""
+"""Blueprint exports for extractor, localizer, and pregen-processor routes."""
 
 from __future__ import annotations
-
-from flask import Blueprint
 
 from vtsearch.routes.processors.crud import (  # noqa: F401
     _EXTRACTOR_FACTORIES,
@@ -15,7 +13,7 @@ from vtsearch.routes.processors.crud import (  # noqa: F401
 )
 from vtsearch.routes.processors.scoring import processors_scoring_bp  # noqa: F401
 
-processors_bp = Blueprint("processors", __name__)
-
-processors_bp.register_blueprint(processors_crud_bp)
-processors_bp.register_blueprint(processors_scoring_bp)
+__all__ = [
+    "processors_crud_bp",
+    "processors_scoring_bp",
+]

--- a/vtsearch/routes/processors/crud.py
+++ b/vtsearch/routes/processors/crud.py
@@ -1,10 +1,25 @@
-"""CRUD routes for autorun extractors, localizers, and pregen processors."""
+"""CRUD routes for autorun extractors, localizers, and pregen processors.
+
+Migrated to ``flask_smorest`` so the routes are described in
+``/api/openapi.json``. See ``docs/plans/openapi-schema.md``.
+"""
 
 from __future__ import annotations
 
-from flask import Blueprint, jsonify
+from flask_smorest import Blueprint, abort
 
-from vtsearch.routes._shared import get_json_or_400
+from vtsearch.schemas.processors import (
+    AutorunExtractorCreateRequestSchema,
+    AutorunExtractorsListResponseSchema,
+    AutorunLocalizerCreateRequestSchema,
+    AutorunLocalizersListResponseSchema,
+    AutorunProcessorCreateResponseSchema,
+    AutorunProcessorDeleteResponseSchema,
+    AutorunProcessorRenameRequestSchema,
+    AutorunProcessorRenameResponseSchema,
+    PregenProcessorsAddResponseSchema,
+    PregenProcessorsListResponseSchema,
+)
 from vtsearch.state import (
     add_autorun_extractor,
     add_autorun_localizer,
@@ -16,7 +31,11 @@ from vtsearch.state import (
     rename_autorun_localizer,
 )
 
-processors_crud_bp = Blueprint("processors_crud", __name__)
+processors_crud_bp = Blueprint(
+    "processors_crud",
+    __name__,
+    description="Manage autorun extractors / localizers and the bundled pregen-processor list.",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -55,65 +74,53 @@ def _build_extractor(name: str, extractor_type: str, config: dict):
 
 
 @processors_crud_bp.route("/api/autorun-extractors")
+@processors_crud_bp.response(200, AutorunExtractorsListResponseSchema)
 def get_autorun_extractors_route():
     """Get all autorun extractors."""
     extractors = get_autorun_extractors()
-    return jsonify({"extractors": list(extractors.values())})
+    return {"extractors": list(extractors.values())}
 
 
 @processors_crud_bp.route("/api/autorun-extractors", methods=["POST"])
-def add_autorun_extractor_route():
+@processors_crud_bp.arguments(AutorunExtractorCreateRequestSchema)
+@processors_crud_bp.response(200, AutorunProcessorCreateResponseSchema)
+@processors_crud_bp.alt_response(400, description="Unbuildable extractor config.")
+def add_autorun_extractor_route(body: dict):
     """Add a new autorun extractor."""
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
+    name = body["name"].strip()
+    extractor_type = body["extractor_type"].strip()
+    media_type = body["media_type"].strip()
+    config = body["config"]
 
-    name = data.get("name", "").strip()
-    extractor_type = data.get("extractor_type", "").strip()
-    media_type = data.get("media_type", "").strip()
-    config = data.get("config")
-
-    if not name:
-        return jsonify({"error": "name is required"}), 400
-    if not extractor_type:
-        return jsonify({"error": "extractor_type is required"}), 400
-    if not media_type:
-        return jsonify({"error": "media_type is required"}), 400
-    if not config or not isinstance(config, dict):
-        return jsonify({"error": "config is required"}), 400
-
-    # Validate that the extractor can be built from this config
     try:
         _build_extractor(name, extractor_type, config)
     except Exception as e:
-        return jsonify({"error": f"Invalid extractor config: {e}"}), 400
+        abort(400, message=f"Invalid extractor config: {e}")
 
     add_autorun_extractor(name, extractor_type, media_type, config)
-    return jsonify({"success": True, "name": name})
+    return {"success": True, "name": name}
 
 
 @processors_crud_bp.route("/api/autorun-extractors/<name>", methods=["DELETE"])
-def delete_autorun_extractor_route(name):
+@processors_crud_bp.response(200, AutorunProcessorDeleteResponseSchema)
+@processors_crud_bp.alt_response(404, description="Extractor not found.")
+def delete_autorun_extractor_route(name: str):
     """Delete a autorun extractor."""
     if remove_autorun_extractor(name):
-        return jsonify({"success": True})
-    return jsonify({"error": "Extractor not found"}), 404
+        return {"success": True}
+    abort(404, message="Extractor not found")
 
 
 @processors_crud_bp.route("/api/autorun-extractors/<name>/rename", methods=["PUT"])
-def rename_autorun_extractor_route(name):
+@processors_crud_bp.arguments(AutorunProcessorRenameRequestSchema)
+@processors_crud_bp.response(200, AutorunProcessorRenameResponseSchema)
+@processors_crud_bp.alt_response(400, description="Extractor not found, or new name already exists.")
+def rename_autorun_extractor_route(body: dict, name: str):
     """Rename a autorun extractor."""
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    new_name = data.get("new_name", "").strip()
-    if not new_name:
-        return jsonify({"error": "new_name is required"}), 400
-
+    new_name = body["new_name"].strip()
     if rename_autorun_extractor(name, new_name):
-        return jsonify({"success": True, "new_name": new_name})
-    return jsonify({"error": "Extractor not found or new name already exists"}), 400
+        return {"success": True, "new_name": new_name}
+    abort(400, message="Extractor not found or new name already exists")
 
 
 # ---------------------------------------------------------------------------
@@ -143,64 +150,53 @@ def _build_localizer(name: str, localizer_type: str, config: dict):
 
 
 @processors_crud_bp.route("/api/autorun-localizers")
+@processors_crud_bp.response(200, AutorunLocalizersListResponseSchema)
 def get_autorun_localizers_route():
     """Get all autorun localizers."""
     localizers = get_autorun_localizers()
-    return jsonify({"localizers": list(localizers.values())})
+    return {"localizers": list(localizers.values())}
 
 
 @processors_crud_bp.route("/api/autorun-localizers", methods=["POST"])
-def add_autorun_localizer_route():
+@processors_crud_bp.arguments(AutorunLocalizerCreateRequestSchema)
+@processors_crud_bp.response(200, AutorunProcessorCreateResponseSchema)
+@processors_crud_bp.alt_response(400, description="Unbuildable localizer config.")
+def add_autorun_localizer_route(body: dict):
     """Add a new autorun localizer."""
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    name = data.get("name", "").strip()
-    localizer_type = data.get("localizer_type", "").strip()
-    media_type = data.get("media_type", "").strip()
-    config = data.get("config")
-
-    if not name:
-        return jsonify({"error": "name is required"}), 400
-    if not localizer_type:
-        return jsonify({"error": "localizer_type is required"}), 400
-    if not media_type:
-        return jsonify({"error": "media_type is required"}), 400
-    if not config or not isinstance(config, dict):
-        return jsonify({"error": "config is required"}), 400
+    name = body["name"].strip()
+    localizer_type = body["localizer_type"].strip()
+    media_type = body["media_type"].strip()
+    config = body["config"]
 
     try:
         _build_localizer(name, localizer_type, config)
     except Exception as e:
-        return jsonify({"error": f"Invalid localizer config: {e}"}), 400
+        abort(400, message=f"Invalid localizer config: {e}")
 
     add_autorun_localizer(name, localizer_type, media_type, config)
-    return jsonify({"success": True, "name": name})
+    return {"success": True, "name": name}
 
 
 @processors_crud_bp.route("/api/autorun-localizers/<name>", methods=["DELETE"])
-def delete_autorun_localizer_route(name):
+@processors_crud_bp.response(200, AutorunProcessorDeleteResponseSchema)
+@processors_crud_bp.alt_response(404, description="Localizer not found.")
+def delete_autorun_localizer_route(name: str):
     """Delete a autorun localizer."""
     if remove_autorun_localizer(name):
-        return jsonify({"success": True})
-    return jsonify({"error": "Localizer not found"}), 404
+        return {"success": True}
+    abort(404, message="Localizer not found")
 
 
 @processors_crud_bp.route("/api/autorun-localizers/<name>/rename", methods=["PUT"])
-def rename_autorun_localizer_route(name):
+@processors_crud_bp.arguments(AutorunProcessorRenameRequestSchema)
+@processors_crud_bp.response(200, AutorunProcessorRenameResponseSchema)
+@processors_crud_bp.alt_response(400, description="Localizer not found, or new name already exists.")
+def rename_autorun_localizer_route(body: dict, name: str):
     """Rename a autorun localizer."""
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    new_name = data.get("new_name", "").strip()
-    if not new_name:
-        return jsonify({"error": "new_name is required"}), 400
-
+    new_name = body["new_name"].strip()
     if rename_autorun_localizer(name, new_name):
-        return jsonify({"success": True, "new_name": new_name})
-    return jsonify({"error": "Localizer not found or new name already exists"}), 400
+        return {"success": True, "new_name": new_name}
+    abort(400, message="Localizer not found or new name already exists")
 
 
 # ---------------------------------------------------------------------------
@@ -235,12 +231,14 @@ _PREGEN_PROCESSORS = [
 
 
 @processors_crud_bp.route("/api/pregen-processors", methods=["GET"])
+@processors_crud_bp.response(200, PregenProcessorsListResponseSchema)
 def list_pregen_processors():
     """Return the list of available pregen processors."""
-    return jsonify({"processors": _PREGEN_PROCESSORS})
+    return {"processors": _PREGEN_PROCESSORS}
 
 
 @processors_crud_bp.route("/api/pregen-processors/add", methods=["POST"])
+@processors_crud_bp.response(200, PregenProcessorsAddResponseSchema)
 def add_pregen_processors():
     """Add all pregen processors as autorun entries.
 
@@ -261,4 +259,4 @@ def add_pregen_processors():
             add_autorun_localizer(name, processor_type, media_type, config)
         added.append(name)
 
-    return jsonify({"success": True, "added": added})
+    return {"success": True, "added": added}

--- a/vtsearch/routes/processors/scoring.py
+++ b/vtsearch/routes/processors/scoring.py
@@ -1,21 +1,36 @@
-"""Extractor and localizer execution routes."""
+"""Extractor and localizer execution routes.
+
+Migrated to ``flask_smorest`` so the routes are described in
+``/api/openapi.json``. See ``docs/plans/openapi-schema.md``.
+"""
 
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 
-from flask import Blueprint, jsonify
+from flask_smorest import Blueprint, abort
 
-from vtsearch.routes._shared import get_json_or_400
+from vtsearch.concurrency.memory_budget import cap_workers_by_memory
 from vtsearch.routes.processors.crud import _build_extractor, _build_localizer
+from vtsearch.schemas.processors import (
+    AutoExtractResponseSchema,
+    AutoLocalizeResponseSchema,
+    ExtractRequestSchema,
+    ExtractResponseSchema,
+    LocalizeRequestSchema,
+    LocalizeResponseSchema,
+)
 from vtsearch.state import (
     get_autorun_extractors_by_media,
     get_autorun_localizers_by_media,
     snapshot_medias,
 )
-from vtsearch.concurrency.memory_budget import cap_workers_by_memory
 
-processors_scoring_bp = Blueprint("processors_scoring", __name__)
+processors_scoring_bp = Blueprint(
+    "processors_scoring",
+    __name__,
+    description="Run extractors / localizers against the active dataset, either one-off or via autorun.",
+)
 
 # Keys excluded from API responses (large binary/vector data).
 _HEAVYWEIGHT_KEYS = ("embedding", "media_bytes", "media_string", "thumbnail_bytes")
@@ -104,73 +119,65 @@ def _auto_run_processors(
 
 
 @processors_scoring_bp.route("/api/extract", methods=["POST"])
-def run_extract():
+@processors_scoring_bp.arguments(ExtractRequestSchema)
+@processors_scoring_bp.response(200, ExtractResponseSchema)
+@processors_scoring_bp.alt_response(400, description="No medias loaded, bad config, or media-type mismatch.")
+def run_extract(body: dict):
     """Run a single extractor on all medias and return per-media extraction results."""
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    extractor_name = data.get("name", "").strip()
-    extractor_type = data.get("extractor_type", "").strip()
-    config = data.get("config")
-
-    if not extractor_type:
-        return jsonify({"error": "extractor_type is required"}), 400
-    if not config or not isinstance(config, dict):
-        return jsonify({"error": "config is required"}), 400
+    extractor_name = body["name"].strip()
+    extractor_type = body["extractor_type"].strip()
+    config = body["config"]
 
     snap = snapshot_medias()
     if not snap:
-        return jsonify({"error": "No medias loaded"}), 400
+        abort(400, message="No medias loaded")
 
     try:
         extractor = _build_extractor(extractor_name or "adhoc", extractor_type, config)
     except Exception as e:
-        return jsonify({"error": f"Invalid extractor config: {e}"}), 400
+        abort(400, message=f"Invalid extractor config: {e}")
 
     media_type = next(iter(snap.values())).get("type", "")
     if extractor.media_type != media_type:
-        return (
-            jsonify({"error": f"Extractor media type '{extractor.media_type}' does not match medias '{media_type}'"}),
+        abort(
             400,
+            message=f"Extractor media type '{extractor.media_type}' does not match medias '{media_type}'",
         )
 
     results = _apply_processor_to_medias(extractor, snap, "extract", "extractions")
 
-    return jsonify(
-        {
-            "extractor_name": extractor.name,
-            "media_type": media_type,
-            "total_medias_with_hits": len(results),
-            "results": results,
-        }
-    )
+    return {
+        "extractor_name": extractor.name,
+        "media_type": media_type,
+        "total_medias_with_hits": len(results),
+        "results": results,
+    }
 
 
 @processors_scoring_bp.route("/api/auto-extract", methods=["POST"])
+@processors_scoring_bp.response(200, AutoExtractResponseSchema)
+@processors_scoring_bp.alt_response(400, description="No medias loaded, or no autorun extractors for active media type.")
 def auto_extract():
     """Run all autorun extractors for the current media type and return extraction results."""
     snap = snapshot_medias()
     if not snap:
-        return jsonify({"error": "No medias loaded"}), 400
+        abort(400, message="No medias loaded")
 
     media_type = next(iter(snap.values())).get("type", "")
     extractors = get_autorun_extractors_by_media(media_type)
 
     if not extractors:
-        return jsonify({"error": f"No autorun extractors found for media type: {media_type}"}), 400
+        abort(400, message=f"No autorun extractors found for media type: {media_type}")
 
     results = _auto_run_processors(
         snap, extractors, _build_extractor, "extractor_type", "extract", "extractions", "extractor_name"
     )
 
-    return jsonify(
-        {
-            "media_type": media_type,
-            "extractors_run": len(results),
-            "results": results,
-        }
-    )
+    return {
+        "media_type": media_type,
+        "extractors_run": len(results),
+        "results": results,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -179,70 +186,62 @@ def auto_extract():
 
 
 @processors_scoring_bp.route("/api/localize", methods=["POST"])
-def run_localize():
+@processors_scoring_bp.arguments(LocalizeRequestSchema)
+@processors_scoring_bp.response(200, LocalizeResponseSchema)
+@processors_scoring_bp.alt_response(400, description="No medias loaded, bad config, or media-type mismatch.")
+def run_localize(body: dict):
     """Run a single localizer on all clips and return per-clip localization results."""
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    localizer_name = data.get("name", "").strip()
-    localizer_type = data.get("localizer_type", "").strip()
-    config = data.get("config")
-
-    if not localizer_type:
-        return jsonify({"error": "localizer_type is required"}), 400
-    if not config or not isinstance(config, dict):
-        return jsonify({"error": "config is required"}), 400
+    localizer_name = body["name"].strip()
+    localizer_type = body["localizer_type"].strip()
+    config = body["config"]
 
     snap = snapshot_medias()
     if not snap:
-        return jsonify({"error": "No medias loaded"}), 400
+        abort(400, message="No medias loaded")
 
     try:
         localizer = _build_localizer(localizer_name or "adhoc", localizer_type, config)
     except Exception as e:
-        return jsonify({"error": f"Invalid localizer config: {e}"}), 400
+        abort(400, message=f"Invalid localizer config: {e}")
 
     media_type = next(iter(snap.values())).get("type", "")
     if localizer.media_type != media_type:
-        return (
-            jsonify({"error": f"Localizer media type '{localizer.media_type}' does not match medias '{media_type}'"}),
+        abort(
             400,
+            message=f"Localizer media type '{localizer.media_type}' does not match medias '{media_type}'",
         )
 
     results = _apply_processor_to_medias(localizer, snap, "localize", "localizations")
 
-    return jsonify(
-        {
-            "localizer_name": localizer.name,
-            "media_type": media_type,
-            "total_medias_with_hits": len(results),
-            "results": results,
-        }
-    )
+    return {
+        "localizer_name": localizer.name,
+        "media_type": media_type,
+        "total_medias_with_hits": len(results),
+        "results": results,
+    }
 
 
 @processors_scoring_bp.route("/api/auto-localize", methods=["POST"])
+@processors_scoring_bp.response(200, AutoLocalizeResponseSchema)
+@processors_scoring_bp.alt_response(400, description="No medias loaded, or no autorun localizers for active media type.")
 def auto_localize():
     """Run all autorun localizers for the current media type."""
     snap = snapshot_medias()
     if not snap:
-        return jsonify({"error": "No medias loaded"}), 400
+        abort(400, message="No medias loaded")
 
     media_type = next(iter(snap.values())).get("type", "")
     localizers = get_autorun_localizers_by_media(media_type)
 
     if not localizers:
-        return jsonify({"error": f"No autorun localizers found for media type: {media_type}"}), 400
+        abort(400, message=f"No autorun localizers found for media type: {media_type}")
 
     results = _auto_run_processors(
         snap, localizers, _build_localizer, "localizer_type", "localize", "localizations", "localizer_name"
     )
 
-    return jsonify(
-        {
-            "media_type": media_type,
-            "localizers_run": len(results),
-            "results": results,
-        }
-    )
+    return {
+        "media_type": media_type,
+        "localizers_run": len(results),
+        "results": results,
+    }

--- a/vtsearch/routes/processors/scoring.py
+++ b/vtsearch/routes/processors/scoring.py
@@ -156,7 +156,9 @@ def run_extract(body: dict):
 
 @processors_scoring_bp.route("/api/auto-extract", methods=["POST"])
 @processors_scoring_bp.response(200, AutoExtractResponseSchema)
-@processors_scoring_bp.alt_response(400, description="No medias loaded, or no autorun extractors for active media type.")
+@processors_scoring_bp.alt_response(
+    400, description="No medias loaded, or no autorun extractors for active media type."
+)
 def auto_extract():
     """Run all autorun extractors for the current media type and return extraction results."""
     snap = snapshot_medias()
@@ -223,7 +225,9 @@ def run_localize(body: dict):
 
 @processors_scoring_bp.route("/api/auto-localize", methods=["POST"])
 @processors_scoring_bp.response(200, AutoLocalizeResponseSchema)
-@processors_scoring_bp.alt_response(400, description="No medias loaded, or no autorun localizers for active media type.")
+@processors_scoring_bp.alt_response(
+    400, description="No medias loaded, or no autorun localizers for active media type."
+)
 def auto_localize():
     """Run all autorun localizers for the current media type."""
     snap = snapshot_medias()

--- a/vtsearch/schemas/processors.py
+++ b/vtsearch/schemas/processors.py
@@ -1,0 +1,275 @@
+"""Schemas for the processors API (extractor / localizer / pregen routes).
+
+CRUD endpoints (``vtsearch/routes/processors/crud.py``):
+
+* ``GET    /api/autorun-extractors``              — :class:`AutorunExtractorsListResponseSchema`
+* ``POST   /api/autorun-extractors``              — :class:`AutorunExtractorCreateRequestSchema` →
+                                                    :class:`AutorunProcessorCreateResponseSchema`
+* ``DELETE /api/autorun-extractors/<name>``       — :class:`AutorunProcessorDeleteResponseSchema`
+* ``PUT    /api/autorun-extractors/<name>/rename`` — :class:`AutorunProcessorRenameRequestSchema` →
+                                                    :class:`AutorunProcessorRenameResponseSchema`
+* ``GET    /api/autorun-localizers``              — :class:`AutorunLocalizersListResponseSchema`
+* ``POST   /api/autorun-localizers``              — :class:`AutorunLocalizerCreateRequestSchema` →
+                                                    :class:`AutorunProcessorCreateResponseSchema`
+* ``DELETE /api/autorun-localizers/<name>``       — :class:`AutorunProcessorDeleteResponseSchema`
+* ``PUT    /api/autorun-localizers/<name>/rename`` — :class:`AutorunProcessorRenameRequestSchema` →
+                                                    :class:`AutorunProcessorRenameResponseSchema`
+* ``GET    /api/pregen-processors``               — :class:`PregenProcessorsListResponseSchema`
+* ``POST   /api/pregen-processors/add``           — :class:`PregenProcessorsAddResponseSchema`
+
+Scoring endpoints (``vtsearch/routes/processors/scoring.py``):
+
+* ``POST /api/extract``       — :class:`ExtractRequestSchema` → :class:`ExtractResponseSchema`
+* ``POST /api/auto-extract``  — :class:`AutoExtractResponseSchema`
+* ``POST /api/localize``      — :class:`LocalizeRequestSchema` → :class:`LocalizeResponseSchema`
+* ``POST /api/auto-localize`` — :class:`AutoLocalizeResponseSchema`
+
+The extract / localize routes accept a request body with the processor's
+``config`` dict, whose inner keys vary per processor type. The ``config``
+field is declared as a permissive :class:`marshmallow.fields.Dict` so any
+shape passes the schema layer; the handler still rejects configs that
+don't construct a valid processor.
+
+Note the ``POST /api/auto-extract`` / ``/api/auto-localize`` routes take
+no body — they read the autorun store and the active dataset. They're
+modelled as plain ``POST`` with no ``arguments`` decorator.
+"""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields, validate
+
+
+# ---------------------------------------------------------------------------
+# CRUD schemas
+# ---------------------------------------------------------------------------
+
+
+class _AutorunExtractorEntrySchema(Schema):
+    """One entry in the autorun-extractor store."""
+
+    name = fields.String(required=True)
+    extractor_type = fields.String(required=True)
+    media_type = fields.String(required=True)
+    config = fields.Dict(required=True)
+    created_at = fields.Float(required=True)
+
+
+class _AutorunLocalizerEntrySchema(Schema):
+    """One entry in the autorun-localizer store."""
+
+    name = fields.String(required=True)
+    localizer_type = fields.String(required=True)
+    media_type = fields.String(required=True)
+    config = fields.Dict(required=True)
+    created_at = fields.Float(required=True)
+
+
+class AutorunExtractorsListResponseSchema(Schema):
+    """Response for ``GET /api/autorun-extractors``."""
+
+    extractors = fields.List(fields.Nested(_AutorunExtractorEntrySchema), required=True)
+
+
+class AutorunLocalizersListResponseSchema(Schema):
+    """Response for ``GET /api/autorun-localizers``."""
+
+    localizers = fields.List(fields.Nested(_AutorunLocalizerEntrySchema), required=True)
+
+
+class AutorunExtractorCreateRequestSchema(Schema):
+    """Body for ``POST /api/autorun-extractors``."""
+
+    name = fields.String(required=True, validate=validate.Length(min=1))
+    media_type = fields.String(required=True, validate=validate.Length(min=1))
+    extractor_type = fields.String(required=True, validate=validate.Length(min=1))
+    config = fields.Dict(required=True)
+
+
+class AutorunLocalizerCreateRequestSchema(Schema):
+    """Body for ``POST /api/autorun-localizers``."""
+
+    name = fields.String(required=True, validate=validate.Length(min=1))
+    media_type = fields.String(required=True, validate=validate.Length(min=1))
+    localizer_type = fields.String(required=True, validate=validate.Length(min=1))
+    config = fields.Dict(required=True)
+
+
+class AutorunProcessorCreateResponseSchema(Schema):
+    """Response for autorun-extractor / autorun-localizer creation."""
+
+    success = fields.Boolean(required=True)
+    name = fields.String(required=True)
+
+
+class AutorunProcessorDeleteResponseSchema(Schema):
+    """Response for ``DELETE /api/autorun-extractors/<name>`` / localizers."""
+
+    success = fields.Boolean(required=True)
+
+
+class AutorunProcessorRenameRequestSchema(Schema):
+    """Body for ``PUT /api/autorun-extractors/<name>/rename`` / localizers."""
+
+    new_name = fields.String(required=True, validate=validate.Length(min=1))
+
+
+class AutorunProcessorRenameResponseSchema(Schema):
+    """Response for autorun-extractor / autorun-localizer rename."""
+
+    success = fields.Boolean(required=True)
+    new_name = fields.String(required=True)
+
+
+class _PregenProcessorEntrySchema(Schema):
+    """One entry in the pregen-processor list.
+
+    ``kind`` is ``"extractor"`` or ``"localizer"`` — it tells the
+    /api/pregen-processors/add handler which autorun store to route the
+    processor into.
+    """
+
+    name = fields.String(required=True)
+    kind = fields.String(required=True, validate=validate.OneOf(["extractor", "localizer"]))
+    processor_type = fields.String(required=True)
+    media_type = fields.String(required=True)
+    config = fields.Dict(required=True)
+
+
+class PregenProcessorsListResponseSchema(Schema):
+    """Response for ``GET /api/pregen-processors``."""
+
+    processors = fields.List(fields.Nested(_PregenProcessorEntrySchema), required=True)
+
+
+class PregenProcessorsAddResponseSchema(Schema):
+    """Response for ``POST /api/pregen-processors/add``."""
+
+    success = fields.Boolean(required=True)
+    added = fields.List(fields.String(), required=True)
+
+
+# ---------------------------------------------------------------------------
+# Scoring schemas
+# ---------------------------------------------------------------------------
+
+
+class _ProcessorHitSchema(Schema):
+    """One scored media entry in an extract / localize ``results`` list.
+
+    The shape is a media dict augmented with an ``extractions`` or
+    ``localizations`` array. The set of media-dict fields is intentionally
+    open — different importers populate different keys — and the
+    extraction/localization arrays themselves are processor-specific
+    (bounding boxes, text strings, etc.).
+    """
+
+    id = fields.Integer(required=True)
+    extractions = fields.List(fields.Dict())
+    localizations = fields.List(fields.Dict())
+
+    class Meta:
+        unknown = "include"
+
+
+class ExtractRequestSchema(Schema):
+    """Body for ``POST /api/extract``.
+
+    ``name`` is optional — when absent the handler labels the extractor as
+    ``"adhoc"``. ``config`` is processor-specific and validated by the
+    factory rather than at the schema layer.
+    """
+
+    name = fields.String(load_default="")
+    extractor_type = fields.String(required=True, validate=validate.Length(min=1))
+    config = fields.Dict(required=True)
+
+
+class ExtractResponseSchema(Schema):
+    """Response for ``POST /api/extract`` (success path)."""
+
+    extractor_name = fields.String(required=True)
+    media_type = fields.String(required=True)
+    total_medias_with_hits = fields.Integer(required=True)
+    results = fields.List(fields.Nested(_ProcessorHitSchema), required=True)
+
+
+class LocalizeRequestSchema(Schema):
+    """Body for ``POST /api/localize``."""
+
+    name = fields.String(load_default="")
+    localizer_type = fields.String(required=True, validate=validate.Length(min=1))
+    config = fields.Dict(required=True)
+
+
+class LocalizeResponseSchema(Schema):
+    """Response for ``POST /api/localize`` (success path)."""
+
+    localizer_name = fields.String(required=True)
+    media_type = fields.String(required=True)
+    total_medias_with_hits = fields.Integer(required=True)
+    results = fields.List(fields.Nested(_ProcessorHitSchema), required=True)
+
+
+class _AutoExtractPerProcessorSchema(Schema):
+    """One entry in ``AutoExtractResponseSchema.results`` (keyed by name)."""
+
+    extractor_name = fields.String(required=True)
+    total_medias_with_hits = fields.Integer(required=True)
+    results = fields.List(fields.Nested(_ProcessorHitSchema), required=True)
+
+
+class AutoExtractResponseSchema(Schema):
+    """Response for ``POST /api/auto-extract`` (success path).
+
+    ``results`` is keyed by extractor name. flask-smorest dumps ``Dict``
+    fields as ``additionalProperties`` in the OpenAPI spec.
+    """
+
+    media_type = fields.String(required=True)
+    extractors_run = fields.Integer(required=True)
+    results = fields.Dict(
+        keys=fields.String(),
+        values=fields.Nested(_AutoExtractPerProcessorSchema),
+        required=True,
+    )
+
+
+class _AutoLocalizePerProcessorSchema(Schema):
+    """One entry in ``AutoLocalizeResponseSchema.results`` (keyed by name)."""
+
+    localizer_name = fields.String(required=True)
+    total_medias_with_hits = fields.Integer(required=True)
+    results = fields.List(fields.Nested(_ProcessorHitSchema), required=True)
+
+
+class AutoLocalizeResponseSchema(Schema):
+    """Response for ``POST /api/auto-localize`` (success path)."""
+
+    media_type = fields.String(required=True)
+    localizers_run = fields.Integer(required=True)
+    results = fields.Dict(
+        keys=fields.String(),
+        values=fields.Nested(_AutoLocalizePerProcessorSchema),
+        required=True,
+    )
+
+
+__all__ = [
+    "AutoExtractResponseSchema",
+    "AutoLocalizeResponseSchema",
+    "AutorunExtractorCreateRequestSchema",
+    "AutorunExtractorsListResponseSchema",
+    "AutorunLocalizerCreateRequestSchema",
+    "AutorunLocalizersListResponseSchema",
+    "AutorunProcessorCreateResponseSchema",
+    "AutorunProcessorDeleteResponseSchema",
+    "AutorunProcessorRenameRequestSchema",
+    "AutorunProcessorRenameResponseSchema",
+    "ExtractRequestSchema",
+    "ExtractResponseSchema",
+    "LocalizeRequestSchema",
+    "LocalizeResponseSchema",
+    "PregenProcessorsAddResponseSchema",
+    "PregenProcessorsListResponseSchema",
+]


### PR DESCRIPTION
## Summary

Continues the OpenAPI migration (`docs/plans/openapi-schema.md`) by moving the processors blueprint onto `flask-smorest` — autorun-extractor / autorun-localizer CRUD, pregen-processor list/add, and the single-shot + auto extract/localize routes. All thirteen endpoints now appear in `/api/openapi.json` with typed request/response bodies.

- New schemas: `vtsearch/schemas/processors.py` (per-route create/rename/list/response shapes plus extract/localize/auto-{extract,localize}).
- `vtsearch/routes/processors/crud.py` and `scoring.py` rewritten to use `flask_smorest.Blueprint` + `@blp.arguments` / `@blp.response` decorators.
- The plain-Flask `processors_bp` aggregator is gone — both blueprints now register directly with the `Api` in `app.py`, mirroring the `detectors/` layout.
- Schema-level validation failures (missing required `name` / `media_type` / `extractor_type` / `localizer_type` / `config`) now return **422** with the standard `errors` envelope. Handler-level rejects (no medias loaded, media-type mismatch, unbuildable config, rename collisions, no autorun processors for active media type) keep their 400 / 404 status but use `message` instead of legacy `{"error": str}`.
- Tests in `tests/detectors/test_extractors.py` and `tests/integration/test_multi_media_coverage.py` updated to match.

## Test plan

- [x] `./run-tests.sh detectors integration` — 873 passed
- [x] `./run-tests.sh` (full suite) — 3481 passed, 1 skipped, 2 xpassed
- [x] Verified all thirteen processor routes appear under `paths` in `/api/openapi.json`

https://claude.ai/code/session_01FFq8ywbDauW5tKComhFHd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFq8ywbDauW5tKComhFHd8)_