### PR TITLE
Rewire AuthService + AchievementsService to the generated TS client

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -604,15 +604,33 @@ checks off this follow-up.
       ``docs/API.md § Machine-readable schema`` and ``docs/CLI.md``
       both point at ``GET /api/openapi.json`` (and Swagger UI at
       ``/api/docs``) as the single source.
+- [x] ``AuthService`` and ``AchievementsService`` rewired to the
+      generated TS client. ``AuthService`` now calls
+      ``apiAuthStatusGet`` / ``apiAuthLoginPost`` / ``apiAuthLogoutPost``;
+      ``AchievementsService`` now calls ``apiAchievementsGet`` /
+      ``apiAchievementsCategoryIdAcknowledgePost`` /
+      ``apiAchievementsCheckPhrasePost``. The local
+      ``AuthStatus`` / ``AchievementInfo`` / ``AchievementsState`` /
+      ``DocInfo`` / ``PendingAnnouncement`` / ``PhraseCheckResult``
+      interfaces were deleted from the service files; consumers
+      (``achievements-tab``, ``achievement-unlock-host``)
+      ``import type``-only the generated ``AchievementEntry`` /
+      ``AchievementState`` / ``DocEntry`` / ``PendingAnnouncement`` from
+      their direct module paths under ``generated/api-client/models/``.
+      ``HttpContext``-based ``SKIP_ERROR_TOAST`` flagging on
+      ``/api/auth/status`` and ``/api/auth/login`` is preserved by
+      passing the ``HttpContext`` through the generated function's
+      4th-positional ``context`` argument.
 
 ## Open follow-ups
 
 - **Migrate the remaining Angular services to the generated client.**
