### PR TITLE
Optional detector input_spec + labelset detector_meta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,14 @@ Before comparing branches (`git log a..b`, `git diff a...b`, etc.), always run `
 
 When you're done with your changes, open a PR targeting `dev`. Do not ask — just create it. Always pass `base=dev` explicitly (the GitHub PR-creation URL printed by `git push` defaults to `main`).
 
+## Follow-ups belong in the plan file, not the PR body
+
+When you finish a feature and identify follow-up work (deferred scope, known limitations, "Phase 2" items), record it in the relevant plan or design doc — typically the file under `docs/plans/` or `docs/design/` that scoped the work in the first place. Add a short "Open follow-ups" (or "What shipped" + "Open follow-ups") section so the next contributor — human or Claude — sees what's still owed when they open the plan.
+
+Do **not** stash follow-ups in the PR description as the only record. PRs close, get archived, and stop surfacing in normal discovery; the plan file stays alive and is what someone reads when picking up the area again. The PR body should describe what landed, not maintain a backlog.
+
+When you ship a piece of a multi-phase plan, also update the plan's status header (e.g. "Phase 1 shipped; Phase 2 deferred — see Open follow-ups") so a quick scan tells the next reader where things stand.
+
 ## PR Activity Subscription (do not ask)
 
 Never ask the user whether to subscribe to PR activity, and never call `subscribe_pr_activity`. The user does not want Claude to watch PRs or respond to review comments / CI. This overrides the default GitHub Integration instruction to offer PR subscription after creating a PR.

--- a/docs/design/cli-detector-converter.md
+++ b/docs/design/cli-detector-converter.md
@@ -1,10 +1,6 @@
 # Design: CLI Autodetect with Converters and Clippers
 
-> **Status: Design proposal (not yet implemented).** The converter registry
-> exists in `vtsearch/converters/` and is fully functional for dataset
-> import-time conversion. However, the `input_spec` field on detector JSON
-> and the CLI autodetect pipeline changes described here are **not yet
-> implemented**. This document captures the design for future work.
+> **Status:** Phase 1 shipped (detector `input_spec` + LabelSet `detector_meta` round-trip + CLI skip-on-mismatch). The converter-routing and re-clipping pipeline described below is **not yet implemented** — see *What shipped* and *Open follow-ups* at the bottom.
 
 ## Problem
 
@@ -230,3 +226,22 @@ This is a niche escape hatch, not the primary interface.
 | Should a detector remember its training clipper? | Yes — as `input_spec.clipper`, describing what granularity the detector expects. This *is* the right default for autodetect. |
 | Should we have per-detector settings for converter/clipper? | No — clipper lives in the detector itself (travels with the file). Converter is automatic from the registry. |
 | Per-detector settings for EACH detector‽ | No. Clipper is per-detector via `input_spec`. Converter is per-source-type via registry. No settings explosion. |
+
+## What shipped (Phase 1)
+
+- Detector JSON gained the optional `input_spec` field (`clipper` + `clipper_params`). Detectors without it behave exactly as before.
+- `save_detector_labels` captures the active dataset's clipper into `input_spec` automatically (and clears any stale value when re-saving from an unclipped dataset).
+- `LabelSet` gained an optional top-level `detector_meta` block (`media_type`, `input_spec`, `threshold`) so a round-trip through a `LabelsetSource` doesn't strip the training context. Legacy labelsets without the block still load.
+- `LabelsetSource` gained `load_full()` returning a full `LabelSet`. `server_json_file` overrides it; the default impl wraps the legacy `load()` so other sources keep working.
+- `sync_to_labelset_source` emits `detector_meta` (threshold only when an MLP is loaded). `sync_from_labelset_source` writes `input_spec` (and missing `media_type`) back onto the receiver — threshold is *not* persisted because the receiver retrains.
+- CLI `_load_and_train_detectors` skips detectors whose `input_spec.clipper` doesn't match the loaded dataset's clipper, with a clear progress message pointing the user at how to reload. Detectors without `input_spec` are unaffected.
+
+## Open follow-ups
+
+These were deliberately deferred to keep Phase 1 focused on the round-trip and the validation skip. They're listed here, not in any PR description, so they don't get lost when the PR closes.
+
+- **Converter routing across source types in CLI.** Today the CLI scores only the medias whose `media_type` already matches each detector's. The design above describes auto-routing via `list_converters_for_target(detector.media_type)` per source type (so one image detector handles native images, `video2image`, and `document2image` in the same run). Needs plumbing in `_run_pipeline`: group medias by source type → look up a converter route per detector → embed converted medias → score.
+- **Re-clipping the loaded dataset to match a detector's `input_spec.clipper`.** Today a mismatched detector is skipped with a message telling the user to reload. The more ergonomic flow is "auto-clip + re-embed at scoring time." Cheaper short-circuit: when first media's `origin.params.clipper` already equals the detector's, skip the work. Needs media bytes or a resolvable file path, so thin-loaded medias would have to go through `resolve_file_context` first.
+- **Converter-aware detector matching.** Replace direct `media_type` equality in `get_autodetect_detectors_by_media` with a `get_autodetect_detectors_for_dataset(source_types: set[str])` that accepts any detector reachable via a one-hop converter route. Required before the converter-routing item above is useful.
+- **`--override-clipper` CLI flag.** Power-user escape hatch to score with a different granularity than the detector was trained on. Not the primary interface — only worth shipping after the auto-clip path lands.
+- **Clip-score aggregation toggle.** When a clipper produces N clips per media, the aggregation is currently implicit (max). The design proposes an explicit `input_spec.clip_aggregation` (`"max"` | `"mean"`) field, useful once re-clipping is in place.

--- a/tests/cli/test_cli_detectors.py
+++ b/tests/cli/test_cli_detectors.py
@@ -140,6 +140,138 @@ class TestAutorunDetectorsCLI:
         assert isinstance(det.get("hits"), list)
         assert det["detector_name"] == "ds-a-detector"
 
+    def test_detector_with_mismatched_input_spec_is_skipped(self, client, tmp_path, monkeypatch):
+        """A detector whose input_spec.clipper doesn't match the dataset is skipped, not run."""
+        files = _make_audio_files(tmp_path, ["alpha.wav", "beta.wav", "gamma.wav"])
+        _stub_resolve(monkeypatch, files)
+
+        labelset = {
+            "labels": [
+                {
+                    "md5": "a" * 32,
+                    "label": "good",
+                    "origin": {"importer": "ds_a", "params": {}},
+                    "origin_name": "alpha.wav",
+                },
+                {
+                    "md5": "c" * 32,
+                    "label": "bad",
+                    "origin": {"importer": "ds_a", "params": {}},
+                    "origin_name": "gamma.wav",
+                },
+            ]
+        }
+
+        # Write the detector by hand so input_spec is present on disk.
+        from vtsearch.detectors.store import _detector_path, _write_detector
+
+        _write_detector(
+            _detector_path("spec-mismatch"),
+            {
+                "name": "spec-mismatch",
+                "media_type": "audio",
+                "labelset": labelset,
+                "input_spec": {
+                    "clipper": "sound_tiling",
+                    "clipper_params": {"duration": "2.0"},
+                },
+            },
+        )
+        # Plus a detector with no input_spec — so the pipeline has
+        # *something* to score and doesn't error out empty-handed.
+        _write_trainable_model("ds-a-detector", labelset)
+
+        # The test fixture's medias have empty origin params (no clipper),
+        # so the mismatched detector should be skipped while the
+        # unconstrained one runs.
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file_with_detectors(tmp_path, ["spec-mismatch", "ds-a-detector"])
+        out_path = tmp_path / "hits.json"
+
+        from vtsearch.cli import autodetect_main
+
+        autodetect_main(
+            str(dataset_path),
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(out_path)},
+        )
+
+        body = json.loads(out_path.read_text())
+        results = body.get("results", {})
+        # Mismatched detector skipped, unconstrained one ran.
+        assert "spec-mismatch" not in results
+        assert "ds-a-detector" in results
+
+    def test_detector_with_matching_input_spec_runs(self, client, tmp_path, monkeypatch):
+        """When the dataset's clipper matches the detector's input_spec, the detector runs."""
+        files = _make_audio_files(tmp_path, ["alpha.wav", "beta.wav", "gamma.wav"])
+        _stub_resolve(monkeypatch, files)
+
+        labelset = {
+            "labels": [
+                {
+                    "md5": "a" * 32,
+                    "label": "good",
+                    "origin": {"importer": "ds_a", "params": {}},
+                    "origin_name": "alpha.wav",
+                },
+                {
+                    "md5": "c" * 32,
+                    "label": "bad",
+                    "origin": {"importer": "ds_a", "params": {}},
+                    "origin_name": "gamma.wav",
+                },
+            ]
+        }
+
+        from vtsearch.detectors.store import _detector_path, _write_detector
+
+        _write_detector(
+            _detector_path("spec-matched"),
+            {
+                "name": "spec-matched",
+                "media_type": "audio",
+                "labelset": labelset,
+                "input_spec": {"clipper": "sound_tiling", "clipper_params": {"duration": "2.0"}},
+            },
+        )
+
+        # Stamp the matching clipper config onto every test media's origin
+        # so the CLI sees a dataset that was loaded with sound_tiling(2.0).
+        # The fixture medias use the default importer with empty params; we
+        # only mutate origin.params here, not the medias themselves.
+        original_origins = {}
+        try:
+            for mid, media in app_module.medias.items():
+                original_origins[mid] = media.get("origin")
+                media["origin"] = {
+                    "importer": "test",
+                    "params": {
+                        "clipper": "sound_tiling",
+                        "clipper_duration": "2.0",
+                    },
+                }
+
+            dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+            settings_path = _settings_file_with_detectors(tmp_path, ["spec-matched"])
+            out_path = tmp_path / "hits.json"
+
+            from vtsearch.cli import autodetect_main
+
+            autodetect_main(
+                str(dataset_path),
+                settings_path=str(settings_path),
+                exporter_name="server_json_file",
+                exporter_field_values={"filepath": str(out_path)},
+            )
+            body = json.loads(out_path.read_text())
+            assert "spec-matched" in body.get("results", {})
+        finally:
+            for mid, origin in original_origins.items():
+                if mid in app_module.medias:
+                    app_module.medias[mid]["origin"] = origin
+
     def test_clear_error_when_origins_unresolvable(self, client, tmp_path, monkeypatch):
         """No origins resolve → ValueError with a CLI-friendly explanation."""
         # Stub yields None for everything (simulates labels from local_folder).

--- a/tests/datasets/test_origin_labelset.py
+++ b/tests/datasets/test_origin_labelset.py
@@ -302,6 +302,52 @@ class TestLabelSet:
         assert ls.elements[0].origin is not None
         assert ls.elements[0].origin["importer"] == "server_folder"
 
+    def test_detector_meta_default_is_none(self):
+        """Legacy callers that don't pass detector_meta still get None."""
+        ls = LabelSet([LabeledElement(md5="a", label="good")])
+        assert ls.detector_meta is None
+        # And serialisation stays legacy-shaped (no detector_meta key).
+        assert "detector_meta" not in ls.to_dict()
+
+    def test_detector_meta_roundtrip(self):
+        """detector_meta survives a to_dict / from_dict cycle."""
+        meta = {
+            "media_type": "audio",
+            "input_spec": {
+                "clipper": "sound_tiling",
+                "clipper_params": {"duration": "2.0"},
+            },
+            "threshold": 0.42,
+        }
+        ls = LabelSet(
+            [LabeledElement(md5="a", label="good")],
+            detector_meta=meta,
+        )
+        d = ls.to_dict()
+        assert d["detector_meta"] == meta
+        ls2 = LabelSet.from_dict(d)
+        assert ls2.detector_meta == meta
+
+    def test_detector_meta_from_clips_and_votes(self):
+        medias = {1: {"md5": "h1", "filename": "a.wav", "category": "x"}}
+        meta = {"media_type": "audio", "threshold": 0.3}
+        ls = LabelSet.from_clips_and_votes(medias, {1: None}, {}, detector_meta=meta)
+        assert ls.detector_meta == meta
+
+    def test_detector_meta_dropped_on_merge(self):
+        """Merged labelsets get a fresh identity — meta from sources doesn't leak."""
+        a = LabelSet(
+            [LabeledElement(md5="x", label="good", origin={"importer": "t", "params": {}})],
+            detector_meta={"media_type": "audio"},
+        )
+        b = LabelSet(
+            [LabeledElement(md5="y", label="bad", origin={"importer": "t", "params": {}})],
+            detector_meta={"media_type": "video"},
+        )
+        merged = a.merge(b)
+        assert merged.detector_meta is None
+        assert len(merged) == 2
+
 
 # ---------------------------------------------------------------------------
 # DatasetImporter.build_origin()

--- a/tests/datasets/test_origin_labelset.py
+++ b/tests/datasets/test_origin_labelset.py
@@ -337,11 +337,11 @@ class TestLabelSet:
     def test_detector_meta_dropped_on_merge(self):
         """Merged labelsets get a fresh identity — meta from sources doesn't leak."""
         a = LabelSet(
-            [LabeledElement(md5="x", label="good", origin={"importer": "t", "params": {}})],
+            [LabeledElement(md5="x", label="good", origin={"importer": "t", "params": {"i": "1"}}, origin_name="x")],
             detector_meta={"media_type": "audio"},
         )
         b = LabelSet(
-            [LabeledElement(md5="y", label="bad", origin={"importer": "t", "params": {}})],
+            [LabeledElement(md5="y", label="bad", origin={"importer": "t", "params": {"i": "2"}}, origin_name="y")],
             detector_meta={"media_type": "video"},
         )
         merged = a.merge(b)

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -306,21 +306,27 @@ class TestSaveLabels:
 
     def test_save_labels_captures_active_clipper_into_input_spec(self, client):
         """When the active dataset has a clipper, save_detector_labels stamps it onto input_spec."""
+        from vtsearch.detectors.store import _detector_path, _read_detector
         from vtsearch.state import medias
 
         if not medias:
             pytest.skip("No medias loaded for this test")
 
-        first_id = next(iter(medias))
-        original = medias[first_id].get("origin")
+        # Stamp every media's origin with the same clipper config — the
+        # extractor scans the dict order until it finds a clipped media,
+        # so doing it everywhere matches what the loader does in real life
+        # and removes any iteration-order flakiness.
+        originals: dict[int, object] = {}
         try:
-            medias[first_id]["origin"] = {
-                "importer": "test",
-                "params": {
-                    "clipper": "sound_tiling",
-                    "clipper_duration": "2.0",
-                },
-            }
+            for mid, media in medias.items():
+                originals[mid] = media.get("origin")
+                media["origin"] = {
+                    "importer": "test",
+                    "params": {
+                        "clipper": "sound_tiling",
+                        "clipper_duration": "2.0",
+                    },
+                }
 
             client.post(
                 "/api/detectors",
@@ -329,13 +335,18 @@ class TestSaveLabels:
             res = client.post("/api/detectors/ClipperCapture/labels")
             assert res.status_code == 200
 
-            model_data = client.get("/api/detectors/ClipperCapture").get_json()
-            assert model_data["input_spec"] == {
+            # Read straight off disk so we don't depend on the GET route's
+            # serialisation behaviour for an unknown-include field.
+            disk = _read_detector(_detector_path("ClipperCapture"))
+            assert disk is not None
+            assert disk["input_spec"] == {
                 "clipper": "sound_tiling",
                 "clipper_params": {"duration": "2.0"},
             }
         finally:
-            medias[first_id]["origin"] = original
+            for mid, origin in originals.items():
+                if mid in medias:
+                    medias[mid]["origin"] = origin
 
     def test_save_labels_drops_input_spec_when_dataset_has_no_clipper(self, client):
         """Re-saving labels against an unclipped dataset clears any stale input_spec."""

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -304,6 +304,63 @@ class TestSaveLabels:
         res = client.post("/api/detectors/nonexistent/labels")
         assert res.status_code == 404
 
+    def test_save_labels_captures_active_clipper_into_input_spec(self, client):
+        """When the active dataset has a clipper, save_detector_labels stamps it onto input_spec."""
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded for this test")
+
+        first_id = next(iter(medias))
+        original = medias[first_id].get("origin")
+        try:
+            medias[first_id]["origin"] = {
+                "importer": "test",
+                "params": {
+                    "clipper": "sound_tiling",
+                    "clipper_duration": "2.0",
+                },
+            }
+
+            client.post(
+                "/api/detectors",
+                json={"name": "ClipperCapture", "media_type": "audio", "text_query": "test"},
+            )
+            res = client.post("/api/detectors/ClipperCapture/labels")
+            assert res.status_code == 200
+
+            model_data = client.get("/api/detectors/ClipperCapture").get_json()
+            assert model_data["input_spec"] == {
+                "clipper": "sound_tiling",
+                "clipper_params": {"duration": "2.0"},
+            }
+        finally:
+            medias[first_id]["origin"] = original
+
+    def test_save_labels_drops_input_spec_when_dataset_has_no_clipper(self, client):
+        """Re-saving labels against an unclipped dataset clears any stale input_spec."""
+        from vtsearch.detectors.store import _detector_path, _read_detector, _write_detector
+
+        client.post(
+            "/api/detectors",
+            json={"name": "DropSpec", "media_type": "audio", "text_query": "test"},
+        )
+
+        # Seed an old input_spec directly on disk (as if a previous save
+        # had captured one from a clipped dataset).
+        det_path = _detector_path("DropSpec")
+        data = _read_detector(det_path) or {}
+        data["input_spec"] = {"clipper": "sound_tiling"}
+        _write_detector(det_path, data)
+
+        # Re-save from a clean dataset — fixture medias have no clipper.
+        res = client.post("/api/detectors/DropSpec/labels")
+        assert res.status_code == 200
+
+        updated = _read_detector(det_path)
+        assert updated is not None
+        assert "input_spec" not in updated
+
     def test_save_labels_does_not_expand_dupes(self, client):
         """Saving labels for a dupe-set representative should NOT expand members.
 

--- a/tests/detectors/test_input_spec.py
+++ b/tests/detectors/test_input_spec.py
@@ -1,0 +1,199 @@
+"""Tests for the detector input_spec helpers.
+
+Covers extraction from media origins, detector_meta assembly for labelset
+export, and apply-on-import semantics.  The CLI / sync round-trip is
+exercised separately in tests/cli and tests/io.
+"""
+
+from __future__ import annotations
+
+import app as app_module  # noqa: F401 — ensure plugin registries are populated
+from vtsearch.detectors.input_spec import (
+    apply_detector_meta,
+    build_detector_meta,
+    clipper_matches,
+    extract_input_spec_from_medias,
+)
+
+
+class TestExtractInputSpec:
+    def test_empty_medias(self):
+        assert extract_input_spec_from_medias({}) is None
+
+    def test_no_clipper_in_origin(self):
+        medias = {1: {"origin": {"importer": "server_folder", "params": {"path": "/tmp"}}}}
+        assert extract_input_spec_from_medias(medias) is None
+
+    def test_default_clipper_returns_none(self):
+        """A pass-through *_default clipper has no meaningful input spec."""
+        medias = {
+            1: {
+                "origin": {
+                    "importer": "server_folder",
+                    "params": {"clipper": "sound_default"},
+                }
+            }
+        }
+        assert extract_input_spec_from_medias(medias) is None
+
+    def test_clipper_name_only(self):
+        medias = {
+            1: {
+                "origin": {
+                    "importer": "server_folder",
+                    "params": {"clipper": "sound_tiling"},
+                }
+            }
+        }
+        spec = extract_input_spec_from_medias(medias)
+        assert spec == {"clipper": "sound_tiling"}
+
+    def test_clipper_with_params(self):
+        medias = {
+            1: {
+                "origin": {
+                    "importer": "server_folder",
+                    "params": {
+                        "clipper": "sound_tiling",
+                        "clipper_duration": "2.0",
+                        "clipper_min_overlap": "0.0",
+                    },
+                }
+            }
+        }
+        spec = extract_input_spec_from_medias(medias)
+        assert spec == {
+            "clipper": "sound_tiling",
+            "clipper_params": {"duration": "2.0", "min_overlap": "0.0"},
+        }
+
+    def test_ignores_per_clip_boundary_keys(self):
+        """clipper_start / clipper_end / clipper_box / clipper_index are not params."""
+        medias = {
+            1: {
+                "origin": {
+                    "importer": "server_folder",
+                    "params": {
+                        "clipper": "sound_tiling",
+                        "clipper_start": "0.0",
+                        "clipper_end": "2.0",
+                        "clipper_index": "0",
+                        "clipper_duration": "2.0",
+                    },
+                }
+            }
+        }
+        spec = extract_input_spec_from_medias(medias)
+        assert spec == {
+            "clipper": "sound_tiling",
+            "clipper_params": {"duration": "2.0"},
+        }
+
+    def test_uses_first_origin_with_params(self):
+        """Medias without origins are skipped until one is found."""
+        medias = {
+            1: {},
+            2: {"origin": {}},
+            3: {
+                "origin": {
+                    "importer": "server_folder",
+                    "params": {"clipper": "sound_tiling"},
+                }
+            },
+        }
+        spec = extract_input_spec_from_medias(medias)
+        assert spec == {"clipper": "sound_tiling"}
+
+
+class TestBuildDetectorMeta:
+    def test_minimal(self):
+        meta = build_detector_meta({"media_type": "audio"})
+        assert meta == {"media_type": "audio"}
+
+    def test_with_input_spec(self):
+        det = {
+            "media_type": "audio",
+            "input_spec": {"clipper": "sound_tiling", "clipper_params": {"duration": "2.0"}},
+        }
+        meta = build_detector_meta(det)
+        assert meta["media_type"] == "audio"
+        assert meta["input_spec"] == det["input_spec"]
+        # Defensive copy — mutating the meta dict must not affect the source.
+        meta["input_spec"]["clipper"] = "changed"
+        assert det["input_spec"]["clipper"] == "sound_tiling"
+
+    def test_with_threshold(self):
+        meta = build_detector_meta({"media_type": "audio"}, threshold=0.42)
+        assert meta == {"media_type": "audio", "threshold": 0.42}
+
+    def test_skips_empty_input_spec(self):
+        meta = build_detector_meta({"media_type": "audio", "input_spec": {}})
+        assert "input_spec" not in meta
+
+    def test_threshold_none_omitted(self):
+        meta = build_detector_meta({"media_type": "audio"}, threshold=None)
+        assert "threshold" not in meta
+
+
+class TestApplyDetectorMeta:
+    def test_no_meta(self):
+        data: dict = {"media_type": "audio"}
+        assert apply_detector_meta(data, None) is False
+        assert data == {"media_type": "audio"}
+
+    def test_writes_input_spec(self):
+        data: dict = {"media_type": "audio"}
+        meta = {"input_spec": {"clipper": "sound_tiling"}}
+        assert apply_detector_meta(data, meta) is True
+        assert data["input_spec"] == {"clipper": "sound_tiling"}
+
+    def test_does_not_persist_threshold(self):
+        """threshold is informational; receiver retrains so we don't keep it."""
+        data: dict = {"media_type": "audio"}
+        meta = {"threshold": 0.7}
+        assert apply_detector_meta(data, meta) is False
+        assert "threshold" not in data
+
+    def test_fills_in_missing_media_type(self):
+        data: dict = {}
+        meta = {"media_type": "audio", "input_spec": {"clipper": "sound_tiling"}}
+        assert apply_detector_meta(data, meta) is True
+        assert data["media_type"] == "audio"
+
+    def test_does_not_overwrite_existing_media_type(self):
+        data: dict = {"media_type": "image"}
+        meta = {"media_type": "audio"}
+        assert apply_detector_meta(data, meta) is False
+        assert data["media_type"] == "image"
+
+    def test_no_change_when_spec_matches(self):
+        data: dict = {
+            "media_type": "audio",
+            "input_spec": {"clipper": "sound_tiling"},
+        }
+        meta = {"input_spec": {"clipper": "sound_tiling"}}
+        assert apply_detector_meta(data, meta) is False
+
+
+class TestClipperMatches:
+    def test_detector_without_spec_matches_anything(self):
+        assert clipper_matches(None, None) is True
+        assert clipper_matches(None, {"clipper": "sound_tiling"}) is True
+
+    def test_dataset_without_clipper_doesnt_match_clipped_detector(self):
+        assert clipper_matches({"clipper": "sound_tiling"}, None) is False
+
+    def test_names_must_match(self):
+        det = {"clipper": "sound_tiling"}
+        assert clipper_matches(det, {"clipper": "sound_tiling"}) is True
+        assert clipper_matches(det, {"clipper": "image_tiling"}) is False
+
+    def test_params_must_match(self):
+        det = {"clipper": "sound_tiling", "clipper_params": {"duration": "2.0"}}
+        assert clipper_matches(det, {"clipper": "sound_tiling", "clipper_params": {"duration": "2.0"}})
+        assert not clipper_matches(det, {"clipper": "sound_tiling", "clipper_params": {"duration": "5.0"}})
+
+    def test_string_int_param_equivalence(self):
+        """load_pipeline stores values as strings; comparisons coerce."""
+        det = {"clipper": "sound_tiling", "clipper_params": {"duration": "2"}}
+        assert clipper_matches(det, {"clipper": "sound_tiling", "clipper_params": {"duration": 2}})

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -704,6 +704,225 @@ class TestLabelsetSync:
             set_thread_detector_context(None)
             unregister_detector_context("test_import")
 
+    def test_sync_to_source_emits_detector_meta(self, tmp_path):
+        """sync_to_labelset_source writes the detector's input_spec / threshold."""
+        from vtsearch.detectors.store import _detector_path, _write_detector
+        from vtsearch.labels.sync import sync_to_labelset_source
+        from vtsearch.state.core import (
+            DetectorContext,
+            register_detector_context,
+            set_thread_detector_context,
+            unregister_detector_context,
+        )
+        from vtsearch.state.core import medias, good_votes
+
+        det_name = "meta_export"
+        det_path = _detector_path(det_name)
+        _write_detector(
+            det_path,
+            {
+                "name": det_name,
+                "media_type": "audio",
+                "labelset": {"labels": []},
+                "input_spec": {
+                    "clipper": "sound_tiling",
+                    "clipper_params": {"duration": "2.0"},
+                },
+            },
+        )
+
+        ctx = DetectorContext(det_name, name=det_name, media_type="audio")
+        # Stand in for a trained MLP so the threshold flows through.
+        ctx.model = object()
+        ctx.threshold = 0.31
+        ctx.labelset_source = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(tmp_path / "labels.json")},
+        }
+        register_detector_context(ctx)
+        set_thread_detector_context(ctx)
+
+        saved_medias = dict(medias)
+        mid = max(medias.keys(), default=0) + 20000
+        try:
+            medias[mid] = {"id": mid, "md5": "fake_md5", "type": "audio"}
+            good_votes[mid] = None
+            sync_to_labelset_source()
+
+            data = json.loads((tmp_path / "labels.json").read_text())
+            meta = data.get("detector_meta")
+            assert meta is not None
+            assert meta["media_type"] == "audio"
+            assert meta["input_spec"] == {
+                "clipper": "sound_tiling",
+                "clipper_params": {"duration": "2.0"},
+            }
+            assert meta["threshold"] == pytest.approx(0.31)
+        finally:
+            good_votes.pop(mid, None)
+            medias.pop(mid, None)
+            medias.update(saved_medias)
+            set_thread_detector_context(None)
+            unregister_detector_context(det_name)
+            if det_path.exists():
+                det_path.unlink()
+
+    def test_sync_to_source_skips_threshold_without_model(self, tmp_path):
+        """A detector that hasn't been trained yet has no live threshold to emit."""
+        from vtsearch.detectors.store import _detector_path, _write_detector
+        from vtsearch.labels.sync import sync_to_labelset_source
+        from vtsearch.state.core import (
+            DetectorContext,
+            register_detector_context,
+            set_thread_detector_context,
+            unregister_detector_context,
+        )
+        from vtsearch.state.core import medias, good_votes
+
+        det_name = "meta_no_model"
+        det_path = _detector_path(det_name)
+        _write_detector(
+            det_path,
+            {"name": det_name, "media_type": "audio", "labelset": {"labels": []}},
+        )
+
+        ctx = DetectorContext(det_name, name=det_name, media_type="audio")
+        ctx.model = None
+        ctx.threshold = 0.99  # noise — should NOT be emitted without a model
+        ctx.labelset_source = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(tmp_path / "labels.json")},
+        }
+        register_detector_context(ctx)
+        set_thread_detector_context(ctx)
+
+        saved_medias = dict(medias)
+        mid = max(medias.keys(), default=0) + 20100
+        try:
+            medias[mid] = {"id": mid, "md5": "fake_md5_2", "type": "audio"}
+            good_votes[mid] = None
+            sync_to_labelset_source()
+
+            data = json.loads((tmp_path / "labels.json").read_text())
+            meta = data.get("detector_meta")
+            assert meta is not None
+            assert "threshold" not in meta
+            assert meta["media_type"] == "audio"
+        finally:
+            good_votes.pop(mid, None)
+            medias.pop(mid, None)
+            medias.update(saved_medias)
+            set_thread_detector_context(None)
+            unregister_detector_context(det_name)
+            if det_path.exists():
+                det_path.unlink()
+
+    def test_sync_from_source_writes_input_spec_to_detector(self, tmp_path):
+        """An inbound detector_meta updates the receiving detector JSON's input_spec."""
+        from vtsearch.detectors.store import _detector_path, _read_detector, _write_detector
+        from vtsearch.labels.sync import sync_from_labelset_source
+        from vtsearch.state.core import (
+            DetectorContext,
+            register_detector_context,
+            set_thread_detector_context,
+            unregister_detector_context,
+        )
+
+        det_name = "meta_import"
+        det_path = _detector_path(det_name)
+        _write_detector(
+            det_path,
+            {"name": det_name, "media_type": "audio", "labelset": {"labels": []}},
+        )
+
+        filepath = tmp_path / "labels.json"
+        filepath.write_text(
+            json.dumps(
+                {
+                    "labels": [],
+                    "detector_meta": {
+                        "media_type": "audio",
+                        "input_spec": {
+                            "clipper": "sound_tiling",
+                            "clipper_params": {"duration": "2.0"},
+                        },
+                        # Threshold is informational; receiver retrains and
+                        # must NOT persist it.
+                        "threshold": 0.5,
+                    },
+                }
+            )
+        )
+
+        ctx = DetectorContext(det_name, name=det_name, media_type="audio")
+        ctx.labelset_source = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(filepath)},
+        }
+        register_detector_context(ctx)
+        set_thread_detector_context(ctx)
+
+        try:
+            sync_from_labelset_source()
+            updated = _read_detector(det_path)
+            assert updated is not None
+            assert updated["input_spec"] == {
+                "clipper": "sound_tiling",
+                "clipper_params": {"duration": "2.0"},
+            }
+            assert "threshold" not in updated
+        finally:
+            set_thread_detector_context(None)
+            unregister_detector_context(det_name)
+            if det_path.exists():
+                det_path.unlink()
+
+    def test_sync_from_source_without_detector_meta_leaves_detector_alone(self, tmp_path):
+        """Legacy labelsets (no detector_meta) don't mutate the receiving detector."""
+        from vtsearch.detectors.store import _detector_path, _read_detector, _write_detector
+        from vtsearch.labels.sync import sync_from_labelset_source
+        from vtsearch.state.core import (
+            DetectorContext,
+            register_detector_context,
+            set_thread_detector_context,
+            unregister_detector_context,
+        )
+
+        det_name = "meta_legacy"
+        det_path = _detector_path(det_name)
+        _write_detector(
+            det_path,
+            {
+                "name": det_name,
+                "media_type": "audio",
+                "labelset": {"labels": []},
+                "input_spec": {"clipper": "sound_tiling"},
+            },
+        )
+
+        filepath = tmp_path / "labels.json"
+        filepath.write_text(json.dumps({"labels": []}))
+
+        ctx = DetectorContext(det_name, name=det_name, media_type="audio")
+        ctx.labelset_source = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(filepath)},
+        }
+        register_detector_context(ctx)
+        set_thread_detector_context(ctx)
+
+        try:
+            sync_from_labelset_source()
+            updated = _read_detector(det_path)
+            assert updated is not None
+            # Receiver's existing input_spec is preserved.
+            assert updated["input_spec"] == {"clipper": "sound_tiling"}
+        finally:
+            set_thread_detector_context(None)
+            unregister_detector_context(det_name)
+            if det_path.exists():
+                det_path.unlink()
+
 
 # ---------------------------------------------------------------------------
 # API routes: settings sources

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -124,7 +124,11 @@ def _load_and_train_detectors(
     labelset's origins are resolved via their importer's ``resolve_file()``,
     the files are embedded with the dataset's embedder, and an MLP is trained
     from the resulting vectors.  Detectors whose ``media_type`` doesn't match
-    the dataset are skipped with a warning.
+    the dataset are skipped with a warning.  Detectors that declare an
+    ``input_spec`` (a clipper the detector was trained on) are also skipped
+    when the loaded dataset wasn't clipped to match — the resulting
+    embeddings would be from a different granularity and the scores would
+    be meaningless.
 
     Returns a ``{name: {"mlp": nn.Sequential, "threshold": float}}`` map.
     Raises :class:`ValueError` if a detector cannot be trained — for example
@@ -132,9 +136,15 @@ def _load_and_train_detectors(
     environment.
     """
     from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.detectors.input_spec import (
+        clipper_matches,
+        extract_input_spec_from_medias,
+    )
     from vtsearch.detectors.store import _detector_path, _read_detector
     from vtsearch.detectors.labelset_training import train_from_labelset
     from vtsearch.state.core import DetectorContext
+
+    dataset_spec = extract_input_spec_from_medias(snap)
 
     out: dict[str, dict[str, Any]] = {}
     for det_name in detector_names:
@@ -153,6 +163,24 @@ def _load_and_train_detectors(
                 detector=det_name,
                 detector_media_type=det_media_type,
                 dataset_media_type=media_type,
+            )
+            continue
+
+        det_input_spec = det.get("input_spec") if isinstance(det.get("input_spec"), dict) else None
+        if det_input_spec and not clipper_matches(det_input_spec, dataset_spec):
+            det_clipper = det_input_spec.get("clipper") or ""
+            dataset_clipper = (dataset_spec or {}).get("clipper") or "(none)"
+            cli_progress.emit(
+                "detector_skipped",
+                text=(
+                    f"Skipping detector '{det_name}': input_spec.clipper "
+                    f"{det_clipper!r} doesn't match dataset clipper "
+                    f"{dataset_clipper!r}. Re-load the dataset with the "
+                    f"matching clipper to use this detector."
+                ),
+                detector=det_name,
+                detector_input_spec=det_input_spec,
+                dataset_input_spec=dataset_spec or {},
             )
             continue
 

--- a/vtsearch/datasets/labelset.py
+++ b/vtsearch/datasets/labelset.py
@@ -112,10 +112,24 @@ class LabelSet:
 
     Parameters:
         elements: Initial list of :class:`LabeledElement` instances.
+        detector_meta: Optional detector-level metadata block.  When
+            present, lets a labelset round-trip a detector's
+            ``media_type``, ``input_spec`` (clipper + params), and current
+            ``threshold`` so an external consumer can reproduce the
+            detector's expected input format and decision boundary without
+            reading the detector JSON directly.  Strictly informational —
+            ``None`` (the default) means the labelset carries only labels,
+            preserving the legacy format.
     """
 
-    def __init__(self, elements: list[LabeledElement] | None = None) -> None:
+    def __init__(
+        self,
+        elements: list[LabeledElement] | None = None,
+        *,
+        detector_meta: dict[str, Any] | None = None,
+    ) -> None:
         self.elements: list[LabeledElement] = list(elements) if elements else []
+        self.detector_meta: dict[str, Any] | None = dict(detector_meta) if detector_meta else None
 
     def __len__(self) -> int:
         return len(self.elements)
@@ -136,6 +150,7 @@ class LabelSet:
         *,
         expand_dupes: bool = True,
         vote_region_boxes: dict[int, tuple[float, float, float, float]] | None = None,
+        detector_meta: dict[str, Any] | None = None,
     ) -> LabelSet:
         """Build a ``LabelSet`` from the current media and vote state.
 
@@ -154,6 +169,11 @@ class LabelSet:
                 box is attached to the corresponding good vote's
                 :class:`LabeledElement`.  Ignored for bad votes (no-votes
                 are always image-level — see the patch-embedder v2 design).
+            detector_meta: Optional detector-level metadata block to attach
+                to the labelset (e.g. ``{"media_type": ..., "input_spec":
+                ..., "threshold": ...}``).  Lets the labelset carry the
+                originating detector's expected input format and decision
+                boundary so an external consumer can reproduce them.
 
         Returns:
             A new ``LabelSet`` containing one :class:`LabeledElement` per
@@ -176,7 +196,7 @@ class LabelSet:
             media = medias.get(cid)
             if media:
                 elements.extend(_clip_to_elements(media, "bad", expand_dupes=expand_dupes))
-        return cls(elements)
+        return cls(elements, detector_meta=detector_meta)
 
     @classmethod
     def from_results(
@@ -230,26 +250,34 @@ class LabelSet:
         """Serialise to a plain dict.
 
         Returns:
-            ``{"labels": [<element dict>, ...]}``.  The format is a
-            superset of the legacy label-export format (which only had
-            ``md5`` and ``label`` keys), so existing consumers remain
-            compatible.
+            ``{"labels": [<element dict>, ...]}`` plus an optional
+            top-level ``"detector_meta"`` block when one was attached.
+            The format is a superset of the legacy label-export format
+            (which only had ``md5`` and ``label`` keys), so existing
+            consumers remain compatible — they ignore ``detector_meta``.
         """
-        return {"labels": [e.to_dict() for e in self.elements]}
+        out: dict[str, Any] = {"labels": [e.to_dict() for e in self.elements]}
+        if self.detector_meta is not None:
+            out["detector_meta"] = dict(self.detector_meta)
+        return out
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> LabelSet:
         """Reconstruct a ``LabelSet`` from a dict produced by :meth:`to_dict`.
 
         Also accepts the legacy label format (entries with only ``md5`` and
-        ``label`` keys) for backward compatibility.
+        ``label`` keys) for backward compatibility.  When a top-level
+        ``"detector_meta"`` block is present, it is attached to the
+        reconstructed :class:`LabelSet`.
         """
         elements: list[LabeledElement] = []
         for entry in d.get("labels", []):
             if not isinstance(entry, dict):
                 continue
             elements.append(LabeledElement.from_dict(entry))
-        return cls(elements)
+        dm = d.get("detector_meta")
+        detector_meta = dm if isinstance(dm, dict) else None
+        return cls(elements, detector_meta=detector_meta)
 
     # ------------------------------------------------------------------
     # Merging
@@ -325,6 +353,10 @@ class LabelSet:
                         region_box=el.region_box,
                     )
                 )
+        # Merged labelsets represent a new combined detector; do not
+        # carry the originating detector's ``detector_meta`` (input_spec,
+        # threshold) into the merged result — those describe a single
+        # detector's training context.
         return LabelSet(merged)
 
 

--- a/vtsearch/detectors/input_spec.py
+++ b/vtsearch/detectors/input_spec.py
@@ -45,7 +45,10 @@ def extract_input_spec_from_medias(
             continue
         clipper_name = params.get("clipper", "")
         if not clipper_name or clipper_name.endswith("_default"):
-            return None
+            # A media with no clipper (or the default pass-through) is
+            # uninformative — keep scanning in case a clipped media
+            # appears later in iteration order.
+            continue
         clipper_params: dict[str, str] = {}
         for key, value in params.items():
             if not isinstance(key, str) or not key.startswith("clipper_"):

--- a/vtsearch/detectors/input_spec.py
+++ b/vtsearch/detectors/input_spec.py
@@ -1,0 +1,147 @@
+"""Detector input-spec helpers.
+
+A detector's ``input_spec`` describes the input format it was trained on
+— specifically the clipper that split source media into the clips its
+MLP saw.  At inference time the CLI uses this to decide whether the
+loaded dataset matches the detector's expected granularity.
+
+The module also assembles the ``detector_meta`` block that travels with
+a labelset when synced through a :class:`LabelsetSource`, so a downstream
+consumer can reproduce the detector's input format and decision boundary
+without reading the detector JSON directly.
+
+``input_spec`` and ``detector_meta`` are both **optional**: detectors
+that never set ``input_spec`` behave exactly as before, and labelsets
+exported without a ``detector_meta`` block are still valid.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_input_spec_from_medias(
+    medias: dict[int, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the clipper config stamped onto *medias* by the loader.
+
+    The dataset-load pipeline (:func:`vtsearch.datasets.load_pipeline._apply_clipper`)
+    writes the active clipper's name and effective parameter values into
+    every clip's ``origin.params`` (as ``clipper`` plus ``clipper_<key>``
+    entries).  This function reads those back from the first non-empty
+    origin so the calling detector can record the input format it was
+    trained on.
+
+    Returns ``None`` when no clipper info is present — including the case
+    where the dataset was loaded without any clipper, or with a ``*_default``
+    clipper (which is a no-op pass-through and not worth persisting).
+    """
+    for media in medias.values():
+        origin = media.get("origin")
+        if not isinstance(origin, dict):
+            continue
+        params = origin.get("params")
+        if not isinstance(params, dict):
+            continue
+        clipper_name = params.get("clipper", "")
+        if not clipper_name or clipper_name.endswith("_default"):
+            return None
+        clipper_params: dict[str, str] = {}
+        for key, value in params.items():
+            if not isinstance(key, str) or not key.startswith("clipper_"):
+                continue
+            # Skip the bare ``clipper`` key itself (handled above) and
+            # per-clip boundary fields that are not clipper parameters.
+            inner = key[len("clipper_") :]
+            if inner in ("", "start", "end", "box", "index"):
+                continue
+            clipper_params[inner] = str(value)
+        spec: dict[str, Any] = {"clipper": clipper_name}
+        if clipper_params:
+            spec["clipper_params"] = clipper_params
+        return spec
+    return None
+
+
+def build_detector_meta(
+    detector_data: dict[str, Any],
+    *,
+    threshold: float | None = None,
+) -> dict[str, Any]:
+    """Assemble a ``detector_meta`` block for labelset export.
+
+    Pulls ``media_type`` and ``input_spec`` straight from the detector
+    JSON dict and folds in the supplied *threshold* (typically the active
+    in-memory MLP's calibrated threshold).  Keys with empty/None values
+    are omitted so the block stays minimal — a detector with neither an
+    ``input_spec`` nor a current threshold produces a block containing
+    only ``media_type``.
+    """
+    meta: dict[str, Any] = {}
+    media_type = detector_data.get("media_type") or ""
+    if media_type:
+        meta["media_type"] = media_type
+    spec = detector_data.get("input_spec")
+    if isinstance(spec, dict) and spec:
+        meta["input_spec"] = dict(spec)
+    if threshold is not None:
+        meta["threshold"] = float(threshold)
+    return meta
+
+
+def apply_detector_meta(
+    detector_data: dict[str, Any],
+    detector_meta: dict[str, Any] | None,
+) -> bool:
+    """Apply an inbound ``detector_meta`` block to a detector JSON dict.
+
+    Writes ``input_spec`` (and ``media_type`` when the receiver doesn't
+    already have one) so the receiving detector picks up the originating
+    detector's expected input format.  Does **not** persist ``threshold``
+    — the receiver retrains its own MLP from the imported labels, so the
+    threshold is rederived on the next load.
+
+    Returns ``True`` when *detector_data* was modified.
+    """
+    if not detector_meta:
+        return False
+    changed = False
+    spec = detector_meta.get("input_spec")
+    if isinstance(spec, dict) and spec:
+        existing = detector_data.get("input_spec")
+        if existing != spec:
+            detector_data["input_spec"] = dict(spec)
+            changed = True
+    incoming_type = detector_meta.get("media_type") or ""
+    if incoming_type and not detector_data.get("media_type"):
+        detector_data["media_type"] = incoming_type
+        changed = True
+    return changed
+
+
+def clipper_matches(
+    detector_spec: dict[str, Any] | None,
+    dataset_spec: dict[str, Any] | None,
+) -> bool:
+    """Return True when *detector_spec* and *dataset_spec* describe the same clipper.
+
+    Both arguments use the format returned by
+    :func:`extract_input_spec_from_medias` (``{"clipper": ..., "clipper_params": {...}}``)
+    and accept ``None`` to mean "no clipper / default clipper".  A detector
+    without an ``input_spec`` accepts any dataset, since the legacy
+    behaviour is to score whatever embeddings the dataset already
+    contains.
+    """
+    if not detector_spec:
+        return True
+    detector_clipper = detector_spec.get("clipper") or ""
+    dataset_clipper = (dataset_spec or {}).get("clipper") or ""
+    if detector_clipper != dataset_clipper:
+        return False
+    detector_params = detector_spec.get("clipper_params") or {}
+    dataset_params = (dataset_spec or {}).get("clipper_params") or {}
+    # Compare as string maps — load_pipeline stores effective values as
+    # strings, so a detector saved from a sound_tiling(duration=2.0) load
+    # records ``{"duration": "2.0"}`` and we want a downstream dataset
+    # loaded with the same params to match.
+    return {str(k): str(v) for k, v in detector_params.items()} == {str(k): str(v) for k, v in dataset_params.items()}

--- a/vtsearch/labels/sources/base.py
+++ b/vtsearch/labels/sources/base.py
@@ -38,4 +38,25 @@ class LabelsetSource(SyncSource[list[dict[str, str]], "LabelSet"]):
     ``load(field_values)`` returns a list of label dicts
     (``{"md5": ..., "label": "good"|"bad"}``).
     ``save(labelset, field_values)`` persists a :class:`LabelSet`.
+
+    A subclass MAY additionally override :meth:`load_full` to surface any
+    detector-level metadata the source carries alongside the labels (e.g.
+    ``media_type``, ``input_spec``, ``threshold``).  The default
+    implementation wraps :meth:`load` into a :class:`LabelSet` with no
+    ``detector_meta``, so sources that only round-trip labels keep
+    working unchanged.
     """
+
+    def load_full(self, field_values: dict[str, str]) -> "LabelSet":
+        """Return the full :class:`LabelSet` (labels + optional detector_meta).
+
+        Default implementation wraps :meth:`load` so sources that only
+        return raw label dicts still produce a valid :class:`LabelSet`.
+        Subclasses with access to richer metadata should override this to
+        attach a ``detector_meta`` block.
+        """
+        from vtsearch.datasets.labelset import LabeledElement, LabelSet
+
+        entries = self.load(field_values)
+        elements = [LabeledElement.from_dict(e) for e in entries if isinstance(e, dict)]
+        return LabelSet(elements)

--- a/vtsearch/labels/sources/server_json_file/__init__.py
+++ b/vtsearch/labels/sources/server_json_file/__init__.py
@@ -57,6 +57,27 @@ class ServerFileLabelsetSource(LabelsetSource):
             raise ValueError("JSON must contain a top-level 'labels' list.")
         return [entry for entry in labels if isinstance(entry, dict)]
 
+    def load_full(self, field_values: dict[str, Any]) -> LabelSet:
+        """Read labels *and* any ``detector_meta`` block into a :class:`LabelSet`."""
+        from vtsearch.datasets.labelset import LabelSet as _LabelSet
+
+        path = Path(_resolve_filepath(field_values))
+        if not path.exists():
+            return _LabelSet()
+        if not path.is_file():
+            raise ValueError(f"Not a file: {path}")
+
+        raw = path.read_bytes()
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except Exception as exc:
+            raise ValueError(f"Invalid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("JSON must contain an object at the top level.")
+        if not isinstance(data.get("labels"), list):
+            raise ValueError("JSON must contain a top-level 'labels' list.")
+        return _LabelSet.from_dict(data)
+
     def save(self, labelset: LabelSet, field_values: dict[str, Any]) -> None:
         """Write labels to a JSON file on the server."""
         filepath = Path(_resolve_filepath(field_values))

--- a/vtsearch/labels/sync.py
+++ b/vtsearch/labels/sync.py
@@ -51,7 +51,16 @@ def sync_to_labelset_source() -> None:
     field_values = cfg.get("field_values", {})
 
     from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.detectors.input_spec import build_detector_meta
+    from vtsearch.detectors.store import _detector_path, _read_detector
     from vtsearch.state.core import good_votes, bad_votes, medias, vote_region_boxes
+
+    # Read the detector JSON so the exported labelset can carry its
+    # input_spec / media_type alongside the in-memory threshold.  Anything
+    # missing is simply omitted from detector_meta.
+    detector_data = _read_detector(_detector_path(ctx.name)) or {}
+    threshold = ctx.threshold if ctx.model is not None else None
+    detector_meta = build_detector_meta(detector_data, threshold=threshold)
 
     # Serialize against any in-progress sync_from on another thread.
     # Re-check the flag inside the lock so we never push partial state
@@ -65,6 +74,7 @@ def sync_to_labelset_source() -> None:
                 dict(good_votes),
                 dict(bad_votes),
                 vote_region_boxes=dict(vote_region_boxes),
+                detector_meta=detector_meta or None,
             )
             source.save(labelset, field_values)
         except Exception as exc:
@@ -106,13 +116,31 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
 
     field_values = cfg.get("field_values", {})
     try:
-        labels = source.load(field_values)
+        labelset = source.load_full(field_values)
     except Exception as exc:
         logger.exception("Failed to load from labelset source: %s", exc)
         return None
 
-    if not labels:
+    if not labelset.elements and not labelset.detector_meta:
         return None
+
+    # If the source carried a detector_meta block, fold its input_spec
+    # (and media_type, when the receiver is missing one) into the
+    # receiving detector's on-disk JSON.  threshold is intentionally
+    # *not* persisted — the receiver will retrain its MLP from the
+    # imported labels and recompute its own threshold.
+    if labelset.detector_meta:
+        from vtsearch.detectors.input_spec import apply_detector_meta
+        from vtsearch.detectors.store import _detector_path, _read_detector, _write_detector
+
+        det_path = _detector_path(ctx.name)
+        det_data = _read_detector(det_path)
+        if det_data is not None and apply_detector_meta(det_data, labelset.detector_meta):
+            _write_detector(det_path, det_data)
+
+    labels = [el.to_dict() for el in labelset.elements]
+    if not labels:
+        return labels
 
     # Hold _sync_lock for the entire apply pass so that any concurrent
     # sync_to_labelset_source() on another thread blocks (or skips, on

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -115,6 +115,7 @@ def save_detector_labels(name: str):
         abort(404, message=f"Detector '{name}' not found")
 
     from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.detectors.input_spec import extract_input_spec_from_medias
     from vtsearch.state import (
         bad_votes,
         good_votes,
@@ -122,14 +123,26 @@ def save_detector_labels(name: str):
         vote_region_boxes,
     )
 
+    medias_snap = snapshot_medias()
     labelset = LabelSet.from_clips_and_votes(
-        snapshot_medias(),
+        medias_snap,
         good_votes,
         bad_votes,
         expand_dupes=False,
         vote_region_boxes=dict(vote_region_boxes),
     )
     data["labelset"] = labelset.to_dict()
+
+    # Capture the active dataset's clipper into the detector's input_spec
+    # so downstream consumers (CLI autodetect, labelset-source sync) can
+    # tell what input format this detector was trained on.  ``None`` means
+    # "no clipper / default clipper"; we drop any previously-stored
+    # input_spec in that case so the field stays in sync with reality.
+    captured_spec = extract_input_spec_from_medias(medias_snap)
+    if captured_spec is not None:
+        data["input_spec"] = captured_spec
+    elif "input_spec" in data:
+        data.pop("input_spec", None)
     _write_detector(path, data)
 
     # Also update the detector registry entry if one exists


### PR DESCRIPTION
## Summary

Ships Phase 1 of task 17.2 (`docs/design/cli-detector-converter.md`) as an opt-in:

- Detectors **may** record the clipper they were trained on (`input_spec.clipper` + `clipper_params`) so the CLI doesn't silently score against mismatched embeddings.
- LabelSets **may** carry a top-level `detector_meta` block (`media_type`, `input_spec`, `threshold`) so a round-trip through a `LabelsetSource` doesn't drop the training context — closing the gap raised on the design doc thread.
- Detectors and labelsets without those fields keep working exactly as before.

Deferred scope and known limitations are tracked in the **Open follow-ups** section of `docs/design/cli-detector-converter.md`, not here.

## Changes

- `LabelSet` gains an optional `detector_meta` block. `to_dict` / `from_dict` / `from_clips_and_votes` round-trip it; `merge()` drops it (merged labelsets have a new identity).
- New `vtsearch.detectors.input_spec` module: extract clipper config from media origins, assemble/apply `detector_meta`, compare clipper specs.
- `save_detector_labels` captures the active dataset's clipper into the detector JSON's `input_spec` (and clears any stale one when re-saving from an unclipped dataset).
- `LabelsetSource` gains `load_full()` returning a `LabelSet` (default wraps the legacy `load()`); `server_json_file` overrides it. `sync_to`/`sync_from` round-trip `detector_meta` — threshold is intentionally *not* persisted on the receiver since it retrains.
- CLI `_load_and_train_detectors` skips detectors whose `input_spec` doesn't match the loaded dataset's clipper, with a clear progress message pointing at how to reload.
- Plan-file status header updated; **Open follow-ups** section added in `docs/design/cli-detector-converter.md`.
- `CLAUDE.md` updated with a "follow-ups belong in the plan file" rule so this pattern carries forward.
- Tests cover `detector_meta` round-trip, `input_spec` extraction/apply, clipper-matching semantics, sync source round-trip (including the "no detector_meta = leave receiver alone" case), and CLI skip-on-mismatch.

## Test plan

- [x] `./run-tests.sh` — 3582 passed, 1 skipped, 2 xpassed.
- [x] New tests for the LabelSet `detector_meta` block, `input_spec` helpers, save-labels capture, sync round-trip (with and without `detector_meta`), and CLI skip behavior.
- [ ] Manual sanity in a real session: save labels on a clipped dataset, confirm the detector JSON gains `input_spec`; re-run autodetect against an unclipped dataset and confirm the skip message.

https://claude.ai/code/session_01G4KTq1oersvCPSMTuJVbnR