### PR TITLE
Remember last embedder per media type across all importers

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -6,6 +6,7 @@ import { FileBrowserComponent } from '../../file-browser/file-browser.component'
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
+import { SettingsStateService } from '../../../services/settings-state.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
@@ -154,7 +155,10 @@ export class DatasetImporterModalComponent implements OnInit {
   clipperChooserContext: 'form' | 'demo' | 'sf' | 'lf' = 'form';
   clipperChooserClippers: ClipperInfo[] = [];
 
-  constructor(private datasetsApi: DatasetsApiService) {}
+  constructor(
+    private datasetsApi: DatasetsApiService,
+    private settingsState: SettingsStateService,
+  ) {}
 
   ngOnInit(): void {
     this.datasetsApi.getAllImporters().subscribe({
@@ -173,6 +177,35 @@ export class DatasetImporterModalComponent implements OnInit {
         this.mediaTypes = res.media_types || [];
       },
     });
+    // Settings carry the per-media-type "last embedder" memory used to
+    // pre-select an embedder when no loaded dataset can supply
+    // ``guessedMediaEmbedder``.
+    this.settingsState.load();
+  }
+
+  /** Pick the initial embedder for a picker view.  Priority:
+   *  1. ``guessedMediaEmbedder`` (computed from currently loaded datasets)
+   *  2. the user's last pick for this media type (per-user setting)
+   *  3. first option, or empty when the list is empty.
+   *
+   *  ``mediaTypeFolderOrTypeId`` accepts either form — the importer form
+   *  values use the folder name (e.g. ``"images"``) while the settings
+   *  map is keyed by canonical type_id (e.g. ``"image"``).  We resolve to
+   *  type_id before looking up the saved setting. */
+  private pickInitialEmbedder(embedders: EmbedderInfo[], mediaTypeFolderOrTypeId: string): string {
+    if (embedders.length === 0) return '';
+    const guessedMatch = this.guessedMediaEmbedder
+      ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
+      : null;
+    if (guessedMatch) return guessedMatch.name;
+    const typeId = this.toTypeId(mediaTypeFolderOrTypeId) || mediaTypeFolderOrTypeId;
+    const savedMap = this.settingsState.settings?.last_embedder_per_media_type || {};
+    const saved = savedMap[typeId];
+    if (saved) {
+      const savedMatch = embedders.find((e) => e.name === saved);
+      if (savedMatch) return savedMatch.name;
+    }
+    return embedders[0].name;
   }
 
   /** Front-of-list order for the picker within each tab.  Importers not
@@ -451,11 +484,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.availableEmbedders = embedders;
-        // Prefer guessed embedder when it's available for this media type
-        const guessedMatch = this.guessedMediaEmbedder
-          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
-          : null;
-        this.selectedEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
+        this.selectedEmbedder = this.pickInitialEmbedder(embedders, mediaType);
       },
     });
   }
@@ -519,11 +548,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.demoEmbedders = embedders;
-        // Prefer guessed embedder when it's available for this media type
-        const guessedMatch = this.guessedMediaEmbedder
-          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
-          : null;
-        this.selectedDemoEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
+        this.selectedDemoEmbedder = this.pickInitialEmbedder(embedders, mediaType);
         this.demoEmbedder = this.selectedDemoEmbedder;
         this.updateDemoStatuses();
         // The initial demo fetch had no embedder/clipper context, so re-fetch
@@ -830,10 +855,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.lfEmbedders = embedders;
-        const guessedMatch = this.guessedMediaEmbedder
-          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
-          : null;
-        this.lfSelectedEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
+        this.lfSelectedEmbedder = this.pickInitialEmbedder(embedders, mediaType);
       },
     });
   }
@@ -1258,11 +1280,7 @@ export class DatasetImporterModalComponent implements OnInit {
     this.datasetsApi.getEmbedders(mediaType).subscribe({
       next: (embedders) => {
         this.sfEmbedders = embedders;
-        // Prefer guessed embedder when it's available for this media type
-        const guessedMatch = this.guessedMediaEmbedder
-          ? embedders.find((e) => e.name === this.guessedMediaEmbedder)
-          : null;
-        this.sfSelectedEmbedder = guessedMatch ? guessedMatch.name : (embedders.length > 0 ? embedders[0].name : '');
+        this.sfSelectedEmbedder = this.pickInitialEmbedder(embedders, mediaType);
       },
     });
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -376,6 +376,7 @@ export interface AppSettings {
   autopilot_hard_reds?: number;
   autopilot_resort_interval?: number;
   autopilot_goal_diversity?: number;
+  last_embedder_per_media_type?: Record<string, string>;
   [key: string]: unknown;
 }
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -591,3 +591,33 @@ class TestSettingsModule:
         # Should fall back to defaults
         assert settings_mod.get_volume() == 1.0
         assert settings_mod.get_autorun_detectors() == []
+
+    def test_last_embedder_per_media_type_default(self):
+        assert settings_mod.get_last_embedder_per_media_type() == {}
+        assert settings_mod.get_last_embedder_for_media_type("image") == ""
+
+    def test_set_last_embedder_for_media_type(self, isolated_settings):
+        settings_mod.set_last_embedder_for_media_type("image", "siglip")
+        assert settings_mod.get_last_embedder_for_media_type("image") == "siglip"
+        assert settings_mod.get_last_embedder_per_media_type() == {"image": "siglip"}
+
+        raw = json.loads(isolated_settings.read_text())
+        assert raw["last_embedder_per_media_type"] == {"image": "siglip"}
+
+    def test_last_embedder_per_media_type_independent_keys(self, isolated_settings):
+        settings_mod.set_last_embedder_for_media_type("image", "siglip")
+        settings_mod.set_last_embedder_for_media_type("audio", "clap")
+        assert settings_mod.get_last_embedder_for_media_type("image") == "siglip"
+        assert settings_mod.get_last_embedder_for_media_type("audio") == "clap"
+
+    def test_last_embedder_for_media_type_ignores_empty_args(self, isolated_settings):
+        settings_mod.set_last_embedder_for_media_type("image", "siglip")
+        # Empty media_type or embedder is a no-op.
+        settings_mod.set_last_embedder_for_media_type("", "anything")
+        settings_mod.set_last_embedder_for_media_type("image", "")
+        assert settings_mod.get_last_embedder_for_media_type("image") == "siglip"
+
+    def test_last_embedder_per_media_type_persists_across_reset(self, isolated_settings):
+        settings_mod.set_last_embedder_for_media_type("image", "siglip")
+        settings_mod.reset()
+        assert settings_mod.get_last_embedder_for_media_type("image") == "siglip"

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1158,6 +1158,50 @@ class TestLoadProgressRaceCondition:
         assert progress["error"] is None, "Starting a new load must clear the stale error from a previous load"
         assert progress["status"] == "loading"
 
+    def test_origin_load_records_last_embedder_per_media_type(self, isolated_settings):
+        """Starting a load with a known media_type + embedder should persist
+        the pick into the per-user ``last_embedder_per_media_type`` map.
+        """
+        from unittest.mock import patch
+
+        from vtsearch import settings as settings_mod
+        from vtsearch.datasets.load_pipeline import _run_origin_load_in_background
+
+        assert settings_mod.get_last_embedder_for_media_type("image") == ""
+
+        with patch("vtsearch.datasets.load_pipeline.threading.Thread"):
+            _run_origin_load_in_background(
+                lambda: None,
+                {"importer": "test", "params": {}},
+                embedder="siglip",
+                media_type="image",
+            )
+
+        assert settings_mod.get_last_embedder_for_media_type("image") == "siglip"
+
+    def test_origin_load_skips_save_without_media_type_or_embedder(self, isolated_settings):
+        """No media_type or no embedder means nothing to remember."""
+        from unittest.mock import patch
+
+        from vtsearch import settings as settings_mod
+        from vtsearch.datasets.load_pipeline import _run_origin_load_in_background
+
+        with patch("vtsearch.datasets.load_pipeline.threading.Thread"):
+            _run_origin_load_in_background(
+                lambda: None,
+                {"importer": "test", "params": {}},
+                embedder="",
+                media_type="image",
+            )
+            _run_origin_load_in_background(
+                lambda: None,
+                {"importer": "test", "params": {}},
+                embedder="siglip",
+                media_type="",
+            )
+
+        assert settings_mod.get_last_embedder_per_media_type() == {}
+
     def test_load_embedder_sets_initial_progress(self):
         """_load_embedder_for_clips must set progress before loading starts.
 

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -663,6 +663,17 @@ def _run_origin_load_in_background(
     if not loading_tasks.has_active_tasks():
         dataset_progress.reset_cancel()
 
+    # Remember the user's embedder pick per media type so the next dataset
+    # importer modal can pre-select it even when no loaded dataset is
+    # around to supply the same hint via ``guessedMediaEmbedder``.
+    if media_type and embedder:
+        from vtsearch.settings import set_last_embedder_for_media_type  # noqa: PLC0415
+
+        try:
+            set_last_embedder_for_media_type(media_type, embedder)
+        except Exception:
+            pass
+
     import time as _time
 
     task_id = f"_loading_{uuid4().hex[:8]}"

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -102,6 +102,9 @@ if TYPE_CHECKING:
     def set_panel_pct_left(value: dict[str, int] | int | float) -> None: ...
     def set_panel_pct_right(value: dict[str, int] | int | float) -> None: ...
 
+    def get_last_embedder_per_media_type() -> dict[str, str]: ...
+    def set_last_embedder_per_media_type(value: dict[str, str]) -> None: ...
+
 
 logger = logging.getLogger(__name__)
 
@@ -695,6 +698,30 @@ get_panel_pct_left, get_panel_pct_right, set_panel_pct_left, set_panel_pct_right
     _PANEL_PX_DEFAULTS,
     value_type="int",
 )
+
+
+def get_last_embedder_for_media_type(media_type: str) -> str:
+    """Return the user's last picked embedder for *media_type*, or ``""``."""
+    if not media_type:
+        return ""
+    raw = get_last_embedder_per_media_type()
+    if isinstance(raw, dict):
+        value = raw.get(media_type, "")
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def set_last_embedder_for_media_type(media_type: str, embedder: str) -> None:
+    """Record *embedder* as the user's last pick for *media_type*."""
+    if not media_type or not embedder:
+        return
+    current = get_last_embedder_per_media_type()
+    updated = dict(current) if isinstance(current, dict) else {}
+    if updated.get(media_type) == embedder:
+        return
+    updated[media_type] = embedder
+    set_last_embedder_per_media_type(updated)
 
 
 def get_autorun_detectors() -> list[str]:

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -126,3 +126,9 @@ class UserSettings(BaseModel):
     focus_mode_right: dict[str, FocusMode] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)
+
+    # Per-media-type memory of the last embedder the user picked, used by the
+    # dataset importer modal to pre-select a sensible default when no loaded
+    # dataset is around to supply the same hint via ``guessedMediaEmbedder``.
+    # Keys are canonical media-type ids (e.g. ``"image"``, ``"audio"``).
+    last_embedder_per_media_type: dict[str, str] = Field(default_factory=dict)


### PR DESCRIPTION
## Summary

Remember the embedder a user picked, keyed by media type, and pre-select it the next time the importer modal opens — for **any** importer, not just demo.

## Behavior

When the dataset importer modal needs to pick an initial embedder for a given media type, it now walks three fallbacks:

1. `guessedMediaEmbedder` — derived from currently loaded datasets and in-progress loads (existing behavior; strongest signal when present)
2. `last_embedder_per_media_type[type_id]` — new per-user setting, populated on every dataset load
3. First option in the embedder list (existing fallback)

This covers the case the prior "guess from loaded datasets" path missed: cold-start with no loaded datasets, or starting a new dataset of a different media type than anything currently loaded.

## Changes

**Backend**

- `vtsearch/settings_models.py`: new `UserSettings.last_embedder_per_media_type: dict[str, str]` field (keyed by canonical media-type id).
- `vtsearch/settings.py`: new `get_last_embedder_for_media_type` / `set_last_embedder_for_media_type` helpers (single-entry read/write on top of the auto-generated dict accessors).
- `vtsearch/datasets/load_pipeline.py`: `_run_origin_load_in_background` records the `(media_type, embedder)` pair into the per-user setting at the start of every load (in the request thread, before the background task kicks off).

**Frontend**

- `frontend/src/app/models/api.models.ts`: new `last_embedder_per_media_type?` on `AppSettings`.
- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts`: injects `SettingsStateService`, exposes a `pickInitialEmbedder()` helper, and routes all four embedder-load paths (generic form, demo, local-folder, server-folder) through it.

**Tests**

- `tests/core/test_settings.py`: defaults, single-key set/get, independent keys, empty-arg no-op, persistence across reset.
- `tests/datasets/test_datasets.py`: `_run_origin_load_in_background` records the embedder for non-empty `(media_type, embedder)` pairs, and skips otherwise.

## Test plan

- [x] `./run-tests.sh` — 3554 passed, 1 skipped
- [x] `cd frontend && npm run build:prod` — clean build
- [x] `ruff check .` / `ruff format --check .` — pass
- [x] `pyright` — 0 errors
- [ ] Manual UI check — no Chrome in the cloud container; not exercised in a browser. Verified end-to-end via unit tests and a Python smoke-test of the new accessors.

https://claude.ai/code/session_01S6UJmxumNo5wqTjiDeNww8

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6UJmxumNo5wqTjiDeNww8)_