### PR TITLE
Standardize labels for path-style plugin fields

### DIFF
--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -170,7 +170,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
     fields = [
         ImporterField(
             key="url",
-            label="Archive URL",
+            label="Path or URL",
             field_type="url",
             description="URL to a publicly accessible archive (.zip, .tar.gz, .rar, \u2026) of media files.",
         ),

--- a/vtsearch/datasets/importers/pickle/__init__.py
+++ b/vtsearch/datasets/importers/pickle/__init__.py
@@ -38,7 +38,7 @@ class PickleDatasetImporter(DatasetImporter):
     fields = [
         ImporterField(
             key="file",
-            label="Dataset File",
+            label="Upload a file",
             field_type="file",
             description="A .pkl file that was exported from VTSearch.",
             accept=".pkl",

--- a/vtsearch/datasets/importers/server_files/__init__.py
+++ b/vtsearch/datasets/importers/server_files/__init__.py
@@ -211,7 +211,7 @@ class ServerFilesDatasetImporter(DatasetImporter):
         ),
         ImporterField(
             key="paths_file",
-            label="Paths File",
+            label="Path or URL",
             field_type="server_path",
             description=(
                 "Absolute server path to a file listing the media to import.  Either:\n"

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -66,7 +66,7 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
     fields = [
         ExporterField(
             key="filepath",
-            label="Server File Path",
+            label="Save to (server path)",
             field_type="server_path",
             description=(
                 "Absolute or relative path on the server where the CSV "

--- a/vtsearch/exporters/server_json_file/__init__.py
+++ b/vtsearch/exporters/server_json_file/__init__.py
@@ -48,7 +48,7 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
     fields = [
         ExporterField(
             key="filepath",
-            label="Server File Path",
+            label="Save to (server path)",
             field_type="server_path",
             description=(
                 "Absolute or relative path on the server where the JSON "

--- a/vtsearch/labels/importers/server_csv_file/__init__.py
+++ b/vtsearch/labels/importers/server_csv_file/__init__.py
@@ -36,7 +36,7 @@ class ServerCsvLabelImporter(LabelImporter):
     fields = [
         LabelImporterField(
             key="filepath",
-            label="Server File Path",
+            label="Path or URL",
             field_type="server_path",
             description=(
                 "Absolute or relative path to a CSV file with md5 and label columns on the server filesystem."

--- a/vtsearch/labels/importers/server_json_file/__init__.py
+++ b/vtsearch/labels/importers/server_json_file/__init__.py
@@ -36,7 +36,7 @@ class ServerJsonLabelImporter(LabelImporter):
     fields = [
         LabelImporterField(
             key="filepath",
-            label="Server File Path",
+            label="Path or URL",
             field_type="server_path",
             description=("Absolute or relative path to a VTSearch labels JSON file on the server filesystem."),
             placeholder="data/labels/my_labels.json",

--- a/vtsearch/labels/sources/server_json_file/__init__.py
+++ b/vtsearch/labels/sources/server_json_file/__init__.py
@@ -28,7 +28,7 @@ class ServerFileLabelsetSource(LabelsetSource):
     fields = [
         LabelsetSourceField(
             key="filepath",
-            label="Server File Path",
+            label="Save to (server path)",
             field_type="server_path",
             description=(
                 "Absolute or relative path to a labels JSON file on the "

--- a/vtsearch/settings_io/exporters/server_json_file/__init__.py
+++ b/vtsearch/settings_io/exporters/server_json_file/__init__.py
@@ -24,7 +24,7 @@ class ServerFileSettingsExporter(SettingsExporter):
     fields = [
         SettingsExporterField(
             key="filepath",
-            label="Server File Path",
+            label="Save to (server path)",
             field_type="server_path",
             description=(
                 "Absolute or relative path on the server where the settings "

--- a/vtsearch/settings_io/importers/local_json_file/__init__.py
+++ b/vtsearch/settings_io/importers/local_json_file/__init__.py
@@ -22,7 +22,7 @@ class LocalFileSettingsImporter(SettingsImporter):
     fields = [
         SettingsImporterField(
             key="file",
-            label="Settings File",
+            label="Upload a file",
             field_type="file",
             description="A VTSearch settings JSON file.",
             accept=".json",

--- a/vtsearch/settings_io/importers/server_json_file/__init__.py
+++ b/vtsearch/settings_io/importers/server_json_file/__init__.py
@@ -23,7 +23,7 @@ class ServerFileSettingsImporter(SettingsImporter):
     fields = [
         SettingsImporterField(
             key="filepath",
-            label="Server File Path",
+            label="Path or URL",
             field_type="server_path",
             description="Absolute or relative path to a VTSearch settings JSON file on the server.",
             placeholder="data/settings.json",

--- a/vtsearch/settings_io/sources/server_json_file/__init__.py
+++ b/vtsearch/settings_io/sources/server_json_file/__init__.py
@@ -25,7 +25,7 @@ class ServerFileSettingsSource(SettingsSource):
     fields = [
         SettingsSourceField(
             key="filepath",
-            label="Server File Path",
+            label="Save to (server path)",
             field_type="server_path",
             description=(
                 "Absolute or relative path to a settings JSON file on the server.  Supports {username} template."


### PR DESCRIPTION
## Summary

Path-style fields across plugins (dataset importers, label importers/sources, exporters, settings I/O importers/exporters/sources) used inconsistent labels for the same underlying concept — "where do I put this file?". The same idea showed up as `"Server File Path"`, `"Paths File"`, `"Archive URL"`, `"Dataset File"`, `"Settings File"`, etc., even though the user-visible question is one of three things.

This PR standardizes on three canonical labels, picked by **direction** rather than field type:

| Label | Used for | Field type backing it |
|---|---|---|
| **Save to (server path)** | Exporters and sync sources that write to a server filesystem path | `server_path` |
| **Path or URL** | Importers that load from a server path or URL | `server_path`, `url` |
| **Upload a file** | Browser file-upload fields | `file` |

### Fields updated

**→ "Save to (server path)"** (5 fields)
- `vtsearch/exporters/server_json_file` — `filepath`
- `vtsearch/exporters/server_csv_file` — `filepath`
- `vtsearch/settings_io/exporters/server_json_file` — `filepath`
- `vtsearch/settings_io/sources/server_json_file` — `filepath` (bidirectional sync; always writes back)
- `vtsearch/labels/sources/server_json_file` — `filepath` (bidirectional sync; always writes back)

**→ "Path or URL"** (5 fields)
- `vtsearch/labels/importers/server_json_file` — `filepath`
- `vtsearch/labels/importers/server_csv_file` — `filepath`
- `vtsearch/settings_io/importers/server_json_file` — `filepath`
- `vtsearch/datasets/importers/server_files` — `paths_file`
- `vtsearch/datasets/importers/http_archive` — `url`

**→ "Upload a file"** (2 fields)
- `vtsearch/datasets/importers/pickle` — `file`
- `vtsearch/settings_io/importers/local_json_file` — `file`

### Out of scope
- `vtsearch/datasets/importers/server_folder` — `path` (`folder` type, label `"Folder"`): different concept (directory picker, not a file/URL), and the task scope listed only `server_path`/`text`/`file` types.
- `vtsearch/datasets/importers/combine_datasets` — `datasets` (`text`, comma-separated list of pickle paths): rendered through a `ui_mode="custom"` UI that doesn't show the generic form label.
- `vtsearch/exporters/webhook` — `url`: a webhook destination URL, not a server path, so neither "Save to (server path)" nor "Path or URL" fits cleanly — left as `"Webhook URL"`.

### Compatibility
Only the human-readable `label` strings change. Field `key`, `field_type`, `description`, `placeholder`, and `accept` values are preserved — so CLI flag names (e.g. `--filepath`, `--paths-file`, `--url`), persisted field values, and stored origin params are unaffected.

## Test plan
- [x] `./run-tests.sh io detectors` — 1488 passed (covers all the touched plugin families).
- [x] `./run-tests.sh api` — 9 failures are pre-existing on `origin/dev` (they require the Angular `static/` bundle, which isn't built in the remote container) and unrelated to this change.
- [ ] Manual smoke: open each affected form in the UI and confirm the new label renders.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Go7aKzqyoWLYmQkzHcYneu)_