### PR TITLE
docs: mark feature-brainstorm §12.16 (Prometheus metrics) as declined

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -526,8 +526,10 @@ Original idea: migrate hot paths (sorting, scoring) to Quart or FastAPI for true
 ### 12.15 Structured logging + request IDs ★★ S
 Today logs are print-style. JSON logs with `dataset_id`/`detector_id`/`request_id` make production debugging tractable.
 
-### 12.16 Prometheus metrics ★★ S
+### 12.16 Prometheus metrics ★★ S — considered, declined for now
 `/metrics` endpoint with vote count, embedding latency, training time, RAM usage by dataset.
+
+Prototyped (PR #1366, closed unmerged) and declined. The pros — real percentiles via histograms, standard tooling, complements §12.15's structured logs — only pay off when a scraper is actually consuming the endpoint, which the current single-user / local-Flask deployment doesn't have. What pushed against shipping: a new runtime dependency (`prometheus-client`), per-worker counter state under gunicorn (correct cluster totals would require `prometheus_client.multiprocess` mode and extra setup), latent label-cardinality footguns if anyone later labels by `user_id` / `dataset_id` on counters, and a small but non-zero perf cost on every vote / embed / train hot path. Worth revisiting when VTSearch grows a multi-tenant or k8s deployment story — at that point the scraper exists and the implementation effort stays small (≈300 LoC plus tests).
 
 ### 12.17 Pydantic models for settings ★ S
 The `_SETTING_SPECS` table is clever but custom; Pydantic v2 would generalise it and produce JSON schemas for free.


### PR DESCRIPTION
## Summary

Captures the §12.16 (Prometheus `/metrics` endpoint) decision directly in the backlog doc, so future readers see the outcome and the conditions for revisiting it without having to dig through the closed prototype PR #1366.

Concretely, the entry now records:
- The benefits (real percentiles via histograms, standard tooling, complements §12.15 structured logs) only pay off once a scraper is actually consuming the endpoint.
- What pushed against shipping: a new `prometheus-client` runtime dep, per-worker counter state under gunicorn (would need `prometheus_client.multiprocess` for correct cluster totals), latent label-cardinality footguns if anyone later labels by `user_id` / `dataset_id`, and a small but non-zero perf cost on every vote / embed / train hot path.
- Trigger to revisit: when VTSearch grows a multi-tenant or k8s deployment story.

No code changes — docs only.

## Test plan

- [x] `grep -n "12.16" docs/plans/feature-brainstorm.md` shows the updated entry.
- [x] No code paths touched, so `./run-tests.sh` would be unaffected; not re-run for a docs-only change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDPZucsCi2WjtSDSjkvs3z)_