### PR TITLE
Add empty-state welcome banner to the dashboard

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -21,7 +21,13 @@
     </div>
 
     @if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
-      <p class="empty-state">No datasets yet. Click + to add one.</p>
+      <div class="welcome-banner">
+        <p class="welcome-banner-text">{{ welcomeBannerMessage }}</p>
+        <button class="btn btn--primary btn--sm welcome-banner-cta"
+          (click)="openImporterModalOnTab(welcomeBannerCtaTab)"
+          [disabled]="isLoading"
+          title="Open the dataset importer">{{ welcomeBannerCtaLabel }}</button>
+      </div>
     } @else {
       <div class="dashboard-grid">
         <table class="dash-table" [class.table-fixed]="datasetCols.tableFixed">
@@ -312,6 +318,7 @@
   <vt-dataset-importer-modal
     [guessedMediaType]="guessedMediaType"
     [guessedMediaEmbedder]="guessedMediaEmbedder"
+    [initialTab]="importerInitialTab"
     (closed)="closeImporterModal()"
     (importStarted)="onImportComplete()"
     (demoSelected)="onDemoSelected($event)"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -412,6 +412,29 @@
   font-style: italic;
 }
 
+.welcome-banner {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+
+  .welcome-banner-text {
+    color: var(--text-primary);
+    margin: 0;
+    max-width: 480px;
+    line-height: 1.45;
+  }
+
+  .welcome-banner-cta {
+    align-self: center;
+  }
+}
+
 .dashboard-actions {
   flex-shrink: 0;
   display: flex;

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -28,10 +28,12 @@ describe('DashboardComponent', () => {
   function flushInitialRequests(
     datasets: any[] = [],
     detectors: any[] = [],
+    importers: any[] = [],
   ): void {
     fixture.detectChanges();
     httpMock.expectOne('/api/datasets/registry').flush({ datasets });
     httpMock.expectOne('/api/detectors/registry').flush({ detectors });
+    httpMock.expectOne('/api/dataset/all-importers').flush({ importers, tabs: [] });
   }
 
   it('should create', () => {
@@ -392,11 +394,71 @@ describe('DashboardComponent', () => {
     expect(component.importerModalOpen).toBeFalse();
   });
 
-  it('should render empty state when no datasets', () => {
+  it('should render welcome banner when no datasets', () => {
     flushInitialRequests();
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.empty-state')?.textContent).toContain('No datasets yet');
+    const banner = el.querySelector('.welcome-banner');
+    expect(banner).toBeTruthy();
+    expect(banner?.textContent || '').toContain('Welcome');
+  });
+
+  describe('welcome banner', () => {
+    it('should default to pushing Server Folder when no Services importers are registered', () => {
+      flushInitialRequests([], [], [
+        { name: 'server_folder', category: 'server' },
+        { name: 'demo', category: 'demo' },
+      ]);
+      expect(component.welcomeBannerMessage).toContain('Server Folder');
+      expect(component.welcomeBannerCtaLabel).toBe('Open Server');
+      expect(component.welcomeBannerCtaTab).toBe('server');
+    });
+
+    it('should name a single Services importer when exactly one is registered', () => {
+      flushInitialRequests([], [], [
+        { name: 'recaller', display_name: 'ReCaller', category: 'services' },
+        { name: 'server_folder', category: 'server' },
+      ]);
+      expect(component.welcomeBannerMessage).toContain('ReCaller');
+      expect(component.welcomeBannerMessage).toContain('Services');
+      expect(component.welcomeBannerCtaLabel).toBe('Open Services');
+      expect(component.welcomeBannerCtaTab).toBe('services');
+    });
+
+    it('should use generic wording when multiple Services importers are registered', () => {
+      flushInitialRequests([], [], [
+        { name: 'recaller', display_name: 'ReCaller', category: 'services' },
+        { name: 'other_service', display_name: 'Other', category: 'services' },
+      ]);
+      expect(component.welcomeBannerMessage).not.toContain('ReCaller');
+      expect(component.welcomeBannerMessage).toContain('Services');
+      expect(component.welcomeBannerCtaLabel).toBe('Open Services');
+      expect(component.welcomeBannerCtaTab).toBe('services');
+    });
+
+    it('should ignore hidden_from_picker importers when picking the welcome branch', () => {
+      flushInitialRequests([], [], [
+        { name: 'recaller', display_name: 'ReCaller', category: 'services', hidden_from_picker: true },
+        { name: 'server_folder', category: 'server' },
+      ]);
+      expect(component.servicesImporters.length).toBe(0);
+      expect(component.welcomeBannerMessage).toContain('Server Folder');
+    });
+
+    it('should open the importer modal pre-pinned to the chosen tab', () => {
+      flushInitialRequests();
+      component.openImporterModalOnTab('services');
+      expect(component.importerModalOpen).toBeTrue();
+      expect(component.importerInitialTab).toBe('services');
+    });
+
+    it('should reset the initial tab when the modal closes', () => {
+      flushInitialRequests();
+      component.openImporterModalOnTab('server');
+      expect(component.importerInitialTab).toBe('server');
+      component.closeImporterModal();
+      expect(component.importerInitialTab).toBe('');
+    });
   });
 
   it('should render dataset table when datasets exist', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -14,7 +14,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
 import { AchievementsService } from '../../services/achievements.service';
-import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, DetectorRegistryEntry } from '../../models/api.models';
+import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, DetectorRegistryEntry, ImporterInfo } from '../../models/api.models';
 import { formatProgressFraction } from '../../utils/format-progress';
 import { ColMeta, ManagedColumns } from '../../utils/managed-columns';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
@@ -76,6 +76,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   importerModalOpen = false;
   importerClosing = false;
+  /** Picker tab id the importer modal should pre-select when it next
+   *  opens — set by the welcome-banner CTA so a fresh user lands in
+   *  the right place. Empty for the normal "+" button flow. */
+  importerInitialTab = '';
+  /** Visible importers (i.e. ``hidden_from_picker !== true``), fetched
+   *  once on init so the welcome banner can detect Services-tab
+   *  importers without waiting for the modal to open. */
+  visibleImporters: ImporterInfo[] = [];
   combineModalOpen = false;
   /** Datasets passed into the Combine modal when it opens. */
   combineModalDatasets: DatasetRegistryEntry[] = [];
@@ -249,6 +257,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.refresh();
     this.resumeActivePolling();
     this.startDiskUsagePolling();
+    this.datasetsApi.getAllImporters().subscribe({
+      next: (res) => {
+        this.visibleImporters = (res.importers || []).filter((imp) => !imp['hidden_from_picker']);
+      },
+    });
   }
 
   private startDiskUsagePolling(): void {
@@ -832,6 +845,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   openImporterModal(): void {
+    this.importerInitialTab = '';
+    this.importerClosing = false;
+    this.importerModalOpen = true;
+  }
+
+  /** Welcome-banner CTA: open the importer modal with one of the picker
+   *  tabs pre-selected so a fresh user lands on the relevant choices. */
+  openImporterModalOnTab(tabId: string): void {
+    this.importerInitialTab = tabId;
     this.importerClosing = false;
     this.importerModalOpen = true;
   }
@@ -839,10 +861,49 @@ export class DashboardComponent implements OnInit, OnDestroy {
   closeImporterModal(): void {
     this.importerModalOpen = false;
     this.importerClosing = true;
+    this.importerInitialTab = '';
   }
 
   onImporterAnimationEnd(): void {
     this.importerClosing = false;
+  }
+
+  // --- First-run welcome banner ---
+
+  /** Visible importers in the Services tab, in registry order. */
+  get servicesImporters(): ImporterInfo[] {
+    return this.visibleImporters.filter((imp) => (imp.category || '') === 'services');
+  }
+
+  /** Pretty name for a Services importer (display_name falls back to name). */
+  private importerLabel(imp: ImporterInfo): string {
+    return imp.display_name || imp.name;
+  }
+
+  /** Body text for the welcome banner. Three branches:
+   *   - no Services importers → push Server Folder
+   *   - exactly one Services importer → name it
+   *   - multiple Services importers → generic Services prompt */
+  get welcomeBannerMessage(): string {
+    const services = this.servicesImporters;
+    if (services.length === 1) {
+      const label = this.importerLabel(services[0]);
+      return `Welcome — load a dataset to get started. You have ${label} registered in the Services tab, which is probably what you want.`;
+    }
+    if (services.length > 1) {
+      return 'Welcome — load a dataset to get started. You have importers registered in the Services tab, which is probably where to start.';
+    }
+    return 'Welcome — load a dataset to get started. Server Folder is the most common starting point: point it at a folder of files already on this machine.';
+  }
+
+  /** CTA label paired with the welcome-banner message. */
+  get welcomeBannerCtaLabel(): string {
+    return this.servicesImporters.length > 0 ? 'Open Services' : 'Open Server';
+  }
+
+  /** Picker tab the welcome-banner CTA pre-selects in the importer modal. */
+  get welcomeBannerCtaTab(): string {
+    return this.servicesImporters.length > 0 ? 'services' : 'server';
   }
 
   onImportComplete(): void {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -201,6 +201,18 @@ describe('DatasetImporterModalComponent', () => {
     expect(el.querySelectorAll('.importer-subtab').length).toBe(0);
   });
 
+  it('should pre-select the initialTab once importers and tabs arrive', () => {
+    component.initialTab = 'server';
+    flushImporters();
+    expect(component.activeImporterTab).toBe('server');
+  });
+
+  it('should ignore an initialTab id that no declared/used tab matches', () => {
+    component.initialTab = 'no-such-tab';
+    flushImporters();
+    expect(component.activeImporterTab).toBe('');
+  });
+
   it('should always render the Services tab even when no importers populate it', () => {
     flushImporters();
     fixture.detectChanges();

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -21,6 +21,10 @@ export class DatasetImporterModalComponent implements OnInit {
   @Input() guessedMediaType = '';
   /** Embedder name guessed from existing datasets/in-progress loads (e.g. "siglip"). */
   @Input() guessedMediaEmbedder = '';
+  /** Picker tab id to pre-select when the modal opens (e.g. "server" from
+   *  the dashboard's first-run welcome banner CTA).  Empty leaves the
+   *  picker in the default "no tab selected" state. */
+  @Input() initialTab = '';
 
   @Output() closed = new EventEmitter<void>();
   @Output() importStarted = new EventEmitter<void>();
@@ -161,6 +165,9 @@ export class DatasetImporterModalComponent implements OnInit {
       next: (res) => {
         this.importers = (res.importers || []).filter((imp) => !imp['hidden_from_picker']);
         this.declaredTabs = res.tabs || [];
+        if (this.initialTab && this.visibleImporterTabs.some((t) => t.id === this.initialTab)) {
+          this.selectImporterTab(this.initialTab);
+        }
       },
     });
     this.datasetsApi.getEmbedders().subscribe({


### PR DESCRIPTION
## Summary

Replaces the dim "No datasets yet. Click + to add one." line on the empty
Datasets table with a richer first-run banner. The copy adapts to what's
actually installed:

- **0 visible Services importers** → push **Server Folder**.
  CTA opens the importer modal pre-pinned to the **Server** tab.
- **1 visible Services importer** → name it explicitly in the copy
  ("You have *X* registered in the Services tab, which is probably
  what you want").
  CTA opens the importer modal pre-pinned to the **Services** tab.
- **2+ visible Services importers** → generic Services plural
  wording, same CTA target.

The default-tab pre-selection re-uses the modal's existing "no
auto-select" policy: the tab is pinned, but the user still picks
the sub-importer themselves.

## Implementation notes

- `DatasetImporterModalComponent` grows an `initialTab` input. When set
  to an id that matches a visible tab, `ngOnInit` calls
  `selectImporterTab(initialTab)` once importers + tabs arrive.
- `DashboardComponent` fetches `/api/dataset/all-importers` once on
  init so the banner can detect Services-tab importers without
  waiting for the modal to open. Hidden-from-picker importers
  (e.g. the `recaller` extension scaffold) are filtered out.
- `welcomeBannerMessage` / `welcomeBannerCtaLabel` / `welcomeBannerCtaTab`
  getters keep the rendering logic out of the template.
- New `openImporterModalOnTab(tabId)` method is wired only to the
  banner CTA; the regular `+` button still calls `openImporterModal()`
  which clears the initial tab so it opens "no tab selected" as before.

## Test plan

- [ ] Spin up the app with zero datasets and verify the banner renders
      with the Server Folder copy and the CTA opens the modal on the
      Server tab.
- [ ] Register a hidden_from_picker Services importer (e.g. `recaller`
      with `hidden_from_picker = False`) and confirm the banner names
      it and the CTA lands on the Services tab.
- [ ] Register two Services importers and verify the plural wording.
- [ ] Confirm the regular `+` button still opens the modal with no
      tab pre-selected.
- [ ] `npm run build:prod` — clean (no `▲ WARNING` lines).
- [ ] Updated `dashboard.component.spec.ts` and
      `dataset-importer-modal.component.spec.ts` cover the three
      banner branches, hidden-from-picker filtering, CTA wiring,
      and `initialTab` pre-selection.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ScWpDHddQRBPMQYUPk9fXF)_