### PR TITLE
Migrate settings/io and settings/sources to flask-smorest

### DIFF
--- a/app.py
+++ b/app.py
@@ -335,8 +335,8 @@ api.register_blueprint(label_importers_bp)
 # it via the Api so its routes appear in /api/openapi.json. Other
 # blueprints stay on the plain Flask path until migrated.
 api.register_blueprint(settings_bp)
-app.register_blueprint(settings_io_bp)
-app.register_blueprint(sync_sources_bp)
+api.register_blueprint(settings_io_bp)
+api.register_blueprint(sync_sources_bp)
 api.register_blueprint(detectors_crud_bp)
 api.register_blueprint(detectors_labels_bp)
 api.register_blueprint(detectors_registry_bp)

--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -540,12 +540,38 @@ request/response gates getting in the way during their migration.
       legacy ``get_json_or_400`` helper because its dual-mode
       multipart-or-JSON dispatcher doesn't fit a single marshmallow
       schema).
+- [x] `settings/io.py` and `settings/sources.py` migrated to flask-smorest
+      (settings-importers / settings-exporters / settings-sources /
+      labelset-sources). The two plugin-field routes
+      (``POST /api/settings-importers/import/<importer_name>``) stay on
+      the legacy plain-Flask path on the same smorest blueprint — same
+      pattern as ``labels/importers.py``. Schema-level validation
+      failures (missing required ``exporter_name`` / ``source_name``)
+      surface as 422 with the standard ``errors`` envelope; handler-
+      level rejects (unknown exporter / source, detector not loaded,
+      missing plugin field, invalid ``filepath``, exporter raised) keep
+      their HTTP codes (404 / 400 / 500) with the standard ``message``
+      envelope. The nullable-GET endpoints
+      (``/api/settings-sources/active`` and
+      ``/api/detectors/<n>/labelset-source``) return ``jsonify(None)``
+      to short-circuit flask-smorest's ``schema.dump`` (which would
+      otherwise turn ``None`` into ``{}``); the sync endpoint always
+      includes a ``keys`` list in its response (even when empty)
+      because marshmallow's ``getattr`` fallback resolves ``keys`` on a
+      dict to the built-in method. The
+      ``test_missing_exporter_name_400`` test in
+      ``tests/io/test_settings_io.py`` was updated to expect 422 with
+      the ``errors`` envelope.
 - [ ] Frontend `SettingsApiService` rewired to generated client
 - [ ] `frontend/src/app/models/api.models.ts` settings section deleted
-- [ ] Remaining blueprints (see Order above)
 - [ ] Delete the pre-existing permissive `/openapi.json` +
-      `--openapi-schema` once flask-smorest covers every blueprint
-      (see "Relationship to the pre-existing permissive spec" above)
+      `--openapi-schema` now that flask-smorest covers every blueprint
+      (see "Relationship to the pre-existing permissive spec" above).
+      The url-map walker in ``vtsearch/openapi.py`` and the ``/openapi.json``
+      route on ``main_bp`` are still in place — flagged as deprecated in
+      their docstrings but kept until a follow-up PR removes them
+      together with the ``--openapi-schema`` CLI flag and the docs
+      references in ``docs/CLI.md`` / ``docs/API.md``.
 
 ## Open follow-ups
 

--- a/tests/io/test_settings_io.py
+++ b/tests/io/test_settings_io.py
@@ -442,13 +442,18 @@ class TestSettingsExportEndpoint:
         )
         assert res.status_code == 404
 
-    def test_missing_exporter_name_400(self, client):
+    def test_missing_exporter_name_422(self, client):
+        # Schema-level validation: marshmallow rejects the missing required
+        # ``exporter_name`` with the standard 422 ``errors`` envelope.
         res = client.post("/api/settings-exporters/export", json={})
-        assert res.status_code == 400
+        assert res.status_code == 422
+        assert "exporter_name" in res.get_json().get("errors", {}).get("json", {})
 
     def test_missing_required_field_400(self, client):
+        # Handler-level validation: plugin field check uses ``message``.
         res = client.post(
             "/api/settings-exporters/export",
             json={"exporter_name": "server_json_file", "field_values": {}},
         )
         assert res.status_code == 400
