### PR TITLE
Add deptry, codespell, ruff-S, coverage, and vulture whitelist

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,33 @@ jobs:
 
       - name: Ruff format check
         run: ruff format --check .
+
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install codespell
+        run: pip install codespell tomli
+
+      - name: Run codespell
+        run: codespell --toml pyproject.toml
+
+  deptry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install deptry
+        run: pip install deptry
+
+      - name: Run deptry
+        run: deptry .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,21 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: ["--maxkb=500"]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+
+  # deptry needs the project's venv to resolve imports, so it runs as
+  # a local hook against `python -m deptry` (installed via
+  # requirements/base.txt's `[dev]` extra).
+  - repo: local
+    hooks:
+      - id: deptry
+        name: deptry
+        entry: python -m deptry .
+        language: system
+        pass_filenames: false
+        files: ^(vtsearch/|pyproject\.toml|requirements/)

--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -1,0 +1,34 @@
+"""Whitelist for vulture's dead-code detector.
+
+Vulture finds defined-but-never-referenced names. This file lists symbols
+that VTSearch DOES use, but only reflectively — so static analysis can't
+see the reference. Running vulture with this file as a second argument
+suppresses the corresponding false positives:
+
+    vulture vtsearch .vulture-whitelist.py --min-confidence 80
+
+Add a new entry whenever you confirm that a vulture finding is reflective
+or framework-managed rather than actually dead.
+"""
+
+# Plugin sentinels. Each `<FAMILY> = SomeClass` line at the bottom of a
+# plugin module is discovered by the `PluginRegistry` scanner via the
+# matching attribute name. Vulture sees the assignment but no reference;
+# discovery happens at import time through `getattr`.
+IMPORTER  # noqa: F821
+EXPORTER  # noqa: F821
+CONVERTER  # noqa: F821
+SOURCE  # noqa: F821
+PROCESSOR  # noqa: F821
+PICKER  # noqa: F821
+MEDIA_TYPE  # noqa: F821
+SETTINGS_IMPORTER  # noqa: F821
+SETTINGS_EXPORTER  # noqa: F821
+SETTINGS_SOURCE  # noqa: F821
+LABEL_IMPORTER  # noqa: F821
+LABELSET_SOURCE  # noqa: F821
+PickerView  # noqa: F821
+
+# argparse.Action.__call__ requires the `option_string` parameter even
+# when the action ignores it.
+option_string  # noqa: F821

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ This applies to:
 - TypeScript errors from `tsc` / `npm run build:prod` (including in `*.spec.ts` files, even though specs do not currently run — they must still typecheck).
 - Angular build warnings of any kind, including `anyComponentStyle` budget warnings (e.g. `▲ [WARNING] ... exceeded maximum budget`). `run-tests.sh` treats every `▲ [WARNING]` line from `build:prod` as a hard test failure, so do not just bump budgets to silence them — fix the underlying bloat (split the component, extract shared styles, or remove dead rules). Bumping a budget is only acceptable when the size is genuinely justified, and requires the user's explicit approval.
 - Python test failures from `./run-tests.sh` and `pytest` runs.
-- Linter errors from `ruff check` and formatting drift from `ruff format --check`. Both run as the first step of `./run-tests.sh`, so the test loop catches them before pytest — but if you're tempted to skip the test loop, run `ruff check . && ruff format --check .` at minimum before pushing. CI (`.github/workflows/lint.yml`) is the backstop.
+- Linter errors from `ruff check` (including the flake8-bandit `S` ruleset), formatting drift from `ruff format --check`, typos from `codespell`, and dependency issues from `deptry`. All four run as the first steps of `./run-tests.sh`, so the test loop catches them before pytest — but if you're tempted to skip the test loop, run `ruff check . && ruff format --check . && codespell --toml pyproject.toml && python -m deptry .` at minimum before pushing. CI (`.github/workflows/lint.yml`) is the backstop.
 - Any other diagnostics surfaced by tooling you invoke.
 
 If a failure is genuinely outside the scope of the current task (e.g. a flaky network test, a failure in unrelated infrastructure you cannot reproduce), explicitly call it out in your end-of-turn summary with one sentence explaining why you did not fix it. The default is **fix it**; skipping requires justification.
