### PR TITLE
Pyright Stage 7: gate tests/ on pyright

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,6 +119,31 @@ api = Api(app)
 
 
 # ---------------------------------------------------------------------------
+# Test-time attributes
+# ---------------------------------------------------------------------------
+# ``tests/conftest.py`` attaches a handful of helpers and proxies to this
+# module so tests can use ``import app as app_module; app_module.medias`` etc.
+# Declaring them here in a ``TYPE_CHECKING`` block lets pyright resolve the
+# attribute accesses without changing runtime behaviour — the values are still
+# only set by conftest and are absent in production. Same pattern as
+# ``vtsearch/settings.py``'s dynamically generated accessors.
+from typing import TYPE_CHECKING  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    NUM_MEDIAS: int
+    SAMPLE_RATE: int
+    generate_wav: Callable[..., bytes]
+    train_and_score: Callable[..., Any]
+    medias: dict[int, dict[str, Any]]
+    good_votes: dict[int, None]
+    bad_votes: dict[int, None]
+    init_medias: Callable[[], None]
+
+
+# ---------------------------------------------------------------------------
 # Per-request user context
 # ---------------------------------------------------------------------------
 

--- a/docs/plans/pyright-type-checking.md
+++ b/docs/plans/pyright-type-checking.md
@@ -27,7 +27,18 @@ package. Rolled out in stages so each PR stays reviewable.
   `schemas/` package — 17 files, 0 new errors) and deletes the advisory
   job from `.github/workflows/pyright.yml`. Gated scope now equals the
   whole `vtsearch/` package (245 files, 0 errors).
-- **Stage 7 (`tests/`):** 📋 optional, deferred.
+- **Stage 7:** ✅ shipped. Adds `tests/` to the gated scope. Baseline
+  was 699 errors across 11 test groups; two surgical pattern fixes
+  (`app.py` `TYPE_CHECKING` block for conftest-injected attributes and
+  explicit `downloader.{core,audio,…}` submodule re-exports) knocked
+  out ~582 of those, and the remaining 117 were resolved per-file with
+  Optional narrowing asserts, HF/cv2/numpy stub-gap ignore comments,
+  and `cast(Any, …)` for test-time ABC attribute writes. Two minor
+  production-code annotation widenings: `resolve_display_name` now
+  accepts `None` (body already handled it), and
+  `stream_progress_events` returns `Generator[str, None, None]` so
+  callers can `.close()` it. Pyright gated scope = `["vtsearch",
+  "tests"]`, 0 errors, 0 warnings.
 
 ## Goal
 
@@ -142,7 +153,7 @@ Each stage is a separate PR. The "errors to fix" column counts real
 | 4 | `routes/`, `converters/` | 40 | ✅ shipped |
 | 5 | `media/` (heaviest — turned out to be the HF-stub gap pattern, not stubs) | 97 | ✅ shipped |
 | 6 | Whole `vtsearch/` (incl. `achievements.py`, `logging_config.py`, `openapi.py`, `schemas/`) — advisory job removed | 0 | ✅ shipped |
-| 7 *(optional)* | `tests/` | TBD | 📋 |
+| 7 | `tests/` | 699 (582 from two patterns + 117 long-tail) | ✅ shipped |
 
 **Stage 0 + Stage 1 landed together in PR #1349.** Subsequent stages are
 separate PRs; each one bumps `include` in `pyrightconfig.json` and fixes
@@ -427,6 +438,119 @@ load + forward calls). All 97 errors collapsed onto these patterns:
     Worth a `grep` of `include` against the on-disk layout when bumping
     the gated scope.
 
