### PR TITLE
Migrate SortingApiService to the generated TS client

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -744,14 +744,89 @@ checks off this follow-up.
       structural subtypes of ``MediaItem`` (every required field
       matches; the extra required fields on ``MediaBatchResponse`` are a
       no-op against ``MediaItem``'s all-optional shape).
+- [x] ``SortingApiService`` rewired to the generated TS client. The
+      service now calls ``apiSortPost`` / ``apiLearnedSortPost`` /
+      ``apiLearnedSortResultGet`` / ``apiVotesGet`` / ``apiVotesClearPost`` /
+      ``apiInclusionGet`` / ``apiInclusionPost`` /
+      ``apiSafeThresholdsGet`` / ``apiSafeThresholdsPost`` /
+      ``apiTextsortSuggestionsGet`` / ``apiTextsortSuggestionsPost`` /
+      ``apiDiversityTreeNextGet`` from ``generated/api-client/fn/sorting/``,
+      plus ``apiLabelsExportGet`` / ``apiLabelsImportPost`` /
+      ``apiLabelsFillFromSortPost`` from ``fn/labels/``,
+      ``apiLabelingStatusGet`` / ``apiIndicatorScoreHistoryGet`` /
+      ``apiEvalTrainAndScorePost`` / ``apiEvalTrainAndScoreResultGet``
+      from ``fn/eval/``, and ``apiServerMediaFilesGet`` /
+      ``apiExampleSortServerPost`` / ``apiExampleSortOriginPost`` from
+      ``fn/media-server/``.
+
+      Return types tightened to the generated DTOs throughout (``SortResponse``,
+      ``LearnedSortResponse``, ``VotesResponse``, ``InclusionResponse``,
+      ``SafeThresholdsResponse``, ``LabelsExportResponse``,
+      ``LabelsImportResponse``, ``FillFromSortResponse``,
+      ``EvalTrainAndScoreResponse``, ``IndicatorScoreHistoryResponse``,
+      ``LabelingStatusResponse``, ``DiversityTreeNextResponse``,
+      ``ExampleSortResponse``, ``LabelFileSortResponse``,
+      ``ServerMediaListResponse``, ``ServerMediaUploadResponse``,
+      ``TextsortSuggestionsResponse``).
+
+      Multipart routes (``exampleSort``, ``labelFileSort``,
+      ``uploadServerMediaFile``) stay on plain ``HttpClient.post`` — same
+      pattern as ``MediasApiService.addToPile``. The
+      ``getDiversityTreeNext`` POST branch (which carries an optional
+      ``{scores, threshold}`` body that the backend reads via
+      ``request.get_json(silent=True)`` and the spec intentionally omits)
+      also stays on plain ``HttpClient.post``; the GET branch uses the
+      generated ``apiDiversityTreeNextGet``. ``getLabelingProgress`` keeps
+      a tiny plain-``HttpClient.post`` wrapper for parity with the legacy
+      surface — production callers were already removed and the spec has
+      no request body for the route.
+
+      Consumers updated:
+
+      * ``ExportModalComponent`` swapped ``LabelEntry`` (legacy) for
+        ``LabeledElement`` (generated).
+      * ``LoadSortModalComponent`` swapped ``ServerFileEntry`` for
+        ``ServerMediaFileEntry``.
+      * ``ProgressModalComponent`` swapped ``EvalTrainAndScoreJobResponse``
+        for the generated ``EvalTrainAndScoreResponse``; the
+        chart-data assignments narrow ``Array<{[key:string]:any}>`` to
+        ``ErrorCostDataPoint[]`` / ``StabilityDataPoint[]`` /
+        ``DiversityDataPoint[]`` via a cast (the chart point types stay
+        in ``api.models.ts`` because ``ChartsService`` consumes them).
+      * ``LabelViewComponent`` swapped ``LearnedSortJobResponse`` for
+        the generated ``LearnedSortResponse``; the inner
+        ``Array<{[key:string]:any}>`` rows are indexed with bracket
+        access (``r['id']`` / ``r['similarity']`` / ``r['best_region']``
+        / ``r['score']``) to satisfy ``noPropertyAccessFromIndexSignature``.
+        The ``labelingStatus`` field stays typed as the legacy
+        ``LabelingStatusResponse`` (a ``StatusIndicator``-bearing shape)
+        with a single cast at the polling subscribe — the autopilot
+        consumer chain (``AutopilotStateService``,
+        ``AutopilotPanelComponent``, ``LeftPanelComponent``) is too wide
+        to retype in this PR and is captured as a follow-up below.
+
+      Deleted from ``frontend/src/app/models/api.models.ts``:
+      ``SortResult``, ``SortResponse``, ``LearnedSortResult``,
+      ``LearnedSortResponse``, ``LearnedSortJobResponse``,
+      ``InclusionResponse``, ``SafeThresholdsResponse``,
+      ``TextsortSuggestionsResponse``, ``FillFromSortRequest``,
+      ``FillFromSortDryRunResponse``, ``FillFromSortConfirmResponse``,
+      ``DiversityTreeNextResponse``, ``LabelEntry``,
+      ``LabelsExportResponse``, ``LabelsImportResponse``,
+      ``ServerFileEntry``, ``ServerMediaFilesResponse``,
+      ``TrainAndScoreResponse``, ``EvalTrainAndScoreJobResponse``,
+      ``IndicatorScoreHistoryResponse``. ``VotesResponse``,
+      ``StatusIndicator``, ``LabelingStatusResponse``,
+      ``SortProgressResponse``, and the three chart-point types stay
+      because they still have non-service consumers.
 
 ## Open follow-ups
 
 - **Migrate the remaining Angular services to the generated client.**
   Settings, auth, achievements, file-browser, exporters, settings-io,
-  label-importers, and medias have all moved over. Each follow-up PR
-  picks one blueprint area (sorting, detectors, datasets, eval,
-  labels, …), rewires the matching Angular service(s) to call the
+  label-importers, medias, and sorting have all moved over. Each
+  follow-up PR picks one blueprint area (detectors, datasets,
+  processors, …), rewires the matching Angular service(s) to call the
   generated function modules under
   ``frontend/src/app/generated/api-client/fn/``, and deletes the
   corresponding hand-maintained interfaces from
@@ -759,6 +834,21 @@ checks off this follow-up.
   (``import type`` for DTOs, direct function-module paths for
   runtime symbols, no barrel) are required to keep the initial bundle
   under the 525 kB budget — see *Bundle-size discipline* above.
+- **Tighten ``LabelingStatusResponse`` consumers to the generated
+  shape.** ``SortingApiService.getLabelingStatus`` returns the generated
+  ``LabelingStatusResponse`` (``smart``/``stable``/``span`` typed as
+  ``{[key: string]: any}``), but ``LabelViewComponent`` keeps the legacy
+  ``LabelingStatusResponse`` (with ``StatusIndicator``-bearing fields)
+  for its ``labelingStatus`` member because the downstream chain
+  (``AutopilotStateService``, ``AutopilotPanelComponent``,
+  ``LeftPanelComponent`` and their spec files) all read
+  ``status.smart?.status`` / ``status.stable?.status`` /
+  ``status.span?.status``. A single cast at the polling subscribe
+  bridges the type gap. A follow-up PR can either retype every consumer
+  to the generated shape (and update the spec literals to include the
+  newly-required ``good_count`` / ``bad_count`` / ``total_count`` /
+  ``smart.status`` / ``stable.status`` / ``span.status`` fields) or
+  introduce a narrow ``StatusIndicator`` typed-projection layer.
 - **Replace ``MediaItem`` with the generated ``MediaIdsListResponse`` /
   ``MediaBatchResponse`` pair.** ``MediaItem`` is the loose union type
   consumed by ~20 components and the metadata cache. The

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -20,7 +20,8 @@ import { ProgressEventsService } from '../../services/progress-events.service';
 import { DetectorRegistryEntry } from '../../models/api.models';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
-import { LabelingStatusResponse, LearnedSortJobResponse } from '../../models/api.models';
+import { LabelingStatusResponse } from '../../models/api.models';
+import type { LearnedSortResponse } from '../../generated/api-client/models/learned-sort-response';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
@@ -388,7 +389,14 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       )
       .subscribe({
         next: (status) => {
-          this.labelingStatus = status;
+          // The generated `LabelingStatusResponse` types `smart` / `stable` /
+          // `span` as `{[key: string]: any}` while the legacy field type
+          // expects `StatusIndicator` with a required `status` string.  The
+          // backend always sends `{status, ...}` for these — the cast is safe
+          // and only crosses the type-system gap until a follow-up tightens
+          // the consumer (autopilot, left-panel, autopilot-panel) to the
+          // generated shape.
+          this.labelingStatus = status as unknown as LabelingStatusResponse;
         },
       });
   }
