### PR TITLE
Migrate MediasApiService to the generated TS client

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -716,20 +716,57 @@ checks off this follow-up.
       ``settings-importer-modal``). The ``LabelImporterInfo`` interface
       was deleted from ``frontend/src/app/models/api.models.ts`` — no
       remaining consumers.
+- [x] ``MediasApiService`` rewired to the generated TS client. The
+      service now calls ``apiMediasIdsGet`` / ``apiMediasBatchPost`` /
+      ``apiMediasMediaIdTextGet`` / ``apiMediasMediaIdVotePost`` from
+      ``generated/api-client/fn/medias/``; return types tightened to the
+      generated ``MediaIdsListResponse`` / ``MediaBatchResponse`` /
+      ``MediaParagraphResponse`` / ``MediaVoteResponse`` /
+      ``MediaAddToPileResponse``, and the request body for ``vote`` now
+      uses the generated ``MediaVoteRequest``. The four binary-stream
+      routes (``getAudio`` / ``getVideo`` / ``getImage`` / ``getMedia``)
+      stay on plain ``HttpClient.get`` with ``responseType: 'blob'`` —
+      ng-openapi-gen doesn't model binary response bodies usefully (the
+      generated function declares the success body as ``Error`` because
+      the spec only carries error responses for these routes). The
+      multipart ``addToPile`` route stays on plain ``HttpClient.post``
+      because the generated function's ``$Params`` has no ``body`` field
+      — same pattern as ``server-media-files/upload``. The local
+      ``TextResponse`` and ``VoteResponse`` interfaces were deleted from
+      ``frontend/src/app/models/api.models.ts`` (no remaining consumers).
+      ``MediaItem`` stays in ``api.models.ts`` for now because it is the
+      loose union type consumed by ~20 components and the metadata
+      cache; rewiring those to the generated ``MediaIdsListResponse`` /
+      ``MediaBatchResponse`` pair is a separate follow-up. The existing
+      consumers (``MediaStateService`` storing ``MediaItem[]``,
+      ``MediaMetadataCacheService`` storing ``Map<number, MediaItem>``)
+      keep typechecking because both generated response types are
+      structural subtypes of ``MediaItem`` (every required field
+      matches; the extra required fields on ``MediaBatchResponse`` are a
+      no-op against ``MediaItem``'s all-optional shape).
 
 ## Open follow-ups
 
 - **Migrate the remaining Angular services to the generated client.**
-  Settings, auth, and achievements have all moved over. Each follow-up
-  PR picks one blueprint area (medias, sorting, detectors, datasets,
-  eval, labels, exporters, …), rewires the matching Angular service(s)
-  to call the generated function modules under
+  Settings, auth, achievements, file-browser, exporters, settings-io,
+  label-importers, and medias have all moved over. Each follow-up PR
+  picks one blueprint area (sorting, detectors, datasets, eval,
+  labels, …), rewires the matching Angular service(s) to call the
+  generated function modules under
   ``frontend/src/app/generated/api-client/fn/``, and deletes the
   corresponding hand-maintained interfaces from
   ``frontend/src/app/models/api.models.ts``. The hybrid imports
   (``import type`` for DTOs, direct function-module paths for
   runtime symbols, no barrel) are required to keep the initial bundle
   under the 525 kB budget — see *Bundle-size discipline* above.
+- **Replace ``MediaItem`` with the generated ``MediaIdsListResponse`` /
+  ``MediaBatchResponse`` pair.** ``MediaItem`` is the loose union type
+  consumed by ~20 components and the metadata cache. The
+  ``MediasApiService`` migration kept it in place because rewiring every
+  consumer is a larger task than swapping the service itself.  A
+  follow-up should narrow each consumer's type (lightweight stub vs.
+  full batch-response) and delete ``MediaItem`` from
+  ``api.models.ts``.
 - **Per-plugin schemas for plugin-field routes.** The four routes
   whose request body is a plugin-field shape stay on the legacy
   plain-Flask path on their (now smorest-typed) blueprints:

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -27,16 +27,6 @@ export interface MediaItem {
   embedder?: string;
 }
 