+### Stage 7 fixes (shipped)
+
+Two bulk patterns cleared most of the 699 baseline errors before any
+per-file work:
+
+1. **`conftest.py` injects attributes onto `app_module` dynamically.**
+   Pyright can't see runtime assignments like
+   ``app_module.medias = medias``, so 471 errors collapsed onto
+   accesses of `app.medias`, `app.good_votes`, `app.bad_votes`,
+   `app.NUM_MEDIAS`, `app.generate_wav`, `app.train_and_score`,
+   `app.SAMPLE_RATE`, and `app.init_medias`. Fix: a ``TYPE_CHECKING``
+   block at the top of ``app.py`` declares each attribute's type with
+   a comment pointing at ``tests/conftest.py``. Same shape as Stage 2
+   fix #1 for the dynamically generated accessors in
+   ``vtsearch/settings.py``.
+2. **`vtsearch.datasets.downloader.X` submodules not visible as
+   package attributes.** Tests mocked `downloader.core.DATA_DIR`,
+   `downloader.text.<helper>`, etc.; at runtime Python exposes
+   submodules once they're imported elsewhere, but pyright doesn't
+   trust that. Fix: ``vtsearch/datasets/downloader/__init__.py``
+   explicitly does ``from vtsearch.datasets.downloader import audio,
+   core, documents, images, text, video`` (and adds them to
+   ``__all__``).
+
+The remaining 117 errors broke down by pattern. None of these are new
+— they're variations of the patterns documented in Stages 2–5,
+recurring in tests/:
+
+3. **Optional return narrowing.** Standard ``assert x is not None``
+   before subscript / attribute access. Affected helpers:
+   ``get_detector(...)``, ``_read_detector(...)``, ``get_converter(...)``,
+   ``get_settings_source_config()``, ``_SOURCE_DIRS`` (lazy dict),
+   ``DiversityTree.next_sample()`` (returns ``int | None``),
+   ``DetectorContext.calibration_cache``, ``get_thread_dataset_context()``
+   / ``get_thread_detector_context()``, and
+   ``generate_waveform_thumbnail()`` (returns ``bytes | None``).
+4. **`MediaResponse.data` is `bytes | dict`.** Tests that do
+   ``resp.data["content"]`` need ``isinstance(resp.data, dict)`` so the
+   subscript type-checks. Same shape narrowing the union from the
+   "Stage 4 fix #1 tuple-unpack" pattern, just on a single value.
+5. **HF processor `__call__` stub gap.** ``ClapProcessor`` (and other
+   HF processor classes) don't list the runtime kwargs ``sampling_rate=``,
+   ``return_tensors=``, ``padding=``, ``max_length=``, ``truncation=`` in
+   their stubs. Fix: ``cast(Any, processor)`` so the call sites type-check.
+   Identical to Stage 5 fix #1; recurs here because the GPU tests
+   construct processors inline rather than going through a
+   ``MediaEmbedder`` (which already has the ``Any`` annotation pattern).
+6. **Abstract-class instantiation tests.** Tests that verify
+   ``ABC()`` raises ``TypeError`` legitimately need to construct the
+   abstract class. ``# pyright: ignore[reportAbstractUsage]`` on the
+   single line — covered ``Processor``, ``Detector``, ``Localizer``,
+   ``MediaConverter``, ``MediaClipper``, ``Extractor``.
+7. **Test-time attribute writes on a MediaType ABC.**
+   ``mt._model = stub_model`` / ``mt._processor = stub`` only works at
+   runtime because the subclass loads them via ``load_models()`` after
+   instantiation — none of the MediaType subclasses declare
+   ``_model`` / ``_processor`` in ``__init__`` so the attributes
+   aren't visible to pyright on a ``MediaType``-typed local. Fix:
+   ``cast(Any, MediaTypeSubclass())`` at the construction site, with a
+   one-line comment. Same pattern in
+   ``tests/downloads/_helpers.py``, ``tests/downloads/test_ucsf_documents_download.py``,
+   ``tests/gpu/test_gpu.py``.
+8. **Monkey-patching method attributes.** Tests that do
+   ``emb._patch_forward_pil_batch = fake_fn`` or
+   ``tm.set_module_tensor_to_device = fake_fn`` need per-line
+   ``# pyright: ignore[reportAttributeAccessIssue]`` — same shape as
+   Stage 5 fix #5 (`set_module_tensor_to_device` HF stub gap), now
+   appearing in tests/ as well.
+9. **`numpy.savez(**dict_of_arrays)` stub bug.** When you splat a
+   dict-of-ndarrays into ``savez``, pyright binds the first kwarg to
+   ``allow_pickle: bool`` (the first named-kw in the stub) and errors.
+   The runtime accepts arbitrary key/array kwargs. Fix:
+   ``# pyright: ignore[reportArgumentType]`` on the call line.
+10. **`importlib.util` submodule access.** ``import importlib`` does
+    NOT pull in ``importlib.util`` for pyright. Fix: add an explicit
+    ``import importlib.util`` alongside it. After that,
+    ``spec = spec_from_file_location(...)`` still returns ``ModuleSpec
+    | None`` — narrow with ``assert spec is not None and spec.loader
+    is not None`` before ``spec.loader.exec_module(mod)``.
+11. **`cv2.VideoWriter_fourcc` opencv-stubs gap.** Same shape as the
+    HF/PaddleOCR stub gaps: the runtime builtin exists but isn't in
+    the type stub. ``# pyright: ignore[reportAttributeAccessIssue]``.
+12. **`@property` overridden by literal class attribute.** A test stub
+    embedder did ``class _Stub(MediaEmbedder): name = "fake";
+    media_type_id = "test"`` which works at runtime (the class attr
+    shadows the inherited property) but pyright treats it as assigning
+    ``Literal["fake"]`` to a ``property`` slot. ``# pyright:
+    ignore[reportAssignmentType]`` is the right fix — converting both
+    to ``@property def name(self): return "fake"`` would clutter the
+    stub without buying anything.
+13. **Iterator vs Generator return type.**
+    ``stream_progress_events`` was annotated ``Iterator[str]`` but the
+    SSE test calls ``gen.close()``, which only exists on
+    ``Generator``. Production fix: change the return annotation to
+    ``Generator[str, None, None]``. That widens the contract (callers
+    can still iterate) and matches the actual returned generator
+    function.
+14. **Test-helper `Optional[dict]` parameter.**
+    ``resolve_display_name(field_values: dict[str, Any])`` couldn't be
+    called as ``resolve_display_name(None)`` even though the body
+    handled it. Production fix: widen the parameter to
+    ``dict[str, Any] | None`` on both ``DatasetImporter`` and the
+    ``PluginBase`` it inherits from. (Override contravariance allows
+    the override to widen, but widening both sites keeps the call
+    chain consistent and matches the runtime semantics.)
+15. **Class-body conditional method capture.** Test fixtures built a
+    one-shot importer with
+    ``if fetch_one is not None: def fetch_record(...): return
+    fetch_one(...)``. Pyright didn't narrow ``fetch_one`` to non-None
+    inside the inner method body. Two viable fixes; this stage used an
+    inner ``assert fetch_one is not None`` at the top of the method
+    body — explicit and runtime-correct.
+
 ### Stage 6 fixes (shipped)
 
 Zero. The advisory job had reported 0 errors since the end of Stage 5,
