### PR TITLE
Hardware-derived defaults for dataset-load concurrency gates

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -358,7 +358,10 @@ Notable fields:
   phase; the embed gate covers CPU/GPU-bound embedding plus post-load
   clipping, dedup, and diversity-tree construction. Changes take
   effect on queued and future loads (running tasks are never
-  preempted). Defaults are `1/1` (serialised).
+  preempted). Defaults derive from hardware on first read (and are
+  **not** persisted to disk): downloads = `min(4, cpu_count)`,
+  embeddings = `1` on CPU-only hosts else `min(2, gpu_count)`. An
+  explicit value in `settings.json` always wins.
 - `settings_source` (not shown above; excluded from defaults) — opt-in
   bidirectional sync. Set to a plugin name + field values to auto-export
   every settings change and auto-import at startup. See `settings_io/sources/`.

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -105,6 +105,37 @@ class TestSettingsModule:
         settings_mod.set_autorun_detectors(["x", "y", "x"])
         assert settings_mod.get_autorun_detectors() == ["x", "y"]
 
+    def test_max_concurrent_downloads_default_from_hardware(self, isolated_settings):
+        """With no override on disk, the default scales with cpu_count (cap 4)."""
+        import os
+
+        expected = max(1, min(4, os.cpu_count() or 1))
+        assert settings_mod.get_max_concurrent_dataset_downloads() == expected
+        # The hardware-derived default must NOT be persisted to disk — only
+        # explicit ``set_*`` calls write keys. (The fixture pre-writes a few
+        # path keys; we just check our key is absent.)
+        raw = isolated_settings.read_text() if isolated_settings.exists() else ""
+        assert "max_concurrent_dataset_downloads" not in raw
+
+    def test_max_concurrent_embeddings_default_from_hardware(self, isolated_settings):
+        """CPU-only boxes default to 1; CUDA boxes default to min(2, gpu_count)."""
+        from vtsearch.embedding.loader import _detect_cuda_devices
+
+        gpus = _detect_cuda_devices()
+        expected = max(1, min(2, gpus)) if gpus > 0 else 1
+        assert settings_mod.get_max_concurrent_dataset_embeddings() == expected
+
+    def test_max_concurrent_explicit_value_wins_over_hardware_default(self, isolated_settings):
+        """An explicit ``set_*`` call overrides the hardware-derived default."""
+        settings_mod.set_max_concurrent_dataset_downloads(7)
+        settings_mod.set_max_concurrent_dataset_embeddings(3)
+        assert settings_mod.get_max_concurrent_dataset_downloads() == 7
+        assert settings_mod.get_max_concurrent_dataset_embeddings() == 3
+        # And it survives a reset (read back from disk).
+        settings_mod.reset()
+        assert settings_mod.get_max_concurrent_dataset_downloads() == 7
+        assert settings_mod.get_max_concurrent_dataset_embeddings() == 3
+
     def test_persistence_survives_reset(self, isolated_settings):
         settings_mod.set_volume(0.7)
         settings_mod.add_autorun_detector("p")

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -588,117 +588,129 @@ class TestLoadingGates:
     """Verify the download/embed gates serialise (or pipeline) concurrent loads."""
 
     def test_second_load_waits_for_first(self):
