### PR TITLE
Draft active-context-switcher plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ When you have a question for the user — to disambiguate requirements, choose b
 
 Use plain prose questions only when the answer is genuinely open-ended (e.g. "What should this field be named?") and a multiple-choice list would be artificial.
 
+## Frontend Scope: Desktop Only
+
+VTSearch is a desktop web app. **Do not design, implement, or test for mobile or narrow viewports.** No responsive breakpoints, no touch-targeted controls, no mobile-only layouts, no concerns about portrait orientation. If a design discussion raises "what about mobile?", the answer is "we don't care." When evaluating a layout, assume a standard desktop viewport and skip mobile considerations entirely.
+
 ## No Persisted Vectors or MLPs (CRITICAL)
 
 **Embeddings and trained MLP weights are in-memory artifacts only.** Never serialize them to disk, to `data/settings.json`, to detector / detector JSON files, or to any other persistent store. Origins are the canonical persisted form: the system rederives `origin → file → embedding → MLP` on demand.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,6 +19,7 @@ or [ARCHITECTURE.md](../ARCHITECTURE.md), the plan file is deleted.
 | [feature-brainstorm.md](feature-brainstorm.md) | **Backlog** | Wide-ranging idea backlog — new media types, converters, clippers, demo datasets, experiments. Items graduate into their own plan doc as they mature. |
 | [ux-brainstorm.md](ux-brainstorm.md) | **Backlog** | Audit of friction across importers, labeling, sorting, settings, and progress UX. ~75 ideas across auto-fill, hints, speed-ups, clarity, streamlining, and consistency. Items graduate into their own plan doc as they mature. |
 | [smart-clipper-defaults.md](smart-clipper-defaults.md) | **Phase 1 shipped; Phase 2 deferred** | "Auto (recommended)" clipper entry for audio and video — resolves to pass-through or tiling per dataset based on median duration. Phase 2 (per-media routing via clipper options) deferred — see Open follow-ups. |
+| [active-context-switcher.md](active-context-switcher.md) | **Proposed** | Top-bar dataset/detector read-only fields become click-to-switch pulldowns (compatibility dim, "Add New" footers, in-place modal launching). Phase 2 encodes the active pair in the URL; Phase 3 surfaces in-flight job spinners + verifies each job-producing view rehydrates from `JobManager`'s signature cache. Graduates ux-brainstorm §6.11 + §8.2. |
 
 ## Recently completed (removed)
 