+        assert "Missing required field" in res.get_json().get("message", "")

--- a/vtsearch/routes/settings/io.py
+++ b/vtsearch/routes/settings/io.py
@@ -1,5 +1,8 @@
 """Flask routes for the Settings Import/Export API.
 
+Migrated to ``flask_smorest`` so these routes appear in
+``/api/openapi.json``.  See ``docs/plans/openapi-schema.md``.
+
 Endpoints
 ---------
 GET  /api/settings-importers
@@ -7,35 +10,55 @@ GET  /api/settings-importers
 
 POST /api/settings-importers/import/<importer_name>
     Run the named settings importer and apply the imported settings.
+    The request body is a plugin-field shape and doesn't fit a static
+    marshmallow schema — this route stays on the legacy plain-Flask path
+    (no ``@arguments`` / ``@response`` decorators) and is omitted from
+    the OpenAPI spec.  See *Resolved questions / Plugin field endpoints*
+    in ``docs/plans/openapi-schema.md``.
 
 GET  /api/settings-exporters
     List all registered settings exporters with their metadata and fields.
 
 POST /api/settings-exporters/export
-    Run the named settings exporter on the current application settings.
+    Run the named settings exporter on the current per-user settings.
+    Schema-level validation failures (missing ``exporter_name``) surface
+    as 422; handler-level rejects (unknown exporter, missing plugin
+    field, invalid ``filepath``, exporter raised) keep their HTTP codes
+    (404 / 400 / 500) with the standard ``message`` envelope.
 """
 
 from __future__ import annotations
 
 import logging
 
-from flask import Blueprint, jsonify
+from flask import jsonify
+from flask_smorest import Blueprint, abort
 
 from vtsearch import settings
-
-logger = logging.getLogger(__name__)
 from vtsearch.routes._shared import (
     extract_plugin_fields,
-    get_json_safe,
     get_plugin_or_404,
     run_plugin_or_error,
     validate_filepath_field,
     validate_required_fields,
 )
+from vtsearch.schemas.settings_io import (
+    RunSettingsExportRequestSchema,
+    RunSettingsExportResponseSchema,
+    SettingsExporterEntrySchema,
+    SettingsImporterEntrySchema,
+)
 from vtsearch.settings_io.exporters import get_settings_exporter, list_settings_exporters
 from vtsearch.settings_io.importers import get_settings_importer, list_settings_importers
 
