### PR TITLE
Reframe docs from "media explorer" to "trainable media search tool"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-Media explorer web app for browsing/voting on audio, images, text, video, or documents. Semantic sorting (LAION-CLAP, SigLIP, X-CLIP, E5 embeddings) and learned sorting (neural net trained on votes). Flask + Angular + PyTorch.
+Trainable media search tool. Searches collections of audio, images, text, video, and documents using a **detector** — a small trained ranker that scores each item by how well it matches. Two ways to search: **train a new detector** (vote good/bad on a handful of items; a small MLP learns to rank the rest) or **use an existing detector** (saved or imported). Trained detectors are reusable across compatible datasets. Text queries (LAION-CLAP, SigLIP, X-CLIP, E5 embeddings) seed either flow or work as a quick stand-alone search. Flask + Angular + PyTorch.
 
 ## Branch Policy (CRITICAL)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-A media explorer web app. Browse collections of audio clips, images, text paragraphs, videos, or documents — listen/view them in the browser and vote items as "good" or "bad." Supports text-based semantic sorting (via LAION-CLAP, SigLIP, X-CLIP, or E5-base-v2 embeddings depending on media type) and learned sorting (via a small neural network trained on your votes). Several demo datasets can be loaded directly from the UI. Built with Flask (Python), Angular (TypeScript), and PyTorch.
+A trainable media search tool. VTSearch searches collections of audio clips, images, text paragraphs, videos, and documents using a **detector** — a small trained ranker that scores every item in the collection by how well it matches what you're looking for. You search either by **training a new detector** (vote a handful of items "good" or "bad" and a small neural net learns from your votes to rank the rest of the collection) or by **using an existing detector** (one you saved earlier, exported from another VTSearch instance, or imported from disk). Trained detectors are reusable — apply the same one to any future dataset of the same media type. A natural-language query ("dog barking", "red car in snow") seeds either flow via pretrained embeddings (LAION-CLAP for audio, SigLIP for images, X-CLIP for video, E5-base-v2 for text), and also works as a quick stand-alone search when you don't need a trained detector. Several demo datasets are available directly from the UI. Built with Flask (Python), Angular (TypeScript), and PyTorch.
 
 ## Setup and running tests
 
