### PR TITLE
Standardize confirm-on-destructive UI pattern (ux-brainstorm 6.5)

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -244,8 +244,15 @@ The "where do I put this file?" concept appears across plugins as `filepath`, `p
 ### 6.4 Modal back-button conventions ★★ XS — SHIPPED
 Convention: every nested-modal flow renders a left-aligned `&larr; Back` button using the shared `btn btn--secondary btn--sm back-btn` class combination (styled by `.back-btn` in `frontend/src/scss/_components.scss`). Documented under "Nested-modal back buttons" in `CLAUDE.md`. All current nested flows (processor / settings / label importer modals, settings exporter, load-sort, resort-prompt, new-detector → media picker, new-detector → trained-importer form) already follow this convention.
 
-### 6.5 Confirm-on-destructive ★★ S
+### 6.5 Confirm-on-destructive ★★ S — shipped
 Delete dataset, delete detector, delete label entry, clear votes, reset settings — currently a mix of inline-hover-confirm, modal-confirm, and no-confirm. Standardize on a single confirm pattern, with the operation name in the confirmation: *"Delete detector 'cats'? This removes its labelset and training metadata. The dataset is unaffected."*
+
+**What shipped**: Added `VtDialogService.confirmDestructive(question, detail, actionLabel?)` and routed every destructive action with a UI surface through it: delete dataset (single + bulk), delete model (single + bulk), reset settings. Messages follow the `<Action>? <What is removed; what is unaffected>.` template, and the primary button uses the action verb ("Delete" / "Reset") instead of "OK".
+
+**Open follow-ups**:
+- *Delete label entry* and *Clear votes* were listed in the original item but don't have any UI surface today (only the `clearVotes()` API client exists, with no caller). When those actions get a button, wire them through `confirmDestructive` — e.g. `"Clear all votes for detector 'X'? This deletes every saved label for this model and cannot be undone."`
+- The labeling-view "press ← twice to vote no and discard the box" inline-confirm is a different UX (two-key chord, not a delete) and was intentionally left as-is. If we ever consolidate it, treat it as its own pattern rather than forcing it through the modal.
+- The destructive primary button has no distinct danger styling yet — it reuses `.btn--primary`. A red variant would make the modal even harder to dismiss-by-accident; deferred.
 
 ### 6.6 Toast / banner / inline error styling ★★ S
 Errors appear in at least three styles: red banner inline, modal-level red text, console-log only. Add a single toast service and route all `error` SSE events + HTTP failure responses through it.

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -370,7 +370,7 @@ describe('DashboardComponent', () => {
     component.selectedDatasetIds.add('d1');
 
     // Mock dialog confirmation
-    spyOn(component['dialog'], 'confirm').and.returnValue(Promise.resolve(true));
+    spyOn(component['dialog'], 'confirmDestructive').and.returnValue(Promise.resolve(true));
 
     component.deleteDataset(datasets[0]);
     tick();

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -496,11 +496,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.deletingSelectedDatasetsConfirm = true;
     let ok = false;
     try {
-      ok = await this.dialog.confirm(
+      const question =
         targets.length === 1
           ? `Delete dataset ${names}?`
-          : `Delete ${targets.length} datasets: ${names}?`,
-      );
+          : `Delete ${targets.length} datasets: ${names}?`;
+      const detail =
+        targets.length === 1
+          ? 'This removes the dataset from the registry and deletes its cached pickle file. Detectors trained against it are unaffected.'
+          : 'This removes the datasets from the registry and deletes their cached pickle files. Detectors trained against them are unaffected.';
+      ok = await this.dialog.confirmDestructive(question, detail);
     } finally {
       this.deletingSelectedDatasetsConfirm = false;
       this.wasDeletingSelectedDatasetsConfirm = true;
@@ -582,11 +586,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.deletingSelectedDetectorsConfirm = true;
     let ok = false;
     try {
-      ok = await this.dialog.confirm(
+      const question =
         targets.length === 1
           ? `Delete detector ${names}?`
-          : `Delete ${targets.length} detectors: ${names}?`,
-      );
+          : `Delete ${targets.length} detectors: ${names}?`;
+      const detail =
+        targets.length === 1
+          ? 'This removes its labelset and training metadata. The dataset is unaffected.'
+          : 'This removes their labelsets and training metadata. The datasets are unaffected.';
+      ok = await this.dialog.confirmDestructive(question, detail);
     } finally {
       this.deletingSelectedDetectorsConfirm = false;
       this.wasDeletingSelectedDetectorsConfirm = true;
@@ -670,7 +678,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   async deleteDataset(dataset: DatasetRegistryEntry): Promise<void> {
     this.deletingDatasetId = dataset.id;
-    const ok = await this.dialog.confirm(`Delete dataset "${dataset.name}"?`);
+    const ok = await this.dialog.confirmDestructive(
+      `Delete dataset "${dataset.name}"?`,
+      'This removes the dataset from the registry and deletes its cached pickle file. Detectors trained against it are unaffected.',
+    );
     this.deletingDatasetId = '';
     if (!ok) return;
     this.datasetsApi.deleteRegistered(dataset.id).subscribe({
@@ -719,7 +730,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   async deleteDetector(model: DetectorRegistryEntry): Promise<void> {
     this.deletingDetectorId = model.id;
-    const ok = await this.dialog.confirm(`Delete detector "${model.name}"?`);
+    const ok = await this.dialog.confirmDestructive(
+      `Delete detector "${model.name}"?`,
+      'This removes its labelset and training metadata. The dataset is unaffected.',
+    );
     this.deletingDetectorId = '';
     if (!ok) return;
     this.detectorsApi.deleteFromRegistry(model.id).subscribe({

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { SettingsModalComponent } from './settings-modal.component';
@@ -108,13 +108,23 @@ describe('SettingsModalComponent', () => {
     expect(component.getViewMode('view_mode_right', 'audio')).toBe('grid');
   });
 
-  it('should reset to defaults', () => {
+  it('should reset to defaults after confirmation', fakeAsync(() => {
     flushInit();
+    spyOn(component['dialog'], 'confirmDestructive').and.returnValue(Promise.resolve(true));
     component.resetDefaults();
+    tick();
     httpMock.expectOne('/api/settings/defaults').flush({ ...mockSettings, theme: 'light' });
     httpMock.expectOne('/api/settings').flush(mockSettings);
     expect(component.settings.theme).toBe('light');
-  });
+  }));
+
+  it('should not reset when confirmation is declined', fakeAsync(() => {
+    flushInit();
+    spyOn(component['dialog'], 'confirmDestructive').and.returnValue(Promise.resolve(false));
+    component.resetDefaults();
+    tick();
+    httpMock.expectNone('/api/settings/defaults');
+  }));
 
   it('should use preselectedViewTab when valid', () => {
     component.preselectedViewTab = 'image';

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -14,6 +14,7 @@ import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { AppSettings, MediaTypeInfo } from '../../../models/api.models';
 import { Theme, ThemeService } from '../../../services/theme.service';
 import { formatVersion } from '../../../utils/format-date';
+import { VtDialogService } from '../../../services/dialog.service';
 
 @Component({
   selector: 'vt-settings-modal',
@@ -45,6 +46,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     private settingsState: SettingsStateService,
     private datasetsApi: DatasetsApiService,
     private themeService: ThemeService,
+    private dialog: VtDialogService,
   ) {}
 
   ngOnDestroy(): void {
@@ -143,7 +145,13 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     this.save();
   }
 
-  resetDefaults(): void {
+  async resetDefaults(): Promise<void> {
+    const ok = await this.dialog.confirmDestructive(
+      'Reset all settings to factory defaults?',
+      'Your current preferences (appearance, view modes, autopilot, calibration, and other per-user settings) will be overwritten and cannot be recovered.',
+      'Reset',
+    );
+    if (!ok) return;
     this.settingsApi
       .getDefaults()
       .pipe(takeUntil(this.destroy$))

--- a/frontend/src/app/services/dialog.service.ts
+++ b/frontend/src/app/services/dialog.service.ts
@@ -63,6 +63,27 @@ export class VtDialogService {
     }) as Promise<boolean>;
   }
 
+  /**
+   * Standardised confirmation for destructive actions.
+   *
+   * `question` should name the operation and its target, e.g.
+   *   "Delete detector 'cats'?"
+   * `detail` should explain what is removed and what is unaffected, e.g.
+   *   "This removes its labelset and training metadata. The dataset is unaffected."
+   * `actionLabel` is the verb on the primary button (default "Delete").
+   */
+  confirmDestructive(question: string, detail: string, actionLabel = 'Delete'): Promise<boolean> {
+    return this.show({
+      message: `${question} ${detail}`,
+      type: 'warning',
+      showInput: false,
+      buttons: [
+        { label: 'Cancel', primary: false, value: false },
+        { label: actionLabel, primary: true, value: true },
+      ],
+    }) as Promise<boolean>;
+  }
+
   prompt(message: string, defaultValue = '', type: DialogType = 'info'): Promise<string | null> {
     return this.show({
       message,


### PR DESCRIPTION
## Summary

Closes UX brainstorm item 6.5 (Confirm-on-destructive). Routes every destructive action with a UI surface through a single `VtDialogService.confirmDestructive(question, detail, actionLabel?)` helper that:

- shows a warning-style modal,
- splits the message into an action question (operation name + target) and a detail sentence explaining what is removed and what is unaffected,
- labels the primary button with the action verb (`Delete` / `Reset`) instead of the generic `OK`.

### Sites updated

| Action | Before | After |
|---|---|---|
| Delete dataset (single) | `Delete dataset "X"?` | `Delete dataset "X"? This removes the dataset from the registry and deletes its cached pickle file. Models trained against it are unaffected.` |
| Delete dataset (bulk) | `Delete N datasets: ...?` | Same + plural detail |
| Delete model (single) | `Delete model "X"?` | `Delete model "X"? This removes its labelset and training metadata. The dataset is unaffected.` |
| Delete model (bulk) | `Delete N models: ...?` | Same + plural detail |
| Reset settings | **No confirmation** | `Reset all settings to factory defaults? Your current preferences ... will be overwritten and cannot be recovered.` (button: `Reset`) |

### Out of scope

- *Delete label entry* and *Clear votes* are listed in the 6.5 item but have no UI surface today (only the `clearVotes()` API client exists, with no caller). When a button is added, route it through `confirmDestructive`. Recorded in the plan file under "Open follow-ups".
- The labeling-view "press ← twice to vote no and discard the box" inline-confirm is a two-key chord, not a delete; intentionally left as-is.

## Test plan

- [x] `npm run build:prod` succeeds with no warnings.
- [x] `tsc -p tsconfig.spec.json --noEmit` succeeds (spec files typecheck).
- [x] Updated `dashboard.component.spec.ts` and `settings-modal.component.spec.ts` to mock `confirmDestructive`; added a new spec covering "decline reset" — no `/api/settings/defaults` request is fired.
- [ ] Manual: open Dashboard → click trash on a dataset → modal reads correctly, `Cancel` aborts, `Delete` fires the DELETE.
- [ ] Manual: open Dashboard → select 2 models → bulk delete → plural copy, same Cancel/Delete behaviour.
- [ ] Manual: open Settings → click `Default` → confirmation appears, `Reset` resets, `Cancel` leaves settings untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Txse49xVJgRxTduugeK2U2)_