### PR TITLE
Standardize "Import Labels" naming across the UI (ux-brainstorm 5.8)

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -208,8 +208,15 @@ In Manual mode these are 3 unlabeled jargon buttons. Either hide them by default
 ### 5.7 The "Load" sort mode is buried ★★ S
 "Load" requires a `+` click that opens another modal where the user picks a detector. Instead expose recently-used detectors as a dropdown in the sort row, with a `Manage…` link for the modal. (Mirrors how Word/Photoshop handle recent files.)
 
-### 5.8 "Add Labels" vs "Import Labels" vs "Label importer" ★★ S
-Same action under three names. Pick one (suggest **Import labels**) and use it everywhere — Models dashboard, right-panel button, modal title.
+### 5.8 "Add Labels" vs "Import Labels" vs "Label importer" ★★ S — shipped
+Standardised on **Import Labels** (Title Case, matching the existing `Export Labels` / `Export Detector` siblings):
+
+- Models dashboard detector-card button: `Add Labels` → `Import Labels` (aria-label + tooltip).
+- New Detector → Trained tab form field: `Label Importer` → `Import Labels From`.
+- Label importer modal title: now `Import Labels` standalone, and `Import Labels into <detectorname>` when launched against a specific detector (per user preference: keep contextual variant).
+- Right-panel button was already `Import Labels`; left as-is.
+
+Internal symbols (`addLabelsModalOpen`, `onAddLabels`, `.add-labels-btn`) were intentionally left alone — out of scope for a UI-string fix and would balloon the diff.
 
 ### 5.9 Vote-pile right panel ★ S
 The right panel shows "Good" and "Bad" as two stacked stacks. There's no drag-to-reorder, no batch operations (`select all → un-vote`), and no obvious way to remove an item from a pile (must reopen the centre, find it, vote the other way). Add multi-select + a context menu (remove, re-vote, copy ID).

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -138,7 +138,7 @@
         <line x1="14.5" y1="4.5" x2="18.5" y2="8.5"></line>
       </svg>
     </button>
-    <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Add Labels" title="Add Labels">
+    <button class="add-labels-btn" (click)="onAddLabels($event)" aria-label="Import Labels" title="Import Labels">
       <svg aria-hidden="true" [class.cap-active]="addLabelsOpen" [class.cap-inactive]="!addLabelsOpen && wasAddLabelsOpen" (animationend)="onCapAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10l-10-5L2 10l10 5 10-5z"/><path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5"/><line x1="22" y1="10" x2="22" y2="16"/></svg>
     </button>
     <button class="export-btn" (click)="onExport($event)" aria-label="Export detector" title="Export">

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -126,7 +126,7 @@
       @if (tab === 'trained') {
         @if (trainedView === 'picker') {
           <div class="form-group">
-            <label class="col-label">Label Importer <span class="required">*</span></label>
+            <label class="col-label">Import Labels From <span class="required">*</span></label>
             <p class="info-text">Choose where to import labels from. The resulting detector's training data will be the imported labels.</p>
             @if (labelImportersLoading) {
               <p class="empty-state">Loading importers...</p>

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -53,7 +53,7 @@ export class LabelImporterModalComponent implements OnInit {
     if (this.view === 'form' && this.selectedImporter) {
       return this.selectedImporter.display_name || this.selectedImporter.name;
     }
-    return this.targetModelName ? 'Add Labels to Detector' : 'Import Labels';
+    return this.targetModelName ? `Import Labels into ${this.targetModelName}` : 'Import Labels';
   }
 
   /** Typed view of the selected importer's plugin fields for the template


### PR DESCRIPTION
## Summary

The same action was surfaced under three different names:

- **Models dashboard detector card** — "Add Labels" (aria-label + tooltip)
- **Right-panel button** — "Import Labels"
- **New Detector → Trained-tab form field** — "Label Importer"
- **Label-importer modal title** — "Import Labels" *or* "Add Labels to Detector", depending on caller

Unify on **Import Labels** (Title Case, matching existing siblings `Export Labels` / `Export Detector` / `Dashboard` / `Settings`). The modal keeps a context-aware variant when launched against a specific detector: **`Import Labels into <detectorname>`** (per user preference — strict "one name everywhere" would have dropped the detector context, which was deemed useful).

Files touched:

- `frontend/.../detector-card.component.html` — `Add Labels` → `Import Labels` (aria-label + tooltip)
- `frontend/.../new-detector-modal.component.html` — `Label Importer` → `Import Labels From` (form field label, with descriptive "From X" framing)
- `frontend/.../label-importer-modal.component.ts` — modal title is `Import Labels` standalone, `Import Labels into ${targetModelName}` when launched against a detector
- `docs/plans/ux-brainstorm.md` — §5.8 marked shipped with notes on the casing decision and contextual-variant carve-out

Internal symbols (`addLabelsModalOpen`, `onAddLabels`, `.add-labels-btn` CSS class, etc.) were intentionally left alone — out of scope for a user-facing-string fix.

## Test plan

- [x] `npm run build:prod` passes — clean build, no TypeScript errors, no budget warnings
- [ ] Open the Models dashboard, hover the labels button on a detector card — tooltip reads "Import Labels"
- [ ] Click the labels button on a detector card — modal title reads "Import Labels into &lt;detector name&gt;"
- [ ] Open the right-panel "Import Labels" button (label view, not Find) — modal title reads "Import Labels"
- [ ] Open New Detector → Trained tab — form field label reads "Import Labels From"

https://claude.ai/code/session_01NsvdVCawnPkZZhyqdEtVHw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsvdVCawnPkZZhyqdEtVHw)_