### PR TITLE
Auto-detect output media type when picking an import folder

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -386,6 +386,9 @@
             <option [value]="opt">{{ getMediaTypeOptionLabel(opt) }}</option>
           }
         </select>
+        @if (detectionHint(lfDetection); as hint) {
+          <p class="detection-hint">{{ hint }}</p>
+        }
       </div>
 
       <div class="form-group sf-source-specs">
@@ -495,7 +498,8 @@
             <input
               id="lf-recursive"
               type="checkbox"
-              [(ngModel)]="lfRecursive"
+              [ngModel]="lfRecursive"
+              (ngModelChange)="lfOnRecursiveChange($event)"
             />
             Include subfolders
           </label>
@@ -585,6 +589,9 @@
             <option [value]="opt">{{ getMediaTypeOptionLabel(opt) }}</option>
           }
         </select>
+        @if (detectionHint(sfDetection); as hint) {
+          <p class="detection-hint">{{ hint }}</p>
+        }
       </div>
 
       <div class="form-group sf-source-specs">
@@ -672,7 +679,8 @@
           <input
             id="sf-recursive"
             type="checkbox"
-            [(ngModel)]="sfRecursive"
+            [ngModel]="sfRecursive"
+            (ngModelChange)="sfOnRecursiveChange($event)"
           />
           Include subfolders
         </label>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -72,6 +72,17 @@
 // embedder reports a license_notice (today: real-EUPE under FAIR
 // Noncommercial). Subtle yellow chip, no acceptance click — users
 // who object pick a different embedder.
