### PR TITLE
Standardize media-type display to singular (ux-brainstorm 6.1)

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -200,7 +200,6 @@ changes to `vtsearch/media/__init__.py` are needed.
 | Property             | Returns     | Default            | Purpose                                   |
 |----------------------|-------------|--------------------|-------------------------------------------|
 | `folder_import_name` | `str`       | `type_id`          | Alias for folder imports (matches `type_id`) |
-| `tab_title`          | `str`       | `name + "s"`       | Plural name for UI tabs                    |
 | `dir_key`            | `str`       | `type_id + "_dir"` | Key in pickle files for external dir       |
 | `legacy_bytes_keys`  | `list[str]` | `[]`               | Legacy keys for inline bytes in old pickles |
 | `pickle_extra_fields`| `list[str]` | `[]`               | Extra fields to preserve in pickle round-trips (e.g. `["width", "height"]`) |

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -19,7 +19,6 @@ GET /api/media-types
       "type_id": "audio",
       "name": "Audio",
       "icon": "🔊",
-      "tab_title": "Sounds",
       "folder_import_name": "audio",
       "loops": true,
       "file_extensions": ["*.wav", "*.mp3"]

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -230,8 +230,10 @@ Train / Find buttons disable for non-obvious reasons (media-type mismatch, nothi
 
 ## 6. Inconsistencies across the app
 
-### 6.1 `media_type` naming ★★ XS
+### 6.1 `media_type` naming ★★ XS ✅
 Plural in dropdown labels ("images") vs singular in API/IDs ("image"). Pick one (singular) and use it everywhere visible.
+
+**Shipped:** Removed the `tab_title` plural-form override from `MediaType` (base + all five subclasses) and from `/api/media-types`. The Angular frontend now uses `name` (singular) everywhere — dropdowns, tabs, demo tabs, and detector picker all read "Audio", "Image", "Text", "Video", "Document". Removed the `tab_title?` field from `MediaTypeInfo` in `frontend/src/app/models/api.models.ts`.
 
 ### 6.2 "Detector" vs "Model" vs "Classifier" ★★ XS
 Code uses `detector`. Dashboard table is labeled "Detectors". Some UI elements (sort modes, the Models dashboard column) call them "models". User Guide uses both interchangeably. Pick one (suggest **detector** to keep alignment with the codebase) and lint the frontend strings.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -35,7 +35,7 @@ describe('DatasetImporterModalComponent', () => {
       picker_view: 'server_folder',
       category: 'server',
       fields: [
-        { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'images'] },
+        { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'image'] },
         { key: 'path', field_type: 'text', label: 'Folder Path', required: true },
       ],
     },
@@ -47,7 +47,7 @@ describe('DatasetImporterModalComponent', () => {
       picker_view: 'form',
       category: 'server',
       fields: [
-        { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'images'] },
+        { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'image'] },
         { key: 'paths_file', field_type: 'server_path', label: 'Paths File', required: true },
       ],
     },
@@ -74,7 +74,7 @@ describe('DatasetImporterModalComponent', () => {
       description: 'A test importer that renders the generic form',
       picker_view: 'form',
       fields: [
-        { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'images'] },
+        { key: 'media_type', field_type: 'select', label: 'Media Type', default: 'audio', options: ['audio', 'image'] },
         { key: 'path', field_type: 'text', label: 'Path', required: true },
       ],
     },
