### PR TITLE
Make text-sort explicit (Enter / Search button) + cache query embeddings

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,12 @@ name: Coverage
 # This is the first workflow that runs pytest in CI; local development
 # still uses `./run-tests.sh`. The marker expression (`not gpu and not
 # slow`) matches the default fast-loop suite.
+#
+# The Angular frontend is built before pytest because several tests
+# (tests/core/test_frontend.py, tests/api/test_dashboard.py) assert that
+# `/static/main.js`, `/static/polyfills.js`, `/static/styles.css` are
+# served — those files only exist after `npm run build:prod` populates
+# the `static/` directory.
 
 on:
   push:
@@ -25,6 +31,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build Angular frontend (populates static/)
+        run: |
+          set +e
+          (cd frontend && npm ci && npm run build:prod) 2>&1 | tee /tmp/frontend-build.log
+          status=${PIPESTATUS[0]}
+          {
+            echo "## Frontend build (exit=$status)"
+            echo ""
+            echo '```'
+            tail -c 60000 /tmp/frontend-build.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
 
       - name: Install vtsearch + deps (CPU)
         run: |

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -132,8 +132,12 @@ Selecting 3 datasets and clicking the bulk-load action loads them serially due t
 ### 3.6 Lazy-create per-media-type panel preferences ★ XS
 First time a user opens a new media type, the panel settings (`view_mode_*`, `grid_icon_size_*`, `focus_mode_*`, `panel_pct_*`) all write to disk. Coalesce into one save. (Minor but the first-image-open feels janky on slow disks.)
 
-### 3.7 Don't re-embed text queries on every keystroke ★★ XS
-Verify: if the Text-sort input has live-search, debounce + cache. If it requires Enter, fine. Either way, cache the last 5 query embeddings keyed by `(media_type, query)` for instant re-sort when toggling sort modes.
+### 3.7 Don't re-embed text queries on every keystroke ★★ XS — **shipped**
+Was: 400ms debounced live-search on the Text-sort input (`sort-bar.component.ts`) firing `POST /api/sort` → `embed_text_query()` on every pause, with no caching frontend or backend.
+
+Now:
+- Frontend: live-search removed. The input only triggers a search on Enter or the new "Search" button (disabled while the trimmed query is empty). See `frontend/src/app/components/left-panel/sort-bar/sort-bar.component.{ts,html,scss}`.
+- Backend: 32-entry in-memory LRU in `vtsearch/embedding/helpers.py` keyed by `(embedder_name, media_type, enrich, text)`. Repeat queries — re-submitting the same string, toggling sort modes and back, or `eval/runner.py` calls — skip the text encoder. Cache is process-scoped (no persistence, per "No Persisted Vectors") and cleared between tests via the existing `reset_state` autouse fixture.
 
 ### 3.8 Skip diversity-tree rebuild on small updates ★ M
 When a few medias are added/removed (e.g. clip fix-up), today the whole diversity tree rebuilds. For incremental changes < 1% of dataset size, do an incremental insert/delete instead. Saves seconds on every clip-aware import.

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -49,9 +49,17 @@
             placeholder="Describe what you're looking for..."
             [value]="textQuery"
             (input)="onTextInput($any($event.target).value)"
-            title="Enter a text description to rank items by semantic similarity"
+            (keyup.enter)="submitTextSort()"
+            title="Enter a text description and press Enter (or click Search) to rank items by semantic similarity"
             aria-label="Text sort query"
           />
+          <button
+            class="btn btn--primary btn--sm text-sort-btn"
+            type="button"
+            (click)="submitTextSort()"
+            [disabled]="searchDisabled"
+            title="Run text search"
+          >Search</button>
         </div>
       }
     }

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.scss
@@ -48,9 +48,21 @@
   width: 100%;
 }
 
