### PR TITLE
Add pre-commit hooks and pip-audit CI workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,72 @@
+name: Audit dependencies
+
+# Scans installed Python packages against the PyPI advisory database.
+#
+# Triggers:
+#   - PRs that change requirements/** (catch new vulns at review time)
+#   - Pushes to main/dev (catch what slipped through)
+#   - Weekly cron (catch newly-disclosed CVEs against pinned versions
+#     even when nothing has changed in the repo)
+#
+# Auditing installed packages (rather than scanning requirements files
+# directly) catches transitive dependencies and resolves the same
+# versions that production will run.
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "requirements/**"
+      - "pyproject.toml"
+      - ".github/workflows/audit.yml"
+  pull_request:
+    paths:
+      - "requirements/**"
+      - "pyproject.toml"
+      - ".github/workflows/audit.yml"
+  schedule:
+    # Mondays 10:00 UTC.
+    - cron: "0 10 * * 1"
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install VTSearch + deps (CPU)
+        run: |
+          set +e
+          bash scripts/install-cpu.sh 2>&1 | tee /tmp/install.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Install step (exit=$status)"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/install.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit
+        run: |
+          set +e
+          pip-audit 2>&1 | tee /tmp/pip-audit.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## pip-audit"
+            echo ""
+            echo "Exit status: \`$status\`"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/pip-audit.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+# Pre-commit hooks for VTSearch.
+#
+# Install once after cloning:
+#   pre-commit install
+#
+# (scripts/install-cpu.sh runs this for you when a .git dir is present.)
+#
+# Run manually against every file:
+#   pre-commit run --all-files
+#
+# Bump pinned versions:
+#   pre-commit autoupdate
+#
+# CI (.github/workflows/lint.yml + pyright.yml + audit.yml) is the source
+# of truth — these hooks just shorten the feedback loop so violations
+# are caught at commit time instead of on the next push.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff
+        name: ruff check
+      - id: ruff-format
+        name: ruff format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=500"]

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,6 +19,7 @@ or [ARCHITECTURE.md](../ARCHITECTURE.md), the plan file is deleted.
 | [ux-brainstorm.md](ux-brainstorm.md) | **Backlog** | Audit of friction across importers, labeling, sorting, settings, and progress UX. ~75 ideas across auto-fill, hints, speed-ups, clarity, streamlining, and consistency. Items graduate into their own plan doc as they mature. |
 | [smart-clipper-defaults.md](smart-clipper-defaults.md) | **Phase 1 shipped; Phase 2 deferred** | "Auto (recommended)" clipper entry for audio and video — resolves to pass-through or tiling per dataset based on median duration. Phase 2 (per-media routing via clipper options) deferred — see Open follow-ups. |
 | [active-context-switcher.md](active-context-switcher.md) | **Proposed** | Top-bar dataset/detector read-only fields become click-to-switch pulldowns (compatibility dim, "Add New" footers, in-place modal launching). Phase 2 encodes the active pair in the URL; Phase 3 surfaces in-flight job spinners + verifies each job-producing view rehydrates from `JobManager`'s signature cache. Graduates ux-brainstorm §6.11 + §8.2. |
+| [python-quality-tools.md](python-quality-tools.md) | **Phase 1 shipped; Phases 2–3 proposed** | pre-commit (ruff + safety hooks) wired up locally and `pip-audit` runs in CI. Phase 2 (deptry, codespell) and Phase 3 (coverage, ruff `S` rules / bandit, vulture) are designed and triaged into one-sitting tasks — see Open follow-ups. |
 
 ## Recently completed (removed)
 

