### PR TITLE
Add coverage.yml CI job; refresh python-quality-tools plan

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,100 @@
+name: Coverage
+
+# Runs the fast CPU test suite with line + branch coverage and publishes
+# the HTML report as an artifact + a per-file summary to the workflow's
+# step summary. Currently publish-only — there is no coverage-delta gate
+# yet. Tests themselves still gate the job (a failed test fails the
+# workflow); the "no PR gate" decision in docs/plans/python-quality-tools.md
+# is specifically about not failing on coverage thresholds.
+#
+# This is the first workflow that runs pytest in CI; local development
+# still uses `./run-tests.sh`. The marker expression (`not gpu and not
+# slow`) matches the default fast-loop suite.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install vtsearch + deps (CPU)
+        run: |
+          set +e
+          bash scripts/install-cpu.sh 2>&1 | tee /tmp/install.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Install step (exit=$status)"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/install.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      - name: Run fast tests with coverage
+        id: pytest
+        run: |
+          set +e
+          python -m pytest tests/ \
+            -q --tb=short --no-header -n auto \
+            -m 'not gpu and not slow' \
+            --cov=vtsearch \
+            --cov-report=term \
+            --cov-report=html:coverage_html \
+            --cov-report=xml:coverage.xml \
+            2>&1 | tee /tmp/pytest.log
+          status=${PIPESTATUS[0]}
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          # Trim the noisy middle of the log when writing to the summary.
+          {
+            echo "## Pytest (exit=$status)"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/pytest.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      # Re-render the coverage report from the .coverage data file so we
+      # get a clean per-file table in the step summary, independent of
+      # whatever pytest printed. Runs even when pytest fails so reviewers
+      # see coverage on failing PRs too — useful for spotting "this PR
+      # didn't add tests for the new code that failed".
+      - name: Publish coverage summary
+        if: always() && hashFiles('.coverage*') != ''
+        run: |
+          {
+            echo "## Coverage"
+            echo ""
+            echo '```'
+            python -m coverage report --skip-covered --sort=cover 2>&1 || \
+              python -m coverage report 2>&1
+            echo '```'
+            echo ""
+            echo "Download the **coverage-html** artifact for the per-line drill-down."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload HTML coverage report
+        if: always() && hashFiles('coverage_html/index.html') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage_html/
+          retention-days: 14
+
+      - name: Upload coverage XML
+        if: always() && hashFiles('coverage.xml') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          retention-days: 14

--- a/docs/plans/python-quality-tools.md
+++ b/docs/plans/python-quality-tools.md
@@ -1,11 +1,12 @@
 # Python quality tools
 
 *Status: Phases 1 + 2 + 3 shipped, plus the pyproject-consolidation
-follow-up. deptry, codespell, ruff's `S` ruleset, opt-in coverage, and a
-vulture whitelist are all in place alongside the original pre-commit +
-pip-audit, and `pyproject.toml` is now the single source of truth for
-runtime + dev dependencies. See "Open follow-ups" at the bottom for the
-remaining maintenance items.*
+follow-up and CI coverage publication. deptry, codespell, ruff's `S`
+ruleset, opt-in coverage (now also published in CI), and a vulture
+whitelist are all in place alongside the original pre-commit + pip-audit,
+and `pyproject.toml` is now the single source of truth for runtime + dev
+dependencies. See "Open follow-ups" at the bottom for the remaining
+maintenance items.*
 
 The ruff + pyright + pytest stack already covers the modern core of
 Python quality tooling. This plan tracks what else is worth adding,
@@ -73,6 +74,20 @@ wire it", and a success criterion so it's a one-sitting task.
   `base.py` docstrings, and the docs (`SETUP.md`, `DEPLOYMENT.md`,
   `HANDOFF.md`, `EXTENDING.md`, `EXTENDING-plugins.md`,
   `plans/RCDatasetImporter.md`).
+
+## What shipped (CI coverage publication)
+
+- **Coverage in CI** (`.github/workflows/coverage.yml`) — runs the fast
+  CPU test suite (`-m 'not gpu and not slow'`) with `pytest-cov`, then
+  publishes the per-file `coverage report --skip-covered --sort=cover`
+  table to `$GITHUB_STEP_SUMMARY` and uploads the HTML report (and the
+  raw `coverage.xml`) as artifacts with a 14-day retention. Runs on
+  every PR plus pushes to `main`/`dev`. This is the **first** workflow
+  that runs pytest in CI — prior to this, tests were only enforced via
+  local `./run-tests.sh` and pre-commit, so the new job also gates merges
+  on test pass/fail (a real failure surfaces in the same job that
+  publishes coverage). There is no coverage-delta gate yet; that
+  decision waits until we have a baseline.
 
 ## What shipped (Phase 3)
 
@@ -294,15 +309,39 @@ added to the whitelist with a comment explaining why.
 
 ## Open follow-ups
 
-- **Coverage publish in CI.** `VTSEARCH_COVERAGE=1` runs locally but
-  there's no CI publication yet. Next step: add a `coverage` job (or
-  extend the existing test job) to upload an HTML report as an
-  artifact and write a per-file summary to `$GITHUB_STEP_SUMMARY`.
-  Decide on a delta gate (e.g. `diff-cover`) once we have a baseline.
-- **Vulture audit pass.** The whitelist makes `--min-confidence 80`
-  clean; doing a real pass at 60 % and deleting confirmed dead code
-  (after extending the whitelist for plugin/reflective references) is
-  still outstanding. Run before each release rather than as a CI gate.
+- **Coverage-delta gate.** `coverage.yml` now publishes the baseline on
+  every PR. Next step (after a few PRs of data): wire `diff-cover`
+  against the merge base and fail the job when the patch's coverage
+  drops below a threshold. Don't gate on total coverage delta — too
+  noisy across unrelated test reshuffles — gate on **lines changed by
+  this PR**, which is what `diff-cover` measures.
+- **Vulture audit pass.** Concrete state after exploring at lower
+  confidence:
+  - `--min-confidence 80` is clean (current invocation).
+  - `--min-confidence 70` is also clean. The first findings appear at
+    60 %, with a baseline of ~410 reports.
+  - About a third of that baseline is Flask route handlers (vulture
+    doesn't follow `@bp.route(...)` decoration). Passing
+    `--ignore-decorators '@*.route,@*.before_request,@*.after_request,@*.errorhandler,@*.teardown_request,@*.context_processor,@bp.*,@app.*'`
+    cuts the 60 %-confidence count to ~260.
+  - The remaining noise dominates in three families: marshmallow
+    schema attributes (`vtsearch/schemas/*.py` — `Meta` inner classes,
+    field aliases, computed properties wired via `@post_load`/
+    `@validates`), CLI entry points dispatched through `app.py`'s
+    argparse layer (`autodetect_main*`, `autodetect_importer_main*`),
+    and HuggingFace model-internal attributes
+    (`_keys_to_ignore_on_load_unexpected`). Each family wants either a
+    targeted `--ignore-names` flag, a decorator filter, or whitelist
+    entries — and the schema family in particular needs care to
+    distinguish marshmallow-managed attributes from genuinely dead
+    fields.
+  - **Recommended approach for the audit:** start by writing the right
+    invocation (decorator filter + `--ignore-names` glob for the
+    schema patterns), get the 60 %-confidence count down to something
+    a human can review (target: under 100), then triage what remains
+    in a single sitting and either delete or whitelist each entry with
+    a one-line justification. Treat the audit as a release-gate task,
+    not a CI gate.
 - **Pyright `S`-equivalent and `C901` complexity.** ruff has McCabe
   complexity via `C901`; consider enabling alongside future
   security-rule tightening if we want a complexity gate.


### PR DESCRIPTION
## Summary

- **New workflow `.github/workflows/coverage.yml`** — runs the fast CPU test suite (`-m 'not gpu and not slow'`) with `pytest-cov`, then publishes a per-file `coverage report --skip-covered --sort=cover` table to `$GITHUB_STEP_SUMMARY` and uploads the HTML report (and raw `coverage.xml`) as 14-day artifacts. Triggers on every PR and on pushes to `main`/`dev`.
- **First pytest-in-CI job.** Until now tests were only enforced locally via `./run-tests.sh` and pre-commit. The new workflow gates merges on test pass/fail in the same job that publishes coverage; there is no coverage-delta gate yet (deferred until we have a baseline).
- **Plan refresh** (`docs/plans/python-quality-tools.md`):
  - Status banner + new "What shipped (CI coverage publication)" section.
  - Removed the "Coverage publish in CI" open follow-up (shipped); replaced with a concrete **diff-cover delta-gate** proposal for the next pass.
  - Replaced the vague vulture follow-up with concrete findings from a `--min-confidence 60` dry run: 80 % and 70 % are clean; 60 % surfaces ~410 reports, of which ~150 are Flask routes that an `--ignore-decorators '@*.route,…'` filter cuts. The remaining noise concentrates in marshmallow schemas, CLI argparse entry points, and HuggingFace model internals — each needs targeted ignore-name globs before triage is feasible. Captured the recommended audit approach (filter first, target <100 reports, then triage in one sitting) so the next contributor doesn't have to rediscover it.

## Test plan

- [x] `ruff check .`, `ruff format --check .`, `codespell --toml pyproject.toml`, `python -m deptry .` — all pass.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"` — YAML valid.
- [x] `vulture vtsearch/ .vulture-whitelist.py --min-confidence 80` — still clean.
- [ ] Coverage workflow's first CI run (will surface on this PR) — verify pytest passes, coverage summary renders, HTML artifact uploads. If the suite has a real failure under CI, fix it; if a CI-specific environment issue surfaces, adjust the install/run step rather than masking it.

https://claude.ai/code/session_01815fUdQtmm6AcDQDtZpToC

---
_Generated by [Claude Code](https://claude.ai/code/session_01815fUdQtmm6AcDQDtZpToC)_