--- a/docs/plans/active-context-switcher.md
+++ b/docs/plans/active-context-switcher.md
@@ -1,0 +1,259 @@
+# Active-context switcher (top-bar dataset/detector pulldowns)
+
+*Status: Proposed (no code yet). Three phases — each ships independently.*
+
+This plan implements [ux-brainstorm.md §6.11](ux-brainstorm.md#611-active-datasetdetector-indicator--s) ("Active-dataset/detector indicator") and largely closes [§8.2](ux-brainstorm.md#82-switching-active-datasetdetector--s) ("Switching active dataset/detector"). It supersedes both entries as the canonical design — when this plan ships those entries will be marked SHIPPED and link here.
+
+## Problem
+
+The top bar at `frontend/src/app/app.component.html:62-63` already shows the active dataset and detector as **read-only text** (`Data: foo` / `Detector: cats`) driven by `ActiveContextService`, which is the same source that drives the `X-Dataset-Id` / `X-Detector-Id` headers sent on every API request.
+
+What it doesn't do:
+
+1. Let the user **switch** the active pair without going back to the Dashboard. Switching today is: navigate to Dashboard → reselect → click Train (or Find). The §6.11 promise was a 2-click pulldown change from the label view.
+2. Let the user **create** a new dataset / detector without that same Dashboard round-trip.
+3. Let the URL **encode** the active pair. Reloading `/label` doesn't reliably restore the previous pair; pasting `/label` to a colleague doesn't share "Train on DataA / DetectorB" (Phase 2 territory).
+4. Let the user **see** that a long-running job is in flight on a non-active pair (Phase 3 territory).
+
+The §6.11 "indicator" half is already shipped via the existing read-only text. This plan delivers the missing **switcher** half plus the two related affordances (URL encoding, in-flight job visibility) that came up while designing it.
+
+## Design summary — rules that govern every behavior in the plan
+
+These came out of the design discussion and are repeated here so a fresh Claude implementing any phase can resolve ambiguity without re-deriving them.
+
+1. **Switcher = Dashboard shortcut, nothing less.** Clicking a pulldown entry is exactly equivalent to "go back to Dashboard, select that item, click Train/Find." Full prep fires — dataset load, detector load, labelset re-resolve against the new embedder, threshold recompute, etc. We **do not** skip any prep just because the user used the shortcut.
+2. **Show everything, don't filter.** The pulldown list mirrors the user's Dashboard grid exactly — same items, same order. Incompatible items (different `media_type` than the other half of the pair) are **dimmed/desaturated**, not hidden, so the user's mental map of "what exists" doesn't shift between surfaces.
+3. **No auto-swap.** Picking an incompatible item never silently swaps the other half "to fix it." Instead the view below collapses to an explainer and the user picks the fix themselves.
+4. **No prep on an incompatible pair.** When the active pair is incompatible, the standard Train/Find prep **does not fire**. We don't want to load a dataset or materialize a labelset just to immediately invalidate it. Prep only runs once both halves are compatible.
+5. **Replace, not widen.** The switcher in Find re-launches single-pair Find on the new pair — it does *not* add a dataset to a running multi-dataset Find. (Multi-N Find lives on the Dashboard via `onOldFind` and is out of scope for this plan; the `/find` route itself is always single-pair.)
+6. **Reset view-local state on switch.** Scroll position, partial Find query input, etc. all reset. Switching is mentally a re-entry to the view, like going through the Dashboard would be.
+7. **Background-continue in-flight jobs (Phase 3).** Jobs run against a `DetectorContext`/`DatasetContext` regardless of which one the UI is looking at, and `JobManager` caches results by signature. So switching away doesn't waste work — the result lives in the cache and the view rehydrates on re-entry. Phase 3 wires the visibility (spinner glyph) + verifies every job-producing view actually rehydrates.
+8. **Honest loading state.** A switch that triggers 30s of prep should look like 30s of prep — same loading affordance the Dashboard route shows today. When the new dataset's embedder differs from the previous dataset's, the message reads "Re-resolving labels for X's embedder…" rather than a generic spinner.
+9. **Desktop only.** No responsive / mobile design. Truncate-with-ellipsis on the closed state, widen the menu on open. (See `CLAUDE.md` § "Frontend Scope: Desktop Only".)
+
+## Architecture — where each piece lives
+
+- **`frontend/src/app/services/active-context.service.ts`** — Today holds `datasetId` / `modelId` as `BehaviorSubject`s and is read by `activeContextInterceptor`. Phase 1 extends it with `setActivePair(datasetId, detectorId)` so the switcher writes both atomically (avoids a transient mismatched pair fighting through the interceptor). Phase 2 drives the subjects from the URL via a route param.
+- **`frontend/src/app/app.component.html` + `.scss` + `.ts`** — Replaces the two read-only `<span class="top-bar-field">` blocks at `app.component.html:62-63` with two instances of a new `<vt-context-pulldown>` component (one for dataset, one for detector).
+- **New: `frontend/src/app/components/context-pulldown/`** — The pulldown component itself. One file set, two instances (dataset / detector) parameterized by `kind: 'dataset' | 'detector'`. Owns the dropdown overlay, row rendering (glyph + fade + label), "Add New" footer, placeholder text, ellipsis truncation, click-outside-to-close, keyboard navigation.
+- **`frontend/src/app/services/datasets-api.service.ts` + `detectors-api.service.ts`** — Already expose `/api/datasets/registry` and `/api/detectors/registry`. The pulldown subscribes to these for its row list.
+- **`frontend/src/app/components/dashboard/dashboard.component.ts`** — Hosts the importer modal and new-detector modal today. Phase 1 hoists their *invocation* into a small service (`NewThingFlowsService` or equivalent) so the pulldown's "Add New" footer can open them in-place over Train/Find without navigating to the Dashboard. The Dashboard's own buttons keep working — they just route through the same service.
+- **`vtsearch/routes/detectors/find.py`** — Backend already supports multi-dataset Find; the switcher does not change this. The `/find` GUI route remains single-pair (`onFind` in `dashboard.component.ts`).
+- **`frontend/src/app/services/find-session.service.ts`** — Will likely be deletable once Phase 2 lands (the URL becomes the source of truth). Phase 1 leaves it alone.
+
+## Phase 1 — Switcher core
+
+Ship the pulldown UI, click-to-switch, compatibility handling, "Add New" footers, and the loading / cancellation behaviors. After Phase 1 the URL is unchanged; the active pair still lives in `ActiveContextService` exactly as today.
+
+### Files
+
+- **New**: `frontend/src/app/components/context-pulldown/context-pulldown.component.{ts,html,scss,spec.ts}`
+- **New**: `frontend/src/app/services/new-thing-flows.service.ts` — invokable launcher for the importer modal and the new-detector modal, decoupled from the Dashboard component. Holds open/close state, completion callbacks.
+- **New**: `frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.{ts,html,scss}` — the explainer rendered in place of Train/Find content when the active pair is incompatible. Owns the two recovery affordances (focus other pulldown / go to Dashboard).
+- **Modify**: `frontend/src/app/app.component.html` — replace `app.component.html:62-63` with two `<vt-context-pulldown>` instances. Wire the incompatible-pair explainer at the page level (sibling of `<router-outlet />`) so it can override view content when the pair is incompatible.
+- **Modify**: `frontend/src/app/app.component.ts` — drop `datasetDisplayName` / `modelDisplayName` direct bindings (the pulldown owns its own labels now); subscribe to `ActiveContextService` for the "is active pair compatible?" predicate that gates the explainer overlay.
+- **Modify**: `frontend/src/app/app.component.scss` — remove `.top-bar-field` / `.top-bar-value` styling (moves into the pulldown). Keep `.top-bar-spacer` etc.
+- **Modify**: `frontend/src/app/services/active-context.service.ts` — add `setActivePair(datasetId, detectorId)` that emits both subjects atomically.
+- **Modify**: `frontend/src/app/components/dashboard/dashboard.component.ts` — refactor the importer modal and new-detector modal openers to go through `NewThingFlowsService`. Dashboard buttons keep working; the pulldown's "Add New" footer also calls into the same service.
+- **Modify**: `frontend/src/app/components/find-view/find-view.component.ts` — handle the pulldown-driven pair change. On a new pair, treat as a fresh entry to `/find` (re-run the same prep that `onFind` runs today). The view should not assume `FindSessionService` was pre-populated — the switcher does not write `FindSessionService`.
+- **Modify**: `frontend/src/app/components/label-view/label-view.component.ts` — same: handle pair changes by re-entering the prep path.
+
+### Pulldown behavior
+
+Each pulldown row shows:
+
+- **Glyph (leftmost)** — three states, single character each:
+  - `○` (or `·`) — registered but not loaded into RAM. Click costs disk + embedding time.
+  - `●` (or `–`) — loaded into RAM. Click is fast (no load needed; detector may still re-resolve labels if embedder differs).
+  - `✓` — loaded **and** currently active. Click is a no-op.
+- **Label** — the registry item's display name. Append a small `· image` / `· audio` / `· text` / `· video` / `· document` tag in a muted color showing the item's `media_type`.
+- **Row state**:
+  - **Compatible with the other half**: full opacity, hover highlight, click switches.
+  - **Incompatible with the other half**: ~50% opacity, no hover highlight, click still switches (the user explicitly opted in by clicking). Tooltip on hover: `"Detector ImgerB embeds images; cannot score audio dataset AudiosC."` (or the appropriate inversion for dataset rows).
+- **Active row marker**: the active row gets the `✓` glyph (already covered above); also use bold or a subtle background tint so it's identifiable at a glance.
+
+Row order: **mirror the Dashboard grid's order exactly.** Don't re-sort compatibles to the top.
+
+Footer (always present, even with empty registry):
+
+- `+ Add New Dataset` / `+ Add New Detector` — visually distinct from the rows above (separator + lighter background). Clicking opens the Dashboard's importer / new-detector modal **in-place over the current view** via `NewThingFlowsService`. On successful completion the new item becomes the active half of the pair (other half unchanged), and the user stays in their current view. If the resulting pair is incompatible, the explainer takes over normally.
+
+Placeholder text when no item is selected for that half (initial state, or after the active item is unloaded/deleted):
+
+- Dataset pulldown: `Select a dataset`
+- Detector pulldown: `Select a detector`
+
+Empty-registry behavior: pulldown contains only the "Add New" footer; the placeholder is unchanged.
+
+Truncation: closed state uses CSS ellipsis on the label. Open state widens the menu (e.g. `max-width: 480px` or wider) so long names render fully. No mobile considerations.
+
+### Compatibility predicate
+
+Single helper, single source of truth (proposed: `frontend/src/app/utils/context-compat.ts`):
+
+```ts
+export function isPairCompatible(
+  dataset: DatasetRegistryEntry | null,
+  detector: DetectorRegistryEntry | null,
+): boolean {
+  if (!dataset || !detector) return false; // half-set pair is "not yet compatible"
+  return dataset.media_type === detector.media_type;
+}
+```
+
+Datasets and detectors each have a single `media_type` (confirmed in design). Strict equality. Implementing this as a predicate function (rather than inlining `===`) means future multi-media-type detectors — if they ever exist — only require updating one place.
+
+### Add-new footer flow (decided)
+
+- The Dashboard's existing importer modal and new-detector modal must be invokable from outside the Dashboard component. Refactor: extract the open/close state and the post-completion callback wiring into `NewThingFlowsService`. The Dashboard's own toolbar buttons re-route through it. The pulldown's "Add New" footer calls the same service methods.
+- On successful import/create:
+  - Service emits a `created` event with the new ID.
+  - The pulldown listens, calls `activeContext.setActivePair(...)` with the new ID in the appropriate half and the other half unchanged.
+  - The user stays in their current view (Train/Find). The standard prep fires for the new pair, including the loading state.
+  - If the new pair is incompatible, the explainer takes over and the user fixes the other half (which can be another "Add New" round if needed).
+
+### Incompatible-pair explainer
+
+Rendered as a sibling of `<router-outlet />` in `app.component.html`, conditionally shown when `isPairCompatible(activeDataset, activeDetector)` returns false **and** the current route is one that consumes the active pair (`/label`, `/find`).
+
+Text template (copy lifted from design discussion, parameterize names):
+
+> **AudiosC** and **ImgerB** are incompatible because they are different media types (audio vs. image).
+>
+> Please choose a compatible pair, or go to the dashboard.
+>
+> [ Pick a compatible detector ]   [ Go to Dashboard ]
+
+- `Pick a compatible detector` (label inverts when the *dataset* half is the one to swap): opens the *other* pulldown with the dropdown menu open and scrolled to the first compatible row.
+- `Go to Dashboard`: `router.navigate(['/dashboard'])`.
+
+The standard Train/Find prep **does not run** while the explainer is showing. The view's data state remains whatever it was before the user clicked an incompatible row; on returning to a compatible pair, normal prep fires for the new pair (not the old one).
+
+### Loading state on switch
+
+The switch triggers exactly the prep path that the Dashboard's "Train" / "Find" buttons trigger today. Reuse the existing loading affordance (`datasetState.setLoading(true)` + progress polling in `dashboard.component.ts:1278`'s `loadRegistered` flow). Two cosmetic refinements:
+
+- When the new dataset's embedder differs from the previously-active dataset's embedder, the progress message shows `Re-resolving labels for <embedder name>…` during the labelset re-materialization step (replaces the generic spinner text). This helps the user understand why a same-MediaType, same-detector switch can still take 30s.
+- Background load: the progress polling mechanism already exists (`startProgressPolling`). The switcher does not invent a new polling loop.
+
+### Cancel-and-replace on rapid re-click
+
+User clicks DataB, prep starts (load + re-resolve, 30s budget), user clicks DataC 5s in. Behavior:
+
+1. Cancel any cancellable in-flight prep step for DataB. `cancel_dataset_progress()` already exists for the dataset load (`vtsearch/concurrency/progress.py`); use it.
+2. For prep steps that aren't gracefully cancellable (most embedding work isn't preemptible), tag each switcher invocation with a monotonic request id. On completion, if the in-flight request id doesn't match `activeContext.currentRequestId`, discard the result (don't write it to the context, don't dismiss the loader).
+3. Start the new prep for DataC.
+
+This matches browser back/forward semantics: the user expects "latest click wins."
+
+If cancellation turns out to be infeasible for some intermediate step, that's acceptable — the request-id check is the actual correctness guarantee. Cancellation is a CPU/bandwidth optimization, not a correctness mechanism.
+
+### View-local state on switch
+
+Reset everything view-local:
+
+- Scroll position in the media list.
+- Partial Find query text (not yet submitted).
+- Any in-progress region-vote draft (rectangle being drawn but not committed).
+- Sort mode selection — actually, this is a *user* setting (per-user-tier), so it persists across switches. Don't reset.
+- Inclusion toggles — also per-user-tier. Persist.
+
+Rule of thumb: per-user settings (in `vtsearch/settings.py` "Per-user tier") survive a switch by design. Per-view ephemeral UI state resets. Per-`DetectorContext` state (votes, last_learned_scores, etc.) is naturally per-pair; switching shows the new pair's state.
+
+### Switcher placement across views
+
+The top bar is global (rendered in `app.component.html`'s `<header>`), so the pulldowns appear on every page. Behavior per route:
+
+- `/label` (Train), `/find` — full behavior as described.
+- `/dashboard` — pulldowns visible and interactive. Picking an item there is silly (the grid is right there) but not disallowed; the active pair updates and the Dashboard's own selection state is independent of the active pair so nothing breaks.
+- Anywhere else (e.g. mid-modal flow) — pulldowns visible. Switching doesn't dismiss the modal; if the modal depends on the active pair (rare), it's expected to either re-fetch or warn. Treat this as a v2 polish question; v1 doesn't add explicit guards.
+
+### Edge cases (Phase 1)
+
+1. **Active pair is half-set** (e.g. dataset selected, no detector): The half that's set shows its label; the empty half shows the placeholder. The explainer takes over the view since `isPairCompatible` returns false for a null half.
+2. **Both halves unset (first run)**: Both pulldowns show placeholders. Explainer shows: "Pick a dataset and detector to begin." Same two buttons (focus dataset pulldown / go to Dashboard).
+3. **Active pair references a deleted/unregistered item**: Detect via subscription to the registry list. Clear that half via `activeContext.setActivePair(...)` with the survivor. Show a toast: `"Dataset 'Foo' was removed. Pick another."`
+4. **User opens pulldown while a switch is mid-prep**: Pulldown opens normally; clicking another row cancel-and-replaces as above. The in-flight loader keeps animating.
+5. **User clicks the active row**: No-op. Don't dismiss; don't re-fire prep.
+6. **Registry endpoint returns an error**: Show pulldown with only the "Add New" footer + a small inline error: `"Couldn't load datasets — retry?"`
+7. **`FindSessionService` mismatch**: Today `find-view` reads from `FindSessionService` to know which detector to query against. With switcher-initiated entries, `FindSessionService` may be stale or empty. Phase 1 fix: read primarily from `ActiveContextService`; treat `FindSessionService` as a soft hint only. (Phase 2 may delete `FindSessionService` entirely.)
+
+## Phase 2 — URL-driven active context
+
+Move the active pair into the route so reload, share-link, and browser back/forward all carry the pair correctly. After Phase 2 the switcher just calls `router.navigate(...)`; `ActiveContextService` is driven by the route, not the other way around.
+
+### Files
+
+- **Modify**: `frontend/src/app/app.routes.ts` — Routes become:
+  ```ts
+  { path: 'label/:datasetId/:detectorId', loadComponent: ... },
+  { path: 'find/:datasetId/:detectorId', loadComponent: ... },
+  { path: 'label', redirectTo: 'dashboard' }, // legacy bare path → dashboard
+  { path: 'find', redirectTo: 'dashboard' },
+  ```
+- **New**: `frontend/src/app/guards/active-context.guard.ts` — Route guard that:
+  1. Validates the URL `datasetId` / `detectorId` against the registry (404 to Dashboard if either is unknown).
+  2. Calls `activeContext.setActivePair(datasetId, detectorId)`.
+  3. Triggers the standard load if either half isn't already loaded.
+  4. Lets the route activate once loading completes (or immediately if both are loaded).
+- **Modify**: `frontend/src/app/services/active-context.service.ts` — The setters become **private** (or at least flagged "called only by the guard / router"); the switcher pulldown calls `router.navigate(['/label', dsId, detId])` instead of `activeContext.setActivePair(...)`. Existing code that calls `setDatasetId` / `setModelId` directly (`dashboard.component.ts:1252-1253`, etc.) is migrated to navigation.
+- **Modify**: `frontend/src/app/components/dashboard/dashboard.component.ts` — `onFind` and `onTrain` change from `setDatasetId + setModelId + router.navigate(['/find'])` to `router.navigate(['/find', dsId, detId])`. The guard handles the rest.
+- **Delete (likely)**: `frontend/src/app/services/find-session.service.ts` — `modelId` / `datasetId` move to route params; `modelName` is derivable from the registry.
+
+### Backwards compatibility
+
+- Bare `/label` and `/find` redirect to Dashboard (no active pair to encode).
+- Bookmarks to old `/label` and `/find` URLs land on Dashboard, not a broken view.
+- localStorage rehydration of the active pair is removed (the URL is authoritative). If we want "remember last pair across sessions," persist it as a setting and have the Dashboard's Train/Find buttons consult it as a default — but that's separate from Phase 2's correctness goal.
+
+### Edge cases (Phase 2)
+
+1. **Race: guard starts loading DataB, user clicks back to a `/label/DataA/DetA` URL**: The router cancels the in-flight navigation and starts the new one. The Phase 1 cancel-and-replace logic (request-id check on completion) already handles the race correctly — no Phase 2-specific work needed.
+2. **Shared URL points to a dataset the recipient doesn't have access to**: Guard returns false, redirects to Dashboard, shows a toast: `"Dataset 'foo' is not available."`
+3. **Pair encoded in URL is incompatible**: Guard allows the navigation (incompatibility is a valid UI state); the explainer renders.
+
+## Phase 3 — In-flight job affordances
+
+Make running async jobs visible in the pulldown, and verify each job-producing view actually re-reads from `JobManager`'s signature cache on re-entry.
+
+### Files
+
+- **Modify**: `frontend/src/app/components/context-pulldown/context-pulldown.component.{ts,html,scss}` — Add a spinner glyph to rows whose pair has a job in flight. Subscribe to a new (or existing) endpoint that exposes the set of pairs with running jobs.
+- **Modify (likely)**: `frontend/src/app/services/active-context.service.ts` or a new `running-jobs.service.ts` — Holds a `Set<string>` of `${datasetId}::${detectorId}` keys with active jobs. Polls or subscribes via SSE.
+- **Verification sweep + wire-up (the harder half of this phase)**: For each job-producing view, confirm that on `ngOnInit` (or context-change subscription) the view queries `JobManager` for the cached result against the current signature, and rehydrates the UI from it if found:
+  - **Eval view** — check that re-entering after switching away mid-eval restores the in-progress UI (or finished results) from cache.
+  - **Labeling-progress training** (`vtsearch/detectors/labeling_progress.py` — the per-step MLP cache + stability analysis) — check the same.
+  - **Learned-sort jobs** — check that scores from a completed background sort are visible on re-entry.
+- For any view that doesn't currently rehydrate, wire it. The cache exists (`JobManager` keeps results by signature); the work is making each view subscribe + render.
+
+### Spinner glyph
+
+In addition to the three-state load glyph (`○ / ● / ✓`), append a small animated spinner (`⟳` or similar) at the right edge of the row if any job is running on that pair. Tooltip: `"Eval running on this pair"` or similar.
+
+The spinner is **per-pair**, not per-half. If DataA/DetX has a job and the user is on DataA/DetY, the spinner shows on the DetX row in the detector pulldown (the row that completes the busy pair), not on the DataA row.
+
+### Verification protocol
+
+Implementer should write a short Markdown table in this plan's "What shipped" section listing each job type, which view consumes it, and whether the view rehydrated already vs. needed wiring. This becomes the durable record of "we checked these."
+
+### Edge cases (Phase 3)
+
+1. **Job completes while the user is on a different pair**: The spinner glyph disappears from the row; no toast or other notification (out of scope — the existing app doesn't have a notification system).
+2. **Multiple jobs on the same pair**: Single spinner; tooltip lists all running job types.
+3. **Job is cancelled by the user from elsewhere**: Spinner disappears.
+4. **JobManager has a pending slot AND a running slot for the same manager** (the "latest wins" pre-emption pattern): Show the spinner for the *intended* pair, which is the pending one — the running one is about to be cancelled. (Or both, with a tooltip explaining. Implementer's call; document choice in "What shipped.")
+
+## Out of scope
+
+These came up in design and were deliberately deferred or rejected.
+
+- **Typeahead search inside the dropdown** — Deferred until the registry routinely exceeds ~10 items per side. Adding it later is a self-contained polish item.
+- **Mobile / narrow viewports** — Never. See `CLAUDE.md` § "Frontend Scope: Desktop Only."
+- **Inline editing of the multi-dataset Find set from the top bar** — Multi-N Find is a Dashboard-launched fire-and-forget flow (`onOldFind`) that renders into a results modal without entering the Find view. Cramming a multi-select into the top-bar pulldown would overload the control (same widget meaning two different things depending on launch path). The Dashboard remains the surface for "Find across N datasets."
+- **Compatibility predicate beyond media-type equality** — Datasets and detectors each have a single `media_type`; multi-MediaType detectors don't exist today and adding the abstraction prematurely would be speculative.
+- **Cross-session "remember my last pair" persistence** — Not part of the switcher itself. If wanted, layer on as a separate per-user setting that the Dashboard's Train/Find buttons consult for default selection. Out of scope here so Phase 2 stays focused on URL-as-identity.
+- **Notification when a backgrounded job completes** — The app has no general notification system; adding one is much bigger than this plan. Phase 3's spinner-disappears-when-done is the affordance for v1.
+
+## Open questions
+
+(None at draft time — the design was fully resolved in conversation before this plan was written. Implementers should add new questions here as they encounter ambiguity, and ping the user before guessing.)

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -269,8 +269,8 @@ Each long-running operation emits a slightly different progress payload (`step`/
 ### 6.10 Date formatting ★ XS — SHIPPED
 "last_trained / created" columns format dates differently from the version string in the footer. ~~Use one formatter (relative for < 7d ago, absolute YYYY-MM-DD otherwise) everywhere.~~ Shipped: a single `frontend/src/app/utils/format-date.ts` is now called from all four sites (detector card, dataset card, dataset stats modal, settings-modal version footer). Always-absolute — no relative branch. Columns render `YYYY-MM-DD HH:MM` (local), version renders `YYYY-MM-DD` (UTC). Relative time was dropped deliberately: it drifts on every reload and the coarse buckets (`2w ago`) throw away precision that matters in a model-management dashboard.
 
-### 6.11 Active-dataset/detector indicator ★★ S
-Inside Train/Find views there's no clear top-bar indicator of which dataset/detector is active. The frontend already sets `X-Dataset-Id` / `X-Detector-Id` headers — surface those names in a fixed header strip "🗂 Dataset: foo · 🧪 Detector: cats" with a click-to-switch dropdown. Removes the dashboard round-trip from §5 of the workflow trace.
+### 6.11 Active-dataset/detector indicator ★★ S — graduated to plan
+**Indicator half is already shipped** as read-only top-bar text (`app.component.html:62-63`, `Data: foo` / `Detector: cats`, driven by `ActiveContextService`). **Switcher half** — turning the read-only fields into click-to-switch pulldowns with compatibility handling, "Add New" footers, in-place modal launching, URL-encoded active pair, and in-flight job spinners — is now scoped as a three-phase plan: see [active-context-switcher.md](active-context-switcher.md). That plan also largely closes [§8.2](#82-switching-active-datasetdetector--s).
 
 ### 6.12 Plugin field types ★ S — shipped
 Free-text fields that should be numbers (`n_mels`, `time_window_s`, `size` for synthetic), enums that should be selects (`colormap`, `language` for OCR), and password fields disguised as text (`auth_header`). Tighten the `PluginField` type system and migrate.
@@ -335,8 +335,8 @@ Workflows the user *can* do today but that take too many steps and clicks.
 Today: open menu → pick importer category → pick importer → fill form → pick media type → pick embedder → submit → wait → close modal → select dataset → click "New detector" → fill form → click Train → vote 7 items → export → pick exporter → fill form → submit. That's ~15 clicks before the user has anything to show.
 **Compressed flow:** "Quick start" CTA on empty dashboard → pick a media type → upload a folder → app auto-creates a detector with the folder's name and drops the user into the labeling view. Export becomes a single header button with a recent-target fallback.
 
-### 8.2 Switching active dataset/detector ★★ S
-Today: navigate back to dashboard → reselect → click Train again. With (§6.11) in place, this becomes a 2-click dropdown switch from the label view. Bonus: the new selection inherits sort mode + query.
+### 8.2 Switching active dataset/detector ★★ S — graduated to plan
+Today: navigate back to dashboard → reselect → click Train again. Scoped together with §6.11 as the [active-context-switcher.md](active-context-switcher.md) plan: top-bar pulldowns make this a 1-click switch from any view. Sort mode is per-user-tier and survives the switch by design; view-local state (scroll, partial Find query) resets per Phase 1's "switch = re-entry" rule.
 
 ### 8.3 Cross-dataset training with a re-used labelset ★★ M
 The labelset-source machinery lets a detector pull labels from a different dataset, but using it requires:


### PR DESCRIPTION
## Summary

Lands `docs/plans/active-context-switcher.md` — the design doc for converting the top-bar dataset/detector read-only fields into click-to-switch pulldowns. Graduates `ux-brainstorm.md` §6.11 (active-dataset/detector indicator) and §8.2 (switching active dataset/detector) into a standalone plan.

Three independently shippable phases:

- **Phase 1 — Switcher core.** Pulldown UI with compatibility dim (incompatible rows desaturated, not hidden), "Add New" footers that open the importer / new-detector modals in-place via a new `NewThingFlowsService`, incompatible-pair explainer rendered as a sibling of `<router-outlet />`, cancel-and-replace on rapid re-click via monotonic request-id check.
- **Phase 2 — URL-driven active context.** Routes become `/label/:datasetId/:detectorId` and `/find/:datasetId/:detectorId`, gated by a new `active-context.guard.ts`. Bare `/label` and `/find` redirect to Dashboard. Likely deletes `find-session.service.ts`.
- **Phase 3 — In-flight job affordances.** Per-pair spinner glyph on pulldown rows, plus a verification sweep that every job-producing view (eval, labeling-progress, learned-sort) rehydrates from `JobManager`'s signature cache on re-entry.

Also folds in the "Frontend Scope: Desktop Only" policy addition to `CLAUDE.md` referenced by the plan's §9 design rule.

## What changed

- `docs/plans/active-context-switcher.md` — new plan (259 lines).
- `docs/plans/README.md` — index entry under "Open plans".
- `docs/plans/ux-brainstorm.md` — §6.11 and §8.2 now link here as the canonical design.
- `CLAUDE.md` — adds "Frontend Scope: Desktop Only" section.

Doc-only — no code changes, no tests to run.

## Test plan

- [ ] Skim the plan top-to-bottom; confirm the three-phase split and the rules in §"Design summary" match the design discussion.
- [ ] Verify the `ux-brainstorm.md` cross-links resolve.
- [ ] Confirm the `README.md` "Open plans" table row reads correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjewHkqDJZvyUCm4HcLiwq)_