@@ -96,8 +96,9 @@ The `.back-btn` rule in `frontend/src/scss/_components.scss` provides the shared
 A flow can legitimately carry both: a nested view shows `← Back` at the top to step back one view, while the outer view's footer shows `Cancel` to dismiss the whole modal. What it should *not* do is use the word "Cancel" for an action that is really navigation back to a parent view.
 
 ## Commands
-- **Run tests (CPU, fast)**: `./run-tests.sh` (also runs `ruff check`, `ruff format --check`, and the frontend TypeScript build)
-- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; every invocation runs ruff first; `core` additionally runs the frontend build check)
+- **Run tests (CPU, fast)**: `./run-tests.sh` (also runs `ruff check`, `ruff format --check`, `codespell`, `deptry`, and the frontend TypeScript build)
+- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; every invocation runs ruff/codespell/deptry first; `core` additionally runs the frontend build check)
+- **Run tests with coverage**: `VTSEARCH_COVERAGE=1 ./run-tests.sh` (opt-in; adds ~10-20% overhead)
 - **Run multiple groups**: `./run-tests.sh core sorting api`
 - **Run tests with extra args**: `./run-tests.sh core -- -x --tb=long` (args after `--` go to pytest)
 - **Run tests (CPU, full)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ -q --tb=short -m 'not gpu'`
@@ -115,6 +116,9 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 - **Frontend audit**: `cd frontend && npm audit` (checks for known vulnerabilities in dependencies)
 - **Lint**: `ruff check .`
 - **Format**: `ruff format .`
+- **Spell check**: `codespell --toml pyproject.toml`
+- **Dependency check**: `python -m deptry .`
+- **Dead code audit** (manual, pre-release): `vulture vtsearch/ .vulture-whitelist.py --min-confidence 80`
 
 ## Architecture
 - `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing, per-request user context via `before_request` middleware, per-request dataset/model context resolution from `X-Dataset-Id`/`X-Detector-Id` headers
@@ -316,4 +320,4 @@ def slow_load():
 - **Multi-media imports**: importers can set the class attribute `multi_media = True` and iterate `self.effective_source_specs(field_values)` inside `run()` to pull in multiple source media types (e.g. images + videos-as-images + documents-as-images) with per-converter params (e.g. `n_clips`). Each `SourceSpec` is `(source_type, converter|None, params)`. Legacy importers (`multi_media = False`, the default) still work unchanged via the comma-separated `converters` field; `effective_source_specs()` also returns a useful list for them so they can migrate the body of `run()` before changing their form schema. See `docs/plans/multi-media-import.md`. Migrated: `server_folder`, `server_files`, `local_folder`, `local_files` (the lf-* importers are upload placeholders that re-enter `server_folder`). Remaining on the shim: `pickle`, `combine_datasets`, `synthetic`, `http_archive`, `recaller`, `demo`
 - `data/` dir created at runtime for embeddings, model cache, media files
 - OMP_NUM_THREADS and MKL_NUM_THREADS set to 1 for memory optimization
-- Linter/formatter: ruff (E402 ignored, line-length 120, target-version py310, see pyproject.toml)
+- Linter/formatter: ruff (default rules + flake8-bandit `S`, line-length 120, target-version py310; E402 and noisy S rules ignored — see `pyproject.toml` for the full list). codespell + deptry round out the lint stage; `pre-commit install` wires them into git pre-commit. See `docs/plans/python-quality-tools.md` for the rationale.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -228,15 +228,22 @@ See `CLAUDE.md` for the complete group-to-file mapping.
   (~16 seconds each)
 - `gpu`: CUDA-only tests
 
-### Linting and formatting
+### Linting, formatting, and other quality tools
 
 ```bash
-ruff check .       # lint
-ruff format .      # format
+ruff check .                          # lint (default rules + flake8-bandit S)
+ruff format .                         # format
+codespell --toml pyproject.toml       # typo check
+python -m deptry .                    # unused / missing / transitive deps
+VTSEARCH_COVERAGE=1 ./run-tests.sh    # opt-in test coverage report
+vulture vtsearch/ .vulture-whitelist.py --min-confidence 80   # dead code audit
 ```
 