-settings_io_bp = Blueprint("settings_io", __name__)
+logger = logging.getLogger(__name__)
+
+
+settings_io_bp = Blueprint(
+    "settings_io",
+    __name__,
+    description="List and run settings importers / exporters.",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -44,19 +67,29 @@ settings_io_bp = Blueprint("settings_io", __name__)
 
 
 @settings_io_bp.route("/api/settings-importers", methods=["GET"])
+@settings_io_bp.response(200, SettingsImporterEntrySchema(many=True))
 def get_settings_importers():
     """Return a list of all registered settings importers."""
-    return jsonify([imp.to_dict() for imp in list_settings_importers()])
+    return [imp.to_dict() for imp in list_settings_importers()]
 
 
 # ---------------------------------------------------------------------------
 # POST /api/settings-importers/import/<importer_name>
+#
+# Plugin-field route — stays on the legacy ``request.get_json`` / multipart
+# path. The request body is the importer's declared ``fields`` (file
+# uploads, free-form params) and doesn't fit a static marshmallow schema.
+# See ``docs/plans/openapi-schema.md`` (Resolved questions / Plugin field
+# endpoints).  Not described in the OpenAPI spec.
 # ---------------------------------------------------------------------------
 
 
 @settings_io_bp.route("/api/settings-importers/import/<importer_name>", methods=["POST"])
 def run_settings_import(importer_name: str):
-    """Run the named settings importer and apply imported settings."""
+    """Run the named settings importer and apply imported settings.
+
+    Plugin-dependent body shape: not described in the OpenAPI spec.
+    """
     importer, err = get_plugin_or_404(
         get_settings_importer, list_settings_importers, importer_name, "settings importer"
     )
@@ -99,9 +132,10 @@ def run_settings_import(importer_name: str):
 
 
 @settings_io_bp.route("/api/settings-exporters", methods=["GET"])
+@settings_io_bp.response(200, SettingsExporterEntrySchema(many=True))
 def get_settings_exporters():
     """Return a list of all registered settings exporters."""
-    return jsonify([exp.to_dict() for exp in list_settings_exporters()])
+    return [exp.to_dict() for exp in list_settings_exporters()]
 
 
 # ---------------------------------------------------------------------------
@@ -110,35 +144,39 @@ def get_settings_exporters():
 
 
 @settings_io_bp.route("/api/settings-exporters/export", methods=["POST"])
-def run_settings_export():
-    """Run the named settings exporter on current application settings."""
-    data = get_json_safe()
-
-    exporter_name = data.get("exporter_name", "").strip()
+@settings_io_bp.arguments(RunSettingsExportRequestSchema)
+@settings_io_bp.response(200, RunSettingsExportResponseSchema)
+@settings_io_bp.alt_response(400, description="Missing plugin field or invalid filepath.")
+@settings_io_bp.alt_response(404, description="Unknown exporter name.")
+@settings_io_bp.alt_response(500, description="Exporter raised an unexpected error.")
+def run_settings_export(body: dict):
+    """Run the named settings exporter on the current per-user settings."""
+    exporter_name = body["exporter_name"].strip()
     if not exporter_name:
-        return jsonify({"error": "exporter_name is required"}), 400
+        abort(422, message="exporter_name is required")
 
-    exporter, err = get_plugin_or_404(
-        get_settings_exporter, list_settings_exporters, exporter_name, "settings exporter"
-    )
-    if err:
-        return err
-    assert exporter is not None  # narrowed by err check
+    exporter = get_settings_exporter(exporter_name)
+    if exporter is None:
+        known = [p.name for p in list_settings_exporters()]
+        abort(404, message=f"Unknown settings exporter '{exporter_name}'. Available: {known}")
 
-    field_values: dict = data.get("field_values", {}) or {}
+    field_values: dict = dict(body.get("field_values") or {})
 
-    # Validate required fields
     missing = [
         f.key
         for f in exporter.fields
         if f.required and (field_values.get(f.key) is None or not str(field_values.get(f.key, "")).strip())
     ]
     if missing:
-        return jsonify({"error": f"Missing required field(s): {missing}", "missing_fields": missing}), 400
+        abort(400, message=f"Missing required field(s): {missing}", missing_fields=missing)
 
-    err = validate_filepath_field(field_values)
-    if err:
-        return err
+    if "filepath" in field_values and str(field_values["filepath"]).strip():
+        import vtsearch.security.path_validation as _paths
+
+        try:
+            _paths.validate_server_filepath(str(field_values["filepath"]), base_dir=_paths.get_file_access_base_dir())
+        except ValueError as exc:
+            abort(400, message=str(exc))
 
     # Export only the current user's per-user settings, not the merged
     # view (which would also carry shared server-tier infra keys).
@@ -147,12 +185,12 @@ def run_settings_export():
     try:
         outcome = exporter.export(settings_data, field_values)
     except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+        abort(400, message=str(exc))
     except Exception as exc:
         logger.exception("Settings export failed (%s): %s", exporter_name, exc)
-        return jsonify({"error": f"Export failed: {exc}"}), 500
+        abort(500, message=f"Export failed: {exc}")
 
-    return jsonify({"success": True, **outcome})
+    return {"success": True, **(outcome or {})}
 
 
 # ---------------------------------------------------------------------------
@@ -160,4 +198,4 @@ def run_settings_export():
 # ---------------------------------------------------------------------------
 
 # Re-export from settings module for backward compatibility and local use.
-from vtsearch.settings import _apply_settings  # noqa: F401
+from vtsearch.settings import _apply_settings  # noqa: F401, E402

--- a/vtsearch/routes/settings/sources.py
+++ b/vtsearch/routes/settings/sources.py
@@ -1,5 +1,8 @@
 """Flask routes for the Sync Sources API.
 
+Migrated to ``flask_smorest`` so these routes appear in
+``/api/openapi.json``.  See ``docs/plans/openapi-schema.md``.
+
 Endpoints
 ---------
 Settings sources:
@@ -9,19 +12,36 @@ Settings sources:
     POST /api/settings-sources/sync         — force import from source
 
 Labelset sources:
-    GET  /api/labelset-sources              — list available source plugins
+    GET  /api/labelset-sources                       — list available source plugins
     GET  /api/detectors/<name>/labelset-source       — get detector's source
     PUT  /api/detectors/<name>/labelset-source       — set or clear source
     POST /api/detectors/<name>/labelset-source/sync  — force import from source
+
+Schema-level validation failures surface as 422 with the standard
+``errors`` envelope; handler-level rejects (unknown source, detector not
+loaded) keep their HTTP codes (404) with the standard ``message``
+envelope.  Sending ``{}`` (empty body) clears the active source.
 """
 
 from __future__ import annotations
 
-from flask import Blueprint, jsonify
+from flask import jsonify
+from flask_smorest import Blueprint, abort
 
-from vtsearch.routes._shared import get_json_or_400
+from vtsearch.schemas.settings_io import (
+    OkMessageSchema,
+    SetSyncSourceRequestSchema,
+    SyncFromLabelsetSourceResponseSchema,
+    SyncFromSourceResponseSchema,
+    SyncSourceConfigSchema,
+    SyncSourceEntrySchema,
+)
 
-sync_sources_bp = Blueprint("sync_sources", __name__)
+sync_sources_bp = Blueprint(
+    "sync_sources",
+    __name__,
+    description="Manage the active settings / labelset sync sources.",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -30,72 +50,77 @@ sync_sources_bp = Blueprint("sync_sources", __name__)
 
 
 @sync_sources_bp.route("/api/settings-sources", methods=["GET"])
+@sync_sources_bp.response(200, SyncSourceEntrySchema(many=True))
 def list_settings_sources_route():
     """Return a list of all registered settings source plugins."""
     from vtsearch.settings_io.sources import list_settings_sources
 
-    return jsonify([src.to_dict() for src in list_settings_sources()])
+    return [src.to_dict() for src in list_settings_sources()]
 
 
 @sync_sources_bp.route("/api/settings-sources/active", methods=["GET"])
+@sync_sources_bp.response(200, SyncSourceConfigSchema)
 def get_active_settings_source():
     """Return the active settings source config, or null."""
     from vtsearch import settings
 
     cfg = settings.get_settings_source_config()
-    return jsonify(cfg)
+    # ``jsonify(None)`` short-circuits flask-smorest's schema.dump, which
+    # would otherwise turn ``None`` into ``{}``. The frontend expects a
+    # literal ``null`` when no source is configured.
+    if cfg is None:
+        return jsonify(None)
+    return cfg
 
 
 @sync_sources_bp.route("/api/settings-sources/active", methods=["PUT"])
-def set_active_settings_source():
+@sync_sources_bp.arguments(SetSyncSourceRequestSchema)
+@sync_sources_bp.response(200, OkMessageSchema)
+@sync_sources_bp.alt_response(404, description="Unknown settings source name.")
+def set_active_settings_source(body: dict):
     """Set or clear the active settings source.
 
-    Request body (JSON)::
-
-        {"source_name": "server_json_file", "field_values": {"filepath": "..."}}
-
-    Send ``null`` or ``{}`` to clear the active source.
+    A body of ``{}`` or one with empty ``source_name`` clears the active
+    source; otherwise both fields specify the new source.
     """
     from vtsearch import settings
     from vtsearch.settings_io.sources import get_settings_source
 
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    if not data or not data.get("source_name"):
+    source_name = (body.get("source_name") or "").strip()
+    if not source_name:
         settings.set_settings_source_config(None)
-        return jsonify({"ok": True, "message": "Settings source cleared."})
+        return {"ok": True, "message": "Settings source cleared."}
 
-    source_name = data["source_name"]
     source = get_settings_source(source_name)
     if source is None:
-        return jsonify({"error": f"Unknown settings source: {source_name!r}"}), 404
+        abort(404, message=f"Unknown settings source: {source_name!r}")
 
     config = {
         "source_name": source_name,
-        "field_values": data.get("field_values", {}),
+        "field_values": body.get("field_values") or {},
     }
     settings.set_settings_source_config(config)
-    return jsonify({"ok": True, "message": f"Settings source set to {source.display_name}."})
+    return {"ok": True, "message": f"Settings source set to {source.display_name}."}
 
 
 @sync_sources_bp.route("/api/settings-sources/sync", methods=["POST"])
+@sync_sources_bp.response(200, SyncFromSourceResponseSchema)
 def sync_settings_from_source():
     """Force a manual import from the active settings source."""
     from vtsearch import settings
 
     imported = settings.sync_from_settings_source()
     if imported is None:
-        return jsonify({"ok": False, "message": "No settings source configured or source is empty."})
+        # Always include ``keys`` (even empty) because marshmallow's
+        # fallback ``getattr(dict, "keys")`` returns ``dict.keys`` (the
+        # built-in method), which then fails to serialize.
+        return {"ok": False, "message": "No settings source configured or source is empty.", "keys": []}
 
-    return jsonify(
-        {
-            "ok": True,
-            "message": f"Imported {len(imported)} setting(s) from source.",
-            "keys": list(imported.keys()),
-        }
-    )
+    return {
+        "ok": True,
+        "message": f"Imported {len(imported)} setting(s) from source.",
+        "keys": list(imported.keys()),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -104,63 +129,63 @@ def sync_settings_from_source():
 
 
 @sync_sources_bp.route("/api/labelset-sources", methods=["GET"])
+@sync_sources_bp.response(200, SyncSourceEntrySchema(many=True))
 def list_labelset_sources_route():
     """Return a list of all registered labelset source plugins."""
     from vtsearch.labels.sources import list_labelset_sources
 
-    return jsonify([src.to_dict() for src in list_labelset_sources()])
+    return [src.to_dict() for src in list_labelset_sources()]
 
 
 @sync_sources_bp.route("/api/detectors/<detector_name>/labelset-source", methods=["GET"])
+@sync_sources_bp.response(200, SyncSourceConfigSchema)
 def get_detector_labelset_source(detector_name: str):
     """Return the labelset source config for a loaded detector, or null."""
     from vtsearch.state.core import get_detector_context
 
     ctx = get_detector_context(detector_name)
-    if ctx is None:
+    # ``jsonify(None)`` short-circuits flask-smorest's schema.dump (see
+    # ``get_active_settings_source``).
+    if ctx is None or ctx.labelset_source is None:
         return jsonify(None)
-
-    return jsonify(ctx.labelset_source)
+    return ctx.labelset_source
 
 
 @sync_sources_bp.route("/api/detectors/<detector_name>/labelset-source", methods=["PUT"])
-def set_detector_labelset_source(detector_name: str):
+@sync_sources_bp.arguments(SetSyncSourceRequestSchema)
+@sync_sources_bp.response(200, OkMessageSchema)
+@sync_sources_bp.alt_response(404, description="Detector not loaded or unknown labelset source.")
+def set_detector_labelset_source(body: dict, detector_name: str):
     """Set or clear the labelset source for a detector.
 
-    Request body (JSON)::
-
-        {"source_name": "server_json_file", "field_values": {"filepath": "..."}}
-
-    Send ``null`` or ``{}`` to clear the source.
+    A body of ``{}`` or one with empty ``source_name`` clears the source.
     """
     from vtsearch.labels.sources import get_labelset_source
     from vtsearch.state.core import get_detector_context
 
     ctx = get_detector_context(detector_name)
     if ctx is None:
-        return jsonify({"error": f"Detector not loaded: {detector_name!r}"}), 404
+        abort(404, message=f"Detector not loaded: {detector_name!r}")
 
-    data = get_json_or_400()
-    if not isinstance(data, dict):
-        return data
-
-    if not data or not data.get("source_name"):
+    source_name = (body.get("source_name") or "").strip()
+    if not source_name:
         ctx.labelset_source = None
-        return jsonify({"ok": True, "message": "Labelset source cleared."})
+        return {"ok": True, "message": "Labelset source cleared."}
 
-    source_name = data["source_name"]
     source = get_labelset_source(source_name)
     if source is None:
-        return jsonify({"error": f"Unknown labelset source: {source_name!r}"}), 404
+        abort(404, message=f"Unknown labelset source: {source_name!r}")
 
     ctx.labelset_source = {
         "source_name": source_name,
-        "field_values": data.get("field_values", {}),
+        "field_values": body.get("field_values") or {},
     }
-    return jsonify({"ok": True, "message": f"Labelset source set to {source.display_name}."})
+    return {"ok": True, "message": f"Labelset source set to {source.display_name}."}
 
 
 @sync_sources_bp.route("/api/detectors/<detector_name>/labelset-source/sync", methods=["POST"])
+@sync_sources_bp.response(200, SyncFromLabelsetSourceResponseSchema)
+@sync_sources_bp.alt_response(404, description="Detector not loaded.")
 def sync_detector_labelset_from_source(detector_name: str):
     """Force a manual import from the detector's labelset source."""
     from vtsearch.labels.sync import sync_from_labelset_source
@@ -168,15 +193,13 @@ def sync_detector_labelset_from_source(detector_name: str):
 
     ctx = get_detector_context(detector_name)
     if ctx is None:
-        return jsonify({"error": f"Detector not loaded: {detector_name!r}"}), 404
+        abort(404, message=f"Detector not loaded: {detector_name!r}")
 
     labels = sync_from_labelset_source(detector_name)
     if labels is None:
-        return jsonify({"ok": False, "message": "No labelset source configured or source is empty."})
+        return {"ok": False, "message": "No labelset source configured or source is empty."}
 
-    return jsonify(
-        {
-            "ok": True,
-            "message": f"Imported {len(labels)} label(s) from source.",
-        }
-    )
+    return {
+        "ok": True,
+        "message": f"Imported {len(labels)} label(s) from source.",
+    }

--- a/vtsearch/schemas/settings_io.py
+++ b/vtsearch/schemas/settings_io.py
@@ -1,0 +1,201 @@
+"""Schemas for the Settings Import/Export and Sync Sources APIs.
+
+Covers:
+
+* ``GET  /api/settings-importers``        — :class:`SettingsImporterEntrySchema`
+* ``POST /api/settings-exporters/export`` — :class:`RunSettingsExportRequestSchema` →
+                                             :class:`RunSettingsExportResponseSchema`
+* ``GET  /api/settings-exporters``        — :class:`SettingsExporterEntrySchema`
+* ``GET  /api/settings-sources``          — :class:`SyncSourceEntrySchema`
+* ``GET  /api/settings-sources/active``   — :class:`SyncSourceConfigSchema`
+* ``PUT  /api/settings-sources/active``   — :class:`SetSyncSourceRequestSchema` →
+                                             :class:`OkMessageSchema`
+* ``POST /api/settings-sources/sync``     — :class:`SyncFromSourceResponseSchema`
+* ``GET  /api/labelset-sources``          — :class:`SyncSourceEntrySchema`
+* ``GET  /api/detectors/<n>/labelset-source``      — :class:`SyncSourceConfigSchema`
+* ``PUT  /api/detectors/<n>/labelset-source``      — :class:`SetSyncSourceRequestSchema` →
+                                                      :class:`OkMessageSchema`
+* ``POST /api/detectors/<n>/labelset-source/sync`` — :class:`SyncFromLabelsetSourceResponseSchema`
+
+The per-plugin shape of ``field_values`` on ``POST
+/api/settings-exporters/export`` is intentionally declared as
+``fields.Dict()``: the inner keys vary per exporter and ``field_values``
+is validated inside the handler against the selected plugin's
+:attr:`fields` declaration.  The multipart-or-JSON ``POST
+/api/settings-importers/import/<importer_name>`` route stays on the
+legacy plain-Flask path (no decorator) for the same reason — see the
+*Resolved questions / Plugin field endpoints* section of
+``docs/plans/openapi-schema.md``.
+"""
+
+from __future__ import annotations
+
+from marshmallow import Schema, fields, validate
+
+
+class _PluginEntrySchema(Schema):
+    """Shared shape for plugin-listing endpoints.
+
+    Mirrors :meth:`vtsearch.plugins.PluginBase.to_dict`; the ``fields``
+    array's inner shape mirrors :meth:`vtsearch.plugins.PluginField.to_dict`
+    but is declared as ``fields.Dict()`` to avoid duplicating the source
+    of truth across schema and dataclass.
+    """
+
+    name = fields.String(required=True)
+    display_name = fields.String(required=True)
+    description = fields.String(required=True)
+    icon = fields.String(required=True)
+    ui_mode = fields.String(required=True)
+    hidden_from_picker = fields.Boolean(required=True)
+    # ``data_key`` / ``attribute`` keep the wire name as ``"fields"`` on both
+    # load and dump without shadowing :attr:`marshmallow.Schema.fields` (a
+    # ``dict[str, Field]`` registry on the base class).
+    plugin_fields = fields.List(
+        fields.Dict(),
+        required=True,
+        data_key="fields",
+        attribute="fields",
+    )
+
+
+class SettingsImporterEntrySchema(_PluginEntrySchema):
+    """One entry in ``GET /api/settings-importers``."""
+
+
+class SettingsExporterEntrySchema(_PluginEntrySchema):
+    """One entry in ``GET /api/settings-exporters``."""
+
+
+class SyncSourceEntrySchema(_PluginEntrySchema):
+    """One entry in ``GET /api/settings-sources`` and ``GET /api/labelset-sources``."""
+
+
+# ---------------------------------------------------------------------------
+# Settings exporter run
+# ---------------------------------------------------------------------------
+
+
+class RunSettingsExportRequestSchema(Schema):
+    """Body for ``POST /api/settings-exporters/export``.
+
+    ``field_values`` is permissive (``fields.Dict``) because its keys
+    depend on the named exporter; the handler validates the inner shape
+    against the selected plugin.
+    """
+
+    exporter_name = fields.String(required=True, validate=validate.Length(min=1))
+    field_values = fields.Dict(load_default=dict)
+
+
+class RunSettingsExportResponseSchema(Schema):
+    """Response for ``POST /api/settings-exporters/export``.
+
+    ``download`` / ``data`` / ``filename`` are populated by the
+    ``local_json_file`` exporter; ``filepath`` by ``server_json_file``;
+    other exporters can return any extra keys.
+    """
+
+    success = fields.Boolean(required=True)
+    message = fields.String()
+    download = fields.Boolean()
+    data = fields.Dict()
+    filename = fields.String()
+    filepath = fields.String()
+
+    class Meta:
+        # Exporter-specific extension keys flow through on dump.
+        unknown = "include"
+
+
+# ---------------------------------------------------------------------------
+# Sync source config (shared by settings-sources and labelset-sources)
+# ---------------------------------------------------------------------------
+
+
+class SyncSourceConfigSchema(Schema):
+    """A persisted sync-source config.
+
+    The wire shape is either ``null`` (no source configured) or
+    ``{"source_name": "...", "field_values": {...}}``.  This schema
+    describes the populated form; the ``null`` case is documented via
+    ``response(... )`` and the handler returning ``None``.
+    """
+
+    source_name = fields.String(required=True)
+    field_values = fields.Dict(load_default=dict)
+
+
+class SetSyncSourceRequestSchema(Schema):
+    """Body for ``PUT /api/settings-sources/active`` and
+    ``PUT /api/detectors/<name>/labelset-source``.
+
+    A body of ``{}`` or one with empty ``source_name`` clears the active
+    source.  Otherwise both fields specify the new source.  ``source_name``
+    is declared as optional so the clear-by-empty-body shape continues to
+    work; the handler 404s on unknown source names.
+    """
+
+    source_name = fields.String(load_default="")
+    field_values = fields.Dict(load_default=dict)
+
+
+class OkMessageSchema(Schema):
+    """``{ok: bool, message: str}`` — generic ack envelope."""
+
+    ok = fields.Boolean(required=True)
+    message = fields.String(required=True)
+
+
+# ---------------------------------------------------------------------------
+# Sync-from-source responses
+# ---------------------------------------------------------------------------
+
+
+class SettingsImportResponseSchema(Schema):
+    """Response for ``POST /api/settings-importers/import/<importer_name>``.
+
+    The route stays on the legacy plain-Flask path (request body is a
+    plugin-field shape), but the success body shape is fixed.  Currently
+    *not* attached to the route via ``@response`` — kept here for the
+    eventual unified plugin-field migration.
+    """
+
+    success = fields.Boolean(required=True)
+    message = fields.String(required=True)
+    keys = fields.List(fields.String(), required=True)
+
+
+class SyncFromSourceResponseSchema(Schema):
+    """Response for ``POST /api/settings-sources/sync``.
+
+    ``ok=true`` carries ``keys`` (imported setting names) and ``message``.
+    ``ok=false`` (no source configured / source empty) carries only
+    ``message``.
+    """
+
+    ok = fields.Boolean(required=True)
+    message = fields.String(required=True)
+    keys = fields.List(fields.String())
+
+
+class SyncFromLabelsetSourceResponseSchema(Schema):
+    """Response for ``POST /api/detectors/<name>/labelset-source/sync``."""
+
+    ok = fields.Boolean(required=True)
+    message = fields.String(required=True)
+
+
+__all__ = [
+    "OkMessageSchema",
+    "RunSettingsExportRequestSchema",
+    "RunSettingsExportResponseSchema",
+    "SetSyncSourceRequestSchema",
+    "SettingsExporterEntrySchema",
+    "SettingsImportResponseSchema",
+    "SettingsImporterEntrySchema",
+    "SyncFromLabelsetSourceResponseSchema",
+    "SyncFromSourceResponseSchema",
+    "SyncSourceConfigSchema",
+    "SyncSourceEntrySchema",
+]


### PR DESCRIPTION
## Summary

The last two plain-Flask blueprints — `settings_io_bp` and
`sync_sources_bp` — now go through `flask_smorest.Blueprint`, so their
routes appear in `/api/openapi.json` and Swagger UI. After this PR
every backend blueprint that returns JSON is migrated; the only routes
still on plain Flask are `events_bp` (SSE) and the four plugin-field
endpoints documented in the *Resolved questions / Plugin field
endpoints* section of `docs/plans/openapi-schema.md`.

### What moved

- `GET  /api/settings-importers` — list, typed
- `POST /api/settings-importers/import/<importer_name>` — **stays on
  plain Flask** on the smorest blueprint (plugin-field shape, same
  pattern as `labels/importers.py`)
- `GET  /api/settings-exporters` — list, typed
- `POST /api/settings-exporters/export` — fully typed
- `GET  /api/settings-sources` — list, typed
- `GET  /api/settings-sources/active` — nullable, typed
- `PUT  /api/settings-sources/active` — fully typed (empty body or
  empty `source_name` clears)
- `POST /api/settings-sources/sync` — typed
- `GET  /api/labelset-sources` — list, typed
- `GET  /api/detectors/<n>/labelset-source` — nullable, typed
- `PUT  /api/detectors/<n>/labelset-source` — fully typed
- `POST /api/detectors/<n>/labelset-source/sync` — typed

Schemas live in the new `vtsearch/schemas/settings_io.py`. Schema-level
validation failures (missing required `exporter_name` / `source_name`)
surface as 422 with the standard `errors` envelope; handler-level
rejects (unknown exporter/source, detector not loaded, missing plugin
field, invalid filepath) keep their HTTP codes (404 / 400 / 500) with
the standard `message` envelope. 404s from `abort()` are still
intercepted by the app-level `NotFound` errorhandler and keep the
legacy `{"error": "Not Found", "request_id": ...}` shape — same as the
other migrated blueprints.

### Two subtleties

- **Nullable GETs return `jsonify(None)`.** flask-smorest runs the
  return value through `schema.dump`, which turns `None` into `{}`.
  The frontend (and the existing test) expects a literal `null`, so
  the nullable endpoints short-circuit by returning `jsonify(None)`
  directly.
- **`/sync` always includes `keys`.** Marshmallow's `getattr` fallback
  resolves `keys` on a plain dict to the built-in `dict.keys` method,
  which then fails to serialize. The handler always returns a `keys`
  list (empty when no source is configured).

## Test plan

- [x] `./run-tests.sh` — 3627 passed, 1 skipped (full suite)
- [x] `pytest tests/io/test_settings_io.py tests/io/test_sync_sources.py` — 118 passed
- [x] `ruff check` + `ruff format --check`
- [x] Updated `tests/io/test_settings_io.py::test_missing_exporter_name_400` →
      `test_missing_exporter_name_422` (schema-level rejection)
- [x] Plan doc (`docs/plans/openapi-schema.md`) updated with the
      shipped item + the two subtleties

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139etydCrgyLqc6c5xiUkSD)_