### PR TITLE
Add Auto (recommended) clipper for audio and video imports

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,6 +18,7 @@ or [ARCHITECTURE.md](../ARCHITECTURE.md), the plan file is deleted.
 | [pyright-type-checking.md](pyright-type-checking.md) | **Stage 1 shipped; stages 2–6 open** | `pyrightconfig.json` gates `utils/`, `auth/`, `plugins/`, `sync/`, `concurrency/`, `exporters/`, `labels/`, `settings_io/`, `cli.py`, `config.py`. Remaining stages: 2 (`settings*`, `state/`, `security/`), 3 (`datasets/`, `detectors/`, `eval/`, `models/`), 4 (`routes/`, `converters/`), 5 (`media/`), 6 (whole `vtsearch/` — advisory job removed). |
 | [feature-brainstorm.md](feature-brainstorm.md) | **Backlog** | Wide-ranging idea backlog — new media types, converters, clippers, demo datasets, experiments. Items graduate into their own plan doc as they mature. |
 | [ux-brainstorm.md](ux-brainstorm.md) | **Backlog** | Audit of friction across importers, labeling, sorting, settings, and progress UX. ~75 ideas across auto-fill, hints, speed-ups, clarity, streamlining, and consistency. Items graduate into their own plan doc as they mature. |
+| [smart-clipper-defaults.md](smart-clipper-defaults.md) | **Phase 1 shipped; Phase 2 deferred** | "Auto (recommended)" clipper entry for audio and video — resolves to pass-through or tiling per dataset based on median duration. Phase 2 (per-media routing via clipper options) deferred — see Open follow-ups. |
 
 ## Recently completed (removed)
 

