### PR TITLE
Vulture audit pass: delete dead code, tune invocation, whitelist public API

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -2,19 +2,54 @@
 
 Vulture finds defined-but-never-referenced names. This file lists symbols
 that VTSearch DOES use, but only reflectively — so static analysis can't
-see the reference. Running vulture with this file as a second argument
-suppresses the corresponding false positives:
+see the reference. Run vulture with this file as an extra argument:
 
-    vulture vtsearch .vulture-whitelist.py --min-confidence 80
+    vulture vtsearch/ app.py tests/ .vulture-whitelist.py --min-confidence 60 \\
+      --exclude '*/vtsearch/schemas/*,*/vtsearch/settings_models.py' \\
+      --ignore-decorators '@*.route,@*.before_request,@*.after_request,@*.errorhandler,@*.teardown_request,@*.context_processor,@bp.*,@app.*,@pytest.fixture,@pytest.mark.*,@fixture,@*.fixture' \\
+      --ignore-names 'Meta,model_config,_keys_to_ignore_on_load_unexpected,test_*,Test*,setup_method,teardown_method,setup_class,teardown_class,pytest_*,pytestmark,__enter__,__exit__,__package__'
 
-Add a new entry whenever you confirm that a vulture finding is reflective
-or framework-managed rather than actually dead.
+Why the excludes / ignores:
+
+* ``vtsearch/schemas/*`` and ``vtsearch/settings_models.py`` are pure
+  framework-managed declaration files. Every field assignment in a
+  marshmallow ``Schema`` subclass or a pydantic ``BaseModel`` looks
+  "unused" to vulture because both frameworks collect fields via
+  metaclass at class-creation time. There is no way to tell vulture
+  about that linkage short of listing every field by hand, so we just
+  skip the directories. Dead schemas, if any, will surface as unused
+  imports in the route files that consume them.
+* ``--ignore-names Meta,model_config`` covers the same metaclass-managed
+  inner-class / config-attribute patterns for any stragglers that aren't
+  in the excluded paths.
+* ``--ignore-names _keys_to_ignore_on_load_unexpected`` is HuggingFace's
+  convention for telling ``transformers.PreTrainedModel`` to skip
+  certain weight keys when loading; the attribute is read by the base
+  class via reflection.
+* Flask route handlers are decorated with ``@bp.route(...)`` etc., which
+  vulture doesn't follow back to a call site — the decorator filter
+  covers ``@*.route``, ``@*.before_request``, ``@*.errorhandler``,
+  ``@bp.*``, ``@app.*``, and the rest of the Flask lifecycle hooks.
+* Test-only names: ``test_*`` and ``Test*`` are pytest-discovered, the
+  ``setup_method``/``teardown_method``/``setup_class``/``teardown_class``
+  hooks are pytest fixture lifecycle, ``pytest_*`` and ``pytestmark`` are
+  framework reserved.
+* Python protocol dunders (``__enter__``, ``__exit__``, ``__package__``)
+  are called by the runtime, not by user code — vulture sees the
+  assignment (e.g. on a ``MagicMock`` instance for a context-manager
+  test) but no read.
+
+Whitelist entries below cover the remaining individual symbols that
+vulture flags but are actually used reflectively or as the public API
+surface of a module.
 """
 
-# Plugin sentinels. Each `<FAMILY> = SomeClass` line at the bottom of a
-# plugin module is discovered by the `PluginRegistry` scanner via the
+# ---------------------------------------------------------------------------
+# Plugin sentinels — each ``<FAMILY> = SomeClass`` line at the bottom of a
+# plugin module is discovered by the ``PluginRegistry`` scanner via the
 # matching attribute name. Vulture sees the assignment but no reference;
-# discovery happens at import time through `getattr`.
+# discovery happens at import time through ``getattr``.
+# ---------------------------------------------------------------------------
 IMPORTER  # noqa: F821
 EXPORTER  # noqa: F821
 CONVERTER  # noqa: F821
@@ -29,6 +64,73 @@ LABEL_IMPORTER  # noqa: F821
 LABELSET_SOURCE  # noqa: F821
 PickerView  # noqa: F821
 
-# argparse.Action.__call__ requires the `option_string` parameter even
+# ---------------------------------------------------------------------------
+# argparse.Action.__call__ requires the ``option_string`` parameter even
 # when the action ignores it.
+# ---------------------------------------------------------------------------
 option_string  # noqa: F821
+
+# ---------------------------------------------------------------------------
+# Flask reads ``app.secret_key`` via attribute access for session signing.
+# Setting it is the side-effecting "use".
+# ---------------------------------------------------------------------------
+secret_key  # noqa: F821
+
+# ---------------------------------------------------------------------------
+# Public-API forwarders in ``vtsearch.concurrency.progress`` that mirror
+# their ``update_<tracker>_progress`` partners. The corresponding
+# trackers (``sort_progress``, ``find_progress``, ``dataset_progress``)
+# are imported and read directly in tests / routes; the helper wrappers
+# stay for API symmetry and are documented in CLAUDE.md.
+# ---------------------------------------------------------------------------
+check_dataset_cancelled  # noqa: F821
+get_sort_progress  # noqa: F821
+get_find_progress  # noqa: F821
+
+# ---------------------------------------------------------------------------
+# Public module constants — referenced by callers via ``module.NAME`` or
+# settings lookup, which vulture treats as the only assignment.
+# ---------------------------------------------------------------------------
+SAVED_DATASETS_DIR  # noqa: F821 — vtsearch.datasets.registry default dir
+DETECTORS_DIR  # noqa: F821 — vtsearch.detectors.store default dir
+SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB  # noqa: F821 — downloader size budget constant
+
+# ---------------------------------------------------------------------------
+# Hardware-derived defaults imported and called from the excluded
+# ``vtsearch/settings_models.py`` (pydantic ``default_factory`` for the
+# two ``max_concurrent_dataset_*`` keys). The exclude hides those uses
+# from vulture; the functions themselves are real.
+# ---------------------------------------------------------------------------
+default_concurrent_downloads  # noqa: F821
+default_concurrent_embeddings  # noqa: F821
+
+# ---------------------------------------------------------------------------
+# Public APIs exposed for external consumers (CLI scripts, future tests,
+# extension authors). Documented in CLAUDE.md but not currently called
+# from within vtsearch/ or tests/.
+# ---------------------------------------------------------------------------
+find_by_pkl_path  # noqa: F821 — vtsearch.datasets.registry
+recreate_model_at_time  # noqa: F821 — vtsearch.detectors.labeling_progress
+update_cache_for_cid  # noqa: F821 — vtsearch.detectors.labelset_training
+collect_media_origins  # noqa: F821 — vtsearch.detectors.training
+train_detector_from_origins  # noqa: F821 — vtsearch.detectors.training
+
+# ---------------------------------------------------------------------------
+# Public context managers exported from ``vtsearch.state`` for callers
+# that need explicit, scoped switching of the active dataset/detector
+# without going through the per-request middleware.
+# ---------------------------------------------------------------------------
+with_dataset_context  # noqa: F821
+with_detector_context  # noqa: F821
+
+# ---------------------------------------------------------------------------
+# TYPE_CHECKING-only accessor stubs in ``vtsearch.settings``. The actual
+# runtime functions are generated by ``make_accessors`` at module-bottom;
+# the ``if TYPE_CHECKING:`` block exists so pyright can resolve
+# ``settings.get_<key>()`` from other modules. Vulture sees the stub but
+# can't connect it to the dynamic definition or the runtime callers.
+# ---------------------------------------------------------------------------
+get_audio_playing  # noqa: F821
+get_swipe_animation  # noqa: F821
+get_hide_autopilot  # noqa: F821
+get_autopilot_resort_interval  # noqa: F821

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 - **Format**: `ruff format .`
 - **Spell check**: `codespell --toml pyproject.toml`
 - **Dependency check**: `python -m deptry .`
-- **Dead code audit** (manual, pre-release): `vulture vtsearch/ .vulture-whitelist.py --min-confidence 80`
+- **Dead code audit** (manual, pre-release): see `.vulture-whitelist.py` for the full invocation (60% confidence, with marshmallow/pydantic field directories excluded and pytest/Flask/dunder noise filtered). Run before each release; not a CI gate.
 
 ## Architecture
 - `app.py` — Flask entry point, registers blueprints, startup logic, CLI argument parsing, per-request user context via `before_request` middleware, per-request dataset/model context resolution from `X-Dataset-Id`/`X-Detector-Id` headers

--- a/docs/plans/python-quality-tools.md
+++ b/docs/plans/python-quality-tools.md
@@ -1,12 +1,12 @@
 # Python quality tools
 
 *Status: Phases 1 + 2 + 3 shipped, plus the pyproject-consolidation
-follow-up and CI coverage publication. deptry, codespell, ruff's `S`
-ruleset, opt-in coverage (now also published in CI), and a vulture
-whitelist are all in place alongside the original pre-commit + pip-audit,
-and `pyproject.toml` is now the single source of truth for runtime + dev
-dependencies. See "Open follow-ups" at the bottom for the remaining
-maintenance items.*
+follow-up, CI coverage publication, and the vulture audit pass. deptry,
+codespell, ruff's `S` ruleset, opt-in coverage (now also published in
+CI), and a tuned vulture invocation + whitelist are all in place
+alongside the original pre-commit + pip-audit, and `pyproject.toml` is
+now the single source of truth for runtime + dev dependencies. See
+"Open follow-ups" at the bottom for the remaining maintenance items.*
 
 The ruff + pyright + pytest stack already covers the modern core of
 Python quality tooling. This plan tracks what else is worth adding,
@@ -117,6 +117,49 @@ wire it", and a success criterion so it's a one-sitting task.
   cleanly. Vulture is intentionally NOT a CI gate — it's a manual
   pre-release audit since lower confidence settings produce too many
   false positives against the plugin-discovery pattern.
+- **Vulture audit pass** at `--min-confidence 60` — completed in
+  May 2026. The invocation now lives in `.vulture-whitelist.py`'s
+  module docstring and is referenced from `CLAUDE.md`'s commands list.
+  Key tunings: `--exclude` for `vtsearch/schemas/*` and
+  `vtsearch/settings_models.py` (every marshmallow field assignment and
+  pydantic field declaration looks "unused" to vulture because both
+  frameworks collect fields via metaclass — there is no static reference
+  to attach), `--ignore-decorators` covering the full Flask + pytest
+  decorator surface, and `--ignore-names` for Meta inner classes,
+  `model_config`, the HuggingFace `_keys_to_ignore_on_load_unexpected`
+  attribute, pytest `test_*`/`Test*`/`pytest_*`/`pytestmark` patterns,
+  and Python protocol dunders (`__enter__`, `__exit__`, `__package__`).
+  The triage:
+  * **Deleted as genuinely dead:** `serialize_job` and the unused
+    `finished_at` attribute in `vtsearch/concurrency/async_jobs.py`,
+    `_search_dir_for_file` in the http-archive importer,
+    `_activate_new_context` in `vtsearch/datasets/load_pipeline.py`,
+    `_pop_embedding_key` in `vtsearch/datasets/loader.py`,
+    `embed_image_file_from_pil` in `vtsearch/datasets/loader_pickle.py`,
+    `_ProtoLeaf` in `vtsearch/media/patch_embed.py`, `_save_for_key` and
+    `_get_active_cache_for_key` in `vtsearch/settings.py`, plus a
+    handful of dead test helpers (`_read_sse_event`, `_make_minimal_wav`,
+    `_make_text_file`, `make_document_media`, `make_minimal_pdf_bytes`,
+    `build_results_dict`, `make_trainable_model_file`, `_populate`,
+    `_StubMedias`) and several unused local variables. Renamed an
+    unused loop variable and a few unused function parameters to the
+    `_<name>` convention.
+  * **Whitelisted as public API / reflective use:** Flask's
+    `secret_key`, the API-symmetry progress wrappers
+    (`check_dataset_cancelled`, `get_sort_progress`, `get_find_progress`),
+    documented public constants (`SAVED_DATASETS_DIR`, `DETECTORS_DIR`,
+    `SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB`), public training/labelset APIs
+    (`find_by_pkl_path`, `recreate_model_at_time`, `update_cache_for_cid`,
+    `collect_media_origins`, `train_detector_from_origins`), the public
+    state context managers (`with_dataset_context`, `with_detector_context`),
+    `default_concurrent_downloads`/`default_concurrent_embeddings`
+    (called from the excluded `settings_models.py`), and the
+    TYPE_CHECKING-only settings accessor stubs that pyright needs but
+    vulture sees as orphans (`get_audio_playing`, `get_swipe_animation`,
+    `get_hide_autopilot`, `get_autopilot_resort_interval`).
+
+  The tuned invocation now exits 0 on a clean tree, so introducing a
+  new piece of dead code reliably surfaces in the audit.
 
 ## Phase 2 — Low-friction additions
 
@@ -315,33 +358,10 @@ added to the whitelist with a comment explaining why.
   drops below a threshold. Don't gate on total coverage delta — too
   noisy across unrelated test reshuffles — gate on **lines changed by
   this PR**, which is what `diff-cover` measures.
-- **Vulture audit pass.** Concrete state after exploring at lower
-  confidence:
-  - `--min-confidence 80` is clean (current invocation).
-  - `--min-confidence 70` is also clean. The first findings appear at
-    60 %, with a baseline of ~410 reports.
-  - About a third of that baseline is Flask route handlers (vulture
-    doesn't follow `@bp.route(...)` decoration). Passing
-    `--ignore-decorators '@*.route,@*.before_request,@*.after_request,@*.errorhandler,@*.teardown_request,@*.context_processor,@bp.*,@app.*'`
-    cuts the 60 %-confidence count to ~260.
-  - The remaining noise dominates in three families: marshmallow
-    schema attributes (`vtsearch/schemas/*.py` — `Meta` inner classes,
-    field aliases, computed properties wired via `@post_load`/
-    `@validates`), CLI entry points dispatched through `app.py`'s
-    argparse layer (`autodetect_main*`, `autodetect_importer_main*`),
-    and HuggingFace model-internal attributes
-    (`_keys_to_ignore_on_load_unexpected`). Each family wants either a
-    targeted `--ignore-names` flag, a decorator filter, or whitelist
-    entries — and the schema family in particular needs care to
-    distinguish marshmallow-managed attributes from genuinely dead
-    fields.
-  - **Recommended approach for the audit:** start by writing the right
-    invocation (decorator filter + `--ignore-names` glob for the
-    schema patterns), get the 60 %-confidence count down to something
-    a human can review (target: under 100), then triage what remains
-    in a single sitting and either delete or whitelist each entry with
-    a one-line justification. Treat the audit as a release-gate task,
-    not a CI gate.
+- **Vulture audit pass.** Completed — see "What shipped (Phase 3)"
+  above for the deletions, whitelist additions, and final tuned
+  invocation. The audit is meant to be re-run before each release;
+  introducing new dead code will surface there.
 - **Pyright `S`-equivalent and `C901` complexity.** ruff has McCabe
   complexity via `C901`; consider enabling alongside future
   security-rule tightening if we want a complexity gate.

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -118,21 +118,6 @@ class TestLoadingTasksTrackerSubscriptions:
 # ---------------------------------------------------------------------------
 
 
-def _read_sse_event(stream, *, timeout=2.0):
-    """Pull one event:/data: pair from the SSE generator."""
-    deadline = time.monotonic() + timeout
-    buf = ""
-    while time.monotonic() < deadline:
-        chunk = next(stream, None)
-        if chunk is None:
-            break
-        buf += chunk
-        if "\n\n" in buf:
-            frame, _, buf = buf.partition("\n\n")
-            return frame, buf
-    return None, buf
-
-
 class TestEventsRoute:
     def test_initial_snapshot_includes_every_channel(self):
         frames = initial_snapshot()

--- a/tests/api/test_file_browser.py
+++ b/tests/api/test_file_browser.py
@@ -217,7 +217,7 @@ def _make_multi_user_provider(user_data_dir: Path, username: str = "alice"):
         def is_authenticated(self, request):
             return True
 
-        def get_user_data_dir(self, uname, base_data_dir):
+        def get_user_data_dir(self, _uname, _base_data_dir):
             return user_data_dir
 
     return _TestMultiProvider()

--- a/tests/cli/test_preload_progress.py
+++ b/tests/cli/test_preload_progress.py
@@ -116,7 +116,7 @@ class TestPreloadConsoleOutput:
 
     @patch("vtsearch.embedding.loader.predict_embedders_to_preload", return_value=["clap"])
     @patch("vtsearch.media.get_embedder")
-    def test_prints_preloading_banner_and_progress(self, mock_get_embedder, mock_predict, capsys):
+    def test_prints_preloading_banner_and_progress(self, mock_get_embedder, _mock_predict, capsys):
         """preload_predicted_embedders should print the banner and forward progress to console."""
         mock_emb = MagicMock()
         mock_emb.name = "clap"
@@ -145,7 +145,7 @@ class TestPreloadConsoleOutput:
 
     @patch("vtsearch.embedding.loader.predict_embedders_to_preload", return_value=["clap"])
     @patch("vtsearch.media.get_embedder")
-    def test_restores_original_callback_after_load(self, mock_get_embedder, mock_predict):
+    def test_restores_original_callback_after_load(self, mock_get_embedder, _mock_predict):
         """The original _on_progress callback should be restored after load_models."""
         original_cb = MagicMock()
         mock_emb = MagicMock()
@@ -160,7 +160,7 @@ class TestPreloadConsoleOutput:
 
     @patch("vtsearch.embedding.loader.predict_embedders_to_preload", return_value=["clap"])
     @patch("vtsearch.media.get_embedder")
-    def test_restores_callback_on_exception(self, mock_get_embedder, mock_predict, capsys):
+    def test_restores_callback_on_exception(self, mock_get_embedder, _mock_predict, capsys):
         """The original callback should be restored even when load_models raises."""
         original_cb = MagicMock()
         mock_emb = MagicMock()
@@ -177,7 +177,7 @@ class TestPreloadConsoleOutput:
         assert "Warning" in captured.out
 
     @patch("vtsearch.embedding.loader.predict_embedders_to_preload", return_value=[])
-    def test_no_predicted_embedders_produces_no_output(self, mock_predict, capsys):
+    def test_no_predicted_embedders_produces_no_output(self, _mock_predict, capsys):
         """When there are no predicted embedders, nothing should be printed."""
         result = preload_predicted_embedders()
 

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -1,6 +1,5 @@
 """Tests for the Document media type and MediaConverter framework."""
 
-import io
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -45,21 +44,6 @@ def _make_two_page_pdf() -> bytes:
     pdf_bytes = doc.tobytes()
     doc.close()
     return pdf_bytes
-
-
-def _make_minimal_wav(duration_s: float = 0.1, sample_rate: int = 16000) -> bytes:
-    """Build a minimal WAV file (mono, 16-bit PCM)."""
-    n_samples = int(duration_s * sample_rate)
-    samples = np.zeros(n_samples, dtype=np.int16)
-    buf = io.BytesIO()
-    import wave
-
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(sample_rate)
-        wf.writeframes(samples.tobytes())
-    return buf.getvalue()
 
 
 def _make_minimal_video(frames: int = 30, width: int = 64, height: int = 64) -> bytes:

--- a/tests/datasets/test_creation_info.py
+++ b/tests/datasets/test_creation_info.py
@@ -49,7 +49,7 @@ class TestBuildCliArgs:
             description = "test"
             fields = [ImporterField("upload", "Upload", "file", accept=".pkl")]
 
-            def run(self, fv, c):
+            def run(self, _fv, _c):
                 pass
 
         imp = _FileImporter()

--- a/tests/datasets/test_thin_loading.py
+++ b/tests/datasets/test_thin_loading.py
@@ -22,13 +22,6 @@ from vtsearch.datasets.loader import (
 from helpers import make_wav_bytes as _make_wav_bytes, make_wav_file as _make_wav_file  # noqa: F401
 
 
-def _make_text_file(tmp_dir: Path, name: str, content: str) -> Path:
-    """Write a text file and return its path."""
-    p = tmp_dir / name
-    p.write_text(content, encoding="utf-8")
-    return p
-
-
 class TestStreamingMD5:
     def test_matches_regular_md5(self, tmp_path):
         content = b"hello world test data"

--- a/tests/downloads/test_download_and_extract.py
+++ b/tests/downloads/test_download_and_extract.py
@@ -299,7 +299,7 @@ class TestDownloadAndExtract:
         # Find extraction progress calls (not the initial 0/0 announcement)
         extract_progress = [(msg, cur, tot) for _, msg, cur, tot in progress_calls if "Extracting" in msg and tot > 0]
         assert len(extract_progress) > 0, "Expected determinate extraction progress"
-        last_msg, last_cur, last_tot = extract_progress[-1]
+        _last_msg, last_cur, last_tot = extract_progress[-1]
         assert last_cur == last_tot, "Final progress should show completion"
 
 
@@ -535,7 +535,7 @@ class TestCaltech101ExtractionProgress:
             if "Extracting 101_ObjectCategories" in msg and tot > 0
         ]
         assert len(inner_progress) > 0, "Inner tar extraction should report progress with total"
-        last_msg, last_cur, last_tot = inner_progress[-1]
+        _last_msg, last_cur, last_tot = inner_progress[-1]
         assert last_cur == last_tot
 
 
@@ -580,7 +580,7 @@ class TestBbcNewsExtractionProgress:
             (msg, cur, tot) for _, msg, cur, tot in progress_calls if "Extracting BBC News dataset" in msg and tot > 0
         ]
         assert len(extract_progress) > 0, "BBC News extraction should report progress with total"
-        last_msg, last_cur, last_tot = extract_progress[-1]
+        _last_msg, last_cur, last_tot = extract_progress[-1]
         assert last_cur == last_tot
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import json
 import struct
 import wave
 from pathlib import Path
@@ -100,37 +99,6 @@ def make_minimal_mp4_bytes() -> bytes:
     )
 
 
-def make_minimal_pdf_bytes() -> bytes:
-    """Return a minimal valid PDF byte string.
-
-    Attempts to use PyMuPDF (fitz) for a real, renderable single-page PDF; if
-    that is unavailable, falls back to a handcrafted PDF that is parseable by
-    PyPDF-style readers.
-    """
-    try:
-        import fitz  # type: ignore  # noqa: PLC0415
-    except ImportError:
-        # Minimal valid PDF 1.4 with one empty page
-        return (
-            b"%PDF-1.4\n"
-            b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
-            b"2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj\n"
-            b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n"
-            b"xref\n0 4\n"
-            b"0000000000 65535 f \n"
-            b"0000000009 00000 n \n"
-            b"0000000053 00000 n \n"
-            b"0000000098 00000 n \n"
-            b"trailer<</Size 4/Root 1 0 R>>\n"
-            b"startxref\n152\n%%EOF\n"
-        )
-    doc = fitz.open()
-    doc.new_page()
-    data = doc.tobytes()
-    doc.close()
-    return data
-
-
 def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test image media dict with a solid-color PNG and fake embedding."""
     import hashlib  # noqa: PLC0415
@@ -204,74 +172,6 @@ def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
         "origin": {"importer": "test", "params": {}},
         "origin_name": f"video_{media_id}.mp4",
     }
-
-
-def make_document_media(media_id: int, embedding_dim: int = 512) -> dict:
-    """Build a test document media dict with a minimal PDF and fake embedding."""
-    import hashlib  # noqa: PLC0415
-
-    import numpy as np  # noqa: PLC0415
-
-    pdf = make_minimal_pdf_bytes()
-    rng = np.random.RandomState(media_id + 3000)
-    return {
-        "id": media_id,
-        "type": "document",
-        "embedder": "siglip",  # via document→image converter
-        "file_size": len(pdf),
-        "md5": hashlib.md5(pdf).hexdigest(),
-        "embedding": rng.randn(embedding_dim).astype("float32"),
-        "media_bytes": pdf,
-        "filename": f"doc_{media_id}.pdf",
-        "category": "test-doc",
-        "origin": {"importer": "test", "params": {}},
-        "origin_name": f"doc_{media_id}.pdf",
-    }
-
-
-# ---------------------------------------------------------------------------
-# Trainable model / results helpers
-# ---------------------------------------------------------------------------
-
-
-def build_results_dict(hits, model_name, media_type="unknown"):
-    """Build a single-model results dict (same shape as exporter input)."""
-    return {
-        "media_type": media_type,
-        "detectors_run": 1,
-        "results": {
-            model_name: {
-                "detector_name": model_name,
-                "threshold": 0.5,
-                "total_hits": len(hits),
-                "hits": hits,
-            }
-        },
-    }
-
-
-def make_trainable_model_file(tmp_path, name, good_ids, bad_ids, snap, media_type="audio"):
-    """Write a detector JSON file populated from *snap* and votes.
-
-    Returns the path to the written JSON file.
-    """
-    from vtsearch.datasets.labelset import LabelSet  # noqa: PLC0415
-
-    good_votes_dict = {k: None for k in good_ids}
-    bad_votes_dict = {k: None for k in bad_ids}
-    labelset = LabelSet.from_clips_and_votes(snap, good_votes_dict, bad_votes_dict, expand_dupes=False)
-
-    data = {
-        "name": name,
-        "text_query": "",
-        "media_example": "",
-        "media_type": media_type,
-        "examples": [],
-        "labelset": labelset.to_dict(),
-    }
-    path = tmp_path / f"{name}.json"
-    path.write_text(json.dumps(data))
-    return path
 
 
 def setup_trainable_model_in_registry(name, good_ids, bad_ids, snap, media_type="audio"):

--- a/tests/integration/test_multi_media_coverage.py
+++ b/tests/integration/test_multi_media_coverage.py
@@ -31,24 +31,6 @@ from vtsearch.state import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _populate(media_factory, count=10, start_id=1):
-    """Clear medias and populate with the given factory."""
-    saved = dict(medias)
-    medias.clear()
-    try:
-        for i in range(start_id, start_id + count):
-            medias[i] = media_factory(i)
-        yield
-    finally:
-        medias.clear()
-        medias.update(saved)
-
-
 # ===================================================================
 # TEXT SORT across media types
 # ===================================================================

--- a/tests/io/test_local_folder_upload.py
+++ b/tests/io/test_local_folder_upload.py
@@ -112,9 +112,6 @@ class TestImportLocalFolderEndpoint:
             captured["origin"] = origin
             captured["kwargs"] = kwargs
 
-            class _StubMedias(dict):
-                pass
-
             # Don't actually invoke the real folder importer (that would try
             # to embed audio).  Just record that load_fn is callable.
             captured["load_fn"] = load_fn

--- a/tests/io/test_picker_tabs.py
+++ b/tests/io/test_picker_tabs.py
@@ -36,13 +36,14 @@ class TestBuiltinTabs:
         assert orders == sorted(orders)
 
 
+@pytest.mark.usefixtures("restore_tabs")
 class TestRegisterPickerTab:
-    def test_register_appends_new_tab(self, restore_tabs):
+    def test_register_appends_new_tab(self):
         register_picker_tab({"id": "cloud", "label": "Cloud", "icon": "cloud", "order": 25})
         ids = [t["id"] for t in list_picker_tabs()]
         assert "cloud" in ids
 
-    def test_register_replaces_existing_tab(self, restore_tabs):
+    def test_register_replaces_existing_tab(self):
         register_picker_tab({"id": "server", "label": "Servers", "icon": "server", "order": 5})
         tabs = list_picker_tabs()
         server = next(t for t in tabs if t["id"] == "server")

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -52,10 +52,10 @@ class TestSettingsSourceBase:
             description = "Minimal source."
             fields = []
 
-            def load(self, fv):
+            def load(self, _fv):
                 return {}
 
-            def save(self, data, fv):
+            def save(self, _data, _fv):
                 pass
 
         d = Minimal().to_dict()
@@ -99,10 +99,10 @@ class TestLabelsetSourceBase:
             description = "Minimal source."
             fields = []
 
-            def load(self, fv):
+            def load(self, _fv):
                 return []
 
-            def save(self, labelset, fv):
+            def save(self, _labelset, _fv):
                 pass
 
         d = Minimal().to_dict()

--- a/tests/sorting/test_safe_thresholds.py
+++ b/tests/sorting/test_safe_thresholds.py
@@ -105,7 +105,7 @@ class TestTrainAndScoreWithSafeThresholds:
         """
         app_module.good_votes.update({k: None for k in [1, 2, 3]})
         app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        _, thresh_off, _m1 = train_and_score(
+        _, _thresh_off, _m1 = train_and_score(
             app_module.medias, app_module.good_votes, app_module.bad_votes, safe_thresholds=False
         )
         _, thresh_on, _m2 = train_and_score(

--- a/vtsearch/concurrency/async_jobs.py
+++ b/vtsearch/concurrency/async_jobs.py
@@ -46,7 +46,6 @@ class AsyncJob:
     total: int = 0
     message: str = ""
     started_at: float = 0.0
-    finished_at: float = 0.0
     cancel_event: threading.Event = field(default_factory=threading.Event)
     done_event: threading.Event = field(default_factory=threading.Event)
     # Username of the request that spawned this job, captured at start()
@@ -225,7 +224,6 @@ class JobManager:
             with self._lock:
                 job.status = "error"
                 job.error = str(exc) or exc.__class__.__name__
-                job.finished_at = time.time()
                 job.done_event.set()
             self._promote_pending_if_any()
             return
@@ -233,7 +231,6 @@ class JobManager:
         next_job: AsyncJob | None = None
         next_target: Callable[[AsyncJob], Any] | None = None
         with self._lock:
-            job.finished_at = time.time()
             if job.is_cancelled and job.status == "running":
                 job.status = "cancelled"
             elif job.status == "running":
@@ -365,18 +362,3 @@ def reset_all_async_jobs_for_tests() -> None:
     """Reset every singleton job manager.  Called from the autouse fixture."""
     for mgr in JOB_MANAGERS.values():
         mgr.reset_for_tests()
-
-
-def serialize_job(job: AsyncJob) -> dict[str, Any]:
-    """Return a JSON-safe snapshot of *job* (without ``result``).
-
-    The result payload differs per endpoint and is added by the route.
-    """
-    return {
-        "job_id": job.job_id,
-        "status": job.status,
-        "current": job.current,
-        "total": job.total,
-        "message": job.message,
-        "error": job.error,
-    }

--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -380,18 +380,4 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         return source.resolve_path(origin_name, filename)
 
 
-def _search_dir_for_file(directory: Path, origin_name: str, filename: str) -> Path | None:
-    """Search a directory for a file matching origin_name or filename."""
-    for name in [origin_name, filename]:
-        if not name:
-            continue
-        candidate = directory / name
-        if candidate.is_file():
-            return candidate
-        matches = list(directory.rglob(Path(name).name))
-        if matches:
-            return matches[0]
-    return None
-
-
 IMPORTER = HttpArchiveDatasetImporter()

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -342,7 +342,7 @@ def ingest_missing_medias(
 
     total_ingested = 0
 
-    for origin_key, (origin_dict, entries) in groups.items():
+    for _origin_key, (origin_dict, entries) in groups.items():
         importer_name = origin_dict.get("importer", "")
 
         on_progress(

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -624,17 +624,6 @@ def _auto_register_dataset(
     return entry
 
 
-def _activate_new_context(dataset_id: str) -> DatasetContext:
-    """Create a fresh DatasetContext and register it.
-
-    The previous contexts (if any) are *preserved* in the context
-    store — nothing is cleared.  This enables the multi-dataset model.
-    """
-    ctx = DatasetContext(dataset_id)
-    register_context(ctx)
-    return ctx
-
-
 # ---------------------------------------------------------------------------
 # Parallel-safe background loading
 # ---------------------------------------------------------------------------

--- a/vtsearch/datasets/loader.py
+++ b/vtsearch/datasets/loader.py
@@ -91,15 +91,6 @@ def _get_md5_value(d: dict[str, Any]) -> str:
     return d.get("md5") or d.get("MD5") or ""
 
 
-def _pop_embedding_key(d: dict[str, Any]) -> Any:
-    """Pop and return the embedding value from *d*, trying ``"embedding"`` key.
-
-    Returns the value (or ``None`` if the key is absent) and removes the
-    matched key from *d* so it doesn't leak into downstream metadata.
-    """
-    return d.pop("embedding", None)
-
-
 def _get_embedding_value(d: dict[str, Any]) -> Any:
     """Return the embedding value from *d* without mutating it.
 
@@ -129,7 +120,6 @@ from vtsearch.datasets.loader_folder import (  # noqa: E402, F401
 from vtsearch.datasets.loader_pickle import (  # noqa: E402, F401
     _write_clipper_sidecar,
     _write_embedder_sidecar,
-    embed_image_file_from_pil,
     load_dataset_from_pickle,
     load_dataset_from_pickle_chunked,
     read_pkl_clipper,

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 import gc
 import hashlib
 from pathlib import Path
-from typing import Any, Iterator, Optional, cast
+from typing import Any, Iterator
 
 import numpy as np
-from PIL import Image
 
 from vtsearch.datasets.loader import (
     ProgressCallback,
@@ -368,37 +367,6 @@ def load_dataset_from_pickle_chunked(
 
         if chunk_medias:
             yield chunk_medias
-
-
-def embed_image_file_from_pil(image: Image.Image, embedder_name: str = "") -> Optional[np.ndarray]:
-    """Generate a CLIP embedding vector for a PIL Image object.
-
-    A convenience wrapper for cases where the image is already in memory
-    (e.g. reconstructed from a NumPy array during CIFAR-10 loading).
-
-    Delegates to the image embedder's ``embed_pil_image`` method.
-
-    Args:
-        image: A PIL Image in any mode.
-        embedder_name: Optional name of a registered embedder.  When empty,
-            the first image embedder is used.
-
-    Returns:
-        A 1-D ``numpy.ndarray`` of shape ``(embedding_dim,)``, or ``None`` if
-        no image embedder is available or an exception occurs.
-    """
-    from vtsearch.media import embedders_for_type, get_embedder
-
-    if embedder_name:
-        emb = get_embedder(embedder_name)
-    else:
-        avail = embedders_for_type("image")
-        if not avail:
-            return None
-        emb = avail[0]
-    # Image-type embedders all implement embed_pil_image, but the method
-    # is not on the MediaEmbedder ABC (only image subclasses define it).
-    return cast(Any, emb).embed_pil_image(image)
 
 
 def _write_embedder_sidecar(pkl_path: Path, embedder_name: str) -> None:

--- a/vtsearch/media/patch_embed.py
+++ b/vtsearch/media/patch_embed.py
@@ -29,7 +29,7 @@ and in :mod:`vtsearch.training.region_similarity`.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple, Optional
 
 import numpy as np
@@ -253,21 +253,6 @@ def eupe_features_to_patch_output(
         patch_grid=_norm_torch(patch_grid).astype(np.float32),
         patch_saliency=saliency.detach().cpu().float().numpy().astype(np.float32),
     )
-
-
-@dataclass
-class _ProtoLeaf:
-    """Intermediate leaf representation during clustering.
-
-    Carries the cell-index set so we can compute the bounding box and the
-    saliency-weighted vector after assignment is finalised.
-    """
-
-    cells: list[tuple[int, int]] = field(default_factory=list)
-    """``(row, col)`` patch-grid indices that landed in this leaf."""
-
-    seed: tuple[int, int] = (0, 0)
-    """The peak cell this leaf is built around."""
 
 
 def propose_leaves(

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -333,16 +333,6 @@ def _save_user(username: str) -> None:
         _sync_to_source(username, cache)
 
 
-def _save_for_key(key: str) -> None:
-    """Persist whichever tier *key* belongs to."""
-    if key in _SERVER_KEYS:
-        _save_server()
-    else:
-        from vtsearch.auth import get_current_user
-
-        _save_user(get_current_user())
-
-
 # ---------------------------------------------------------------------------
 # Low-level value get/set used by accessor factories
 # ---------------------------------------------------------------------------
@@ -375,20 +365,6 @@ def _write_value(key: str, value: Any) -> None:
     cache = _ensure_user_loaded(username)
     cache[key] = value
     _save_user(username)
-
-
-def _get_active_cache_for_key(key: str) -> dict[str, Any]:
-    """Return the underlying cache dict that owns *key* for the active user.
-
-    Exposed for backwards compatibility with accessor factories that
-    previously called ``_ensure_loaded()`` and mutated the returned dict
-    directly.
-    """
-    if key in _SERVER_KEYS:
-        return _ensure_server_loaded()
-    from vtsearch.auth import get_current_user
-
-    return _ensure_user_loaded(get_current_user())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the **Vulture audit** follow-up from `docs/plans/python-quality-tools.md`. The tuned invocation now exits 0 on a clean tree, so introducing new dead code reliably surfaces in the audit.

- **Tuned invocation** (recorded in the `.vulture-whitelist.py` module docstring + CLAUDE.md): adds `app.py` and `tests/` as input so cross-module references resolve, excludes `vtsearch/schemas/*` and `vtsearch/settings_models.py` (every marshmallow / pydantic field assignment looks "unused" to vulture because both frameworks collect fields via metaclass), and filters Flask + pytest decorators plus Python protocol dunders (`__enter__`, `__exit__`, `__package__`).
- **Deleted as genuinely dead** (vtsearch/): `serialize_job` and the orphaned `finished_at` attribute in `vtsearch/concurrency/async_jobs.py`, `_search_dir_for_file` in the http-archive importer, `_activate_new_context`, `_pop_embedding_key`, `embed_image_file_from_pil`, `_ProtoLeaf`, `_save_for_key`, `_get_active_cache_for_key`. Cleaned up the leftover imports each one orphaned.
- **Deleted dead test helpers**: `_read_sse_event`, `_make_minimal_wav`, `_make_text_file`, `make_document_media`, `make_minimal_pdf_bytes`, `build_results_dict`, `make_trainable_model_file`, `_populate`, `_StubMedias`, plus a handful of unused locals (renamed to the `_<name>` convention where they're loop / unpacking artefacts) and a `restore_tabs` fixture flipped to `@pytest.mark.usefixtures`.
- **Whitelisted as public API / reflective use**: Flask's `secret_key`, the API-symmetric progress wrappers (`check_dataset_cancelled`, `get_sort_progress`, `get_find_progress`), public constants (`SAVED_DATASETS_DIR`, `DETECTORS_DIR`, `SAMPLE_VIDEOS_DOWNLOAD_SIZE_MB`), public training/labelset APIs (`find_by_pkl_path`, `recreate_model_at_time`, `update_cache_for_cid`, `collect_media_origins`, `train_detector_from_origins`), the state context managers (`with_dataset_context`, `with_detector_context`), `default_concurrent_downloads` / `default_concurrent_embeddings` (called from the excluded `settings_models.py`), and the TYPE_CHECKING-only settings accessor stubs (`get_audio_playing`, `get_swipe_animation`, `get_hide_autopilot`, `get_autopilot_resort_interval`).

Plan file (`docs/plans/python-quality-tools.md`) updated: "What shipped (Phase 3)" now describes the completed audit, and the Open follow-ups entry is collapsed to a pointer back to that section. CLAUDE.md commands list points at the whitelist module docstring for the full invocation instead of inlining it.

## Test plan

- [x] `./run-tests.sh` — 3615 passed / 1 skipped (lint, format, codespell, deptry, frontend build, full pytest suite)
- [x] Vulture with the new tuned invocation: 0 findings on a clean tree
- [x] Settings TYPE_CHECKING stubs verified to still resolve in pyright (TYPE_CHECKING block unchanged; only whitelist entries added)

https://claude.ai/code/session_01KaVRRyvMKddZ4gfaYEnt4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaVRRyvMKddZ4gfaYEnt4G)_