-Configuration is in `pyproject.toml` (E402 ignored, line-length 120,
-target Python 3.10).
+Configuration is in `pyproject.toml`. `pre-commit install` wires up
+ruff, codespell, and deptry as git hooks; the same checks plus
+`pip-audit` run on every push via the `Lint` and `Audit dependencies`
+workflows. See `docs/plans/python-quality-tools.md` for the rationale
+behind which security rules are enabled and which are ignored.
 
 ---
 

--- a/docs/plans/python-quality-tools.md
+++ b/docs/plans/python-quality-tools.md
@@ -1,8 +1,9 @@
 # Python quality tools
 
-*Status: Phase 1 shipped — pre-commit (ruff + safety hooks) is wired up
-and `pip-audit` runs in CI. Phases 2 and 3 are proposed; see "Open
-follow-ups" at the bottom for what's still owed.*
+*Status: Phases 1 + 2 + 3 shipped. deptry, codespell, ruff's `S`
+ruleset, opt-in coverage, and a vulture whitelist are all in place
+alongside the original pre-commit + pip-audit. See "Open follow-ups"
+at the bottom for the remaining maintenance items.*
 
 The ruff + pyright + pytest stack already covers the modern core of
 Python quality tooling. This plan tracks what else is worth adding,
@@ -13,9 +14,10 @@ wire it", and a success criterion so it's a one-sitting task.
 
 - **pre-commit** (`.pre-commit-config.yaml`) — runs `ruff check`,
   `ruff format`, trailing-whitespace, end-of-file-fixer, yaml/toml/json
-  syntax checks, merge-conflict markers, and a 500 KB large-file guard
-  at commit time. Pinned to `ruff-pre-commit v0.15.8` and
-  `pre-commit-hooks v5.0.0`; bump with `pre-commit autoupdate`.
+  syntax checks, merge-conflict markers, a 500 KB large-file guard,
+  plus codespell and deptry at commit time. Pinned to
+  `ruff-pre-commit v0.15.8`, `pre-commit-hooks v5.0.0`, and
+  `codespell v2.4.2`; bump with `pre-commit autoupdate`.
 - **`pip-audit`** (`.github/workflows/audit.yml`) — scans installed
   packages against the PyPI advisory database. Runs on PRs that touch
   `requirements/**` or `pyproject.toml`, on pushes to `main`/`dev`, and
@@ -25,6 +27,59 @@ wire it", and a success criterion so it's a one-sitting task.
   `scripts/install-cpu.sh` runs `pre-commit install --install-hooks`
   automatically when `.git` is present so contributors get the git hook
   on first install.
