### PR TITLE
Lock new-detector media type to active dataset

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -30,27 +30,50 @@
       @if (tab === 'blank') {
         <div class="form-group">
           <label class="col-label" title="The type of media this model will process">Media Type</label>
-          <div class="custom-select" [class.open]="mediaTypeDropdownOpen" title="The type of media this model will process">
-            <button type="button" class="custom-select-trigger form-input" (click)="mediaTypeDropdownOpen = !mediaTypeDropdownOpen" title="Select the media type for this model">
-              <span class="select-option-content">
-                @if (getMediaTypeIcon(mediaType)) {
-                  <vt-icon [type]="getMediaTypeIcon(mediaType)" [size]="14"></vt-icon>
+          <div class="media-type-row">
+            <div class="custom-select"
+              [class.open]="mediaTypeDropdownOpen"
+              [class.locked]="mediaTypeLocked"
+              [title]="mediaTypeLocked ? 'Locked to the active dataset\'s media type. Click the unlock button to choose a different type.' : 'The type of media this model will process'">
+              <button type="button" class="custom-select-trigger form-input"
+                [class.is-locked]="mediaTypeLocked"
+                [disabled]="mediaTypeLocked"
+                [attr.aria-disabled]="mediaTypeLocked"
+                (click)="toggleMediaTypeDropdown()"
+                [title]="mediaTypeLocked ? 'Locked to the active dataset\'s media type' : 'Select the media type for this model'">
+                <span class="select-option-content">
+                  @if (getMediaTypeIcon(mediaType)) {
+                    <vt-icon [type]="getMediaTypeIcon(mediaType)" [size]="14"></vt-icon>
+                  }
+                  <span>{{ getMediaTypeLabel(mediaType) }}</span>
+                </span>
+                @if (!mediaTypeLocked) {
+                  <svg class="select-arrow" width="10" height="6" viewBox="0 0 10 6" fill="currentColor" aria-hidden="true"><path d="M0 0l5 6 5-6z"/></svg>
                 }
-                <span>{{ getMediaTypeLabel(mediaType) }}</span>
-              </span>
-              <svg class="select-arrow" width="10" height="6" viewBox="0 0 10 6" fill="currentColor" aria-hidden="true"><path d="M0 0l5 6 5-6z"/></svg>
-            </button>
-            @if (mediaTypeDropdownOpen) {
-              <div class="custom-select-options">
-                @for (mt of mediaTypes; track mt) {
-                  <button type="button" class="custom-select-option" [class.selected]="mt === mediaType" (click)="mediaType = mt; mediaTypeDropdownOpen = false">
-                    @if (getMediaTypeIcon(mt)) {
-                      <vt-icon [type]="getMediaTypeIcon(mt)" [size]="14"></vt-icon>
-                    }
-                    <span>{{ getMediaTypeLabel(mt) }}</span>
-                  </button>
-                }
-              </div>
+              </button>
+              @if (mediaTypeDropdownOpen && !mediaTypeLocked) {
+                <div class="custom-select-options">
+                  @for (mt of mediaTypes; track mt) {
+                    <button type="button" class="custom-select-option" [class.selected]="mt === mediaType" (click)="mediaType = mt; mediaTypeDropdownOpen = false">
+                      @if (getMediaTypeIcon(mt)) {
+                        <vt-icon [type]="getMediaTypeIcon(mt)" [size]="14"></vt-icon>
+                      }
+                      <span>{{ getMediaTypeLabel(mt) }}</span>
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+            @if (mediaTypeLocked) {
+              <button type="button" class="lock-toggle"
+                (click)="unlockMediaType()"
+                title="Unlock to choose a different media type"
+                aria-label="Unlock media type">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                  <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
+                </svg>
+              </button>
             }
           </div>
         </div>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -254,8 +254,43 @@
   padding: 16px 0;
 }
 
+// Media-type field row: dropdown + optional unlock button.
+.media-type-row {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+
+  .custom-select { flex: 1; min-width: 0; }
+}
+
+.lock-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg, 6px);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--accent);
+    background: var(--bg-hover);
+  }
+}
+
 // Custom select dropdown (supports icons inside options)
 .custom-select { position: relative; }