-export interface TextResponse {
-  content: string;
-  word_count?: number;
-  character_count?: number;
-}
-
-export interface VoteResponse {
-  ok: boolean;
-}
-
 // --- Sorting ---
 
 export interface SortResult {

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -1,45 +1,61 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import {
-  MediaItem,
-  TextResponse,
-  VoteResponse,
-} from '../models/api.models';
+import { map } from 'rxjs/operators';
+
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+import type { MediaParagraphResponse } from '../generated/api-client/models/media-paragraph-response';
+import type { MediaVoteRequest } from '../generated/api-client/models/media-vote-request';
+import type { MediaVoteResponse } from '../generated/api-client/models/media-vote-response';
+import type { MediaAddToPileResponse } from '../generated/api-client/models/media-add-to-pile-response';
+import { apiMediasIdsGet } from '../generated/api-client/fn/medias/api-medias-ids-get';
+import { apiMediasBatchPost } from '../generated/api-client/fn/medias/api-medias-batch-post';
+import { apiMediasMediaIdTextGet } from '../generated/api-client/fn/medias/api-medias-media-id-text-get';
+import { apiMediasMediaIdVotePost } from '../generated/api-client/fn/medias/api-medias-media-id-vote-post';
 
 @Injectable({ providedIn: 'root' })
 export class MediasApiService {
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
 
   /**
    * Lightweight listing of every media in the loaded dataset.  Returns
-   * only ``id``, ``type``, and ``embedder`` — the rest of the metadata is
-   * fetched on demand via {@link getMediasBatch}.
+   * only ``id``, ``type``, and (optionally) ``embedder`` — the rest of the
+   * metadata is fetched on demand via {@link getMediasBatch}.
    */
-  getMediaIds(): Observable<MediaItem[]> {
-    return this.http.get<MediaItem[]>('/api/medias/ids');
+  getMediaIds(): Observable<MediaIdsListResponse[]> {
+    return apiMediasIdsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  getMediasBatch(ids: number[]): Observable<MediaItem[]> {
-    return this.http.post<MediaItem[]>('/api/medias/batch', { ids });
+  getMediasBatch(ids: number[]): Observable<MediaBatchResponse[]> {
+    return apiMediasBatchPost(this.http, this.config.rootUrl, { body: { ids } }).pipe(map((r) => r.body));
   }
 
+  /** Binary stream — stays on plain HttpClient because ng-openapi-gen
+   *  doesn't model binary response bodies usefully (the generated function
+   *  declares the success body as ``Error`` because the spec only carries
+   *  error responses for these routes). */
   getAudio(id: number): Observable<Blob> {
     return this.http.get(`/api/medias/${id}/audio`, { responseType: 'blob' });
   }
 
+  /** Binary stream — see {@link getAudio}. */
   getVideo(id: number): Observable<Blob> {
     return this.http.get(`/api/medias/${id}/video`, { responseType: 'blob' });
   }
 
+  /** Binary stream — see {@link getAudio}. */
   getImage(id: number): Observable<Blob> {
     return this.http.get(`/api/medias/${id}/image`, { responseType: 'blob' });
   }
 
-  getText(id: number): Observable<TextResponse> {
-    return this.http.get<TextResponse>(`/api/medias/${id}/text`);
+  getText(id: number): Observable<MediaParagraphResponse> {
+    return apiMediasMediaIdTextGet(this.http, this.config.rootUrl, { media_id: id }).pipe(map((r) => r.body));
   }
 
+  /** Binary stream — see {@link getAudio}. */
   getMedia(id: number): Observable<Blob> {
     return this.http.get(`/api/medias/${id}/media`, { responseType: 'blob' });
   }
@@ -48,16 +64,21 @@ export class MediasApiService {
     id: number,
     label: 'good' | 'bad',
     regionBox?: readonly number[] | null,
-  ): Observable<VoteResponse> {
-    const body: { vote: string; region_box?: number[] } = { vote: label };
+  ): Observable<MediaVoteResponse> {
+    const body: MediaVoteRequest = { vote: label };
     if (regionBox && regionBox.length === 4) body.region_box = [...regionBox];
-    return this.http.post<VoteResponse>(`/api/medias/${id}/vote`, body);
+    return apiMediasMediaIdVotePost(this.http, this.config.rootUrl, { media_id: id, body }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  addToPile(file: File, label: 'good' | 'bad'): Observable<{ ok: boolean; media_id: number; is_new: boolean }> {
+  /** Multipart upload — stays on plain HttpClient because ng-openapi-gen
+   *  doesn't model multipart bodies (the generated function's ``$Params``
+   *  has no ``body`` field at all). */
+  addToPile(file: File, label: 'good' | 'bad'): Observable<MediaAddToPileResponse> {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('label', label);
-    return this.http.post<{ ok: boolean; media_id: number; is_new: boolean }>('/api/medias/add-to-pile', formData);
+    return this.http.post<MediaAddToPileResponse>('/api/medias/add-to-pile', formData);
   }
 }


### PR DESCRIPTION
## Summary

Next step on `docs/plans/openapi-schema.md` — moves the medias blueprint area off hand-maintained DTOs and onto the generated TS client.

- `apiMediasIdsGet` / `apiMediasBatchPost` / `apiMediasMediaIdTextGet` / `apiMediasMediaIdVotePost` from `frontend/src/app/generated/api-client/fn/medias/` replace the hand-rolled `HttpClient` calls in `MediasApiService`.
- Return types tighten from local `TextResponse` / `VoteResponse` to the generated `MediaIdsListResponse` / `MediaBatchResponse` / `MediaParagraphResponse` / `MediaVoteResponse` / `MediaAddToPileResponse`; the vote request body uses the generated `MediaVoteRequest`.
- The four binary-stream routes (`getAudio`, `getVideo`, `getImage`, `getMedia`) stay on plain `HttpClient.get` with `responseType: 'blob'` — ng-openapi-gen declares those success bodies as `Error` because the spec only carries error responses for them. Same pattern as the `add-to-pile` / `server-media-files/upload` carve-outs in earlier migrations.
- The multipart `addToPile` route stays on plain `HttpClient.post`; the generated function's `$Params` has no `body` field.
- `TextResponse` and `VoteResponse` are deleted from `frontend/src/app/models/api.models.ts` (no remaining consumers). `MediaItem` stays — it's the loose union consumed by ~20 components and the metadata cache, and both generated response types remain structural subtypes of it so existing storage typechecks unchanged. Replacing `MediaItem` with the strict pair is captured as a follow-up in the plan doc.

## Test plan

- [x] `./run-tests.sh` (3615 passed, 1 skipped)
- [x] `./run-tests.sh core api` (900 passed)
- [x] `npm run build:prod` — no errors, no warnings, initial bundle 478.81 kB (under the 525 kB budget)

---
_Generated by [Claude Code](https://claude.ai/code/session_0156767M63droZT6iH36Wod9)_