### PR TITLE
Default exporter filepaths to timestamped names

### DIFF
--- a/tests/io/test_csv_webhook_exporters.py
+++ b/tests/io/test_csv_webhook_exporters.py
@@ -105,7 +105,9 @@ class TestCsvExporterCLI:
         exp.add_cli_arguments(parser)
 
         args = parser.parse_args([])
-        assert args.filepath == "data/autodetect_results.csv"
+        # Default includes a timestamp template so consecutive runs do not
+        # silently overwrite one another.
+        assert args.filepath == "data/autodetect_results_{YYYYMMDD-HHMMSS}.csv"
 
     def test_validate_passes(self):
         from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
@@ -802,3 +804,122 @@ class TestWebhookExporterIntegration:
     def test_unknown_exporter_still_raises(self):
         with pytest.raises(ValueError, match="Unknown exporter"):
             _run_exporter("nonexistent_exporter", {}, {})
+
+
+# ---------------------------------------------------------------------------
+# Filepath template expansion (shared by CSV + JSON exporters)
+# ---------------------------------------------------------------------------
+
+
+class TestFilepathTemplateExpansion:
+    """Default filepaths embed a timestamp; templates expand at export time."""
+
+    def test_csv_default_contains_timestamp_template(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("server_csv_file")
+        fp = next(f for f in exp.fields if f.key == "filepath")
+        assert fp.default == "data/autodetect_results_{YYYYMMDD-HHMMSS}.csv"
+        assert fp.placeholder == "data/autodetect_results_{YYYYMMDD-HHMMSS}.csv"
+
+    def test_json_default_contains_timestamp_template(self):
+        from vtsearch.exporters import get_exporter
+
+        exp = get_exporter("server_json_file")
+        fp = next(f for f in exp.fields if f.key == "filepath")
+        assert fp.default == "data/autodetect_results_{YYYYMMDD-HHMMSS}.json"
+        assert fp.placeholder == "data/autodetect_results_{YYYYMMDD-HHMMSS}.json"
+
+    def test_consecutive_csv_exports_do_not_overwrite(self, tmp_path):
+        """Two exports a second apart should land in distinct files."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        results = _make_sample_results()
+        template = str(tmp_path / "out_{YYYYMMDD-HHMMSS}.csv")
+
+        with mock.patch("vtsearch.exporters._template.datetime") as mock_dt:
+            from datetime import datetime as real_dt
+            from datetime import timezone
+
+            mock_dt.now.return_value = real_dt(2026, 5, 16, 14, 30, 22, tzinfo=timezone.utc)
+            r1 = exp.export(results, {"filepath": template})
+            mock_dt.now.return_value = real_dt(2026, 5, 16, 14, 30, 23, tzinfo=timezone.utc)
+            r2 = exp.export(results, {"filepath": template})
+
+        # Both files exist with distinct, timestamp-stamped names.
+        assert r1["filepath"] != r2["filepath"]
+        assert (tmp_path / "out_20260516-143022.csv").exists()
+        assert (tmp_path / "out_20260516-143023.csv").exists()
+        assert "{YYYYMMDD-HHMMSS}" not in r1["filepath"]
+
+    def test_json_template_expands_timestamp(self, tmp_path):
+        from datetime import datetime as real_dt
+        from datetime import timezone
+
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        template = str(tmp_path / "j_{YYYYMMDD-HHMMSS}.json")
+
+        with mock.patch("vtsearch.exporters._template.datetime") as mock_dt:
+            mock_dt.now.return_value = real_dt(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+            result = exp.export(_make_sample_results(), {"filepath": template})
+
+        expected = tmp_path / "j_20260102-030405.json"
+        assert expected.exists()
+        assert result["filepath"] == str(expected.resolve())
+
+    def test_username_template_expands(self, tmp_path):
+        """The {username} template substitutes get_current_user(), sanitised."""
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        template = str(tmp_path / "{username}.json")
+
+        with mock.patch("vtsearch.auth.get_current_user", return_value="alice"):
+            exp.export(_make_sample_results(), {"filepath": template})
+
+        assert (tmp_path / "alice.json").exists()
+
+    def test_username_template_sanitises_path_separators(self, tmp_path):
+        """A malicious username with ``/`` cannot escape the parent directory."""
+        from vtsearch.exporters.server_json_file import ServerJsonLabelsetExporter
+
+        exp = ServerJsonLabelsetExporter()
+        template = str(tmp_path / "{username}.json")
+
+        with mock.patch("vtsearch.auth.get_current_user", return_value="../evil"):
+            exp.export(_make_sample_results(), {"filepath": template})
+
+        # ``/`` and ``..`` are replaced with ``_``, so the result stays inside tmp_path.
+        assert (tmp_path / ".._evil.json").exists()
+
+    def test_detector_name_template_expands(self, tmp_path):
+        """The {detector_name} template pulls from the active detector context."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtsearch.state.core import DetectorContext, set_thread_detector_context
+
+        exp = ServerCsvLabelsetExporter()
+        template = str(tmp_path / "{detector_name}.csv")
+
+        ctx = DetectorContext("det-id-1", name="dog_bark")
+        set_thread_detector_context(ctx)
+        try:
+            exp.export(_make_sample_results(), {"filepath": template})
+        finally:
+            set_thread_detector_context(None)
+
+        assert (tmp_path / "dog_bark.csv").exists()
+
+    def test_detector_name_template_with_no_active_context_uses_placeholder(self, tmp_path):
+        """An empty detector context (fallback) sanitises to ``_``."""
+        from vtsearch.exporters.server_csv_file import ServerCsvLabelsetExporter
+
+        exp = ServerCsvLabelsetExporter()
+        template = str(tmp_path / "{detector_name}.csv")
+
+        exp.export(_make_sample_results(), {"filepath": template})
+
+        # sanitize_template_value("") -> "_"
+        assert (tmp_path / "_.csv").exists()

--- a/vtsearch/exporters/_template.py
+++ b/vtsearch/exporters/_template.py
@@ -1,0 +1,38 @@
+"""Filepath template expansion shared by file-based exporters.
+
+Supports three placeholders, sanitised so user-controlled values cannot
+escape the directory implied by the admin-configured template:
+
+* ``{YYYYMMDD-HHMMSS}`` – current UTC time (e.g. ``20260516-143022``);
+  defaulted into the path so consecutive runs do not silently overwrite
+  one another.
+* ``{detector_name}`` – the active :class:`DetectorContext`'s ``name``.
+* ``{username}`` – the current request user
+  (see :func:`vtsearch.auth.get_current_user`).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def resolve_export_filepath(filepath: str) -> str:
+    """Return *filepath* with supported ``{...}`` placeholders substituted."""
+    if "{YYYYMMDD-HHMMSS}" in filepath:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        filepath = filepath.replace("{YYYYMMDD-HHMMSS}", stamp)
+
+    if "{detector_name}" in filepath:
+        from vtsearch.security.path_validation import sanitize_template_value
+        from vtsearch.state.core import get_active_detector_context
+
+        ctx = get_active_detector_context()
+        filepath = filepath.replace("{detector_name}", sanitize_template_value(ctx.name))
+
+    if "{username}" in filepath:
+        from vtsearch.auth import get_current_user
+        from vtsearch.security.path_validation import sanitize_template_value
+
+        filepath = filepath.replace("{username}", sanitize_template_value(get_current_user() or "default"))
+
+    return filepath

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from vtsearch.exporters._template import resolve_export_filepath
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
@@ -70,10 +71,11 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
             description=(
                 "Absolute or relative path on the server where the CSV "
                 "results file will be written.  Parent directories are "
-                "created automatically."
+                "created automatically.  Supports {YYYYMMDD-HHMMSS}, "
+                "{detector_name} and {username} templates."
             ),
-            placeholder="data/autodetect_results.csv",
-            default="data/autodetect_results.csv",
+            placeholder="data/autodetect_results_{YYYYMMDD-HHMMSS}.csv",
+            default="data/autodetect_results_{YYYYMMDD-HHMMSS}.csv",
         ),
     ]
 
@@ -86,7 +88,7 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         if not filepath_str:
             raise ValueError("A file path is required.")
 
-        filepath = Path(filepath_str)
+        filepath = Path(resolve_export_filepath(filepath_str))
         filepath.parent.mkdir(parents=True, exist_ok=True)
 
         # Labels format (from the export modal UI)

--- a/vtsearch/exporters/server_json_file/__init__.py
+++ b/vtsearch/exporters/server_json_file/__init__.py
@@ -15,6 +15,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from vtsearch.exporters._template import resolve_export_filepath
 from vtsearch.exporters.base import ExporterField, LabelsetExporter
 
 
@@ -52,10 +53,11 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
             description=(
                 "Absolute or relative path on the server where the JSON "
                 "results file will be written.  Parent directories are "
-                "created automatically."
+                "created automatically.  Supports {YYYYMMDD-HHMMSS}, "
+                "{detector_name} and {username} templates."
             ),
-            placeholder="data/autodetect_results.json",
-            default="data/autodetect_results.json",
+            placeholder="data/autodetect_results_{YYYYMMDD-HHMMSS}.json",
+            default="data/autodetect_results_{YYYYMMDD-HHMMSS}.json",
         ),
     ]
 
@@ -64,7 +66,7 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
         if not filepath_str:
             raise ValueError("A file path is required.")
 
-        filepath = Path(filepath_str)
+        filepath = Path(resolve_export_filepath(filepath_str))
         filepath.parent.mkdir(parents=True, exist_ok=True)
 
         # Labels format (from the export modal UI) — filter to selected columns


### PR DESCRIPTION
## Summary

Addresses ux-brainstorm 1.7: `server_csv_file` / `server_json_file` exporters defaulted to `data/autodetect_results.csv|json`, silently overwriting previous output on every run.

- Default both exporter `filepath` fields to `data/autodetect_results_{YYYYMMDD-HHMMSS}.csv|json` so consecutive runs produce distinct files.
- New shared helper `vtsearch/exporters/_template.py::resolve_export_filepath()` expands three placeholders at export time, matching the existing `LabelsetSource` / `SettingsSource` patterns:
  - `{YYYYMMDD-HHMMSS}` — current UTC time
  - `{detector_name}` — active `DetectorContext.name`, sanitised
  - `{username}` — `get_current_user()`, sanitised
- User-controlled substitutions go through `sanitize_template_value`, so a malicious detector name or username (e.g. containing `/` or `..`) cannot escape the directory implied by the admin-configured template.

## Test plan
- [x] `./run-tests.sh io` — 638 passed (includes the new `TestFilepathTemplateExpansion` class covering timestamp uniqueness across consecutive runs, JSON timestamp expansion, `{username}` substitution + sanitisation, `{detector_name}` substitution with an active and empty context, and the updated default-value assertion)
- [x] `./run-tests.sh` — 3555 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` — clean

https://claude.ai/code/session_01Sc3eNP9ZRo6srwHs3mtbpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sc3eNP9ZRo6srwHs3mtbpY)_