### PR TITLE
Migrate DetectorsApiService and DatasetsApiService to generated TS client

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -819,21 +819,137 @@ checks off this follow-up.
       ``StatusIndicator``, ``LabelingStatusResponse``,
       ``SortProgressResponse``, and the three chart-point types stay
       because they still have non-service consumers.
+- [x] ``DetectorsApiService`` and ``DatasetsApiService`` rewired to the
+      generated TS client in a single PR.
+
+      ``DetectorsApiService`` now calls the generated functions under
+      ``generated/api-client/fn/detectors-crud/``,
+      ``generated/api-client/fn/detectors-registry/``,
+      ``generated/api-client/fn/detectors-labels/``,
+      ``generated/api-client/fn/detector-scoring/``,
+      ``generated/api-client/fn/detector-find/``,
+      ``generated/api-client/fn/processors-crud/``, and
+      ``generated/api-client/fn/processors-scoring/``. Return types
+      tightened to the generated DTOs throughout
+      (``DetectorsListResponse``, ``DetectorCreateResponse``,
+      ``DetectorDetail``, ``DetectorDeleteResponse``,
+      ``DetectorRenameResponse``, ``DetectorExamplesResponse``,
+      ``DetectorSaveLabelsResponse``, ``DetectorLabelsDetailResponse``,
+      ``DetectorLabelVoteResponse``, ``DetectorCombineResponse``,
+      ``DetectorRegistryListResponse``,
+      ``DetectorRegistryCreateResponse``,
+      ``DetectorRegistryDeleteResponse``,
+      ``DetectorRegistryRenameResponse``,
+      ``DetectorRegistryLoadResponse``,
+      ``DetectorRegistryUnloadResponse``,
+      ``DetectorRegistryAutorunResponse``, ``DetectorCancelResponse``,
+      ``AutorunExtractorsListResponse``,
+      ``AutorunLocalizersListResponse``,
+      ``AutorunProcessorCreateResponse``,
+      ``AutorunProcessorDeleteResponse``,
+      ``AutorunProcessorRenameResponse``, ``AutoDetectResponse``,
+      ``AutoExtractResponse``, ``AutoLocalizeResponse``,
+      ``ExtractResponse``, ``LocalizeResponse``, ``FindResponse``,
+      ``FindLabelResponse``, ``FindCheckLabelsResponse``,
+      ``PregenProcessorsListResponse``, ``PregenProcessorsAddResponse``).
+      Request types tightened to ``DetectorCreateRequest``,
+      ``DetectorCombineRequest``, ``DetectorRegistryCreateRequest``,
+      ``DetectorExamplesRequest``, ``AutorunExtractorCreateRequest``,
+      ``AutorunLocalizerCreateRequest``, ``ExtractRequest``,
+      ``LocalizeRequest``, ``AutoDetectRequest``,
+      ``FindRequest``, ``FindLabelRequest``,
+      ``FindCheckLabelsRequest``. The ``FindLabelWarning`` interface
+      exported from the service is re-aliased to the generated
+      ``FindCheckLabelsWarning`` so existing callers keep working.
+
+      ``DatasetsApiService`` now calls the generated functions under
+      ``generated/api-client/fn/datasets-listings/``,
+      ``generated/api-client/fn/datasets-load/``,
+      ``generated/api-client/fn/datasets-registry/``,
+      ``generated/api-client/fn/datasets-staging/``,
+      ``generated/api-client/fn/datasets-status/``, and
+      ``generated/api-client/fn/datasets-ui/``. Return types tightened
+      to the generated DTOs (``DatasetStatusResponse``,
+      ``DemoDatasetListResponse``, ``DemoCategoriesResponse``,
+      ``BrowseMediaFilesResponse``, ``BrowseMediaFilesSelectResponse``,
+      ``DetectMediaTypeResponse``, ``DatasetAvailableFilesResponse``,
+      ``DatasetLoadStartedResponse``, ``DatasetStageFileResponse``,
+      ``DatasetStagingStartedResponse``, ``ClearStagingResponse``,
+      ``CancelDatasetLoadResponse``, ``DatasetClearResponse``,
+      ``DatasetsRegistryListResponse``, ``DatasetRegistryLoadResponse``,
+      ``DatasetRegistryOkResponse``, ``DatasetRegistryRenameResponse``,
+      ``DatasetRegistryReadersResponse``, ``DatasetRegistryStatsResponse``,
+      ``DashboardDiskUsageResponse``, ``ImporterFieldOptionsResponse``).
+      Request types tightened to ``DatasetCombineRequest``,
+      ``DatasetLoadDemoRequest``, ``DatasetLoadSourceRequest``.
+
+      The plugin ``to_dict()`` payloads (importers, clippers, embedders,
+      converters, media types) are generated as
+      ``Array<{[key: string]: any}>`` — the service casts each list at
+      the boundary to the richer ``ImporterInfo`` / ``ClipperInfo`` /
+      ``EmbedderInfo`` / ``ConverterInfo`` / ``MediaTypeInfo``
+      interfaces in ``api.models.ts``, same pattern as
+      ``ExportersApiService`` and ``LabelImportersApiService``. The
+      generated ``DatasetsRegistryListResponse.datasets`` is similarly
+      loose; the service-level cast keeps consumers reading the rich
+      local ``DatasetRegistryEntry`` shape unchanged.
+
+      Multipart routes (``importLocalFolder``, ``loadFile``,
+      ``stageFile``) and the binary-stream ``exportDataset`` stay on
+      plain ``HttpClient`` — same pattern as
+      ``MediasApiService.addToPile`` /
+      ``SortingApiService.exampleSort``. The two plugin-field routes
+      (``runImporter`` → ``POST /api/dataset/import/<importer_name>``,
+      ``stageImport`` → ``POST /api/dataset/stage-import/<importer_name>``)
+      stay on plain ``HttpClient`` because their body shapes are
+      plugin-dependent and not described in the OpenAPI spec — see
+      *Open follow-ups / Per-plugin schemas for plugin-field routes*.
+
+      Consumers updated:
+
+      * ``CombineDetectorsModalComponent`` swapped
+        ``CombineDetectorsResult`` for the generated
+        ``DetectorCombineResponse``.
+      * ``DatasetStatsModalComponent`` swapped ``DatasetStatsResponse``
+        for the generated ``DatasetRegistryStatsResponse``.
+      * ``LabelsetStateService``, ``LabelsetListComponent``, and
+        ``RightPanelComponent`` swapped ``LabelElement`` /
+        ``LabelsDetailResponse`` for the generated ``DetectorLabelView``
+        / ``DetectorLabelsDetailResponse``.
+      * ``DatasetStateService`` casts the loose generated
+        ``DatasetsRegistryListResponse.datasets`` array to the local
+        ``DatasetRegistryEntry[]`` shape at assignment.
+
+      Deleted from ``frontend/src/app/models/api.models.ts``:
+      ``DatasetStatus``, ``DatasetStatsResponse``, ``DatasetRegistryResponse``,
+      ``ImportersResponse``, ``DemoListResponse``, ``MediaTypesResponse``,
+      ``LoadingTasksResponse``, ``LabelElement``, ``LabelsDetailResponse``,
+      ``Detector``, ``DetectorsResponse``, ``DetectorsRegistryResponse``,
+      ``CombineDetectorsResult``, ``AutoDetectResponse``,
+      ``ClippersResponse``, ``ConvertersResponse``, ``EmbeddersResponse``,
+      ``ApiError``, ``OkResponse``, ``ExportResult``, and a duplicate
+      loose ``ConverterInfo`` definition (the richer named-fields
+      version stays). ``DatasetRegistryEntry`` / ``DetectorRegistryEntry``
+      stay because the generated equivalents are loose
+      ``{[key: string]: any}`` and the local versions describe the
+      actual fields consumers read.
 
 ## Open follow-ups
 
 - **Migrate the remaining Angular services to the generated client.**
   Settings, auth, achievements, file-browser, exporters, settings-io,