--- a/docs/plans/smart-clipper-defaults.md
+++ b/docs/plans/smart-clipper-defaults.md
@@ -1,0 +1,99 @@
+# Smart clipper defaults
+
+*Status: Phase 1 shipped — picker now offers an "Auto (recommended)"
+clipper for audio and video that resolves to pass-through or tiling
+based on the dataset's median duration. Phase 2 deferred — see Open
+follow-ups.*
+
+This plan implements [ux-brainstorm.md §1.10](ux-brainstorm.md#110-clipper-default-from-media-type--duration-) ("Clipper default from media type + duration").
+
+## Problem
+
+Most users don't know what a clipper is. The importer modal exposes one
+anyway and defaults to `*_default` (pass-through), which is the wrong
+choice for a folder of hour-long podcasts: every file becomes a single
+embedding and semantic sort is useless. Picking the right clipper
+manually means knowing the difference between `sound_default`,
+`sound_tiling`, and `sound_clip` — and what good values for `duration`
+and `min_overlap` are. The user doesn't have that context.
+
+## Phase 1 — Auto clippers (shipped)
+
+Add an **Auto (recommended)** entry to the clipper picker for the two
+duration-bearing media types: audio and video. Register it FIRST in
+each media type's `CLIPPERS` list so the picker defaults to it, and
+have the load pipeline resolve it to a concrete clipper for the whole
+dataset based on the median media duration.
+
+### Files
+
+- `vtsearch/media/clipper.py` — Added `MediaClipper.resolve_for_durations(durations)` on the base class, default returns `self`.
+- `vtsearch/media/audio/clipper.py` — Added `SoundAutoClipper(threshold=30, tile_duration=10)`.
+- `vtsearch/media/video/clipper.py` — Added `VideoAutoClipper(threshold=30, tile_duration=10)`.
+- `vtsearch/media/audio/__init__.py` — `SoundAutoClipper()` first in `CLIPPERS`.
+- `vtsearch/media/video/__init__.py` — `VideoAutoClipper()` first in `CLIPPERS`.
+- `vtsearch/datasets/load_pipeline.py` — `_apply_clipper` calls `clipper.resolve_for_durations(durations)` once per dataset and uses the resolved clipper's `name` and `to_dict()` for origin tagging.
+
+### Behavior
+
+- Picker shows **Auto (recommended)** first (the importer modal default-selects the first clipper, and the chooser tab bar prefers the first non-`*_default` clipper).
+- When the user accepts Auto, the load pipeline collects `media["duration"]` across the staged medias, takes the median, and resolves:
+  - `median <= 30s` → `*_default` (pass-through).
+  - `median > 30s` → `*_tiling` with `duration=10s`.
+- The threshold and tile length are configurable via the chooser's parameter fields (`threshold`, `tile_duration`).
+- Each resulting clip records the **resolved** clipper in its origin (`clipper=sound_tiling` or `clipper=sound_default`), not `sound_auto`. Cross-dataset replay is deterministic and ignores the original auto policy.
+- Direct calls (`SoundAutoClipper().clip(media)` outside the load pipeline) fall back to per-media routing using the same threshold, so the clipper still works correctly if used without a dataset context.
+
+### Why per-dataset, not per-media
+
+Phase 1 makes the routing decision once per dataset because that matches the existing clipper UX: the picker takes one choice for the whole import. Per-media routing — "for this video, pass through; for that one, tile" — is a more powerful behavior but it changes the mental model and the origin format. It's deferred to Phase 2.
+
+## What shipped
+
+- `MediaClipper.resolve_for_durations()` hook on the base class.
+- `SoundAutoClipper` and `VideoAutoClipper` registered first per media type.
+- Load pipeline resolution before clipping begins.
+- Origin records the resolved concrete clipper, so replay is stable.
+
+## Open follow-ups
+
+### Phase 2 — Per-media auto routing via clipper options
+
+Today the auto clipper picks one concrete clipper for the whole dataset
+based on median duration. A more powerful approach is to expose the
+"sometimes clip depending on length" behavior **through the
+MediaClipper's options**, so a single clipper instance routes per
+media:
+
+- Each media item gets clipped via the strategy that matches its own
+  duration: short clips pass through, long clips get tiled.
+- The clipper's `parameters` would include the threshold and the tile
+  configuration, and `clip(media)` would branch on
+  `media["duration"]`.
+- This subsumes Phase 1: the picker still shows one "Auto" entry, but
+  resolution becomes a no-op (it returns self) and the per-media
+  branching lives inside `clip()`.
+
+Open questions for Phase 2:
+
+- **Origin recording**: each clip's origin needs to record which
+  branch was taken (`sound_tiling` vs `sound_default`) so cross-dataset
+  resolution still works. Either the auto clipper emits the resolved
+  branch name in its `clip()` output, or origins carry the auto clipper
+  plus a per-clip "branch" marker.
+- **UI**: the parameter fields ("threshold", "tile length") stay the
+  same — users don't need to know whether the decision is per-dataset
+  or per-media. But the description string should change from
+  "tile *the dataset* if median > 30s" to "tile *each item* if > 30s".
+- **Other media types**: image and text don't have a meaningful
+  duration. Should we extend the same pattern (e.g. tile tall images
+  automatically, sentence-split long paragraphs)? Out of scope for now
+  — but the design should not assume "duration" is the only routing
+  signal.
+
+### Phase 3 — Hide the clipper picker behind Advanced (deferred)
+
+The ux-brainstorm entry also proposed hiding the clipper button entirely
+until the user opens an "Advanced" section, on the theory that the
+default is almost always right. Deferred until we have evidence on how
+often users tweak the default after Phase 1 lands.

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -52,6 +52,8 @@ Demo dataset picker re-asks for embedder every time. Remember the last embedder 
 ### 1.10 Clipper default from media type + duration ★ M
 Most users don't know what a clipper is. For audio, default to `null_clipper` for clips < 30s and `overlap_chunks` for longer. For video, default to `chunks` with frame-aware step size. The "Clipper" button can hide entirely until the user opens `Advanced`.
 
+→ Promoted to [smart-clipper-defaults.md](smart-clipper-defaults.md). Phase 1 (per-dataset "Auto (recommended)" picker entry) shipped; Phase 2 (per-media routing via MediaClipper options) deferred.
+
 ### 1.11 Detector name from query/seed ★ XS
 The new-detector modal asks for a `name` and a text/media seed. If the user typed a seed query first, pre-fill `name` with it (sanitized). They almost always type the same thing twice today.
 

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -1461,3 +1461,226 @@ class TestApplyClipperWithParams:
         # 2s clips with 1s min overlap: max_stride=1, ceil((10-2)/1)+1 = 9 tiles
         _apply_clipper(clips, "sound_tiling", {"duration": 2.0, "min_overlap": 1.0})
         assert len(clips) == 9
+
+
+# ---------------------------------------------------------------------------
+# SoundAutoClipper / VideoAutoClipper
+# ---------------------------------------------------------------------------
+
+
+class TestSoundAutoClipper:
+    def test_identity(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper
+
+        c = SoundAutoClipper()
+        assert c.name == "sound_auto"
+        assert c.media_type == "audio"
+        assert c.threshold == 30.0
+        assert c.tile_duration == 10.0
+        assert c.display_name == "Auto (recommended)"
+        assert isinstance(c, MediaClipper)
+
+    def test_rejects_non_positive_params(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper
+
+        with pytest.raises(ValueError):
+            SoundAutoClipper(threshold=0)
+        with pytest.raises(ValueError):
+            SoundAutoClipper(threshold=-1)
+        with pytest.raises(ValueError):
+            SoundAutoClipper(tile_duration=0)
+        with pytest.raises(ValueError):
+            SoundAutoClipper(tile_duration=-1)
+
+    def test_resolve_short_returns_default(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
+
+        resolved = SoundAutoClipper().resolve_for_durations([1.0, 5.0, 10.0, 20.0])
+        assert isinstance(resolved, SoundDefaultClipper)
+
+    def test_resolve_long_returns_tiling(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
+
+        resolved = SoundAutoClipper().resolve_for_durations([60.0, 120.0, 180.0])
+        assert isinstance(resolved, SoundTilingClipper)
+        assert resolved.duration == 10.0
+
+    def test_resolve_empty_returns_default(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
+
+        resolved = SoundAutoClipper().resolve_for_durations([])
+        assert isinstance(resolved, SoundDefaultClipper)
+
+    def test_resolve_uses_median_not_mean(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
+
+        # Mean is 100, median is 5 → should pass through
+        resolved = SoundAutoClipper().resolve_for_durations([5.0, 5.0, 5.0, 500.0])
+        assert isinstance(resolved, SoundDefaultClipper)
+
+    def test_with_params_overrides_threshold(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
+
+        c = SoundAutoClipper().with_params({"threshold": 5.0, "tile_duration": 3.0})
+        assert c.threshold == 5.0
+        assert c.tile_duration == 3.0
+        # 10s exceeds 5s threshold → tiling with 3s segments
+        resolved = c.resolve_for_durations([10.0])
+        assert isinstance(resolved, SoundTilingClipper)
+        assert resolved.duration == 3.0
+
+    def test_to_dict_exposes_params_and_strategy_fields(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper
+
+        d = SoundAutoClipper().to_dict()
+        assert d["name"] == "sound_auto"
+        assert d["display_name"] == "Auto (recommended)"
+        assert d["media_type"] == "audio"
+        assert d["threshold"] == 30.0
+        assert d["tile_duration"] == 10.0
+        param_keys = [p["key"] for p in d["parameters"]]
+        assert "threshold" in param_keys
+        assert "tile_duration" in param_keys
+
+    def test_clip_fallback_per_media(self):
+        """Direct .clip() use (outside the load pipeline) routes per-media."""
+        from vtsearch.media.audio.audio_generator import generate_wav
+        from vtsearch.media.audio.clipper import SoundAutoClipper
+
+        c = SoundAutoClipper(threshold=3.0, tile_duration=1.0)
+        # Short clip → pass-through
+        short_wav = generate_wav(440, 2.0)
+        short = {"id": 1, "type": "audio", "media_bytes": short_wav, "duration": 2.0}
+        assert SoundAutoClipper(threshold=3.0).clip(short) == [short]
+        # Long clip → tiled
+        long_wav = generate_wav(440, 5.0)
+        long_media = {"id": 1, "type": "audio", "media_bytes": long_wav, "duration": 5.0}
+        result = c.clip(long_media)
+        assert len(result) > 1
+
+    def test_first_in_audio_clipper_registry(self):
+        from vtsearch.media import clippers_for_type
+
+        names = [c.name for c in clippers_for_type("audio")]
+        assert names[0] == "sound_auto"
+
+
+class TestVideoAutoClipper:
+    def test_identity(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper
+
+        c = VideoAutoClipper()
+        assert c.name == "video_auto"
+        assert c.media_type == "video"
+        assert c.threshold == 30.0
+        assert c.tile_duration == 10.0
+        assert c.display_name == "Auto (recommended)"
+        assert isinstance(c, MediaClipper)
+
+    def test_rejects_non_positive_params(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper
+
+        with pytest.raises(ValueError):
+            VideoAutoClipper(threshold=0)
+        with pytest.raises(ValueError):
+            VideoAutoClipper(tile_duration=0)
+
+    def test_resolve_short_returns_default(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper, VideoDefaultClipper
+
+        resolved = VideoAutoClipper().resolve_for_durations([5.0, 10.0, 20.0])
+        assert isinstance(resolved, VideoDefaultClipper)
+
+    def test_resolve_long_returns_tiling(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper, VideoTilingClipper
+
+        resolved = VideoAutoClipper().resolve_for_durations([60.0, 120.0])
+        assert isinstance(resolved, VideoTilingClipper)
+        assert resolved.duration == 10.0
+
+    def test_resolve_empty_returns_default(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper, VideoDefaultClipper
+
+        resolved = VideoAutoClipper().resolve_for_durations([])
+        assert isinstance(resolved, VideoDefaultClipper)
+
+    def test_with_params_overrides(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper, VideoTilingClipper
+
+        c = VideoAutoClipper().with_params({"threshold": 4.0, "tile_duration": 2.0})
+        assert c.threshold == 4.0
+        resolved = c.resolve_for_durations([10.0])
+        assert isinstance(resolved, VideoTilingClipper)
+        assert resolved.duration == 2.0
+
+    def test_first_in_video_clipper_registry(self):
+        from vtsearch.media import clippers_for_type
+
+        names = [c.name for c in clippers_for_type("video")]
+        assert names[0] == "video_auto"
+
+
+class TestApplyClipperResolvesAuto:
+    """_apply_clipper resolves auto clippers per-dataset and tags origin
+    with the resolved concrete clipper, not the auto one."""
+
+    def test_short_dataset_resolves_to_default(self):
+        from vtsearch.media.audio.audio_generator import generate_wav
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        wav = generate_wav(440, 5.0)
+        media = {
+            "id": 1,
+            "type": "audio",
+            "media_bytes": wav,
+            "duration": 5.0,
+            "origin": {"importer": "test", "params": {}},
+        }
+        clips = {1: media}
+        _apply_clipper(clips, "sound_auto")
+        # 5s < 30s threshold → pass-through, one clip
+        assert len(clips) == 1
+        # Origin records the resolved concrete clipper.
+        clip = next(iter(clips.values()))
+        assert clip["origin"]["params"]["clipper"] == "sound_default"
+
+    def test_long_dataset_resolves_to_tiling(self):
+        from vtsearch.media.audio.audio_generator import generate_wav
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        wav = generate_wav(440, 60.0)
+        media = {
+            "id": 1,
+            "type": "audio",
+            "media_bytes": wav,
+            "duration": 60.0,
+            "origin": {"importer": "test", "params": {}},
+        }
+        clips = {1: media}
+        _apply_clipper(clips, "sound_auto")
+        # 60s > 30s threshold → tiled with 10s segments → 6 tiles
+        assert len(clips) == 6
+        first = next(iter(clips.values()))
+        assert first["origin"]["params"]["clipper"] == "sound_tiling"
+        # Origin records the resolved clipper's parameter values.
+        assert first["origin"]["params"]["clipper_duration"] == "10.0"
+
+    def test_user_threshold_override_propagates(self):
+        from vtsearch.media.audio.audio_generator import generate_wav
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        wav = generate_wav(440, 8.0)
+        media = {
+            "id": 1,
+            "type": "audio",
+            "media_bytes": wav,
+            "duration": 8.0,
+            "origin": {"importer": "test", "params": {}},
+        }
+        clips = {1: media}
+        # Lower threshold so 8s triggers tiling, with 4s tiles → 2 tiles
+        _apply_clipper(clips, "sound_auto", {"threshold": 5.0, "tile_duration": 4.0})
+        assert len(clips) == 2
+        first = next(iter(clips.values()))
+        assert first["origin"]["params"]["clipper"] == "sound_tiling"
+        assert first["origin"]["params"]["clipper_duration"] == "4.0"

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -265,6 +265,13 @@ def _apply_clipper(
     if clipper_params:
         clipper = clipper.with_params(clipper_params)
 
+    # Resolve auto-selecting clippers to a concrete clipper for the
+    # whole dataset based on its typical media duration.  Non-auto
+    # clippers return self, so this is a no-op for them.
+    durations = [float(m.get("duration", 0) or 0) for m in clips_dict.values()]
+    clipper = clipper.resolve_for_durations(durations)
+    clipper_name = clipper.name
+
     # Extract the effective clipper parameter values so they can be
     # stored in each clip's origin.  This uses to_dict() which concrete
     # clippers override to add their current values (duration, threshold,

--- a/vtsearch/media/audio/__init__.py
+++ b/vtsearch/media/audio/__init__.py
@@ -1,5 +1,5 @@
-from vtsearch.media.audio.clipper import SoundDefaultClipper, SoundTilingClipper
+from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper, SoundTilingClipper
 from vtsearch.media.audio.media_type import AudioMediaType
 
 MEDIA_TYPE = AudioMediaType()
-CLIPPERS = [SoundDefaultClipper(), SoundTilingClipper(2.0)]
+CLIPPERS = [SoundAutoClipper(), SoundDefaultClipper(), SoundTilingClipper(2.0)]

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -177,6 +177,114 @@ class SoundTilingClipper(MediaClipper):
         return d
 
 
+class SoundAutoClipper(MediaClipper):
+    """Pass-through for short audio, tile longer audio.
+
+    Designed as the recommended default in the importer picker. The
+    decision is made once per dataset: if the median media duration
+    exceeds *threshold*, the clipper resolves to a
+    :class:`SoundTilingClipper` with the configured *tile_duration*;
+    otherwise it resolves to :class:`SoundDefaultClipper`.
+
+    The chosen concrete clipper is what gets recorded in each clip's
+    origin, so cross-dataset replay is deterministic.
+    """
+
+    def __init__(self, threshold: float = 30.0, tile_duration: float = 10.0) -> None:
+        if threshold <= 0:
+            raise ValueError("threshold must be positive")
+        if tile_duration <= 0:
+            raise ValueError("tile_duration must be positive")
+        self._threshold = threshold
+        self._tile_duration = tile_duration
+
+    @property
+    def name(self) -> str:
+        return "sound_auto"
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    @property
+    def display_name(self) -> str:
+        return "Auto (recommended)"
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Pass short audio through unchanged; tile audio longer than "
+            f"{self._threshold:g}s into {self._tile_duration:g}s segments."
+        )
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    @property
+    def tile_duration(self) -> float:
+        return self._tile_duration
+
+    def resolve_for_durations(self, durations: list[float]) -> "MediaClipper":
+        if not durations:
+            return SoundDefaultClipper()
+        median = sorted(durations)[len(durations) // 2]
+        if median > self._threshold:
+            return SoundTilingClipper(self._tile_duration)
+        return SoundDefaultClipper()
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        # Fallback path for direct use (outside the load pipeline).
+        # The load pipeline resolves auto → concrete before calling clip(),
+        # so this code only runs if someone uses SoundAutoClipper directly.
+        wav_bytes = media.get("media_bytes")
+        if wav_bytes is None:
+            return [media]
+        try:
+            duration = _wav_duration(wav_bytes)
+        except Exception:
+            return [media]
+        if duration > self._threshold:
+            return SoundTilingClipper(self._tile_duration).clip(media)
+        return SoundDefaultClipper().clip(media)
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "threshold",
+                "label": "Auto-tile threshold (seconds)",
+                "description": "Audio longer than this is automatically tiled into segments.",
+                "type": "number",
+                "default": self._threshold,
+                "min": 1,
+                "max": 600,
+                "step": 1,
+            },
+            {
+                "key": "tile_duration",
+                "label": "Tile length when tiling (seconds)",
+                "description": "Segment length used when auto-tiling is triggered.",
+                "type": "number",
+                "default": self._tile_duration,
+                "min": 0.5,
+                "max": 300,
+                "step": 0.5,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "SoundAutoClipper":
+        threshold = float(params.get("threshold", self._threshold))
+        tile_duration = float(params.get("tile_duration", self._tile_duration))
+        return SoundAutoClipper(threshold=threshold, tile_duration=tile_duration)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["threshold"] = self._threshold
+        d["tile_duration"] = self._tile_duration
+        return d
+
+
 class SoundClipClipper(MediaClipper):
     """Extract a single user-specified ``[start, end)`` slice from an audio media.
 

--- a/vtsearch/media/clipper.py
+++ b/vtsearch/media/clipper.py
@@ -139,6 +139,26 @@ class MediaClipper(ABC):
         """
 
     # ------------------------------------------------------------------
+    # Dataset-level resolution
+    # ------------------------------------------------------------------
+
+    def resolve_for_durations(self, durations: list[float]) -> "MediaClipper":
+        """Return a concrete clipper for the dataset given its media durations.
+
+        Called by the load pipeline once per dataset, before any
+        :meth:`clip` calls.  Most clippers ignore *durations* and return
+        ``self``.  Auto-selecting clippers (e.g. ``SoundAutoClipper``)
+        override this to pick a different concrete clipper based on the
+        dataset's typical duration — for example, pass-through for short
+        clips, tiling for longer ones.
+
+        The resolved clipper's :attr:`name` and parameter values are what
+        get recorded in each clip's origin, so cross-dataset replay is
+        deterministic regardless of the original auto policy.
+        """
+        return self
+
+    # ------------------------------------------------------------------
     # Serialisation
     # ------------------------------------------------------------------
 

--- a/vtsearch/media/video/__init__.py
+++ b/vtsearch/media/video/__init__.py
@@ -1,5 +1,5 @@
-from vtsearch.media.video.clipper import VideoDefaultClipper, VideoSceneClipper, VideoTilingClipper
+from vtsearch.media.video.clipper import VideoAutoClipper, VideoDefaultClipper, VideoSceneClipper, VideoTilingClipper
 from vtsearch.media.video.media_type import VideoMediaType
 
 MEDIA_TYPE = VideoMediaType()
-CLIPPERS = [VideoDefaultClipper(), VideoTilingClipper(2.0), VideoSceneClipper()]
+CLIPPERS = [VideoAutoClipper(), VideoDefaultClipper(), VideoTilingClipper(2.0), VideoSceneClipper()]

--- a/vtsearch/media/video/clipper.py
+++ b/vtsearch/media/video/clipper.py
@@ -140,6 +140,106 @@ class VideoTilingClipper(MediaClipper):
         return d
 
 
+class VideoAutoClipper(MediaClipper):
+    """Pass-through for short video, tile longer video.
+
+    Designed as the recommended default in the importer picker. The
+    decision is made once per dataset: if the median media duration
+    exceeds *threshold*, the clipper resolves to a
+    :class:`VideoTilingClipper` with the configured *tile_duration*;
+    otherwise it resolves to :class:`VideoDefaultClipper`.
+
+    The chosen concrete clipper is what gets recorded in each clip's
+    origin, so cross-dataset replay is deterministic.
+    """
+
+    def __init__(self, threshold: float = 30.0, tile_duration: float = 10.0) -> None:
+        if threshold <= 0:
+            raise ValueError("threshold must be positive")
+        if tile_duration <= 0:
+            raise ValueError("tile_duration must be positive")
+        self._threshold = threshold
+        self._tile_duration = tile_duration
+
+    @property
+    def name(self) -> str:
+        return "video_auto"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    @property
+    def display_name(self) -> str:
+        return "Auto (recommended)"
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Pass short videos through unchanged; tile videos longer than "
+            f"{self._threshold:g}s into {self._tile_duration:g}s segments."
+        )
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    @property
+    def tile_duration(self) -> float:
+        return self._tile_duration
+
+    def resolve_for_durations(self, durations: list[float]) -> "MediaClipper":
+        if not durations:
+            return VideoDefaultClipper()
+        median = sorted(durations)[len(durations) // 2]
+        if median > self._threshold:
+            return VideoTilingClipper(self._tile_duration)
+        return VideoDefaultClipper()
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        # Fallback path for direct use (outside the load pipeline).
+        duration = float(media.get("duration", 0) or 0)
+        if duration > self._threshold:
+            return VideoTilingClipper(self._tile_duration).clip(media)
+        return VideoDefaultClipper().clip(media)
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "threshold",
+                "label": "Auto-tile threshold (seconds)",
+                "description": "Videos longer than this are automatically tiled into segments.",
+                "type": "number",
+                "default": self._threshold,
+                "min": 1,
+                "max": 600,
+                "step": 1,
+            },
+            {
+                "key": "tile_duration",
+                "label": "Tile length when tiling (seconds)",
+                "description": "Segment length used when auto-tiling is triggered.",
+                "type": "number",
+                "default": self._tile_duration,
+                "min": 0.5,
+                "max": 300,
+                "step": 0.5,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "VideoAutoClipper":
+        threshold = float(params.get("threshold", self._threshold))
+        tile_duration = float(params.get("tile_duration", self._tile_duration))
+        return VideoAutoClipper(threshold=threshold, tile_duration=tile_duration)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["threshold"] = self._threshold
+        d["tile_duration"] = self._tile_duration
+        return d
+
+
 def _detect_scene_boundaries(
     video_path: str,
     threshold: float,


### PR DESCRIPTION
## Summary

Promotes [ux-brainstorm.md §1.10](../blob/dev/docs/plans/ux-brainstorm.md#110-clipper-default-from-media-type--duration-) — "Clipper default from media type + duration" — into its own plan and ships Phase 1.

- New `SoundAutoClipper` and `VideoAutoClipper`, registered first in their media types' `CLIPPERS` lists so the importer picker and the clipper chooser tab bar both default to **Auto (recommended)**.
- New `MediaClipper.resolve_for_durations(durations)` hook on the base class (default returns `self`). `_apply_clipper` calls it once per dataset with `media["duration"]` for each staged item; if the median exceeds the configured threshold (30s by default) the auto clipper resolves to its tiling sibling with a 10s tile length, otherwise to pass-through.
- Both `threshold` and `tile_duration` are exposed as parameters on the chooser, so users can tweak the policy if 30s/10s isn't right for their dataset.
- Each clip's origin records the resolved concrete clipper (e.g. `sound_tiling`, not `sound_auto`), so cross-dataset replay is deterministic and ignores the original auto policy.
- Direct `SoundAutoClipper().clip(media)` use (outside the load pipeline) falls back to per-media routing, so the clipper still works correctly without a dataset context.

Phase 2 — moving "sometimes clip depending on length" inside the clipper's own options so the decision happens per media — is captured under Open follow-ups in `docs/plans/smart-clipper-defaults.md`.

## Test plan

- [x] `./run-tests.sh` — 3613 passed, 1 skipped, 2 xpassed
- [x] `tests/detectors/test_clippers.py` — 147 passed (18 new tests covering `SoundAutoClipper`, `VideoAutoClipper`, and `_apply_clipper`'s resolution path)
- [ ] Manual: open the importer modal for an audio folder → confirm "Auto (recommended)" is the default and the threshold/tile fields appear when its tab is active in the clipper chooser
- [ ] Manual: import a folder of short clips → verify clips are pass-through (origin params show `clipper=sound_default`)
- [ ] Manual: import a folder of long clips → verify they're tiled with 10s segments (origin params show `clipper=sound_tiling`, `clipper_duration=10.0`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdgK2tP94LBTXJMWYC5R5)_