### PR TITLE
Enable ruff C901 + diff-cover patch gate; clean up quality-tools plan

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,11 @@
 name: Coverage
 
-# Runs the fast CPU test suite with line + branch coverage and publishes
+# Runs the fast CPU test suite with line + branch coverage, publishes
 # the HTML report as an artifact + a per-file summary to the workflow's
-# step summary. Currently publish-only — there is no coverage-delta gate
-# yet. Tests themselves still gate the job (a failed test fails the
-# workflow); the "no PR gate" decision in docs/plans/python-quality-tools.md
-# is specifically about not failing on coverage thresholds.
+# step summary, and gates pull requests on the coverage of lines they
+# changed (via diff-cover).  The total-coverage number is *not* gated —
+# only patch-level coverage is — because total moves up and down with
+# unrelated test reshuffles and would be noisy.
 #
 # This is the first workflow that runs pytest in CI; local development
 # still uses `./run-tests.sh`. The marker expression (`not gpu and not
@@ -27,6 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # diff-cover needs the merge-base commit to compute the patch
+          # diff.  Fetch the full history on PR runs; push runs only need
+          # the tip so leave them on the default shallow checkout.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
 
       - uses: actions/setup-python@v5
         with:
@@ -65,6 +70,10 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           exit $status
+
+      - name: Install diff-cover
+        if: github.event_name == 'pull_request'
+        run: pip install diff-cover
 
       - name: Run fast tests with coverage
         id: pytest
@@ -108,6 +117,36 @@ jobs:
             echo ""
             echo "Download the **coverage-html** artifact for the per-line drill-down."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Gate PRs on patch-level coverage only: how well the lines this PR
+      # added/changed are covered by tests.  Total-coverage gating is
+      # intentionally avoided — it moves with unrelated test reshuffles
+      # and produces noisy red on PRs that didn't touch tested code.
+      # Threshold of 80% is a starting point; revisit once we have a few
+      # PRs of data on how realistic it is.
+      - name: Patch coverage gate (diff-cover)
+        if: always() && github.event_name == 'pull_request' && hashFiles('coverage.xml') != ''
+        run: |
+          set +e
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          diff-cover coverage.xml \
+            --compare-branch="origin/${{ github.base_ref }}" \
+            --fail-under=80 \
+            --markdown-report=/tmp/diff-cover.md \
+            2>&1 | tee /tmp/diff-cover.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Patch coverage (diff-cover, fail-under=80%)"
+            echo ""
+            if [ -f /tmp/diff-cover.md ]; then
+              cat /tmp/diff-cover.md
+            else
+              echo '```'
+              tail -c 60000 /tmp/diff-cover.log
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
 
       - name: Upload HTML coverage report
         if: always() && hashFiles('coverage_html/index.html') != ''

--- a/docs/plans/python-quality-tools.md
+++ b/docs/plans/python-quality-tools.md
@@ -1,12 +1,13 @@
 # Python quality tools
 
-*Status: Phases 1 + 2 + 3 shipped, plus the pyproject-consolidation
-follow-up, CI coverage publication, and the vulture audit pass. deptry,
-codespell, ruff's `S` ruleset, opt-in coverage (now also published in
-CI), and a tuned vulture invocation + whitelist are all in place
-alongside the original pre-commit + pip-audit, and `pyproject.toml` is
-now the single source of truth for runtime + dev dependencies. See
-"Open follow-ups" at the bottom for the remaining maintenance items.*
+*Status: all planned phases shipped. The current stack: pre-commit +
+pip-audit (Phase 1); deptry + codespell (Phase 2); ruff `S` security
+ruleset + opt-in coverage + vulture whitelist (Phase 3); pyproject
+consolidation; CI coverage publication; full vulture audit pass; ruff
+`C901` McCabe complexity gate with `max-complexity = 25`; and a
+`diff-cover` patch-coverage gate on PRs. `pre-commit autoupdate` is the
+only remaining recurring maintenance item — see "Open follow-ups" at
+the bottom.*
 
 The ruff + pyright + pytest stack already covers the modern core of
 Python quality tooling. This plan tracks what else is worth adding,