-        """With the default limit of 1, a second load should show 'Waiting…'
+        """With the download limit at 1, a second load should show 'Waiting…'
         for the download gate and only proceed after the first releases it."""
+        from vtsearch import settings as settings_mod
         from vtsearch.datasets.load_pipeline import (
             _download_gate,
             _run_origin_load_in_background,
         )
 
-        first_started = threading.Event()
-        first_proceed = threading.Event()
-        second_started = threading.Event()
-        load_order = []
+        original = settings_mod.get_max_concurrent_dataset_downloads()
+        settings_mod.set_max_concurrent_dataset_downloads(1)
+        try:
+            first_started = threading.Event()
+            first_proceed = threading.Event()
+            second_started = threading.Event()
+            load_order = []
 
-        def first_load(medias):
-            load_order.append("first_start")
-            first_started.set()
-            first_proceed.wait(timeout=10)
-            load_order.append("first_end")
+            def first_load(medias):
+                load_order.append("first_start")
+                first_started.set()
+                first_proceed.wait(timeout=10)
+                load_order.append("first_end")
 
-        def second_load(medias):
-            load_order.append("second_start")
-            second_started.set()
+            def second_load(medias):
+                load_order.append("second_start")
+                second_started.set()
 
-        task1 = _run_origin_load_in_background(
-            first_load,
-            {"importer": "test1", "params": {}},
-            name="First",
-        )
+            task1 = _run_origin_load_in_background(
+                first_load,
+                {"importer": "test1", "params": {}},
+                name="First",
+            )
 
-        # Wait for first load to actually start running.
-        assert first_started.wait(timeout=10)
+            # Wait for first load to actually start running.
+            assert first_started.wait(timeout=10)
 
-        task2 = _run_origin_load_in_background(
-            second_load,
-            {"importer": "test2", "params": {}},
-            name="Second",
-        )
+            task2 = _run_origin_load_in_background(
+                second_load,
+                {"importer": "test2", "params": {}},
+                name="Second",
+            )
 
-        # Second load should be waiting — give it a moment to start its
-        # thread and hit the gate wait.
-        time.sleep(0.3)
-        assert not second_started.is_set(), "Second load should be queued, not running"
+            # Second load should be waiting — give it a moment to start its
+            # thread and hit the gate wait.
+            time.sleep(0.3)
+            assert not second_started.is_set(), "Second load should be queued, not running"
 
-        # Check that the second task shows a "Waiting" message.
-        task2_info = loading_tasks.get_tracker(task2)
-        assert task2_info is not None
-        status = task2_info.get()
-        assert "Waiting" in status.get("message", "")
+            # Check that the second task shows a "Waiting" message.
+            task2_info = loading_tasks.get_tracker(task2)
+            assert task2_info is not None
+            status = task2_info.get()
+            assert "Waiting" in status.get("message", "")
 
-        # Let the first load finish.
-        first_proceed.set()
+            # Let the first load finish.
+            first_proceed.set()
 
-        # Now the second should proceed.
-        assert second_started.wait(timeout=10), "Second load never started after first finished"
-        assert load_order[:2] == ["first_start", "first_end"]
-        assert "second_start" in load_order
+            # Now the second should proceed.
+            assert second_started.wait(timeout=10), "Second load never started after first finished"
+            assert load_order[:2] == ["first_start", "first_end"]
+            assert "second_start" in load_order
 
-        # Clean up — wait for tasks to finish.
-        deadline = time.time() + 10
-        while loading_tasks.has_active_tasks() and time.time() < deadline:
-            time.sleep(0.1)
-        loading_tasks.remove_task(task1)
-        loading_tasks.remove_task(task2)
-        # Sanity: gates fully released after both tasks finish.
-        assert _download_gate.active == 0
+            # Clean up — wait for tasks to finish.
+            deadline = time.time() + 10
+            while loading_tasks.has_active_tasks() and time.time() < deadline:
+                time.sleep(0.1)
+            loading_tasks.remove_task(task1)
+            loading_tasks.remove_task(task2)
+            # Sanity: gates fully released after both tasks finish.
+            assert _download_gate.active == 0
+        finally:
+            settings_mod.set_max_concurrent_dataset_downloads(original)
 
     def test_cancel_while_waiting_does_not_corrupt_gate(self):
         """Cancelling a queued task must not release the gate it never
         acquired, which would let extra loads through."""
+        from vtsearch import settings as settings_mod
         from vtsearch.datasets.load_pipeline import (
             _download_gate,
             _run_origin_load_in_background,
         )
 
-        first_started = threading.Event()
-        first_proceed = threading.Event()
+        original = settings_mod.get_max_concurrent_dataset_downloads()
+        settings_mod.set_max_concurrent_dataset_downloads(1)
+        try:
+            first_started = threading.Event()
+            first_proceed = threading.Event()
 
-        def first_load(medias):
-            first_started.set()
-            first_proceed.wait(timeout=10)
+            def first_load(medias):
+                first_started.set()
+                first_proceed.wait(timeout=10)
 
-        task1 = _run_origin_load_in_background(
-            first_load,
-            {"importer": "test1", "params": {}},
-            name="First",
-        )
-        assert first_started.wait(timeout=10)
+            task1 = _run_origin_load_in_background(
+                first_load,
+                {"importer": "test1", "params": {}},
+                name="First",
+            )
+            assert first_started.wait(timeout=10)
 
-        # Start a second load — it will be queued on the download gate.
-        task2 = _run_origin_load_in_background(
-            lambda medias: None,
-            {"importer": "test2", "params": {}},
-            name="Second",
-        )
-        time.sleep(0.3)
+            # Start a second load — it will be queued on the download gate.
+            task2 = _run_origin_load_in_background(
+                lambda medias: None,
+                {"importer": "test2", "params": {}},
+                name="Second",
+            )
+            time.sleep(0.3)
 
-        # Cancel the queued task before it acquires the gate.
-        loading_tasks.cancel_task(task2)
-        time.sleep(0.5)
+            # Cancel the queued task before it acquires the gate.
+            loading_tasks.cancel_task(task2)
+            time.sleep(0.5)
 
-        # The gate should still show exactly one holder (the first load).
-        # If the cancel wrongly released, active would drop to 0.
-        assert _download_gate.active == 1, "Cancelled task that never held the gate must not release it"
+            # The gate should still show exactly one holder (the first load).
+            # If the cancel wrongly released, active would drop to 0.
+            assert _download_gate.active == 1, "Cancelled task that never held the gate must not release it"
 
-        # Clean up.
-        first_proceed.set()
-        deadline = time.time() + 10
-        while loading_tasks.has_active_tasks() and time.time() < deadline:
-            time.sleep(0.1)
-        loading_tasks.remove_task(task1)
-        loading_tasks.remove_task(task2)
-        assert _download_gate.active == 0
+            # Clean up.
+            first_proceed.set()
+            deadline = time.time() + 10
+            while loading_tasks.has_active_tasks() and time.time() < deadline:
+                time.sleep(0.1)
+            loading_tasks.remove_task(task1)
+            loading_tasks.remove_task(task2)
+            assert _download_gate.active == 0
+        finally:
+            settings_mod.set_max_concurrent_dataset_downloads(original)
 
     def test_download_and_embed_can_overlap(self):
         """When the importer signals the embedding phase, the download gate

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -74,7 +74,9 @@ class ConcurrencyGate:
 # one dataset download while another is still embedding, instead of forcing
 # strict end-to-end serialisation.  Limits are user-configurable via the
 # ``max_concurrent_dataset_downloads`` and ``max_concurrent_dataset_embeddings``
