### PR TITLE
Auto-derive dataset name in generic importer form

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -179,7 +179,7 @@
                 [value]="formValues[field.key] || ''"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
                 [extensions]="field.accept || ''"
-                (pathSelected)="formValues[field.key] = $event"
+                (pathSelected)="formOnServerPathSelected(field.key, $event)"
               />
             } @else if (field.field_type === 'file') {
               <input
@@ -220,6 +220,15 @@
               @if (field.dynamic_options && dynamicFieldError[field.key]) {
                 <p class="error-text">{{ dynamicFieldError[field.key] }}</p>
               }
+            } @else if (field.key === 'dataset_name') {
+              <input
+                [id]="'field-' + field.key"
+                type="text"
+                class="form-input"
+                [ngModel]="formValues['dataset_name'] || ''"
+                (ngModelChange)="formOnDatasetNameInput($event)"
+                [placeholder]="field.description || field.label || field.key"
+              />
             } @else {
               <input
                 [id]="'field-' + field.key"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -32,6 +32,9 @@ export class DatasetImporterModalComponent implements OnInit {
   selectedFile: File | null = null;
   submitting = false;
   error = '';
+  /** Whether the user has manually edited the generic-form dataset_name
+   *  input (so we stop auto-deriving it from path/url/file fields). */
+  private formDatasetNameDirty = false;
 
   // Clipper state
   availableClippers: ClipperInfo[] = [];
@@ -307,6 +310,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.dynamicFieldOptions = {};
     this.dynamicFieldLoading = {};
     this.dynamicFieldError = {};
+    this.formDatasetNameDirty = false;
 
     // Pre-populate defaults
     if (importer.fields) {
@@ -356,7 +360,8 @@ export class DatasetImporterModalComponent implements OnInit {
   /** Called whenever a form field value changes.  Refreshes options for
    *  every dynamic-options field whose ``depends_on`` includes *changedKey*.
    *  Also clears the dependent field's current value so the user can't
-   *  submit a now-stale selection. */
+   *  submit a now-stale selection.  Also re-derives a default
+   *  ``dataset_name`` from the change unless the user has typed one. */
   onFormFieldChanged(changedKey: string): void {
     const importer = this.selectedImporter;
     if (!importer?.fields) return;
@@ -366,6 +371,67 @@ export class DatasetImporterModalComponent implements OnInit {
       this.formValues[field.key] = '';
       this.refreshDynamicFieldOptions(field);
     }
+    if (changedKey !== 'dataset_name') {
+      this.maybeApplyDerivedDatasetName();
+    }
+  }
+
+  /** Called when the user types into the generic-form ``Dataset Name``
+   *  input.  Marks the field as dirty so subsequent path/url/file changes
+   *  do not overwrite the user's value. */
+  formOnDatasetNameInput(value: string): void {
+    this.formValues['dataset_name'] = value;
+    this.formDatasetNameDirty = true;
+  }
+
+  /** Called when the user picks a server path via ``vt-file-browser``.
+   *  Updates the form value and re-derives the dataset name when the
+   *  user hasn't typed one yet. */
+  formOnServerPathSelected(key: string, path: string): void {
+    this.formValues[key] = path;
+    this.onFormFieldChanged(key);
+  }
+
+  /** Re-derive a default dataset name from the current form values when
+   *  the user hasn't manually edited the dataset_name input.  Inspects
+   *  the importer's fields and uses the first source-style field with a
+   *  value (url, server_path, file, or a field keyed ``path``). */
+  private maybeApplyDerivedDatasetName(): void {
+    if (this.formDatasetNameDirty) return;
+    const derived = this.formDerivedDatasetName();
+    if (derived) {
+      this.formValues['dataset_name'] = derived;
+    }
+  }
+
+  /** Compute a derived dataset name from the current form values. */
+  private formDerivedDatasetName(): string {
+    const fields = this.selectedImporter?.fields || [];
+    for (const f of fields) {
+      if (f.key === 'dataset_name') continue;
+      const raw = this.formValues[f.key];
+      if (typeof raw !== 'string' || !raw) continue;
+      if (f.field_type === 'url') {
+        const cleaned = raw.split('?')[0].replace(/\/+$/, '');
+        const tail = cleaned.split('/').pop() || '';
+        if (!tail) continue;
+        const stripped = tail.replace(
+          /\.(?:tar\.gz|tar\.bz2|tar\.xz|tar|zip|rar)$/i, '',
+        );
+        return stripped || tail;
+      }
+      if (f.field_type === 'server_path' || f.field_type === 'file') {
+        const basename = raw.split(/[\\/]/).pop() || '';
+        if (!basename) continue;
+        const dot = basename.lastIndexOf('.');
+        return dot > 0 ? basename.slice(0, dot) : basename;
+      }
+      if (f.key === 'path') {
+        const parts = raw.split(/[\\/]/).filter(Boolean);
+        if (parts.length > 0) return parts[parts.length - 1];
+      }
+    }
+    return '';
   }
 
   /** Fetch the option list for a dynamic-options field from the backend. */
@@ -1420,6 +1486,7 @@ export class DatasetImporterModalComponent implements OnInit {
     if (input.files && input.files.length > 0) {
       this.selectedFile = input.files[0];
       this.formValues[fieldName] = input.files[0].name;
+      this.maybeApplyDerivedDatasetName();
     }
   }
 


### PR DESCRIPTION
## Summary

The local-folder and server-folder pickers already pre-fill the Dataset Name input from the picked folder/file as soon as the user chooses one (`lfDatasetName` / `sfDatasetName`). Form-style importers like `server_files` left it blank — even though the backend's `default_display_name` would compute a sensible default from `paths_file` / `url` / `file` on submit, the user couldn't see what the name was going to be.

Extend the generic form view in the dataset importer modal to do the same live derivation:

- `url` field — last URL path segment, with common archive extensions (`.zip`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar`, `.rar`) stripped
- `server_path` field — basename stem
- `file` field — basename stem
- Any field keyed `path` — folder basename

Derivation runs on every source-field change unless the user has typed into the Dataset Name input themselves, in which case a per-importer dirty flag freezes their value (matching the existing `sf*`/`lf*` pattern). The field stays fully editable.

The visible beneficiary today is `server_files` (the other form-style importers — `http_archive`, `pickle`, `recaller` — are `hidden_from_picker`), but any future form-style importer that adds a `url` / `server_path` / `file` / `path` field automatically gets the same behavior with no extra wiring.

## Test plan

- [x] `./run-tests.sh core api datasets io` — all 2015 passing
- [x] `cd frontend && npm run build:prod` — clean, no warnings
- [x] `npx tsc -p tsconfig.spec.json --noEmit` — clean
- [ ] Manual: open the dataset importer modal → Server → Files (`server_files`), pick a `.txt`/`.npz` paths file, confirm the Dataset Name input populates with the file's stem
- [ ] Manual: edit the Dataset Name after auto-fill, then pick a different paths file — the user's value should be preserved


---
_Generated by [Claude Code](https://claude.ai/code/session_01W184kYeUNDAQ6Kz1o92wdN)_