### PR TITLE
Rewire ExportersApiService + SettingsIoApiService to the generated TS client

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -635,6 +635,34 @@ checks off this follow-up.
       generated entry types both carry ``modified_at`` as a required
       string (empty on stat failure), matching the backend's
       marshmallow schema.
+- [x] ``ExportersApiService`` (labelset exporters) rewired to the
+      generated TS client. The service now calls ``apiExportersGet`` /
+      ``apiExportersExportPost`` from
+      ``generated/api-client/fn/exporters/``; the ``runExport`` method's
+      argument type tightened from a free-form
+      ``{ exporter_name: string; [key: string]: unknown }`` to the
+      generated ``RunExportRequest`` (``exporter_name`` plus optional
+      ``field_values`` / ``results``). The three consumers
+      (``export-modal``, ``label-exporter-modal``,
+      ``autodetect-results-modal``) ``import type``-only the generated
+      ``ExporterEntry`` from
+      ``generated/api-client/models/exporter-entry``; ``ExporterInfo``
+      stays in ``api.models.ts`` for now because
+      ``settings-io-api.service.ts`` still uses it (the
+      ``/api/settings-exporters`` endpoint returns a different generated
+      type, ``SettingsExporterEntry``, so a separate follow-up rewires
+      that service and deletes ``ExporterInfo``). Plugin-field shapes
+      are not described in the OpenAPI spec, so ``ExporterEntry.fields``
+      is generated as ``Array<{[key: string]: any}>``; consumers cast it
+      to the legacy ``ImporterField[]`` at the point of use via a small
+      private helper. The ``export-modal`` template now iterates a typed
+      ``activeTabExporterFields: ImporterField[]`` getter (Angular's
+      template type-checker rejects dot-syntax access on index
+      signatures). A dead-code reference to ``exp['label']`` in the
+      ``autodetect-results-modal`` template — never populated by the
+      backend, always fell through to ``exp.name`` — was fixed to
+      ``exp.display_name || exp.name`` to match the actual response
+      shape.
 
 ## Open follow-ups
 

--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -663,6 +663,36 @@ checks off this follow-up.
       backend, always fell through to ``exp.name`` — was fixed to
       ``exp.display_name || exp.name`` to match the actual response
       shape.
+- [x] ``SettingsIoApiService`` rewired to the generated TS client. The
+      service now calls ``apiSettingsImportersGet`` /
+      ``apiSettingsExportersGet`` / ``apiSettingsExportersExportPost``
+      from ``generated/api-client/fn/settings-io/``; ``runExport``'s
+      response tightens from a local ``SettingsExportResponse`` to the
+      generated ``RunSettingsExportResponse``. The plugin-field
+      ``POST /api/settings-importers/import/<importer_name>`` route
+      stays on plain ``HttpClient.post`` (same pattern as
+      ``LabelImportersApiService.runImport``) — its body shape is
+      plugin-dependent and not described in the OpenAPI spec; the local
+      ``SettingsImportResponse`` interface stays in the service file for
+      the same reason (the spec types the route's response as just
+      ``Error``, but the backend actually returns
+      ``{success, message, keys?}``). The two consumers
+      (``settings-exporter-modal``, ``settings-importer-modal``)
+      replaced their local ``SettingsExporterInfo`` /
+      ``SettingsImporterInfo`` shim interfaces with
+      ``import type``-only ``SettingsExporterEntry`` /
+      ``SettingsImporterEntry`` from
+      ``generated/api-client/models/``; both modal templates now iterate
+      typed ``selectedExporterFields`` / ``selectedImporterFields``
+      getters (same Angular template-type-checker workaround as
+      ``export-modal``). With this migration ``settings-io`` no longer
+      imports ``ExporterInfo``, so the ``ExporterInfo`` interface was
+      deleted from ``frontend/src/app/models/api.models.ts`` (no
+      remaining consumers — ``settings-exporter-modal``'s local
+      ``SettingsExporterInfo`` was a separately-named shim, not a
+      reference). ``ImporterInfo`` stays because many other services
+      (label-importers, processor-importers, dataset-importer-modal,
+      etc.) still use it.
 
 ## Open follow-ups
 

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -51,7 +51,7 @@
     <div class="export-row">
       <select class="form-select" [(ngModel)]="selectedExporter" (ngModelChange)="onExporterChange()" title="Choose export destination">
         @for (exp of exporters; track exp.name) {
-          <option [value]="exp.name">{{ exp['label'] || exp.name }}</option>
+          <option [value]="exp.name">{{ exp.display_name || exp.name }}</option>
         }
       </select>
     </div>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -8,9 +8,9 @@ import { ExportersApiService } from '../../../services/exporters-api.service';
 import {
   AutoDetectHit,
   AutoDetectResultsData,
-  ExporterInfo,
   ImporterField,
 } from '../../../models/api.models';