+
+## What shipped (Phase 2)
+
+- **deptry** (`[tool.deptry]` in `pyproject.toml`, `.pre-commit-config.yaml`
+  local hook, `.github/workflows/lint.yml` job) — verifies that every
+  imported package is declared as a runtime dependency. Configured with
+  a `package_module_name_map` for the usual module/distribution
+  mismatches (`PIL`/`Pillow`, `cv2`/`opencv-python-headless`,
+  `sklearn`/`scikit-learn`, `fitz`/`PyMuPDF`, `dns`/`dnspython`, etc.)
+  and a `per_rule_ignores` list for optional/dev-only deps
+  (`paddleocr`, `whisper`, `mediapipe`, `rarfile`, `torchvision`,
+  `safetensors`, `huggingface_hub` for DEP001; `pytest`, `ruff`,
+  `gunicorn`, `sentencepiece`, `protobuf`, etc. for DEP002). The runtime
+  dep list lives in `[project.dependencies]` so deptry sees it; the
+  install spec (with `--extra-index-url` and the plugin `.txt`
+  fan-out) remains `requirements/base.txt`.
+- **codespell** (`[tool.codespell]` in `pyproject.toml`,
+  `.pre-commit-config.yaml`, `.github/workflows/lint.yml` job) — catches
+  typos in identifiers, comments, docstrings, and Markdown. Configured
+  with a `skip` list for generated/binary files and an
+  `ignore-words-list` of project-specific terms (embedder names like
+  `clap`/`siglip`/`xclip`, code identifiers like `numer`/`denom`/`medias`/`fpr`,
+  and stylistic spellings the project uses consistently like `re-use`
+  and `pre-select`).
+
+## What shipped (Phase 3)
+
+- **Ruff `S` ruleset** (`select = ["E4", "E7", "E9", "F", "S"]` in
+  `[tool.ruff.lint]`) — flake8-bandit security checks now run as part
+  of `ruff check`. Several rules are globally disabled because they
+  don't match VTSearch's threat model (single-user, on-prem) and
+  produce noise more than signal: S101 (assert used for type
+  narrowing), S104 (bind 0.0.0.0 is intentional for the dev server),
+  S105 (false-positive-prone on env-var names), S110/S112 (silent
+  except is intentional in best-effort code paths), S311 (random
+  used for dataset splitting, not crypto), S324 (md5/sha1 used as
+  content fingerprints). Real security-relevant rules — S301
+  (pickle.load), S314 (xml parsing), S603/S607 (subprocess) — stay
+  enabled with targeted per-file ignores for the few legitimate
+  uses (`safe_pickle_load`, the arXiv RSS-feed parser, git/ffmpeg/unrar
+  invocations).
+- **Coverage via `pytest-cov`** (`[tool.coverage]` in `pyproject.toml`,
+  opt-in flag in `run-tests.sh`) — coverage is gathered when
+  `VTSEARCH_COVERAGE=1 ./run-tests.sh` is run; off by default to keep
+  the fast-loop test time unchanged. No PR gate yet — the next step is
+  to publish a step summary in CI and then decide on a delta gate.
+- **Vulture whitelist** (`.vulture-whitelist.py`) — a curated list of
+  plugin sentinels (`IMPORTER`, `EXPORTER`, `CONVERTER`, `SOURCE`,
+  etc.) and other reflectively-referenced symbols, so
+  `vulture vtsearch .vulture-whitelist.py --min-confidence 80` runs
+  cleanly. Vulture is intentionally NOT a CI gate — it's a manual
+  pre-release audit since lower confidence settings produce too many
+  false positives against the plugin-discovery pattern.
 
 ## Phase 2 — Low-friction additions
 
@@ -217,14 +272,26 @@ added to the whitelist with a comment explaining why.
 
 ## Open follow-ups
 
-- Phase 2: wire up **deptry** and **codespell** (both ~1-hour tasks).
-- Phase 3a: turn on **ruff `S` ruleset** (covers most of what bandit
-  would). Triage the first-run findings, add targeted ignores.
-- Phase 3b: wire up **coverage** via `pytest-cov`. Publish-only first;
-  decide on a delta gate after we see real numbers.
-- Phase 3c: one-shot **vulture** audit. Build a whitelist for the
-  plugin sentinels, delete what's actually dead, then leave vulture as
-  a manual pre-release command rather than a CI gate.
+- **Coverage publish in CI.** `VTSEARCH_COVERAGE=1` runs locally but
+  there's no CI publication yet. Next step: add a `coverage` job (or
+  extend the existing test job) to upload an HTML report as an
+  artifact and write a per-file summary to `$GITHUB_STEP_SUMMARY`.
+  Decide on a delta gate (e.g. `diff-cover`) once we have a baseline.
+- **Vulture audit pass.** The whitelist makes `--min-confidence 80`
+  clean; doing a real pass at 60 % and deleting confirmed dead code
+  (after extending the whitelist for plugin/reflective references) is
+  still outstanding. Run before each release rather than as a CI gate.
+- **Pyright `S`-equivalent and `C901` complexity.** ruff has McCabe
+  complexity via `C901`; consider enabling alongside future
+  security-rule tightening if we want a complexity gate.
+- **`[project.dependencies]` vs `requirements/base.txt` drift.**
+  Phase 2's deptry config duplicates the runtime dep list across both
+  files (pyproject.toml for deptry, requirements/base.txt for the
+  pinned install). deptry will catch new imports missing from
+  pyproject.toml, but a contributor adding a dep to `requirements/`
+  alone won't see a failure. Consider consolidating to
+  `-e .[plugins,dev]` in `requirements/base.txt` so the project
+  metadata becomes the single source of truth.
 - Periodic: `pre-commit autoupdate` on a cadence so pinned hook
   versions don't drift too far from CI's `pip install ruff` (which
   always pulls latest). Worth a quarterly reminder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,62 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "vtsearch"
 version = "0.1.0"
 requires-python = ">=3.10"
 description = "Media explorer for browsing and voting on audio, images, text, video, or documents"
 