@@ -32,11 +32,11 @@ VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
 
 See [docs/SETUP.md](docs/SETUP.md#running-the-app) and [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for details.
 
-> **New to VTSearch?** Read **[docs/USER_GUIDE.md](docs/USER_GUIDE.md)** — a walkthrough of loading a dataset, using Autopilot to label, and exporting results. Most users never need anything else.
+> **New to VTSearch?** Read **[docs/USER_GUIDE.md](docs/USER_GUIDE.md)** — a walkthrough of loading a dataset, training a detector with Autopilot (or applying an existing one), and exporting the matches. Most users never need anything else.
 
 ## Command-line interface
 
-VTSearch provides several CLI workflows for running detectors, importing labels, and importing processors — all without starting the web server. See [docs/CLI.md](docs/CLI.md) for the full CLI reference.
+VTSearch provides several CLI workflows for applying detectors to datasets, importing labels, and importing processors — all without starting the web server. See [docs/CLI.md](docs/CLI.md) for the full CLI reference.
 
 ## Loading a demo dataset
 
@@ -52,25 +52,37 @@ You can also load your own data from pickle files or folders via the same menu.
 ├── app.py                          # Flask entry point, registers blueprints, CLI arg parsing
 ├── gunicorn.conf.py                # Gunicorn WSGI config (single worker + threads)
 ├── vtsearch/                       # Main application package
-│   ├── config.py                   # Constants (CLAP_SAMPLE_RATE, paths, model IDs)
-│   ├── medias.py                   # Test media generation & embedding cache
+│   ├── config.py                   # Constants (paths, model IDs, sample rates)
 │   ├── cli.py                      # CLI utilities: autodetect workflow
-│   ├── settings.py                 # Persistent settings & autorun processors
+│   ├── cli_pipeline.py             # CLI orchestration shared by autodetect
+│   ├── cli_progress.py             # CLI progress bars
+│   ├── settings.py                 # Persistent settings (server tier + per-user tier)
+│   ├── settings_factory.py         # Accessor factories for the settings table
+│   ├── settings_models.py          # Settings dataclass schemas
+│   ├── achievements.py             # User-achievement state machine
+│   ├── logging_config.py           # Logging setup
 │   ├── auth/                       # Authentication (LoginProvider ABC, DefaultLoginProvider)
-│   ├── routes/                     # Flask blueprints
-│   ├── models/                     # ML models (embeddings, training, progress)
-│   ├── media/                      # Media type plugins (audio, image, text, video, document)
-│   ├── converters/                 # Media converters (document→image, video→audio, etc.)
-│   ├── datasets/                   # Dataset loading, downloading, importers
-│   ├── eval/                       # Evaluation framework (metrics, runner, visualisation)
+│   ├── routes/                     # Flask blueprints (datasets, detectors, processors, media, settings, labels, …)
+│   ├── detectors/                  # Detector lifecycle: registry, store, training, label sync, restoration
+│   ├── training/                   # Generic learned-sort training primitives (MLP, thresholds, SVM, region-sim)
+│   ├── embedding/                  # Embedder façades, torch runtime, smart preload, cached embedding matrix
+│   ├── media/                      # Media type plugins (audio, image, text, video, document) + embedders, clippers
+│   ├── converters/                 # Media converters (document→image/text, video→audio/image, audio→image, image→text)
+│   ├── datasets/                   # Dataset loading, importers, origin tracking, labelsets, media sources
+│   ├── eval/                       # Evaluation framework (metrics, runner, visualisation, voting iterations)
 │   ├── exporters/                  # Results exporter plugins
-│   ├── labels/                     # Label importers & labelset sync sources
-│   ├── processors/importers/       # Processor importer plugins
-│   ├── settings_io/                # Settings importers, exporters & sync sources
-│   ├── audio/                      # Audio generation utility
-│   └── utils/                      # State proxies (per-dataset/per-detector contexts) & progress helpers
+│   ├── labels/                     # Label importers and labelset sync sources
+│   ├── settings_io/                # Settings importers, exporters and sync sources
+│   ├── state/                      # Per-dataset / per-detector context registries; medias/votes proxies
+│   ├── plugins/                    # Plugin registry, PluginBase, sentinel-based discovery
+│   ├── sync/                       # Generic SyncSource base for settings + labelset sources
+│   ├── concurrency/                # Async job manager, memory-aware worker capping, progress trackers
+│   ├── security/                   # Path/URL/pickle safety validation
+│   ├── schemas/                    # JSON / OpenAPI schemas
+│   └── utils/                      # build_media_hit helper + offline synthetic-media generators
 ├── static/                         # Angular build output (HTML, JS, CSS, assets)
-├── tests/                          # Test suite (pytest)
+├── frontend/                       # Angular SPA source (TypeScript, SCSS) — builds into static/
+├── tests/                          # Test suite (pytest) — grouped by folder (core, api, sorting, datasets, io, …)
 ├── docs/                           # Extended documentation
 │   ├── HANDOFF.md                  # Project handoff & orientation guide
 │   ├── DEPLOYMENT.md               # Deployment, offline mode, operations
@@ -84,7 +96,7 @@ You can also load your own data from pickle files or folders via the same menu.
 │   ├── CLI.md                      # CLI reference
 │   ├── ML.md                       # ML model details
 │   ├── SETUP.md                    # Setup instructions
-│   ├── USER_GUIDE.md               # End-user walkthrough (Autopilot, voting, sorting)
+│   ├── USER_GUIDE.md               # End-user walkthrough (training detectors, applying detectors, exporting)
 │   ├── demos.md                    # Demo dataset listing
 │   ├── plans/                      # Open design plans (see plans/README.md)
 │   └── design/                     # Architecture design documents
@@ -93,7 +105,7 @@ You can also load your own data from pickle files or folders via the same menu.
 
 ## HTTP API
 
-VTSearch exposes a REST-style JSON API. See [docs/API.md](docs/API.md) for the full endpoint reference, including media listing, sorting, voting, dataset management, detector/exporter/importer operations, settings, and detectors.
+VTSearch exposes a REST-style JSON API. See [docs/API.md](docs/API.md) for the full endpoint reference, including media listing, sorting, voting, dataset management, detector CRUD and scoring, exporter and importer operations, and settings.
 
 ## Deployment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,15 +21,22 @@ which pieces you need and how to pull them out.
 
 ## What VTSearch does
 
-VTSearch is a media-explorer web app for browsing, voting on, and
-semantically sorting collections of audio, images, text, video, or
-documents.  It combines:
+VTSearch is a trainable media search tool. The thing the user searches
+*with* is a **detector**: a small ranker that scores every item in a
+dataset by how well it matches. Detectors come from two places —
+either trained in the UI from good/bad votes in a labeling pass, or
+imported/loaded from disk and applied as-is. The architecture combines:
 
-- **Semantic sorting** — LAION-CLAP (audio), SigLIP (images), X-CLIP
-  (video), E5-base-v2 (text) for embedding-based similarity search,
-  with alternative embedders available (CLAP Music, BGE).
-- **Learned sorting** — a small MLP trained on user votes to predict
-  good/bad labels.
+- **Detectors (learned search)** — a small MLP trained on user votes
+  to predict good/bad labels. This is the primary search mechanism.
+  Detectors are persisted as **labelsets** (origin info + labels — never
+  weights; weights are an in-memory artifact, re-derived on demand from
+  origins and the active embedder).
+- **Semantic sort (text-similarity search)** — LAION-CLAP (audio),
+  SigLIP (images), X-CLIP (video), E5-base-v2 (text) for
+  embedding-based similarity search, with alternative embedders
+  available (CLAP Music, BGE). Used to seed a detector during the
+  training loop, or as a quick stand-alone search.
 - **Flask web UI** — Angular SPA frontend with a REST API.
 - **Plugin systems** — auto-discovered dataset importers, results
   exporters, label importers, and processor importers.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -21,14 +21,26 @@ to know first.
 
 ## What is VTSearch?
 
-VTSearch is a media explorer web app for browsing and voting on collections
-of audio, images, text, video, or documents. It supports two sorting
-strategies:
+VTSearch is a trainable media search tool. It searches collections of
+audio, images, text, video, and documents using a **detector** — a
+small trained ranker that scores every item in the dataset by how well
+it matches what you're looking for. There are two ways to search:
 
-- **Semantic sorting** — uses pretrained embedding models (CLAP, CLIP,
-  X-CLIP, E5) to rank items by similarity to a text query.
-- **Learned sorting** — trains a small MLP neural network on user votes to
-  predict good/bad labels.
+- **Train a new detector.** Vote a handful of items good or bad in the
+  UI; a small MLP neural network learns from those votes to rank the
+  rest of the collection. **Autopilot** drives this loop, picking which
+  item to show next and when each phase ends, so most users never need
+  to think about sort modes or selection strategies directly.
+- **Use an existing detector.** Apply a previously trained detector —
+  one you saved earlier, exported from another VTSearch instance, or
+  imported from disk — to a fresh dataset of the same media type. No
+  new labeling required.
+
+A natural-language query ("dog barking", "red car in snow") seeds
+either flow via pretrained embeddings (CLAP, CLIP/SigLIP, X-CLIP, E5),
+giving the detector a useful starting point. The text-similarity sort
+also works as a quick stand-alone search when you don't need the
+precision of a trained detector.
 
 Built with Flask + Angular + PyTorch. Single-user by default;
 pluggable authentication via `LoginProvider` ABC supports multi-user
@@ -41,7 +53,7 @@ deployments. Runs locally or in Docker.
 | Document | Purpose |
 |----------|---------|
 | [SETUP.md](SETUP.md) | Installation, prerequisites, getting started, basic Docker usage |
-| [USER_GUIDE.md](USER_GUIDE.md) | End-user walkthrough — Autopilot labeling, manual mode, sort modes, dashboard, exporting |
+| [USER_GUIDE.md](USER_GUIDE.md) | End-user walkthrough — training a detector with Autopilot, manual mode, applying existing detectors, sort modes, dashboard, exporting |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Production deployment, offline mode, network deps, env vars, data directory, troubleshooting |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Module structure, dependency graph, extractability matrix, state management |
 | [API.md](API.md) | HTTP API reference (all REST endpoints, request/response formats) |
@@ -272,12 +284,13 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for full details.
 
 ## Common workflows
 
-### Load and explore a dataset
+### Load a dataset and start a search
 
 1. Start the app
 2. Click the hamburger menu (top-left)
 3. Select a demo dataset or use an importer
-4. Browse, listen/view, and vote
+4. Listen/view items and vote good/bad to train a detector, or load an
+   existing detector and apply it directly
 
 ### Run autodetect from CLI
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -282,7 +282,7 @@ docker run --gpus all -p 5000:5000 -v vtsearch-data:/app/data vtsearch:gpu
 
 ### LabBench (SigLIP-only image search)
 
-For the LabBench deployment — browsing/voting on images with the SigLIP
+For the LabBench deployment — image search with the SigLIP
 embedder — use the streamlined `docker/Dockerfile.labbench` variant. It skips
 audio, video, document, text, and extractor plugin dependencies, and **bakes
 the SigLIP model weights into the image at build time** so the container is

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,9 +1,10 @@
 # VTSearch User Guide
 
 A walkthrough for people who want to **use** VTSearch — not install,
-extend, or debug it. Open it, load a dataset, label a few things,
-export results. For installation see [SETUP.md](SETUP.md). For
-CLI workflows (no browser) see [CLI.md](CLI.md).
+extend, or debug it. Open it, load a dataset, train a detector (or
+apply an existing one), and export the matches. For installation see
+[SETUP.md](SETUP.md). For CLI workflows (no browser) see
+[CLI.md](CLI.md).
 
 ## Contents
 
@@ -25,18 +26,29 @@ CLI workflows (no browser) see [CLI.md](CLI.md).
 
 VTSearch helps you **find the items you care about** inside a large
 collection of audio clips, images, text paragraphs, videos, or
-documents. You vote items **good** or **bad**, and a small neural net
-learns from your votes to rank the rest of the collection by how likely
-each item is to match what you're looking for. You can also search by
-typing a natural-language description ("dog barking", "red car in
-snow"), and the app uses a pretrained embedding model to rank items
-by semantic similarity to your query.
+documents. You search using a **detector** — a small trained ranker
+that scores every item in the dataset by how well it matches what
+you're looking for. There are two ways to search:
 
-In practice, you usually combine the two: search for a rough starting
-point, vote a handful of items, and let the learned detector refine the
-ranking. VTSearch's **Autopilot** drives that loop for you — so most
-users never need to think about sort modes or selection strategies
-directly.
+1. **Train a new detector.** Vote a handful of items **good** or
+   **bad** and a small neural net learns from your votes to rank the
+   rest of the dataset. Detectors are reusable — once trained, you can
+   save one and re-apply it to any future dataset of the same media
+   type, or share it with another VTSearch user.
+2. **Use an existing detector.** Load one you (or someone else)
+   trained earlier and score a fresh dataset with it. No new labeling
+   required. Loaded detectors can also be re-trained against the new
+   dataset's votes if you want to refine them further.
+
+A natural-language query ("dog barking", "red car in snow") seeds
+either flow: a pretrained embedding model ranks items by semantic
+similarity to your query, giving the detector a useful starting point.
+The text-similarity ranking also works as a quick stand-alone search
+when you don't need the precision of a trained detector.
+
+VTSearch's **Autopilot** drives the training loop for you — picking
+which item to show next and when each phase ends — so most users never
+need to think about sort modes or selection strategies directly.
 
 ---
 


### PR DESCRIPTION
## Summary

The README and the rest of the docs framed VTSearch as a "media explorer web app for browsing/voting on" collections. That framing buries the product: VTSearch is a **search tool**. The thing you search *with* is a **detector** — either one you train in the UI from good/bad votes, or one you import/load and apply as-is.

This PR rewrites the positioning across the user-facing docs to make that clear, with two pillars consistently:

- **Train a new detector** — vote → MLP learns to rank the rest. Autopilot drives the loop.
- **Use an existing detector** — load one you saved earlier (or someone else trained) and score a fresh dataset.

Text-similarity sort is reframed as a starting point that seeds either flow (or works as a quick stand-alone search), not a parallel "sorting strategy" alongside the learned MLP.

## Files touched

- **`README.md`** — main one-paragraph summary rewritten around detectors. Also refreshed the **Project structure** tree to match the current layout (dropped stale `medias.py` and `models/`; added `detectors/`, `training/`, `embedding/`, `state/`, `plugins/`, `sync/`, `concurrency/`, `security/`, `schemas/`, `cli_pipeline.py`, `cli_progress.py`, `settings_factory.py`, `settings_models.py`, `achievements.py`, `logging_config.py`, plus `frontend/`). Fixed a duplicate "detectors" in the HTTP API blurb and tightened the CLI / Autopilot one-liners.
- **`CLAUDE.md`** — one-line project description rewritten to match.
- **`docs/HANDOFF.md`** — "What is VTSearch?" section rewritten around the two search modes. "Load and explore a dataset" workflow renamed and reworded. USER_GUIDE.md doc-map entry updated.
- **`docs/ARCHITECTURE.md`** — "What VTSearch does" section rewritten; detectors are explicitly the primary search mechanism and semantic sort is the seed.
- **`docs/USER_GUIDE.md`** — intro and "What VTSearch does" rewritten with the same two-mode framing, then funnels into Autopilot.
- **`docs/SETUP.md`** — LabBench blurb changed from "browsing/voting on images" to "image search".

Legitimate mentions of "in your browser" (web browser), "File browser API" (the literal file-browser feature), the demo-list UI "browse the available demo datasets", and exporter names like `gui` ("in-browser / console display") are unchanged.

## Test plan

- [ ] Read the new README top-line and confirm it answers "what is this thing?" without using "media explorer" or framing browsing/voting as the product purpose.
- [ ] Skim HANDOFF.md, ARCHITECTURE.md, USER_GUIDE.md openings — confirm the two search modes (train vs. use) read consistently.
- [ ] Confirm the README project-structure tree matches `ls vtsearch/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyRxnU6CFveDukk4BEYzgC)_