+import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 
 @Component({
   selector: 'vt-autodetect-results-modal',
@@ -24,7 +24,7 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   @Output() closed = new EventEmitter<void>();
 
   exportSides: 'good' | 'bad' | 'both' = 'good';
-  exporters: ExporterInfo[] = [];
+  exporters: ExporterEntry[] = [];
   selectedExporter = '';
   exporterFields: ImporterField[] = [];
   exportFieldValues: Record<string, string> = {};
@@ -112,7 +112,7 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
 
   private updateExporterFields(): void {
     const exp = this.exporters.find((e) => e.name === this.selectedExporter);
-    this.exporterFields = exp?.fields || [];
+    this.exporterFields = (exp?.fields ?? []) as ImporterField[];
     this.exportFieldValues = {};
     for (const field of this.exporterFields) {
       if (field.default) {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -154,8 +154,8 @@
         </div>
       } @else if (activeTabExporter) {
         <div class="tab-pane">
-          @if (activeTabExporter.fields && activeTabExporter.fields.length > 0) {
-            @for (field of activeTabExporter.fields; track field.key) {
+          @if (activeTabExporterFields.length > 0) {
+            @for (field of activeTabExporterFields; track field.key) {
               <div class="tab-field">
                 <label class="form-label" [for]="'field-' + field.key">
                   {{ field.label || field.key }}

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -11,7 +11,8 @@ import { ExportersApiService } from '../../../services/exporters-api.service';
 import { FindSessionService } from '../../../services/find-session.service';
 import { LabelSessionService } from '../../../services/label-session.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
-import { ExporterInfo, LabelEntry } from '../../../models/api.models';
+import { ImporterField, LabelEntry } from '../../../models/api.models';
+import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 
 export interface ColumnDef {
   key: string;
@@ -32,7 +33,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() exported = new EventEmitter<void>();
 
-  exporters: ExporterInfo[] = [];
+  exporters: ExporterEntry[] = [];
   loading = true;
   error = '';
   status = '';
@@ -60,7 +61,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   activeTab = 'clipboard';
 
   /** Exporter form state. */
-  selectedExporter: ExporterInfo | null = null;
+  selectedExporter: ExporterEntry | null = null;
   formValues: Record<string, string> = {};
   submitting = false;
 
@@ -249,9 +250,16 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return `${stem}.${ext}`;
   }
 
+  /** The exporter's plugin-defined fields, narrowed to the legacy
+   *  ImporterField shape (the OpenAPI spec types it as an open dict
+   *  because plugin field schemas aren't part of the generated client). */
+  private exporterFieldsOf(exporter: ExporterEntry): ImporterField[] {
+    return (exporter.fields ?? []) as ImporterField[];
+  }
+
   /** Apply the dynamic default filename to the filepath form field if present. */
-  private applyDefaultFilename(exporter: ExporterInfo): void {
-    const filepathField = (exporter.fields || []).find((f) => f.key === 'filepath');
+  private applyDefaultFilename(exporter: ExporterEntry): void {
+    const filepathField = this.exporterFieldsOf(exporter).find((f) => f.key === 'filepath');
     if (filepathField) {
       const staticDefault = filepathField.default || '';
       // Derive extension from the static default (e.g. ".json", ".csv") or fall back
@@ -262,8 +270,8 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   /** Start exporter flow — if no fields, export immediately. */
-  startExporter(exporter: ExporterInfo): void {
-    const fields = exporter.fields || [];
+  startExporter(exporter: ExporterEntry): void {
+    const fields = this.exporterFieldsOf(exporter);
     if (fields.length === 0) {
       this.exportLabelsWith(exporter, {});
       return;
@@ -279,11 +287,11 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   /** Select an exporter tab and initialise its form values. */
-  selectExporterTab(exporter: ExporterInfo): void {
+  selectExporterTab(exporter: ExporterEntry): void {
     this.activeTab = exporter.name;
     this.selectedExporter = exporter;
     this.formValues = {};
-    for (const f of exporter.fields || []) {
+    for (const f of this.exporterFieldsOf(exporter)) {
       this.formValues[f.key] = f.default || '';
     }
     this.applyDefaultFilename(exporter);
@@ -300,9 +308,17 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   /** The exporter object for the currently active tab (null if clipboard). */
-  get activeTabExporter(): ExporterInfo | null {
+  get activeTabExporter(): ExporterEntry | null {
     if (this.activeTab === 'clipboard') return null;
     return this.exporters.find((e) => e.name === this.activeTab) || null;
+  }
+
+  /** Typed view of the active tab's plugin fields for the template (the
+   *  generated ExporterEntry types `fields` as an open dict because plugin
+   *  field schemas aren't part of the OpenAPI client). */
+  get activeTabExporterFields(): ImporterField[] {
+    const exp = this.activeTabExporter;
+    return exp ? this.exporterFieldsOf(exp) : [];
   }
 
   /** Label for the action button on the active exporter tab. */
@@ -334,7 +350,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     this.exportLabelsWith(this.selectedExporter, { ...this.formValues });
   }
 
-  exportLabelsWith(exporter: ExporterInfo, fieldValues: Record<string, string>): void {
+  exportLabelsWith(exporter: ExporterEntry, fieldValues: Record<string, string>): void {
     this.status = 'Exporting...';
     this.error = '';
     this.submitting = true;
@@ -366,7 +382,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   }
 
   /** Map an exporter's emoji icon to an SVG icon type. */
-  getExporterIconType(exp: ExporterInfo): string {
+  getExporterIconType(exp: ExporterEntry): string {
     const icon = exp.icon || '';
     if (icon === '📧' || icon.includes('📧')) return 'email';
     if (icon === '🖥️' || icon === '\uD83D\uDDA5' || icon === '\uD83D\uDDA5\uFE0F') return 'server';

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
@@ -6,7 +6,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
-import { ExporterInfo } from '../../../models/api.models';
+import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 
 @Component({
   selector: 'vt-label-exporter-modal',
@@ -21,7 +21,7 @@ export class LabelExporterModalComponent implements OnInit, OnDestroy {
   @Output() closed = new EventEmitter<void>();
   @Output() exportComplete = new EventEmitter<void>();
 
-  exporters: ExporterInfo[] = [];
+  exporters: ExporterEntry[] = [];
   loading = true;
   error = '';
 
@@ -55,7 +55,7 @@ export class LabelExporterModalComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  selectExporter(exporter: ExporterInfo): void {
+  selectExporter(exporter: ExporterEntry): void {
     this.sortingApi.exportLabels(this.goodsOnly).subscribe({
       next: (labelsData) => {
         this.exportersApi

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -29,8 +29,8 @@
     <div class="exporter-form">
       <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to exporter list">&larr; Back</button>
 
-      @if (selectedExporter.fields && selectedExporter.fields.length > 0) {
-        @for (field of selectedExporter.fields; track field.key) {
+      @if (selectedExporterFields.length > 0) {
+        @for (field of selectedExporterFields; track field.key) {
           <div class="form-group">
             <label class="form-label" [for]="'sef-' + field.key">
               {{ field.label || field.key }}

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -4,18 +4,10 @@ import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
-import { SettingsIoApiService, SettingsExportResponse } from '../../../services/settings-io-api.service';
+import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
-
-interface SettingsExporterInfo {
-  name: string;
-  display_name?: string;
-  description?: string;
-  icon?: string;
-  fields?: ImporterField[];
-  ui_mode?: string;
-  hidden_from_picker?: boolean;
-}
+import type { SettingsExporterEntry } from '../../../generated/api-client/models/settings-exporter-entry';
+import type { RunSettingsExportResponse } from '../../../generated/api-client/models/run-settings-export-response';
 
 type ModalView = 'picker' | 'form';
 
@@ -31,9 +23,9 @@ export class SettingsExporterModalComponent implements OnInit {
   @Output() exported = new EventEmitter<void>();
 
   view: ModalView = 'picker';
-  exporters: SettingsExporterInfo[] = [];
+  exporters: SettingsExporterEntry[] = [];
   loading = true;
-  selectedExporter: SettingsExporterInfo | null = null;
+  selectedExporter: SettingsExporterEntry | null = null;
   formValues: Record<string, string> = {};
   submitting = false;
   error = '';
@@ -48,9 +40,16 @@ export class SettingsExporterModalComponent implements OnInit {
     return 'Export Settings';
   }
 
+  /** Typed view of the selected exporter's plugin fields for the template
+   *  (the generated SettingsExporterEntry types `fields` as an open dict
+   *  because plugin field schemas aren't part of the OpenAPI client). */
+  get selectedExporterFields(): ImporterField[] {
+    return (this.selectedExporter?.fields ?? []) as ImporterField[];
+  }
+
   ngOnInit(): void {
     this.settingsIoApi.listExporters().subscribe({
-      next: (list: SettingsExporterInfo[]) => {
+      next: (list) => {
         this.exporters = list.filter((exp) => !exp.hidden_from_picker);
         this.loading = false;
       },
@@ -61,18 +60,17 @@ export class SettingsExporterModalComponent implements OnInit {
     });
   }
 
-  selectExporter(exporter: SettingsExporterInfo): void {
+  selectExporter(exporter: SettingsExporterEntry): void {
     this.selectedExporter = exporter;
     this.formValues = {};
     this.error = '';
     this.successMessage = '';
-    if (exporter.fields) {
-      for (const field of exporter.fields) {
-        if (field.default) this.formValues[field.key] = field.default;
-      }
+    const fields = (exporter.fields ?? []) as ImporterField[];
+    for (const field of fields) {
+      if (field.default) this.formValues[field.key] = field.default;
     }
     // If the exporter has no fields, submit immediately
-    if (!exporter.fields || exporter.fields.length === 0) {
+    if (fields.length === 0) {
       this.view = 'form';
       this.submit();
     } else {
@@ -94,7 +92,7 @@ export class SettingsExporterModalComponent implements OnInit {
     this.successMessage = '';
 
     this.settingsIoApi.runExport(this.selectedExporter.name, this.formValues).subscribe({
-      next: (res: SettingsExportResponse) => {
+      next: (res: RunSettingsExportResponse) => {
         this.submitting = false;
 
         // Handle browser download response

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -29,8 +29,8 @@
     <div class="importer-form">
       <button class="btn btn--secondary btn--sm back-btn" (click)="back()" title="Return to importer list">&larr; Back</button>
 
-      @if (selectedImporter.fields && selectedImporter.fields.length > 0) {
-        @for (field of selectedImporter.fields; track field.key) {
+      @if (selectedImporterFields.length > 0) {
+        @for (field of selectedImporterFields; track field.key) {
           <div class="form-group">
             <label class="form-label" [for]="'sif-' + field.key">
               {{ field.label || field.key }}

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -6,16 +6,7 @@ import { FileBrowserComponent } from '../../file-browser/file-browser.component'
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsIoApiService } from '../../../services/settings-io-api.service';
 import { ImporterField } from '../../../models/api.models';
-
-interface SettingsImporterInfo {
-  name: string;
-  display_name?: string;
-  description?: string;
-  icon?: string;
-  fields?: ImporterField[];
-  ui_mode?: string;
-  hidden_from_picker?: boolean;
-}
+import type { SettingsImporterEntry } from '../../../generated/api-client/models/settings-importer-entry';
 
 type ModalView = 'picker' | 'form';
 
@@ -31,9 +22,9 @@ export class SettingsImporterModalComponent implements OnInit {
   @Output() imported = new EventEmitter<void>();
 
   view: ModalView = 'picker';
-  importers: SettingsImporterInfo[] = [];
+  importers: SettingsImporterEntry[] = [];
   loading = true;
-  selectedImporter: SettingsImporterInfo | null = null;
+  selectedImporter: SettingsImporterEntry | null = null;
   formValues: Record<string, string> = {};
   selectedFile: File | null = null;
   selectedFileFieldKey: string | null = null;
@@ -50,9 +41,16 @@ export class SettingsImporterModalComponent implements OnInit {
     return 'Import Settings';
   }
 
+  /** Typed view of the selected importer's plugin fields for the template
+   *  (the generated SettingsImporterEntry types `fields` as an open dict
+   *  because plugin field schemas aren't part of the OpenAPI client). */
+  get selectedImporterFields(): ImporterField[] {
+    return (this.selectedImporter?.fields ?? []) as ImporterField[];
+  }
+
   ngOnInit(): void {
     this.settingsIoApi.listImporters().subscribe({
-      next: (list: SettingsImporterInfo[]) => {
+      next: (list) => {
         this.importers = list.filter((imp) => !imp.hidden_from_picker);
         this.loading = false;
       },
@@ -63,17 +61,16 @@ export class SettingsImporterModalComponent implements OnInit {
     });
   }
 
-  selectImporter(importer: SettingsImporterInfo): void {
+  selectImporter(importer: SettingsImporterEntry): void {
     this.selectedImporter = importer;
     this.formValues = {};
     this.selectedFile = null;
     this.selectedFileFieldKey = null;
     this.error = '';
     this.successMessage = '';
-    if (importer.fields) {
-      for (const field of importer.fields) {
-        if (field.default) this.formValues[field.key] = field.default;
-      }
+    const fields = (importer.fields ?? []) as ImporterField[];
+    for (const field of fields) {
+      if (field.default) this.formValues[field.key] = field.default;
     }
     this.view = 'form';
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -367,19 +367,6 @@ export interface AutoDetectResponse {
   [key: string]: unknown;
 }
 
-// --- Exporters ---
-
-export interface ExporterInfo {
-  name: string;
-  display_name?: string;
-  description?: string;
-  icon?: string;
-  fields?: ImporterField[];
-  ui_mode?: string;
-  hidden_from_picker?: boolean;
-  [key: string]: unknown;
-}
-
 // --- Detectors ---
 
 export interface Detector {

--- a/frontend/src/app/services/exporters-api.service.ts
+++ b/frontend/src/app/services/exporters-api.service.ts
@@ -1,17 +1,27 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { ExporterInfo } from '../models/api.models';
+import { map } from 'rxjs/operators';
+
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { ExporterEntry } from '../generated/api-client/models/exporter-entry';
+import type { RunExportRequest } from '../generated/api-client/models/run-export-request';
+import type { RunExportResponse } from '../generated/api-client/models/run-export-response';
+import { apiExportersGet } from '../generated/api-client/fn/exporters/api-exporters-get';
+import { apiExportersExportPost } from '../generated/api-client/fn/exporters/api-exporters-export-post';
 
 @Injectable({ providedIn: 'root' })
 export class ExportersApiService {
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
 
-  getExporters(): Observable<ExporterInfo[]> {
-    return this.http.get<ExporterInfo[]>('/api/exporters');
+  getExporters(): Observable<ExporterEntry[]> {
+    return apiExportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  runExport(params: { exporter_name: string; [key: string]: unknown }): Observable<unknown> {
-    return this.http.post('/api/exporters/export', params);
+  runExport(body: RunExportRequest): Observable<RunExportResponse> {
+    return apiExportersExportPost(this.http, this.config.rootUrl, { body }).pipe(
+      map((r) => r.body),
+    );
   }
 }

--- a/frontend/src/app/services/settings-io-api.service.ts
+++ b/frontend/src/app/services/settings-io-api.service.ts
@@ -1,29 +1,34 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { ImporterInfo, ExporterInfo } from '../models/api.models';
+import { map } from 'rxjs/operators';
 
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { SettingsImporterEntry } from '../generated/api-client/models/settings-importer-entry';
+import type { SettingsExporterEntry } from '../generated/api-client/models/settings-exporter-entry';
+import type { RunSettingsExportRequest } from '../generated/api-client/models/run-settings-export-request';
+import type { RunSettingsExportResponse } from '../generated/api-client/models/run-settings-export-response';
+import { apiSettingsImportersGet } from '../generated/api-client/fn/settings-io/api-settings-importers-get';
+import { apiSettingsExportersGet } from '../generated/api-client/fn/settings-io/api-settings-exporters-get';
+import { apiSettingsExportersExportPost } from '../generated/api-client/fn/settings-io/api-settings-exporters-export-post';
+
+/** Response shape for the plugin-field import route. The body shape is
+ *  plugin-dependent and not described in the OpenAPI spec (the spec
+ *  declares it as just an Error response), so we keep a local interface
+ *  matching what the backend actually returns. */
 export interface SettingsImportResponse {
   success: boolean;
   message: string;
   keys?: string[];
 }
 
-export interface SettingsExportResponse {
-  success: boolean;
-  message: string;
-  download?: boolean;
-  data?: Record<string, unknown>;
-  filename?: string;
-  filepath?: string;
-}
-
 @Injectable({ providedIn: 'root' })
 export class SettingsIoApiService {
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
 
-  listImporters(): Observable<ImporterInfo[]> {
-    return this.http.get<ImporterInfo[]>('/api/settings-importers');
+  listImporters(): Observable<SettingsImporterEntry[]> {
+    return apiSettingsImportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   runImport(
@@ -32,6 +37,10 @@ export class SettingsIoApiService {
     file?: File,
     fileFieldKey?: string,
   ): Observable<SettingsImportResponse> {
+    // Plugin-field route — body shape is plugin-dependent and not
+    // described in the OpenAPI spec (see plan "Open follow-ups /
+    // Per-plugin schemas"), so this stays on plain HttpClient.
+    const url = `/api/settings-importers/import/${encodeURIComponent(importerName)}`;
     if (file && fileFieldKey) {
       const formData = new FormData();
       formData.append(fileFieldKey, file, file.name);
@@ -40,28 +49,25 @@ export class SettingsIoApiService {
           formData.append(key, String(value ?? ''));
         }
       }
-      return this.http.post<SettingsImportResponse>(
-        `/api/settings-importers/import/${encodeURIComponent(importerName)}`,
-        formData,
-      );
+      return this.http.post<SettingsImportResponse>(url, formData);
     }
-    return this.http.post<SettingsImportResponse>(
-      `/api/settings-importers/import/${encodeURIComponent(importerName)}`,
-      params,
-    );
+    return this.http.post<SettingsImportResponse>(url, params);
   }
 
-  listExporters(): Observable<ExporterInfo[]> {
-    return this.http.get<ExporterInfo[]>('/api/settings-exporters');
+  listExporters(): Observable<SettingsExporterEntry[]> {
+    return apiSettingsExportersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   runExport(
     exporterName: string,
     fieldValues: Record<string, unknown>,
-  ): Observable<SettingsExportResponse> {
-    return this.http.post<SettingsExportResponse>('/api/settings-exporters/export', {
+  ): Observable<RunSettingsExportResponse> {
+    const body: RunSettingsExportRequest = {
       exporter_name: exporterName,
-      field_values: fieldValues,
-    });
+      field_values: fieldValues as { [key: string]: unknown },
+    };
+    return apiSettingsExportersExportPost(this.http, this.config.rootUrl, { body }).pipe(
+      map((r) => r.body),
+    );
   }
 }


### PR DESCRIPTION
## Summary

Two consecutive steps from `docs/plans/openapi-schema.md`, both
following the established "Settings/Auth/Achievements/FileBrowser"
pattern of replacing a hand-maintained Angular service with calls to
the generated `ng-openapi-gen` function modules.

### Commit 1 — `ExportersApiService` (labelset exporters)

- Now calls `apiExportersGet` / `apiExportersExportPost` from
  `generated/api-client/fn/exporters/`. `runExport`'s body tightens
  from a free-form `{exporter_name, [k]:unknown}` to the generated
  `RunExportRequest`.
- The three consumers (`export-modal`, `label-exporter-modal`,
  `autodetect-results-modal`) `import type`-only the generated
  `ExporterEntry` from its direct module path under
  `generated/api-client/models/`.
- Plugin-field shapes aren't in the spec, so `ExporterEntry.fields` is
  `Array<{[k]: any}>`; consumers narrow it to `ImporterField[]` at the
  point of use via a small private helper. The `export-modal` template
  iterates a typed `activeTabExporterFields` getter (Angular's
  template type-checker rejects dot-syntax access on index
  signatures).
- Drive-by: fixed a dead-code reference to `exp['label']` in the
  `autodetect-results-modal` template (never populated by the
  backend, always fell through to `exp.name`) to
  `exp.display_name || exp.name`.

### Commit 2 — `SettingsIoApiService`

- `listImporters` / `listExporters` now call `apiSettingsImportersGet`
  / `apiSettingsExportersGet`; `runExport` now calls
  `apiSettingsExportersExportPost` with a typed
  `RunSettingsExportRequest` body and a typed
  `RunSettingsExportResponse` return.
- `runImport` (plugin-field route) stays on plain `HttpClient.post`
  — its body shape is plugin-dependent and not described in the
  OpenAPI spec (same pattern as `LabelImportersApiService.runImport`).
  The local `SettingsImportResponse` interface stays in the service
  file because the spec types this route's response as just `Error`,
  but the backend actually returns `{success, message, keys?}`.
- The two consumers (`settings-exporter-modal`,
  `settings-importer-modal`) replaced their local
  `SettingsExporterInfo` / `SettingsImporterInfo` shim interfaces
  with `import type`-only `SettingsExporterEntry` /
  `SettingsImporterEntry`; both modal templates iterate typed
  `selectedExporterFields` / `selectedImporterFields` getters.
- With this migration nothing else in the codebase imports
  `ExporterInfo`, so that interface was **deleted** from
  `api.models.ts`. `ImporterInfo` stays — many other services still
  use it.

## Test plan

- [x] `npm run build:prod` — clean, initial bundle 477.73 kB
      (unchanged from baseline).
- [x] `./run-tests.sh` — 3615 passed, 1 skipped, 2 xpassed.