+
+.custom-select-trigger.is-locked {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: var(--bg-disabled, var(--bg-subtle));
+  color: var(--text-muted);
+}
 
 .custom-select-trigger {
   display: flex;

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -128,4 +128,64 @@ describe('NewDetectorModalComponent', () => {
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
   });
+
+  it('should not lock media type when no default is provided', () => {
+    expect(component.mediaTypeLocked).toBeFalse();
+  });
+
+  it('should ignore toggleMediaTypeDropdown when locked', () => {
+    component.mediaTypeLocked = true;
+    component.mediaTypeDropdownOpen = false;
+    component.toggleMediaTypeDropdown();
+    expect(component.mediaTypeDropdownOpen).toBeFalse();
+  });
+
+  it('should open dropdown via toggle when unlocked', () => {
+    component.mediaTypeLocked = false;
+    component.mediaTypeDropdownOpen = false;
+    component.toggleMediaTypeDropdown();
+    expect(component.mediaTypeDropdownOpen).toBeTrue();
+  });
+
+  it('should unlock media type on explicit unlock', () => {
+    component.mediaTypeLocked = true;
+    component.unlockMediaType();
+    expect(component.mediaTypeLocked).toBeFalse();
+  });
+});
+
+describe('NewDetectorModalComponent with defaultMediaType', () => {
+  let component: NewDetectorModalComponent;
+  let fixture: ComponentFixture<NewDetectorModalComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NewDetectorModalComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewDetectorModalComponent);
+    component = fixture.componentInstance;
+    component.defaultMediaType = 'image';
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/media-types').flush({
+      media_types: [
+        { type_id: 'audio', name: 'Audio', icon: 'audio', tab_title: 'Sounds' },
+        { type_id: 'image', name: 'Image', icon: 'image', tab_title: 'Images' },
+      ],
+    });
+    // No /api/datasets/registry call when defaultMediaType is provided.
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should lock media type to the active dataset type', () => {
+    expect(component.mediaType).toBe('image');
+    expect(component.mediaTypeLocked).toBeTrue();
+  });
 });

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -66,6 +66,11 @@ export class NewDetectorModalComponent implements OnInit {
   submitting = false;
   error = '';
   mediaTypeDropdownOpen = false;
+  /** True when the media-type field is locked to the active dataset's type.
+   *  Set on init whenever `defaultMediaType` is provided; cleared when the
+   *  user clicks the unlock button. The dropdown trigger is disabled while
+   *  locked so the user can't accidentally change it. */
+  mediaTypeLocked = false;
 
   // Single example (text or media, not both)
   exampleType: 'text' | 'media' | null = null;
@@ -197,8 +202,11 @@ export class NewDetectorModalComponent implements OnInit {
     });
 
     // Prefer the explicit default (active dataset's type) over the all-datasets guess.
+    // When the active dataset dictates the type, lock the field so the user
+    // can't change it without an explicit unlock click.
     if (this.defaultMediaType) {
       this.mediaType = this.defaultMediaType;
+      this.mediaTypeLocked = true;
     } else {
       this.datasetsApi.getRegistry().subscribe({
         next: (res) => {
@@ -211,6 +219,15 @@ export class NewDetectorModalComponent implements OnInit {
         },
       });
     }
+  }
+
+  unlockMediaType(): void {
+    this.mediaTypeLocked = false;
+  }
+
+  toggleMediaTypeDropdown(): void {
+    if (this.mediaTypeLocked) return;
+    this.mediaTypeDropdownOpen = !this.mediaTypeDropdownOpen;
   }
 
   get modalTitle(): string {


### PR DESCRIPTION
## Summary

Implements UX item **1.6 Detector media type from selected dataset**.

The New Model modal already pre-filled `media_type` from the active dataset on the dashboard. This change extends that behavior so the field is also **locked and grayed out** while pre-filled — preventing accidental mismatches between the model and the dataset it'll be used against — and adds an explicit unlock button (open-padlock icon) for the rare case where the user really does want a different type.

### Behavior

- When the dashboard implies a single media type (one selected dataset, one loaded dataset, or one in-progress load), the modal opens with that type pre-selected **and** locked. The dropdown trigger is disabled, dimmed, and shows no dropdown caret.
- An open-padlock button appears beside the dropdown. Clicking it unlocks the field, re-enables the dropdown, and lets the user pick any media type.
- When no single dataset implies a type (empty dashboard, mixed types, etc.), the field opens unlocked with the existing fallback heuristic — no change.

### Files touched

- `new-detector-modal.component.ts` — new `mediaTypeLocked` flag, `unlockMediaType()` / `toggleMediaTypeDropdown()` methods, set lock on init when `defaultMediaType` is provided.
- `new-detector-modal.component.html` — wrap the dropdown in a flex row with the unlock button; pass `disabled` + `is-locked` class when locked; hide the dropdown caret and options panel while locked.
- `new-detector-modal.component.scss` — `.media-type-row`, `.lock-toggle`, and `.is-locked` styles (dimmed trigger, `cursor: not-allowed`).
- `new-detector-modal.component.spec.ts` — coverage for lock state, unlock action, toggle no-op while locked, and a separate fixture that confirms `defaultMediaType` triggers the lock.

## Test plan

- [x] `./run-tests.sh` — 3547 passed, 1 skipped, 0 failed (full suite including the frontend `build:prod` check)
- [x] Frontend `npm run build:prod` — clean, no warnings
- [ ] Manual: open dashboard with one loaded dataset, click "+ New Model", confirm media type is locked to that dataset's type and unlock button works
- [ ] Manual: open dashboard with no dataset selected, confirm field is unlocked


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Kjr57mAme4dDsQFFCsaF)_