@@ -462,8 +586,9 @@ producing a single new error. Stage 6 is therefore config-only:
 
 ```json
 {
-  "include": ["vtsearch"],
-  "exclude": ["**/__pycache__", "**/node_modules", "tests", "frontend", "scripts", "data"],
+  "include": ["vtsearch", "tests"],
+  "exclude": ["**/__pycache__", "**/node_modules", "frontend", "scripts", "data"],
+  "extraPaths": ["tests"],
   "pythonVersion": "3.10",
   "typeCheckingMode": "basic",
   "useLibraryCodeForTypes": true,
@@ -476,7 +601,10 @@ producing a single new error. Stage 6 is therefore config-only:
   package code when stubs are missing — important for `torch`,
   `transformers`, `laion_clap`.
 - `reportMissingTypeStubs` is silenced; we don't ship stubs.
-- `tests/` is excluded for now (Stage 7).
+- `extraPaths: ["tests"]` lets the test files import each other via
+  the unprefixed names defined in ``pyproject.toml``'s
+  ``pythonpath = ["tests"]`` (e.g. ``from helpers import ...``,
+  ``from tests.fixtures.medias import ...``).
 
 ## CI shape
 
@@ -495,7 +623,7 @@ caught up to the full package.
 
 - Strict mode.
 - Annotating every public function.
-- Type-checking `tests/`, `frontend/`, or `scripts/`.
+- Type-checking `frontend/` or `scripts/`.
 - Wiring pyright into `./run-tests.sh` (CI-only — keeps the local
   test loop fast since pyright on a fresh repo takes ~30 s).
 

--- a/docs/plans/pyright-type-checking.md
+++ b/docs/plans/pyright-type-checking.md
@@ -550,6 +550,29 @@ recurring in tests/:
     inside the inner method body. Two viable fixes; this stage used an
     inner ``assert fetch_one is not None`` at the top of the method
     body — explicit and runtime-correct.
+16. **pandas `_typing.py` differs between Python 3.10 and 3.11
+    (CI-only).** The same pandas wheel ships different ``_typing.py``
+    files based on the host Python version. In 3.10 the file is
+    pre-PEP-613 (``Axes = ListLike`` with no ``TypeAlias``
+    annotation), and pyright can't see ``Axes`` as an alias for
+    ``ListLike = Union[AnyArrayLike, SequenceNotStr, range]``. The
+    DataFrame constructor's ``columns: Axes | None`` then rejects
+    ``list[str]`` because pyright treats ``Axes`` as an opaque
+    structural type and ``list.index(value: str)`` doesn't satisfy
+    ``SequenceNotStr.index(value: Any)`` under contravariance. In 3.11
+    the same file uses ``Axes: TypeAlias = ListLike`` and pyright
+    resolves the alias correctly, so the error vanishes locally. CI
+    pins ``python-version: "3.10"`` so the 3.10 stubs are what counts.
+    Fix: per-line ``# pyright: ignore[reportArgumentType]`` on each
+    ``pd.DataFrame(..., columns=[...])`` call site, with a one-line
+    comment naming the stub-version mismatch. Two sites in
+    ``tests/detectors/test_eval_visualize.py``. **Lesson:** when
+    ``pythonVersion`` in ``pyrightconfig.json`` (3.10) doesn't match
+    the local development Python (3.11), run pyright in a 3.10 venv
+    before pushing — package-shipped stubs can change shape with the
+    Python version. ``python3.10 -m venv /tmp/py310 && source
+    /tmp/py310/bin/activate && bash scripts/install-cpu.sh && pyright``
+    is a faithful reproduction of the CI gated job.
 
 ### Stage 6 fixes (shipped)
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,13 +1,13 @@
 {
-  "include": ["vtsearch"],
+  "include": ["vtsearch", "tests"],
   "exclude": [
     "**/__pycache__",
     "**/node_modules",
-    "tests",
     "frontend",
     "scripts",
     "data"
   ],
+  "extraPaths": ["tests"],
   "pythonVersion": "3.10",
   "typeCheckingMode": "basic",
   "useLibraryCodeForTypes": true,

--- a/tests/cli/test_cli_detectors.py
+++ b/tests/cli/test_cli_detectors.py
@@ -363,6 +363,7 @@ class TestImportLabelsIntoDetectorCLI:
         assert skipped == 1
 
         saved = _read_detector(_detector_path("import-tm"))
+        assert saved is not None
         ls = LabelSet.from_dict(saved["labelset"])
         md5s = sorted(el.md5 for el in ls.elements)
         assert md5s == sorted(["a" * 32, "b" * 32, "c" * 32])

--- a/tests/cli/test_preload_progress.py
+++ b/tests/cli/test_preload_progress.py
@@ -380,10 +380,12 @@ class TestInterceptWeightLoadingProgress:
 
     def test_set_module_tensor_to_device_tracking(self):
         """set_module_tensor_to_device interception should count dispatched tensors."""
+        # ``set_module_tensor_to_device`` is re-exported from ``accelerate`` at
+        # runtime but isn't in the transformers stubs.
         try:
             import transformers.modeling_utils as tm
 
-            orig = tm.set_module_tensor_to_device
+            orig = tm.set_module_tensor_to_device  # pyright: ignore[reportAttributeAccessIssue]
         except (ImportError, AttributeError):
             # accelerate not installed — patch it onto transformers.modeling_utils
             # so the interceptor can find it
@@ -394,7 +396,7 @@ class TestInterceptWeightLoadingProgress:
             def fake_set_module(model, name, device, value=None, **kw):
                 call_log.append((name, device))
 
-            tm.set_module_tensor_to_device = fake_set_module
+            tm.set_module_tensor_to_device = fake_set_module  # pyright: ignore[reportAttributeAccessIssue]
             orig = None
 
         calls: list[tuple] = []
@@ -419,11 +421,11 @@ class TestInterceptWeightLoadingProgress:
                 # Simulate 5 tensor dispatches
                 model = nn.Linear(2, 2)
                 for i in range(5):
-                    tm.set_module_tensor_to_device(model, "weight", "cpu", torch.zeros(2, 2))
+                    tm.set_module_tensor_to_device(model, "weight", "cpu", torch.zeros(2, 2))  # pyright: ignore[reportAttributeAccessIssue]
         finally:
             st.load_file = original_lf
             if orig is not None:
-                tm.set_module_tensor_to_device = orig
+                tm.set_module_tensor_to_device = orig  # pyright: ignore[reportAttributeAccessIssue]
             else:
                 delattr(tm, "set_module_tensor_to_device")
 

--- a/tests/converters/test_audio2image_and_image2text.py
+++ b/tests/converters/test_audio2image_and_image2text.py
@@ -46,7 +46,7 @@ def _fake_paddleocr_module(fake_cls: type) -> object:
     import types
 
     mod = types.ModuleType("paddleocr")
-    mod.PaddleOCR = fake_cls
+    mod.PaddleOCR = fake_cls  # pyright: ignore[reportAttributeAccessIssue]
     return mod
 
 

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -628,6 +628,7 @@ class TestEmbedAndMd5Helpers:
 
         result = _embed_converted_output(mock_mt, {"media_bytes": png_bytes, "filename": "test.png"})
 
+        assert result is not None
         assert np.array_equal(result, fake_embedding)
         mock_mt.embed_media.assert_called_once()
 
@@ -641,6 +642,7 @@ class TestEmbedAndMd5Helpers:
 
         result = _embed_converted_output(mock_mt, {"media_string": "hello world", "filename": "doc.txt"})
 
+        assert result is not None
         assert np.array_equal(result, fake_embedding)
         mock_mt.embed_media.assert_called_once()
 
@@ -946,6 +948,7 @@ class TestConverterFieldsInToDict:
         from vtsearch.converters import get_converter
 
         c = get_converter("video2image")
+        assert c is not None
         d = c.to_dict()
         fields = d.get("fields") or []
         assert any(f["key"] == "n_clips" for f in fields)
@@ -959,6 +962,7 @@ class TestConverterAcceptsParams:
         from vtsearch.converters import get_converter
 
         c = get_converter("video2audio")
+        assert c is not None
         # Empty params, empty source media → returns empty list (no crash).
         assert c.convert({}, {}) == []
 
@@ -966,6 +970,7 @@ class TestConverterAcceptsParams:
         from vtsearch.converters import get_converter
 
         c = get_converter("document2image")
+        assert c is not None
         assert c.convert({}, None) == []
 
     def test_video2image_reads_n_clips_param(self):
@@ -973,6 +978,7 @@ class TestConverterAcceptsParams:
         from vtsearch.converters import get_converter
 
         c = get_converter("video2image")
+        assert c is not None
         # Bogus media → empty list, but get_param resolution exercised below.
         assert c.get_param({"n_clips": "30"}, "n_clips") == "30"
         # Default falls back to the field's declared default.

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -75,7 +75,8 @@ def _make_minimal_video(frames: int = 30, width: int = 64, height: int = 64) -> 
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
         tmp_path = f.name
 
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    # cv2 stubs miss VideoWriter_fourcc (runtime-only opencv builtin).
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # pyright: ignore[reportAttributeAccessIssue]
     writer = cv2.VideoWriter(tmp_path, fourcc, 10.0, (width, height))
     for i in range(frames):
         frame = np.full((height, width, 3), fill_value=(i * 8) % 256, dtype=np.uint8)
@@ -200,7 +201,7 @@ class TestDocumentRegistration:
 class TestMediaConverterAbstract:
     def test_cannot_instantiate(self):
         with pytest.raises(TypeError):
-            MediaConverter()
+            MediaConverter()  # pyright: ignore[reportAbstractUsage]
 
     def test_concrete_subclass(self):
         class DummyConverter(MediaConverter):

--- a/tests/core/test_audio.py
+++ b/tests/core/test_audio.py
@@ -19,6 +19,7 @@ class TestGenerateWaveformThumbnail:
 
         wav_bytes = app_module.generate_wav(440.0, 1.0)
         result = generate_waveform_thumbnail(wav_bytes)
+        assert result is not None
         img = Image.open(io.BytesIO(result))
         assert img.size == (128, 128)
 
@@ -27,6 +28,7 @@ class TestGenerateWaveformThumbnail:
 
         wav_bytes = app_module.generate_wav(440.0, 1.0)
         result = generate_waveform_thumbnail(wav_bytes, size=64)
+        assert result is not None
         img = Image.open(io.BytesIO(result))
         assert img.size == (64, 64)
 

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -50,6 +50,7 @@ class TestInitMedias:
         temp_path.write_bytes(media["media_bytes"])
         embedding = embed_audio_file(temp_path)
         temp_path.unlink(missing_ok=True)
+        assert embedding is not None
         np.testing.assert_array_almost_equal(embedding, media["embedding"])
 
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -481,7 +481,7 @@ class TestSettingsModule:
 
     def test_panel_pct_invalid_value(self):
         with pytest.raises(ValueError):
-            settings_mod.set_panel_pct_left({"audio": "invalid"})
+            settings_mod.set_panel_pct_left({"audio": "invalid"})  # pyright: ignore[reportArgumentType]
 
     def test_panel_pct_clamped_on_read(self, isolated_settings):
         """Out-of-range values stored on disk are clamped when read."""

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -174,6 +174,7 @@ class TestCombineDatasetsEnabledFlag:
         registry.register_dataset(name="solo", media_type="audio", num_items=10, pkl_path="/tmp/solo.pkl")
         try:
             imp = self._find_combine(client)
+            assert imp is not None
             assert imp["enabled"] is False
         finally:
             entries = registry.list_datasets()
@@ -189,6 +190,7 @@ class TestCombineDatasetsEnabledFlag:
         e2 = registry.register_dataset(name="image_ds", media_type="image", num_items=10, pkl_path="/tmp/b.pkl")
         try:
             imp = self._find_combine(client)
+            assert imp is not None
             assert imp["enabled"] is False
         finally:
             registry.unregister_dataset(e1["id"])
@@ -202,6 +204,7 @@ class TestCombineDatasetsEnabledFlag:
         e2 = registry.register_dataset(name="audio_b", media_type="audio", num_items=5, pkl_path="/tmp/b.pkl")
         try:
             imp = self._find_combine(client)
+            assert imp is not None
             assert imp["enabled"] is True
         finally:
             registry.unregister_dataset(e1["id"])

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -11,6 +11,7 @@ class TestIndex:
     def test_serves_index_html(self, client):
         from pathlib import Path
 
+        assert app_module.app.static_folder is not None
         static_index = Path(app_module.app.static_folder) / "index.html"
         if not static_index.exists():
             pytest.skip("Angular build not present (run 'npm run build:prod' in frontend/)")

--- a/tests/datasets/test_media_sources.py
+++ b/tests/datasets/test_media_sources.py
@@ -23,7 +23,7 @@ class TestMediaItem:
     def test_frozen(self):
         item = MediaItem(key="k", filename="f", source_name="s")
         with pytest.raises(AttributeError):
-            item.key = "other"
+            item.key = "other"  # pyright: ignore[reportAttributeAccessIssue]
 
 
 # ── LocalFolderSource ─────────────────────────────────────────────────

--- a/tests/datasets/test_multi_dataset.py
+++ b/tests/datasets/test_multi_dataset.py
@@ -651,6 +651,7 @@ class TestSyncLabelsAcrossDatasets:
             assert resp.status_code == 200
 
             saved = _read_detector(tm_path)
+            assert saved is not None
             saved_labels = saved["labelset"]["labels"]
             assert len(saved_labels) == original_label_count, (
                 f"Expected {original_label_count} training labels but load_model "
@@ -723,6 +724,7 @@ class TestSyncLabelsAcrossDatasets:
 
             # The model file must still have the original labels
             saved = _read_detector(tm_path)
+            assert saved is not None
             saved_labels = saved["labelset"]["labels"]
             assert len(saved_labels) == original_label_count, (
                 f"Expected {original_label_count} training labels but load_model "

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -542,8 +542,8 @@ class TestConcurrentModelLoading:
         proceed = threading.Event()
 
         class FakeEmbedder(MediaEmbedder):
-            name = "fake"
-            media_type_id = "test"
+            name = "fake"  # pyright: ignore[reportAssignmentType]
+            media_type_id = "test"  # pyright: ignore[reportAssignmentType]
 
             def __init__(self):
                 super().__init__()

--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -82,7 +82,8 @@ class TestRequestScopedDataset:
             assert 100 not in medias
 
         # Thread-local active pointer was NOT mutated
-        assert get_thread_dataset_context().dataset_id == "req_ds_a"
+        ctx_a = get_thread_dataset_context()
+        assert ctx_a is not None and ctx_a.dataset_id == "req_ds_a"
 
     def test_header_with_unloaded_id_falls_back_to_active(self, client):
         """If X-Dataset-Id refers to a dataset not in memory, fall back to global active."""
@@ -147,7 +148,8 @@ class TestRequestScopedModel:
         assert 1 not in good_ids
 
         # Thread-local active pointer was NOT mutated
-        assert get_thread_detector_context().detector_id == "req_det_a"
+        det_a = get_thread_detector_context()
+        assert det_a is not None and det_a.detector_id == "req_det_a"
 
     def test_model_header_with_unloaded_id_falls_back(self, client):
         """If X-Detector-Id refers to a detector not in memory, fall back to global."""
@@ -253,7 +255,8 @@ class TestRequestIsolation:
                 assert 900 in medias
 
         # Thread-local pointer untouched
-        assert get_thread_dataset_context().dataset_id == "req_nomut_a"
+        ctx_nomut = get_thread_dataset_context()
+        assert ctx_nomut is not None and ctx_nomut.dataset_id == "req_nomut_a"
         assert 800 in medias
 
 

--- a/tests/datasets/test_thin_loading.py
+++ b/tests/datasets/test_thin_loading.py
@@ -423,6 +423,7 @@ class TestClipResponseLazyLoading:
             "character_count": 0,
         }
         resp = mt.media_response(media)
+        assert isinstance(resp.data, dict)
         assert resp.data["content"] == content
         assert resp.data["word_count"] == 3  # "lazy loaded paragraph"
         assert resp.data["character_count"] == len(content)

--- a/tests/detectors/test_clipper_workflow.py
+++ b/tests/detectors/test_clipper_workflow.py
@@ -421,6 +421,7 @@ class TestLabelExportWithClips:
             ls2 = LabelSet.from_dict(data)
             assert len(ls2) == 2
             for elem in ls2:
+                assert elem.origin is not None
                 assert elem.origin["params"]["clipper"] == "sound_tiling"
         finally:
             medias.clear()

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -17,7 +17,7 @@ from vtsearch.media.clipper import MediaClipper
 class TestMediaClipperABC:
     def test_cannot_instantiate(self):
         with pytest.raises(TypeError):
-            MediaClipper()
+            MediaClipper()  # pyright: ignore[reportAbstractUsage]
 
     def test_to_dict_on_concrete(self):
         from vtsearch.media.audio.clipper import SoundDefaultClipper

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -777,6 +777,7 @@ class TestVoteSyncsToLoadedModel:
 
         # Check that the registry entry was updated
         entry = get_detector(detector_id)
+        assert entry is not None
         assert entry["num_training"] == 1
         assert entry.get("last_trained_at") is not None
 
@@ -860,6 +861,7 @@ class TestVoteSyncsToLoadedModel:
         assert len(model_data["labelset"]["labels"]) == 1
 
         entry = get_detector(detector_id)
+        assert entry is not None
         assert entry["num_training"] == 1
 
 

--- a/tests/detectors/test_eval_visualize.py
+++ b/tests/detectors/test_eval_visualize.py
@@ -101,7 +101,12 @@ def _make_voting_iterations_df(n_seeds=2, n_steps=10) -> pd.DataFrame:
                     "elapsed_seconds": elapsed,
                 }
             )
-    return pd.DataFrame(rows, columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"])
+    # pandas' Python-3.10 _typing.py doesn't mark Axes as TypeAlias,
+    # so pyright can't see list[str] satisfies the Axes alias.
+    return pd.DataFrame(
+        rows,
+        columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"],  # pyright: ignore[reportArgumentType]
+    )
 
 
 # ------------------------------------------------------------------
@@ -200,7 +205,9 @@ class TestPlotVotingIterations:
             assert p.stat().st_size > 0
 
     def test_empty_dataframe_generates_no_plots(self, tmp_dir):
-        df = pd.DataFrame(columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"])
+        df = pd.DataFrame(
+            columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"],  # pyright: ignore[reportArgumentType]
+        )
         paths = plot_voting_iterations(df, output_dir=tmp_dir)
         assert paths == []
 

--- a/tests/detectors/test_extractors.py
+++ b/tests/detectors/test_extractors.py
@@ -37,7 +37,7 @@ class TestExtractorABC:
 
     def test_cannot_instantiate_abc(self):
         with pytest.raises(TypeError):
-            Extractor()
+            Extractor()  # pyright: ignore[reportAbstractUsage]
 
     def test_stub_extractor_name(self):
         ext = StubExtractor(name="my-ext")

--- a/tests/detectors/test_image_bulk_embedding.py
+++ b/tests/detectors/test_image_bulk_embedding.py
@@ -259,9 +259,9 @@ class TestSiglipBulkOverride:
         assert len(out) == 3
         assert all(v is not None for v in out)
         # Position-based vectors confirm slot alignment.
-        assert out[0][0] == 0.0
-        assert out[1][0] == 1.0
-        assert out[2][0] == 2.0
+        assert out[0][0] == 0.0  # pyright: ignore[reportOptionalSubscript]
+        assert out[1][0] == 1.0  # pyright: ignore[reportOptionalSubscript]
+        assert out[2][0] == 2.0  # pyright: ignore[reportOptionalSubscript]
 
     def test_routes_through_bulk_helper(self, tmp_path):
         from vtsearch.media.image.embedder_siglip import ImageSiglipEmbedder
@@ -329,7 +329,8 @@ class TestDinov2BulkOverride:
             _write_image(p)
 
         out = emb.embed_media_bulk([_media(p) for p in paths])
-        assert [v[0] for v in out] == [0.0, 1.0]
+        assert all(v is not None for v in out)
+        assert [v[0] for v in out if v is not None] == [0.0, 1.0]
 
 
 class TestDinov3BulkOverride:
@@ -368,7 +369,8 @@ class TestEupeBulkOverride:
             _write_image(p)
 
         out = emb.embed_media_bulk([_media(p) for p in paths])
-        assert [v[0] for v in out] == [0.0, 1.0, 2.0]
+        assert all(v is not None for v in out)
+        assert [v[0] for v in out if v is not None] == [0.0, 1.0, 2.0]
 
 
 # ---------------------------------------------------------------------------
@@ -461,7 +463,7 @@ class TestPatchForwardBulkOverrides:
             seen.append(len(images))
             return [{"i": i} for i, _ in enumerate(images)]
 
-        emb._patch_forward_pil_batch = fake_patch_forward
+        emb._patch_forward_pil_batch = fake_patch_forward  # pyright: ignore[reportAttributeAccessIssue]
 
         paths = [tmp_path / f"img_{i}.png" for i in range(3)]
         for p in paths:
@@ -484,7 +486,7 @@ class TestPatchForwardBulkOverrides:
         def fake_patch_forward(images):
             return [{"i": i} for i, _ in enumerate(images)]
 
-        emb._patch_forward_pil_batch = fake_patch_forward
+        emb._patch_forward_pil_batch = fake_patch_forward  # pyright: ignore[reportAttributeAccessIssue]
 
         p = tmp_path / "img.png"
         _write_image(p)

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -259,6 +259,7 @@ class TestCrossDatasetVoteDoesNotWipeLabels:
         sync_labels_to_loaded_detector()
 
         saved = _read_detector(_detector_path("cross-ds-model"))
+        assert saved is not None
         keys = {
             (el.get("origin", {}).get("importer", ""), el.get("origin_name", "")) for el in saved["labelset"]["labels"]
         }
@@ -342,6 +343,7 @@ class TestCrossDatasetMLPTraining:
         from vtsearch.detectors.store import _detector_path, _read_detector
 
         saved = _read_detector(_detector_path("cross-ds-model"))
+        assert saved is not None
         ls = LabelSet.from_dict(saved["labelset"])
         for el in ls.elements:
             assert stable_element_id(el) in det_ctx.label_embeddings

--- a/tests/detectors/test_new_embedders.py
+++ b/tests/detectors/test_new_embedders.py
@@ -613,6 +613,7 @@ class TestEmbedderSentinelDiscovery:
         like a flat ``embedder_*.py`` module.
         """
         import importlib
+        import importlib.util
         import sys
         from pathlib import Path
 
@@ -652,6 +653,7 @@ class TestEmbedderSentinelDiscovery:
             str(fake_pkg / "__init__.py"),
             submodule_search_locations=[str(fake_pkg)],
         )
+        assert spec is not None and spec.loader is not None
         mod = importlib.util.module_from_spec(spec)
         sys.modules[package_name] = mod
         try:
@@ -678,6 +680,7 @@ class TestEmbedderSentinelDiscovery:
         should be auto-discovered with no ``__init__.py`` edits.
         """
         import importlib
+        import importlib.util
         import sys
         from pathlib import Path
 
@@ -715,6 +718,7 @@ class TestEmbedderSentinelDiscovery:
             str(fake_pkg / "__init__.py"),
             submodule_search_locations=[str(fake_pkg)],
         )
+        assert spec is not None and spec.loader is not None
         mod = importlib.util.module_from_spec(spec)
         sys.modules[package_name] = mod
         try:

--- a/tests/detectors/test_processors.py
+++ b/tests/detectors/test_processors.py
@@ -78,7 +78,7 @@ class StubExtractor(Extractor):
 class TestProcessorABC:
     def test_cannot_instantiate(self):
         with pytest.raises(TypeError):
-            Processor()
+            Processor()  # pyright: ignore[reportAbstractUsage]
 
     def test_detector_is_processor(self):
         det = StubDetector()
@@ -110,7 +110,7 @@ class TestProcessorABC:
 class TestDetectorABC:
     def test_cannot_instantiate(self):
         with pytest.raises(TypeError):
-            Detector()
+            Detector()  # pyright: ignore[reportAbstractUsage]
 
     def test_detect_returns_bool(self):
         det = StubDetector(result=True)
@@ -146,7 +146,7 @@ class TestDetectorABC:
 class TestLocalizerABC:
     def test_cannot_instantiate(self):
         with pytest.raises(TypeError):
-            Localizer()
+            Localizer()  # pyright: ignore[reportAbstractUsage]
 
     def test_localize_returns_bboxes(self):
         boxes = [

--- a/tests/downloads/_helpers.py
+++ b/tests/downloads/_helpers.py
@@ -10,6 +10,7 @@ and assertions.
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 
@@ -17,7 +18,9 @@ def make_text_media_type_stub(embedding_dim: int = 768):
     """Return a ``TextMediaType`` instance with its embedding model stubbed."""
     from vtsearch.media.text.media_type import TextMediaType
 
-    mt = TextMediaType()
+    # _model is a runtime-only attr set by load_models on the subclass; not
+    # declared on the ABC, so cast to Any to assign it directly.
+    mt = cast(Any, TextMediaType())
     stub_model = MagicMock()
     stub_model.encode.return_value = [0.1] * embedding_dim
     mt._model = stub_model

--- a/tests/downloads/test_ucsf_documents_download.py
+++ b/tests/downloads/test_ucsf_documents_download.py
@@ -1,6 +1,7 @@
 """Tests for UCSF Industry Documents demo dataset download and load_demo_source integration."""
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -222,7 +223,9 @@ class TestLoadDemoSourceUcsfDocuments:
     def _make_image_media_type(self):
         from vtsearch.media.image.media_type import ImageMediaType
 
-        mt = ImageMediaType()
+        # _model / _processor are runtime-only attrs set by load_models on the
+        # subclass; not declared on the ABC, so cast to Any to assign them.
+        mt = cast(Any, ImageMediaType())
         mt._model = MagicMock()
         mt._processor = MagicMock()
         return mt

--- a/tests/downloads/test_video_datasets_download.py
+++ b/tests/downloads/test_video_datasets_download.py
@@ -444,9 +444,11 @@ class TestVideoDemoDatasetRegistration:
         # Force lazy init
         demo_module._source_directory("hmdb51")
 
-        assert "hmdb51" in demo_module._SOURCE_DIRS
-        assert "ucf101_full" in demo_module._SOURCE_DIRS
-        assert "kth" in demo_module._SOURCE_DIRS
+        source_dirs = demo_module._SOURCE_DIRS
+        assert source_dirs is not None
+        assert "hmdb51" in source_dirs
+        assert "ucf101_full" in source_dirs
+        assert "kth" in source_dirs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/medias.py
+++ b/tests/fixtures/medias.py
@@ -102,4 +102,4 @@ def init_medias():
         save_data = {"cache_key": np.array(cache_key)}
         for i in range(1, NUM_MEDIAS + 1):
             save_data[f"emb_{i}"] = medias[i]["embedding"]
-        np.savez(cache_path, **save_data)
+        np.savez(cache_path, **save_data)  # pyright: ignore[reportArgumentType]

--- a/tests/gpu/test_gpu.py
+++ b/tests/gpu/test_gpu.py
@@ -21,6 +21,7 @@ Coverage areas
 """
 
 import gc
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -463,7 +464,10 @@ class TestCLAPEmbeddingGPU:
     def test_clap_model_loads_on_gpu(self, device):
         from vtsearch.media.audio.media_type import AudioMediaType
 
-        mt = AudioMediaType()
+        # _model is set dynamically by load_models() on the subclass; not
+        # declared on the MediaType ABC, so pyright can't see it. cast keeps
+        # the runtime behaviour while satisfying the type-checker.
+        mt = cast(Any, AudioMediaType())
         mt.load_models()
         assert mt._model is not None
         mt._model = mt._model.to(device)
@@ -478,7 +482,8 @@ class TestCLAPEmbeddingGPU:
 
         cache_dir = str(MODELS_CACHE_DIR)
         model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir).to(device)
-        processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir)
+        # ClapProcessor's __call__ stub doesn't enumerate the runtime kwargs.
+        processor = cast(Any, ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir))
 
         inputs = processor(text=["a dog barking"], return_tensors="pt")
         inputs = {k: v.to(device) for k, v in inputs.items()}
@@ -504,7 +509,7 @@ class TestCLAPEmbeddingGPU:
 
         cache_dir = str(MODELS_CACHE_DIR)
         model = ClapModel.from_pretrained(CLAP_MODEL_ID, low_cpu_mem_usage=True, cache_dir=cache_dir).to(device)
-        processor = ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir)
+        processor = cast(Any, ClapProcessor.from_pretrained(CLAP_MODEL_ID, cache_dir=cache_dir))
 
         inputs = processor(
             audio=audio,
@@ -529,7 +534,7 @@ class TestXCLIPEmbeddingGPU:
     def test_xclip_model_loads_on_gpu(self, device):
         from vtsearch.media.video.media_type import VideoMediaType
 
-        mt = VideoMediaType()
+        mt = cast(Any, VideoMediaType())  # see _model note above
         mt.load_models()
         assert mt._model is not None
         mt._model = mt._model.to(device)

--- a/tests/io/test_bulk_embedding.py
+++ b/tests/io/test_bulk_embedding.py
@@ -88,9 +88,10 @@ class TestEmbedderDefaults:
 
         vecs = emb.embed_media_bulk(medias)
         assert len(vecs) == 3
-        assert vecs[0][0] == 1.0
-        assert vecs[1][0] == 2.0
-        assert vecs[2][0] == 3.0
+        assert all(v is not None for v in vecs)
+        assert vecs[0][0] == 1.0  # pyright: ignore[reportOptionalSubscript]
+        assert vecs[1][0] == 2.0  # pyright: ignore[reportOptionalSubscript]
+        assert vecs[2][0] == 3.0  # pyright: ignore[reportOptionalSubscript]
 
     def test_default_bulk_impl_emits_per_item_progress(self, tmp_path):
         """The default bulk loop must call _on_progress on each iteration
@@ -381,9 +382,10 @@ class TestEmbedMediasDictWrapper:
         out = emb.embed_medias(medias)
 
         assert set(out.keys()) == {1, 2, 7}
-        assert out[1][0] == 10.0
-        assert out[2][0] == 20.0
-        assert out[7][0] == 70.0
+        assert all(v is not None for v in out.values())
+        assert out[1][0] == 10.0  # pyright: ignore[reportOptionalSubscript]
+        assert out[2][0] == 20.0  # pyright: ignore[reportOptionalSubscript]
+        assert out[7][0] == 70.0  # pyright: ignore[reportOptionalSubscript]
 
     def test_handles_sparse_keys(self):
         """Non-contiguous keys (e.g. post-collapse_duplicates) round-trip."""
@@ -410,6 +412,7 @@ class TestEmbedMediasDictWrapper:
         medias = {1: {"tag": 1}, 3: {"tag": 3}, 5: {"tag": 5}}
         out = emb.embed_medias(medias)
         assert list(out.keys()) == [1, 3, 5]
+        assert out[3] is not None
         assert out[3][0] == 3.0
 
     def test_propagates_none_for_failed_embeddings(self):
@@ -497,6 +500,7 @@ class TestEmbedMediasDictWrapper:
         assert len(captured) == 1
         assert captured[0] == [{"x": 1}, {"x": 2}, {"x": 3}]
         assert set(out.keys()) == {10, 20, 30}
-        assert out[10][0] == 1.0
-        assert out[20][0] == 2.0
-        assert out[30][0] == 3.0
+        assert all(v is not None for v in out.values())
+        assert out[10][0] == 1.0  # pyright: ignore[reportOptionalSubscript]
+        assert out[20][0] == 2.0  # pyright: ignore[reportOptionalSubscript]
+        assert out[30][0] == 3.0  # pyright: ignore[reportOptionalSubscript]

--- a/tests/io/test_importer_loading.py
+++ b/tests/io/test_importer_loading.py
@@ -71,7 +71,7 @@ class TestLoadDatasetContentVectors:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with self._patch_media_registry(mt):
             load_dataset_from_folder(
@@ -97,7 +97,7 @@ class TestLoadDatasetContentVectors:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with self._patch_media_registry(mt):
             load_dataset_from_folder(tmp_path, "audio", medias, content_vectors={}, on_progress=_noop)
@@ -124,7 +124,7 @@ class TestLoadDatasetContentVectors:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with self._patch_media_registry(mt):
             load_dataset_from_folder(
@@ -152,7 +152,7 @@ class TestLoadDatasetContentVectors:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with self._patch_media_registry(mt):
             load_dataset_from_folder(tmp_path, "audio", medias, on_progress=_noop)
@@ -214,7 +214,7 @@ class TestLoadDatasetContentVectors:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(
@@ -429,7 +429,7 @@ class TestLoadDatasetContentMD5s:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "audio", medias, content_md5s={"a.wav": pre_md5}, on_progress=_noop)
@@ -455,7 +455,7 @@ class TestLoadDatasetContentMD5s:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "audio", medias, content_md5s={}, on_progress=_noop)
@@ -484,7 +484,7 @@ class TestLoadDatasetContentMD5s:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "audio", medias, content_md5s={"a.wav": pre_md5}, on_progress=_noop)
@@ -512,7 +512,7 @@ class TestLoadDatasetContentMD5s:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(tmp_path, "audio", medias, on_progress=_noop)
@@ -537,7 +537,7 @@ class TestLoadDatasetContentMD5s:
         medias: dict = {}
 
         def _noop(*a):
-            None
+            pass
 
         with mock.patch("vtsearch.media.get_by_folder_name", return_value=mt):
             load_dataset_from_folder(

--- a/tests/io/test_importer_symlinks.py
+++ b/tests/io/test_importer_symlinks.py
@@ -42,6 +42,7 @@ class TestSymlinkedImporterDiscovery:
         import importlib
 
         parent = importlib.import_module("vtsearch.datasets.importers")
+        assert parent.__file__ is not None
         pkg_dir = os.path.dirname(parent.__file__)
         link = os.path.join(pkg_dir, "symlink_test_pkg")
         os.symlink(str(ext_pkg), link)
@@ -92,6 +93,7 @@ class TestSymlinkedImporterDiscovery:
         import importlib
 
         parent = importlib.import_module("vtsearch.datasets.importers")
+        assert parent.__file__ is not None
         pkg_dir = os.path.dirname(parent.__file__)
         link = os.path.join(pkg_dir, "dx_uuid.symbolic_link")
         os.symlink(str(ext_pkg), link)
@@ -138,6 +140,7 @@ class TestSymlinkedImporterDiscovery:
         import importlib
 
         parent = importlib.import_module("vtsearch.datasets.importers")
+        assert parent.__file__ is not None
         pkg_dir = os.path.dirname(parent.__file__)
         link = os.path.join(pkg_dir, "attr_check_pkg")
         os.symlink(str(ext_pkg), link)

--- a/tests/io/test_importers.py
+++ b/tests/io/test_importers.py
@@ -622,11 +622,13 @@ class TestImporterBulkHooks:
             if fetch_one is not None:
 
                 def fetch_record(self, record, field_values, thin=False):
+                    assert fetch_one is not None  # narrowed by enclosing if
                     return fetch_one(record, field_values, thin)
 
             if fetch_bulk is not None:
 
                 def _fetch_records_bulk_impl(self, recs, field_values, thin=False):
+                    assert fetch_bulk is not None
                     return fetch_bulk(recs, field_values, thin)
 
         return _BulkTestImporter()
@@ -688,7 +690,8 @@ class TestImporterBulkHooks:
         out = imp.fetch_records_bulk(["x", "y"], {})
 
         assert seen == ["x", "y"]
-        assert [m["filename"] for m in out] == ["x", "y"]
+        assert all(m is not None for m in out)
+        assert [m["filename"] for m in out if m is not None] == ["x", "y"]
 
     def test_bulk_override_used_when_implemented(self):
         # When a subclass overrides _fetch_records_bulk_impl, fetch_record must
@@ -771,6 +774,7 @@ class TestReCallerBulkOverride:
 
         assert len(per_item) == len(bulk) == 3
         for a, b in zip(per_item, bulk):
+            assert a is not None and b is not None
             assert a["filename"] == b["filename"]
             assert a["origin"] == b["origin"]
             assert a["custom_metadata"] == b["custom_metadata"]

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -229,6 +229,7 @@ class TestLabelImportEndpoint:
 
         # The registry entry should now reflect the updated label count
         updated = get_detector(entry["id"])
+        assert updated is not None
         assert updated["num_training"] == 1
 
     def test_path_traversal_absolute_rejected(self, client):

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -53,7 +53,8 @@ class TestReadNpzFilenamesAndVectors:
         npz = tmp_path / "vecs.npz"
         v1 = np.array([1, 2, 3], dtype=np.float32)
         v2 = np.array([4, 5, 6], dtype=np.float32)
-        np.savez(npz, **{"x.wav": v1, "y.wav": v2})
+        # numpy savez stubs mis-bind unpacked kwargs to allow_pickle.
+        np.savez(npz, **{"x.wav": v1, "y.wav": v2})  # pyright: ignore[reportArgumentType]
 
         mapping = read_npz_filenames_and_vectors(npz)
         assert set(mapping) == {"x.wav", "y.wav"}
@@ -224,7 +225,7 @@ class TestServerFilesNpzRunsEndToEnd:
         # Per-key layout: each filename is a top-level key in the npz.
         vec = np.full(256, 7.0, dtype=np.float32)
         npz = tmp_path / "list.npz"
-        np.savez(npz, **{str(src): vec})
+        np.savez(npz, **{str(src): vec})  # pyright: ignore[reportArgumentType]
 
         imp = ServerFilesDatasetImporter()
         medias: dict = {}

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -88,7 +88,7 @@ class TestLabelsetSourceBase:
 
         src = LabelsetSource()
         with pytest.raises(NotImplementedError):
-            src.save(None, {})
+            src.save(None, {})  # pyright: ignore[reportArgumentType]
 
     def test_to_dict_contains_standard_keys(self):
         from vtsearch.labels.sources.base import LabelsetSource
@@ -346,6 +346,7 @@ class TestSettingsSourceConfig:
         settings.set_settings_source_config(config)
 
         result = settings.get_settings_source_config()
+        assert result is not None
         assert result["source_name"] == "server_json_file"
         assert result["field_values"]["filepath"] == "/tmp/test.json"
 

--- a/tests/sorting/test_diversity_tree.py
+++ b/tests/sorting/test_diversity_tree.py
@@ -387,6 +387,7 @@ class TestNextSample:
         vecs = _make_vectors(100)
         tree = DiversityTree(vecs, k=2, min_node_size=10)
         first = tree.next_sample()
+        assert first is not None
         tree.label(first)
 
         # Next sample should not be the same element anymore
@@ -415,6 +416,7 @@ class TestNextSample:
 
         # First sample is from root
         s1 = tree.next_sample()
+        assert s1 is not None
         assert s1 in tree.nodes["0"]["ids"]
 
         # After labeling, next should be from first unseen child

--- a/tests/sorting/test_diversity_tree_integration.py
+++ b/tests/sorting/test_diversity_tree_integration.py
@@ -108,6 +108,7 @@ class TestDiversityTreeNextSample:
     def test_advances_after_labeling(self):
         _build_tree()
         first = diversity_tree_next_sample()
+        assert first is not None
         diversity_tree_label(first)
         second = diversity_tree_next_sample()
         # After labeling the first sample, the tree should suggest

--- a/tests/sorting/test_enrich_descriptions.py
+++ b/tests/sorting/test_enrich_descriptions.py
@@ -196,6 +196,7 @@ class TestEmbedTextEnriched:
             embed_fn=mock_embed,
         )
         result = mt.embed_text_enriched("test")
+        assert result is not None
         assert abs(np.linalg.norm(result) - 1.0) < 1e-6
 
 

--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -468,6 +468,7 @@ class TestCalibrationCache:
             app_module.bad_votes,
             det_ctx=det_ctx,
         )
+        assert det_ctx.calibration_cache is not None
         first_key = det_ctx.calibration_cache[0]
 
         # Flip one media's label — calibration must recompute.
@@ -486,6 +487,7 @@ class TestCalibrationCache:
                 det_ctx=det_ctx,
             )
         assert patched.call_count == 1
+        assert det_ctx.calibration_cache is not None
         assert det_ctx.calibration_cache[0] != first_key
 
     def test_inclusion_change_invalidates_cache(self):

--- a/vtsearch/concurrency/events.py
+++ b/vtsearch/concurrency/events.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import queue
 import time
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Generator
 
 from vtsearch.concurrency.progress import (
     LoadingTasksTracker,
@@ -63,7 +63,9 @@ def initial_snapshot() -> list[str]:
     return frames
 
 
-def stream_progress_events(*, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024) -> Iterator[str]:
+def stream_progress_events(
+    *, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024
+) -> Generator[str, None, None]:
     """Yield SSE-formatted strings for every progress channel until disconnect.
 
     Each connected client gets a private bounded queue; tracker subscriptions

--- a/vtsearch/datasets/downloader/__init__.py
+++ b/vtsearch/datasets/downloader/__init__.py
@@ -16,6 +16,20 @@ All public symbols are re-exported here for backward compatibility so that
 ``from vtsearch.datasets.downloader import download_esc50`` continues to work.
 """
 
+# Re-export each submodule as an attribute of the package so that
+# ``from vtsearch.datasets import downloader; downloader.core.X`` is visible
+# to static type-checkers. (At runtime Python adds these automatically once
+# the ``from ... import`` statements below execute, but pyright doesn't trust
+# that.)
+from vtsearch.datasets.downloader import (
+    audio,
+    core,
+    documents,
+    images,
+    text,
+    video,
+)
+
 # Core utilities & constants
 from vtsearch.datasets.downloader.core import (
     AG_NEWS_DOWNLOAD_SIZE_MB,
@@ -127,6 +141,13 @@ from vtsearch.datasets.downloader.text import (
 from vtsearch.datasets.downloader.documents import download_ucsf_documents
 
 __all__ = [
+    # Submodules
+    "audio",
+    "core",
+    "documents",
+    "images",
+    "text",
+    "video",
     # Core (private helpers re-exported for tests)
     "_default_progress",
     "_download_and_extract",

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -239,7 +239,7 @@ class DatasetImporter(PluginBase):
         """
         return self.display_name
 
-    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+    def resolve_display_name(self, field_values: dict[str, Any] | None) -> str:
         """Return the human-readable name to use for a dataset loaded with *field_values*.
 
         Importer subclasses should override :meth:`default_display_name`

--- a/vtsearch/plugins/__init__.py
+++ b/vtsearch/plugins/__init__.py
@@ -160,7 +160,7 @@ class PluginBase:
     #: a dedicated code path (e.g. the GUI exporter).
     hidden_from_picker: bool = False
 
-    def resolve_display_name(self, field_values: dict[str, Any]) -> str:
+    def resolve_display_name(self, field_values: dict[str, Any] | None) -> str:
         """Return a human-readable name for a dataset loaded with *field_values*.
 
         The default returns :attr:`display_name`.  Subclasses (e.g. the demo


### PR DESCRIPTION
## Summary

Final stage of the pyright rollout. Adds `tests/` to the gated pyright scope and clears every type error it surfaces.

- Baseline (`tests/` previously excluded): **699 errors** across 11 test groups.
- After two bulk-pattern fixes: **117 errors**.
- After per-file walk: **0 errors, 0 warnings**.
- All 3600 tests still pass (`./run-tests.sh`).

The two bulk patterns:

1. **`app.py` TYPE_CHECKING stub for conftest-injected attributes** (`app.medias`, `app.good_votes`, `app.bad_votes`, `app.NUM_MEDIAS`, `app.SAMPLE_RATE`, `app.generate_wav`, `app.train_and_score`, `app.init_medias`). Same shape as Stage 2 fix #1 for `vtsearch/settings.py`'s dynamically generated accessors. Knocks out **~471 errors**.
2. **`vtsearch/datasets/downloader/__init__.py`** now explicitly re-exports its submodules (`core`, `audio`, `images`, `video`, `text`, `documents`) so tests that monkey-patch `downloader.core.DATA_DIR` etc. type-check. Knocks out **~115 errors**.

The remaining 117 are all variants of patterns documented in Stages 2–5 (Optional narrowing asserts, HF/numpy/cv2 stub-gap ignore comments, `cast(Any, ...)` for test-time ABC attribute writes, etc.). Full breakdown in `docs/plans/pyright-type-checking.md`.

Two minor production-code annotation widenings — both already correct at runtime:

- `resolve_display_name(field_values)` now accepts `None` on `DatasetImporter` and the `PluginBase` it inherits from (the body already handled it).
- `stream_progress_events` returns `Generator[str, None, None]` instead of `Iterator[str]` so callers can `.close()` it.

`pyrightconfig.json` is updated: `tests` moves out of `exclude` and into `include`, and `extraPaths: ["tests"]` mirrors `pyproject.toml`'s `pythonpath` so cross-test imports resolve.

## Test plan

- [x] `pyright` — 0 errors, 0 warnings across the full `vtsearch` + `tests` scope.
- [x] `ruff check .` — clean.
- [x] `ruff format --check .` — clean.
- [x] `./run-tests.sh` — `ALL 3600 TESTS PASSED (1 skipped, total: 3601)`.

https://claude.ai/code/session_01CSDn6DPTNxqzpLnUHeDVVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSDn6DPTNxqzpLnUHeDVVD)_