### PR TITLE
Add "saved" indicator to settings modal (UX 6.7)

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -210,6 +210,7 @@
     @if (version) {
       <span class="settings-version" title="App version (UTC timestamp of the last dev to main merge). Include this when reporting issues.">v {{ version }}</span>
     }
+    <span class="settings-saved" [class.settings-saved--visible]="savedVisible" role="status" aria-live="polite" title="Settings auto-save as you change them">&#10003; saved</span>
     <button class="btn btn--secondary" (click)="resetDefaults()" title="Reset all settings to their factory defaults">Default</button>
     <button class="btn btn--secondary" (click)="openImporter()" title="Import settings from a file">Import</button>
     <button class="btn btn--secondary" (click)="openExporter()" title="Export settings to a file">Export</button>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -182,63 +182,6 @@
 }
 
 
-.embedder-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-.embedder-grid-header {
-  display: grid;
-  grid-template-columns: 1fr 10rem;
-  gap: var(--space-md);
-  padding: 0 0 0.4rem calc(1.25rem + 0.5rem);
-  font-size: var(--font-xs);
-  font-weight: 600;
-  color: var(--text-secondary);
-  border-bottom: 1px solid var(--border-color);
-  margin-bottom: var(--space-xs);
-}
-
-.embedder-row {
-  display: grid;
-  grid-template-columns: auto 1fr 10rem;
-  gap: var(--space-md);
-  align-items: center;
-  padding: 0.35rem 0;
-  font-size: var(--font-md);
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background 0.1s;
-
-  &:hover {
-    background: var(--bg-secondary);
-  }
-
-  input[type='checkbox'] {
-    margin: 0;
-  }
-}
-
-.embedder-name {
-  color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.embedder-media-type {
-  color: var(--text-secondary);
-  font-size: var(--font-sm);
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.embedder-media-type-icon {
-  font-size: var(--font-xl);
-}
-
 .settings-tab-icon {
   transition: transform 0.4s ease;
   transform: rotate(0deg);
@@ -261,4 +204,16 @@
   font-family: var(--font-mono, monospace);
   color: var(--text-secondary);
   user-select: text;
+}
+
+.settings-saved {
+  display: inline-flex;
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+  user-select: none;
+
+  &--visible { opacity: 1; }
 }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -34,6 +34,8 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   showImporterModal = false;
   showExporterModal = false;
   version = '';
+  savedVisible = false;
+  private savedTimer: ReturnType<typeof setTimeout> | null = null;
 
   private destroy$ = new Subject<void>();
 
@@ -45,6 +47,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnDestroy(): void {
+    if (this.savedTimer !== null) clearTimeout(this.savedTimer);
     this.destroy$.next();
     this.destroy$.complete();
   }
@@ -183,10 +186,23 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
       .update(this.settings)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
+        next: () => {
+          this.error = '';
+          this.flashSaved();
+        },
         error: () => {
           this.error = 'Failed to save settings';
         },
       });
+  }
+
+  private flashSaved(): void {
+    if (this.savedTimer !== null) clearTimeout(this.savedTimer);
+    this.savedVisible = true;
+    this.savedTimer = setTimeout(() => {
+      this.savedVisible = false;
+      this.savedTimer = null;
+    }, 1800);
   }
 
   close(): void {


### PR DESCRIPTION
## Summary

Settings in the Settings modal auto-save on every change but previously gave no feedback that the save happened. This PR adds a subtle `✓ saved` indicator to the modal footer that fades in on each successful save and fades out after ~1.8 s.

Addresses UX punch-list item **6.7 Saved-state indicator (★ XS)**: "Settings auto-save but show no 'saved' feedback. … always auto-save with a tiny ✓ saved indicator."

## Changes
- `settings-modal.component.ts`: track `savedVisible` + `savedTimer`; flip on save success, reset on each new save, clear on destroy. Also clear stale `error` on success.
- `settings-modal.component.html`: render `✓ saved` next to the version string in the footer, with a tooltip explaining auto-save.
- `settings-modal.component.scss`: small `.settings-saved` rule with a 0.4 s opacity transition; also dropped four dead `.embedder-*` rule blocks (no template usage anywhere) to keep the initial bundle under its 500 kB budget.

## Test plan
- [x] `npm run build:prod` — clean, initial bundle 499.03 kB (was 499.34 kB before this PR; the dead-CSS cleanup more than offsets the new state).
- [x] `./run-tests.sh core` — 494/494 passed (includes the frontend build check).
- [ ] Manual: open Settings, toggle any control → `✓ saved` flashes briefly in the footer next to the version string; rapidly toggling restarts the fade instead of stacking timers.

https://claude.ai/code/session_017U6Cc2b3dJrAvcC6wJLV19

---
_Generated by [Claude Code](https://claude.ai/code/session_017U6Cc2b3dJrAvcC6wJLV19)_