--- a/docs/plans/python-quality-tools.md
+++ b/docs/plans/python-quality-tools.md
@@ -1,0 +1,230 @@
+# Python quality tools
+
+*Status: Phase 1 shipped — pre-commit (ruff + safety hooks) is wired up
+and `pip-audit` runs in CI. Phases 2 and 3 are proposed; see "Open
+follow-ups" at the bottom for what's still owed.*
+
+The ruff + pyright + pytest stack already covers the modern core of
+Python quality tooling. This plan tracks what else is worth adding,
+grouped by friction. Each tool gets a clear "what it catches", "how to
+wire it", and a success criterion so it's a one-sitting task.
+
+## What shipped (Phase 1)
+
+- **pre-commit** (`.pre-commit-config.yaml`) — runs `ruff check`,
+  `ruff format`, trailing-whitespace, end-of-file-fixer, yaml/toml/json
+  syntax checks, merge-conflict markers, and a 500 KB large-file guard
+  at commit time. Pinned to `ruff-pre-commit v0.15.8` and
+  `pre-commit-hooks v5.0.0`; bump with `pre-commit autoupdate`.
+- **`pip-audit`** (`.github/workflows/audit.yml`) — scans installed
+  packages against the PyPI advisory database. Runs on PRs that touch
+  `requirements/**` or `pyproject.toml`, on pushes to `main`/`dev`, and
+  on a weekly cron so newly-disclosed CVEs surface even when nothing
+  has changed in the repo.
+- **`pre-commit` package** added to `requirements/base.txt`;
+  `scripts/install-cpu.sh` runs `pre-commit install --install-hooks`
+  automatically when `.git` is present so contributors get the git hook
+  on first install.
+
+## Phase 2 — Low-friction additions
+
+These are each a one-config-file change with an obvious failure mode.
+Worth doing soon; can be done independently in any order.
+
+### deptry — unused / missing / transitive deps
+
+Catches three kinds of dependency bugs:
+
+- A package is imported but not listed in `requirements/base.txt` (works
+  on your laptop because something else dragged it in, breaks in a
+  fresh container).
+- A package is listed but never imported (dead weight in installs).
+- A package is imported but only available transitively (will break the
+  day the direct dep drops it).
+
+Important for VTSearch because plugin auto-discovery means
+`requirements/plugins.txt` can drift from the actual `import` graph
+quickly.
+
+**Wire-up:**
+- Add `deptry` to `requirements/base.txt` dev tools.
+- `[tool.deptry]` block in `pyproject.toml`:
+  - `extend_exclude = ["frontend", "scripts", "data"]`
+  - Map heavy-but-aliased packages (e.g. `torch` is `pytorch`?
+    `scikit-learn` is `sklearn`) via
+    `[tool.deptry.package_module_name_map]`.
+  - Mark `pytest`, `pytest-xdist`, `pre-commit`, `ruff`, `pip-audit` as
+    dev-only via `[tool.deptry.per_rule_ignores]` (DEP002) — they're
+    intentionally not imported.
+- Add to `.pre-commit-config.yaml` (local hook, since deptry needs the
+  project venv to resolve imports):
+  ```yaml
+  - repo: local
+    hooks:
+      - id: deptry
+        name: deptry
+        entry: deptry .
+        language: system
+        pass_filenames: false
+        files: ^(vtsearch/|pyproject\.toml|requirements/)
+  ```
+- Add a `deptry` job to `lint.yml` so PRs are gated.
+
+**Success criterion:** `deptry .` returns 0 against the current tree;
+introducing an unused import or a missing dep fails CI.
+
+### codespell — misspellings in code and docs
+
+Catches typos in identifiers, comments, docstrings, and Markdown. Very
+low signal-to-noise once configured. The cost is one config block to
+exclude domain-specific terms that aren't in the dictionary.
+
+**Wire-up:**
+- Add codespell hook to `.pre-commit-config.yaml`:
+  ```yaml
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+  ```
+- `[tool.codespell]` block in `pyproject.toml` with:
+  - `skip = "*.lock,*.svg,*.json,frontend/node_modules,data,static,*.pkl"`
+  - `ignore-words-list = "..."` for ML terms it doesn't know
+    (`clap`, `siglip`, `xclip`, `wrest`, `caller`, etc. — populate as
+    false-positives surface).
+- Add codespell to `lint.yml` for the CI gate.
+
+**Success criterion:** `codespell` passes against the current tree;
+introducing a typo in a comment or docstring fails CI.
+
+## Phase 3 — Medium-friction additions
+
+These each need a real config pass — not because the tool is hard but
+because the first run will surface a backlog of findings that someone
+has to triage. Plan for an afternoon per tool, not five minutes.
+
+### coverage.py / pytest-cov — line + branch coverage
+
+Tells us which lines and branches the test suite exercises. Useful for
+two things: spotting modules without test coverage, and (eventually)
+gating PRs on "don't lower coverage by more than N%".
+
+**Open questions to settle before wiring:**
+- Coverage target — pick a starting number from the first measured run,
+  don't pluck one out of the air. (Realistic: VTSearch probably lands
+  in the 60–80% range given the size of the test suite.)
+- Whether to gate PRs on coverage delta (e.g. via `diff-cover`) or just
+  publish a report to the GitHub step summary. Start with publish-only
+  for the first cycle.
+
+**Wire-up:**
+- Add `pytest-cov` to `requirements/base.txt`.
+- `pyproject.toml`:
+  ```toml
+  [tool.coverage.run]
+  source = ["vtsearch"]
+  branch = true
+  omit = ["vtsearch/_version.txt"]
+
+  [tool.coverage.report]
+  exclude_lines = [
+      "pragma: no cover",
+      "if TYPE_CHECKING:",
+      "raise NotImplementedError",
+  ]
+  ```
+- `./run-tests.sh` invokes `pytest --cov=vtsearch --cov-report=term-missing`.
+- `lint.yml` (or a dedicated `coverage.yml`) uploads HTML report as an
+  artifact + writes summary to `$GITHUB_STEP_SUMMARY`.
+
+**Success criterion:** `./run-tests.sh` prints a coverage summary at
+the end; CI artifact shows the per-file breakdown.
+
+### bandit (or ruff's `S` ruleset) — security linter
+
+Catches `pickle.load` on untrusted input, `subprocess` with `shell=True`,
+weak crypto, hard-coded passwords, SQL injection patterns, etc. VTSearch
+already does some of this manually (`safe_pickle_load`,
+`validate_server_filepath`); a linter is a backstop.
+
+**Important call:** ruff has the `S` (flake8-bandit) ruleset built in.
+Enabling that is strictly simpler than adding bandit as a second tool —
+no new dep, no new CI job, and config lives in the existing ruff block.
+The catch is ruff's S rules are a subset of full bandit. For VTSearch's
+threat model (single-user, on-prem, no untrusted callers in the
+critical path), the ruff subset is enough.
+
+**Wire-up:**
+- Add to `[tool.ruff.lint]` in `pyproject.toml`:
+  ```toml
+  select = ["E", "F", "S"]   # default rules + flake8-bandit
+  ```
+- `[tool.ruff.lint.per-file-ignores]`:
+  - `"tests/**" = ["S101"]` (allow `assert` in tests)
+  - `"vtsearch/security/pickle.py" = ["S301"]` (the whole point of the
+    file is to call `pickle.load` carefully)
+  - Other case-by-case waivers as findings surface.
+- First-pass triage commit fixes the easy ones and adds targeted
+  `# noqa: S###` for the legitimate exceptions.
+
+**Success criterion:** `ruff check .` with `S` rules enabled returns 0
+against the current tree; introducing a new `subprocess(..., shell=True)`
+or `pickle.load` of untrusted bytes fails lint.
+
+### vulture — dead code finder
+
+Finds functions, classes, imports, and variables that are defined but
+never referenced. Best run as a periodic audit (it has false positives
+from dynamic dispatch and plugin discovery) rather than a CI gate.
+
+**Why not in Phase 2:** VTSearch's plugin-discovery pattern (sentinel
+constants like `IMPORTER`, `EXPORTER`, `SETTINGS_SOURCE`,
+`LABEL_IMPORTER`, etc.) means every plugin class looks unused to
+vulture. The whitelist will need real curation, and the value is a
+one-shot cleanup rather than ongoing enforcement.
+
+**Wire-up (when we get to it):**
+- Add `vulture` to dev deps.
+- Create `.vulture-whitelist.py` exporting all plugin classes + any
+  reflection-only symbols.
+- Run as a manual command: `vulture vtsearch .vulture-whitelist.py
+  --min-confidence 80`.
+- Don't gate CI on it — just run it before each release and act on the
+  high-confidence findings.
+
+**Success criterion:** the audit produces a short, hand-reviewable
+list of dead code; the obvious findings are deleted, the rest are
+added to the whitelist with a comment explaining why.
+
+## What we considered and skipped
+
+- **mypy** — second type checker, redundant with pyright. Adding it
+  would mean reconciling two type-checker opinions on every diff. Not
+  worth it unless we hit a concrete pyright limitation.
+- **interrogate** (docstring coverage) — we don't enforce docstrings
+  anywhere, and the codebase doesn't have a "every public function
+  needs a docstring" norm. Adding it would create a large backlog with
+  little payoff.
+- **radon / xenon** (cyclomatic complexity) — ruff already has McCabe
+  via the `C901` rule. Enable that in the same pass as Phase 3's
+  bandit/S work if we want complexity gating.
+- **semgrep** — powerful pattern-based static analysis but heavy for a
+  single-app repo. Revisit if we ever start shipping VTSearch as a
+  library or hosting multi-tenant.
+- **safety** (the package) — overlaps `pip-audit` and has a more
+  restrictive license. `pip-audit` is the right choice here.
+
+## Open follow-ups
+
+- Phase 2: wire up **deptry** and **codespell** (both ~1-hour tasks).
+- Phase 3a: turn on **ruff `S` ruleset** (covers most of what bandit
+  would). Triage the first-run findings, add targeted ignores.
+- Phase 3b: wire up **coverage** via `pytest-cov`. Publish-only first;
+  decide on a delta gate after we see real numbers.
+- Phase 3c: one-shot **vulture** audit. Build a whitelist for the
+  plugin sentinels, delete what's actually dead, then leave vulture as
+  a manual pre-release command rather than a CI gate.
+- Periodic: `pre-commit autoupdate` on a cadence so pinned hook
+  versions don't drift too far from CI's `pip install ruff` (which
+  always pulls latest). Worth a quarterly reminder.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,6 +31,7 @@ torch>=2.0.0
 pytest
 pytest-xdist
 ruff