-# All runtime dependencies live in requirements/base.txt (core) and per-plugin
-# requirements.txt files (auto-discovered by scripts/install-plugin-deps.sh).
-# This file is kept for editable installs (`pip install -e .`) and tool config.
+# Runtime dependencies. These mirror requirements/base.txt + the per-plugin
+# requirements.txt files so deptry can verify that every imported package is
+# declared. requirements/base.txt remains the install spec (pins,
+# --extra-index-url, plugin .txt fan-out); pyproject.toml is the source of
+# truth deptry reads from.
+dependencies = [
+    # Core framework
+    "flask",
+    "flask-smorest",
+    "marshmallow",
+    "pydantic>=2",
+    "gunicorn",
+    "werkzeug",
+    "numpy",
+    "requests",
+    "tqdm",
+    "scikit-learn",
+    "transformers",
+    "pandas",
+    "pyyaml",
+    "matplotlib",
+    "scipy",
+    "torch>=2.0.0",
+    # Plugin deps that are imported from the codebase
+    "sentence-transformers",
+    "dnspython>=2.0.0",
+    "PyMuPDF",
+    "librosa",
+    "soundfile",
+    "sentencepiece",
+    "protobuf",
+    "Pillow",
+    "ultralytics",
+    "opencv-python-headless",
+    "imageio-ffmpeg",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-xdist",
+    "pytest-cov",
+    "ruff",
+    "pre-commit",
+    "deptry",
+    "codespell",
+    "vulture",
+    "pip-audit",
+]
 
 [tool.setuptools.packages.find]
 include = ["vtsearch*"]