-  The settings pilot proves the pattern. Each follow-up PR picks one
-  blueprint area (medias, sorting, detectors, datasets, eval, …),
-  rewires the matching Angular service(s) to call the generated
-  function modules under ``frontend/src/app/generated/api-client/fn/``,
-  and deletes the corresponding hand-maintained interfaces from
+  Settings, auth, and achievements have all moved over. Each follow-up
+  PR picks one blueprint area (medias, sorting, detectors, datasets,
+  eval, labels, exporters, …), rewires the matching Angular service(s)
+  to call the generated function modules under
+  ``frontend/src/app/generated/api-client/fn/``, and deletes the
+  corresponding hand-maintained interfaces from
   ``frontend/src/app/models/api.models.ts``. The hybrid imports
   (``import type`` for DTOs, direct function-module paths for
   runtime symbols, no barrel) are required to keep the initial bundle

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
@@ -4,10 +4,8 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../modal/modal.component';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
-import {
-  AchievementsService,
-  PendingAnnouncement,
-} from '../../services/achievements.service';
+import { AchievementsService } from '../../services/achievements.service';
+import type { PendingAnnouncement } from '../../generated/api-client/models/pending-announcement';
 
 /**
  * Global host that listens to `AchievementsService.unlocks` and pops a

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -4,16 +4,14 @@ import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
-import {
-  AchievementInfo,
-  AchievementsService,
-  AchievementsState,
-  DocInfo,
-} from '../../services/achievements.service';
+import { AchievementsService } from '../../services/achievements.service';
+import type { AchievementEntry } from '../../generated/api-client/models/achievement-entry';
+import type { AchievementState } from '../../generated/api-client/models/achievement-state';
+import type { DocEntry } from '../../generated/api-client/models/doc-entry';
 
 const TIER_NAMES = ['Bronze', 'Silver', 'Gold', 'Platinum'];
 
-interface AchievementRow extends AchievementInfo {
+interface AchievementRow extends AchievementEntry {
   tierName: string;
   prevThreshold: number;
   progressPct: number;
@@ -29,7 +27,7 @@ interface AchievementRow extends AchievementInfo {
 })
 export class AchievementsTabComponent implements OnInit, OnDestroy {
   rows: AchievementRow[] = [];
-  docs: DocInfo[] = [];
+  docs: DocEntry[] = [];
   loading = true;
   totalScore = 0;
 
@@ -91,7 +89,7 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
     });
   }
 
-  private applyState(state: AchievementsState): void {
+  private applyState(state: AchievementState): void {
     this.rows = state.achievements.map((a) => this.toRow(a));
     this.docs = state.docs;
     this.loading = state.achievements.length === 0;
@@ -101,7 +99,7 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
     );
   }
 
-  private toRow(a: AchievementInfo): AchievementRow {
+  private toRow(a: AchievementEntry): AchievementRow {
     const tierName = a.tier_idx >= 0 ? TIER_NAMES[a.tier_idx] : 'Locked';
     const prevThreshold = a.tier_idx >= 0 ? a.tiers[a.tier_idx] : 0;
     let progressPct = 100;

--- a/frontend/src/app/services/achievements.service.ts
+++ b/frontend/src/app/services/achievements.service.ts
@@ -1,50 +1,17 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 
-export interface AchievementInfo {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  tiers: number[];
-  counter: number;
-  tier_idx: number;
-  next_threshold: number | null;
-}
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { AchievementState } from '../generated/api-client/models/achievement-state';
+import type { CheckPhraseResponse } from '../generated/api-client/models/check-phrase-response';
+import type { PendingAnnouncement } from '../generated/api-client/models/pending-announcement';
+import { apiAchievementsCategoryIdAcknowledgePost } from '../generated/api-client/fn/achievements/api-achievements-category-id-acknowledge-post';
+import { apiAchievementsCheckPhrasePost } from '../generated/api-client/fn/achievements/api-achievements-check-phrase-post';
+import { apiAchievementsGet } from '../generated/api-client/fn/achievements/api-achievements-get';
 
-export interface PendingAnnouncement {
-  id: string;
-  name: string;
-  icon: string;
-  tier_idx: number;
-  tier_name: string;
-  threshold: number;
-}
-
-export interface DocInfo {
-  id: string;
-  name: string;
-  path: string;
-  read: boolean;
-}
-
-export interface AchievementsState {
-  tier_names: string[];
-  achievements: AchievementInfo[];
-  pending_announcements: PendingAnnouncement[];
-  docs: DocInfo[];
-}
-
-export interface PhraseCheckResult {
-  matched: boolean;
-  doc_id: string | null;
-  doc_name: string | null;
-  already_read: boolean;
-}
-
-const EMPTY_STATE: AchievementsState = {
+const EMPTY_STATE: AchievementState = {
   tier_names: [],
   achievements: [],
   pending_announcements: [],
@@ -62,14 +29,15 @@ const EMPTY_STATE: AchievementsState = {
  */
 @Injectable({ providedIn: 'root' })
 export class AchievementsService {
-  private readonly state$ = new BehaviorSubject<AchievementsState>(EMPTY_STATE);
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
+
+  private readonly state$ = new BehaviorSubject<AchievementState>(EMPTY_STATE);
   private readonly unlock$ = new Subject<PendingAnnouncement>();
   private inFlight = false;
 
-  constructor(private http: HttpClient) {}
-
   /** Stream of state snapshots for UI binding. */
-  get state(): Observable<AchievementsState> {
+  get state(): Observable<AchievementState> {
     return this.state$.asObservable();
   }
 
@@ -78,7 +46,7 @@ export class AchievementsService {
     return this.unlock$.asObservable();
   }
 
-  get snapshot(): AchievementsState {
+  get snapshot(): AchievementState {
     return this.state$.value;
   }
 
@@ -89,9 +57,11 @@ export class AchievementsService {
   refresh(): void {
     if (this.inFlight) return;
     this.inFlight = true;
-    this.http
-      .get<AchievementsState>('/api/achievements')
-      .pipe(catchError(() => of(EMPTY_STATE)))
+    apiAchievementsGet(this.http, this.config.rootUrl)
+      .pipe(
+        map((r) => r.body),
+        catchError(() => of(EMPTY_STATE)),
+      )
       .subscribe((next) => {
         this.inFlight = false;
         this.state$.next(next);
@@ -106,10 +76,10 @@ export class AchievementsService {
    * Refreshes state afterward to update the panel display.
    */
   acknowledge(categoryId: string, tierIdx: number): void {
-    this.http
-      .post(`/api/achievements/${encodeURIComponent(categoryId)}/acknowledge`, {
-        tier_idx: tierIdx,
-      })
+    apiAchievementsCategoryIdAcknowledgePost(this.http, this.config.rootUrl, {
+      category_id: categoryId,
+      body: { tier_idx: tierIdx },
+    })
       .pipe(catchError(() => of(null)))
       .subscribe(() => this.refresh());
   }
@@ -119,13 +89,13 @@ export class AchievementsService {
    * (matched / which doc / whether already credited) and refreshes the state
    * so the docs panel reflects the new read state on success.
    */
-  checkPhrase(phrase: string): Observable<PhraseCheckResult> {
-    return new Observable<PhraseCheckResult>((subscriber) => {
-      this.http
-        .post<PhraseCheckResult>('/api/achievements/check-phrase', { phrase })
+  checkPhrase(phrase: string): Observable<CheckPhraseResponse> {
+    return new Observable<CheckPhraseResponse>((subscriber) => {
+      apiAchievementsCheckPhrasePost(this.http, this.config.rootUrl, { body: { phrase } })
         .pipe(
+          map((r) => r.body),
           catchError(() =>
-            of<PhraseCheckResult>({
+            of<CheckPhraseResponse>({
               matched: false,
               doc_id: null,
               doc_name: null,

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,18 +1,20 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpContext } from '@angular/common/http';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
-import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
+import { map, tap } from 'rxjs/operators';
 
-export interface AuthStatus {
-  provider: string;
-  user: string;
-  authenticated: boolean;
-  login_required: boolean;
-}
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { AuthStatus } from '../generated/api-client/models/auth-status';
+import { apiAuthLoginPost } from '../generated/api-client/fn/auth/api-auth-login-post';
+import { apiAuthLogoutPost } from '../generated/api-client/fn/auth/api-auth-logout-post';
+import { apiAuthStatusGet } from '../generated/api-client/fn/auth/api-auth-status-get';
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
+
   private statusSubject = new BehaviorSubject<AuthStatus | null>(null);
   status$ = this.statusSubject.asObservable();
 
@@ -20,30 +22,30 @@ export class AuthService {
   private readySubject = new BehaviorSubject<boolean>(false);
   ready$ = this.readySubject.asObservable();
 
-  constructor(private http: HttpClient) {}
-
   /** Fetch auth status from the server.  Called once at app startup. */
   checkStatus(): void {
     // Skip the global error banner: auth-status failures are handled inline
     // (we fall back to "no login required") and would otherwise pop up a
     // banner every time the user opens the app while offline.
     const context = new HttpContext().set(SKIP_ERROR_TOAST, true);
-    this.http.get<AuthStatus>('/api/auth/status', { context }).subscribe({
-      next: (status) => {
-        this.statusSubject.next(status);
-        this.readySubject.next(true);
-      },
-      error: () => {
-        // If the endpoint fails, assume no login required.
-        this.statusSubject.next({
-          provider: 'default',
-          user: 'default',
-          authenticated: true,
-          login_required: false,
-        });
-        this.readySubject.next(true);
-      },
-    });
+    apiAuthStatusGet(this.http, this.config.rootUrl, undefined, context)
+      .pipe(map((r) => r.body))
+      .subscribe({
+        next: (status) => {
+          this.statusSubject.next(status);
+          this.readySubject.next(true);
+        },
+        error: () => {
+          // If the endpoint fails, assume no login required.
+          this.statusSubject.next({
+            provider: 'default',
+            user: 'default',
+            authenticated: true,
+            login_required: false,
+          });
+          this.readySubject.next(true);
+        },
+      });
   }
 
   /** Whether the user needs to log in before using the app. */
@@ -56,14 +58,16 @@ export class AuthService {
     // Skip the global error banner: the login form renders its own
     // inline error message, and a duplicate banner would be redundant.
     const context = new HttpContext().set(SKIP_ERROR_TOAST, true);
-    return this.http
-      .post<AuthStatus>('/api/auth/login', { username }, { context })
-      .pipe(tap((status) => this.statusSubject.next(status)));
+    return apiAuthLoginPost(this.http, this.config.rootUrl, { body: { username } }, context).pipe(
+      map((r) => r.body),
+      tap((status) => this.statusSubject.next(status)),
+    );
   }
 
   logout(): Observable<AuthStatus> {
-    return this.http
-      .post<AuthStatus>('/api/auth/logout', {})
-      .pipe(tap((status) => this.statusSubject.next(status)));
+    return apiAuthLogoutPost(this.http, this.config.rootUrl).pipe(
+      map((r) => r.body),
+      tap((status) => this.statusSubject.next(status)),
+    );
   }
 }

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -9,7 +9,7 @@ describe('SettingsStateService', () => {
 
   const mockSettings = {
     volume: 0.8,
-    theme: 'dark',
+    theme: 'dark' as const,
     swipe_animation: true,
     view_mode_left: { audio: 'grid' as const, image: 'grid' as const },
     view_mode_right: { audio: 'list' as const, image: 'list' as const },


### PR DESCRIPTION
## Summary

Next step in `docs/plans/openapi-schema.md` — migrates the next-smallest
blueprint area (auth + achievements) onto the generated TS client
introduced by the settings pilot.

- `AuthService` now calls `apiAuthStatusGet` / `apiAuthLoginPost` /
  `apiAuthLogoutPost`; the local `AuthStatus` interface is gone, replaced
  by `import type { AuthStatus }` from the generated module.
- `AchievementsService` now calls `apiAchievementsGet` /
  `apiAchievementsCategoryIdAcknowledgePost` /
  `apiAchievementsCheckPhrasePost`; the local `AchievementInfo` /
  `AchievementsState` / `DocInfo` / `PendingAnnouncement` /
  `PhraseCheckResult` interfaces are gone.
- Consumers (`achievements-tab`, `achievement-unlock-host`)
  `import type`-only the generated `AchievementEntry` / `AchievementState`
  / `DocEntry` / `PendingAnnouncement` from their direct module paths
  under `generated/api-client/models/` (no barrel, to keep the initial
  bundle under the 525 kB budget — see *Bundle-size discipline* in the
  plan).
- `HttpContext`-based `SKIP_ERROR_TOAST` flagging on `/api/auth/status`
  and `/api/auth/login` is preserved by passing the `HttpContext` through
  the generated function's 4th-positional `context` argument.
- Plan doc updated with a checked status entry and the open-follow-up
  list trimmed accordingly.

Also fixes a pre-existing TS narrowing error in
`settings-state.service.spec.ts` (`theme: 'dark'` → `theme: 'dark' as const`)
that surfaces under `tsconfig.spec.json` now that `AppSettings.theme` is a
literal union.

## Test plan

- [x] `npm run build:prod` — clean, no warnings, initial total 513.88 kB
  (under 525 kB budget).
- [x] `npx tsc --noEmit -p tsconfig.spec.json` — clean (including
  `*.spec.ts`).
- [x] `python scripts/dump_openapi.py` diff vs checked-in
  `frontend/openapi.json` — no drift.
- [x] `ruff check .` + `ruff format --check .` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_014wSEqWH3QyQezo4NUmfqgi)_