@@ -161,176 +162,55 @@ wire it", and a success criterion so it's a one-sitting task.
   The tuned invocation now exits 0 on a clean tree, so introducing a
   new piece of dead code reliably surfaces in the audit.
 
-## Phase 2 — Low-friction additions
+## What shipped (C901 complexity gate)
 
-These are each a one-config-file change with an obvious failure mode.
-Worth doing soon; can be done independently in any order.
+- **Ruff `C901` McCabe complexity** added to `select` in
+  `[tool.ruff.lint]`, with `max-complexity = 25` configured under
+  `[tool.ruff.lint.mccabe]`. The bar is intentionally a *soft ceiling*
+  rather than the conventional 10: VTSearch's data-pipeline functions
+  (folder loaders, demo-source loaders, multi-find) legitimately weave
+  many branches, and forcing them down to 10 would mean a multi-day
+  refactor sprint without changing behaviour. 25 catches genuinely
+  runaway complexity — the rule fires on anything new that creeps into
+  the 25+ range — while letting the existing pipeline code stay as-is.
+  The ten functions currently above 25 are grandfathered with a
+  per-function `# noqa: C901` so the rule passes on a clean tree:
+  * `run_converters_on_folder` (28) — `vtsearch/converters/runner.py`
+  * `_run_origin_load_in_background` (31) and nested `task` (27) —
+    `vtsearch/datasets/load_pipeline.py`
+  * `load_dataset_from_folder` (34) and
+    `load_dataset_from_folder_chunked` (35) —
+    `vtsearch/datasets/loader_folder.py`
+  * `load_dataset_from_pickle` (26) —
+    `vtsearch/datasets/loader_pickle.py`
+  * `load_demo_source` (52) — `vtsearch/media/image/_demo_sources.py`
+  * `load_demo_source` (31) — `vtsearch/media/text/media_type.py`
+  * `multi_find` (41) — `vtsearch/routes/detectors/find.py`
+  * `learned_sort` (29) — `vtsearch/routes/sorting.py`
 
-### deptry — unused / missing / transitive deps
+  The intent is to ratchet `max-complexity` down over time as those
+  functions get split. Future contributors should prefer fixing the
+  underlying function over adding another `# noqa: C901` — adding a
+  noqa is allowed but counts as a known regression of the ratchet.
 
-Catches three kinds of dependency bugs:
+## What shipped (patch-coverage gate via diff-cover)
 