-  label-importers, medias, and sorting have all moved over. Each
-  follow-up PR picks one blueprint area (detectors, datasets,
-  processors, …), rewires the matching Angular service(s) to call the
-  generated function modules under
-  ``frontend/src/app/generated/api-client/fn/``, and deletes the
-  corresponding hand-maintained interfaces from
-  ``frontend/src/app/models/api.models.ts``. The hybrid imports
-  (``import type`` for DTOs, direct function-module paths for
-  runtime symbols, no barrel) are required to keep the initial bundle
-  under the 525 kB budget — see *Bundle-size discipline* above.
+  label-importers, medias, sorting, detectors, and datasets have all
+  moved over. The remaining service is ``ProcessorImportersApiService``
+  (~17 LOC) which still references ``/api/processor-importers`` — a
+  legacy route with no live backend handler; the consuming
+  ``processor-importer-modal`` is wired up but the endpoint isn't in
+  the OpenAPI spec, so this service is left untouched until the
+  backend route is rebuilt under ``vtsearch/routes/processors/``
+  (probably as a flask-smorest blueprint with a per-plugin field
+  schema). The hybrid imports (``import type`` for DTOs, direct
+  function-module paths for runtime symbols, no barrel) are required
+  to keep the initial bundle under the 525 kB budget — see
+  *Bundle-size discipline* above.
 - **Tighten ``LabelingStatusResponse`` consumers to the generated
   shape.** ``SortingApiService.getLabelingStatus`` returns the generated
   ``LabelingStatusResponse`` (``smart``/``stable``/``span`` typed as

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -3,7 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
-import { CombineDetectorsResult, DetectorRegistryEntry } from '../../../models/api.models';
+import type { DetectorCombineResponse } from '../../../generated/api-client/models/detector-combine-response';
+import { DetectorRegistryEntry } from '../../../models/api.models';
 
 interface SourceRow {
   name: string;
@@ -83,7 +84,7 @@ export class CombineDetectorsModalComponent implements OnInit {
     this.error = '';
 
     this.detectorsApi.combine(names, trimmed, this.conflictPolicy).subscribe({
-      next: (resp: CombineDetectorsResult) => {
+      next: (resp: DetectorCombineResponse) => {
         this.submitting = false;
         this.created.emit(resp?.name || trimmed);
       },

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
-import { DatasetStatsResponse } from '../../../models/api.models';
+import type { DatasetRegistryStatsResponse } from '../../../generated/api-client/models/dataset-registry-stats-response';
 import { formatTimestamp as formatTs } from '../../../utils/format-date';
 
 @Component({
@@ -19,7 +19,7 @@ export class DatasetStatsModalComponent implements OnInit {
 
   loading = true;
   error = '';
-  stats: DatasetStatsResponse | null = null;
+  stats: DatasetRegistryStatsResponse | null = null;
 
   constructor(private datasetsApi: DatasetsApiService) {}
 

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -10,11 +10,11 @@ import {
   ViewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LabelElement } from '../../../models/api.models';
+import type { DetectorLabelView } from '../../../generated/api-client/models/detector-label-view';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 
-interface SortedElement extends LabelElement {
+interface SortedElement extends DetectorLabelView {
   confidence: number;
 }
 
@@ -27,13 +27,13 @@ interface SortedElement extends LabelElement {
 })
 export class LabelsetListComponent implements OnChanges, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
-  @Input() elements: LabelElement[] = [];
+  @Input() elements: DetectorLabelView[] = [];
   @Input() modelName: string = '';
   @Input() sortMode: LabelSortMode = 'time-desc';
   @Input() viewMode: 'grid' | 'list' = 'grid';
   @Input() gridGoalWidth: number = 80;
   @Input() focusMode: 'click' | 'hover' = 'click';
-  @Output() elementSelected = new EventEmitter<LabelElement>();
+  @Output() elementSelected = new EventEmitter<DetectorLabelView>();
   @Output() elementVote = new EventEmitter<{ id: string; vote: 'good' | 'bad' }>();
 
   @ViewChild('voteListContainer') voteListContainer?: ElementRef<HTMLDivElement>;
@@ -104,7 +104,7 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
     return this.viewMode === 'grid';
   }
 
-  hasThumbnailUrl(entry: LabelElement): boolean {
+  hasThumbnailUrl(entry: DetectorLabelView): boolean {
     const url = this.thumbnailUrl(entry);
     if (url && this.thumbnailFailedUrls.has(url)) return false;
     return (
@@ -115,7 +115,7 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
     );
   }
 
-  thumbnailUrl(entry: LabelElement): string {
+  thumbnailUrl(entry: DetectorLabelView): string {
     if (!this.modelName) return '';
     return this.detectorsApi.labelThumbnailUrl(this.modelName, entry.id);
   }
@@ -124,18 +124,18 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
     if (url) this.thumbnailFailedUrls.add(url);
   }
 
-  placeholderIcon(entry: LabelElement): string | null {
+  placeholderIcon(entry: DetectorLabelView): string | null {
     if (this.hasThumbnailUrl(entry)) return null;
     if (entry.media_type === 'audio') return '♫';
     if (entry.media_type === 'text') return '¶';
     return '□';
   }
 
-  isMissing(entry: LabelElement): boolean {
+  isMissing(entry: DetectorLabelView): boolean {
     return entry.cid === null || entry.cid === undefined;
   }
 
-  onEntryClick(entry: LabelElement): void {
+  onEntryClick(entry: DetectorLabelView): void {
     if (this.focusMode === 'hover') {
       this.elementVote.emit({ id: entry.id, vote: 'bad' });
     } else {
@@ -143,20 +143,20 @@ export class LabelsetListComponent implements OnChanges, AfterViewChecked {
     }
   }
 
-  onEntryContextMenu(event: MouseEvent, entry: LabelElement): void {
+  onEntryContextMenu(event: MouseEvent, entry: DetectorLabelView): void {
     if (this.focusMode === 'hover') {
       event.preventDefault();
       this.elementVote.emit({ id: entry.id, vote: 'good' });
     }
   }
 
-  onEntryMouseEnter(entry: LabelElement): void {
+  onEntryMouseEnter(entry: DetectorLabelView): void {
     if (this.focusMode === 'hover') {
       this.elementSelected.emit(entry);
     }
   }
 
-  onEntryKeydown(event: KeyboardEvent, entry: LabelElement): void {
+  onEntryKeydown(event: KeyboardEvent, entry: DetectorLabelView): void {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       this.elementSelected.emit(entry);

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -3,7 +3,8 @@ import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DetectorsApiService } from '../../services/detectors-api.service';
-import { LabelElement, MediaItem } from '../../models/api.models';
+import type { DetectorLabelView } from '../../generated/api-client/models/detector-label-view';
+import { MediaItem } from '../../models/api.models';
 import { VoteStateService } from '../../services/vote-state.service';
 import { LabelsetStateService } from '../../services/labelset-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
@@ -59,8 +60,8 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   badIds: number[] = [];
   clickTimes: Record<string, number> = {};
   learnedScores: Record<string, number> = {};
-  goodElements: LabelElement[] = [];
-  badElements: LabelElement[] = [];
+  goodElements: DetectorLabelView[] = [];
+  badElements: DetectorLabelView[] = [];
   sortMode: LabelSortMode = 'time-desc';
   viewMode: 'grid' | 'list' = 'grid';
   gridGoalWidth: number = 80;
@@ -139,7 +140,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
    *  on the left when the element resolves into the active dataset;
    *  otherwise the element exists only in the labelset (e.g. trained on a
    *  different dataset) and there's nothing to focus. */
-  onLabelsetElementSelected(elem: LabelElement): void {
+  onLabelsetElementSelected(elem: DetectorLabelView): void {
     if (elem.cid !== null && elem.cid !== undefined) {
       this.mediaSelected.emit(elem.cid);
     }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -61,14 +61,6 @@ export interface SortProgressResponse {
 
 // --- Datasets ---
 
-export interface DatasetStatus {
-  loaded: boolean;
-  num_medias: number;
-  has_votes: boolean;
-  media_type?: string;
-  display_name?: string;
-}
-
 export interface DatasetProgress {
   status?: string;
   message?: string;
@@ -95,10 +87,6 @@ export interface LoadingTask {
   detector_id?: string;
   media_type?: string;
   embedder?: string;
-}
-
-export interface LoadingTasksResponse {
-  tasks: LoadingTask[];
 }
 
 export interface ImporterInfo {
@@ -176,14 +164,6 @@ export interface ImporterPickerTab {
   order?: number;
 }
 
-export interface ImportersResponse {
-  importers: ImporterInfo[];
-  /** Picker tab declarations.  When present, the frontend renders one tab
-   *  per entry; when absent (older backends) the frontend falls back to
-   *  inferring tabs from importer ``category`` values. */
-  tabs?: ImporterPickerTab[];
-}
-
 export interface DemoDataset {
   name: string;
   label: string;
@@ -196,10 +176,6 @@ export interface DemoDataset {
   num_categories: number;
   pkl_embedder?: string;
   pkl_clipper?: string;
-}
-
-export interface DemoListResponse {
-  datasets: DemoDataset[];
 }
 
 export interface MediaTypeInfo {
@@ -223,10 +199,6 @@ export interface MediaTypeDetectionResponse {
   truncated?: boolean;
 }
 
-export interface MediaTypesResponse {
-  media_types: MediaTypeInfo[];
-}
-
 export interface DatasetRegistryEntry {
   id: string;
   name: string;
@@ -236,57 +208,7 @@ export interface DatasetRegistryEntry {
   [key: string]: unknown;
 }
 
-export interface DatasetStatsResponse {
-  num_items: number;
-  num_dupes: number;
-  file_type_counts: Record<string, number>;
-  ingest_started_at: number | null;
-  ingest_finished_at: number | null;
-  origin: string;
-  source: { importer?: string; params?: Record<string, string> } | Record<string, unknown>;
-  clipper: string;
-  embedder: string;
-}
-
-export interface DatasetRegistryResponse {
-  datasets: DatasetRegistryEntry[];
-}
-
-// --- Detector scoring ---
-
-export interface AutoDetectResponse {
-  [key: string]: unknown;
-}
-
 // --- Detectors ---
-
-export interface Detector {
-  name: string;
-  [key: string]: unknown;
-}
-
-export interface DetectorsResponse {
-  detectors: Detector[];
-}
-
-export interface LabelElement {
-  id: string;
-  label: 'good' | 'bad';
-  media_type: string;
-  name: string;
-  filename: string;
-  origin_name: string;
-  md5: string;
-  cid: number | null;
-  time: number;
-  score: number;
-}
-
-export interface LabelsDetailResponse {
-  good: LabelElement[];
-  bad: LabelElement[];
-  media_type: string;
-}
 
 export interface DetectorRegistryEntry {
   id: string;
@@ -300,20 +222,6 @@ export interface DetectorRegistryEntry {
   autorun?: boolean;
   last_trained_at?: number | null;
   [key: string]: unknown;
-}
-
-export interface DetectorsRegistryResponse {
-  detectors: DetectorRegistryEntry[];
-}
-
-export interface CombineDetectorsResult {
-  success: boolean;
-  name: string;
-  media_type: string;
-  num_labels: number;
-  combined_from: string[];
-  source_label_counts: number[];
-  examples: { type: string; value: string }[];
 }
 
 // --- Clippers ---
@@ -337,32 +245,6 @@ export interface ClipperInfo {
   parameters?: ClipperParameter[];
   creation_questions?: ClipperParameter[];
   [key: string]: unknown;
-}
-
-export interface ClippersResponse {
-  clippers: ClipperInfo[];
-}
-
-// --- Converters ---
-
-export interface ConverterInfo {
-  [key: string]: unknown;
-}
-
-export interface ConvertersResponse {
-  converters: ConverterInfo[];
-}
-
-// --- Error ---
-
-export interface ApiError {
-  error: string;
-}
-
-// --- OK response ---
-
-export interface OkResponse {
-  ok: boolean;
 }
 
 // --- Eval / Progress Charts ---
@@ -465,14 +347,3 @@ export interface EmbedderInfo {
   license_notice?: string | null;
 }
 
-export interface EmbeddersResponse {
-  embedders: EmbedderInfo[];
-}
-
-// --- Export Result ---
-
-export interface ExportResult {
-  success: boolean;
-  message?: string;
-  error?: string;
-}

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -61,7 +61,9 @@ export class DatasetStateService implements OnDestroy {
             if (!this.loadedSubject.value) this.loadedSubject.next(true);
             return;
           }
-          this.datasetsSubject.next(res.datasets.datasets || []);
+          this.datasetsSubject.next(
+            (res.datasets.datasets || []) as unknown as DatasetRegistryEntry[],
+          );
           this.detectorsSubject.next(res.detectors.detectors || []);
           if (this.errorSubject.value !== null) this.errorSubject.next(null);
           if (!this.loadedSubject.value) this.loadedSubject.next(true);

--- a/frontend/src/app/services/datasets-api.service.ts
+++ b/frontend/src/app/services/datasets-api.service.ts
@@ -1,82 +1,134 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import {
-  DatasetStatus,
-  DatasetStatsResponse,
-  ImportersResponse,
-  DemoListResponse,
-  MediaTypesResponse,
-  MediaTypeDetectionResponse,
-  DatasetRegistryResponse,
+
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { BrowseMediaFilesResponse } from '../generated/api-client/models/browse-media-files-response';
+import type { BrowseMediaFilesSelectResponse } from '../generated/api-client/models/browse-media-files-select-response';
+import type { CancelDatasetLoadResponse } from '../generated/api-client/models/cancel-dataset-load-response';
+import type { ClearStagingResponse } from '../generated/api-client/models/clear-staging-response';
+import type { DashboardDiskUsageResponse } from '../generated/api-client/models/dashboard-disk-usage-response';
+import type { DatasetAllImportersListResponse } from '../generated/api-client/models/dataset-all-importers-list-response';
+import type { DatasetAvailableFilesResponse } from '../generated/api-client/models/dataset-available-files-response';
+import type { DatasetClearResponse } from '../generated/api-client/models/dataset-clear-response';
+import type { DatasetCombineRequest } from '../generated/api-client/models/dataset-combine-request';
+import type { DatasetImportersListResponse } from '../generated/api-client/models/dataset-importers-list-response';
+import type { DatasetLoadDemoRequest } from '../generated/api-client/models/dataset-load-demo-request';
+import type { DatasetLoadFolderRequest } from '../generated/api-client/models/dataset-load-folder-request';
+import type { DatasetLoadSourceRequest } from '../generated/api-client/models/dataset-load-source-request';
+import type { DatasetLoadStartedResponse } from '../generated/api-client/models/dataset-load-started-response';
+import type { DatasetRegistryLoadResponse } from '../generated/api-client/models/dataset-registry-load-response';
+import type { DatasetRegistryOkResponse } from '../generated/api-client/models/dataset-registry-ok-response';
+import type { DatasetRegistryReadersResponse } from '../generated/api-client/models/dataset-registry-readers-response';
+import type { DatasetRegistryRenameResponse } from '../generated/api-client/models/dataset-registry-rename-response';
+import type { DatasetRegistryStatsResponse } from '../generated/api-client/models/dataset-registry-stats-response';
+import type { DatasetsRegistryListResponse } from '../generated/api-client/models/datasets-registry-list-response';
+import type { DatasetStageFileResponse } from '../generated/api-client/models/dataset-stage-file-response';
+import type { DatasetStagingStartedResponse } from '../generated/api-client/models/dataset-staging-started-response';
+import type { DatasetStatusResponse } from '../generated/api-client/models/dataset-status-response';
+import type { DemoCategoriesResponse } from '../generated/api-client/models/demo-categories-response';
+import type { DemoDatasetListResponse } from '../generated/api-client/models/demo-dataset-list-response';
+import type { DetectMediaTypeResponse } from '../generated/api-client/models/detect-media-type-response';
+import type { ImporterFieldOptionsResponse } from '../generated/api-client/models/importer-field-options-response';
+import type {
   ClipperInfo,
-  ClippersResponse,
   ConverterInfo,
-  ConvertersResponse,
   EmbedderInfo,
-  EmbeddersResponse,
-  OkResponse,
+  ImporterInfo,
+  ImporterPickerTab,
 } from '../models/api.models';
+import { apiBrowseMediaFilesGet } from '../generated/api-client/fn/datasets-ui/api-browse-media-files-get';
+import { apiBrowseMediaFilesSelectPost } from '../generated/api-client/fn/datasets-ui/api-browse-media-files-select-post';
+import { apiClippersGet } from '../generated/api-client/fn/datasets-listings/api-clippers-get';
+import { apiConvertersGet } from '../generated/api-client/fn/datasets-listings/api-converters-get';
+import { apiDashboardDiskUsageGet } from '../generated/api-client/fn/datasets-ui/api-dashboard-disk-usage-get';
+import { apiDatasetAllImportersGet } from '../generated/api-client/fn/datasets-listings/api-dataset-all-importers-get';
+import { apiDatasetAvailableFilesGet } from '../generated/api-client/fn/datasets-staging/api-dataset-available-files-get';
+import { apiDatasetCancelPost } from '../generated/api-client/fn/datasets-status/api-dataset-cancel-post';
+import { apiDatasetCancelTaskIdPost } from '../generated/api-client/fn/datasets-status/api-dataset-cancel-task-id-post';
+import { apiDatasetClearPost } from '../generated/api-client/fn/datasets-load/api-dataset-clear-post';
+import { apiDatasetCombinePost } from '../generated/api-client/fn/datasets-staging/api-dataset-combine-post';
+import { apiDatasetDemoCategoriesNameGet } from '../generated/api-client/fn/datasets-ui/api-dataset-demo-categories-name-get';
+import { apiDatasetDemoListGet } from '../generated/api-client/fn/datasets-ui/api-dataset-demo-list-get';
+import { apiDatasetDetectMediaTypeGet } from '../generated/api-client/fn/datasets-ui/api-dataset-detect-media-type-get';
+import { apiDatasetImportImporterNameOptionsPost } from '../generated/api-client/fn/datasets-staging/api-dataset-import-importer-name-options-post';
+import { apiDatasetImportersGet } from '../generated/api-client/fn/datasets-listings/api-dataset-importers-get';
+import { apiDatasetLoadDemoPost } from '../generated/api-client/fn/datasets-load/api-dataset-load-demo-post';
+import { apiDatasetLoadFolderPost } from '../generated/api-client/fn/datasets-load/api-dataset-load-folder-post';
+import { apiDatasetLoadSourcePost } from '../generated/api-client/fn/datasets-load/api-dataset-load-source-post';
+import { apiDatasetStageDemoNamePost } from '../generated/api-client/fn/datasets-staging/api-dataset-stage-demo-name-post';
+import { apiDatasetStagingDelete } from '../generated/api-client/fn/datasets-staging/api-dataset-staging-delete';
+import { apiDatasetStatusGet } from '../generated/api-client/fn/datasets-status/api-dataset-status-get';
+import { apiDatasetsRegistryDatasetIdDelete } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-delete';
+import { apiDatasetsRegistryDatasetIdLoadPost } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-load-post';
+import { apiDatasetsRegistryDatasetIdReadersPut } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-readers-put';
+import { apiDatasetsRegistryDatasetIdRenamePut } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-rename-put';
+import { apiDatasetsRegistryDatasetIdStatsGet } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-stats-get';
+import { apiDatasetsRegistryDatasetIdUnloadPost } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-dataset-id-unload-post';
+import { apiDatasetsRegistryGet } from '../generated/api-client/fn/datasets-registry/api-datasets-registry-get';
+import { apiEmbeddersGet } from '../generated/api-client/fn/datasets-listings/api-embedders-get';
+import { apiMediaTypesGet } from '../generated/api-client/fn/datasets-listings/api-media-types-get';
+
+/** The importer/clipper/embedder/converter listings return plugin
+ *  ``to_dict()`` payloads — the generated types describe them as
+ *  ``Array<{[key: string]: any}>`` because the inner shapes are
+ *  plugin-dependent.  The richer ``ImporterInfo`` / ``ClipperInfo`` /
+ *  ``EmbedderInfo`` / ``ConverterInfo`` interfaces in
+ *  ``frontend/src/app/models/api.models.ts`` describe the actual fields
+ *  consumers read off these payloads; this service casts at the boundary
+ *  so callers don't have to. */
+type ImportersResponse = { importers: ImporterInfo[]; tabs?: ImporterPickerTab[] };
 
 @Injectable({ providedIn: 'root' })
 export class DatasetsApiService {
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
 
-  getStatus(): Observable<DatasetStatus> {
-    return this.http.get<DatasetStatus>('/api/dataset/status');
+  getStatus(): Observable<DatasetStatusResponse> {
+    return apiDatasetStatusGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getImporters(): Observable<ImportersResponse> {
-    return this.http.get<ImportersResponse>('/api/dataset/importers');
-  }
-
-  getAllImporters(): Observable<ImportersResponse> {
-    return this.http.get<ImportersResponse>('/api/dataset/all-importers');
-  }
-
-  getDemoList(embedder?: string, clipper?: string): Observable<DemoListResponse> {
-    const params: Record<string, string> = {};
-    if (embedder) {
-      params['embedder'] = embedder;
-    }
-    if (clipper) {
-      params['clipper'] = clipper;
-    }
-    return this.http.get<DemoListResponse>('/api/dataset/demo-list', { params });
-  }
-
-  getDemoCategories(name: string): Observable<{ categories: string[] }> {
-    return this.http.get<{ categories: string[] }>(`/api/dataset/demo-categories/${encodeURIComponent(name)}`);
-  }
-
-  browseMediaFiles(
-    source: string,
-    path: string,
-  ): Observable<{
-    directories: { name: string; path: string; modified_at?: string }[];
-    files: { name: string; path: string; size_bytes: number; modified_at?: string }[];
-    root_path: string;
-  }> {
-    return this.http.get<{
-      directories: { name: string; path: string; modified_at?: string }[];
-      files: { name: string; path: string; size_bytes: number; modified_at?: string }[];
-      root_path: string;
-    }>('/api/browse-media-files', { params: { source, path } });
-  }
-
-  selectBrowsedFile(
-    source: string,
-    path: string,
-  ): Observable<{ filename: string; original_name: string }> {
-    return this.http.post<{ filename: string; original_name: string }>(
-      '/api/browse-media-files/select',
-      { source, path },
+    return apiDatasetImportersGet(this.http, this.config.rootUrl).pipe(
+      map((r) => r.body as unknown as ImportersResponse),
     );
   }
 
-  getMediaTypes(): Observable<MediaTypesResponse> {
-    return this.http.get<MediaTypesResponse>('/api/media-types');
+  getAllImporters(): Observable<ImportersResponse> {
+    return apiDatasetAllImportersGet(this.http, this.config.rootUrl).pipe(
+      map((r) => r.body as unknown as ImportersResponse),
+    );
+  }
+
+  getDemoList(embedder?: string, clipper?: string): Observable<DemoDatasetListResponse> {
+    return apiDatasetDemoListGet(this.http, this.config.rootUrl, { embedder, clipper }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  getDemoCategories(name: string): Observable<DemoCategoriesResponse> {
+    return apiDatasetDemoCategoriesNameGet(this.http, this.config.rootUrl, { name }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  browseMediaFiles(source: string, path: string): Observable<BrowseMediaFilesResponse> {
+    return apiBrowseMediaFilesGet(this.http, this.config.rootUrl, { source, path }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  selectBrowsedFile(source: string, path: string): Observable<BrowseMediaFilesSelectResponse> {
+    return apiBrowseMediaFilesSelectPost(this.http, this.config.rootUrl, {
+      body: { source, path },
+    }).pipe(map((r) => r.body));
+  }
+
+  getMediaTypes(): Observable<{ media_types: import('../models/api.models').MediaTypeInfo[] }> {
+    return apiMediaTypesGet(this.http, this.config.rootUrl).pipe(
+      map((r) => r.body as unknown as { media_types: import('../models/api.models').MediaTypeInfo[] }),
+    );
   }
 
   detectMediaType(
@@ -84,51 +136,39 @@ export class DatasetsApiService {
     path: string,
     recursive: boolean,
     limit = 50,
-  ): Observable<MediaTypeDetectionResponse> {
-    return this.http.get<MediaTypeDetectionResponse>('/api/dataset/detect-media-type', {
-      params: {
-        source,
-        path,
-        recursive: recursive ? 'true' : 'false',
-        limit: String(limit),
-      },
-    });
+  ): Observable<DetectMediaTypeResponse> {
+    return apiDatasetDetectMediaTypeGet(this.http, this.config.rootUrl, {
+      source,
+      path,
+      recursive,
+      limit,
+    }).pipe(map((r) => r.body));
   }
 
   getClippers(mediaType?: string): Observable<ClipperInfo[]> {
-    const params: Record<string, string> = {};
-    if (mediaType) {
-      params['media_type'] = mediaType;
-    }
-    return this.http.get<ClippersResponse>('/api/clippers', { params }).pipe(
-      map((res) => res.clippers),
+    return apiClippersGet(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
+      map((r) => r.body.clippers as unknown as ClipperInfo[]),
     );
   }
 
   getEmbedders(mediaType?: string): Observable<EmbedderInfo[]> {
-    const params: Record<string, string> = {};
-    if (mediaType) {
-      params['media_type'] = mediaType;
-    }
-    return this.http.get<EmbeddersResponse>('/api/embedders', { params }).pipe(
-      map((res) => res.embedders),
+    return apiEmbeddersGet(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
+      map((r) => r.body.embedders as unknown as EmbedderInfo[]),
     );
   }
 
   getConverters(target?: string): Observable<ConverterInfo[]> {
-    const params: Record<string, string> = {};
-    if (target) {
-      params['target'] = target;
-    }
-    return this.http.get<ConvertersResponse>('/api/converters', { params }).pipe(
-      map((res) => res.converters),
+    return apiConvertersGet(this.http, this.config.rootUrl, { target }).pipe(
+      map((r) => r.body.converters as unknown as ConverterInfo[]),
     );
   }
 
-  getAvailableFiles(): Observable<{ files: { name: string; path: string; size_mb: number }[] }> {
-    return this.http.get<{ files: { name: string; path: string; size_mb: number }[] }>('/api/dataset/available-files');
+  getAvailableFiles(): Observable<DatasetAvailableFilesResponse> {
+    return apiDatasetAvailableFilesGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
+  /** Plugin-field route — body shape is plugin-dependent, not described in
+   *  the OpenAPI spec.  Stays on plain ``HttpClient``. */
   runImporter(importerName: string, params: Record<string, unknown>): Observable<unknown> {
     return this.http.post(`/api/dataset/import/${encodeURIComponent(importerName)}`, params);
   }
@@ -136,118 +176,145 @@ export class DatasetsApiService {
   /**
    * Fetch dropdown options for an importer field whose options are computed
    * at runtime by the importer (``dynamic_options=true``).
-   *
-   * The backend calls the importer's ``get_field_options(field_key, values)``
-   * Python method and returns the resulting list.  Errors from the remote
-   * service are surfaced as HTTP errors with an ``error`` message body.
    */
   getImporterFieldOptions(
     importerName: string,
     fieldKey: string,
     values: Record<string, unknown>,
-  ): Observable<{ options: string[] }> {
-    return this.http.post<{ options: string[] }>(
-      `/api/dataset/import/${encodeURIComponent(importerName)}/options`,
-      { field_key: fieldKey, values },
-    );
+  ): Observable<ImporterFieldOptionsResponse> {
+    return apiDatasetImportImporterNameOptionsPost(this.http, this.config.rootUrl, {
+      importer_name: importerName,
+      body: { field_key: fieldKey, values },
+    }).pipe(map((r) => r.body));
   }
 
-  /**
-   * Upload a folder selected from the user's *browser* machine.
-   *
-   * The caller is responsible for building the FormData with the files
-   * (each appended under the key ``"files"`` with their
-   * ``webkitRelativePath`` as the multipart filename) plus ``media_type``
-   * and the optional ``embedder`` / ``clipper`` / ``clipper_params``
-   * fields.
-   */
-  importLocalFolder(formData: FormData): Observable<unknown> {
-    return this.http.post('/api/dataset/import-local-folder', formData);
+  /** Multipart upload — the caller builds the FormData with the files,
+   *  ``media_type``, optional ``embedder`` / ``clipper`` / ``clipper_params``.
+   *  Stays on plain ``HttpClient`` because ng-openapi-gen doesn't model
+   *  multipart bodies (the generated function's ``$Params`` has no ``body``
+   *  field). */
+  importLocalFolder(formData: FormData): Observable<DatasetLoadStartedResponse> {
+    return this.http.post<DatasetLoadStartedResponse>('/api/dataset/import-local-folder', formData);
   }
 
-  loadDemo(name: string, params?: Record<string, string>): Observable<unknown> {
-    return this.http.post('/api/dataset/load-demo', { name, ...params });
+  loadDemo(name: string, params?: Record<string, string>): Observable<DatasetLoadStartedResponse> {
+    const body: DatasetLoadDemoRequest = { name, ...params };
+    return apiDatasetLoadDemoPost(this.http, this.config.rootUrl, { body }).pipe(map((r) => r.body));
   }
 
-  loadFile(file: File): Observable<unknown> {
+  /** Multipart upload — see {@link importLocalFolder}. */
+  loadFile(file: File): Observable<DatasetLoadStartedResponse> {
     const formData = new FormData();
     formData.append('file', file);
-    return this.http.post('/api/dataset/load-file', formData);
+    return this.http.post<DatasetLoadStartedResponse>('/api/dataset/load-file', formData);
   }
 
-  stageFile(file: File): Observable<unknown> {
+  /** Multipart upload — see {@link importLocalFolder}. */
+  stageFile(file: File): Observable<DatasetStageFileResponse> {
     const formData = new FormData();
     formData.append('file', file);
-    return this.http.post('/api/dataset/stage-file', formData);
+    return this.http.post<DatasetStageFileResponse>('/api/dataset/stage-file', formData);
   }
 
+  /** Plugin-field route — body shape is plugin-dependent, not described in
+   *  the OpenAPI spec.  Stays on plain ``HttpClient``. */
   stageImport(importerName: string, params: Record<string, unknown>): Observable<unknown> {
     return this.http.post(`/api/dataset/stage-import/${encodeURIComponent(importerName)}`, params);
   }
 
-  stageDemo(name: string): Observable<unknown> {
-    return this.http.post(`/api/dataset/stage-demo/${encodeURIComponent(name)}`, {});
+  stageDemo(name: string): Observable<DatasetStagingStartedResponse> {
+    return apiDatasetStageDemoNamePost(this.http, this.config.rootUrl, {
+      name,
+      body: {},
+    }).pipe(map((r) => r.body));
   }
 
-  clearStaging(): Observable<unknown> {
-    return this.http.delete('/api/dataset/staging');
+  clearStaging(): Observable<ClearStagingResponse> {
+    return apiDatasetStagingDelete(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  combineDatasets(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/dataset/combine', params);
+  combineDatasets(params: DatasetCombineRequest): Observable<DatasetLoadStartedResponse> {
+    return apiDatasetCombinePost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  cancelIngest(): Observable<OkResponse> {
-    return this.http.post<OkResponse>('/api/dataset/cancel', {});
+  cancelIngest(): Observable<CancelDatasetLoadResponse> {
+    return apiDatasetCancelPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  cancelTask(taskId: string): Observable<OkResponse> {
-    return this.http.post<OkResponse>(`/api/dataset/cancel/${encodeURIComponent(taskId)}`, {});
+  cancelTask(taskId: string): Observable<CancelDatasetLoadResponse> {
+    return apiDatasetCancelTaskIdPost(this.http, this.config.rootUrl, { task_id: taskId }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  clearDataset(): Observable<OkResponse> {
-    return this.http.post<OkResponse>('/api/dataset/clear', {});
+  clearDataset(): Observable<DatasetClearResponse> {
+    return apiDatasetClearPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
+  /** Binary stream — stays on plain ``HttpClient`` so ``responseType: 'blob'``
+   *  produces a ``Blob`` (the generated function declares the success body as
+   *  ``Error`` because the spec only carries error responses for this route). */
   exportDataset(): Observable<Blob> {
     return this.http.get('/api/dataset/export', { responseType: 'blob' });
   }
 
-  getRegistry(): Observable<DatasetRegistryResponse> {
-    return this.http.get<DatasetRegistryResponse>('/api/datasets/registry');
+  getRegistry(): Observable<DatasetsRegistryListResponse> {
+    return apiDatasetsRegistryGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  loadRegistered(datasetId: string): Observable<unknown> {
-    return this.http.post(`/api/datasets/registry/${encodeURIComponent(datasetId)}/load`, {});
+  loadRegistered(datasetId: string): Observable<DatasetRegistryLoadResponse> {
+    return apiDatasetsRegistryDatasetIdLoadPost(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+    }).pipe(map((r) => r.body));
   }
 
-  unloadRegistered(datasetId: string): Observable<unknown> {
-    return this.http.post(`/api/datasets/registry/${encodeURIComponent(datasetId)}/unload`, {});
+  unloadRegistered(datasetId: string): Observable<DatasetRegistryOkResponse> {
+    return apiDatasetsRegistryDatasetIdUnloadPost(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+    }).pipe(map((r) => r.body));
   }
 
-  deleteRegistered(datasetId: string): Observable<unknown> {
-    return this.http.delete(`/api/datasets/registry/${encodeURIComponent(datasetId)}`);
+  deleteRegistered(datasetId: string): Observable<DatasetRegistryOkResponse> {
+    return apiDatasetsRegistryDatasetIdDelete(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+    }).pipe(map((r) => r.body));
   }
 
-  renameRegistered(datasetId: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/datasets/registry/${encodeURIComponent(datasetId)}/rename`, { name: newName });
+  renameRegistered(
+    datasetId: string,
+    newName: string,
+  ): Observable<DatasetRegistryRenameResponse> {
+    return apiDatasetsRegistryDatasetIdRenamePut(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+      body: { name: newName },
+    }).pipe(map((r) => r.body));
   }
 
-  updateReaders(datasetId: string, readers: string[]): Observable<unknown> {
-    return this.http.put(`/api/datasets/registry/${encodeURIComponent(datasetId)}/readers`, { readers });
+  updateReaders(
+    datasetId: string,
+    readers: string[],
+  ): Observable<DatasetRegistryReadersResponse> {
+    return apiDatasetsRegistryDatasetIdReadersPut(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+      body: { readers },
+    }).pipe(map((r) => r.body));
   }
 
-  loadSource(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/dataset/load-source', params);
-  }
-
-  getDatasetStats(datasetId: string): Observable<DatasetStatsResponse> {
-    return this.http.get<DatasetStatsResponse>(`/api/datasets/registry/${encodeURIComponent(datasetId)}/stats`);
-  }
-
-  getDiskUsage(): Observable<{ total: number; used: number; free: number; path: string }> {
-    return this.http.get<{ total: number; used: number; free: number; path: string }>(
-      '/api/dashboard/disk-usage',
+  loadSource(params: DatasetLoadSourceRequest): Observable<DatasetLoadStartedResponse> {
+    return apiDatasetLoadSourcePost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
     );
+  }
+
+  getDatasetStats(datasetId: string): Observable<DatasetRegistryStatsResponse> {
+    return apiDatasetsRegistryDatasetIdStatsGet(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+    }).pipe(map((r) => r.body));
+  }
+
+  getDiskUsage(): Observable<DashboardDiskUsageResponse> {
+    return apiDashboardDiskUsageGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -1,21 +1,96 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import {
-  AutoDetectResponse,
-  CombineDetectorsResult,
-  DetectorsRegistryResponse,
-  DetectorsResponse,
-  LabelsDetailResponse,
-} from '../models/api.models';
+import { map } from 'rxjs/operators';
+
+import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { AutoDetectRequest } from '../generated/api-client/models/auto-detect-request';
+import type { AutoDetectResponse } from '../generated/api-client/models/auto-detect-response';
+import type { AutoExtractResponse } from '../generated/api-client/models/auto-extract-response';
+import type { AutoLocalizeResponse } from '../generated/api-client/models/auto-localize-response';
+import type { AutorunExtractorCreateRequest } from '../generated/api-client/models/autorun-extractor-create-request';
+import type { AutorunExtractorsListResponse } from '../generated/api-client/models/autorun-extractors-list-response';
+import type { AutorunLocalizerCreateRequest } from '../generated/api-client/models/autorun-localizer-create-request';
+import type { AutorunLocalizersListResponse } from '../generated/api-client/models/autorun-localizers-list-response';
+import type { AutorunProcessorCreateResponse } from '../generated/api-client/models/autorun-processor-create-response';
+import type { AutorunProcessorDeleteResponse } from '../generated/api-client/models/autorun-processor-delete-response';
+import type { AutorunProcessorRenameResponse } from '../generated/api-client/models/autorun-processor-rename-response';
+import type { DetectorCancelResponse } from '../generated/api-client/models/detector-cancel-response';
+import type { DetectorCombineRequest } from '../generated/api-client/models/detector-combine-request';
+import type { DetectorCombineResponse } from '../generated/api-client/models/detector-combine-response';
+import type { DetectorCreateRequest } from '../generated/api-client/models/detector-create-request';
+import type { DetectorCreateResponse } from '../generated/api-client/models/detector-create-response';
+import type { DetectorDeleteResponse } from '../generated/api-client/models/detector-delete-response';
+import type { DetectorDetail } from '../generated/api-client/models/detector-detail';
+import type { DetectorExamplesRequest } from '../generated/api-client/models/detector-examples-request';
+import type { DetectorExamplesResponse } from '../generated/api-client/models/detector-examples-response';
+import type { DetectorLabelVoteResponse } from '../generated/api-client/models/detector-label-vote-response';
+import type { DetectorLabelsDetailResponse } from '../generated/api-client/models/detector-labels-detail-response';
+import type { DetectorRegistryAutorunResponse } from '../generated/api-client/models/detector-registry-autorun-response';
+import type { DetectorRegistryCreateRequest } from '../generated/api-client/models/detector-registry-create-request';
+import type { DetectorRegistryCreateResponse } from '../generated/api-client/models/detector-registry-create-response';
+import type { DetectorRegistryDeleteResponse } from '../generated/api-client/models/detector-registry-delete-response';
+import type { DetectorRegistryListResponse } from '../generated/api-client/models/detector-registry-list-response';
+import type { DetectorRegistryLoadResponse } from '../generated/api-client/models/detector-registry-load-response';
+import type { DetectorRegistryRenameResponse } from '../generated/api-client/models/detector-registry-rename-response';
+import type { DetectorRegistryUnloadResponse } from '../generated/api-client/models/detector-registry-unload-response';
+import type { DetectorRenameResponse } from '../generated/api-client/models/detector-rename-response';
+import type { DetectorSaveLabelsResponse } from '../generated/api-client/models/detector-save-labels-response';
+import type { DetectorsListResponse } from '../generated/api-client/models/detectors-list-response';
+import type { ExtractRequest } from '../generated/api-client/models/extract-request';
+import type { ExtractResponse } from '../generated/api-client/models/extract-response';
+import type { FindCheckLabelsRequest } from '../generated/api-client/models/find-check-labels-request';
+import type { FindCheckLabelsResponse } from '../generated/api-client/models/find-check-labels-response';
+import type { FindCheckLabelsWarning } from '../generated/api-client/models/find-check-labels-warning';
+import type { FindLabelRequest } from '../generated/api-client/models/find-label-request';
+import type { FindLabelResponse } from '../generated/api-client/models/find-label-response';
+import type { FindRequest } from '../generated/api-client/models/find-request';
+import type { FindResponse } from '../generated/api-client/models/find-response';
+import type { LocalizeRequest } from '../generated/api-client/models/localize-request';
+import type { LocalizeResponse } from '../generated/api-client/models/localize-response';
+import type { PregenProcessorsAddResponse } from '../generated/api-client/models/pregen-processors-add-response';
+import type { PregenProcessorsListResponse } from '../generated/api-client/models/pregen-processors-list-response';
+import { apiAutoDetectPost } from '../generated/api-client/fn/detector-scoring/api-auto-detect-post';
+import { apiAutoExtractPost } from '../generated/api-client/fn/processors-scoring/api-auto-extract-post';
+import { apiAutoLocalizePost } from '../generated/api-client/fn/processors-scoring/api-auto-localize-post';
+import { apiAutorunExtractorsGet } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-get';
+import { apiAutorunExtractorsNameDelete } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-name-delete';
+import { apiAutorunExtractorsNameRenamePut } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-name-rename-put';
+import { apiAutorunExtractorsPost } from '../generated/api-client/fn/processors-crud/api-autorun-extractors-post';
+import { apiAutorunLocalizersGet } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-get';
+import { apiAutorunLocalizersNameDelete } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-name-delete';
+import { apiAutorunLocalizersNameRenamePut } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-name-rename-put';
+import { apiAutorunLocalizersPost } from '../generated/api-client/fn/processors-crud/api-autorun-localizers-post';
+import { apiDetectorsCancelTaskIdPost } from '../generated/api-client/fn/detectors-registry/api-detectors-cancel-task-id-post';
+import { apiDetectorsCombinePost } from '../generated/api-client/fn/detectors-crud/api-detectors-combine-post';
+import { apiDetectorsGet } from '../generated/api-client/fn/detectors-crud/api-detectors-get';
+import { apiDetectorsNameDelete } from '../generated/api-client/fn/detectors-crud/api-detectors-name-delete';
+import { apiDetectorsNameExamplesPut } from '../generated/api-client/fn/detectors-crud/api-detectors-name-examples-put';
+import { apiDetectorsNameGet } from '../generated/api-client/fn/detectors-crud/api-detectors-name-get';
+import { apiDetectorsNameLabelsDetailGet } from '../generated/api-client/fn/detectors-labels/api-detectors-name-labels-detail-get';
+import { apiDetectorsNameLabelsElementIdVotePost } from '../generated/api-client/fn/detectors-labels/api-detectors-name-labels-element-id-vote-post';
+import { apiDetectorsNameLabelsPost } from '../generated/api-client/fn/detectors-labels/api-detectors-name-labels-post';
+import { apiDetectorsNameRenamePut } from '../generated/api-client/fn/detectors-crud/api-detectors-name-rename-put';
+import { apiDetectorsPost } from '../generated/api-client/fn/detectors-crud/api-detectors-post';
+import { apiDetectorsRegistryDetectorIdAutorunPut } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-autorun-put';
+import { apiDetectorsRegistryDetectorIdDelete } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-delete';
+import { apiDetectorsRegistryDetectorIdRenamePut } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-rename-put';
+import { apiDetectorsRegistryDetectorIdUnloadPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-unload-post';
+import { apiDetectorsRegistryGet } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-get';
+import { apiDetectorsRegistryLoadPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-load-post';
+import { apiDetectorsRegistryPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-post';
+import { apiExtractPost } from '../generated/api-client/fn/processors-scoring/api-extract-post';
+import { apiFindCheckLabelsPost } from '../generated/api-client/fn/detector-find/api-find-check-labels-post';
+import { apiFindLabelPost } from '../generated/api-client/fn/detector-scoring/api-find-label-post';
+import { apiFindPost } from '../generated/api-client/fn/detector-find/api-find-post';
+import { apiLocalizePost } from '../generated/api-client/fn/processors-scoring/api-localize-post';
+import { apiPregenProcessorsAddPost } from '../generated/api-client/fn/processors-crud/api-pregen-processors-add-post';
+import { apiPregenProcessorsGet } from '../generated/api-client/fn/processors-crud/api-pregen-processors-get';
 import { ActiveContextService } from './active-context.service';
 
-export interface FindLabelWarning {
-  detector_name: string;
-  total_labels: number;
-  resolved_labels: number;
-  failed_labels: number;
-}
+/** Backwards-compatible alias for the generated ``FindCheckLabelsWarning`` —
+ *  consumers of this service still import this name. */
+export type FindLabelWarning = FindCheckLabelsWarning;
 
 /**
  * API surface for detector CRUD, the detector registry, and detector-driven
@@ -25,51 +100,77 @@ export interface FindLabelWarning {
  */
 @Injectable({ providedIn: 'root' })
 export class DetectorsApiService {
-  constructor(private http: HttpClient, private activeContext: ActiveContextService) {}
+  private http = inject(HttpClient);
+  private config = inject(ApiConfiguration);
+  private activeContext = inject(ActiveContextService);
 
   // --- Detector CRUD ---
 
-  list(): Observable<DetectorsResponse> {
-    return this.http.get<DetectorsResponse>('/api/detectors');
+  list(): Observable<DetectorsListResponse> {
+    return apiDetectorsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  create(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/detectors', params);
-  }
-
-  get(name: string): Observable<unknown> {
-    return this.http.get(`/api/detectors/${encodeURIComponent(name)}`);
-  }
-
-  delete(name: string): Observable<unknown> {
-    return this.http.delete(`/api/detectors/${encodeURIComponent(name)}`);
-  }
-
-  rename(name: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/detectors/${encodeURIComponent(name)}/rename`, { new_name: newName });
-  }
-
-  setExamples(name: string, examples: unknown[]): Observable<unknown> {
-    return this.http.put(`/api/detectors/${encodeURIComponent(name)}/examples`, { examples });
-  }
-
-  saveLabels(name: string): Observable<unknown> {
-    return this.http.post(`/api/detectors/${encodeURIComponent(name)}/labels`, {});
-  }
-
-  getLabelsDetail(name: string): Observable<LabelsDetailResponse> {
-    return this.http.get<LabelsDetailResponse>(
-      `/api/detectors/${encodeURIComponent(name)}/labels-detail`,
+  create(params: DetectorCreateRequest): Observable<DetectorCreateResponse> {
+    return apiDetectorsPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
     );
   }
 
-  voteLabelElement(name: string, elementId: string, vote: 'good' | 'bad'): Observable<unknown> {
-    return this.http.post(
-      `/api/detectors/${encodeURIComponent(name)}/labels/${encodeURIComponent(elementId)}/vote`,
-      { vote },
+  get(name: string): Observable<DetectorDetail> {
+    return apiDetectorsNameGet(this.http, this.config.rootUrl, { name }).pipe(map((r) => r.body));
+  }
+
+  delete(name: string): Observable<DetectorDeleteResponse> {
+    return apiDetectorsNameDelete(this.http, this.config.rootUrl, { name }).pipe(
+      map((r) => r.body),
     );
   }
 
+  rename(name: string, newName: string): Observable<DetectorRenameResponse> {
+    return apiDetectorsNameRenamePut(this.http, this.config.rootUrl, {
+      name,
+      body: { new_name: newName },
+    }).pipe(map((r) => r.body));
+  }
+
+  setExamples(
+    name: string,
+    examples: DetectorExamplesRequest['examples'],
+  ): Observable<DetectorExamplesResponse> {
+    return apiDetectorsNameExamplesPut(this.http, this.config.rootUrl, {
+      name,
+      body: { examples },
+    }).pipe(map((r) => r.body));
+  }
+
+  saveLabels(name: string): Observable<DetectorSaveLabelsResponse> {
+    return apiDetectorsNameLabelsPost(this.http, this.config.rootUrl, { name }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  getLabelsDetail(name: string): Observable<DetectorLabelsDetailResponse> {
+    return apiDetectorsNameLabelsDetailGet(this.http, this.config.rootUrl, { name }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  voteLabelElement(
+    name: string,
+    elementId: string,
+    vote: 'good' | 'bad',
+  ): Observable<DetectorLabelVoteResponse> {
+    return apiDetectorsNameLabelsElementIdVotePost(this.http, this.config.rootUrl, {
+      name,
+      element_id: elementId,
+      body: { vote },
+    }).pipe(map((r) => r.body));
+  }
+
+  /** Preview/thumbnail URLs are binary streams — kept as direct URLs so the
+   *  active-context query params reach the backend (the generated function
+   *  for these declares the success body as ``Error`` because the spec only
+   *  carries error responses). */
   labelPreviewUrl(name: string, elementId: string): string {
     return this.activeContext.mediaUrl(
       `/api/detectors/${encodeURIComponent(name)}/labels/${encodeURIComponent(elementId)}/preview`,
@@ -85,25 +186,30 @@ export class DetectorsApiService {
   combine(
     names: string[],
     newName: string,
-    conflictPolicy: 'drop' = 'drop',
-  ): Observable<CombineDetectorsResult> {
-    return this.http.post<CombineDetectorsResult>('/api/detectors/combine', {
-      names,
-      new_name: newName,
-      conflict_policy: conflictPolicy,
-    });
+    conflictPolicy: DetectorCombineRequest['conflict_policy'] = 'drop',
+  ): Observable<DetectorCombineResponse> {
+    return apiDetectorsCombinePost(this.http, this.config.rootUrl, {
+      body: { names, new_name: newName, conflict_policy: conflictPolicy },
+    }).pipe(map((r) => r.body));
   }
 
   // --- Detector Registry ---
 
-  getRegistry(): Observable<DetectorsRegistryResponse> {
-    return this.http.get<DetectorsRegistryResponse>('/api/detectors/registry');
+  getRegistry(): Observable<DetectorRegistryListResponse> {
+    return apiDetectorsRegistryGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  registerDetector(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/detectors/registry', params);
+  registerDetector(
+    params: DetectorRegistryCreateRequest,
+  ): Observable<DetectorRegistryCreateResponse> {
+    return apiDetectorsRegistryPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
+  /** Plugin-field route — stays on plain ``HttpClient`` because the body
+   *  shape is plugin-dependent and not described in the OpenAPI spec.
+   *  Same pattern as ``LabelImportersApiService.runImport``. */
   registerDetectorFromLabelset(
     importerName: string,
     params: Record<string, unknown>,
@@ -124,109 +230,154 @@ export class DetectorsApiService {
     return this.http.post(url, params);
   }
 
-  deleteFromRegistry(detectorId: string): Observable<unknown> {
-    return this.http.delete(`/api/detectors/registry/${encodeURIComponent(detectorId)}`);
+  deleteFromRegistry(detectorId: string): Observable<DetectorRegistryDeleteResponse> {
+    return apiDetectorsRegistryDetectorIdDelete(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+    }).pipe(map((r) => r.body));
   }
 
-  renameInRegistry(detectorId: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/detectors/registry/${encodeURIComponent(detectorId)}/rename`, { name: newName });
+  renameInRegistry(
+    detectorId: string,
+    newName: string,
+  ): Observable<DetectorRegistryRenameResponse> {
+    return apiDetectorsRegistryDetectorIdRenamePut(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+      body: { name: newName },
+    }).pipe(map((r) => r.body));
   }
 
-  loadDetector(detectorId: string | null): Observable<unknown> {
-    return this.http.post('/api/detectors/registry/load', { detector_id: detectorId });
+  loadDetector(detectorId: string | null): Observable<DetectorRegistryLoadResponse> {
+    return apiDetectorsRegistryLoadPost(this.http, this.config.rootUrl, {
+      body: { detector_id: detectorId },
+    }).pipe(map((r) => r.body));
   }
 
-  unloadDetector(detectorId: string): Observable<unknown> {
-    return this.http.post(`/api/detectors/registry/${encodeURIComponent(detectorId)}/unload`, {});
+  unloadDetector(detectorId: string): Observable<DetectorRegistryUnloadResponse> {
+    return apiDetectorsRegistryDetectorIdUnloadPost(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+    }).pipe(map((r) => r.body));
   }
 
-  cancelDetectorLoadingTask(taskId: string): Observable<unknown> {
-    return this.http.post(`/api/detectors/cancel/${encodeURIComponent(taskId)}`, {});
+  cancelDetectorLoadingTask(taskId: string): Observable<DetectorCancelResponse> {
+    return apiDetectorsCancelTaskIdPost(this.http, this.config.rootUrl, {
+      task_id: taskId,
+    }).pipe(map((r) => r.body));
   }
 
-  setAutorun(detectorId: string, autorun: boolean): Observable<unknown> {
-    return this.http.put(`/api/detectors/registry/${encodeURIComponent(detectorId)}/autorun`, { autorun });
+  setAutorun(detectorId: string, autorun: boolean): Observable<DetectorRegistryAutorunResponse> {
+    return apiDetectorsRegistryDetectorIdAutorunPut(this.http, this.config.rootUrl, {
+      detector_id: detectorId,
+      body: { autorun },
+    }).pipe(map((r) => r.body));
   }
 
   // --- Extractors ---
 
-  getAutorunExtractors(): Observable<{ extractors: unknown[] }> {
-    return this.http.get<{ extractors: unknown[] }>('/api/autorun-extractors');
+  getAutorunExtractors(): Observable<AutorunExtractorsListResponse> {
+    return apiAutorunExtractorsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  createExtractor(params: { name: string; media_type?: string }): Observable<unknown> {
-    return this.http.post('/api/autorun-extractors', params);
+  createExtractor(
+    params: AutorunExtractorCreateRequest,
+  ): Observable<AutorunProcessorCreateResponse> {
+    return apiAutorunExtractorsPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  deleteExtractor(name: string): Observable<unknown> {
-    return this.http.delete(`/api/autorun-extractors/${encodeURIComponent(name)}`);
+  deleteExtractor(name: string): Observable<AutorunProcessorDeleteResponse> {
+    return apiAutorunExtractorsNameDelete(this.http, this.config.rootUrl, { name }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  renameExtractor(name: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/autorun-extractors/${encodeURIComponent(name)}/rename`, { new_name: newName });
+  renameExtractor(name: string, newName: string): Observable<AutorunProcessorRenameResponse> {
+    return apiAutorunExtractorsNameRenamePut(this.http, this.config.rootUrl, {
+      name,
+      body: { new_name: newName },
+    }).pipe(map((r) => r.body));
   }
 
   // --- Localizers ---
 
-  getAutorunLocalizers(): Observable<{ localizers: unknown[] }> {
-    return this.http.get<{ localizers: unknown[] }>('/api/autorun-localizers');
+  getAutorunLocalizers(): Observable<AutorunLocalizersListResponse> {
+    return apiAutorunLocalizersGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  createLocalizer(params: { name: string; media_type?: string }): Observable<unknown> {
-    return this.http.post('/api/autorun-localizers', params);
+  createLocalizer(
+    params: AutorunLocalizerCreateRequest,
+  ): Observable<AutorunProcessorCreateResponse> {
+    return apiAutorunLocalizersPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  deleteLocalizer(name: string): Observable<unknown> {
-    return this.http.delete(`/api/autorun-localizers/${encodeURIComponent(name)}`);
+  deleteLocalizer(name: string): Observable<AutorunProcessorDeleteResponse> {
+    return apiAutorunLocalizersNameDelete(this.http, this.config.rootUrl, { name }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  renameLocalizer(name: string, newName: string): Observable<unknown> {
-    return this.http.put(`/api/autorun-localizers/${encodeURIComponent(name)}/rename`, { new_name: newName });
+  renameLocalizer(name: string, newName: string): Observable<AutorunProcessorRenameResponse> {
+    return apiAutorunLocalizersNameRenamePut(this.http, this.config.rootUrl, {
+      name,
+      body: { new_name: newName },
+    }).pipe(map((r) => r.body));
   }
 
   // --- Scoring ---
 
-  autoDetect(params: Record<string, unknown>): Observable<AutoDetectResponse> {
-    return this.http.post<AutoDetectResponse>('/api/auto-detect', params);
+  autoDetect(params: AutoDetectRequest): Observable<AutoDetectResponse> {
+    return apiAutoDetectPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  extract(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/extract', params);
+  extract(params: ExtractRequest): Observable<ExtractResponse> {
+    return apiExtractPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  autoExtract(): Observable<unknown> {
-    return this.http.post('/api/auto-extract', {});
+  autoExtract(): Observable<AutoExtractResponse> {
+    return apiAutoExtractPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  localize(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/localize', params);
+  localize(params: LocalizeRequest): Observable<LocalizeResponse> {
+    return apiLocalizePost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  autoLocalize(): Observable<unknown> {
-    return this.http.post('/api/auto-localize', {});
+  autoLocalize(): Observable<AutoLocalizeResponse> {
+    return apiAutoLocalizePost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   // --- Find ---
 
-  findCheckLabels(params: Record<string, unknown>): Observable<{ warnings: FindLabelWarning[] }> {
-    return this.http.post<{ warnings: FindLabelWarning[] }>('/api/find/check-labels', params);
+  findCheckLabels(params: FindCheckLabelsRequest): Observable<FindCheckLabelsResponse> {
+    return apiFindCheckLabelsPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
-  find(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/find', params);
+  find(params: FindRequest): Observable<FindResponse> {
+    return apiFindPost(this.http, this.config.rootUrl, { body: params }).pipe(map((r) => r.body));
   }
 
-  findLabel(params: Record<string, unknown>): Observable<unknown> {
-    return this.http.post('/api/find-label', params);
+  findLabel(params: FindLabelRequest): Observable<FindLabelResponse> {
+    return apiFindLabelPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
   }
 
   // --- Pregen processors ---
 
-  getPregenProcessors(): Observable<{ processors: unknown[] }> {
-    return this.http.get<{ processors: unknown[] }>('/api/pregen-processors');
+  getPregenProcessors(): Observable<PregenProcessorsListResponse> {
+    return apiPregenProcessorsGet(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
-  addPregenProcessors(): Observable<unknown> {
-    return this.http.post('/api/pregen-processors/add', {});
+  addPregenProcessors(): Observable<PregenProcessorsAddResponse> {
+    return apiPregenProcessorsAddPost(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 }

--- a/frontend/src/app/services/labelset-state.service.ts
+++ b/frontend/src/app/services/labelset-state.service.ts
@@ -1,13 +1,14 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, EMPTY, Observable, Subject, timer } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { LabelElement, LabelsDetailResponse } from '../models/api.models';
+import type { DetectorLabelView } from '../generated/api-client/models/detector-label-view';
+import type { DetectorLabelsDetailResponse } from '../generated/api-client/models/detector-labels-detail-response';
 import { DetectorsApiService } from './detectors-api.service';
 
 @Injectable({ providedIn: 'root' })
 export class LabelsetStateService implements OnDestroy {
-  private readonly goodSubject = new BehaviorSubject<LabelElement[]>([]);
-  private readonly badSubject = new BehaviorSubject<LabelElement[]>([]);
+  private readonly goodSubject = new BehaviorSubject<DetectorLabelView[]>([]);
+  private readonly badSubject = new BehaviorSubject<DetectorLabelView[]>([]);
   private readonly mediaTypeSubject = new BehaviorSubject<string>('');
   private readonly stopPolling$ = new Subject<void>();
   private readonly destroy$ = new Subject<void>();
@@ -26,11 +27,11 @@ export class LabelsetStateService implements OnDestroy {
     this.destroy$.complete();
   }
 
-  get good(): LabelElement[] {
+  get good(): DetectorLabelView[] {
     return this.goodSubject.value;
   }
 
-  get bad(): LabelElement[] {
+  get bad(): DetectorLabelView[] {
     return this.badSubject.value;
   }
 
@@ -89,14 +90,14 @@ export class LabelsetStateService implements OnDestroy {
       return;
     }
     // Flip
-    const flipped: LabelElement = { ...elem, label: vote };
+    const flipped: DetectorLabelView = { ...elem, label: vote };
     if (vote === 'good') nextGood.push(flipped);
     else nextBad.push(flipped);
     this.goodSubject.next(nextGood);
     this.badSubject.next(nextBad);
   }
 
-  private fetch$(): Observable<LabelsDetailResponse | never> {
+  private fetch$(): Observable<DetectorLabelsDetailResponse | never> {
     if (!this.modelName) {
       this.goodSubject.next([]);
       this.badSubject.next([]);


### PR DESCRIPTION
## Summary

The two largest remaining Angular services move from hand-written `HttpClient` calls to the generated function modules under `frontend/src/app/generated/api-client/fn/`. Return types tighten to the generated DTOs (47 across the two services) and 20 legacy interfaces are deleted from `frontend/src/app/models/api.models.ts`.

- **`DetectorsApiService`** now calls generated functions under `detectors-crud/`, `detectors-registry/`, `detectors-labels/`, `detector-scoring/`, `detector-find/`, `processors-crud/`, and `processors-scoring/`.
- **`DatasetsApiService`** now calls generated functions under `datasets-listings/`, `datasets-load/`, `datasets-registry/`, `datasets-staging/`, `datasets-status/`, and `datasets-ui/`.

Plugin-field routes (`runImporter`, `stageImport`, `registerDetectorFromLabelset`), multipart uploads (`importLocalFolder`, `loadFile`, `stageFile`), and the binary-stream `exportDataset` stay on plain `HttpClient` — same patterns established by prior migrations (`MediasApiService.addToPile`, `SortingApiService.exampleSort`, etc.). The plugin `to_dict()` payloads for importers/clippers/embedders/converters/media-types come back as `Array<{[key:string]:any}>` from the generated client; the service casts each list at the boundary to the richer `ImporterInfo` / `ClipperInfo` / `EmbedderInfo` / `ConverterInfo` / `MediaTypeInfo` interfaces in `api.models.ts` so consumers don't have to (same pattern as `ExportersApiService`).

Consumers updated where the legacy interface diverged from the generated shape:
- `CombineDetectorsModalComponent`: `CombineDetectorsResult` → `DetectorCombineResponse`
- `DatasetStatsModalComponent`: `DatasetStatsResponse` → `DatasetRegistryStatsResponse`
- `LabelsetStateService`, `LabelsetListComponent`, `RightPanelComponent`: `LabelElement` / `LabelsDetailResponse` → `DetectorLabelView` / `DetectorLabelsDetailResponse`
- `DatasetStateService`: cast the loose generated `DatasetsRegistryListResponse.datasets` to the local `DatasetRegistryEntry[]`

Deleted from `api.models.ts`: `DatasetStatus`, `DatasetStatsResponse`, `DatasetRegistryResponse`, `ImportersResponse`, `DemoListResponse`, `MediaTypesResponse`, `LoadingTasksResponse`, `LabelElement`, `LabelsDetailResponse`, `Detector`, `DetectorsResponse`, `DetectorsRegistryResponse`, `CombineDetectorsResult`, `AutoDetectResponse`, `ClippersResponse`, `ConvertersResponse`, `EmbeddersResponse`, `ApiError`, `OkResponse`, `ExportResult`, and a duplicate loose `ConverterInfo` definition. `DatasetRegistryEntry` / `DetectorRegistryEntry` stay because the generated equivalents are loose and the local versions describe the actual fields consumers read.

Initial bundle: 512.16 kB (unchanged, under the 525 kB budget).

## Test plan

- [x] `./run-tests.sh` — 3620 passed, 1 skipped, 2 xpassed
- [x] `./run-tests.sh core` (includes frontend `npm run build:prod`) — 494 passed
- [x] OpenAPI snapshot drift check — `frontend/openapi.json` matches a freshly-dumped spec
- [x] `npx tsc -p tsconfig.spec.json --noEmit` — spec files typecheck

https://claude.ai/code/session_01JU4mY5mVrq7i4DqKzndLS3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU4mY5mVrq7i4DqKzndLS3)_