-# settings (defaults: 1 each, matching the previous behaviour).
+# settings; defaults derive from the host's CPU/GPU counts (see
+# :func:`vtsearch.embedding.loader.default_concurrent_downloads` and
+# :func:`vtsearch.embedding.loader.default_concurrent_embeddings`).
 _download_gate = ConcurrencyGate(get_max_concurrent_dataset_downloads)
 _embed_gate = ConcurrencyGate(get_max_concurrent_dataset_embeddings)
 

--- a/vtsearch/embedding/loader.py
+++ b/vtsearch/embedding/loader.py
@@ -11,6 +11,7 @@ to work unchanged.
 """
 
 import gc
+import os
 import sys
 from typing import Any, cast
 
@@ -28,6 +29,48 @@ def get_torch_device():
     import torch  # noqa: PLC0415
 
     return torch.device(resolve_device())
+
+
+def _detect_cuda_devices() -> int:
+    """Return the count of visible CUDA GPUs, or 0 if none / torch missing.
+
+    Imports torch lazily so callers (e.g. settings default factories) can
+    run before torch is loaded. All exceptions degrade to ``0`` — a missing
+    or broken CUDA stack must not block startup.
+    """
+    try:
+        import torch  # noqa: PLC0415
+
+        if torch.cuda.is_available():
+            return int(torch.cuda.device_count())
+    except Exception:
+        pass
+    return 0
+
+
+def default_concurrent_downloads() -> int:
+    """Default for ``max_concurrent_dataset_downloads`` derived from hardware.
+
+    The download phase is bandwidth- and disk-bound. Allowing a handful of
+    parallel downloads usually saturates a home connection without thrashing
+    the disk; capped at 4 to keep memory and FD pressure reasonable on small
+    boxes.
+    """
+    return max(1, min(4, os.cpu_count() or 1))
+
+
+def default_concurrent_embeddings() -> int:
+    """Default for ``max_concurrent_dataset_embeddings`` derived from hardware.
+
+    The embed phase is CPU/GPU- and RAM-bound. On CPU-only boxes one worker
+    keeps the box hot without thrashing; with GPUs we allow one task per
+    visible CUDA device (capped at 2) so two datasets can embed in parallel
+    on a multi-GPU rig without overcommitting a single device's VRAM.
+    """
+    gpus = _detect_cuda_devices()
+    if gpus <= 0:
+        return 1
+    return max(1, min(2, gpus))
 
 
 def initialize_models() -> None:

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -84,6 +84,24 @@ def _upper(v: Any) -> Any:
     return v.upper() if isinstance(v, str) else v
 
 
+def _default_concurrent_downloads() -> int:
+    """Lazily resolve the hardware-derived default for parallel downloads.
+
+    Imported lazily to avoid pulling :mod:`vtsearch.embedding.loader` (and
+    transitively torch) at settings-model import time.
+    """
+    from vtsearch.embedding.loader import default_concurrent_downloads
+
+    return default_concurrent_downloads()
+
+
+def _default_concurrent_embeddings() -> int:
+    """Lazily resolve the hardware-derived default for parallel embeddings."""
+    from vtsearch.embedding.loader import default_concurrent_embeddings
+
+    return default_concurrent_embeddings()
+
+
 class ServerSettings(BaseModel):
     """Server-tier (shared) settings persisted in ``data/settings.json``."""
 
@@ -91,8 +109,14 @@ class ServerSettings(BaseModel):
 
     saved_datasets_dir: str = Field(default_factory=lambda: str(DATA_DIR / "saved_datasets"))
     detectors_dir: str = Field(default_factory=lambda: str(DATA_DIR / "detectors"))
-    max_concurrent_dataset_downloads: Annotated[int, _clamp(1, 16)] = 1
-    max_concurrent_dataset_embeddings: Annotated[int, _clamp(1, 16)] = 1
+    # Defaults derive from cores/GPUs at first read (not persisted to disk);
+    # a manual override in ``data/settings.json`` always wins.
+    max_concurrent_dataset_downloads: Annotated[int, _clamp(1, 16)] = Field(
+        default_factory=_default_concurrent_downloads
+    )
+    max_concurrent_dataset_embeddings: Annotated[int, _clamp(1, 16)] = Field(
+        default_factory=_default_concurrent_embeddings
+    )
     autorun_detectors: list[str] = Field(default_factory=list)
 
 


### PR DESCRIPTION
## Summary

Closes brainstorm item **1.5 Concurrency limits from hardware** (`docs/plans/ux-brainstorm.md`).

`max_concurrent_dataset_downloads` and `max_concurrent_dataset_embeddings` both defaulted to `1`, serialising every dataset load even on multi-core / multi-GPU boxes. This PR makes the defaults derive from host hardware at first read — via the pydantic spec's `default_factory`, so the value is **not** baked into `data/settings.json`. An explicit override on disk always wins.

New defaults:
- **downloads** = `min(4, cpu_count)` — bandwidth/disk-bound, capped to keep FD pressure reasonable
- **embeddings** = `1` on CPU-only hosts, else `min(2, gpu_count)` — avoids VRAM contention on single-GPU rigs

### Changes
- `vtsearch/embedding/loader.py`: new `default_concurrent_downloads()` / `default_concurrent_embeddings()` plus a `_detect_cuda_devices()` helper (lazy torch import).
- `vtsearch/settings_models.py`: `ServerSettings` fields switch to `Field(default_factory=...)` that lazily defers to the loader helpers — no eager torch import at settings-model load time, the existing `_clamp(1, 16)` still gates manual overrides.
- `vtsearch/datasets/load_pipeline.py`: docstring updated to point at the new default callables.
- `docs/DEPLOYMENT.md`: documented the hardware-derived defaults and that they're not persisted.
- `tests/datasets/test_parallel_loading.py`: `test_second_load_waits_for_first` and `test_cancel_while_waiting_does_not_corrupt_gate` now explicitly set the download limit to `1` (they were implicitly relying on the old default — would fail on a multi-core CI runner with the new defaults). Save/restore via the existing pattern.
- `tests/core/test_settings.py`: three new tests cover (a) the cpu-derived download default, (b) the gpu-derived embedding default, (c) that an explicit `set_*` override wins and survives `reset()`, and that the hardware-derived default is **not** written to `settings.json`.

### Test plan
- [x] `./run-tests.sh` — **3550 passed**, 1 skipped (full CPU suite, ~45s)
- [x] `ruff check` + `ruff format --check` clean on changed files

https://claude.ai/code/session_01VHP9JG7BjDRB1SujuhxGRU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHP9JG7BjDRB1SujuhxGRU)_