+pre-commit
 
 # ── Plugin dependencies (auto-discovered) ────────────────────────────
 # Regenerate with:  bash scripts/install-plugin-deps.sh

--- a/scripts/install-cpu.sh
+++ b/scripts/install-cpu.sh
@@ -24,4 +24,11 @@ pip install -r "$REPO_ROOT/requirements/base.txt" -q
 # Step 3: Editable install so 'import vtsearch' works.
 pip install --no-deps -e "$REPO_ROOT" -q
 
+# Step 4: Wire up the pre-commit git hook (no-op if not in a git checkout
+# or if .pre-commit-config.yaml is absent).
+if [ -d "$REPO_ROOT/.git" ] && [ -f "$REPO_ROOT/.pre-commit-config.yaml" ]; then
+    (cd "$REPO_ROOT" && pre-commit install --install-hooks) || \
+        echo "warning: pre-commit install failed; run it manually to enable git hooks"
+fi
+
 echo "CPU dependencies installed successfully."


### PR DESCRIPTION
## Summary

Phase 1 of the new `docs/plans/python-quality-tools.md` plan:

- **`.pre-commit-config.yaml`** runs `ruff check`, `ruff format`, and a minimal safety set (trailing-whitespace, end-of-file-fixer, yaml/toml/json syntax, merge-conflict markers, 500 KB large-file guard) at commit time. Ruff hooks pinned to `v0.15.8` to match what local + CI install today; bump with `pre-commit autoupdate`.
- **`.github/workflows/audit.yml`** scans installed Python packages against the PyPI advisory database via `pip-audit`. Triggers on PRs that touch `requirements/**` or `pyproject.toml`, on pushes to `main`/`dev`, and on a weekly cron so newly-disclosed CVEs surface even when nothing has changed in the repo. Auditing installed packages (rather than scanning requirements files) catches transitive deps.
- **`scripts/install-cpu.sh`** now runs `pre-commit install --install-hooks` when `.git` is present, so contributors get the git hook on first install without a separate step. `pre-commit` added to `requirements/base.txt`.
- **`docs/plans/python-quality-tools.md`** documents what shipped and triages future work — Phase 2 (deptry, codespell) and Phase 3 (coverage via pytest-cov, ruff `S` ruleset / bandit, vulture) — into one-sitting tasks with config snippets and success criteria. Also records what was considered and rejected (mypy, interrogate, radon, semgrep, safety) with rationale.

## Test plan

- [ ] CI: `lint.yml` and `pyright.yml` still pass.
- [ ] CI: new `audit.yml` runs and reports `pip-audit` status to the step summary.
- [ ] Local: `pre-commit run --all-files` passes against the current tree.
- [ ] Local: introducing a deliberate ruff violation in a working-copy file is caught by `git commit` before it lands.
- [ ] Local: re-running `bash scripts/install-cpu.sh` is idempotent and prints the pre-commit install line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfRTuqVnqqjaNq8q1eo82S)_