### PR TITLE
Embedder dropdown: split Recommended vs Advanced per media type

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -80,8 +80,19 @@
                 [ngModel]="selectedDemoEmbedder"
                 (ngModelChange)="onDemoEmbedderChange($event)"
               >
-                @for (embedder of demoEmbedders; track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                @if (recommendedEmbedders(demoEmbedders).length > 0) {
+                  <optgroup label="Recommended">
+                    @for (embedder of recommendedEmbedders(demoEmbedders); track embedder.name) {
+                      <option [value]="embedder.name">{{ embedder.name }}</option>
+                    }
+                  </optgroup>
+                }
+                @if (advancedEmbedders(demoEmbedders).length > 0) {
+                  <optgroup label="Advanced ▾">
+                    @for (embedder of advancedEmbedders(demoEmbedders); track embedder.name) {
+                      <option [value]="embedder.name">{{ embedder.name }}</option>
+                    }
+                  </optgroup>
                 }
               </select>
             }
@@ -285,8 +296,19 @@
             class="form-select"
             [(ngModel)]="selectedEmbedder"
           >
-            @for (embedder of availableEmbedders; track embedder.name) {
-              <option [value]="embedder.name">{{ embedder.name }}</option>
+            @if (recommendedEmbedders(availableEmbedders).length > 0) {
+              <optgroup label="Recommended">
+                @for (embedder of recommendedEmbedders(availableEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </optgroup>
+            }
+            @if (advancedEmbedders(availableEmbedders).length > 0) {
+              <optgroup label="Advanced ▾">
+                @for (embedder of advancedEmbedders(availableEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </optgroup>
             }
           </select>
           @if (licenseNoticeFor(selectedEmbedder, availableEmbedders); as notice) {
@@ -479,8 +501,19 @@
             class="form-select"
             [(ngModel)]="lfSelectedEmbedder"
           >
-            @for (embedder of lfEmbedders; track embedder.name) {
-              <option [value]="embedder.name">{{ embedder.name }}</option>
+            @if (recommendedEmbedders(lfEmbedders).length > 0) {
+              <optgroup label="Recommended">
+                @for (embedder of recommendedEmbedders(lfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </optgroup>
+            }
+            @if (advancedEmbedders(lfEmbedders).length > 0) {
+              <optgroup label="Advanced ▾">
+                @for (embedder of advancedEmbedders(lfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </optgroup>
             }
           </select>
           @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
@@ -644,8 +677,19 @@
             class="form-select"
             [(ngModel)]="sfSelectedEmbedder"
           >
-            @for (embedder of sfEmbedders; track embedder.name) {
-              <option [value]="embedder.name">{{ embedder.name }}</option>
+            @if (recommendedEmbedders(sfEmbedders).length > 0) {
+              <optgroup label="Recommended">
+                @for (embedder of recommendedEmbedders(sfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </optgroup>
+            }
+            @if (advancedEmbedders(sfEmbedders).length > 0) {
+              <optgroup label="Advanced ▾">
+                @for (embedder of advancedEmbedders(sfEmbedders); track embedder.name) {
+                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                }
+              </optgroup>
             }
           </select>
           @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -712,6 +712,16 @@ export class DatasetImporterModalComponent implements OnInit {
     return found?.license_notice ?? null;
   }
 
+  /** Embedders flagged ``is_default`` for the active media type. */
+  recommendedEmbedders(list: EmbedderInfo[]): EmbedderInfo[] {
+    return list.filter((e) => e.is_default);
+  }
+
+  /** Non-default embedders, shown under the "Advanced" optgroup. */
+  advancedEmbedders(list: EmbedderInfo[]): EmbedderInfo[] {
+    return list.filter((e) => !e.is_default);
+  }
+
   selectDemo(demo: DemoDataset): void {
     const userName = (this.demoDatasetName || '').trim();
     this.demoSelected.emit({

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -616,6 +616,12 @@ export interface EmbedderInfo {
   name: string;
   media_type_id: string;
   /**
+   * Whether this embedder is the recommended default for its media type
+   * (exactly one per media type). The dropdown surfaces this entry under a
+   * "Recommended" optgroup and tucks the rest under "Advanced".
+   */
+  is_default?: boolean;
+  /**
    * Whether this embedder can embed text queries into the same vector space as
    * its media. ``false`` for vision-only encoders (DINOv3, Perception Encoder)
    * — the UI hides text-search affordances for datasets using them.

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -37,6 +37,7 @@ class TestImageClipEmbedder:
         assert ImageClipEmbedder().to_dict() == {
             "name": "clip",
             "media_type_id": "image",
+            "is_default": False,
             "supports_text": True,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -107,6 +108,7 @@ class TestImageSiglip2Embedder:
         assert ImageSiglip2Embedder().to_dict() == {
             "name": "siglip2",
             "media_type_id": "image",
+            "is_default": False,
             "supports_text": True,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -173,6 +175,7 @@ class TestImageDinov2SingleEmbedder:
         assert ImageDinov2SingleEmbedder().to_dict() == {
             "name": "dinov2_single",
             "media_type_id": "image",
+            "is_default": False,
             "supports_text": False,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -236,6 +239,7 @@ class TestImageDinov2PatchEmbedder:
         assert ImageDinov2PatchEmbedder().to_dict() == {
             "name": "dinov2_patch",
             "media_type_id": "image",
+            "is_default": False,
             "supports_text": False,
             "supports_patch_regions": True,
             "license_notice": None,
@@ -281,6 +285,7 @@ class TestImageDinov3SingleEmbedder:
         assert ImageDinov3SingleEmbedder().to_dict() == {
             "name": "dinov3_single",
             "media_type_id": "image",
+            "is_default": False,
             "supports_text": False,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -342,6 +347,7 @@ class TestImageDinov3PatchEmbedder:
         assert ImageDinov3PatchEmbedder().to_dict() == {
             "name": "dinov3_patch",
             "media_type_id": "image",
+            "is_default": False,
             "supports_text": False,
             "supports_patch_regions": True,
             "license_notice": None,

--- a/tests/detectors/test_new_embedders.py
+++ b/tests/detectors/test_new_embedders.py
@@ -55,6 +55,7 @@ class TestImageSiglipEmbedderProperties:
         assert d == {
             "name": "siglip",
             "media_type_id": "image",
+            "is_default": True,
             "supports_text": True,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -149,6 +150,7 @@ class TestAudioClapMusicEmbedderProperties:
         assert d == {
             "name": "clap_music",
             "media_type_id": "audio",
+            "is_default": False,
             "supports_text": True,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -230,6 +232,7 @@ class TestTextBGEEmbedderProperties:
         assert d == {
             "name": "bge",
             "media_type_id": "text",
+            "is_default": False,
             "supports_text": True,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -358,6 +361,7 @@ class TestVideoLanguageBindEmbedderProperties:
         assert d == {
             "name": "languagebind",
             "media_type_id": "video",
+            "is_default": False,
             "supports_text": True,
             "supports_patch_regions": False,
             "license_notice": None,
@@ -541,6 +545,7 @@ class TestAllEmbeddersRegistration:
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d
+            assert "is_default" in d
             assert "supports_text" in d
             assert "supports_patch_regions" in d
             assert "license_notice" in d

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -726,6 +726,7 @@ class MediaEmbedder(ABC):
         return {
             "name": self.name,
             "media_type_id": self.media_type_id,
+            "is_default": self.is_default,
             "supports_text": self.supports_text,
             "supports_patch_regions": self.supports_patch_regions,
             "license_notice": self.license_notice,


### PR DESCRIPTION
## Summary

Addresses **1.3 — Embedder default per media type** from the UX brainstorm.

The embedder dropdown in the dataset-import modal previously listed every embedder for the chosen media type as a flat list (`siglip`, `siglip2`, `clip`, `dinov2_single`, `dinov2_patch`, `dinov3_single`, `dinov3_patch`, `eupe_single`, `eupe_patch`, …). The default was already first thanks to `embedders_for_type()` sorting on `is_default`, but the user had no visual cue that the first one is the recommended/demo embedder vs. just whatever happened to be returned first.

This PR:

- **Backend:** Exposes `is_default` in `MediaEmbedder.to_dict()` (and therefore in the `/api/embedders` response).
- **Frontend:** Adds `is_default` to `EmbedderInfo`. The four embedder pickers in `DatasetImporterModalComponent` (demo, generic form, local folder, server folder) now render two `<optgroup>`s — **Recommended** (the one with `is_default=true` — `siglip` for image, `clap` for audio, `e5` for text, `xclip` for video) and **Advanced ▾** (everything else). Recommended sits at the top and stays auto-selected, so behavior is unchanged for users who don't touch the dropdown.
- **Tests:** Updated the `to_dict()` exact-shape assertions in `tests/detectors/test_new_embedders.py` and `tests/detectors/test_image_embedders.py` to include the new `is_default` key, plus the `all_embedders_dict()` shape sweep.

No API breakage beyond the new key — the same dropdown still posts the same `embedder` name.

## Test plan

- [x] `./run-tests.sh detectors core` → 1287 passed
- [x] `./run-tests.sh api` → 418 passed
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Frontend `npm run build:prod` succeeds (run as part of `core`)
- [ ] Manual: open the dataset-import modal on each of the 4 pickers (demo / generic / local folder / server folder) and confirm the recommended embedder sits under a "Recommended" group and the rest under "Advanced ▾"

https://claude.ai/code/session_01Fyfjc4aVoe2WzvjazRxNdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyfjc4aVoe2WzvjazRxNdr)_