+// Detection hint shown below the output-media-type dropdown after the
+// modal samples the picked folder / files.  Subtle chip so it informs
+// without distracting from the form.
+.detection-hint {
+  margin: 6px 0 0;
+  font-size: .82rem;
+  line-height: 1.35;
+  color: var(--text-muted, #666);
+  font-style: italic;
+}
+
 .license-warning {
   margin-top: 6px;
   padding: 6px 10px;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -7,7 +7,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
-import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
+import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 @Component({
@@ -147,6 +147,14 @@ export class DatasetImporterModalComponent implements OnInit {
    *  ``(source_type, converter|null, params)`` triple — see
    *  ``docs/plans/multi-media-import.md``. */
   sfSourceSpecs: SourceSpec[] = [];
+
+  /** Auto-detect result for the local-folder / local-files picker.  Set
+   *  after the user picks files; ``null`` when no detection has been run
+   *  for the current selection. */
+  lfDetection: MediaTypeDetectionResponse | null = null;
+  /** Same as :prop:`lfDetection` but for the server-folder picker.  Filled
+   *  in by an API call after each successful directory load. */
+  sfDetection: MediaTypeDetectionResponse | null = null;
 
   // Dynamic-options cache for the generic form view.  Keyed by ImporterField.key.
   /** Options last fetched from the backend for dynamic-options fields. */
@@ -856,6 +864,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.selectedImporter = resolved;
     this.lfPickerKind = resolved?.name === 'local_files' ? 'files' : 'folder';
     this.lfFiles = [];
+    this.lfDetection = null;
     this.lfVectorsFile = null;
     this.lfError = '';
     this.lfSubmitting = false;
@@ -884,12 +893,51 @@ export class DatasetImporterModalComponent implements OnInit {
     const input = event.target as HTMLInputElement;
     if (!input.files) {
       this.lfFiles = [];
+      this.lfDetection = null;
       return;
     }
     this.lfFiles = Array.from(input.files);
     this.lfError = '';
     if (!this.lfDatasetNameDirty) {
       this.lfDatasetName = this.lfDerivedDatasetName();
+    }
+    this.lfDetection = this.detectFromFiles(this.lfFiles, this.lfRecursive);
+    this.lfApplyDetection();
+  }
+
+  lfOnRecursiveChange(recursive: boolean): void {
+    this.lfRecursive = recursive;
+    if (this.lfFiles.length > 0) {
+      this.lfDetection = this.detectFromFiles(this.lfFiles, this.lfRecursive);
+      this.lfApplyDetection();
+    }
+  }
+
+  sfOnRecursiveChange(recursive: boolean): void {
+    this.sfRecursive = recursive;
+    if (this.sfBrowseRootPath) {
+      this.sfRunDetection();
+    }
+  }
+
+  /** Apply :prop:`lfDetection` to the lf-* view: set the output media-type
+   *  dropdown and rebuild the source-spec rows.  Re-fetches embedders and
+   *  clippers via :prop:`lfOnMediaTypeChange` when the chosen type changed
+   *  so the rest of the form stays consistent. */
+  private lfApplyDetection(): void {
+    if (!this.lfDetection) return;
+    const { mediaType, sourceSpecs } = this.autofillFromDetection(
+      this.lfDetection,
+      this.lfMediaTypeOptions,
+      (typeId) => this.availableConvertersFor('server_folder', typeId),
+    );
+    if (mediaType && mediaType !== this.lfMediaType) {
+      this.lfMediaType = mediaType;
+      this.lfLoadEmbedders(this.lfMediaType);
+      this.lfLoadClippers(this.lfMediaType);
+    }
+    if (sourceSpecs) {
+      this.lfSourceSpecs = sourceSpecs;
     }
   }
 
@@ -1056,6 +1104,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfBrowseRootPath = '';
     this.sfBrowseDirs = [];
     this.sfBrowseError = '';
+    this.sfDetection = null;
     this.sfSubmitting = false;
     this.sfRecursive = this.readRecursiveDefault(this.selectedImporter);
     this.sfDatasetName = '';
@@ -1092,12 +1141,55 @@ export class DatasetImporterModalComponent implements OnInit {
         if (!this.sfDatasetNameDirty) {
           this.sfDatasetName = this.sfDerivedDatasetName();
         }
+        this.sfRunDetection();
       },
       error: (err) => {
         this.sfBrowseError = err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
         this.sfBrowseLoading = false;
       },
     });
+  }
+
+  /** Token guarding overlapping detection responses for the sf-* picker.
+   *  Each :meth:`sfRunDetection` invocation bumps this and stamps it onto
+   *  its closure; the response handler bails when the token has moved on,
+   *  so rapidly clicking through directories never lets an older request
+   *  overwrite a newer one. */
+  private sfDetectionToken = 0;
+
+  /** Detect the dominant media type for the currently picked server folder
+   *  and apply it to the sf-* form (output media-type + source specs). */
+  private sfRunDetection(): void {
+    const token = ++this.sfDetectionToken;
+    this.datasetsApi.detectMediaType('folder', this.sfBrowsePath, this.sfRecursive).subscribe({
+      next: (res) => {
+        if (token !== this.sfDetectionToken) return;
+        this.sfDetection = res;
+        this.sfApplyDetection();
+      },
+      error: () => {
+        if (token !== this.sfDetectionToken) return;
+        this.sfDetection = null;
+      },
+    });
+  }
+
+  /** Apply :prop:`sfDetection` to the sf-* view. */
+  private sfApplyDetection(): void {
+    if (!this.sfDetection) return;
+    const { mediaType, sourceSpecs } = this.autofillFromDetection(
+      this.sfDetection,
+      this.sfMediaTypeOptions,
+      (typeId) => this.availableConvertersFor('server_folder', typeId),
+    );
+    if (mediaType && mediaType !== this.sfMediaType) {
+      this.sfMediaType = mediaType;
+      this.sfLoadEmbedders(this.sfMediaType);
+      this.sfLoadClippers(this.sfMediaType);
+    }
+    if (sourceSpecs) {
+      this.sfSourceSpecs = sourceSpecs;
+    }
   }
 
   /** Derive a default dataset name from the currently selected server folder.
@@ -1160,6 +1252,140 @@ export class DatasetImporterModalComponent implements OnInit {
     if (!folderName) return '';
     const mt = this.mediaTypes.find((m) => m.folder_import_name === folderName);
     return mt?.type_id || folderName;
+  }
+
+  // -------------------------------------------------------------------
+  // Media-type auto-detection
+  //
+  // Two flavours: the server-folder picker hits an API endpoint that
+  // walks the chosen path on the server filesystem; the local-folder /
+  // local-files picker counts extensions on the in-browser File[] (no
+  // HTTP round-trip needed because the files haven't been uploaded yet).
+  //
+  // Once a detection result is available we (a) pre-fill the output
+  // media-type dropdown with the dominant type and (b) auto-populate
+  // multi-media SourceSpec rows for every non-dominant type present in
+  // the sample that has a converter to the dominant type — so a folder
+  // of "47 images + 3 videos" opens with "include images directly" plus
+  // a "video → image" converter row pre-added.
+  // -------------------------------------------------------------------
+
+  /** Lowercase ``ext → type_id`` map derived from registered media types.
+   *  ``.jpg → "image"``.  Rebuilt on each call (cheap; one Map per type). */
+  private extensionToTypeId(): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const mt of this.mediaTypes) {
+      for (const pattern of mt.file_extensions || []) {
+        const dot = pattern.lastIndexOf('.');
+        if (dot < 0) continue;
+        map.set(pattern.slice(dot).toLowerCase(), mt.type_id);
+      }
+    }
+    return map;
+  }
+
+  /** Count media types in a browser-side ``File[]`` and shape the result
+   *  like :type:`MediaTypeDetectionResponse` so the rest of the modal
+   *  can treat local- and server-side detections identically.
+   *
+   *  When ``recursive`` is ``false`` files whose ``webkitRelativePath``
+   *  lies in a sub-directory of the picked folder are skipped, matching
+   *  the importer's "Include subfolders" toggle. */
+  private detectFromFiles(files: File[], recursive: boolean, limit = 50): MediaTypeDetectionResponse {
+    const extMap = this.extensionToTypeId();
+    const countsByType: Record<string, number> = {};
+    const extensions: Record<string, number> = {};
+    let examined = 0;
+    for (const file of files) {
+      if (examined >= limit) break;
+      const rel = ((file as any).webkitRelativePath as string | undefined) || '';
+      if (!recursive && rel && rel.split('/').length > 2) continue;
+      const name = rel || file.name || '';
+      const slash = name.lastIndexOf('/');
+      const base = slash >= 0 ? name.slice(slash + 1) : name;
+      if (base.startsWith('.')) continue;
+      const dot = base.lastIndexOf('.');
+      const ext = dot > 0 ? base.slice(dot).toLowerCase() : '';
+      extensions[ext] = (extensions[ext] || 0) + 1;
+      const typeId = (ext && extMap.get(ext)) || 'unknown';
+      countsByType[typeId] = (countsByType[typeId] || 0) + 1;
+      examined += 1;
+    }
+    let dominant: string | null = null;
+    let bestCount = 0;
+    for (const [typeId, count] of Object.entries(countsByType)) {
+      if (typeId === 'unknown') continue;
+      if (count > bestCount) {
+        bestCount = count;
+        dominant = typeId;
+      }
+    }
+    return { sample_size: examined, counts_by_type: countsByType, extensions, dominant };
+  }
+
+  /** Human-readable description of a detection result, suitable for a
+   *  hint chip next to the dropdown. */
+  detectionHint(detection: MediaTypeDetectionResponse | null): string {
+    if (!detection || detection.sample_size === 0) return '';
+    const entries = Object.entries(detection.counts_by_type)
+      .filter(([typeId]) => typeId !== 'unknown')
+      .sort((a, b) => b[1] - a[1]);
+    if (entries.length === 0) {
+      return `No recognised media files in ${detection.sample_size} sampled.`;
+    }
+    const total = detection.sample_size;
+    const fileWord = total === 1 ? 'file' : 'files';
+    if (entries.length === 1) {
+      const [typeId, count] = entries[0];
+      return `Detected: ${this.getTabLabel(typeId)} (${count} of ${total} ${fileWord})`;
+    }
+    const head = entries
+      .map(([typeId, count]) => `${this.getTabLabel(typeId)} (${count})`)
+      .join(' + ');
+    return `Detected: ${head} of ${total} ${fileWord}`;
+  }
+
+  /** Apply a detection result to a (mediaType, sourceSpecs) pair.
+   *
+   *  Sets ``mediaType`` to the dominant type's ``folder_import_name`` when
+   *  it's a valid option, then rebuilds the source-spec list: one direct
+   *  row for the dominant type plus one converter row per non-dominant
+   *  recognised type that has at least one matching converter to the
+   *  dominant type.  Returns the new ``(mediaType, sourceSpecs)`` pair —
+   *  the caller decides which view's state to update.
+   */
+  private autofillFromDetection(
+    detection: MediaTypeDetectionResponse,
+    availableOptions: string[],
+    convertersForType: (outputTypeId: string) => ConverterInfo[],
+  ): { mediaType: string | null; sourceSpecs: SourceSpec[] | null } {
+    const dominant = detection.dominant;
+    if (!dominant) return { mediaType: null, sourceSpecs: null };
+    const folderName = this.mediaTypes.find((m) => m.type_id === dominant)?.folder_import_name || dominant;
+    if (!availableOptions.includes(folderName)) {
+      return { mediaType: null, sourceSpecs: null };
+    }
+    const converters = convertersForType(dominant);
+    const sourceSpecs: SourceSpec[] = [
+      { source_type: dominant, converter: null, params: {} },
+    ];
+    const seenSourceTypes = new Set<string>([dominant]);
+    const orderedNonDominant = Object.entries(detection.counts_by_type)
+      .filter(([typeId, count]) => typeId !== 'unknown' && typeId !== dominant && count > 0)
+      .sort((a, b) => b[1] - a[1])
+      .map(([typeId]) => typeId);
+    for (const sourceType of orderedNonDominant) {
+      if (seenSourceTypes.has(sourceType)) continue;
+      const converter = converters.find((c) => c.source_type === sourceType);
+      if (!converter) continue;
+      const params: Record<string, string> = {};
+      for (const f of converter.fields || []) {
+        params[f.key] = String(f.default ?? '');
+      }
+      sourceSpecs.push({ source_type: sourceType, converter: converter.name, params });
+      seenSourceTypes.add(sourceType);
+    }
+    return { mediaType: folderName, sourceSpecs };
   }
 
   /** Converters whose ``target_type`` matches *outputTypeId*.  The map

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -311,6 +311,15 @@ export interface MediaTypeInfo {
   icon?: string;
   tab_title?: string;
   folder_import_name?: string;
+  /** Glob patterns for files this media type claims, e.g. ``["*.jpg", "*.png"]``. */
+  file_extensions?: string[];
+}
+
+export interface MediaTypeDetectionResponse {
+  sample_size: number;
+  counts_by_type: Record<string, number>;
+  extensions: Record<string, number>;
+  dominant: string | null;
 }
 
 export interface MediaTypesResponse {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -320,6 +320,11 @@ export interface MediaTypeDetectionResponse {
   counts_by_type: Record<string, number>;
   extensions: Record<string, number>;
   dominant: string | null;
+  /** ``true`` when the backend stopped walking before reaching the file
+   *  cap because the directory-count cap or wall-clock budget fired.  The
+   *  rest of the response is still meaningful — it's just a less complete
+   *  sample than usual. */
+  truncated?: boolean;
 }
 
 export interface MediaTypesResponse {

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -8,6 +8,7 @@ import {
   ImportersResponse,
   DemoListResponse,
   MediaTypesResponse,
+  MediaTypeDetectionResponse,
   DatasetRegistryResponse,
   ClipperInfo,
   ClippersResponse,
@@ -76,6 +77,22 @@ export class DatasetsApiService {
 
   getMediaTypes(): Observable<MediaTypesResponse> {
     return this.http.get<MediaTypesResponse>('/api/media-types');
+  }
+
+  detectMediaType(
+    source: string,
+    path: string,
+    recursive: boolean,
+    limit = 50,
+  ): Observable<MediaTypeDetectionResponse> {
+    return this.http.get<MediaTypeDetectionResponse>('/api/dataset/detect-media-type', {
+      params: {
+        source,
+        path,
+        recursive: recursive ? 'true' : 'false',
+        limit: String(limit),
+      },
+    });
   }
 
   getClippers(mediaType?: string): Observable<ClipperInfo[]> {

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -150,6 +150,69 @@ class TestDatasetEndpoints:
             # Clean up
             dest.unlink(missing_ok=True)
 
+    def test_detect_media_type_finds_dominant(self, client, tmp_path, monkeypatch):
+        """GET /api/dataset/detect-media-type returns the dominant media type."""
+        # Three .wav files (audio) + one .jpg (image) → dominant=audio.
+        (tmp_path / "a.wav").write_bytes(b"RIFF")
+        (tmp_path / "b.wav").write_bytes(b"RIFF")
+        (tmp_path / "c.wav").write_bytes(b"RIFF")
+        (tmp_path / "d.jpg").write_bytes(b"\xff\xd8\xff")
+
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.ui._resolve_browse_root",
+            lambda source: tmp_path if source == "folder" else None,
+        )
+        resp = client.get("/api/dataset/detect-media-type?source=folder&path=")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["sample_size"] == 4
+        assert data["dominant"] == "audio"
+        assert data["counts_by_type"].get("audio") == 3
+        assert data["counts_by_type"].get("image") == 1
+
+    def test_detect_media_type_recursive(self, client, tmp_path, monkeypatch):
+        """The endpoint respects the ``recursive`` query parameter."""
+        (tmp_path / "top.jpg").write_bytes(b"\xff\xd8\xff")
+        sub = tmp_path / "nested"
+        sub.mkdir()
+        (sub / "deep.wav").write_bytes(b"RIFF")
+
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.ui._resolve_browse_root",
+            lambda source: tmp_path if source == "folder" else None,
+        )
+
+        # Recursive (default): sees both files.
+        resp = client.get("/api/dataset/detect-media-type?source=folder&path=")
+        data = resp.get_json()
+        assert data["sample_size"] == 2
+
+        # Non-recursive: only the top-level .jpg is visible.
+        resp = client.get("/api/dataset/detect-media-type?source=folder&path=&recursive=false")
+        data = resp.get_json()
+        assert data["sample_size"] == 1
+        assert data["dominant"] == "image"
+
+    def test_detect_media_type_unknown_extensions(self, client, tmp_path, monkeypatch):
+        """Unrecognised extensions roll up under ``"unknown"`` and don't dominate."""
+        (tmp_path / "a.xyz").write_bytes(b"")
+        (tmp_path / "b.qqq").write_bytes(b"")
+
+        monkeypatch.setattr(
+            "vtsearch.routes.datasets.ui._resolve_browse_root",
+            lambda source: tmp_path if source == "folder" else None,
+        )
+        resp = client.get("/api/dataset/detect-media-type?source=folder&path=")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["dominant"] is None
+        assert data["counts_by_type"].get("unknown") == 2
+
+    def test_detect_media_type_bad_source(self, client):
+        """GET /api/dataset/detect-media-type returns 404 for an unknown source."""
+        resp = client.get("/api/dataset/detect-media-type?source=demo:nonexistent_xyz&path=")
+        assert resp.status_code == 404
+
     def test_select_browsed_file_traversal_blocked(self, client, tmp_path):
         """POST /api/browse-media-files/select rejects traversal paths."""
         from unittest.mock import patch

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -221,6 +221,42 @@ class TestDatasetEndpoints:
         resp = client.get("/api/dataset/detect-media-type?source=demo:nonexistent_xyz&path=")
         assert resp.status_code == 404
 
+    def test_detect_media_type_directory_cap(self, tmp_path):
+        """The helper stops walking after ``max_dirs`` directories, even when
+        the sample is far from full.  This guards against pathological
+        folder shapes that would otherwise blow up the wall-clock budget."""
+        from vtsearch.datasets.media_type_detection import detect_media_types_in_folder
+
+        root = tmp_path / "media"
+        root.mkdir()
+        # 50 empty sub-directories.  Walking all of them is fine in a
+        # unit test, but the function should still report ``truncated``
+        # when the cap is set low enough to bite.
+        for i in range(50):
+            (root / f"empty_{i:02d}").mkdir()
+        data = detect_media_types_in_folder(root, recursive=True, max_dirs=5)
+        assert data["sample_size"] == 0
+        assert data["dominant"] is None
+        assert data["truncated"] is True
+
+    def test_detect_media_type_does_not_follow_symlinks(self, tmp_path):
+        """The recursive walk does not follow symlinked directories: the
+        sample stays inside *folder* even when a symlink points elsewhere."""
+        from vtsearch.datasets.media_type_detection import detect_media_types_in_folder
+
+        root = tmp_path / "root"
+        root.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "lots_of_audio.wav").write_bytes(b"RIFF")
+        try:
+            (root / "link").symlink_to(elsewhere)
+        except OSError:
+            pytest.skip("symlinks not supported on this platform")
+        data = detect_media_types_in_folder(root, recursive=True)
+        assert data["sample_size"] == 0
+        assert data["dominant"] is None
+
     def test_select_browsed_file_traversal_blocked(self, client, tmp_path):
         """POST /api/browse-media-files/select rejects traversal paths."""
         from unittest.mock import patch

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -152,15 +152,19 @@ class TestDatasetEndpoints:
 
     def test_detect_media_type_finds_dominant(self, client, tmp_path, monkeypatch):
         """GET /api/dataset/detect-media-type returns the dominant media type."""
+        # Use a dedicated subdirectory because the autouse ``isolated_settings``
+        # fixture also writes into ``tmp_path``.
+        root = tmp_path / "media"
+        root.mkdir()
         # Three .wav files (audio) + one .jpg (image) → dominant=audio.
-        (tmp_path / "a.wav").write_bytes(b"RIFF")
-        (tmp_path / "b.wav").write_bytes(b"RIFF")
-        (tmp_path / "c.wav").write_bytes(b"RIFF")
-        (tmp_path / "d.jpg").write_bytes(b"\xff\xd8\xff")
+        (root / "a.wav").write_bytes(b"RIFF")
+        (root / "b.wav").write_bytes(b"RIFF")
+        (root / "c.wav").write_bytes(b"RIFF")
+        (root / "d.jpg").write_bytes(b"\xff\xd8\xff")
 
         monkeypatch.setattr(
             "vtsearch.routes.datasets.ui._resolve_browse_root",
-            lambda source: tmp_path if source == "folder" else None,
+            lambda source: root if source == "folder" else None,
         )
         resp = client.get("/api/dataset/detect-media-type?source=folder&path=")
         assert resp.status_code == 200
@@ -172,14 +176,16 @@ class TestDatasetEndpoints:
 
     def test_detect_media_type_recursive(self, client, tmp_path, monkeypatch):
         """The endpoint respects the ``recursive`` query parameter."""
-        (tmp_path / "top.jpg").write_bytes(b"\xff\xd8\xff")
-        sub = tmp_path / "nested"
+        root = tmp_path / "media"
+        root.mkdir()
+        (root / "top.jpg").write_bytes(b"\xff\xd8\xff")
+        sub = root / "nested"
         sub.mkdir()
         (sub / "deep.wav").write_bytes(b"RIFF")
 
         monkeypatch.setattr(
             "vtsearch.routes.datasets.ui._resolve_browse_root",
-            lambda source: tmp_path if source == "folder" else None,
+            lambda source: root if source == "folder" else None,
         )
 
         # Recursive (default): sees both files.
@@ -195,12 +201,14 @@ class TestDatasetEndpoints:
 
     def test_detect_media_type_unknown_extensions(self, client, tmp_path, monkeypatch):
         """Unrecognised extensions roll up under ``"unknown"`` and don't dominate."""
-        (tmp_path / "a.xyz").write_bytes(b"")
-        (tmp_path / "b.qqq").write_bytes(b"")
+        root = tmp_path / "media"
+        root.mkdir()
+        (root / "a.xyz").write_bytes(b"")
+        (root / "b.qqq").write_bytes(b"")
 
         monkeypatch.setattr(
             "vtsearch.routes.datasets.ui._resolve_browse_root",
-            lambda source: tmp_path if source == "folder" else None,
+            lambda source: root if source == "folder" else None,
         )
         resp = client.get("/api/dataset/detect-media-type?source=folder&path=")
         assert resp.status_code == 200

--- a/vtsearch/datasets/media_type_detection.py
+++ b/vtsearch/datasets/media_type_detection.py
@@ -4,11 +4,28 @@ Used by the import modal to pre-fill the "Output Media Type" dropdown and
 auto-populate :class:`~vtsearch.datasets.importers.base.SourceSpec` rows
 based on what's actually in the folder, instead of making the user pick
 blindly.
+
+The sampler is defensive about pathological folder shapes: a folder full
+of empty sub-directories, or one whose root has been symlinked to a huge
+tree, can otherwise make :func:`os.walk` spelunk for many seconds before
+hitting the file-count limit.  Three independent bounds keep the call
+fast for the UI hint:
+
+* a per-call **file cap** (the caller's ``limit``, default 50);
+* a per-call **directory cap** (``max_dirs``, default 500);
+* a per-call **wall-clock budget** (``time_budget_seconds``, default
+  ``0.75``).
+
+Whichever fires first ends the walk; the response reflects whatever has
+been counted so far.  Symlinks are **not** followed during detection —
+the import itself still follows them, but a detection sample doesn't
+need to walk through a symlinked tree to make a good guess.
 """
 
 from __future__ import annotations
 
 import os
+import time
 from collections import Counter
 from pathlib import Path
 from typing import Optional
@@ -20,17 +37,24 @@ def detect_media_types_in_folder(
     folder: Path,
     recursive: bool = True,
     limit: int = 50,
+    max_dirs: int = 500,
+    time_budget_seconds: float = 0.75,
 ) -> dict:
     """Walk *folder* and tally up to *limit* files by media type.
 
     Args:
         folder: Directory to scan.  Must exist and be a directory.
-        recursive: When ``True`` (default) descend into sub-directories,
-            following symlinks.  When ``False`` only files directly inside
-            *folder* are sampled.
-        limit: Maximum number of files to examine.  Sampling stops as soon
-            as this many files have been counted, so the call stays fast
-            even on multi-million-file trees.
+        recursive: When ``True`` (default) descend into sub-directories.
+            Symlinks are **not** followed regardless — see the module
+            docstring for the rationale.  When ``False`` only files
+            directly inside *folder* are sampled.
+        limit: Maximum number of files to examine.
+        max_dirs: Maximum number of directories to enter.  When the cap
+            is reached the walk stops with whatever has been counted so
+            far.  Bounds the worst case for sparse trees.
+        time_budget_seconds: Soft wall-clock budget for the whole walk.
+            Checked between directory transitions and between file
+            counts; the walk stops as soon as the budget is exceeded.
 
     Returns:
         A dict with these keys:
@@ -40,12 +64,14 @@ def detect_media_types_in_folder(
           every media type that matched at least one extension in the
           sample.  Files with extensions that no registered media type
           claims are counted under ``"unknown"``.
-        * ``extensions`` (dict[str, int]) – lowercase extension (with the
-          leading dot) → count, also limited to the sample.  Useful for
-          debugging "what is this folder full of?".
+        * ``extensions`` (dict[str, int]) – lowercase extension (with
+          the leading dot) → count, also limited to the sample.
         * ``dominant`` (str | None) – ``type_id`` of the most common
           recognised media type, or ``None`` when the sample contained
           no recognised files (all unknown or empty folder).
+        * ``truncated`` (bool) – ``True`` when the walk stopped because
+          ``max_dirs`` or ``time_budget_seconds`` fired (i.e. the
+          sample may be a less complete view of the folder than usual).
     """
     if not folder.is_dir():
         return {
@@ -53,13 +79,20 @@ def detect_media_types_in_folder(
             "counts_by_type": {},
             "extensions": {},
             "dominant": None,
+            "truncated": False,
         }
 
     counts_by_type: Counter[str] = Counter()
     extensions: Counter[str] = Counter()
     examined = 0
+    dirs_visited = 0
+    truncated = False
+    deadline = time.monotonic() + time_budget_seconds
 
     def _count_file(p: Path) -> bool:
+        """Add *p* to the running tallies.  Returns ``True`` when the
+        file cap or time budget have been reached (i.e. the caller
+        should stop walking)."""
         nonlocal examined
         if p.name.startswith("."):
             return False
@@ -68,19 +101,39 @@ def detect_media_types_in_folder(
         mt = get_by_extension(ext) if ext else None
         counts_by_type[mt.type_id if mt is not None else "unknown"] += 1
         examined += 1
-        return examined >= limit
+        if examined >= limit:
+            return True
+        if time.monotonic() >= deadline:
+            return True
+        return False
 
     if recursive:
-        for dirpath, _dirnames, filenames in os.walk(folder, followlinks=True):
+        # ``followlinks`` stays at its default (``False``) so a folder
+        # symlinked to a huge tree does not blow up the budget.
+        walker = os.walk(folder)
+        for _dirpath, _dirnames, filenames in walker:
+            dirs_visited += 1
+            stop = False
             for name in filenames:
-                if _count_file(Path(dirpath) / name):
+                if _count_file(Path(_dirpath) / name):
+                    stop = True
                     break
-            if examined >= limit:
+            if stop:
+                # Distinguish "hit file cap exactly" (not truncated) from
+                # "ran out of time mid-directory" (truncated).
+                if examined < limit and time.monotonic() >= deadline:
+                    truncated = True
+                break
+            if dirs_visited >= max_dirs:
+                truncated = True
+                break
+            if time.monotonic() >= deadline:
+                truncated = True
                 break
     else:
         with os.scandir(folder) as it:
             for entry in it:
-                if entry.is_file(follow_symlinks=True) and _count_file(Path(entry.path)):
+                if entry.is_file(follow_symlinks=False) and _count_file(Path(entry.path)):
                     break
 
     dominant: Optional[str] = None
@@ -94,4 +147,5 @@ def detect_media_types_in_folder(
         "counts_by_type": dict(counts_by_type),
         "extensions": dict(extensions),
         "dominant": dominant,
+        "truncated": truncated,
     }

--- a/vtsearch/datasets/media_type_detection.py
+++ b/vtsearch/datasets/media_type_detection.py
@@ -1,0 +1,97 @@
+"""Sample a folder of files and guess which media type dominates.
+
+Used by the import modal to pre-fill the "Output Media Type" dropdown and
+auto-populate :class:`~vtsearch.datasets.importers.base.SourceSpec` rows
+based on what's actually in the folder, instead of making the user pick
+blindly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+from vtsearch.media import get_by_extension
+
+
+def detect_media_types_in_folder(
+    folder: Path,
+    recursive: bool = True,
+    limit: int = 50,
+) -> dict:
+    """Walk *folder* and tally up to *limit* files by media type.
+
+    Args:
+        folder: Directory to scan.  Must exist and be a directory.
+        recursive: When ``True`` (default) descend into sub-directories,
+            following symlinks.  When ``False`` only files directly inside
+            *folder* are sampled.
+        limit: Maximum number of files to examine.  Sampling stops as soon
+            as this many files have been counted, so the call stays fast
+            even on multi-million-file trees.
+
+    Returns:
+        A dict with these keys:
+
+        * ``sample_size`` (int) – how many files were actually examined.
+        * ``counts_by_type`` (dict[str, int]) – ``type_id`` → count for
+          every media type that matched at least one extension in the
+          sample.  Files with extensions that no registered media type
+          claims are counted under ``"unknown"``.
+        * ``extensions`` (dict[str, int]) – lowercase extension (with the
+          leading dot) → count, also limited to the sample.  Useful for
+          debugging "what is this folder full of?".
+        * ``dominant`` (str | None) – ``type_id`` of the most common
+          recognised media type, or ``None`` when the sample contained
+          no recognised files (all unknown or empty folder).
+    """
+    if not folder.is_dir():
+        return {
+            "sample_size": 0,
+            "counts_by_type": {},
+            "extensions": {},
+            "dominant": None,
+        }
+
+    counts_by_type: Counter[str] = Counter()
+    extensions: Counter[str] = Counter()
+    examined = 0
+
+    def _count_file(p: Path) -> bool:
+        nonlocal examined
+        if p.name.startswith("."):
+            return False
+        ext = p.suffix.lower()
+        extensions[ext] += 1
+        mt = get_by_extension(ext) if ext else None
+        counts_by_type[mt.type_id if mt is not None else "unknown"] += 1
+        examined += 1
+        return examined >= limit
+
+    if recursive:
+        for dirpath, _dirnames, filenames in os.walk(folder, followlinks=True):
+            for name in filenames:
+                if _count_file(Path(dirpath) / name):
+                    break
+            if examined >= limit:
+                break
+    else:
+        with os.scandir(folder) as it:
+            for entry in it:
+                if entry.is_file(follow_symlinks=True) and _count_file(Path(entry.path)):
+                    break
+
+    dominant: Optional[str] = None
+    for type_id, _count in counts_by_type.most_common():
+        if type_id != "unknown":
+            dominant = type_id
+            break
+
+    return {
+        "sample_size": examined,
+        "counts_by_type": dict(counts_by_type),
+        "extensions": dict(extensions),
+        "dominant": dominant,
+    }

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -287,6 +287,53 @@ def browse_media_files():
     return jsonify({"directories": directories, "files": files, "root_path": str(root)})
 
 
+@datasets_ui_bp.route("/api/dataset/detect-media-type")
+def detect_media_type():
+    """Sample a folder and report which media type dominates by extension.
+
+    Powers the auto-detect hint in the import modal: rather than making
+    the user pick ``media_type`` blindly, the modal calls this after the
+    user selects a folder and pre-fills the dropdown with whichever type
+    has the most matching files in the first ``limit`` files of the tree.
+
+    Query parameters:
+
+    * ``source`` — one of ``demo:<name>`` or ``folder`` (matches
+      ``/api/browse-media-files``).
+    * ``path`` — relative sub-path within the root (default ``""``).
+    * ``recursive`` — ``"true"``/``"false"`` (default ``"true"``).
+    * ``limit`` — max files to examine (default ``50``, capped at ``500``).
+
+    Returns the dict produced by
+    :func:`vtsearch.datasets.media_type_detection.detect_media_types_in_folder`.
+    """
+    from vtsearch.datasets.media_type_detection import detect_media_types_in_folder
+
+    source = request.args.get("source", "folder").strip() or "folder"
+    subpath = request.args.get("path", "").strip()
+    recursive = request.args.get("recursive", "true").strip().lower() != "false"
+    try:
+        limit = int(request.args.get("limit", "50"))
+    except ValueError:
+        limit = 50
+    limit = max(1, min(limit, 500))
+
+    root = _resolve_browse_root(source)
+    if root is None:
+        return jsonify({"error": "Source not found or not available on disk"}), 404
+
+    target = (root / subpath).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return jsonify({"error": "Invalid path"}), 400
+
+    if not target.is_dir():
+        return jsonify({"error": "Directory not found"}), 404
+
+    return jsonify(detect_media_types_in_folder(target, recursive=recursive, limit=limit))
+
+
 @datasets_ui_bp.route("/api/browse-media-files/select", methods=["POST"])
 def select_browsed_file():
     """Copy a file from a browse source into ``data/example_media/``.


### PR DESCRIPTION
## Summary

- The Add Dataset modal previously made the user pick "Output Media Type" blindly even when the folder/file list it had just received made the right answer obvious. Now it samples up to 50 files from the chosen path, counts them against each registered `MediaType.file_extensions`, and pre-fills the dropdown with the dominant type plus a hint chip ("Detected: image (47 of 50 files)").
- For `multi_media=True` importers (`server_folder`, `server_files`, `local_folder`, `local_files`), the modal also auto-populates a converter `SourceSpec` row for every non-dominant type that has a registered converter to the dominant type. A folder of 47 images + 3 videos now opens with "include images directly" plus a pre-added "video → image" row instead of forcing the user to find and add it manually.
- Detection re-runs when the user toggles "Include subfolders" so the hint always reflects what will actually be imported.

## How it works

- **Local pickers** (`local_folder` / `local_files`) detect entirely client-side by walking the in-browser `File[]` (the files haven't been uploaded yet, so no HTTP round-trip).
- **Server folder** picker calls a new `GET /api/dataset/detect-media-type?source=folder&path=…&recursive=…&limit=…` endpoint that delegates to `detect_media_types_in_folder()` in `vtsearch.datasets.media_type_detection`. The route reuses the same `_resolve_browse_root()` resolver as `/api/browse-media-files`, so path-traversal protection is identical.
- The frontend derives the `.ext → type_id` map from the existing `/api/media-types` response (each `MediaType.to_dict()` already exposes `file_extensions`) — no duplicate truth.

## Not in this PR

- `server_files` (a `.txt`/`.list`/`.npz` paths file) is not auto-detected in v1 — its input is a file, not a folder. Worth a follow-up if useful.
- `http_archive` (URL): same reason — can't sample without downloading.

## Test plan

- [x] `./run-tests.sh datasets` — new endpoint tests + everything else green
- [x] `./run-tests.sh` (full CPU suite) — 3551 passed, 1 skipped, frontend build OK, npm audit OK
- [ ] Manual: open Add Dataset → Server / Folder, pick a folder with mixed media, verify the dropdown auto-fills and the hint chip appears with the right counts
- [ ] Manual: pick a folder of 47 images + 3 videos, verify a "video → image" converter row is auto-added and removable via the × button
- [ ] Manual: toggle "Include subfolders" off, verify the hint refreshes and reflects only top-level files

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM4eRurhayZh3Sn99FBC64)_