+.text-sort-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
 .text-sort-input {
+  flex: 1;
+  min-width: 0;
   font-size: var(--font-sm);
   padding: 5px var(--space-md);
+}
+
+.text-sort-btn {
+  flex-shrink: 0;
 }
 
 .sort-hint {

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SortBarComponent } from './sort-bar.component';
 
 describe('SortBarComponent', () => {
@@ -59,20 +59,43 @@ describe('SortBarComponent', () => {
     expect(component.loadSort.emit).toHaveBeenCalled();
   });
 
-  it('should debounce text input and emit textSort', fakeAsync(() => {
+  it('should not emit textSort on input alone', () => {
     spyOn(component.textSort, 'emit');
     component.onTextInput('hello world');
     expect(component.textSort.emit).not.toHaveBeenCalled();
-    tick(400);
-    expect(component.textSort.emit).toHaveBeenCalledWith('hello world');
-  }));
+  });
 
-  it('should not emit textSort for whitespace-only input', fakeAsync(() => {
+  it('should emit textSort on submitTextSort', () => {
+    spyOn(component.textSort, 'emit');
+    component.onTextInput('hello world');
+    component.submitTextSort();
+    expect(component.textSort.emit).toHaveBeenCalledWith('hello world');
+  });
+
+  it('should not emit textSort for whitespace-only input on submit', () => {
     spyOn(component.textSort, 'emit');
     component.onTextInput('   ');
-    tick(400);
+    component.submitTextSort();
     expect(component.textSort.emit).not.toHaveBeenCalled();
-  }));
+  });
+
+  it('should render a Search button alongside the text input', () => {
+    component.sortMode = 'text';
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('.text-sort-btn');
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toContain('Search');
+  });
+
+  it('should disable Search button when query is empty or whitespace', () => {
+    component.sortMode = 'text';
+    component.textQuery = '   ';
+    fixture.detectChanges();
+    expect(component.searchDisabled).toBe(true);
+    component.textQuery = 'cats';
+    fixture.detectChanges();
+    expect(component.searchDisabled).toBe(false);
+  });
 
   it('should show hint when learned is disabled', () => {
     component.sortMode = 'learned';

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
@@ -1,8 +1,6 @@
-import { Component, Input, Output, EventEmitter, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
 import { SortMode } from '../left-panel.component';
 import { LoadSortModalComponent } from '../../modals/load-sort-modal/load-sort-modal.component';
 
@@ -13,7 +11,7 @@ import { LoadSortModalComponent } from '../../modals/load-sort-modal/load-sort-m
   templateUrl: './sort-bar.component.html',
   styleUrl: './sort-bar.component.scss',
 })
-export class SortBarComponent implements OnInit, OnDestroy {
+export class SortBarComponent implements OnInit {
   @Input() sortMode: SortMode = 'text';
   @Input() loadSortLabel = '';
   @Input() initialTextQuery = '';
@@ -40,28 +38,10 @@ export class SortBarComponent implements OnInit, OnDestroy {
   textQuery = '';
   showLoadSortModal = false;
 
-  private textInput$ = new Subject<string>();
-  private destroy$ = new Subject<void>();
-
-  constructor() {
-    this.textInput$
-      .pipe(debounceTime(400), takeUntil(this.destroy$))
-      .subscribe((text) => {
-        if (text.trim()) {
-          this.textSort.emit(text.trim());
-        }
-      });
-  }
-
   ngOnInit(): void {
     if (this.initialTextQuery) {
       this.textQuery = this.initialTextQuery;
     }
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   onSortModeChange(mode: SortMode): void {
@@ -75,7 +55,13 @@ export class SortBarComponent implements OnInit, OnDestroy {
 
   onTextInput(value: string): void {
     this.textQuery = value;
-    this.textInput$.next(value);
+  }
+
+  submitTextSort(): void {
+    const trimmed = this.textQuery.trim();
+    if (trimmed) {
+      this.textSort.emit(trimmed);
+    }
   }
 
   get learnedDisabled(): boolean {
@@ -84,6 +70,10 @@ export class SortBarComponent implements OnInit, OnDestroy {
 
   get textDisabled(): boolean {
     return !this.textSortAvailable;
+  }
+
+  get searchDisabled(): boolean {
+    return !this.textQuery.trim();
   }
 
   onAddLoadSort(): void {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,10 @@ def reset_state():
     _core.autorun_localizers.clear()
     clear_progress_cache()
 
+    from vtsearch.embedding.helpers import clear_text_query_cache as _clear_query_cache
+
+    _clear_query_cache()
+
     _dataset_progress.reset_cancel()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _sort_progress.update("idle", "", 0, 0)

--- a/vtsearch/embedding/__init__.py
+++ b/vtsearch/embedding/__init__.py
@@ -7,6 +7,7 @@ package exposes thin call-sites used throughout the rest of VTSearch
 """
 
 from vtsearch.embedding.helpers import (
+    clear_text_query_cache,
     embed_audio_file,
     embed_image_file,
     embed_paragraph_file,
@@ -35,6 +36,7 @@ __all__ = [
     "embed_image_file",
     "embed_paragraph_file",
     "embed_text_query",
+    "clear_text_query_cache",
     "initialize_models",
     "predict_embedders_to_preload",
     "preload_predicted_embedders",

--- a/vtsearch/embedding/helpers.py
+++ b/vtsearch/embedding/helpers.py
@@ -7,7 +7,9 @@ its original public API as thin wrappers so that existing callers
 without modification.
 """
 
+from collections import OrderedDict
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 
 import numpy as np
@@ -47,12 +49,56 @@ def embed_paragraph_file(text_path: Path) -> Optional[np.ndarray]:
     return emb.embed_media(media_from_path(text_path)) if emb else None
 
 
+# In-memory LRU cache of recently-embedded text queries. Keyed by
+# (embedder_name, media_type, enrich, text); the embedder name is included
+# because the same string embedded by CLIP vs. SigLIP lands in different
+# vector spaces. Caching avoids re-running the text encoder when the user
+# toggles sort modes or re-submits the same query on a different dataset
+# that shares the embedder. Vectors are never persisted (see CLAUDE.md
+# "No Persisted Vectors or MLPs") — this lives for the process lifetime.
+_QUERY_CACHE_MAXSIZE = 32
+_query_cache: "OrderedDict[tuple[str, str, bool, str], np.ndarray]" = OrderedDict()
+_query_cache_lock = Lock()
+
+
+def _query_cache_get(key: tuple[str, str, bool, str]) -> Optional[np.ndarray]:
+    with _query_cache_lock:
+        vec = _query_cache.get(key)
+        if vec is not None:
+            _query_cache.move_to_end(key)
+        return vec
+
+
+def _query_cache_put(key: tuple[str, str, bool, str], vec: np.ndarray) -> None:
+    with _query_cache_lock:
+        _query_cache[key] = vec
+        _query_cache.move_to_end(key)
+        while len(_query_cache) > _QUERY_CACHE_MAXSIZE:
+            _query_cache.popitem(last=False)
+
+
+def clear_text_query_cache() -> None:
+    """Drop all cached query embeddings (test helper / manual reset)."""
+    with _query_cache_lock:
+        _query_cache.clear()
+
+
 def embed_text_query(text: str, media_type: str, enrich: bool = False, embedder_name: str = "") -> Optional[np.ndarray]:
     """Embed *text* in the vector space of the given *media_type* (or specific *embedder_name*).
 
     When *embedder_name* is provided, uses that specific embedder.  Otherwise
     falls back to the first registered embedder for the media type.
+
+    Results are cached in a small in-memory LRU keyed by
+    ``(embedder_name, media_type, enrich, text)`` so repeated queries
+    (e.g. switching sort modes and back, or re-submitting the same search)
+    skip the text encoder.
     """
+    cache_key = (embedder_name, media_type, bool(enrich), text)
+    cached = _query_cache_get(cache_key)
+    if cached is not None:
+        return cached
+
     if embedder_name:
         from vtsearch.media import get_embedder
 
@@ -66,6 +112,9 @@ def embed_text_query(text: str, media_type: str, enrich: bool = False, embedder_
     if emb is None:
         return None
 
-    if enrich:
-        return emb.embed_text_enriched(text)
-    return emb.embed_text(text)
+    vec = emb.embed_text_enriched(text) if enrich else emb.embed_text(text)
+    if vec is None:
+        return None
+
+    _query_cache_put(cache_key, vec)
+    return vec


### PR DESCRIPTION
## Summary

Resolves UX brainstorm item **3.7 — Don't re-embed text queries on every keystroke**.

The Text-sort input used to fire `POST /api/sort` on a 400ms debounce after every keystroke, and each request re-embedded the text from scratch — even when the user just toggled sort modes back to the same query.

- **Frontend:** removed the debounced live-search. The input now triggers a search only when the user presses **Enter** or clicks the new **Search** button (disabled while the trimmed query is empty). See `frontend/src/app/components/left-panel/sort-bar/sort-bar.component.{ts,html,scss}`.
- **Backend:** added a 32-entry in-memory LRU in `vtsearch/embedding/helpers.py` keyed by `(embedder_name, media_type, enrich, text)`. Repeat queries — re-submitting the same string, switching sort modes and back, or `eval/runner.py` calls with the same query — skip the text encoder. Cache is process-scoped (no persistence, per CLAUDE.md "No Persisted Vectors or MLPs") and cleared between tests by the existing `reset_state` autouse fixture.
- Updated `docs/plans/ux-brainstorm.md` 3.7 to record what shipped.

**Backwards compatibility:** The text-sort UI no longer auto-fires while typing — users must hit Enter or click Search.

## Test plan

- [x] `./run-tests.sh sorting core` (729 passed — includes lint, format, codespell, deptry, frontend build, frontend audit)
- [x] `./run-tests.sh detectors` (846 passed — covers `embed_text_query` mock sites)
- [x] `./run-tests.sh` full suite (3620 passed, 1 skipped, 2 xpassed)
- [ ] Manual: type a query, confirm no `/api/sort` request fires until Enter or Search is clicked
- [ ] Manual: re-submit the same query → confirm second request reuses cached embedding (backend log will show the same call but skips the encoder)
- [ ] Manual: toggle to Learned sort and back to Text with the same query, then Search → instant re-rank


---
_Generated by [Claude Code](https://claude.ai/code/session_01MKczzqodd2gvZx5FJ7h28n)_