### PR TITLE
Rewire FileBrowserApiService to the generated TS client

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -621,6 +621,20 @@ checks off this follow-up.
       ``/api/auth/status`` and ``/api/auth/login`` is preserved by
       passing the ``HttpContext`` through the generated function's
       4th-positional ``context`` argument.
+- [x] ``FileBrowserApiService`` rewired to the generated TS client. The
+      service now calls ``apiBrowseGet`` from
+      ``generated/api-client/fn/file-browser/api-browse-get``; the local
+      ``BrowseEntry`` / ``BrowseResponse`` interfaces in the service
+      file were deleted. The sole consumer
+      (``components/file-browser/file-browser.component.ts``) now
+      ``import type``-only the generated ``BrowseDirectoryEntry`` /
+      ``BrowseFileEntry`` from their direct module paths under
+      ``generated/api-client/models/`` (directory and file entries are
+      now distinct types in the spec, where the legacy single
+      ``BrowseEntry`` had ``size_bytes`` as an optional field). The
+      generated entry types both carry ``modified_at`` as a required
+      string (empty on stat failure), matching the backend's
+      marshmallow schema.
 
 ## Open follow-ups
 

--- a/frontend/src/app/components/file-browser/file-browser.component.ts
+++ b/frontend/src/app/components/file-browser/file-browser.component.ts
@@ -1,7 +1,9 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { FileBrowserApiService, BrowseEntry } from '../../services/file-browser-api.service';
+import { FileBrowserApiService } from '../../services/file-browser-api.service';
+import type { BrowseDirectoryEntry } from '../../generated/api-client/models/browse-directory-entry';
+import type { BrowseFileEntry } from '../../generated/api-client/models/browse-file-entry';
 
 @Component({
   selector: 'vt-file-browser',
@@ -27,8 +29,8 @@ export class FileBrowserComponent implements OnInit, OnChanges {
   loading = false;
   error = '';
 
-  directories: BrowseEntry[] = [];
-  files: BrowseEntry[] = [];
+  directories: BrowseDirectoryEntry[] = [];
+  files: BrowseFileEntry[] = [];
   currentPath = '';
 
   /** The text value in the manual input field. */
@@ -84,12 +86,12 @@ export class FileBrowserComponent implements OnInit, OnChanges {
   }
 
   /** Enter a subdirectory. */
-  enterDirectory(dir: BrowseEntry): void {
+  enterDirectory(dir: BrowseDirectoryEntry): void {
     this.loadDirectory(dir.path);
   }
 
   /** Select a file and emit its relative path. */
-  selectFile(file: BrowseEntry): void {
+  selectFile(file: BrowseFileEntry): void {
     this.inputValue = file.path;
     this.pathSelected.emit(file.path);
     this.browserOpen = false;

--- a/frontend/src/app/services/file-browser-api.service.ts
+++ b/frontend/src/app/services/file-browser-api.service.ts
@@ -1,29 +1,20 @@
-import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-export interface BrowseEntry {
-  name: string;
-  path: string;
-  size_bytes?: number;
-  modified_at?: string;
-}
-
-export interface BrowseResponse {
-  directories: BrowseEntry[];
-  files: BrowseEntry[];
-  current_path: string;
-}
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { BrowseResponse } from '../generated/api-client/models/browse-response';
+import { apiBrowseGet } from '../generated/api-client/fn/file-browser/api-browse-get';
 
 @Injectable({ providedIn: 'root' })
 export class FileBrowserApiService {
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
 
   browse(path: string, extensions?: string): Observable<BrowseResponse> {
-    let params = new HttpParams().set('path', path);
-    if (extensions) {
-      params = params.set('extensions', extensions);
-    }
-    return this.http.get<BrowseResponse>('/api/browse', { params });
+    return apiBrowseGet(this.http, this.config.rootUrl, { path, extensions }).pipe(
+      map((r) => r.body),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Rewires `FileBrowserApiService` to the generated TS client (`apiBrowseGet` from `generated/api-client/fn/file-browser/`), deleting the hand-maintained `BrowseEntry` / `BrowseResponse` interfaces from the service file.
- Updates the sole consumer (`components/file-browser/file-browser.component.ts`) to `import type`-only the generated `BrowseDirectoryEntry` / `BrowseFileEntry` from their direct module paths (no barrel) — directories and files are now distinct types in the spec, matching the backend's marshmallow schema.
- Adds a checkbox for this migration under "Status" in `docs/plans/openapi-schema.md`.

This is the next step in the migrate-Angular-services-to-the-generated-client follow-up. Settings, auth, and achievements were done previously; this picks up the smallest remaining blueprint area.

## Test plan

- [x] `npm run build:prod` — clean (no errors / no `▲ [WARNING]` lines); initial bundle 477.73 kB / 126.94 kB transfer (within budget)
- [x] `./run-tests.sh core` — 494/494 pass (also runs the frontend build check)
- [x] `./run-tests.sh api` — 406/406 pass

https://claude.ai/code/session_01SHWrf69JJQFRf4ytdv8RAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHWrf69JJQFRf4ytdv8RAu)_