@@ -407,7 +415,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortingApi.sort({ text }).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
         this.sortState.setSortResults(
-          response.results.map((r) => ({ id: r.id, score: r.similarity, bestRegion: r.best_region })),
+          response.results.map((r) => ({
+            id: r['id'],
+            score: r['similarity'],
+            bestRegion: r['best_region'],
+          })),
           response.threshold,
         );
         this.sortState.setSortBusy(false);
@@ -467,11 +479,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       });
   }
 
-  private applyLearnedSortResult(response: LearnedSortJobResponse, autoSelect: boolean): void {
+  private applyLearnedSortResult(response: LearnedSortResponse, autoSelect: boolean): void {
     const results = response.results ?? [];
     const threshold = response.threshold ?? 0;
     this.sortState.setSortResults(
-      results.map((r) => ({ id: r.id, score: r.score, bestRegion: r.best_region })),
+      results.map((r) => ({ id: r['id'], score: r['score'], bestRegion: r['best_region'] })),
       threshold,
     );
     this.sortState.setSortBusy(false);

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -11,8 +11,9 @@ import { ExportersApiService } from '../../../services/exporters-api.service';
 import { FindSessionService } from '../../../services/find-session.service';
 import { LabelSessionService } from '../../../services/label-session.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
-import { ImporterField, LabelEntry } from '../../../models/api.models';
+import { ImporterField } from '../../../models/api.models';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
+import type { LabeledElement } from '../../../generated/api-client/models/labeled-element';
 
 export interface ColumnDef {
   key: string;
@@ -39,7 +40,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
   status = '';
 
   /** Labels fetched from the server. */
-  labels: LabelEntry[] = [];
+  labels: LabeledElement[] = [];
   labelsLoaded = false;
 
   /** Column definitions with selection state — built dynamically from API response. */
@@ -158,7 +159,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return this.columns.filter((c) => c.enabled);
   }
 
-  get filteredLabels(): LabelEntry[] {
+  get filteredLabels(): LabeledElement[] {
     if (this.labelFilter === 'good') {
       return this.labels.filter((e) => e.label === 'good');
     }
@@ -176,7 +177,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return this.labels.some((e) => e.is_correction === true);
   }
 
-  get previewLabels(): LabelEntry[] {
+  get previewLabels(): LabeledElement[] {
     return this.filteredLabels.slice(0, 50);
   }
 
@@ -188,7 +189,7 @@ export class ExportModalComponent implements OnInit, OnDestroy {
     return this.selectedExporter !== null;
   }
 
-  getCellValue(entry: LabelEntry, col: ColumnDef): string {
+  getCellValue(entry: LabeledElement, col: ColumnDef): string {
     if (col.isMetadata) {
       const meta = entry.custom_metadata;
       if (meta && col.key in meta) {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -5,7 +5,8 @@ import { IconComponent } from '../../icon/icon.component';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
-import { ServerFileEntry, DetectorRegistryEntry, ImporterInfo } from '../../../models/api.models';
+import { DetectorRegistryEntry, ImporterInfo } from '../../../models/api.models';
+import type { ServerMediaFileEntry } from '../../../generated/api-client/models/server-media-file-entry';
 import {
   MediaCropModalComponent,
   MediaCropResult,
@@ -38,7 +39,7 @@ export class LoadSortModalComponent implements OnInit {
   @Output() modelSelected = new EventEmitter<string>();
   @Output() exampleSortStarted = new EventEmitter<unknown>();
 
-  serverMediaFiles: ServerFileEntry[] = [];
+  serverMediaFiles: ServerMediaFileEntry[] = [];
   registryModels: DetectorRegistryEntry[] = [];
   loading = true;
   status = '';

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,7 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
-import { EvalTrainAndScoreJobResponse } from '../../../models/api.models';
 import { ModalComponent } from '../../modal/modal.component';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -13,6 +12,7 @@ import {
   StabilityDataPoint,
   DiversityDataPoint,
 } from '../../../models/api.models';
+import type { EvalTrainAndScoreResponse } from '../../../generated/api-client/models/eval-train-and-score-response';
 
 export type ProgressMetric = 'smart' | 'stable' | 'diverse';
 
@@ -73,7 +73,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     this.sortingApi.getIndicatorScoreHistory(this.metric).subscribe({
       next: (res) => {
         this.analyzing = false;
-        this.chartData = res.history || [];
+        this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
         this.emptyHistory = this.chartData.length === 0;
         if (!this.emptyHistory) {
           setTimeout(() => this.renderChart(), 50);
@@ -143,14 +143,14 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
       });
   }
 
-  private applyEvalResult(res: EvalTrainAndScoreJobResponse): void {
+  private applyEvalResult(res: EvalTrainAndScoreResponse): void {
     this.analyzing = false;
     if (this.metric === 'smart') {
-      this.chartData = res.error_cost || [];
+      this.chartData = (res.error_cost || []) as ErrorCostDataPoint[];
     } else if (this.metric === 'stable') {
-      this.chartData = res.stability || [];
+      this.chartData = (res.stability || []) as StabilityDataPoint[];
     } else {
-      this.chartData = res.diversity || [];
+      this.chartData = (res.diversity || []) as DiversityDataPoint[];
     }
     setTimeout(() => this.renderChart(), 50);
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -29,46 +29,6 @@ export interface MediaItem {
 
 // --- Sorting ---
 
-export interface SortResult {
-  id: number;
-  similarity: number;
-  /** Patch-region-aware embedders only: normalised [x0, y0, x1, y1] of the
-   *  region that scored highest against the query. */
-  best_region?: number[];
-}
-
-export interface SortResponse {
-  results: SortResult[];
-  threshold: number;
-}
-
-export interface LearnedSortResult {
-  id: number;
-  score: number;
-  /** Patch-region-aware embedders only: normalised [x0, y0, x1, y1] of the
-   *  region that scored highest under the MLP. */
-  best_region?: number[];
-}
-
-export interface LearnedSortResponse {
-  results: LearnedSortResult[];
-  threshold: number;
-}
-
-/** Initial response to ``POST /api/learned-sort`` and shape returned by the
- *  result-polling endpoint.  ``status: "done"`` carries the full result;
- *  ``status: "running"`` means the client should poll
- *  ``GET /api/learned-sort/result?job_id=…`` until done. */
-export interface LearnedSortJobResponse {
-  job_id: string;
-  status: 'running' | 'done' | 'error' | 'cancelled' | 'missing';
-  results?: LearnedSortResult[];
-  threshold?: number;
-  current?: number;
-  total?: number;
-  error?: string;
-}
-
 export interface VotesResponse {
   good: number[];
   bad: number[];
@@ -76,65 +36,6 @@ export interface VotesResponse {
   learned_scores: Record<string, number>;
   labelset_good_count?: number;
   labelset_bad_count?: number;
-}
-
-export interface InclusionResponse {
-  inclusion: number;
-}
-
-export interface SafeThresholdsResponse {
-  safe_thresholds: boolean;
-}
-
-export interface TextsortSuggestionsResponse {
-  suggestions: string[];
-}
-
-export interface FillFromSortRequest {
-  sort_results: { id: number; score: number }[];
-  threshold: number;
-  sides: string;
-  confirm: boolean;
-}
-
-export interface FillFromSortDryRunResponse {
-  good_count: number;
-  bad_count: number;
-}
-
-export interface FillFromSortConfirmResponse {
-  good_applied: number;
-  bad_applied: number;
-  results: Record<string, unknown>;
-}
-
-export interface DiversityTreeNextResponse {
-  id: number | null;
-  diversity_level: number;
-  exhausted: boolean;
-}
-
-// --- Labels ---
-
-export interface LabelEntry {
-  md5: string;
-  label: 'good' | 'bad';
-  origin_name?: string;
-  filename?: string;
-  category?: string;
-  is_correction?: boolean;
-  custom_metadata?: Record<string, unknown>;
-  [key: string]: unknown;
-}
-
-export interface LabelsExportResponse {
-  labels: LabelEntry[];
-  available_columns?: string[];
-}
-
-export interface LabelsImportResponse {
-  applied: number;
-  skipped: number;
 }
 
 // --- Labeling Status ---
@@ -471,19 +372,6 @@ export interface OkResponse {
   ok: boolean;
 }
 
-// --- Server Files ---
-
-export interface ServerFileEntry {
-  name: string;
-  filename?: string;
-  path?: string;
-  size_bytes?: number;
-}
-
-export interface ServerMediaFilesResponse {
-  files: ServerFileEntry[];
-}
-
 // --- Eval / Progress Charts ---
 
 export interface ErrorCostDataPoint {
@@ -500,32 +388,6 @@ export interface DiversityDataPoint {
   num_labels: number;
   diversity_level: number;
   depth: number;
-}
-
-export interface TrainAndScoreResponse {
-  error_cost?: ErrorCostDataPoint[];
-  stability?: StabilityDataPoint[];
-  diversity?: DiversityDataPoint[];
-  [key: string]: unknown;
-}
-
-/** Job envelope for ``/api/eval/train-and-score``.  Mirrors
- *  :class:`LearnedSortJobResponse`. */
-export interface EvalTrainAndScoreJobResponse {
-  job_id: string;
-  status: 'running' | 'done' | 'error' | 'cancelled' | 'missing';
-  metric?: 'smart' | 'stable' | 'diverse';
-  error_cost?: ErrorCostDataPoint[];
-  stability?: StabilityDataPoint[];
-  diversity?: DiversityDataPoint[];
-  current?: number;
-  total?: number;
-  error?: string;
-}
-
-export interface IndicatorScoreHistoryResponse {
-  metric: string;
-  history: ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
 }
 
 export interface VotingIterationsResponse {

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -1,95 +1,123 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import {
-  SortResponse,
-  LearnedSortResponse,
-  LearnedSortJobResponse,
-  VotesResponse,
-  InclusionResponse,
-  SafeThresholdsResponse,
-  LabelsExportResponse,
-  LabelsImportResponse,
-  FillFromSortRequest,
-  FillFromSortDryRunResponse,
-  FillFromSortConfirmResponse,
-  TextsortSuggestionsResponse,
-  OkResponse,
-  LabelingStatusResponse,
-  DiversityTreeNextResponse,
-  ServerMediaFilesResponse,
-  EvalTrainAndScoreJobResponse,
-  IndicatorScoreHistoryResponse,
-} from '../models/api.models';
+import { map } from 'rxjs/operators';
+
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { DiversityTreeNextResponse } from '../generated/api-client/models/diversity-tree-next-response';
+import type { EvalTrainAndScoreResponse } from '../generated/api-client/models/eval-train-and-score-response';
+import type { ExampleSortResponse } from '../generated/api-client/models/example-sort-response';
+import type { FillFromSortRequest } from '../generated/api-client/models/fill-from-sort-request';
+import type { FillFromSortResponse } from '../generated/api-client/models/fill-from-sort-response';
+import type { InclusionResponse } from '../generated/api-client/models/inclusion-response';
+import type { IndicatorScoreHistoryResponse } from '../generated/api-client/models/indicator-score-history-response';
+import type { LabelFileSortResponse } from '../generated/api-client/models/label-file-sort-response';
+import type { LabelingStatusResponse } from '../generated/api-client/models/labeling-status-response';
+import type { LabelsExportResponse } from '../generated/api-client/models/labels-export-response';
+import type { LabelsImportRequest } from '../generated/api-client/models/labels-import-request';
+import type { LabelsImportResponse } from '../generated/api-client/models/labels-import-response';
+import type { LearnedSortResponse } from '../generated/api-client/models/learned-sort-response';
+import type { OkResponse } from '../generated/api-client/models/ok-response';
+import type { SafeThresholdsResponse } from '../generated/api-client/models/safe-thresholds-response';
+import type { ServerMediaListResponse } from '../generated/api-client/models/server-media-list-response';
+import type { ServerMediaUploadResponse } from '../generated/api-client/models/server-media-upload-response';
+import type { SortResponse } from '../generated/api-client/models/sort-response';
+import type { TextsortSuggestionsResponse } from '../generated/api-client/models/textsort-suggestions-response';
+import type { VotesResponse } from '../generated/api-client/models/votes-response';
+import { apiDiversityTreeNextGet } from '../generated/api-client/fn/sorting/api-diversity-tree-next-get';
+import { apiInclusionGet } from '../generated/api-client/fn/sorting/api-inclusion-get';
+import { apiInclusionPost } from '../generated/api-client/fn/sorting/api-inclusion-post';
+import { apiLearnedSortPost } from '../generated/api-client/fn/sorting/api-learned-sort-post';
+import { apiLearnedSortResultGet } from '../generated/api-client/fn/sorting/api-learned-sort-result-get';
+import { apiSafeThresholdsGet } from '../generated/api-client/fn/sorting/api-safe-thresholds-get';
+import { apiSafeThresholdsPost } from '../generated/api-client/fn/sorting/api-safe-thresholds-post';
+import { apiSortPost } from '../generated/api-client/fn/sorting/api-sort-post';
+import { apiTextsortSuggestionsGet } from '../generated/api-client/fn/sorting/api-textsort-suggestions-get';
+import { apiTextsortSuggestionsPost } from '../generated/api-client/fn/sorting/api-textsort-suggestions-post';
+import { apiVotesClearPost } from '../generated/api-client/fn/sorting/api-votes-clear-post';
+import { apiVotesGet } from '../generated/api-client/fn/sorting/api-votes-get';
+import { apiLabelsExportGet } from '../generated/api-client/fn/labels/api-labels-export-get';
+import { apiLabelsFillFromSortPost } from '../generated/api-client/fn/labels/api-labels-fill-from-sort-post';
+import { apiLabelsImportPost } from '../generated/api-client/fn/labels/api-labels-import-post';
+import { apiEvalTrainAndScorePost } from '../generated/api-client/fn/eval/api-eval-train-and-score-post';
+import { apiEvalTrainAndScoreResultGet } from '../generated/api-client/fn/eval/api-eval-train-and-score-result-get';
+import { apiIndicatorScoreHistoryGet } from '../generated/api-client/fn/eval/api-indicator-score-history-get';
+import { apiLabelingStatusGet } from '../generated/api-client/fn/eval/api-labeling-status-get';
+import { apiExampleSortOriginPost } from '../generated/api-client/fn/media-server/api-example-sort-origin-post';
+import { apiExampleSortServerPost } from '../generated/api-client/fn/media-server/api-example-sort-server-post';
+import { apiServerMediaFilesGet } from '../generated/api-client/fn/media-server/api-server-media-files-get';
 
 @Injectable({ providedIn: 'root' })
 export class SortingApiService {
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
 
   sort(params: { text: string }): Observable<SortResponse> {
-    return this.http.post<SortResponse>('/api/sort', params);
+    return apiSortPost(this.http, this.config.rootUrl, { body: params }).pipe(map((r) => r.body));
   }
 
   /** Kick off a learned-sort training job.  The response will be ``done``
    *  immediately when the cached signature matches; otherwise the caller
    *  must poll {@link getLearnedSortResult} with the returned ``job_id``. */
-  learnedSort(): Observable<LearnedSortJobResponse> {
-    return this.http.post<LearnedSortJobResponse>('/api/learned-sort', {});
+  learnedSort(): Observable<LearnedSortResponse> {
+    return apiLearnedSortPost(this.http, this.config.rootUrl, { body: {} }).pipe(map((r) => r.body));
   }
 
   /** Poll for a learned-sort job's completion. */
-  getLearnedSortResult(jobId: string): Observable<LearnedSortJobResponse> {
-    return this.http.get<LearnedSortJobResponse>('/api/learned-sort/result', {
-      params: { job_id: jobId },
-    });
-  }
-
-  getVotes(): Observable<VotesResponse> {
-    return this.http.get<VotesResponse>('/api/votes');
-  }
-
-  clearVotes(): Observable<OkResponse> {
-    return this.http.post<OkResponse>('/api/votes/clear', {});
-  }
-
-  getInclusion(): Observable<InclusionResponse> {
-    return this.http.get<InclusionResponse>('/api/inclusion');
-  }
-
-  setInclusion(value: number): Observable<InclusionResponse> {
-    return this.http.post<InclusionResponse>('/api/inclusion', { inclusion: value });
-  }
-
-  getSafeThresholds(): Observable<SafeThresholdsResponse> {
-    return this.http.get<SafeThresholdsResponse>('/api/safe-thresholds');
-  }
-
-  setSafeThresholds(value: boolean): Observable<SafeThresholdsResponse> {
-    return this.http.post<SafeThresholdsResponse>('/api/safe-thresholds', { safe_thresholds: value });
-  }
-
-  exportLabels(goodsOnly?: boolean, options?: { enrich?: boolean }): Observable<LabelsExportResponse> {
-    const params: Record<string, string> = {};
-    if (goodsOnly) {
-      params['goods_only'] = 'true';
-    }
-    if (options?.enrich) {
-      params['enrich'] = 'true';
-    }
-    return this.http.get<LabelsExportResponse>('/api/labels/export', { params });
-  }
-
-  importLabels(data: { labels: { md5: string; label: string }[] }): Observable<LabelsImportResponse> {
-    return this.http.post<LabelsImportResponse>('/api/labels/import', data);
-  }
-
-  fillFromSort(request: FillFromSortRequest): Observable<FillFromSortDryRunResponse | FillFromSortConfirmResponse> {
-    return this.http.post<FillFromSortDryRunResponse | FillFromSortConfirmResponse>(
-      '/api/labels/fill-from-sort',
-      request,
+  getLearnedSortResult(jobId: string): Observable<LearnedSortResponse> {
+    return apiLearnedSortResultGet(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
+      map((r) => r.body),
     );
   }
 
+  getVotes(): Observable<VotesResponse> {
+    return apiVotesGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  clearVotes(): Observable<OkResponse> {
+    return apiVotesClearPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  getInclusion(): Observable<InclusionResponse> {
+    return apiInclusionGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  setInclusion(value: number): Observable<InclusionResponse> {
+    return apiInclusionPost(this.http, this.config.rootUrl, { body: { inclusion: value } }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  getSafeThresholds(): Observable<SafeThresholdsResponse> {
+    return apiSafeThresholdsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  setSafeThresholds(value: boolean): Observable<SafeThresholdsResponse> {
+    return apiSafeThresholdsPost(this.http, this.config.rootUrl, {
+      body: { safe_thresholds: value },
+    }).pipe(map((r) => r.body));
+  }
+
+  exportLabels(goodsOnly?: boolean, options?: { enrich?: boolean }): Observable<LabelsExportResponse> {
+    return apiLabelsExportGet(this.http, this.config.rootUrl, {
+      goods_only: goodsOnly || undefined,
+      enrich: options?.enrich || undefined,
+    }).pipe(map((r) => r.body));
+  }
+
+  importLabels(data: LabelsImportRequest): Observable<LabelsImportResponse> {
+    return apiLabelsImportPost(this.http, this.config.rootUrl, { body: data }).pipe(map((r) => r.body));
+  }
+
+  fillFromSort(request: FillFromSortRequest): Observable<FillFromSortResponse> {
+    return apiLabelsFillFromSortPost(this.http, this.config.rootUrl, { body: request }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  /** Multipart upload — stays on plain HttpClient because ng-openapi-gen
+   *  doesn't model multipart bodies (the generated function's ``$Params``
+   *  has no ``body`` field). */
   exampleSort(file: File, cropParams?: Record<string, unknown>): Observable<SortResponse> {
     const formData = new FormData();
     formData.append('file', file);
@@ -99,24 +127,34 @@ export class SortingApiService {
     return this.http.post<SortResponse>('/api/example-sort', formData);
   }
 
-  getServerMediaFiles(): Observable<ServerMediaFilesResponse> {
-    return this.http.get<ServerMediaFilesResponse>('/api/server-media-files');
+  getServerMediaFiles(): Observable<ServerMediaListResponse> {
+    return apiServerMediaFilesGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  exampleSortServer(params: { filename: string; crop_params?: Record<string, unknown> }): Observable<SortResponse> {
-    return this.http.post<SortResponse>('/api/example-sort-server', params);
+  exampleSortServer(params: {
+    filename: string;
+    crop_params?: Record<string, unknown>;
+  }): Observable<ExampleSortResponse> {
+    return apiExampleSortServerPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  exampleSortOrigin(
-    params: { origin: Record<string, unknown>; key: string; crop_params?: Record<string, unknown> },
-  ): Observable<SortResponse> {
-    return this.http.post<SortResponse>('/api/example-sort-origin', params);
+  exampleSortOrigin(params: {
+    origin: Record<string, unknown>;
+    key: string;
+    crop_params?: Record<string, unknown>;
+  }): Observable<ExampleSortResponse> {
+    return apiExampleSortOriginPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
+  /** Multipart upload — see {@link exampleSort}. */
   uploadServerMediaFile(
     file: File,
     options?: { mediaType?: string; cropParams?: Record<string, unknown> },
-  ): Observable<{ filename: string; original_name: string }> {
+  ): Observable<ServerMediaUploadResponse> {
     const formData = new FormData();
     formData.append('file', file);
     if (options?.cropParams) {
@@ -125,55 +163,73 @@ export class SortingApiService {
         formData.append('media_type', options.mediaType);
       }
     }
-    return this.http.post<{ filename: string; original_name: string }>('/api/server-media-files/upload', formData);
+    return this.http.post<ServerMediaUploadResponse>('/api/server-media-files/upload', formData);
   }
 
-  labelFileSort(file: File): Observable<LearnedSortResponse> {
+  /** Multipart upload — see {@link exampleSort}. */
+  labelFileSort(file: File): Observable<LabelFileSortResponse> {
     const formData = new FormData();
     formData.append('file', file);
-    return this.http.post<LearnedSortResponse>('/api/label-file-sort', formData);
+    return this.http.post<LabelFileSortResponse>('/api/label-file-sort', formData);
   }
 
   getTextsortSuggestions(): Observable<TextsortSuggestionsResponse> {
-    return this.http.get<TextsortSuggestionsResponse>('/api/textsort-suggestions');
+    return apiTextsortSuggestionsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   addTextsortSuggestion(text: string): Observable<OkResponse> {
-    return this.http.post<OkResponse>('/api/textsort-suggestions', { text });
+    return apiTextsortSuggestionsPost(this.http, this.config.rootUrl, { body: { text } }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  getLabelingProgress(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/labeling-progress', params);
+  /** ``/api/labeling-progress`` reads global state (votes, label history) and
+   *  takes no request body — the spec's ``ApiLabelingProgressPost$Params``
+   *  reflects that.  Production callers were removed; the method is kept for
+   *  parity with the legacy surface. */
+  getLabelingProgress(): Observable<unknown> {
+    return this.http.post('/api/labeling-progress', {});
   }
 
   getLabelingStatus(): Observable<LabelingStatusResponse> {
-    return this.http.get<LabelingStatusResponse>('/api/labeling-status');
+    return apiLabelingStatusGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  getIndicatorScoreHistory(metric: string): Observable<IndicatorScoreHistoryResponse> {
-    return this.http.get<IndicatorScoreHistoryResponse>('/api/indicator-score-history', {
-      params: { metric },
-    });
+  getIndicatorScoreHistory(
+    metric: 'smart' | 'stable' | 'diverse',
+  ): Observable<IndicatorScoreHistoryResponse> {
+    return apiIndicatorScoreHistoryGet(this.http, this.config.rootUrl, { metric }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  getDiversityTreeNext(scores?: Record<string, number>, threshold?: number): Observable<DiversityTreeNextResponse> {
+  /** The POST branch carries an optional ``{scores, threshold}`` body that the
+   *  backend reads via ``request.get_json(silent=True)`` — the OpenAPI spec
+   *  intentionally omits that body so GET and POST share one declaration, so
+   *  the POST call stays on plain ``HttpClient``.  The GET branch uses the
+   *  generated function. */
+  getDiversityTreeNext(
+    scores?: Record<string, number>,
+    threshold?: number,
+  ): Observable<DiversityTreeNextResponse> {
     if (scores) {
       return this.http.post<DiversityTreeNextResponse>('/api/diversity-tree/next', { scores, threshold });
     }
-    return this.http.get<DiversityTreeNextResponse>('/api/diversity-tree/next');
+    return apiDiversityTreeNextGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Kick off an eval train-and-score job.  Like {@link learnedSort}, the
    *  response will be ``done`` immediately on a cache hit; otherwise poll
    *  {@link getEvalTrainAndScoreResult}. */
-  trainAndScore(metric: string): Observable<EvalTrainAndScoreJobResponse> {
-    return this.http.post<EvalTrainAndScoreJobResponse>('/api/eval/train-and-score', { metric });
+  trainAndScore(metric: 'smart' | 'stable' | 'diverse'): Observable<EvalTrainAndScoreResponse> {
+    return apiEvalTrainAndScorePost(this.http, this.config.rootUrl, { body: { metric } }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  getEvalTrainAndScoreResult(jobId: string): Observable<EvalTrainAndScoreJobResponse> {
-    return this.http.get<EvalTrainAndScoreJobResponse>('/api/eval/train-and-score/result', {
-      params: { job_id: jobId },
-    });
+  getEvalTrainAndScoreResult(jobId: string): Observable<EvalTrainAndScoreResponse> {
+    return apiEvalTrainAndScoreResultGet(this.http, this.config.rootUrl, { job_id: jobId }).pipe(
+      map((r) => r.body),
+    );
   }
-
 }


### PR DESCRIPTION
## Summary

- Rewires `SortingApiService` to call 21 generated functions across the `sorting`, `labels`, `eval`, and `media-server` fn modules under `frontend/src/app/generated/api-client/fn/`, with return types tightened to the generated DTOs.
- Multipart routes (`exampleSort`, `labelFileSort`, `uploadServerMediaFile`) and the `getDiversityTreeNext` POST branch (body read via `request.get_json(silent=True)` on the backend; intentionally omitted from the spec) stay on plain `HttpClient` — same pattern as `MediasApiService.addToPile`.
- Consumers updated: `ExportModalComponent` swaps `LabelEntry` for `LabeledElement`; `LoadSortModalComponent` swaps `ServerFileEntry` for `ServerMediaFileEntry`; `ProgressModalComponent` swaps `EvalTrainAndScoreJobResponse` for the generated `EvalTrainAndScoreResponse` (with a cast where chart-data narrows to typed point arrays); `LabelViewComponent` swaps `LearnedSortJobResponse` for the generated `LearnedSortResponse` with bracket-access on index-signature properties.
- Deletes 20 now-unused interfaces from `api.models.ts`: `SortResult`, `SortResponse`, `LearnedSortResult`, `LearnedSortResponse`, `LearnedSortJobResponse`, `InclusionResponse`, `SafeThresholdsResponse`, `TextsortSuggestionsResponse`, `FillFromSortRequest/DryRun/Confirm`, `DiversityTreeNextResponse`, `LabelEntry`, `LabelsExportResponse`, `LabelsImportResponse`, `ServerFileEntry`, `ServerMediaFilesResponse`, `TrainAndScoreResponse`, `EvalTrainAndScoreJobResponse`, `IndicatorScoreHistoryResponse`. `VotesResponse`, `StatusIndicator`, `LabelingStatusResponse`, `SortProgressResponse`, and the three chart-point types stay because they still have non-service consumers.
- `LabelingStatusResponse` consumer tightening (autopilot chain + spec literals) is captured as a follow-up in `docs/plans/openapi-schema.md` — too wide to retype in this PR.

## Test plan

- [x] `./run-tests.sh core` — 494 passed (also runs ruff, codespell, deptry, frontend `build:prod` typecheck, and `npm audit`).
- [x] `./run-tests.sh api sorting` — 641 passed.
- [x] `npx tsc --project tsconfig.spec.json --noEmit` — no errors (spec files still typecheck).
- [x] `python scripts/dump_openapi.py` matches the checked-in `frontend/openapi.json` (no backend drift).
- [x] Initial bundle still under budget: 478.81 kB raw / 127.25 kB transfer (525 kB budget).

https://claude.ai/code/session_01L51DhaHK1k9K9kqCEJ61Nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01L51DhaHK1k9K9kqCEJ61Nv)_