@@ -16,12 +66,97 @@ line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
-# E402: Module level import not at top of file
-ignore = ["E402"]
+# Default rules (E4, E7, E9, F) + flake8-bandit (S) security checks.
+# Stays conservative on style rules (E501 line-length etc. remain off)
+# while adding the security backstop.
+select = ["E4", "E7", "E9", "F", "S"]
+# E402: Module level import not at top of file.
+# S101 (assert): used for type narrowing where pyright needs help; the
+#   project never runs under `python -O`.
+# S104 (bind 0.0.0.0): intentional for `python app.py --host 0.0.0.0`,
+#   and tests/api/test_ssrf_validation.py uses the literal as a fixture.
+# S105 (hardcoded password): false-positive-prone on env-var name strings.
+# S110/S112 (silent except): used as best-effort fallbacks for optional
+#   imports, logging setup, and progress-tracker teardown.
+# S311 (non-crypto random): used for dataset splitting and shuffling.
+# S324 (md5/sha1): used as content fingerprints throughout the codebase,
+#   never for cryptographic purposes.
+ignore = ["E402", "S101", "S104", "S105", "S110", "S112", "S311", "S324"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests use /tmp paths, pickle round-trips, and xml fixtures freely.
+"tests/**" = ["S108", "S301", "S314"]
+# safe_pickle_load is the centralized helper that calls pickle.load on
+# whitelisted bytes — flagging it would defeat the purpose of the wrapper.
+"vtsearch/security/pickle.py" = ["S301"]
+# Intentional `git` / `unrar` / `ffmpeg` invocations: arguments are
+# project-controlled paths, no shell expansion.
+"vtsearch/__init__.py" = ["S603", "S607"]
+"vtsearch/converters/video2audio.py" = ["S603"]
+"vtsearch/datasets/downloader/video.py" = ["S603", "S607"]
+"vtsearch/routes/media/list.py" = ["S603"]
+# Atom feed parsing for the arXiv text-dataset downloader.
+"vtsearch/datasets/downloader/text.py" = ["S314"]
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.deptry]
+# scripts/ and tests/ pull in dev-only deps; data/ and frontend/ aren't Python.
+extend_exclude = [
+    "scripts",
+    "frontend",
+    "data",
+    "static",
+    "model_cache",
+]
+
+# Module name → distribution name. Deptry needs these when the importable
+# module differs from the PyPI package.
+[tool.deptry.package_module_name_map]
+"scikit-learn" = "sklearn"
+"opencv-python-headless" = "cv2"
+"PyMuPDF" = "fitz"
+"Pillow" = "PIL"
+"pyyaml" = "yaml"
+"dnspython" = "dns"
+"imageio-ffmpeg" = "imageio_ffmpeg"
+"flask-smorest" = "flask_smorest"
+"sentence-transformers" = "sentence_transformers"
+
+[tool.deptry.per_rule_ignores]
+# DEP001 — imported but not declared. These are optional / opportunistic
+# imports that the codebase guards with try/except or pyright ignores;
+# users opt in by installing the extra package.
+DEP001 = [
+    "paddleocr",
+    "rarfile",
+    "whisper",
+    "mediapipe",
+    "torchvision",
+    "safetensors",
+    "huggingface_hub",
+]
+# DEP002 — declared but not imported. Tools we run via their CLIs
+# (pytest, ruff, …), runtime helpers loaded by name (gunicorn), or
+# tokenizer dependencies pulled in transitively by transformers
+# (sentencepiece, protobuf) that are needed at runtime even though
+# our code never imports them directly.
+DEP002 = [
+    "pytest",
+    "pytest-xdist",
+    "pytest-cov",
+    "ruff",
+    "pre-commit",
+    "deptry",
+    "codespell",
+    "vulture",
+    "pip-audit",
+    "gunicorn",
+    "sentencepiece",
+    "protobuf",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -41,3 +176,28 @@ markers = [
     "converters: document and media converters",
 ]
 addopts = "-m 'not gpu and not slow'"
+
+[tool.coverage.run]
+source = ["vtsearch"]
+branch = true
+omit = [
+    "vtsearch/_version.txt",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+
+[tool.codespell]
+# Skip generated, binary, frontend node_modules, and serialized formats.
+skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,frontend/node_modules,data,static,model_cache,.git,*.ipynb,package-lock.json"
+# Domain terms (clap/siglip/xclip = embedder names; wrest/caller/recaller =
+# extension scaffold names), legitimate code identifiers (numer/denom in
+# slope formulas, medias as the global state proxy, goup as a TS method),
+# and stylistic spellings the project uses consistently (re-use,
+# pre-select, unparseable, invokable).
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,8 +30,13 @@ torch>=2.0.0
 # ── Dev tools ────────────────────────────────────────────────────────
 pytest
 pytest-xdist
+pytest-cov
 ruff
 pre-commit
+codespell
+deptry
+vulture
+pip-audit
 
 # ── Plugin dependencies (auto-discovered) ────────────────────────────
 # Regenerate with:  bash scripts/install-plugin-deps.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -43,6 +43,25 @@ if ! ruff format --check . ; then
     exit 1
 fi
 
+# codespell + deptry — same checks the lint workflow runs in CI. Cheap
+# locally and worth catching before pytest.
+echo "Running codespell..."
+if ! codespell --toml pyproject.toml ; then
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: codespell found typos"
+    echo "============================================================"
+    exit 1
+fi
+echo "Running deptry..."
+if ! python -m deptry . ; then
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: deptry found dependency issues"
+    echo "============================================================"
+    exit 1
+fi
+
 # Split arguments into groups and extra pytest args
 TEST_GROUPS=()
 EXTRA_ARGS=()
@@ -134,13 +153,21 @@ else
     done
 fi
 
+# Coverage is opt-in via VTSEARCH_COVERAGE=1 (or `--cov` as first arg).
+# Default off because tests already run in ~35s; coverage adds ~10-20%
+# overhead and the coverage report is most useful when explicitly asked for.
+COV_ARGS=()
+if [[ "${VTSEARCH_COVERAGE:-}" == "1" ]]; then
+    COV_ARGS=(--cov=vtsearch --cov-report=term-missing)
+fi
+
 # Run pytest with:
 #   --tb=short  — brief tracebacks (enough to diagnose, not overwhelming)
 #   --no-header — skip the platform/plugin header noise
 #   -q          — quiet mode (dots instead of full test names)
 #   -n auto     — parallel execution via pytest-xdist (one worker per CPU)
 if [[ -n "$MARKER_EXPR" ]]; then
-    python -m pytest tests/ -q --tb=short --no-header -n auto -m "$MARKER_EXPR" "${EXTRA_ARGS[@]}"
+    python -m pytest tests/ -q --tb=short --no-header -n auto -m "$MARKER_EXPR" "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
 else
-    python -m pytest tests/ -q --tb=short --no-header -n auto "${EXTRA_ARGS[@]}"
+    python -m pytest tests/ -q --tb=short --no-header -n auto "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
 fi


### PR DESCRIPTION
## Summary

Implements Phases 2 + 3 of `docs/plans/python-quality-tools.md`:

- **deptry** — verifies every imported package is declared. Runtime deps now live in `[project.dependencies]` (mirroring `requirements/base.txt` + plugin reqs); `[tool.deptry]` adds the module→package map (`PIL`/`Pillow`, `cv2`/`opencv-python-headless`, `sklearn`/`scikit-learn`, etc.) and per-rule ignores for optional + dev tools. Wired into pre-commit (local hook) and a new lint job.
- **codespell** — typo check across code + docs. `[tool.codespell]` skips generated/binary paths and ignores embedder names (`clap`/`siglip`/`xclip`), code identifiers (`numer`/`denom`/`medias`/`fpr`), and stylistic spellings (`re-use`/`pre-select`). Wired into pre-commit and CI.
- **ruff `S` ruleset** — flake8-bandit security checks. Globally ignores rules that don't fit the on-prem single-user threat model (`S101` assert, `S104` 0.0.0.0, `S110/S112` silent except, `S311` random, `S324` md5/sha1 as content fingerprint). Real security signals (`S301` pickle, `S314` xml, `S603/S607` subprocess) stay on with targeted per-file ignores.
- **pytest-cov** — opt-in via `VTSEARCH_COVERAGE=1 ./run-tests.sh`. `[tool.coverage]` configured; off by default to keep the fast loop intact.
- **vulture whitelist** (`.vulture-whitelist.py`) — lists plugin sentinels (`IMPORTER`, `EXPORTER`, `CONVERTER`, …) and reflective-only symbols so `vulture vtsearch .vulture-whitelist.py --min-confidence 80` runs clean. Manual pre-release audit, not a CI gate.

`run-tests.sh` now runs codespell + deptry alongside ruff. `requirements/base.txt` picks up the new dev tools. `CLAUDE.md`, `docs/HANDOFF.md`, and the plan file are updated; remaining follow-ups (CI coverage publish, vulture audit pass, dep-list consolidation) are recorded in the plan's "Open follow-ups" section.

### Breaking change

`pyproject.toml` now declares `[project.dependencies]`. Adding a runtime dep to `requirements/base.txt` without listing it in `pyproject.toml` will fail deptry. Tracked as a follow-up to consolidate to `-e .[plugins,dev]` so pyproject.toml becomes the single source of truth.

## Test plan

- [x] `ruff check .` → clean
- [x] `ruff format --check .` → clean
- [x] `codespell --toml pyproject.toml` → clean
- [x] `python -m deptry .` → clean
- [x] `vulture vtsearch/ .vulture-whitelist.py --min-confidence 80` → clean
- [x] `pre-commit run --files <changed>` → all hooks pass
- [ ] CI: Lint workflow's three jobs (ruff, codespell, deptry) all green
- [ ] CI: Audit dependencies workflow still green

https://claude.ai/code/session_015oBk9Mhh43Ht2VZA9HVLN1

---
_Generated by [Claude Code](https://claude.ai/code/session_015oBk9Mhh43Ht2VZA9HVLN1)_