@@ -122,8 +122,8 @@ describe('DatasetImporterModalComponent', () => {
   ];
 
   const mockMediaTypes = [
-    { type_id: 'audio', name: 'Audio', icon: 'audio', tab_title: 'Audio' },
-    { type_id: 'image', name: 'Images', icon: 'image', tab_title: 'Images' },
+    { type_id: 'audio', name: 'Audio', icon: 'audio' },
+    { type_id: 'image', name: 'Image', icon: 'image' },
   ];
 
   beforeEach(async () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -762,7 +762,7 @@ export class DatasetImporterModalComponent implements OnInit {
   getMediaTypeOptionLabel(opt: string): string {
     const mt = this.mediaTypes.find((m) => m.folder_import_name === opt);
     if (mt) {
-      return (mt.tab_title || mt.name).trim();
+      return mt.name.trim();
     }
     return opt;
   }
@@ -770,7 +770,7 @@ export class DatasetImporterModalComponent implements OnInit {
   getTabLabel(mediaType: string): string {
     const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
     if (mt) {
-      return (mt.tab_title || mt.name).trim();
+      return mt.name.trim();
     }
     return mediaType;
   }
@@ -783,7 +783,7 @@ export class DatasetImporterModalComponent implements OnInit {
   getTabText(mediaType: string): string {
     const mt = this.mediaTypes.find((m) => m.type_id === mediaType);
     if (mt) {
-      return mt.tab_title || mt.name;
+      return mt.name;
     }
     return mediaType;
   }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -22,8 +22,8 @@ describe('NewDetectorModalComponent', () => {
     // Flush the media types request from ngOnInit
     httpMock.expectOne('/api/media-types').flush({
       media_types: [
-        { type_id: 'audio', name: 'Audio', icon: 'audio', tab_title: 'Sounds' },
-        { type_id: 'image', name: 'Image', icon: 'image', tab_title: 'Images' },
+        { type_id: 'audio', name: 'Audio', icon: 'audio' },
+        { type_id: 'image', name: 'Image', icon: 'image' },
       ],
     });
     httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
@@ -173,8 +173,8 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
 
     httpMock.expectOne('/api/media-types').flush({
       media_types: [
-        { type_id: 'audio', name: 'Audio', icon: 'audio', tab_title: 'Sounds' },
-        { type_id: 'image', name: 'Image', icon: 'image', tab_title: 'Images' },
+        { type_id: 'audio', name: 'Audio', icon: 'audio' },
+        { type_id: 'image', name: 'Image', icon: 'image' },
       ],
     });
     // No /api/datasets/registry call when defaultMediaType is provided.

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -725,7 +725,7 @@ export class NewDetectorModalComponent implements OnInit {
 
   getDemoTabLabel(typeId: string): string {
     const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
-    if (mt) return (mt.tab_title || mt.name).trim();
+    if (mt) return mt.name.trim();
     return typeId;
   }
 
@@ -918,7 +918,7 @@ export class NewDetectorModalComponent implements OnInit {
   getMediaTypeLabel(typeId: string): string {
     const mt = this.mediaTypeInfos.find((m) => m.type_id === typeId);
     if (mt) {
-      return (mt.tab_title || mt.name).trim();
+      return mt.name.trim();
     }
     return typeId;
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -309,7 +309,6 @@ export interface MediaTypeInfo {
   type_id: string;
   name: string;
   icon?: string;
-  tab_title?: string;
   folder_import_name?: string;
   /** Glob patterns for files this media type claims, e.g. ``["*.jpg", "*.png"]``. */
   file_extensions?: string[];

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -128,10 +128,6 @@ class AudioMediaType(MediaType):
         return "audio"
 
     @property
-    def tab_title(self) -> str:
-        return "Sounds"
-
-    @property
     def dir_key(self) -> str:
         return "audio_dir"
 

--- a/vtsearch/media/base.py
+++ b/vtsearch/media/base.py
@@ -233,15 +233,6 @@ class MediaType(ABC):
         return self.type_id
 
     @property
-    def tab_title(self) -> str:
-        """Plural display name used for UI tabs (e.g. ``"Videos"``, ``"Sounds"``).
-
-        Defaults to :attr:`name` + ``"s"``.  Override for irregular plurals
-        or custom labels.
-        """
-        return self.name + "s"
-
-    @property
     def dir_key(self) -> str:
         """Key used in pickle files to store the external media directory path.
 
@@ -481,7 +472,6 @@ class MediaType(ABC):
             "type_id": self.type_id,
             "name": self.name,
             "icon": self.icon,
-            "tab_title": self.tab_title,
             "folder_import_name": self.folder_import_name,
             "loops": self.loops,
             "file_extensions": self.file_extensions,

--- a/vtsearch/media/document/media_type.py
+++ b/vtsearch/media/document/media_type.py
@@ -66,10 +66,6 @@ class DocumentMediaType(MediaType):
         return "document"
 
     @property
-    def tab_title(self) -> str:
-        return "Documents"
-
-    @property
     def dir_key(self) -> str:
         return "document_dir"
 

--- a/vtsearch/media/image/media_type.py
+++ b/vtsearch/media/image/media_type.py
@@ -60,10 +60,6 @@ class ImageMediaType(MediaType):
         return "image"
 
     @property
-    def tab_title(self) -> str:
-        return "Images"
-
-    @property
     def dir_key(self) -> str:
         return "image_dir"
 

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -55,10 +55,6 @@ class TextMediaType(MediaType):
         return "text"
 
     @property
-    def tab_title(self) -> str:
-        return "Texts"
-
-    @property
     def dir_key(self) -> str:
         return "text_dir"
 

--- a/vtsearch/media/video/media_type.py
+++ b/vtsearch/media/video/media_type.py
@@ -235,10 +235,6 @@ class VideoMediaType(MediaType):
         return "video"
 
     @property
-    def tab_title(self) -> str:
-        return "Videos"
-
-    @property
     def dir_key(self) -> str:
         return "video_dir"
 


### PR DESCRIPTION
## Summary

Implements ux-brainstorm §6.1: media-type names were plural in UI labels (`Images`, `Sounds`, `Videos`, `Documents`, `Texts`) but singular in API/IDs (`image`, `audio`, ...). Standardized on **singular everywhere visible**.

- Removed the `tab_title` plural-form override from `MediaType` (base + all five subclasses) and from the `/api/media-types` response payload.
- Removed `tab_title?` from `MediaTypeInfo` in `frontend/src/app/models/api.models.ts`.
- Updated the four frontend helpers that read `mt.tab_title || mt.name` to use `mt.name` directly (importer modal tabs/dropdowns, detector picker, demo tab labels).
- Updated specs (`*.spec.ts`) to drop `tab_title` from their mock media-type fixtures.
- Updated `docs/EXTENDING-media.md` (removed `tab_title` row from optional properties), `docs/api/datasets.md` (removed `tab_title` from sample response), and marked §6.1 shipped in `docs/plans/ux-brainstorm.md`.

User-visible result: importer dropdowns, tabs, demo picker, and detector media-type picker all read "Audio", "Image", "Text", "Video", "Document" — matching the singular type IDs used by the API.

## Test plan

- [x] `ruff check .` and `ruff format --check .` clean
- [x] `./run-tests.sh` — 3626 passed, 1 skipped, 2 xpassed
- [ ] Manual UI check: dataset importer modal media-type dropdown and tabs show singular labels
- [ ] Manual UI check: new-detector modal media-type picker shows singular labels

https://claude.ai/code/session_01NX83wPmgWumXATsooNxmxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX83wPmgWumXATsooNxmxP)_