-- A package is imported but not listed in `requirements/base.txt` (works
-  on your laptop because something else dragged it in, breaks in a
-  fresh container).
-- A package is listed but never imported (dead weight in installs).
-- A package is imported but only available transitively (will break the
-  day the direct dep drops it).
-
-Important for VTSearch because plugin auto-discovery means
-`requirements/plugins.txt` can drift from the actual `import` graph
-quickly.
-
-**Wire-up:**
-- Add `deptry` to `requirements/base.txt` dev tools.
-- `[tool.deptry]` block in `pyproject.toml`:
-  - `extend_exclude = ["frontend", "scripts", "data"]`
-  - Map heavy-but-aliased packages (e.g. `torch` is `pytorch`?
-    `scikit-learn` is `sklearn`) via
-    `[tool.deptry.package_module_name_map]`.
-  - Mark `pytest`, `pytest-xdist`, `pre-commit`, `ruff`, `pip-audit` as
-    dev-only via `[tool.deptry.per_rule_ignores]` (DEP002) — they're
-    intentionally not imported.
-- Add to `.pre-commit-config.yaml` (local hook, since deptry needs the
-  project venv to resolve imports):
-  ```yaml
-  - repo: local
-    hooks:
-      - id: deptry
-        name: deptry
-        entry: deptry .
-        language: system
-        pass_filenames: false
-        files: ^(vtsearch/|pyproject\.toml|requirements/)
-  ```
-- Add a `deptry` job to `lint.yml` so PRs are gated.
-
-**Success criterion:** `deptry .` returns 0 against the current tree;
-introducing an unused import or a missing dep fails CI.
-
-### codespell — misspellings in code and docs
-
-Catches typos in identifiers, comments, docstrings, and Markdown. Very
-low signal-to-noise once configured. The cost is one config block to
-exclude domain-specific terms that aren't in the dictionary.
-
-**Wire-up:**
-- Add codespell hook to `.pre-commit-config.yaml`:
-  ```yaml
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
-    hooks:
-      - id: codespell
-        additional_dependencies: [tomli]
-  ```
-- `[tool.codespell]` block in `pyproject.toml` with:
-  - `skip = "*.lock,*.svg,*.json,frontend/node_modules,data,static,*.pkl"`
-  - `ignore-words-list = "..."` for ML terms it doesn't know
-    (`clap`, `siglip`, `xclip`, `wrest`, `caller`, etc. — populate as
-    false-positives surface).
-- Add codespell to `lint.yml` for the CI gate.
-
-**Success criterion:** `codespell` passes against the current tree;
-introducing a typo in a comment or docstring fails CI.
-
-## Phase 3 — Medium-friction additions
-
-These each need a real config pass — not because the tool is hard but
-because the first run will surface a backlog of findings that someone
-has to triage. Plan for an afternoon per tool, not five minutes.
-
-### coverage.py / pytest-cov — line + branch coverage
-
-Tells us which lines and branches the test suite exercises. Useful for
-two things: spotting modules without test coverage, and (eventually)
-gating PRs on "don't lower coverage by more than N%".
-
-**Open questions to settle before wiring:**
-- Coverage target — pick a starting number from the first measured run,
-  don't pluck one out of the air. (Realistic: VTSearch probably lands
-  in the 60–80% range given the size of the test suite.)
-- Whether to gate PRs on coverage delta (e.g. via `diff-cover`) or just
-  publish a report to the GitHub step summary. Start with publish-only
-  for the first cycle.
-
-**Wire-up:**
-- Add `pytest-cov` to `requirements/base.txt`.
-- `pyproject.toml`:
-  ```toml
-  [tool.coverage.run]
-  source = ["vtsearch"]
-  branch = true
-  omit = ["vtsearch/_version.txt"]
-
-  [tool.coverage.report]
-  exclude_lines = [
-      "pragma: no cover",
-      "if TYPE_CHECKING:",
-      "raise NotImplementedError",
-  ]
-  ```
-- `./run-tests.sh` invokes `pytest --cov=vtsearch --cov-report=term-missing`.
-- `lint.yml` (or a dedicated `coverage.yml`) uploads HTML report as an
-  artifact + writes summary to `$GITHUB_STEP_SUMMARY`.
-
-**Success criterion:** `./run-tests.sh` prints a coverage summary at
-the end; CI artifact shows the per-file breakdown.
-
-### bandit (or ruff's `S` ruleset) — security linter
-
-Catches `pickle.load` on untrusted input, `subprocess` with `shell=True`,
-weak crypto, hard-coded passwords, SQL injection patterns, etc. VTSearch
-already does some of this manually (`safe_pickle_load`,
-`validate_server_filepath`); a linter is a backstop.
-
-**Important call:** ruff has the `S` (flake8-bandit) ruleset built in.
-Enabling that is strictly simpler than adding bandit as a second tool —
-no new dep, no new CI job, and config lives in the existing ruff block.
-The catch is ruff's S rules are a subset of full bandit. For VTSearch's
-threat model (single-user, on-prem, no untrusted callers in the
-critical path), the ruff subset is enough.
-
-**Wire-up:**
-- Add to `[tool.ruff.lint]` in `pyproject.toml`:
-  ```toml
-  select = ["E", "F", "S"]   # default rules + flake8-bandit
-  ```
-- `[tool.ruff.lint.per-file-ignores]`:
-  - `"tests/**" = ["S101"]` (allow `assert` in tests)
-  - `"vtsearch/security/pickle.py" = ["S301"]` (the whole point of the
-    file is to call `pickle.load` carefully)
-  - Other case-by-case waivers as findings surface.
-- First-pass triage commit fixes the easy ones and adds targeted
-  `# noqa: S###` for the legitimate exceptions.
-
-**Success criterion:** `ruff check .` with `S` rules enabled returns 0
-against the current tree; introducing a new `subprocess(..., shell=True)`
-or `pickle.load` of untrusted bytes fails lint.
-
-### vulture — dead code finder
-
-Finds functions, classes, imports, and variables that are defined but
-never referenced. Best run as a periodic audit (it has false positives
-from dynamic dispatch and plugin discovery) rather than a CI gate.
-
-**Why not in Phase 2:** VTSearch's plugin-discovery pattern (sentinel
-constants like `IMPORTER`, `EXPORTER`, `SETTINGS_SOURCE`,
-`LABEL_IMPORTER`, etc.) means every plugin class looks unused to
-vulture. The whitelist will need real curation, and the value is a
-one-shot cleanup rather than ongoing enforcement.
-
-**Wire-up (when we get to it):**
-- Add `vulture` to dev deps.
-- Create `.vulture-whitelist.py` exporting all plugin classes + any
-  reflection-only symbols.
-- Run as a manual command: `vulture vtsearch .vulture-whitelist.py
-  --min-confidence 80`.
-- Don't gate CI on it — just run it before each release and act on the
-  high-confidence findings.
-
-**Success criterion:** the audit produces a short, hand-reviewable
-list of dead code; the obvious findings are deleted, the rest are
-added to the whitelist with a comment explaining why.
+- **`diff-cover` gate** in `.github/workflows/coverage.yml` — installs
+  `diff-cover` on PR runs, fetches `origin/${{ github.base_ref }}` to a
+  depth that lets diff-cover see the merge base, and runs
+  `diff-cover coverage.xml --compare-branch=origin/<base>
+  --fail-under=80`. The job uploads a markdown report into
+  `$GITHUB_STEP_SUMMARY` so reviewers see exactly which patch lines are
+  uncovered. **Patch-level only — not total-coverage gating.** Total
+  coverage moves up and down with unrelated test reshuffles and would
+  produce noisy red on PRs that didn't touch tested code; the patch
+  number measures "did this PR cover the lines it added?", which is the
+  signal we actually care about. The 80% threshold is a starting point
+  and is easy to revisit once we have a few PRs of real data — change
+  `--fail-under=80` in `coverage.yml` to retune. The gate runs only on
+  `pull_request` events; push runs to `main`/`dev` still publish the
+  total-coverage summary but don't compute a patch number (there's no
+  meaningful "base" to diff against).
 
 ## What we considered and skipped
 
