### PR TITLE
Embedder display names in importer picker

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -83,18 +83,21 @@
                 @if (recommendedEmbedders(demoEmbedders).length > 0) {
                   <optgroup label="Recommended">
                     @for (embedder of recommendedEmbedders(demoEmbedders); track embedder.name) {
-                      <option [value]="embedder.name">{{ embedder.name }}</option>
+                      <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                     }
                   </optgroup>
                 }
                 @if (advancedEmbedders(demoEmbedders).length > 0) {
                   <optgroup label="Advanced ▾">
                     @for (embedder of advancedEmbedders(demoEmbedders); track embedder.name) {
-                      <option [value]="embedder.name">{{ embedder.name }}</option>
+                      <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                     }
                   </optgroup>
                 }
               </select>
+              @if (selectedEmbedderRawId(selectedDemoEmbedder, demoEmbedders); as rawId) {
+                <small class="embedder-raw-id">{{ rawId }}</small>
+              }
             }
             @if (licenseNoticeFor(selectedDemoEmbedder, demoEmbedders); as notice) {
               <div class="license-warning" role="note">⚠ {{ notice }}</div>
@@ -308,18 +311,21 @@
             @if (recommendedEmbedders(availableEmbedders).length > 0) {
               <optgroup label="Recommended">
                 @for (embedder of recommendedEmbedders(availableEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                 }
               </optgroup>
             }
             @if (advancedEmbedders(availableEmbedders).length > 0) {
               <optgroup label="Advanced ▾">
                 @for (embedder of advancedEmbedders(availableEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                 }
               </optgroup>
             }
           </select>
+          @if (selectedEmbedderRawId(selectedEmbedder, availableEmbedders); as rawId) {
+            <small class="embedder-raw-id">{{ rawId }}</small>
+          }
           @if (licenseNoticeFor(selectedEmbedder, availableEmbedders); as notice) {
             <div class="license-warning" role="note">⚠ {{ notice }}</div>
           }
@@ -517,18 +523,21 @@
             @if (recommendedEmbedders(lfEmbedders).length > 0) {
               <optgroup label="Recommended">
                 @for (embedder of recommendedEmbedders(lfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                 }
               </optgroup>
             }
             @if (advancedEmbedders(lfEmbedders).length > 0) {
               <optgroup label="Advanced ▾">
                 @for (embedder of advancedEmbedders(lfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                 }
               </optgroup>
             }
           </select>
+          @if (selectedEmbedderRawId(lfSelectedEmbedder, lfEmbedders); as rawId) {
+            <small class="embedder-raw-id">{{ rawId }}</small>
+          }
           @if (licenseNoticeFor(lfSelectedEmbedder, lfEmbedders); as notice) {
             <div class="license-warning" role="note">⚠ {{ notice }}</div>
           }
@@ -697,18 +706,21 @@
             @if (recommendedEmbedders(sfEmbedders).length > 0) {
               <optgroup label="Recommended">
                 @for (embedder of recommendedEmbedders(sfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                 }
               </optgroup>
             }
             @if (advancedEmbedders(sfEmbedders).length > 0) {
               <optgroup label="Advanced ▾">
                 @for (embedder of advancedEmbedders(sfEmbedders); track embedder.name) {
-                  <option [value]="embedder.name">{{ embedder.name }}</option>
+                  <option [value]="embedder.name">{{ embedderLabel(embedder) }}</option>
                 }
               </optgroup>
             }
           </select>
+          @if (selectedEmbedderRawId(sfSelectedEmbedder, sfEmbedders); as rawId) {
+            <small class="embedder-raw-id">{{ rawId }}</small>
+          }
           @if (licenseNoticeFor(sfSelectedEmbedder, sfEmbedders); as notice) {
             <div class="license-warning" role="note">⚠ {{ notice }}</div>
           }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -83,6 +83,15 @@
   font-style: italic;
 }
 
+.embedder-raw-id {
+  display: block;
+  margin-top: 2px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: .75rem;
+  color: var(--text-muted, #888);
+  line-height: 1.2;
+}
+
 .license-warning {
   margin-top: 6px;
   padding: 6px 10px;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -828,6 +828,28 @@ export class DatasetImporterModalComponent implements OnInit {
     return list.filter((e) => !e.is_default);
   }
 
+  /**
+   * Human-readable label for the option element. Falls back to the raw name
+   * for embedders that don't yet supply a friendlier label.
+   */
+  embedderLabel(embedder: EmbedderInfo): string {
+    return embedder.display_name || embedder.name;
+  }
+
+  /**
+   * Raw registry ID for the currently-selected embedder, used as a secondary
+   * ``<small>`` line under the picker so power users can still see it. Returns
+   * an empty string when the display name equals the raw name (no need to
+   * repeat it) or when no embedder is selected.
+   */
+  selectedEmbedderRawId(name: string, list: EmbedderInfo[]): string {
+    if (!name) return '';
+    const found = list.find((e) => e.name === name);
+    if (!found) return '';
+    const label = found.display_name || found.name;
+    return label === found.name ? '' : found.name;
+  }
+
   selectDemo(demo: DemoDataset): void {
     const userName = (this.demoDatasetName || '').trim();
     this.demoSelected.emit({

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -629,6 +629,13 @@ export interface AutoDetectResultsData {
 
 export interface EmbedderInfo {
   name: string;
+  /**
+   * Human-readable label shown in pickers, e.g. ``"SigLIP (general images)"``.
+   * Falls back to ``name`` for legacy embedders that don't supply a friendlier
+   * label; the raw ``name`` is also rendered as a secondary line so power
+   * users can still see the registry key.
+   */
+  display_name?: string;
   media_type_id: string;
   /**
    * Whether this embedder is the recommended default for its media type

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -36,6 +36,7 @@ class TestImageClipEmbedder:
 
         assert ImageClipEmbedder().to_dict() == {
             "name": "clip",
+            "display_name": "CLIP (general images)",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": True,
@@ -107,6 +108,7 @@ class TestImageSiglip2Embedder:
 
         assert ImageSiglip2Embedder().to_dict() == {
             "name": "siglip2",
+            "display_name": "SigLIP 2 (general images)",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": True,
@@ -174,6 +176,7 @@ class TestImageDinov2SingleEmbedder:
 
         assert ImageDinov2SingleEmbedder().to_dict() == {
             "name": "dinov2_single",
+            "display_name": "DINOv2 single (image vector)",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -238,6 +241,7 @@ class TestImageDinov2PatchEmbedder:
 
         assert ImageDinov2PatchEmbedder().to_dict() == {
             "name": "dinov2_patch",
+            "display_name": "DINOv2 patch (region-aware images)",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -284,6 +288,7 @@ class TestImageDinov3SingleEmbedder:
 
         assert ImageDinov3SingleEmbedder().to_dict() == {
             "name": "dinov3_single",
+            "display_name": "DINOv3 single (image vector)",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -346,6 +351,7 @@ class TestImageDinov3PatchEmbedder:
 
         assert ImageDinov3PatchEmbedder().to_dict() == {
             "name": "dinov3_patch",
+            "display_name": "DINOv3 patch (region-aware images)",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,

--- a/tests/detectors/test_new_embedders.py
+++ b/tests/detectors/test_new_embedders.py
@@ -54,6 +54,7 @@ class TestImageSiglipEmbedderProperties:
         d = emb.to_dict()
         assert d == {
             "name": "siglip",
+            "display_name": "SigLIP (general images)",
             "media_type_id": "image",
             "is_default": True,
             "supports_text": True,
@@ -149,6 +150,7 @@ class TestAudioClapMusicEmbedderProperties:
         d = emb.to_dict()
         assert d == {
             "name": "clap_music",
+            "display_name": "CLAP (music)",
             "media_type_id": "audio",
             "is_default": False,
             "supports_text": True,
@@ -231,6 +233,7 @@ class TestTextBGEEmbedderProperties:
         d = emb.to_dict()
         assert d == {
             "name": "bge",
+            "display_name": "BGE (text)",
             "media_type_id": "text",
             "is_default": False,
             "supports_text": True,
@@ -360,6 +363,7 @@ class TestVideoLanguageBindEmbedderProperties:
         d = emb.to_dict()
         assert d == {
             "name": "languagebind",
+            "display_name": "LanguageBind (video)",
             "media_type_id": "video",
             "is_default": False,
             "supports_text": True,

--- a/vtsearch/media/audio/embedder_clap.py
+++ b/vtsearch/media/audio/embedder_clap.py
@@ -41,6 +41,10 @@ class AudioClapEmbedder(MediaEmbedder):
         return "clap"
 
     @property
+    def display_name(self) -> str:
+        return "CLAP (general audio)"
+
+    @property
     def media_type_id(self) -> str:
         return "audio"
 

--- a/vtsearch/media/audio/embedder_clap_music.py
+++ b/vtsearch/media/audio/embedder_clap_music.py
@@ -45,6 +45,10 @@ class AudioClapMusicEmbedder(MediaEmbedder):
         return "clap_music"
 
     @property
+    def display_name(self) -> str:
+        return "CLAP (music)"
+
+    @property
     def media_type_id(self) -> str:
         return "audio"
 

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -439,6 +439,17 @@ class MediaEmbedder(ABC):
         """Unique identifier for this embedder, e.g. ``"clap"``, ``"siglip"``."""
 
     @property
+    def display_name(self) -> str:
+        """Human-readable label for this embedder, shown in pickers.
+
+        Defaults to :attr:`name` so legacy embedders keep working unchanged.
+        Subclasses should override to surface a friendlier label (e.g.
+        ``"SigLIP (general images)"``) while the raw :attr:`name` stays
+        available as a secondary line for power users.
+        """
+        return self.name
+
+    @property
     @abstractmethod
     def media_type_id(self) -> str:
         """The ``type_id`` of the media type this embedder works with."""
@@ -731,6 +742,7 @@ class MediaEmbedder(ABC):
         """Return a JSON-serialisable summary of this embedder."""
         return {
             "name": self.name,
+            "display_name": self.display_name,
             "media_type_id": self.media_type_id,
             "is_default": self.is_default,
             "supports_text": self.supports_text,

--- a/vtsearch/media/image/embedder_clip.py
+++ b/vtsearch/media/image/embedder_clip.py
@@ -43,6 +43,10 @@ class ImageClipEmbedder(MediaEmbedder):
         return "clip"
 
     @property
+    def display_name(self) -> str:
+        return "CLIP (general images)"
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtsearch/media/image/embedder_dinov2_patch.py
+++ b/vtsearch/media/image/embedder_dinov2_patch.py
@@ -36,6 +36,10 @@ class ImageDinov2PatchEmbedder(_Dinov2Base):
         return "dinov2_patch"
 
     @property
+    def display_name(self) -> str:
+        return "DINOv2 patch (region-aware images)"
+
+    @property
     def supports_patch_regions(self) -> bool:
         return True
 

--- a/vtsearch/media/image/embedder_dinov2_single.py
+++ b/vtsearch/media/image/embedder_dinov2_single.py
@@ -31,5 +31,9 @@ class ImageDinov2SingleEmbedder(_Dinov2Base):
     def name(self) -> str:
         return "dinov2_single"
 
+    @property
+    def display_name(self) -> str:
+        return "DINOv2 single (image vector)"
+
 
 EMBEDDER = ImageDinov2SingleEmbedder()

--- a/vtsearch/media/image/embedder_dinov3_patch.py
+++ b/vtsearch/media/image/embedder_dinov3_patch.py
@@ -42,6 +42,10 @@ class ImageDinov3PatchEmbedder(_Dinov3Base):
         return "dinov3_patch"
 
     @property
+    def display_name(self) -> str:
+        return "DINOv3 patch (region-aware images)"
+
+    @property
     def supports_patch_regions(self) -> bool:
         return True
 

--- a/vtsearch/media/image/embedder_dinov3_single.py
+++ b/vtsearch/media/image/embedder_dinov3_single.py
@@ -32,5 +32,9 @@ class ImageDinov3SingleEmbedder(_Dinov3Base):
     def name(self) -> str:
         return "dinov3_single"
 
+    @property
+    def display_name(self) -> str:
+        return "DINOv3 single (image vector)"
+
 
 EMBEDDER = ImageDinov3SingleEmbedder()

--- a/vtsearch/media/image/embedder_eupe_patch.py
+++ b/vtsearch/media/image/embedder_eupe_patch.py
@@ -37,6 +37,10 @@ class ImageEupePatchEmbedder(_EupeBase):
         return "eupe_patch"
 
     @property
+    def display_name(self) -> str:
+        return "EUPE patch (region-aware images)"
+
+    @property
     def supports_patch_regions(self) -> bool:
         return True
 

--- a/vtsearch/media/image/embedder_eupe_single.py
+++ b/vtsearch/media/image/embedder_eupe_single.py
@@ -30,5 +30,9 @@ class ImageEupeSingleEmbedder(_EupeBase):
     def name(self) -> str:
         return "eupe_single"
 
+    @property
+    def display_name(self) -> str:
+        return "EUPE single (image vector)"
+
 
 EMBEDDER = ImageEupeSingleEmbedder()

--- a/vtsearch/media/image/embedder_siglip.py
+++ b/vtsearch/media/image/embedder_siglip.py
@@ -49,6 +49,10 @@ class ImageSiglipEmbedder(MediaEmbedder):
         return "siglip"
 
     @property
+    def display_name(self) -> str:
+        return "SigLIP (general images)"
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtsearch/media/image/embedder_siglip2.py
+++ b/vtsearch/media/image/embedder_siglip2.py
@@ -49,6 +49,10 @@ class ImageSiglip2Embedder(MediaEmbedder):
         return "siglip2"
 
     @property
+    def display_name(self) -> str:
+        return "SigLIP 2 (general images)"
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtsearch/media/text/embedder_bge.py
+++ b/vtsearch/media/text/embedder_bge.py
@@ -64,6 +64,10 @@ class TextBGEEmbedder(MediaEmbedder):
         return "bge"
 
     @property
+    def display_name(self) -> str:
+        return "BGE (text)"
+
+    @property
     def media_type_id(self) -> str:
         return "text"
 

--- a/vtsearch/media/text/embedder_e5.py
+++ b/vtsearch/media/text/embedder_e5.py
@@ -64,6 +64,10 @@ class TextE5Embedder(MediaEmbedder):
         return "e5"
 
     @property
+    def display_name(self) -> str:
+        return "E5 (text)"
+
+    @property
     def media_type_id(self) -> str:
         return "text"
 

--- a/vtsearch/media/video/embedder_languagebind.py
+++ b/vtsearch/media/video/embedder_languagebind.py
@@ -83,6 +83,10 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
         return "languagebind"
 
     @property
+    def display_name(self) -> str:
+        return "LanguageBind (video)"
+
+    @property
     def media_type_id(self) -> str:
         return "video"
 

--- a/vtsearch/media/video/embedder_xclip.py
+++ b/vtsearch/media/video/embedder_xclip.py
@@ -43,6 +43,10 @@ class VideoXClipEmbedder(MediaEmbedder):
         return "xclip"
 
     @property
+    def display_name(self) -> str:
+        return "X-CLIP (video)"
+
+    @property
     def media_type_id(self) -> str:
         return "video"
 


### PR DESCRIPTION
## Summary

Embedder dropdowns previously showed bare registry IDs (`siglip`, `dinov3_patch`, `e5`) — fine for engineers but cryptic for new users.

- Added a `display_name` property to `MediaEmbedder` (defaults to `name` so legacy embedders keep working).
- Overrode `display_name` on every shipping embedder with a human-readable label, e.g. `"SigLIP (general images)"`, `"DINOv3 patch (region-aware images)"`, `"E5 (text)"`, `"CLAP (general audio)"`, `"X-CLIP (video)"`.
- Field round-trips through `MediaEmbedder.to_dict()` and the `/api/embedders` response.
- Frontend `EmbedderInfo` interface picks up the new field, and all four `<select>` blocks in the dataset-importer modal now render the friendly label as the `<option>` text, with the raw registry ID shown as a secondary `<small>` line below the picker so power users can still see the key (e.g. SigLIP picker shows `siglip` underneath).

The dataset-stats modal still shows the titlecased raw ID — out of scope for this XS task, left alone to keep the change minimal.

## Test plan

- [x] `./run-tests.sh detectors` — 846 passed (includes updated `to_dict` equality assertions in `test_image_embedders.py` and `test_new_embedders.py`)
- [x] `./run-tests.sh core` — 494 passed (includes frontend TypeScript build)
- [x] `./run-tests.sh` — 3626 passed, 1 skipped, 2 xpassed
- [x] `ruff check` / `ruff format --check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01HrLTTGk8DhFYsueotwNgGE)_