### PR TITLE
Move Achievements out of Settings into a header trophy button

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -63,6 +63,20 @@
   <vt-context-pulldown kind="detector" />
   <span class="top-bar-spacer"></span>
   <button
+    class="achievements-btn"
+    aria-label="Achievements"
+    title="Achievements — your usage milestones and tier progress"
+    (click)="onAchievements()"
+  ><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 4h12v4a6 6 0 0 1-12 0z"/>
+      <path d="M6 6H3a2 2 0 0 0 0 4h3"/>
+      <path d="M18 6h3a2 2 0 0 1 0 4h-3"/>
+      <line x1="10" y1="14" x2="10" y2="18"/>
+      <line x1="14" y1="14" x2="14" y2="18"/>
+      <rect x="7" y="18" width="10" height="3" rx="1"/>
+    </svg></button>
+  <button
     class="help-btn"
     aria-label="Keyboard shortcuts"
     title="Keyboard shortcuts (?)"
@@ -115,6 +129,11 @@
 @defer (when showSettings) {
   @if (showSettings) {
     <vt-settings-modal [preselectedViewTab]="settingsViewTab" (closed)="onSettingsClosed()" />
+  }
+}
+@defer (when showAchievements) {
+  @if (showAchievements) {
+    <vt-achievements-modal (closed)="onAchievementsClosed()" />
   }
 }
 @defer (when showKeyboardHelp) {

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -140,7 +140,8 @@ header {
   flex: 1;
 }
 
-.help-btn {
+.help-btn,
+.achievements-btn {
   background: transparent;
   border: 1px solid var(--header-btn-border);
   border-radius: var(--radius-md);

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { DialogHostComponent } from './components/dialog-host/dialog-host.compon
 import { ToastContainerComponent } from './components/toast-container/toast-container.component';
 import { AchievementUnlockHostComponent } from './components/achievement-unlock-host/achievement-unlock-host.component';
 import { SettingsModalComponent } from './components/modals/settings-modal/settings-modal.component';
+import { AchievementsModalComponent } from './components/modals/achievements-modal/achievements-modal.component';
 import { KeyboardHelpModalComponent } from './components/modals/keyboard-help-modal/keyboard-help-modal.component';
 import { LoginComponent } from './components/login/login.component';
 import { ContextPulldownComponent } from './components/context-pulldown/context-pulldown.component';
@@ -42,6 +43,7 @@ import { isPairCompatible } from './utils/context-compat';
     ToastContainerComponent,
     AchievementUnlockHostComponent,
     SettingsModalComponent,
+    AchievementsModalComponent,
     KeyboardHelpModalComponent,
     LoginComponent,
     ContextPulldownComponent,
@@ -56,6 +58,7 @@ export class AppComponent {
   title = 'VTSearch';
   menuOpen = false;
   showSettings = false;
+  showAchievements = false;
   showKeyboardHelp = false;
   gearClosing = false;
   isOnLabelView = false;
@@ -221,6 +224,15 @@ export class AppComponent {
   onSettingsClosed(): void {
     this.showSettings = false;
     this.gearClosing = true;
+  }
+
+  onAchievements(): void {
+    this.menuOpen = false;
+    this.showAchievements = true;
+  }
+
+  onAchievementsClosed(): void {
+    this.showAchievements = false;
   }
 
   onGearAnimationEnd(): void {

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -1,4 +1,3 @@
-<h3>Achievements</h3>
 <div class="achievements-total" title="1pt Bronze · 2pts Silver · 4pts Gold · 8pts Platinum">
   <span class="achievements-total-label">Total Score</span>
   <span class="achievements-total-value">{{ totalScore.toLocaleString() }}</span>

--- a/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.html
+++ b/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.html
@@ -1,0 +1,6 @@
+<vt-modal title="Achievements" [open]="true" (closed)="close()">
+  <vt-achievements-tab />
+  <div modal-footer>
+    <button class="btn btn--primary" (click)="close()" title="Close the achievements panel">Close</button>
+  </div>
+</vt-modal>

--- a/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.ts
+++ b/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.ts
@@ -1,0 +1,17 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { ModalComponent } from '../../modal/modal.component';
+import { AchievementsTabComponent } from '../../achievements-tab/achievements-tab.component';
+
+@Component({
+  selector: 'vt-achievements-modal',
+  standalone: true,
+  imports: [ModalComponent, AchievementsTabComponent],
+  templateUrl: './achievements-modal.component.html',
+})
+export class AchievementsModalComponent {
+  @Output() closed = new EventEmitter<void>();
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -28,14 +28,6 @@
           <vt-icon type="sort-descending" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'sorting'"></vt-icon>
           Sorting
         </button>
-        <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab === 'achievements'"
-          (click)="activeSettingsTab = 'achievements'"
-          title="See your usage milestones and current Bronze/Silver/Gold/Platinum tiers">
-          <vt-icon type="trophy" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab === 'achievements'"></vt-icon>
-          Achievements
-        </button>
       </nav>
 
       <div class="settings-panel">
@@ -194,10 +186,6 @@
 
         }
 
-        <!-- Achievements -->
-        @if (activeSettingsTab === 'achievements') {
-          <vt-achievements-tab />
-        }
       </div>
     </div>
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -7,7 +7,6 @@ import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsImporterModalComponent } from '../settings-importer-modal/settings-importer-modal.component';
 import { SettingsExporterModalComponent } from '../settings-exporter-modal/settings-exporter-modal.component';
-import { AchievementsTabComponent } from '../../achievements-tab/achievements-tab.component';
 import { SettingsApiService } from '../../../services/settings-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
@@ -20,7 +19,7 @@ import { VtDialogService } from '../../../services/dialog.service';
 @Component({
   selector: 'vt-settings-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent, AchievementsTabComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, SettingsImporterModalComponent, SettingsExporterModalComponent],
   templateUrl: './settings-modal.component.html',
   styleUrl: './settings-modal.component.scss',
 })


### PR DESCRIPTION
## Summary

Achievements was buried as a tab inside the Settings modal — users go there for settings, not gamification rewards. Lift it to its own discoverable affordance: a trophy icon in the header next to the existing Help and Settings buttons.

- New `AchievementsModalComponent` wraps the existing `vt-achievements-tab` content (the tab component stays so future entry points can reuse it).
- Remove the Achievements tab + its lazy import from `SettingsModalComponent`.
- Drop the now-duplicate `<h3>Achievements</h3>` from the tab template — the modal header already shows the title.
- Add a trophy SVG button in the header (`onAchievements` / `onAchievementsClosed` in `AppComponent`); the modal renders via `@defer` so it stays out of the initial bundle.
- Share styling with `.help-btn` so the new button matches the existing utility icons exactly.

## Test plan

- [x] `./run-tests.sh` — 3620 passed, 1 skipped, 2 xpassed (incl. ruff / codespell / deptry / frontend production build)
- [x] `npm run build:prod` — clean build, no warnings; new chunk `achievements-modal-component` (3.27 kB transfer) is lazy-loaded as expected
- [ ] Manual: click the trophy button → modal opens with the achievements list and total score; close via × / Close / backdrop / Escape; Settings modal no longer shows the Achievements tab


---
_Generated by [Claude Code](https://claude.ai/code/session_01AvvfcPNQVZUQH8wXeb6hwm)_