### PR TITLE
Standardize "detector" terminology in frontend strings

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -14,7 +14,7 @@ CLI workflows (no browser) see [CLI.md](CLI.md).
 5. [Autopilot — the guided workflow](#autopilot--the-guided-workflow) *(start here)*
 6. [Manual mode — for power users](#manual-mode--for-power-users)
 7. [View options](#view-options)
-8. [Dashboard — managing datasets and models](#dashboard--managing-datasets-and-models)
+8. [Dashboard — managing datasets and detectors](#dashboard--managing-datasets-and-detectors)
 9. [Exporting your work](#exporting-your-work)
 10. [Importing pre-trained detectors](#importing-pre-trained-detectors)
 11. [Where to go next](#where-to-go-next)
@@ -33,7 +33,7 @@ snow"), and the app uses a pretrained embedding model to rank items
 by semantic similarity to your query.
 
 In practice, you usually combine the two: search for a rough starting
-point, vote a handful of items, and let the learned model refine the
+point, vote a handful of items, and let the learned detector refine the
 ranking. VTSearch's **Autopilot** drives that loop for you — so most
 users never need to think about sort modes or selection strategies
 directly.
@@ -154,27 +154,27 @@ just picks *which* items to show you and *when* each phase ends.
 ### The four phases
 
 1. **Good examples** — Vote some **good** items (default: 3). The
-   model needs positive examples before it can learn anything.
+   detector needs positive examples before it can learn anything.
    Autopilot offers strong candidates first via the same semantic
    ranking the Text sort uses. If you don't see anything good, type
    a text query into the sort bar to jump-start the ranking.
 2. **Bad examples** — Vote some **bad** items (default: 4). Now
-   the model has both sides of the boundary. Autopilot flips to
+   the detector has both sides of the boundary. Autopilot flips to
    items ranked low, so finding clear bad examples is usually quick.
 3. **Boundary refinement (hard)** — Autopilot serves items the
-   model is **uncertain about** — the hardest cases near the
-   decision boundary. Voting these teaches the model fastest.
-   This phase continues until the model's confidence stabilises
+   detector is **uncertain about** — the hardest cases near the
+   decision boundary. Voting these teaches the detector fastest.
+   This phase continues until the detector's confidence stabilises
    (the "smart" and "stable" indicators in the status bar both
    turn green).
 4. **Diversity exploration (new)** — Autopilot serves items from
-   parts of the dataset the model hasn't seen yet, using the
+   parts of the dataset the detector hasn't seen yet, using the
    diversity tree. This catches edge cases the boundary phase
    missed. Phase ends when the diversity coverage hits your goal
    (default: 40%).
 
 When all four phases are done, Autopilot says **done**. You can
-keep labeling if you want — the model continues to improve — or
+keep labeling if you want — the detector continues to improve — or
 move on to exporting results.
 
 ### The collapsed bar
@@ -193,12 +193,12 @@ exposes:
 
 - **Top greens** — how many good votes phase 1 requires (default 3).
 - **Hard reds** — how many bad votes phase 2 requires (default 4).
-- **Resort interval** — how often the learned model is retrained
+- **Resort interval** — how often the learned detector is retrained
   during phases 3 and 4 (default every 10 votes).
 - **Goal diversity** — the fraction of the dataset's diversity
   tree that phase 4 must cover before finishing (default 40%).
 
-Raising these numbers trains a more thorough model at the cost of
+Raising these numbers trains a more thorough detector at the cost of
 more labelling effort.
 
 ---
@@ -228,7 +228,7 @@ Picks how the left-panel list is ordered.
   from another VTSearch instance). Opens a modal to pick a
   detector file or an example media item to sort by.
 
-You can freely switch modes — votes and the model persist across
+You can freely switch modes — votes and the detector persist across
 switches.
 
 ### 2. Selection strategy
@@ -238,7 +238,7 @@ Picks *which unlabeled item* the app highlights next.
 - **Top** — Pick the highest-ranked unlabeled item. Best for
   quickly finding strong matches.
 - **Hard** — Pick the item closest to the decision boundary.
-  These uncertain cases improve model accuracy fastest.
+  These uncertain cases improve detector accuracy fastest.
 - **New** — Pick an item from an underexplored region of the
   dataset using diversity sampling. Ensures broad coverage.
 
@@ -249,7 +249,7 @@ but in Manual mode you choose directly.
 
 A slider from **-10** (strict) to **+10** (lenient), default 0.
 
-Nudges the classification threshold after the learned model runs.
+Nudges the classification threshold after the learned detector runs.
 Negative values mean "only call it good if you're very sure" —
 fewer positives, higher precision. Positive values mean "include
 borderline items" — more positives, higher recall. The slider
@@ -284,7 +284,7 @@ with the same controls.
 When the dataset's embedder is patch-region-aware (DINOv2, DINOv3,
 or EUPE with a `_patch` slug — set when the dataset was created),
 you can vote **good** on a *region* of the image instead of the
-whole image.  This tells the model "this specific part is what I
+whole image.  This tells the detector "this specific part is what I
 like", and the learned sort uses that hint to find similar regions
 elsewhere in the dataset.
 
@@ -327,9 +327,9 @@ rectangle away — and drawing a rectangle is real work, so VTSearch
 There is **no timer** — the confirmation state waits as long as you
 need.
 
-### What region voting does to the model
+### What region voting does to the detector
 
-Region-voted good examples train the model on the *region* (pooled
+Region-voted good examples train the detector on the *region* (pooled
 from the patch grid) instead of the full image.  Bad votes are
 unaffected — VTSearch already treats every bad vote as "no region
 in this image is good" regardless of whether you drew a rectangle.
@@ -340,7 +340,7 @@ media types have no region affordance.
 
 ---
 
-## Dashboard — managing datasets and models
+## Dashboard — managing datasets and detectors
 
 The Dashboard is your inventory view. Two tables stacked vertically
 and a pair of action buttons underneath.
@@ -357,16 +357,16 @@ and a pair of action buttons underneath.
   state. Per-row icon buttons: **Rename**, **Add Labels** (import
   labels into this detector), **Export**, and **Delete**.
 
-**Starting a labeling session:** click a dataset row and a model
+**Starting a labeling session:** click a dataset row and a detector
 row to select them, then click the **Train** button in the action
 bar below the two tables. That opens the three-panel labeling view
 against your selection.
 
-**Scoring a dataset:** select a dataset and a model, then click
+**Scoring a dataset:** select a dataset and a detector, then click
 **Find** in the action bar. VTSearch scores every item in the
-dataset with the model and opens a ranked results modal.
+dataset with the detector and opens a ranked results modal.
 
-You can keep multiple datasets and multiple models loaded at once.
+You can keep multiple datasets and multiple detectors loaded at once.
 Loading just pulls them into memory; the Train / Find buttons work
 on whichever rows you currently have selected.
 
@@ -385,8 +385,8 @@ your current labels. Formats:
 - **Webhook** — POSTs the result to a URL you configure.
 - **Email (SMTP)** — emails the result if SMTP is configured.
 
-You can also export **detector weights** from the Models dashboard —
-useful for sharing a trained classifier with another VTSearch
+You can also export **detector weights** from the Detectors dashboard —
+useful for sharing a trained detector with another VTSearch
 instance, or for running it from the CLI. See [CLI.md](CLI.md) for
 command-line autodetect.
 
@@ -400,9 +400,9 @@ Two ways to bring in existing work:
   a JSON or CSV of `{md5, label}` pairs and populates your vote
   piles from it. Useful for continuing labelling across sessions
   or merging work from multiple labellers.
-- **Detectors (models)** — the **Load** sort mode and the Models
+- **Detectors** — the **Load** sort mode and the Detectors
   dashboard both have "import detector" options. A detector file
-  contains the trained model weights plus the threshold and
+  contains the trained detector weights plus the threshold and
   metadata needed to score a new dataset. Once imported, you can
   use it for Load-sort or for autorun scoring.
 

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -29,7 +29,7 @@
         role="menuitem"
         tabindex="-1"
         (click)="onDashboard()"
-        title="Return to the Dashboard to manage datasets and models"
+        title="Return to the Dashboard to manage datasets and detectors"
       ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <rect x="1" y="1" width="14" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
           <rect x="3.5" y="3" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
@@ -57,7 +57,7 @@
     [class.disabled]="!isOnLabelView"
     [disabled]="!isOnLabelView"
     (click)="onDashboard()"
-    title="Return to the Dashboard to manage datasets and models"
+    title="Return to the Dashboard to manage datasets and detectors"
   >Dashboard</button>
   <span class="top-bar-field" title="The currently active dataset being browsed and labeled"><strong>Data:</strong> <span class="top-bar-value">{{ datasetDisplayName }}</span></span>
   <span class="top-bar-field" title="The currently active detector used for scoring and sorting"><strong>Detector:</strong> <span class="top-bar-value">{{ modelDisplayName }}</span></span>

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
@@ -1,7 +1,7 @@
-<vt-modal [open]="true" title="Combine Trainable Models" [showCloseButton]="false" (closed)="close()">
+<vt-modal [open]="true" title="Combine Trainable Detectors" [showCloseButton]="false" (closed)="close()">
   <form class="combine-form" (ngSubmit)="submit()">
     <div class="form-group">
-      <label class="col-label" title="Trainable models being combined">Sources</label>
+      <label class="col-label" title="Trainable detectors being combined">Sources</label>
       <ul class="source-list">
         @for (row of rows; track row.name) {
           <li class="source-row">
@@ -15,18 +15,18 @@
           </li>
         }
       </ul>
-      <p class="info-text">{{ rows.length }} models · {{ totalLabels }} total labels (will dedupe + drop conflicts) · media type: {{ mediaType }}</p>
+      <p class="info-text">{{ rows.length }} detectors · {{ totalLabels }} total labels (will dedupe + drop conflicts) · media type: {{ mediaType }}</p>
     </div>
 
     <div class="form-group">
-      <label class="col-label" for="combine-new-name" title="The name of the new combined model">New Name <span class="required">*</span></label>
+      <label class="col-label" for="combine-new-name" title="The name of the new combined detector">New Name <span class="required">*</span></label>
       <input
         id="combine-new-name"
         class="form-input"
         [(ngModel)]="newName"
         name="newName"
         placeholder="e.g. All Dog Barks"
-        title="A short name for the combined model"
+        title="A short name for the combined detector"
         autofocus
       />
       @if (nameValidationMessage) {
@@ -56,7 +56,7 @@
 
   <div modal-footer>
     <button type="button" class="btn btn--secondary" [disabled]="submitting" (click)="close()" title="Discard and close the dialog">Cancel</button>
-    <button type="button" class="btn btn--primary" [disabled]="!canSubmit" (click)="submit()" title="Combine the selected models into a new one">
+    <button type="button" class="btn btn--primary" [disabled]="!canSubmit" (click)="submit()" title="Combine the selected detectors into a new one">
       {{ submitting ? 'Combining...' : 'Combine' }}
     </button>
   </div>

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -94,15 +94,15 @@ export class CombineDetectorsModalComponent implements OnInit {
         if (status === 422) {
           this.error =
             serverMsg ||
-            'Every label was a conflict — no model was created. Try fewer or more aligned sources.';
+            'Every label was a conflict — no detector was created. Try fewer or more aligned sources.';
         } else if (status === 409) {
-          this.error = serverMsg || `A model named "${trimmed}" already exists.`;
+          this.error = serverMsg || `A detector named "${trimmed}" already exists.`;
         } else if (status === 404) {
-          this.error = serverMsg || 'A source model was not found.';
+          this.error = serverMsg || 'A source detector was not found.';
         } else if (status === 400) {
           this.error = serverMsg || 'Invalid combine request.';
         } else {
-          this.error = serverMsg || 'Failed to combine models.';
+          this.error = serverMsg || 'Failed to combine detectors.';
         }
       },
     });

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -282,7 +282,7 @@
         class="btn btn--primary"
         [class.loading-active]="trainLoading"
         [disabled]="!labelEnabled || isLoading"
-        [title]="labelHint || 'Open the labeling view to vote on items and train the selected model on the selected dataset'"
+        [title]="labelHint || 'Open the labeling view to vote on items and train the selected detector on the selected dataset'"
         (click)="onLabel()"
       >
         <svg aria-hidden="true" [class.icon-waggle]="trainLoading" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
@@ -295,7 +295,7 @@
         class="btn btn--primary"
         [class.loading-active]="findLoading"
         [disabled]="!findEnabled || isLoading"
-        [title]="findHint || 'Score every item in the selected dataset using the selected model and show ranked results'"
+        [title]="findHint || 'Score every item in the selected dataset using the selected detector and show ranked results'"
         (click)="onFind()"
       >
         <svg aria-hidden="true" [class.icon-waggle]="findLoading" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/></svg>

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -272,7 +272,7 @@ describe('DashboardComponent', () => {
       flushInitialRequests();
       component.selectedDatasetIds.add('d1');
       component.selectedDetectorIds.clear();
-      expect(component.labelHint).toBe('Select a model');
+      expect(component.labelHint).toBe('Select a detector');
     });
 
     it('should hint about multiple datasets', () => {
@@ -287,7 +287,7 @@ describe('DashboardComponent', () => {
       component.selectedDatasetIds.add('d1');
       component.selectedDetectorIds.add('m1');
       component.selectedDetectorIds.add('m2');
-      expect(component.labelHint).toBe('Select exactly 1 model');
+      expect(component.labelHint).toBe('Select exactly 1 detector');
     });
 
     it('should hint about media type mismatch', () => {
@@ -301,7 +301,7 @@ describe('DashboardComponent', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
       const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
-      expect(component.labelHint).toBe('Open Train Mode with the selected dataset and model');
+      expect(component.labelHint).toBe('Open Train Mode with the selected dataset and detector');
     });
   });
 
@@ -310,7 +310,7 @@ describe('DashboardComponent', () => {
       flushInitialRequests();
       component.selectedDatasetIds.clear();
       component.selectedDetectorIds.clear();
-      expect(component.findHint).toBe('Select a dataset and a model');
+      expect(component.findHint).toBe('Select a dataset and a detector');
     });
 
     it('should hint about missing dataset', () => {
@@ -324,7 +324,7 @@ describe('DashboardComponent', () => {
       flushInitialRequests();
       component.selectedDatasetIds.add('d1');
       component.selectedDetectorIds.clear();
-      expect(component.findHint).toBe('Select a model');
+      expect(component.findHint).toBe('Select a detector');
     });
 
     it('should hint about media type mismatch', () => {
@@ -338,14 +338,14 @@ describe('DashboardComponent', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
       const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
-      expect(component.findHint).toBe('Score selected datasets with selected models');
+      expect(component.findHint).toBe('Score selected datasets with selected detectors');
     });
 
     it('should hint about untrained model', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
       const models = [{ id: 'm1', name: 'M', media_type: 'audio', num_training: 0 }];
       flushInitialRequests(datasets, models);
-      expect(component.findHint).toBe('Selected model has no training labels');
+      expect(component.findHint).toBe('Selected detector has no training labels');
     });
   });
 

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -603,8 +603,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     try {
       ok = await this.dialog.confirm(
         targets.length === 1
-          ? `Delete model ${names}?`
-          : `Delete ${targets.length} models: ${names}?`,
+          ? `Delete detector ${names}?`
+          : `Delete ${targets.length} detectors: ${names}?`,
       );
     } finally {
       this.deletingSelectedDetectorsConfirm = false;
@@ -638,14 +638,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   get combineSelectedDetectorsHint(): string {
     if (this.selectedDetectorIds.size < 2) {
-      return 'Select two or more trainable models to combine';
+      return 'Select two or more trainable detectors to combine';
     }
     const targets = this.detectors.filter((d) => this.selectedDetectorIds.has(d.id));
     const types = new Set(targets.map((m) => m.media_type));
     if (types.size !== 1) {
-      return 'All selected models must be of the same media type';
+      return 'All selected detectors must be of the same media type';
     }
-    return 'Combine selected models into a new one';
+    return 'Combine selected detectors into a new one';
   }
 
   get combineSelectedDetectorSources(): DetectorRegistryEntry[] {
@@ -742,7 +742,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   async deleteDetector(model: DetectorRegistryEntry): Promise<void> {
     this.deletingDetectorId = model.id;
-    const ok = await this.dialog.confirm(`Delete model "${model.name}"?`);
+    const ok = await this.dialog.confirm(`Delete detector "${model.name}"?`);
     this.deletingDetectorId = '';
     if (!ok) return;
     this.detectorsApi.deleteFromRegistry(model.id).subscribe({
@@ -1191,12 +1191,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get findHint(): string {
     const nDatasets = this.resolvedSelectedDatasets.length;
     const nModels = this.resolvedSelectedModels.length;
-    if (nDatasets === 0 && nModels === 0) return 'Select a dataset and a model';
+    if (nDatasets === 0 && nModels === 0) return 'Select a dataset and a detector';
     if (nDatasets === 0) return 'Select a dataset';
-    if (nModels === 0) return 'Select a model';
+    if (nModels === 0) return 'Select a detector';
     if (!this.findMediaTypesMatch()) return 'Media type mismatch';
-    if (this.hasUntrainedModel()) return 'Selected model has no training labels';
-    return 'Score selected datasets with selected models';
+    if (this.hasUntrainedModel()) return 'Selected detector has no training labels';
+    return 'Score selected datasets with selected detectors';
   }
 
   get labelHint(): string {
@@ -1204,14 +1204,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const nModels = this.resolvedSelectedModels.length;
     if (nDatasets === 0) return 'Select a dataset';
     if (nDatasets > 1) return 'Select exactly 1 dataset';
-    if (nModels === 0) return 'Create a new model and start training';
-    if (nModels > 1) return 'Select exactly 1 model';
+    if (nModels === 0) return 'Create a new detector and start training';
+    if (nModels > 1) return 'Select exactly 1 detector';
     const model = this.resolvedSelectedModels[0];
     const dataset = this.resolvedSelectedDatasets[0];
     if (model && dataset && model.media_type !== dataset.media_type) {
       return 'Media type mismatch';
     }
-    return 'Open Train Mode with the selected dataset and model';
+    return 'Open Train Mode with the selected dataset and detector';
   }
 
   private storeSelectedModelTextQuery(): void {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -7,8 +7,8 @@
       (keydown)="onRenameKeydown($event)"
       (blur)="confirmRename()"
       (click)="$event.stopPropagation()"
-      title="Enter a new name for the model"
-      aria-label="Model name"
+      title="Enter a new name for the detector"
+      aria-label="Detector name"
     />
   } @else {
     <span class="name-cell">
@@ -98,13 +98,13 @@
       @case ('detector_loaded') {
         <td>
           @if (detector.detector_loaded) {
-            <span class="status-loaded" aria-label="Loaded" title="Model is loaded">
+            <span class="status-loaded" aria-label="Loaded" title="Detector is loaded">
               <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="20 6 9 17 4 12"></polyline>
               </svg>
             </span>
           } @else {
-            <button class="load-action" (click)="onLoad($event)" title="Click to load this model" aria-label="Load model">
+            <button class="load-action" (click)="onLoad($event)" title="Click to load this detector" aria-label="Load detector">
               <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18"></line>
                 <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -117,7 +117,7 @@
   }
   <td class="actions-col">
     <div class="actions-cell">
-    <button class="edit-btn" (click)="startRename($event)" aria-label="Rename model" title="Rename">
+    <button class="edit-btn" (click)="startRename($event)" aria-label="Rename detector" title="Rename">
       <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
         <line x1="7.5" y1="19.5" x2="3.5" y2="15.5"></line>
@@ -127,13 +127,13 @@
     <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
       <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
     </button>
-    <button class="export-btn" (click)="onExport($event)" aria-label="Export model" title="Export">
+    <button class="export-btn" (click)="onExport($event)" aria-label="Export detector" title="Export">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="15 14 20 9 15 4"></polyline>
         <path d="M4 20v-7a4 4 0 0 1 4-4h12"></path>
       </svg>
     </button>
-    <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete model" title="Delete">
+    <button class="delete-btn" (click)="onDelete($event)" aria-label="Delete detector" title="Delete">
       <svg aria-hidden="true" [class.trash-active]="deleteConfirmOpen" [class.trash-inactive]="!deleteConfirmOpen && wasDeleteOpen" (animationend)="onTrashAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
@@ -142,7 +142,7 @@
         <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
       </svg>
     </button>
-    <button class="select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect model' : 'Select model'" [attr.title]="selected ? 'Deselect' : 'Select'">
+    <button class="select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect detector' : 'Select detector'" [attr.title]="selected ? 'Deselect' : 'Select'">
       @if (selected) {
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <rect x="3" y="3" width="18" height="18" rx="2"/>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -5,42 +5,42 @@
         [class.active]="tab === 'blank'"
         [attr.aria-selected]="tab === 'blank'"
         (click)="setTab('blank')"
-        title="Start a fresh model from a single text description or media example. The model learns from your votes as you label.">Blank</button>
+        title="Start a fresh detector from a single text description or media example. The detector learns from your votes as you label.">Blank</button>
       <button type="button" class="tab-btn" role="tab"
         [class.active]="tab === 'trained'"
         [attr.aria-selected]="tab === 'trained'"
         (click)="onSelectTrainedTab()"
-        title="Create a model pre-trained on labels imported from an external source (file, URL, or service).">Trained</button>
+        title="Create a detector pre-trained on labels imported from an external source (file, URL, or service).">Trained</button>
     </div>
 
-    <form class="new-model-form" (ngSubmit)="submit()">
+    <form class="new-detector-form" (ngSubmit)="submit()">
       <div class="form-group">
-        <label class="col-label" for="model-name" title="A short name to identify this model">Model Name <span class="required">*</span></label>
+        <label class="col-label" for="detector-name" title="A short name to identify this detector">Detector Name <span class="required">*</span></label>
         <input
-          id="model-name"
+          id="detector-name"
           class="form-input"
           [(ngModel)]="name"
           name="name"
           placeholder="e.g. Dog Barks"
-          title="A short name to identify this model"
+          title="A short name to identify this detector"
           autofocus
         />
       </div>
 
       @if (tab === 'blank') {
         <div class="form-group">
-          <label class="col-label" title="The type of media this model will process">Media Type</label>
+          <label class="col-label" title="The type of media this detector will process">Media Type</label>
           <div class="media-type-row">
             <div class="custom-select"
               [class.open]="mediaTypeDropdownOpen"
               [class.locked]="mediaTypeLocked"
-              [title]="mediaTypeLocked ? 'Locked to the active dataset\'s media type. Click the unlock button to choose a different type.' : 'The type of media this model will process'">
+              [title]="mediaTypeLocked ? 'Locked to the active dataset\'s media type. Click the unlock button to choose a different type.' : 'The type of media this detector will process'">
               <button type="button" class="custom-select-trigger form-input"
                 [class.is-locked]="mediaTypeLocked"
                 [disabled]="mediaTypeLocked"
                 [attr.aria-disabled]="mediaTypeLocked"
                 (click)="toggleMediaTypeDropdown()"
-                [title]="mediaTypeLocked ? 'Locked to the active dataset\'s media type' : 'Select the media type for this model'">
+                [title]="mediaTypeLocked ? 'Locked to the active dataset\'s media type' : 'Select the media type for this detector'">
                 <span class="select-option-content">
                   @if (getMediaTypeIcon(mediaType)) {
                     <vt-icon [type]="getMediaTypeIcon(mediaType)" [size]="14"></vt-icon>
@@ -103,7 +103,7 @@
                   [(ngModel)]="pendingText"
                   name="pendingText"
                   placeholder="e.g. dog barking sounds"
-                  title="A text description of what this model should find"
+                  title="A text description of what this detector should find"
                   (keydown.enter)="$event.preventDefault(); submit()"
                 />
               </div>
@@ -127,7 +127,7 @@
         @if (trainedView === 'picker') {
           <div class="form-group">
             <label class="col-label">Label Importer <span class="required">*</span></label>
-            <p class="info-text">Choose where to import labels from. The resulting model's training data will be the imported labels.</p>
+            <p class="info-text">Choose where to import labels from. The resulting detector's training data will be the imported labels.</p>
             @if (labelImportersLoading) {
               <p class="empty-state">Loading importers...</p>
             } @else if (labelImporters.length === 0) {
@@ -251,15 +251,15 @@
 
   @if (view === 'main') {
     <div modal-footer>
-      <button class="btn btn--secondary" (click)="close()" title="Discard this model and close the dialog">Cancel</button>
+      <button class="btn btn--secondary" (click)="close()" title="Discard this detector and close the dialog">Cancel</button>
       @if (tab === 'blank') {
         <button class="btn btn--primary" [disabled]="!canSubmitBlank" (click)="submit()"
-          title="Create the model with the example you provided">
+          title="Create the detector with the example you provided">
           {{ submitting ? 'Creating...' : 'Create' }}
         </button>
       } @else {
         <button class="btn btn--primary" [disabled]="!canSubmitTrained" (click)="submit()"
-          title="Create the model and import labels from the selected source">
+          title="Create the detector and import labels from the selected source">
           {{ submitting ? 'Importing...' : 'Create & Import' }}
         </button>
       }
@@ -268,7 +268,7 @@
 
   @if (view === 'media-picker') {
     <div class="media-picker">
-      <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()" title="Return to the model creation form">&larr; Back</button>
+      <button class="btn btn--secondary btn--sm back-btn" (click)="backToMain()" title="Return to the detector creation form">&larr; Back</button>
 
       <!-- Category tabs (mirrors the Add Dataset modal so users see the same layout). -->
       <div class="importer-picker">
@@ -508,7 +508,7 @@
         <div class="local-folder-uploader">
           <p class="info-text">
             Pick a media file on <strong>this computer</strong>. It will be uploaded to the server
-            and used as the example for this model.
+            and used as the example for this detector.
           </p>
           @if (activePickerView === 'local_folder') {
             <input

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -57,7 +57,7 @@
   font-size: 0.95rem;
 }
 
-.new-model-form {
+.new-detector-form {
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -232,7 +232,7 @@ export class NewDetectorModalComponent implements OnInit {
 
   get modalTitle(): string {
     if (this.view === 'media-picker') return 'Select Media Example';
-    return 'New Model';
+    return 'New Detector';
   }
 
   get hasExample(): boolean {

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -481,7 +481,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!modelId) return;
     this.sortState.setSortMode('load');
     this.sortState.setSortBusy(true);
-    this.sortState.setSortStatus('Scoring with model…');
+    this.sortState.setSortStatus('Scoring with detector…');
     this.sortState.setSortProgress(0, 0);
 
     this.startScoringProgressPoll();
@@ -507,7 +507,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       error: () => {
         this.stopScoringProgressPoll();
         this.sortState.setSortBusy(false);
-        this.sortState.setSortStatus('Model sort failed');
+        this.sortState.setSortStatus('Detector sort failed');
         this.sortState.setSortProgress(0, 0);
       },
     });

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -40,6 +40,6 @@
     <span class="media-name">{{ displayName }}</span>
   }
   @if (score !== null) {
-    <span class="media-score" title="Model confidence score">{{ score | number:'1.2-2' }}</span>
+    <span class="media-score" title="Detector confidence score">{{ score | number:'1.2-2' }}</span>
   }
 </div>

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -16,7 +16,7 @@
       [attr.data-status]="smartStatus"
       (click)="onClick('smart')"
       aria-label="Smart indicator"
-      [title]="smartSubtext ? 'Smart: ' + smartSubtext + '. Tracks model accuracy over labeling steps.' : 'Tracks model accuracy over labeling steps. Green when error cost has leveled off (model has converged). Yellow when still improving. Red when more votes are needed.'"
+      [title]="smartSubtext ? 'Smart: ' + smartSubtext + '. Tracks detector accuracy over labeling steps.' : 'Tracks detector accuracy over labeling steps. Green when error cost has leveled off (detector has converged). Yellow when still improving. Red when more votes are needed.'"
     >
       <span class="indicator-dot"></span>
       <span class="indicator-label">Smart</span>
@@ -27,7 +27,7 @@
       [attr.data-status]="stableStatus"
       (click)="onClick('stable')"
       aria-label="Stable indicator"
-      [title]="stableSubtext ? 'Stable: ' + stableSubtext + '. Tracks prediction stability.' : 'Tracks prediction stability. Green when predictions stop changing between labeling steps (model is confident). Yellow when predictions are still shifting. Red when more votes are needed.'"
+      [title]="stableSubtext ? 'Stable: ' + stableSubtext + '. Tracks prediction stability.' : 'Tracks prediction stability. Green when predictions stop changing between labeling steps (detector is confident). Yellow when predictions are still shifting. Red when more votes are needed.'"
     >
       <span class="indicator-dot"></span>
       <span class="indicator-label">Stable</span>

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.html
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.html
@@ -10,7 +10,7 @@
     />
     Top
   </label>
-  <label class="sort-radio" [class.active]="selectMode === 'hard'" title="Pick the item closest to the decision boundary. These uncertain cases improve model accuracy fastest.">
+  <label class="sort-radio" [class.active]="selectMode === 'hard'" title="Pick the item closest to the decision boundary. These uncertain cases improve detector accuracy fastest.">
     <input
       type="radio"
       name="selectMode"

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -1,6 +1,6 @@
 <div class="sort-bar">
   <div class="sort-mode-group">
-    <span class="sort-label" title="Choose how items are ranked. Text uses a search query, Learned trains on your votes, Load applies a saved model.">Sort:</span>
+    <span class="sort-label" title="Choose how items are ranked. Text uses a search query, Learned trains on your votes, Load applies a saved detector.">Sort:</span>
     <label class="sort-radio" [class.active]="sortMode === 'text'" [title]="textDisabled ? 'This dataset’s embedder does not support text queries.' : 'Rank items by similarity to a text query using semantic embeddings (e.g. CLIP, CLAP, E5).'">
       <input
         type="radio"
@@ -12,7 +12,7 @@
       />
       Text
     </label>
-    <label class="sort-radio" [class.active]="sortMode === 'load'" title="Load a previously saved model or detector and rank items using its predictions.">
+    <label class="sort-radio" [class.active]="sortMode === 'load'" title="Load a previously saved detector and rank items using its predictions.">
       <input
         type="radio"
         name="sortMode"
@@ -22,7 +22,7 @@
       />
       Load
     </label>
-    <label class="sort-radio" [class.active]="sortMode === 'learned'" title="Train a model on your good/bad votes and rank items by predicted score. Requires at least 1 good and 1 bad vote.">
+    <label class="sort-radio" [class.active]="sortMode === 'learned'" title="Train a detector on your good/bad votes and rank items by predicted score. Requires at least 1 good and 1 bad vote.">
       <input
         type="radio"
         name="sortMode"
@@ -61,7 +61,7 @@
         @if (learnedDisabled) {
           <span class="sort-hint">Need at least 1 good and 1 bad label</span>
         } @else {
-          <span class="sort-desc">Sorting by trained model.</span>
+          <span class="sort-desc">Sorting by trained detector.</span>
         }
       </div>
     }

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -62,7 +62,7 @@ export class LabelImporterModalComponent implements OnInit {
     if (this.view === 'form' && this.selectedImporter) {
       return this.selectedImporter.display_name || this.selectedImporter.name;
     }
-    return this.targetModelName ? 'Add Labels to Model' : 'Import Labels';
+    return this.targetModelName ? 'Add Labels to Detector' : 'Import Labels';
   }
 
   ngOnInit(): void {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -91,13 +91,13 @@
     </div>
   } @else {
     <div class="load-sort-sections">
-      <!-- Sort by Trained Model -->
+      <!-- Sort by Trained Detector -->
       <div class="sort-section">
-        <h3 title="Load a trained model and use it to find matching items in the active dataset">Sort by Model</h3>
+        <h3 title="Load a trained detector and use it to find matching items in the active dataset">Sort by Detector</h3>
         @if (registryModels.length > 0) {
           <div class="file-list">
             @for (model of registryModels; track model.id) {
-              <button class="file-item" (click)="loadRegistryModel(model)" [title]="'Load model: ' + model.name">
+              <button class="file-item" (click)="loadRegistryModel(model)" [title]="'Load detector: ' + model.name">
                 {{ model.name }}
                 @if (model.num_training) {
                   <span class="item-meta">{{ model.num_training | number }} labels</span>
@@ -106,7 +106,7 @@
             }
           </div>
         } @else {
-          <p class="empty-state">No trained models found. Add some labels in the Dashboard first.</p>
+          <p class="empty-state">No trained detectors found. Add some labels in the Dashboard first.</p>
         }
       </div>
 

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -93,7 +93,7 @@ export class LoadSortModalComponent implements OnInit {
   // --- Model loading ---
 
   loadRegistryModel(model: DetectorRegistryEntry): void {
-    this.status = 'Loading model…';
+    this.status = 'Loading detector…';
     this.modelSelected.emit(model.id);
     this.closed.emit();
   }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -4,7 +4,7 @@
       @if (useCachedHistory) {
         <p aria-live="polite">Loading indicator history...</p>
       } @else {
-        <p aria-live="polite">Training models over label history...</p>
+        <p aria-live="polite">Training detectors over label history...</p>
         <vt-progress-bar [value]="analysisProgress" [max]="100"></vt-progress-bar>
         <p class="progress-text">{{ analysisProgress }}%</p>
       }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -154,7 +154,7 @@
             <input type="checkbox" [ngModel]="settings.enrich_descriptions" (ngModelChange)="onToggle('enrich_descriptions', $event)" />
             Enrich descriptions
           </label>
-          <label class="checkbox-row" title="Blend the learned threshold toward 0.5 to reduce aggressive inclusion/exclusion. Useful when the model has few training examples.">
+          <label class="checkbox-row" title="Blend the learned threshold toward 0.5 to reduce aggressive inclusion/exclusion. Useful when the detector has few training examples.">
             <input type="checkbox" [ngModel]="settings.safe_thresholds" (ngModelChange)="onToggle('safe_thresholds', $event)" />
             Safe thresholds
           </label>

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
@@ -2,7 +2,7 @@
   <div class="train-context-bar">
     <div class="train-context-header">
       <div>
-        <span class="train-context-label" title="The model being trained on your good/bad votes in this session">Detector</span>
+        <span class="train-context-label" title="The detector being trained on your good/bad votes in this session">Detector</span>
         @if (!editing) {
           <span class="train-context-name">{{ detectorName }}</span>
           <button

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
@@ -6,7 +6,7 @@
     class="label-sort-select"
     [ngModel]="mode"
     (ngModelChange)="onSortChange($event)"
-    title="Order labeled items by time, name, model confidence, or ID"
+    title="Order labeled items by time, name, detector confidence, or ID"
   >
     <option value="time-desc">Newest first</option>
     <option value="time-asc">Oldest first</option>


### PR DESCRIPTION
Closes ux-brainstorm.md §6.2.

## Summary
- Replaces user-visible "Model"/"Models"/"classifier" with "detector" across HTML templates, TS user-facing strings (status messages, dialog confirms, hints), and the matching spec assertions.
- Updates `docs/USER_GUIDE.md` to use "detector" consistently for the trainable per-user classifier, keeping "embedding model" intact where it refers to the pretrained embedder (CLIP, CLAP, etc.).
- Renames `id="model-name"` → `id="detector-name"` and `.new-model-form` → `.new-detector-form` in the New Detector modal; no other code identifiers were touched (preserved `modelId`, `registryModels`, `[(ngModel)]`, etc.).

## Out of scope
- Backend Python identifiers (already `detector` throughout).
- Internal property names like `modelId`, `modelName`, `registryModels`, `trainMode.model.name` — these are code-structure references with no user impact.
- Code comments that mention "model" — left in place since they describe internal data flow, not UI strings.

## Test plan
- [x] `./run-tests.sh core` — 494 passed, 0 skipped (ruff, frontend `build:prod`, audit, core pytest all clean).
- [x] Updated `dashboard.component.spec.ts` assertions to match new hint strings.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jbvBE9eaaDVR16nmSxiob)_