@@ -342,8 +222,8 @@ added to the whitelist with a comment explaining why.
   needs a docstring" norm. Adding it would create a large backlog with
   little payoff.
 - **radon / xenon** (cyclomatic complexity) — ruff already has McCabe
-  via the `C901` rule. Enable that in the same pass as Phase 3's
-  bandit/S work if we want complexity gating.
+  via the `C901` rule, which is now enabled (see "What shipped (C901
+  complexity gate)"). No second tool needed.
 - **semgrep** — powerful pattern-based static analysis but heavy for a
   single-app repo. Revisit if we ever start shipping VTSearch as a
   library or hosting multi-tenant.
@@ -352,19 +232,23 @@ added to the whitelist with a comment explaining why.
 
 ## Open follow-ups
 
-- **Coverage-delta gate.** `coverage.yml` now publishes the baseline on
-  every PR. Next step (after a few PRs of data): wire `diff-cover`
-  against the merge base and fail the job when the patch's coverage
-  drops below a threshold. Don't gate on total coverage delta — too
-  noisy across unrelated test reshuffles — gate on **lines changed by
-  this PR**, which is what `diff-cover` measures.
-- **Vulture audit pass.** Completed — see "What shipped (Phase 3)"
-  above for the deletions, whitelist additions, and final tuned
-  invocation. The audit is meant to be re-run before each release;
-  introducing new dead code will surface there.
-- **Pyright `S`-equivalent and `C901` complexity.** ruff has McCabe
-  complexity via `C901`; consider enabling alongside future
-  security-rule tightening if we want a complexity gate.
-- Periodic: `pre-commit autoupdate` on a cadence so pinned hook
-  versions don't drift too far from CI's `pip install ruff` (which
-  always pulls latest). Worth a quarterly reminder.
+- **Re-run the vulture audit before each release.** The tuned
+  invocation lives in `.vulture-whitelist.py`'s module docstring; the
+  audit is not a CI gate, so introducing new dead code only surfaces
+  when someone runs it. A release-checklist reminder is the lightest-
+  weight way to keep it from rotting.
+- **Ratchet `max-complexity` downward over time.** Current value is
+  25, with 10 grandfathered `# noqa: C901` sites listed under "What
+  shipped (C901 complexity gate)". As those functions get split (or
+  when somebody is in the area for unrelated reasons), drop the
+  threshold a notch and remove the corresponding noqa. The end state
+  is something close to ruff's 10 default — but there is no rush.
+- **Revisit the diff-cover threshold.** Currently `--fail-under=80` in
+  `coverage.yml` — a guess. After a handful of PRs, look at what
+  patch-coverage numbers feel like noise vs. signal and retune. If
+  legitimate refactor-only PRs keep tripping the gate (because
+  refactored lines have to be re-touched and so look "new" but
+  weren't tested explicitly), consider relaxing it.
+- **Periodic `pre-commit autoupdate`.** Pinned hook versions drift over
+  time vs. CI's `pip install ruff` (which always pulls latest). Worth a
+  quarterly reminder to bump `.pre-commit-config.yaml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,11 @@ line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
-# Default rules (E4, E7, E9, F) + flake8-bandit (S) security checks.
-# Stays conservative on style rules (E501 line-length etc. remain off)
-# while adding the security backstop.
-select = ["E4", "E7", "E9", "F", "S"]
+# Default rules (E4, E7, E9, F) + flake8-bandit (S) security checks +
+# McCabe complexity (C901).  Stays conservative on style rules (E501
+# line-length etc. remain off) while adding the security and complexity
+# backstops.
+select = ["E4", "E7", "E9", "F", "S", "C901"]
 # E402: Module level import not at top of file.
 # S101 (assert): used for type narrowing where pyright needs help; the
 #   project never runs under `python -O`.
@@ -101,6 +102,15 @@ ignore = ["E402", "S101", "S104", "S105", "S110", "S112", "S311", "S324"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.ruff.lint.mccabe]
+# Soft ceiling — catches genuinely runaway complexity without forcing a
+# refactor sprint on the data-pipeline functions that legitimately weave
+# many branches (folder loaders, demo-source loaders, multi-find).  The
+# ten functions currently above this bar are grandfathered with a
+# per-function ``# noqa: C901``.  Ratchet down over time as those
+# functions get split.
+max-complexity = 25
 
 [tool.deptry]
 # scripts/ and tests/ pull in dev-only deps; data/ and frontend/ aren't Python.

--- a/vtsearch/converters/runner.py
+++ b/vtsearch/converters/runner.py
@@ -75,7 +75,7 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
-def run_converters_on_folder(
+def run_converters_on_folder(  # noqa: C901
     folder_path: Path,
     converter_names: list[str] | None = None,
     target_media_type: str = "",

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -629,7 +629,7 @@ def _auto_register_dataset(
 # ---------------------------------------------------------------------------
 
 
-def _run_origin_load_in_background(
+def _run_origin_load_in_background(  # noqa: C901
     load_fn,
     origin: dict,
     *,
@@ -687,7 +687,7 @@ def _run_origin_load_in_background(
     # state (settings writes, settings_source sync) resolves correctly.
     _request_user = created_by or get_current_user()
 
-    def task():
+    def task():  # noqa: C901
         from vtsearch.auth import set_thread_user
 
         set_thread_user(_request_user)

--- a/vtsearch/datasets/loader_folder.py
+++ b/vtsearch/datasets/loader_folder.py
@@ -199,7 +199,7 @@ def _attach_patch_regions(media_data: dict[str, Any], patch_out: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def load_dataset_from_folder(
+def load_dataset_from_folder(  # noqa: C901
     folder_path: Path,
     media_type: str,
     medias: dict[int, dict[str, Any]],
@@ -541,7 +541,7 @@ def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
     return count
 
 
-def load_dataset_from_folder_chunked(
+def load_dataset_from_folder_chunked(  # noqa: C901
     folder_path: Path,
     media_type: str,
     chunk_size: int,

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -21,7 +21,7 @@ from vtsearch.datasets.loader import (
 from vtsearch.security.pickle import safe_pickle_load
 
 
-def load_dataset_from_pickle(
+def load_dataset_from_pickle(  # noqa: C901
     file_path: Path,
     medias: dict[int, dict[str, Any]],
     thin: bool = False,

--- a/vtsearch/media/image/_demo_sources.py
+++ b/vtsearch/media/image/_demo_sources.py
@@ -337,7 +337,7 @@ def build_demo_datasets() -> list[DemoDataset]:
     ]
 
 
-def load_demo_source(
+def load_demo_source(  # noqa: C901
     source,
     categories,
     slice_start,

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -455,7 +455,7 @@ class TextMediaType(MediaType):
     # Demo dataset loading
     # ------------------------------------------------------------------
 
-    def load_demo_source(
+    def load_demo_source(  # noqa: C901
         self,
         source,
         categories,

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -139,7 +139,7 @@ def find_check_labels(body: dict):
 )
 @detector_find_bp.alt_response(404, description="A selected dataset or detector ID is unknown / missing.")
 @detector_find_bp.alt_response(500, description="A dataset pkl file could not be loaded.")
-def multi_find(body: dict):
+def multi_find(body: dict):  # noqa: C901
     """Run selected detectors on selected datasets and return merged results.
 
     For each dataset: loads it from its saved pkl, then for each detector runs

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -233,7 +233,7 @@ def _learned_sort_done_payload(job) -> dict:
 @sorting_bp.response(200, LearnedSortResponseSchema)
 @sorting_bp.alt_response(400, description="No good/bad votes available for training.")
 @sorting_bp.alt_response(500, description="Background learned-sort job failed (only when ``wait=true``).")
-def learned_sort(body: dict):
+def learned_sort(body: dict):  # noqa: C901
     """Kick off (or short-circuit) a learned-sort training job.
 
     Training is GIL-bound and ran inline used to stall every other request


### PR DESCRIPTION
## Summary

Closes the remaining work items in `docs/plans/python-quality-tools.md`.

- **Ruff `C901` complexity gate.** Adds `C901` to `[tool.ruff.lint].select` with `max-complexity = 25` under `[tool.ruff.lint.mccabe]`. The 10 functions currently above that bar are grandfathered with per-function `# noqa: C901` so the rule passes on a clean tree; intent is to ratchet the threshold down over time rather than burn a refactor sprint right now. Files touched: `vtsearch/converters/runner.py`, `vtsearch/datasets/load_pipeline.py`, `vtsearch/datasets/loader_folder.py`, `vtsearch/datasets/loader_pickle.py`, `vtsearch/media/image/_demo_sources.py`, `vtsearch/media/text/media_type.py`, `vtsearch/routes/detectors/find.py`, `vtsearch/routes/sorting.py`.
- **`diff-cover` patch-coverage gate.** Adds a PR-only step to `.github/workflows/coverage.yml` that runs `diff-cover coverage.xml --compare-branch=origin/<base> --fail-under=80` and uploads the markdown report into `$GITHUB_STEP_SUMMARY`. Patch-level only; total-coverage is still publish-only because it moves noisily with unrelated test reshuffles. The 80% threshold is a starting point — easy to retune in `coverage.yml`.
- **Plan-doc cleanup.** Drops the now-redundant Phase 2 / Phase 3 detail sections (everything they described shipped), adds "What shipped" entries for the two new gates, fixes the stale "enable C901 later" line under "considered and skipped", and rewrites Open follow-ups to reflect the new reality (vulture audit cadence, complexity ratchet, diff-cover threshold retune, `pre-commit autoupdate`).

## Test plan

- [x] `ruff check .` passes (was 79 C901 violations at default 10; now 0 at max-complexity=25 with 10 noqas).
- [x] `ruff format --check .` passes.
- [x] `codespell --toml pyproject.toml` passes.
- [x] `coverage.yml` is valid YAML.
- [ ] The `diff-cover` step gets a real workout on this PR itself — it's the first PR run with the gate active, so the markdown report in the workflow's step summary is the canonical confirmation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm28uXM9nuQiqMXVe9k13x)_