### PR TITLE
Active-context switcher Phase 1: top-bar pulldowns + incompatible-pair explainer

### DIFF
--- a/docs/plans/active-context-switcher.md
+++ b/docs/plans/active-context-switcher.md
@@ -1,6 +1,6 @@
 # Active-context switcher (top-bar dataset/detector pulldowns)
 
-*Status: Proposed (no code yet). Three phases — each ships independently.*
+*Status: Phase 1 shipped (core switching, "+ Add New" footers, incompatible-pair explainer). Phase 2 (URL-driven context) and Phase 3 (in-flight job affordances) deferred — see "Open follow-ups" below.*
 
 This plan implements [ux-brainstorm.md §6.11](ux-brainstorm.md#611-active-datasetdetector-indicator--s) ("Active-dataset/detector indicator") and largely closes [§8.2](ux-brainstorm.md#82-switching-active-datasetdetector--s) ("Switching active dataset/detector"). It supersedes both entries as the canonical design — when this plan ships those entries will be marked SHIPPED and link here.
 
@@ -253,6 +253,31 @@ These came up in design and were deliberately deferred or rejected.
 - **Compatibility predicate beyond media-type equality** — Datasets and detectors each have a single `media_type`; multi-MediaType detectors don't exist today and adding the abstraction prematurely would be speculative.
 - **Cross-session "remember my last pair" persistence** — Not part of the switcher itself. If wanted, layer on as a separate per-user setting that the Dashboard's Train/Find buttons consult for default selection. Out of scope here so Phase 2 stays focused on URL-as-identity.
 - **Notification when a backgrounded job completes** — The app has no general notification system; adding one is much bigger than this plan. Phase 3's spinner-disappears-when-done is the affordance for v1.
+
+## What shipped (Phase 1)
+
+- **`utils/context-compat.ts`** with `isPairCompatible()` — single source of truth for the media-type-equality predicate.
+- **`services/active-context.service.ts`** gained `setActivePair(datasetId, modelId)`, `pair$` (atomic-pair observable), `pairKey$` (joined-key for switchMap triggers), `nextRequestId()` / `currentRequestId` for cancel-and-replace tracking.
+- **`services/new-thing-flows.service.ts`** — singleton openers for the dataset importer + new-detector modals plus emit subjects (`importStarted$`, `demoSelected$`, `created$`) so the modals can be invoked from outside the Dashboard.
+- **`services/context-switch.service.ts`** — drives a pulldown-initiated pair change end-to-end (atomic flip, parallel dataset/detector load, request-id guard, best-effort cancellation of stale loads).
+- **`components/context-pulldown/context-pulldown.component.*`** — top-bar pulldown with closed-state button + dropdown listbox (one row per registry entry, loaded/active glyph, dimmed-when-incompatible row, ellipsis truncation, "+ Add New" footer). Keyboard: ArrowUp / ArrowDown / Home / End / Enter / Escape.
+- **`components/context-pulldown/incompatible-pair-explainer.component.*`** — sibling of `<router-outlet />` that takes over `/label` and `/find` when the active pair is incompatible (mismatch, half-set, or fully empty).
+- **`app.component.*`** — replaced the read-only `Data: foo` / `Detector: cats` spans with `<vt-context-pulldown>` instances. Hosts the hoisted importer + new-detector modals via `@defer` blocks so they lazy-load (kept initial bundle at 476 kB, well under the 525 kB budget) and the explainer overlay.
+- **`components/dashboard/dashboard.component.*`** — opens its two `+` modals through `NewThingFlowsService` (instead of owning the open-state), and subscribes to the service's `importStarted$` / `demoSelected$` / `created$` so the existing post-action flows (progress polling, train-after-create) still work. Combine modals remain Dashboard-local.
+- **`components/find-view`, `components/label-view`** — subscribe to `activeContext.pair$` and re-run their loads when the pair changes mid-route, so a pulldown click on `/label` or `/find` re-prepares against the new pair.
+- **Tests**: `./run-tests.sh` green (3615 passed, 1 skipped, 2 xpassed). Dashboard specs updated to drive `NewThingFlowsService` directly for the two affected cases.
+
+## Open follow-ups (Phase 1)
+
+These came out of Phase 1 build-out but were deliberately scoped out for the first cut; pick them up in a follow-on PR or fold them into Phase 2 / 3 work.
+
+- **Focus-other-pulldown affordance on the explainer** — the design called for a `[ Pick a compatible detector ]` button that opens the *other* pulldown with its menu open and scrolled to the first compatible row. Phase 1 only renders the `Go to Dashboard` button. Wiring this needs a shared "open this pulldown programmatically" signal (e.g. a method on `ContextPulldownComponent` driven via a shared service or `@ViewChild`).
+- **"Re-resolving labels for X's embedder…" progress message** — the design called for a custom progress message when the new dataset's embedder differs from the previous one. Phase 1 reuses the generic loading affordance; the message is just whatever the dataset-load progress tracker emits.
+- **Toast when the active item is deleted/unregistered** — design § "Edge cases" #3 says we should detect via subscription and clear that half via `setActivePair(..., '')` with a toast `"Dataset 'Foo' was removed. Pick another."`. Not implemented in Phase 1 — the pulldown will just stop showing the deleted item, but the active-context ids remain pointing at the dead entry until the user picks a new one.
+- **Empty-registry error affordance** — design § "Edge cases" #6 says the pulldown should show an inline `"Couldn't load datasets — retry?"` when the registry endpoint errors. Phase 1 just shows the empty state.
+- **"Add New" footer auto-selects the new item** — design says: on successful create, the pulldown listens to `created$` and `setActivePair(...)` with the new id in its half. Phase 1 wires the `created$` emit but the pulldown doesn't yet auto-select. (The Dashboard's auto-select-newly-added logic still fires for the Dashboard route.)
+- **Pulldown row order should mirror Dashboard grid sort** — design § Pulldown behavior says "mirror the Dashboard grid's order exactly." Phase 1 sorts by name (the Dashboard's default), but doesn't track the user's column-sort preference. Plumbing this would require sharing the `ManagedColumns` sort key out of `DashboardComponent`.
+- **`FindSessionService` deletion** — the plan notes this service "will likely be deletable once Phase 2 lands." Phase 1 still uses it (writes datasetId/modelId on pair change so `runFindLabel()` picks up the new pair). Defer the deletion to the Phase 2 URL refactor.
 
 ## Open questions
 

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -59,8 +59,8 @@
     (click)="onDashboard()"
     title="Return to the Dashboard to manage datasets and detectors"
   >Dashboard</button>
-  <span class="top-bar-field" title="The currently active dataset being browsed and labeled"><strong>Data:</strong> <span class="top-bar-value">{{ datasetDisplayName }}</span></span>
-  <span class="top-bar-field" title="The currently active detector used for scoring and sorting"><strong>Detector:</strong> <span class="top-bar-value">{{ modelDisplayName }}</span></span>
+  <vt-context-pulldown kind="dataset" />
+  <vt-context-pulldown kind="detector" />
   <span class="top-bar-spacer"></span>
   <button
     class="help-btn"
@@ -85,13 +85,42 @@
     </svg></button>
 </header>
 <div class="main-content" role="main">
-  <router-outlet />
+  @if (showIncompatibleExplainer) {
+    <vt-incompatible-pair-explainer />
+  } @else {
+    <router-outlet />
+  }
 </div>
-@if (showSettings) {
-  <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="onSettingsClosed()" />
+@defer (when importerFlow.open) {
+  @if (importerFlow.open) {
+    <vt-dataset-importer-modal
+      [guessedMediaType]="importerFlow.guessedMediaType"
+      [guessedMediaEmbedder]="importerFlow.guessedMediaEmbedder"
+      [initialTab]="importerFlow.initialTab"
+      (closed)="onImporterClosed()"
+      (importStarted)="onImportStarted()"
+      (demoSelected)="onDemoSelected($event)"
+    />
+  }
 }
-@if (showKeyboardHelp) {
-  <vt-keyboard-help-modal (closed)="onKeyboardHelpClosed()" />
+@defer (when newDetectorFlow.open) {
+  @if (newDetectorFlow.open) {
+    <vt-new-detector-modal
+      [defaultMediaType]="newDetectorFlow.defaultMediaType"
+      (closed)="onNewDetectorClosed()"
+      (created)="onDetectorCreated($event)"
+    />
+  }
+}
+@defer (when showSettings) {
+  @if (showSettings) {
+    <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="onSettingsClosed()" />
+  }
+}
+@defer (when showKeyboardHelp) {
+  @if (showKeyboardHelp) {
+    <vt-keyboard-help-modal (closed)="onKeyboardHelpClosed()" />
+  }
 }
 <vt-dialog-host />
 <vt-achievement-unlock-host />

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -136,26 +136,6 @@ header {
   }
 }
 
-.top-bar-field {
-  color: var(--header-text-dim);
-  font-size: var(--font-sm);
-  white-space: nowrap;
-  width: 160px;
-  min-width: 0;
-  overflow: hidden;
-  display: flex;
-
-  strong {
-    flex-shrink: 0;
-    margin-right: var(--space-xs);
-  }
-}
-
-.top-bar-value {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .top-bar-spacer {
   flex: 1;
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostListener } from '@angular/core';
 import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { combineLatest } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
 import { ToastContainerComponent } from './components/toast-container/toast-container.component';
@@ -8,17 +9,45 @@ import { AchievementUnlockHostComponent } from './components/achievement-unlock-
 import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
 import { KeyboardHelpModalComponent } from './components/modals/keyboard-help-modal/keyboard-help-modal.component';
 import { LoginComponent } from './components/login/login.component';
+import { ContextPulldownComponent } from './components/context-pulldown/context-pulldown.component';
+import { IncompatiblePairExplainerComponent } from './components/context-pulldown/incompatible-pair-explainer.component';
+// Importer / new-detector modals are imported here AND used exclusively
+// inside `@defer` blocks in the template — Angular splits them into
+// lazy chunks (they drag in the file browser, crop modal, etc., which
+// together push the initial bundle over budget when eagerly loaded).
+import { DatasetImporterModalComponent } from './components/dashboard/dataset-importer-modal/dataset-importer-modal.component';
+import { NewDetectorModalComponent } from './components/dashboard/new-detector-modal/new-detector-modal.component';
 import { MediaStateService } from './services/media-state.service';
 import { DatasetStateService } from './services/dataset-state.service';
 import { ActiveContextService } from './services/active-context.service';
-import { TopBarStateService } from './services/top-bar-state.service';
 import { AuthService } from './services/auth.service';
 import { AchievementsService } from './services/achievements.service';
 import { ThemeService } from './services/theme.service';
 import { ToastService } from './services/toast.service';
+import {
+  NewThingFlowsService,
+  ImporterFlowState,
+  NewDetectorFlowState,
+} from './services/new-thing-flows.service';
+import { DemoDataset } from './models/api.models';
+import { isPairCompatible } from './utils/context-compat';
+
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, RouterOutlet, DialogHostComponent, ToastContainerComponent, AchievementUnlockHostComponent, SettingsModalComponent, KeyboardHelpModalComponent, LoginComponent],
+  imports: [
+    CommonModule,
+    RouterOutlet,
+    DialogHostComponent,
+    ToastContainerComponent,
+    AchievementUnlockHostComponent,
+    SettingsModalComponent,
+    KeyboardHelpModalComponent,
+    LoginComponent,
+    ContextPulldownComponent,
+    IncompatiblePairExplainerComponent,
+    DatasetImporterModalComponent,
+    NewDetectorModalComponent,
+  ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
@@ -30,18 +59,31 @@ export class AppComponent {
   gearClosing = false;
   isOnLabelView = false;
   settingsViewTab = '';
-  datasetDisplayName = '';
-  modelDisplayName = '';
+  /** True when the current route consumes the active pair (label / find)
+   *  and the pair is not compatible — the explainer takes over the
+   *  router-outlet area in that state. */
+  showIncompatibleExplainer = false;
+
+  importerFlow: ImporterFlowState = {
+    open: false,
+    initialTab: '',
+    guessedMediaType: '',
+    guessedMediaEmbedder: '',
+  };
+  newDetectorFlow: NewDetectorFlowState = {
+    open: false,
+    defaultMediaType: '',
+  };
 
   constructor(
     private router: Router,
     private mediaState: MediaStateService,
     private datasetState: DatasetStateService,
     private activeContext: ActiveContextService,
-    public topBarState: TopBarStateService,
     public auth: AuthService,
     private achievements: AchievementsService,
     private themeService: ThemeService,
+    private newThingFlows: NewThingFlowsService,
     _toast: ToastService,
   ) {
     this.auth.checkStatus();
@@ -52,28 +94,35 @@ export class AppComponent {
       .subscribe((e) => {
         this.isOnLabelView =
           e.urlAfterRedirects.startsWith('/label') || e.urlAfterRedirects.startsWith('/find');
-        this.updateDisplayNames();
+        this.recomputeExplainer();
       });
 
-    this.topBarState.datasetLabel$.subscribe(() => this.updateDisplayNames());
-    this.topBarState.modelLabel$.subscribe(() => this.updateDisplayNames());
-    this.activeContext.datasetId$.subscribe(() => this.updateDisplayNames());
-    this.activeContext.modelId$.subscribe(() => this.updateDisplayNames());
+    combineLatest([
+      this.activeContext.pair$,
+      this.datasetState.datasets$,
+      this.datasetState.detectors$,
+    ]).subscribe(() => this.recomputeExplainer());
+
+    this.newThingFlows.importer$.subscribe((state) => {
+      this.importerFlow = state;
+    });
+    this.newThingFlows.newDetector$.subscribe((state) => {
+      this.newDetectorFlow = state;
+    });
   }
 
-  private updateDisplayNames(): void {
-    if (this.isOnLabelView) {
-      const dsId = this.activeContext.datasetId;
-      const ds = this.datasetState.datasets.find((d) => d.id === dsId);
-      this.datasetDisplayName = ds?.name || '';
-
-      const mId = this.activeContext.modelId;
-      const m = this.datasetState.detectors.find((mod) => mod.id === mId);
-      this.modelDisplayName = m?.name || '';
-    } else {
-      this.datasetDisplayName = this.topBarState.datasetLabel;
-      this.modelDisplayName = this.topBarState.modelLabel;
+  private recomputeExplainer(): void {
+    if (!this.isOnLabelView) {
+      this.showIncompatibleExplainer = false;
+      return;
     }
+    const ds = this.activeContext.datasetId
+      ? this.datasetState.datasets.find((d) => d.id === this.activeContext.datasetId) ?? null
+      : null;
+    const det = this.activeContext.modelId
+      ? this.datasetState.detectors.find((d) => d.id === this.activeContext.modelId) ?? null
+      : null;
+    this.showIncompatibleExplainer = !isPairCompatible(ds, det);
   }
 
   toggleMenu(event: Event): void {
@@ -173,6 +222,34 @@ export class AppComponent {
 
   onGearAnimationEnd(): void {
     this.gearClosing = false;
+  }
+
+  // --- Hoisted new-thing modal handlers (delegate to NewThingFlowsService) ---
+
+  onImporterClosed(): void {
+    this.newThingFlows.closeImporter();
+  }
+
+  onImportStarted(): void {
+    // Emit BEFORE close so subscribers that watch open→close transitions
+    // see the success event first; otherwise the close-handler runs first
+    // and may clear state the success handler needs.
+    this.newThingFlows.emitImportStarted();
+    this.newThingFlows.closeImporter();
+  }
+
+  onDemoSelected(demo: DemoDataset): void {
+    this.newThingFlows.emitDemoSelected(demo);
+    this.newThingFlows.closeImporter();
+  }
+
+  onNewDetectorClosed(): void {
+    this.newThingFlows.closeNewDetector();
+  }
+
+  onDetectorCreated(id: string): void {
+    this.newThingFlows.emitDetectorCreated(id || '');
+    this.newThingFlows.closeNewDetector();
   }
 
   private inferMediaType(): string {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.html
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.html
@@ -1,0 +1,59 @@
+<button
+  type="button"
+  class="pulldown-trigger"
+  [class.is-open]="open"
+  [title]="fieldTitle"
+  [attr.aria-expanded]="open"
+  aria-haspopup="listbox"
+  (click)="toggle()"
+  (keydown)="onKeydown($event)"
+>
+  <strong class="trigger-label">{{ fieldLabel }}:</strong>
+  <span class="trigger-value" [class.is-placeholder]="!activeRowExists">{{ activeRowExists ? activeName : placeholderLabel }}</span>
+  <span class="trigger-caret" aria-hidden="true">▾</span>
+</button>
+
+@if (open) {
+  <div
+    #menuRef
+    class="pulldown-menu"
+    role="listbox"
+    [attr.aria-label]="isDataset ? 'Datasets' : 'Detectors'"
+    (mousedown)="onMenuMouseDown($event)"
+    (keydown)="onKeydown($event)"
+  >
+    @if (rows.length === 0) {
+      <div class="pulldown-empty">No {{ isDataset ? 'datasets' : 'detectors' }} yet.</div>
+    } @else {
+      <div class="pulldown-rows">
+        @for (row of rows; track trackRow($index, row); let i = $index) {
+          <button
+            type="button"
+            class="pulldown-row"
+            role="option"
+            [class.is-active]="row.active"
+            [class.is-incompatible]="!row.compatibleWithOther"
+            [class.is-focused]="i === focusedIndex"
+            [attr.aria-selected]="row.active"
+            [attr.title]="row.incompatReason || null"
+            (click)="pickRow(row)"
+            (mouseenter)="focusedIndex = i"
+          >
+            <span class="row-glyph" [title]="glyphTitle(row)">{{ glyphFor(row) }}</span>
+            <span class="row-name">{{ row.name }}</span>
+            <span class="row-type">· {{ row.mediaType }}</span>
+          </button>
+        }
+      </div>
+    }
+    <div class="pulldown-footer">
+      <button
+        type="button"
+        class="pulldown-add"
+        [class.is-focused]="focusedIndex === -1 && rows.length === 0"
+        (click)="addNew()"
+        (mouseenter)="focusedIndex = -1"
+      >{{ addNewLabel }}</button>
+    </div>
+  </div>
+}

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.scss
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.scss
@@ -1,0 +1,168 @@
+:host {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 200px;
+}
+
+.pulldown-trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  width: 100%;
+  min-width: 0;
+  padding: var(--space-xs) 0.5rem;
+  background: var(--header-btn-bg);
+  border: 1px solid var(--header-btn-border);
+  border-radius: var(--radius-md);
+  color: var(--header-text);
+  font-size: var(--font-sm);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  white-space: nowrap;
+
+  &:hover,
+  &.is-open {
+    background: var(--header-btn-hover-bg);
+    border-color: var(--header-btn-hover-border);
+  }
+
+  .trigger-label {
+    flex: 0 0 auto;
+    color: var(--header-text-dim);
+    font-weight: 600;
+  }
+
+  .trigger-value {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+
+    &.is-placeholder {
+      color: var(--header-text-dim);
+      font-style: italic;
+    }
+  }
+
+  .trigger-caret {
+    flex: 0 0 auto;
+    color: var(--header-text-dim);
+    font-size: 0.7rem;
+  }
+}
+
+.pulldown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 100%;
+  max-width: 480px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 4px 12px var(--shadow-dropdown);
+  z-index: var(--z-burger-menu);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pulldown-rows {
+  max-height: 360px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.pulldown-empty {
+  padding: var(--space-md) var(--space-lg);
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+  font-style: italic;
+}
+
+.pulldown-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: var(--font-md);
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  white-space: nowrap;
+
+  &.is-focused,
+  &:hover {
+    background: var(--bg-hover);
+  }
+
+  &.is-active {
+    background: var(--accent-highlight-bg);
+    font-weight: 600;
+
+    &.is-focused,
+    &:hover {
+      background: var(--accent-highlight-bg);
+    }
+  }
+
+  &.is-incompatible {
+    opacity: 0.5;
+
+    &:hover,
+    &.is-focused {
+      background: transparent;
+    }
+  }
+
+  .row-glyph {
+    flex: 0 0 1.1rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-family: monospace;
+  }
+
+  &.is-active .row-glyph {
+    color: var(--color-good);
+  }
+
+  .row-name {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row-type {
+    flex: 0 0 auto;
+    color: var(--text-dim);
+    font-size: var(--font-xs);
+  }
+}
+
+.pulldown-footer {
+  border-top: 1px solid var(--border);
+  background: var(--bg-subtle);
+}
+
+.pulldown-add {
+  display: block;
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font-size: var(--font-md);
+  text-align: left;
+  cursor: pointer;
+
+  &.is-focused,
+  &:hover {
+    background: var(--bg-hover);
+  }
+}

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,0 +1,296 @@
+import { Component, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DatasetStateService } from '../../services/dataset-state.service';
+import { ActiveContextService } from '../../services/active-context.service';
+import { ContextSwitchService } from '../../services/context-switch.service';
+import { NewThingFlowsService } from '../../services/new-thing-flows.service';
+import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.models';
+import { isPairCompatible } from '../../utils/context-compat';
+
+type PulldownKind = 'dataset' | 'detector';
+
+interface PulldownRow {
+  id: string;
+  name: string;
+  mediaType: string;
+  loaded: boolean;
+  active: boolean;
+  compatibleWithOther: boolean;
+  incompatReason: string;
+}
+
+/**
+ * Top-bar pulldown that lets the user switch the active dataset or
+ * detector without going back to the Dashboard. One instance per half
+ * of the pair (parameterised by `kind`).
+ *
+ * Renders a closed-state button (glyph + label + caret) and, when
+ * opened, a dropdown with one row per registry entry plus a
+ * "+ Add New" footer. Click outside to close. Keyboard: ArrowUp /
+ * ArrowDown to navigate, Enter to pick, Escape to close.
+ *
+ * See `docs/plans/active-context-switcher.md` § Phase 1.
+ */
+@Component({
+  selector: 'vt-context-pulldown',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './context-pulldown.component.html',
+  styleUrl: './context-pulldown.component.scss',
+})
+export class ContextPulldownComponent implements OnInit, OnDestroy {
+  @Input() kind: PulldownKind = 'dataset';
+
+  @ViewChild('menuRef') menuRef?: ElementRef<HTMLDivElement>;
+
+  open = false;
+  focusedIndex = -1;
+  rows: PulldownRow[] = [];
+  activeName = '';
+  activeRowExists = false;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private host: ElementRef<HTMLElement>,
+    private datasetState: DatasetStateService,
+    private activeContext: ActiveContextService,
+    private contextSwitch: ContextSwitchService,
+    private newThingFlows: NewThingFlowsService,
+  ) {}
+
+  ngOnInit(): void {
+    this.datasetState.datasets$.pipe(takeUntil(this.destroy$)).subscribe(() => this.rebuildRows());
+    this.datasetState.detectors$.pipe(takeUntil(this.destroy$)).subscribe(() => this.rebuildRows());
+    this.activeContext.pair$.pipe(takeUntil(this.destroy$)).subscribe(() => this.rebuildRows());
+    this.rebuildRows();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  get isDataset(): boolean {
+    return this.kind === 'dataset';
+  }
+
+  get placeholderLabel(): string {
+    return this.isDataset ? 'Select a dataset' : 'Select a detector';
+  }
+
+  get addNewLabel(): string {
+    return this.isDataset ? '+ Add New Dataset' : '+ Add New Detector';
+  }
+
+  get fieldLabel(): string {
+    return this.isDataset ? 'Data' : 'Detector';
+  }
+
+  get fieldTitle(): string {
+    return this.isDataset
+      ? 'Active dataset — click to switch'
+      : 'Active detector — click to switch';
+  }
+
+  toggle(): void {
+    this.open = !this.open;
+    this.focusedIndex = this.open ? this.findActiveIndex() : -1;
+  }
+
+  close(): void {
+    this.open = false;
+    this.focusedIndex = -1;
+  }
+
+  pickRow(row: PulldownRow): void {
+    if (row.active) {
+      this.close();
+      return;
+    }
+    if (this.isDataset) {
+      this.contextSwitch.switchTo(row.id, this.activeContext.modelId);
+    } else {
+      this.contextSwitch.switchTo(this.activeContext.datasetId, row.id);
+    }
+    this.close();
+  }
+
+  addNew(): void {
+    this.close();
+    if (this.isDataset) {
+      this.newThingFlows.openImporter();
+    } else {
+      const other = this.activeContext.datasetId
+        ? this.datasetState.datasets.find((d) => d.id === this.activeContext.datasetId)
+        : null;
+      this.newThingFlows.openNewDetector({ defaultMediaType: other?.media_type || '' });
+    }
+  }
+
+  /** Row click in the Add-New footer should swallow the click so the
+   *  document-level outside-click listener doesn't immediately close
+   *  the modal we just opened (modals listen on document too). */
+  onMenuMouseDown(event: MouseEvent): void {
+    event.stopPropagation();
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (!this.open) {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        this.toggle();
+      }
+      return;
+    }
+    const rowsLen = this.rows.length;
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (rowsLen === 0) {
+          this.focusedIndex = -1; // footer
+        } else if (this.focusedIndex === -1 || this.focusedIndex >= rowsLen - 1) {
+          this.focusedIndex = 0;
+        } else {
+          this.focusedIndex += 1;
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (rowsLen === 0) {
+          this.focusedIndex = -1;
+        } else if (this.focusedIndex <= 0) {
+          this.focusedIndex = rowsLen - 1;
+        } else {
+          this.focusedIndex -= 1;
+        }
+        break;
+      case 'Home':
+        event.preventDefault();
+        if (rowsLen > 0) this.focusedIndex = 0;
+        break;
+      case 'End':
+        event.preventDefault();
+        if (rowsLen > 0) this.focusedIndex = rowsLen - 1;
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        if (this.focusedIndex >= 0 && this.focusedIndex < rowsLen) {
+          this.pickRow(this.rows[this.focusedIndex]);
+        } else {
+          this.addNew();
+        }
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.close();
+        break;
+    }
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: Event): void {
+    if (!this.open) return;
+    const target = event.target as Node | null;
+    if (target && this.host.nativeElement.contains(target)) return;
+    this.close();
+  }
+
+  glyphFor(row: PulldownRow): string {
+    if (row.active) return '✓';
+    return row.loaded ? '●' : '○';
+  }
+
+  glyphTitle(row: PulldownRow): string {
+    if (row.active) return 'Currently active';
+    if (row.loaded) return 'Loaded in memory';
+    return 'Not loaded (click to load)';
+  }
+
+  trackRow(_: number, row: PulldownRow): string {
+    return row.id;
+  }
+
+  private findActiveIndex(): number {
+    const id = this.isDataset ? this.activeContext.datasetId : this.activeContext.modelId;
+    return this.rows.findIndex((r) => r.id === id);
+  }
+
+  private rebuildRows(): void {
+    const datasets = this.datasetState.datasets;
+    const detectors = this.datasetState.detectors;
+    const activeDsId = this.activeContext.datasetId;
+    const activeDetId = this.activeContext.modelId;
+    const activeDataset = activeDsId ? datasets.find((d) => d.id === activeDsId) : null;
+    const activeDetector = activeDetId ? detectors.find((d) => d.id === activeDetId) : null;
+
+    const sortByName = <T extends { name: string }>(arr: T[]): T[] =>
+      [...arr].sort((a, b) => a.name.localeCompare(b.name));
+
+    if (this.isDataset) {
+      const sorted = sortByName(datasets);
+      this.rows = sorted.map((d) => this.datasetRow(d, activeDsId, activeDetector));
+    } else {
+      const sorted = sortByName(detectors);
+      this.rows = sorted.map((d) => this.detectorRow(d, activeDetId, activeDataset));
+    }
+
+    const active = this.rows.find((r) => r.active);
+    this.activeRowExists = !!active;
+    this.activeName = active?.name || '';
+    if (this.open) {
+      const i = this.findActiveIndex();
+      if (i !== -1) this.focusedIndex = i;
+      else if (this.focusedIndex >= this.rows.length) this.focusedIndex = -1;
+    }
+  }
+
+  private datasetRow(
+    dataset: DatasetRegistryEntry,
+    activeId: string,
+    activeDetector: DetectorRegistryEntry | null | undefined,
+  ): PulldownRow {
+    const compatible = activeDetector
+      ? isPairCompatible(dataset, activeDetector)
+      : true;
+    let reason = '';
+    if (!compatible && activeDetector) {
+      reason = `Active detector "${activeDetector.name}" works on ${activeDetector.media_type}; this dataset is ${dataset.media_type}.`;
+    }
+    return {
+      id: dataset.id,
+      name: dataset.name,
+      mediaType: dataset.media_type,
+      loaded: !!dataset.loaded,
+      active: dataset.id === activeId,
+      compatibleWithOther: compatible,
+      incompatReason: reason,
+    };
+  }
+
+  private detectorRow(
+    detector: DetectorRegistryEntry,
+    activeId: string,
+    activeDataset: DatasetRegistryEntry | null | undefined,
+  ): PulldownRow {
+    const compatible = activeDataset
+      ? isPairCompatible(activeDataset, detector)
+      : true;
+    let reason = '';
+    if (!compatible && activeDataset) {
+      reason = `This detector embeds ${detector.media_type}; active dataset "${activeDataset.name}" is ${activeDataset.media_type}.`;
+    }
+    return {
+      id: detector.id,
+      name: detector.name,
+      mediaType: detector.media_type,
+      loaded: !!detector.detector_loaded,
+      active: detector.id === activeId,
+      compatibleWithOther: compatible,
+      incompatReason: reason,
+    };
+  }
+}

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.html
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.html
@@ -1,0 +1,35 @@
+<div class="explainer">
+  <div class="explainer-card">
+    @if (bothMissing) {
+      <p class="explainer-title">Pick a dataset and detector to begin.</p>
+      <p class="explainer-detail">Use the pulldowns in the top bar, or go to the Dashboard to create new ones.</p>
+    } @else if (datasetMissing) {
+      <p class="explainer-title">No dataset selected.</p>
+      <p class="explainer-detail">
+        Pick a dataset compatible with detector
+        <strong>{{ detector?.name }}</strong>
+        (<em>{{ detector?.media_type }}</em>) from the top-bar pulldown,
+        or go to the Dashboard.
+      </p>
+    } @else if (detectorMissing) {
+      <p class="explainer-title">No detector selected.</p>
+      <p class="explainer-detail">
+        Pick a detector compatible with dataset
+        <strong>{{ dataset?.name }}</strong>
+        (<em>{{ dataset?.media_type }}</em>) from the top-bar pulldown,
+        or go to the Dashboard.
+      </p>
+    } @else if (mediaTypeMismatch) {
+      <p class="explainer-title">
+        <strong>{{ dataset?.name }}</strong> and
+        <strong>{{ detector?.name }}</strong> are incompatible: they are
+        different media types (<em>{{ dataset?.media_type }}</em> vs.
+        <em>{{ detector?.media_type }}</em>).
+      </p>
+      <p class="explainer-detail">Choose a compatible pair using the pulldowns above, or go to the Dashboard.</p>
+    }
+    <div class="explainer-actions">
+      <button type="button" class="btn btn--secondary" (click)="goToDashboard()">Go to Dashboard</button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.scss
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.scss
@@ -1,0 +1,48 @@
+.explainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: var(--space-2xl);
+  background: var(--bg-body);
+}
+
+.explainer-card {
+  max-width: 560px;
+  padding: var(--space-2xl);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  text-align: center;
+}
+
+.explainer-title {
+  font-size: var(--font-2xl);
+  color: var(--text-primary);
+  margin: 0;
+  line-height: 1.4;
+
+  strong {
+    color: var(--accent);
+  }
+}
+
+.explainer-detail {
+  font-size: var(--font-lg);
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+
+  strong {
+    color: var(--text-primary);
+  }
+}
+
+.explainer-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-md);
+}

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
@@ -1,0 +1,86 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { Subject, combineLatest } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DatasetStateService } from '../../services/dataset-state.service';
+import { ActiveContextService } from '../../services/active-context.service';
+import { DatasetRegistryEntry, DetectorRegistryEntry } from '../../models/api.models';
+
+/**
+ * Renders in place of `/label` and `/find` content when the active
+ * dataset/detector pair is incompatible (different media types, or one
+ * half unset). Tells the user what's wrong and offers two ways out:
+ * fix the other half via its pulldown, or go to the Dashboard.
+ *
+ * Visibility is governed by the parent (`AppComponent`); this component
+ * just renders the explanation given the current active pair.
+ *
+ * See `docs/plans/active-context-switcher.md` § "Incompatible-pair
+ * explainer".
+ */
+@Component({
+  selector: 'vt-incompatible-pair-explainer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './incompatible-pair-explainer.component.html',
+  styleUrl: './incompatible-pair-explainer.component.scss',
+})
+export class IncompatiblePairExplainerComponent implements OnInit, OnDestroy {
+  dataset: DatasetRegistryEntry | null = null;
+  detector: DetectorRegistryEntry | null = null;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private router: Router,
+    private activeContext: ActiveContextService,
+    private datasetState: DatasetStateService,
+  ) {}
+
+  ngOnInit(): void {
+    combineLatest([
+      this.activeContext.pair$,
+      this.datasetState.datasets$,
+      this.datasetState.detectors$,
+    ])
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(([pair, datasets, detectors]) => {
+        this.dataset = pair.datasetId
+          ? datasets.find((d) => d.id === pair.datasetId) ?? null
+          : null;
+        this.detector = pair.modelId
+          ? detectors.find((d) => d.id === pair.modelId) ?? null
+          : null;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  get bothMissing(): boolean {
+    return !this.dataset && !this.detector;
+  }
+
+  get datasetMissing(): boolean {
+    return !this.dataset && !!this.detector;
+  }
+
+  get detectorMissing(): boolean {
+    return !!this.dataset && !this.detector;
+  }
+
+  get mediaTypeMismatch(): boolean {
+    return (
+      !!this.dataset &&
+      !!this.detector &&
+      this.dataset.media_type !== this.detector.media_type
+    );
+  }
+
+  goToDashboard(): void {
+    this.router.navigate(['/dashboard']);
+  }
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -305,30 +305,11 @@
   </div>
 </div>
 
-@if (importerModalOpen) {
-  <vt-dataset-importer-modal
-    [guessedMediaType]="guessedMediaType"
-    [guessedMediaEmbedder]="guessedMediaEmbedder"
-    [initialTab]="importerInitialTab"
-    (closed)="closeImporterModal()"
-    (importStarted)="onImportComplete()"
-    (demoSelected)="onDemoSelected($event)"
-  />
-}
-
 @if (combineModalOpen) {
   <vt-combine-datasets-modal
     [datasets]="combineModalDatasets"
     (closed)="closeCombineModal()"
     (combineStarted)="onCombineStarted()"
-  />
-}
-
-@if (newDetectorModalOpen) {
-  <vt-new-detector-modal
-    [defaultMediaType]="activeDatasetMediaType"
-    (closed)="closeNewDetectorModal()"
-    (created)="onDetectorCreated($event)"
   />
 }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideRouter } from '@angular/router';
 import { DashboardComponent } from './dashboard.component';
 import { LabelSessionService } from '../../services/label-session.service';
+import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -385,12 +386,13 @@ describe('DashboardComponent', () => {
     httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   }));
 
-  it('should open and close importer modal', () => {
+  it('should open and close importer modal via NewThingFlowsService', () => {
     flushInitialRequests();
+    const flows = TestBed.inject(NewThingFlowsService);
     expect(component.importerModalOpen).toBeFalse();
     component.openImporterModal();
     expect(component.importerModalOpen).toBeTrue();
-    component.closeImporterModal();
+    flows.closeImporter();
     expect(component.importerModalOpen).toBeFalse();
   });
 
@@ -447,17 +449,19 @@ describe('DashboardComponent', () => {
 
     it('should open the importer modal pre-pinned to the chosen tab', () => {
       flushInitialRequests();
+      const flows = TestBed.inject(NewThingFlowsService);
       component.openImporterModalOnTab('services');
       expect(component.importerModalOpen).toBeTrue();
-      expect(component.importerInitialTab).toBe('services');
+      expect(flows.importer.initialTab).toBe('services');
     });
 
     it('should reset the initial tab when the modal closes', () => {
       flushInitialRequests();
+      const flows = TestBed.inject(NewThingFlowsService);
       component.openImporterModalOnTab('server');
-      expect(component.importerInitialTab).toBe('server');
-      component.closeImporterModal();
-      expect(component.importerInitialTab).toBe('');
+      expect(flows.importer.initialTab).toBe('server');
+      flows.closeImporter();
+      expect(flows.importer.initialTab).toBe('');
     });
   });
 
@@ -568,7 +572,8 @@ describe('DashboardComponent', () => {
 
   it('should continue polling after HTTP error on progress endpoint', fakeAsync(() => {
     flushInitialRequests();
-    component.onDemoSelected({ name: 'gtzan', label: 'GTZAN' });
+    const flows = TestBed.inject(NewThingFlowsService);
+    flows.emitDemoSelected({ name: 'gtzan', label: 'GTZAN' } as any);
 
     const demoReq = httpMock.expectOne('/api/dataset/load-demo');
     demoReq.flush({});
@@ -594,9 +599,12 @@ describe('DashboardComponent', () => {
 
   it('should load demo dataset on demoSelected', () => {
     flushInitialRequests();
-    component.importerModalOpen = true;
-    const demo = { name: 'gtzan', label: 'GTZAN' };
-    component.onDemoSelected(demo);
+    const flows = TestBed.inject(NewThingFlowsService);
+    flows.openImporter();
+    expect(component.importerModalOpen).toBeTrue();
+    const demo = { name: 'gtzan', label: 'GTZAN' } as any;
+    flows.emitDemoSelected(demo);
+    flows.closeImporter();
 
     expect(component.importerModalOpen).toBeFalse();
     expect(component.loading).toBeTrue();

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -13,17 +13,16 @@ import { DatasetStateService } from '../../services/dataset-state.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
+import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { AchievementsService } from '../../services/achievements.service';
-import { AutoDetectResultsData, DatasetRegistryEntry, LoadingTask, DetectorRegistryEntry, ImporterInfo } from '../../models/api.models';
+import { AutoDetectResultsData, DatasetRegistryEntry, DemoDataset, LoadingTask, DetectorRegistryEntry, ImporterInfo } from '../../models/api.models';
 import { formatProgressFraction } from '../../utils/format-progress';
 import { ColMeta, ManagedColumns } from '../../utils/managed-columns';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { AutoDetectResultsModalComponent } from '../modals/autodetect-results-modal/autodetect-results-modal.component';
 import { DatasetCardComponent } from './dataset-card/dataset-card.component';
 import { DetectorCardComponent } from './detector-card/detector-card.component';
-import { DatasetImporterModalComponent } from './dataset-importer-modal/dataset-importer-modal.component';
 import { CombineDatasetsModalComponent } from './combine-datasets-modal/combine-datasets-modal.component';
-import { NewDetectorModalComponent } from './new-detector-modal/new-detector-modal.component';
 import { CombineDetectorsModalComponent } from './combine-detectors-modal/combine-detectors-modal.component';
 import { LabelExporterModalComponent } from '../modals/label-exporter-modal/label-exporter-modal.component';
 import { LabelImporterModalComponent } from '../modals/label-importer-modal/label-importer-modal.component';
@@ -40,9 +39,7 @@ import { DiskUsageComponent, DiskUsageBytes } from './disk-usage/disk-usage.comp
     AutoDetectResultsModalComponent,
     DatasetCardComponent,
     DetectorCardComponent,
-    DatasetImporterModalComponent,
     CombineDatasetsModalComponent,
-    NewDetectorModalComponent,
     CombineDetectorsModalComponent,
     LabelExporterModalComponent,
     LabelImporterModalComponent,
@@ -71,12 +68,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   loadingTasks: LoadingTask[] = [];
   detectorLoadingTasks: LoadingTask[] = [];
 
-  importerModalOpen = false;
   importerClosing = false;
-  /** Picker tab id the importer modal should pre-select when it next
-   *  opens — set by the welcome-banner CTA so a fresh user lands in
-   *  the right place. Empty for the normal "+" button flow. */
-  importerInitialTab = '';
   /** Visible importers (i.e. ``hidden_from_picker !== true``), fetched
    *  once on init so the welcome banner can detect Services-tab
    *  importers without waiting for the modal to open. */
@@ -84,7 +76,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   combineModalOpen = false;
   /** Datasets passed into the Combine modal when it opens. */
   combineModalDatasets: DatasetRegistryEntry[] = [];
-  newDetectorModalOpen = false;
   newDetectorClosing = false;
   combineDetectorsModalOpen = false;
   exportModalOpen = false;
@@ -195,6 +186,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private activeContext: ActiveContextService,
     private authService: AuthService,
     private topBarState: TopBarStateService,
+    private newThingFlows: NewThingFlowsService,
     private achievements: AchievementsService,
     private progressEvents: ProgressEventsService,
   ) {}
@@ -259,6 +251,65 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.visibleImporters = (res.importers || []).filter((imp) => !imp['hidden_from_picker']);
       },
     });
+    this.subscribeNewThingFlows();
+  }
+
+  /** Translate `NewThingFlowsService` events into the legacy Dashboard
+   *  behaviors: kick off background polls after an import, auto-select
+   *  newly created detectors, drive the `+` icon's close animation,
+   *  etc. The importer / new-detector modals themselves are hosted on
+   *  `AppComponent`; this component just reacts to their outcomes. */
+  private subscribeNewThingFlows(): void {
+    this.newThingFlows.importStarted$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.handleImportStarted());
+    this.newThingFlows.demoSelected$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ demo }) => this.handleDemoSelected(demo));
+    this.newThingFlows.created$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ kind, id }) => {
+        if (kind === 'detector') this.handleDetectorCreated(id);
+        else this.datasetState.refresh();
+      });
+    // Trigger the close-animation when the modal flips from open → closed.
+    let importerWasOpen = false;
+    this.newThingFlows.importer$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((state) => {
+        if (importerWasOpen && !state.open) this.importerClosing = true;
+        importerWasOpen = state.open;
+      });
+    let detectorWasOpen = false;
+    this.newThingFlows.newDetector$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((state) => {
+        if (detectorWasOpen && !state.open) {
+          this.newDetectorClosing = true;
+          // Reset the "navigate to Train after create" intent if the
+          // user dismissed without creating. The handler in
+          // handleDetectorCreated() also clears it on success.
+          this.trainAfterModelCreation = false;
+        }
+        detectorWasOpen = state.open;
+      });
+  }
+
+  private handleDetectorCreated(modelId: string): void {
+    this.datasetState.refresh();
+    if (this.trainAfterModelCreation && modelId) {
+      this.trainAfterModelCreation = false;
+      this.selectedDetectorIds.clear();
+      this.selectedDetectorIds.add(modelId);
+      this.knownDetectorIds.add(modelId);
+      this.datasetState.detectors$
+        .pipe(
+          filter((models) => models.some((m) => m.id === modelId)),
+          take(1),
+          takeUntil(this.destroy$),
+        )
+        .subscribe(() => this.onLabel());
+    }
   }
 
   private startDiskUsagePolling(): void {
@@ -816,23 +867,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   openImporterModal(): void {
-    this.importerInitialTab = '';
     this.importerClosing = false;
-    this.importerModalOpen = true;
+    this.newThingFlows.openImporter({
+      guessedMediaType: this.guessedMediaType,
+      guessedMediaEmbedder: this.guessedMediaEmbedder,
+    });
   }
 
   /** Welcome-banner CTA: open the importer modal with one of the picker
    *  tabs pre-selected so a fresh user lands on the relevant choices. */
   openImporterModalOnTab(tabId: string): void {
-    this.importerInitialTab = tabId;
     this.importerClosing = false;
-    this.importerModalOpen = true;
-  }
-
-  closeImporterModal(): void {
-    this.importerModalOpen = false;
-    this.importerClosing = true;
-    this.importerInitialTab = '';
+    this.newThingFlows.openImporter({
+      initialTab: tabId,
+      guessedMediaType: this.guessedMediaType,
+      guessedMediaEmbedder: this.guessedMediaEmbedder,
+    });
   }
 
   onImporterAnimationEnd(): void {
@@ -877,26 +927,39 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.servicesImporters.length > 0 ? 'services' : 'server';
   }
 
-  onImportComplete(): void {
-    this.importerModalOpen = false;
+  /** Open-state of the dataset importer modal (hosted on AppComponent;
+   *  this getter just proxies the singleton state). Drives the `+` icon
+   *  animation. */
+  get importerModalOpen(): boolean {
+    return this.newThingFlows.importer.open;
+  }
+
+  /** Open-state of the new-detector modal (hosted on AppComponent). */
+  get newDetectorModalOpen(): boolean {
+    return this.newThingFlows.newDetector.open;
+  }
+
+  private handleImportStarted(): void {
     this.importerClosing = true;
     this.startProgressPolling();
   }
 
-  onDemoSelected(demo: { label: string; name: string; embedder?: string; clipper?: string; dataset_name?: string }): void {
-    this.importerModalOpen = false;
+  private handleDemoSelected(demo: DemoDataset): void {
     this.importerClosing = true;
+    // The importer modal augments the DemoDataset payload with the
+    // user-chosen embedder / clipper / display name before emitting;
+    // those extras aren't part of the typed schema so we read them
+    // through a permissive cast.
+    const extras = demo as DemoDataset & {
+      embedder?: string;
+      clipper?: string;
+      dataset_name?: string;
+    };
     const params: Record<string, string> = {};
-    if (demo.embedder) {
-      params['embedder'] = demo.embedder;
-    }
-    if (demo.clipper) {
-      params['clipper'] = demo.clipper;
-    }
-    const userName = (demo.dataset_name || '').trim();
-    if (userName) {
-      params['dataset_name'] = userName;
-    }
+    if (extras.embedder) params['embedder'] = extras.embedder;
+    if (extras.clipper) params['clipper'] = extras.clipper;
+    const userName = (extras.dataset_name || '').trim();
+    if (userName) params['dataset_name'] = userName;
     this.datasetsApi.loadDemo(demo.name, params).subscribe({
       next: () => {
         this.startProgressPolling();
@@ -924,38 +987,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   openNewDetectorModal(): void {
     this.newDetectorClosing = false;
-    this.newDetectorModalOpen = true;
-  }
-
-  closeNewDetectorModal(): void {
-    this.newDetectorModalOpen = false;
-    this.newDetectorClosing = true;
-    this.trainAfterModelCreation = false;
+    this.newThingFlows.openNewDetector({ defaultMediaType: this.activeDatasetMediaType });
   }
 
   onNewDetectorAnimationEnd(): void {
     this.newDetectorClosing = false;
-  }
-
-  onDetectorCreated(modelId?: string): void {
-    this.newDetectorModalOpen = false;
-    this.newDetectorClosing = true;
-    this.datasetState.refresh();
-
-    if (this.trainAfterModelCreation && modelId) {
-      this.trainAfterModelCreation = false;
-      // Select the newly created model and proceed to training once models list is refreshed
-      this.selectedDetectorIds.clear();
-      this.selectedDetectorIds.add(modelId);
-      this.knownDetectorIds.add(modelId);
-      this.datasetState.detectors$
-        .pipe(
-          filter((models) => models.some((m) => m.id === modelId)),
-          take(1),
-          takeUntil(this.destroy$),
-        )
-        .subscribe(() => this.onLabel());
-    }
   }
 
   // --- Cancel ---

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -9,6 +9,7 @@ import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { FindSessionService } from '../../services/find-session.service';
+import { ActiveContextService } from '../../services/active-context.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
@@ -60,6 +61,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private datasetsApi: DatasetsApiService,
     private ngZone: NgZone,
     private findSession: FindSessionService,
+    private activeContext: ActiveContextService,
     public mediaState: MediaStateService,
     public voteState: VoteStateService,
     public sortState: SortStateService,
@@ -95,6 +97,38 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       });
 
     // Run find-label to score and label all medias
+    this.runFindLabel();
+
+    // Reload + rescore when the active pair changes via the top-bar
+    // switcher. Skip the first emission (ngOnInit already triggered the
+    // initial loads + runFindLabel call above).
+    let firstPair = true;
+    this.activeContext.pair$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((pair) => {
+        if (firstPair) {
+          firstPair = false;
+          return;
+        }
+        // FindSessionService was populated by the Dashboard on the
+        // original entry; the switcher does not write to it. Refresh it
+        // from the active context so runFindLabel() uses the new pair.
+        this.findSession.datasetId = pair.datasetId;
+        this.findSession.modelId = pair.modelId;
+        this.reloadForNewPair();
+      });
+  }
+
+  private reloadForNewPair(): void {
+    this.sortState.setSortResults([], 0);
+    this.sortState.setSortStatus('');
+    this.sortState.setSortProgress(0, 0);
+    this.voteState.clear();
+    this.mediaState.loadMedias();
+    this.voteState.loadVotes();
+    this.datasetsApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (status) => { this.datasetName = status.display_name || ''; },
+    });
     this.runFindLabel();
   }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -122,6 +122,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe((modelId) => this.refreshTrainableModelName(modelId));
     this.refreshTrainableModelName(this.activeContext.modelId);
 
+    // Reload data when the active pair changes via the top-bar switcher.
+    // Skip the first emission — `ngOnInit` above already triggered the
+    // initial loads.
+    let firstPair = true;
+    this.activeContext.pair$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (firstPair) {
+          firstPair = false;
+          return;
+        }
+        this.reloadForNewPair();
+      });
+
     this.mediaState.medias$
       .pipe(takeUntil(this.destroy$))
       .subscribe((medias) => {
@@ -175,6 +189,22 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngAfterViewInit(): void {
     setTimeout(() => this.centerPanel?.init());
+  }
+
+  /** Triggered by the top-bar context switcher whenever the active
+   *  (dataset, detector) pair changes. Resets the view-local ephemeral
+   *  state (sort results, votes cache) and re-runs the same loads that
+   *  ngOnInit fires on first entry. */
+  private reloadForNewPair(): void {
+    this.sortState.setSortResults([], 0);
+    this.sortState.setSortStatus('');
+    this.sortState.setSortProgress(0, 0);
+    this.voteState.clear();
+    this.mediaState.loadMedias();
+    this.voteState.loadVotes();
+    this.datasetsApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (status) => { this.datasetName = status.display_name || ''; },
+    });
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/services/active-context.service.ts
+++ b/frontend/src/app/services/active-context.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 
 /**
  * Tracks which dataset and model the user is currently working with.
@@ -13,9 +14,32 @@ import { BehaviorSubject } from 'rxjs';
 export class ActiveContextService {
   private readonly datasetIdSubject = new BehaviorSubject<string>('');
   private readonly modelIdSubject = new BehaviorSubject<string>('');
+  private readonly pairSubject = new BehaviorSubject<{ datasetId: string; modelId: string }>({
+    datasetId: '',
+    modelId: '',
+  });
+  private requestCounter = 0;
 
   readonly datasetId$ = this.datasetIdSubject.asObservable();
   readonly modelId$ = this.modelIdSubject.asObservable();
+
+  /**
+   * Emits whenever either half of the pair changes. Use this when a view
+   * needs to react to a swap — subscribing to the two halves separately
+   * would fire twice for an atomic `setActivePair()` call.
+   */
+  readonly pair$: Observable<{ datasetId: string; modelId: string }> = this.pairSubject.pipe(
+    distinctUntilChanged((a, b) => a.datasetId === b.datasetId && a.modelId === b.modelId),
+  );
+
+  /**
+   * Emits whenever the (datasetId, modelId) tuple changes, as a joined key
+   * (`<datasetId>::<modelId>`). Useful as a `switchMap` trigger.
+   */
+  readonly pairKey$: Observable<string> = combineLatest([this.datasetId$, this.modelId$]).pipe(
+    map(([d, m]) => `${d}::${m}`),
+    distinctUntilChanged(),
+  );
 
   get datasetId(): string {
     return this.datasetIdSubject.value;
@@ -26,16 +50,52 @@ export class ActiveContextService {
   }
 
   setDatasetId(id: string): void {
+    if (this.datasetIdSubject.value === id) return;
     this.datasetIdSubject.next(id);
+    this.pairSubject.next({ datasetId: id, modelId: this.modelIdSubject.value });
   }
 
   setModelId(id: string): void {
+    if (this.modelIdSubject.value === id) return;
     this.modelIdSubject.next(id);
+    this.pairSubject.next({ datasetId: this.datasetIdSubject.value, modelId: id });
+  }
+
+  /**
+   * Set both halves of the active pair in a single change. Avoids the
+   * transient mismatched-pair window that would result from two separate
+   * setter calls fighting through the HTTP interceptor.
+   */
+  setActivePair(datasetId: string, modelId: string): void {
+    const dsChanged = this.datasetIdSubject.value !== datasetId;
+    const mChanged = this.modelIdSubject.value !== modelId;
+    if (!dsChanged && !mChanged) return;
+    if (dsChanged) this.datasetIdSubject.next(datasetId);
+    if (mChanged) this.modelIdSubject.next(modelId);
+    this.pairSubject.next({ datasetId, modelId });
   }
 
   clear(): void {
-    this.datasetIdSubject.next('');
-    this.modelIdSubject.next('');
+    this.setActivePair('', '');
+  }
+
+  /**
+   * Allocate a fresh request id for a switcher-driven prep flow. Latest
+   * caller wins: when a prep step completes, the caller compares the id
+   * it captured at start to the current id and discards the result if
+   * they differ. Cancellation of in-flight work is best-effort; this
+   * request-id check is the correctness guarantee.
+   *
+   * See `docs/plans/active-context-switcher.md` § "Cancel-and-replace
+   * on rapid re-click".
+   */
+  nextRequestId(): number {
+    this.requestCounter += 1;
+    return this.requestCounter;
+  }
+
+  get currentRequestId(): number {
+    return this.requestCounter;
   }
 
   /**

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -1,0 +1,247 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, EMPTY, Observable, Subject } from 'rxjs';
+import { catchError, filter, take, takeUntil } from 'rxjs/operators';
+import { ActiveContextService } from './active-context.service';
+import { DatasetStateService } from './dataset-state.service';
+import { DatasetsApiService } from './datasets-api.service';
+import { DetectorsApiService } from './detectors-api.service';
+import { ProgressEventsService } from './progress-events.service';
+import { LoadingTask } from '../models/api.models';
+
+interface ActiveSwitch {
+  requestId: number;
+  datasetId: string;
+  detectorId: string;
+  cancelled: boolean;
+  cancellable: Subject<void>;
+}
+
+/**
+ * Drives a pulldown-initiated active-pair change end-to-end: sets the
+ * pair atomically on `ActiveContextService`, kicks off any dataset /
+ * detector loads that are needed, and exposes a `switching$` observable
+ * so view code (and the top-bar pulldowns) can render a loading state.
+ *
+ * Cancel-and-replace semantics: rapidly clicking a different row tags
+ * each invocation with a monotonic request id. When a prep step
+ * completes, the captured id is compared with the current id and the
+ * result is discarded if they differ. The previous load's HTTP request
+ * is also cancelled when possible. See
+ * `docs/plans/active-context-switcher.md` § "Cancel-and-replace on
+ * rapid re-click".
+ */
+@Injectable({ providedIn: 'root' })
+export class ContextSwitchService {
+  private readonly switchingSubject = new BehaviorSubject<boolean>(false);
+  readonly switching$ = this.switchingSubject.asObservable();
+
+  private active: ActiveSwitch | null = null;
+
+  constructor(
+    private activeContext: ActiveContextService,
+    private datasetState: DatasetStateService,
+    private datasetsApi: DatasetsApiService,
+    private detectorsApi: DetectorsApiService,
+    private progressEvents: ProgressEventsService,
+  ) {}
+
+  get switching(): boolean {
+    return this.switchingSubject.value;
+  }
+
+  /**
+   * Switch the active pair, kicking off any needed dataset / detector
+   * loads. Returns nothing — callers observe completion via
+   * `activeContext.pair$` (set as soon as the pair flips) plus the
+   * `datasetState.loading$` signal.
+   *
+   * Passing `''` for either half clears that half — no load is fired
+   * for an empty id.
+   */
+  switchTo(datasetId: string, detectorId: string): void {
+    const previous = this.active;
+    if (previous && previous.datasetId === datasetId && previous.detectorId === detectorId) {
+      return;
+    }
+
+    // Cancel any in-flight prep — best effort. The request-id check on
+    // completion is what actually guards against stale results.
+    if (previous && !previous.cancelled) {
+      previous.cancelled = true;
+      previous.cancellable.next();
+      previous.cancellable.complete();
+      this.cancelInFlightLoads();
+    }
+
+    const requestId = this.activeContext.nextRequestId();
+    const current: ActiveSwitch = {
+      requestId,
+      datasetId,
+      detectorId,
+      cancelled: false,
+      cancellable: new Subject<void>(),
+    };
+    this.active = current;
+
+    // Flip the pair atomically so the HTTP interceptor immediately
+    // routes against the new ids.
+    this.activeContext.setActivePair(datasetId, detectorId);
+
+    const datasets = this.datasetState.datasets;
+    const detectors = this.datasetState.detectors;
+    const dataset = datasetId ? datasets.find((d) => d.id === datasetId) : null;
+    const detector = detectorId ? detectors.find((d) => d.id === detectorId) : null;
+
+    const needsDatasetLoad = !!dataset && !dataset.loaded;
+    const needsDetectorLoad = !!detector && !detector.detector_loaded;
+
+    if (!needsDatasetLoad && !needsDetectorLoad) {
+      this.finishIfCurrent(current);
+      return;
+    }
+
+    this.switchingSubject.next(true);
+    this.datasetState.setLoading(true);
+
+    let pending = 0;
+    const tick = (): void => {
+      pending -= 1;
+      if (pending <= 0) this.finishIfCurrent(current);
+    };
+
+    if (needsDatasetLoad && dataset) {
+      pending += 1;
+      this.runDatasetLoad(current, dataset.id).subscribe({
+        next: tick,
+      });
+    }
+    if (needsDetectorLoad && detector) {
+      pending += 1;
+      this.runDetectorLoad(current, detector.id).subscribe({
+        next: tick,
+      });
+    }
+  }
+
+  private runDatasetLoad(current: ActiveSwitch, datasetId: string): Observable<void> {
+    return new Observable<void>((sub) => {
+      this.datasetsApi
+        .loadRegistered(datasetId)
+        .pipe(
+          takeUntil(current.cancellable),
+          catchError(() => {
+            sub.next();
+            sub.complete();
+            return EMPTY;
+          }),
+        )
+        .subscribe({
+          next: () => {
+            this.waitForDatasetLoad(current, datasetId).subscribe({
+              next: () => {
+                sub.next();
+                sub.complete();
+              },
+            });
+          },
+        });
+    });
+  }
+
+  private runDetectorLoad(current: ActiveSwitch, detectorId: string): Observable<void> {
+    return new Observable<void>((sub) => {
+      this.detectorsApi
+        .loadDetector(detectorId)
+        .pipe(
+          takeUntil(current.cancellable),
+          catchError(() => {
+            sub.next();
+            sub.complete();
+            return EMPTY;
+          }),
+        )
+        .subscribe({
+          next: () => {
+            this.waitForDetectorLoad(current, detectorId).subscribe({
+              next: () => {
+                sub.next();
+                sub.complete();
+              },
+            });
+          },
+        });
+    });
+  }
+
+  private waitForDatasetLoad(current: ActiveSwitch, datasetId: string): Observable<void> {
+    return new Observable<void>((sub) => {
+      this.progressEvents.loadingTasks$
+        .pipe(
+          takeUntil(current.cancellable),
+          filter(
+            (tasks: LoadingTask[]) =>
+              !tasks.some((t) => t.dataset_id === datasetId && t.status !== 'idle'),
+          ),
+          take(1),
+        )
+        .subscribe({
+          next: () => {
+            this.datasetState.refresh();
+            sub.next();
+            sub.complete();
+          },
+        });
+    });
+  }
+
+  private waitForDetectorLoad(current: ActiveSwitch, detectorId: string): Observable<void> {
+    return new Observable<void>((sub) => {
+      this.progressEvents.detectorLoadingTasks$
+        .pipe(
+          takeUntil(current.cancellable),
+          filter(
+            (tasks: LoadingTask[]) =>
+              !tasks.some((t) => t.detector_id === detectorId && t.status !== 'idle'),
+          ),
+          take(1),
+        )
+        .subscribe({
+          next: () => {
+            this.datasetState.refresh();
+            sub.next();
+            sub.complete();
+          },
+        });
+    });
+  }
+
+  private finishIfCurrent(current: ActiveSwitch): void {
+    if (this.active !== current || current.cancelled) return;
+    if (current.requestId !== this.activeContext.currentRequestId) return;
+    this.switchingSubject.next(false);
+    this.datasetState.setLoading(false);
+    this.active = null;
+  }
+
+  private cancelInFlightLoads(): void {
+    // Best-effort: cancel any active dataset/detector loading tasks so
+    // we don't waste CPU on a load whose result will be discarded. The
+    // request-id check is the actual correctness guarantee.
+    const datasetTasks = this.progressEvents.loadingTasks.filter((t) => t.status !== 'idle');
+    for (const t of datasetTasks) {
+      this.datasetsApi.cancelTask(t.task_id).subscribe({
+        error: () => {
+          /* tolerate races: the task may have completed already */
+        },
+      });
+    }
+    const detectorTasks = this.progressEvents.detectorLoadingTasks.filter((t) => t.status !== 'idle');
+    for (const t of detectorTasks) {
+      this.detectorsApi.cancelDetectorLoadingTask(t.task_id).subscribe({
+        error: () => {
+          /* tolerate races */
+        },
+      });
+    }
+  }
+}

--- a/frontend/src/app/services/new-thing-flows.service.ts
+++ b/frontend/src/app/services/new-thing-flows.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { DemoDataset } from '../models/api.models';
+
+export interface ImporterFlowState {
+  open: boolean;
+  initialTab: string;
+  guessedMediaType: string;
+  guessedMediaEmbedder: string;
+}
+
+export interface NewDetectorFlowState {
+  open: boolean;
+  defaultMediaType: string;
+}
+
+export interface ThingCreatedEvent {
+  kind: 'dataset' | 'detector';
+  /** Empty when the creator did not return an ID (e.g. the dataset
+   *  importer kicks off a background load and the new ID isn't known
+   *  until the load completes — callers should listen to the registry
+   *  for new entries in that case). */
+  id: string;
+}
+
+export interface DemoSelectedEvent {
+  demo: DemoDataset;
+}
+
+/**
+ * Singleton openers for the "add new dataset" and "add new detector"
+ * flows. Decouples the modal invocations from the Dashboard component so
+ * the top-bar context pulldowns (`vt-context-pulldown`) can open them
+ * in-place over Train / Find.
+ *
+ * The modal components themselves are rendered as siblings of the
+ * router-outlet in `AppComponent` and bind to the state subjects on
+ * this service.
+ *
+ * See `docs/plans/active-context-switcher.md` § "Add-new footer flow".
+ */
+@Injectable({ providedIn: 'root' })
+export class NewThingFlowsService {
+  private readonly importerSubject = new BehaviorSubject<ImporterFlowState>({
+    open: false,
+    initialTab: '',
+    guessedMediaType: '',
+    guessedMediaEmbedder: '',
+  });
+  private readonly newDetectorSubject = new BehaviorSubject<NewDetectorFlowState>({
+    open: false,
+    defaultMediaType: '',
+  });
+  private readonly createdSubject = new Subject<ThingCreatedEvent>();
+  private readonly demoSelectedSubject = new Subject<DemoSelectedEvent>();
+  private readonly importStartedSubject = new Subject<void>();
+
+  readonly importer$ = this.importerSubject.asObservable();
+  readonly newDetector$ = this.newDetectorSubject.asObservable();
+  /** Fires after a successful import or detector-creation. The detector
+   *  flow knows the new id immediately; the dataset importer flow leaves
+   *  `id` empty because the new dataset's id isn't known until the
+   *  background load registers it. */
+  readonly created$ = this.createdSubject.asObservable();
+  readonly demoSelected$ = this.demoSelectedSubject.asObservable();
+  /** Fires when the dataset importer kicks off an import (background
+   *  load started, but new id not yet known). Consumers refresh the
+   *  registry and/or start polling for the new dataset. */
+  readonly importStarted$ = this.importStartedSubject.asObservable();
+
+  get importer(): ImporterFlowState {
+    return this.importerSubject.value;
+  }
+
+  get newDetector(): NewDetectorFlowState {
+    return this.newDetectorSubject.value;
+  }
+
+  openImporter(opts: Partial<Omit<ImporterFlowState, 'open'>> = {}): void {
+    this.importerSubject.next({
+      open: true,
+      initialTab: opts.initialTab ?? '',
+      guessedMediaType: opts.guessedMediaType ?? '',
+      guessedMediaEmbedder: opts.guessedMediaEmbedder ?? '',
+    });
+  }
+
+  closeImporter(): void {
+    this.importerSubject.next({
+      open: false,
+      initialTab: '',
+      guessedMediaType: '',
+      guessedMediaEmbedder: '',
+    });
+  }
+
+  openNewDetector(opts: Partial<Omit<NewDetectorFlowState, 'open'>> = {}): void {
+    this.newDetectorSubject.next({
+      open: true,
+      defaultMediaType: opts.defaultMediaType ?? '',
+    });
+  }
+
+  closeNewDetector(): void {
+    this.newDetectorSubject.next({
+      open: false,
+      defaultMediaType: '',
+    });
+  }
+
+  emitImportStarted(): void {
+    this.importStartedSubject.next();
+  }
+
+  emitDemoSelected(demo: DemoDataset): void {
+    this.demoSelectedSubject.next({ demo });
+  }
+
+  emitDetectorCreated(id: string): void {
+    this.createdSubject.next({ kind: 'detector', id });
+  }
+
+  emitDatasetCreated(id: string): void {
+    this.createdSubject.next({ kind: 'dataset', id });
+  }
+}

--- a/frontend/src/app/utils/context-compat.ts
+++ b/frontend/src/app/utils/context-compat.ts
@@ -1,0 +1,19 @@
+import { DatasetRegistryEntry, DetectorRegistryEntry } from '../models/api.models';
+
+/**
+ * Whether the given dataset/detector pair can be used together.
+ *
+ * Datasets and detectors each have a single `media_type`; a pair is
+ * compatible when both halves are present and their media types match.
+ *
+ * Centralised so future generalisations (multi-media-type detectors,
+ * embedder-family checks) have a single edit point. See
+ * `docs/plans/active-context-switcher.md` § Compatibility predicate.
+ */
+export function isPairCompatible(
+  dataset: DatasetRegistryEntry | null | undefined,
+  detector: DetectorRegistryEntry | null | undefined,
+): boolean {
+  if (!dataset || !detector) return false;
+  return dataset.media_type === detector.media_type;
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of `docs/plans/active-context-switcher.md` — replaces the read-only `Data: foo` / `Detector: cats` text in the top bar with two interactive pulldowns so the user can switch the active dataset/detector pair without going back to the Dashboard. Includes the supporting plumbing for atomic pair changes, "+ Add New" footers that invoke the importer/new-detector modals in-place, and an explainer overlay that takes over `/label` and `/find` when the active pair is incompatible (media-type mismatch or half-set).

Phase 2 (URL-driven context) and Phase 3 (in-flight job spinners) are deferred — see the "Open follow-ups" section in the plan doc for the gaps left in Phase 1 (focus-other-pulldown affordance, "Re-resolving labels…" message, deleted-item toast, etc.).

## What changed

- **New** `frontend/src/app/utils/context-compat.ts` — `isPairCompatible()` predicate.
- **New** services: `context-switch.service.ts` (drives the prep flow on switch, with request-id cancel-and-replace), `new-thing-flows.service.ts` (singleton openers for the dataset importer + new-detector modals so they can be opened from outside the Dashboard).
- **New** `components/context-pulldown/` — pulldown component + incompatible-pair explainer component.
- **Extended** `ActiveContextService` with `setActivePair()`, `pair$`, `pairKey$`, `nextRequestId()`.
- **Modified** `AppComponent` to host the pulldowns + explainer + hoisted importer/new-detector modals (via `@defer` to keep the initial bundle under budget; settings & keyboard-help modals were also moved to `@defer` for the same reason).
- **Modified** `DashboardComponent` to drive its `+` modals through `NewThingFlowsService` and react to the service's emit subjects.
- **Modified** `LabelViewComponent` + `FindViewComponent` to subscribe to `activeContext.pair$` and re-run their loads when the pair changes mid-route.

## Test plan

- [x] `./run-tests.sh` — 3615 passed, 1 skipped, 2 xpassed.
- [x] `npm run build:prod` — clean, 476 kB initial bundle (well under the 525 kB budget; deferred modal chunks split out cleanly).
- [ ] Manual smoke (cannot run in this environment — Phase 1 has no automated end-to-end coverage): open `/label`, pick a different dataset from the pulldown, verify the view reloads against the new dataset; verify "+ Add New" footer opens the importer modal over the label view; verify the explainer takes over when picking an incompatible row.

https://claude.ai/code/session_01PJh8tneijP5ULyUBBzA47q

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJh8tneijP5ULyUBBzA47q)_