### PR TITLE
Widen panel-divider hit targets to 8px

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -228,8 +228,10 @@ The right panel shows "Good" and "Bad" as two stacked stacks. There's no drag-to
 ### 5.10 Crop modal optionality ★ S
 After picking an example media, a crop modal appears even if the user wants to use the full file. Add a clear "Use full file" button alongside "Crop and confirm", and skip the modal entirely for text and audio < 5s.
 
-### 5.11 Settings tab nesting ★ S
+### 5.11 Settings tab nesting ★ S ❌
 The Settings modal has tabs → sub-tabs (per media type) → twin columns (left/right panel). That's three levels of nesting in a modal. Flatten by adopting (§5.4)'s mirror toggle and grouping per-media settings under a single accordion per type.
+
+**Rejected:** Not pursuing. The current Settings layout stays as-is — tabs → media-type sub-tabs → twin Left/Right columns.
 
 ### 5.12 "Achievements" tab discoverability ★ XS
 Achievements live in Settings, where users go for *settings*, not gamification rewards. Either move to its own menu item or a small trophy icon in the header.

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -1,6 +1,6 @@
 .layout {
   display: grid;
-  grid-template-columns: var(--left-width, 300px) 4px 1fr 4px var(--right-width, 300px);
+  grid-template-columns: var(--left-width, 300px) 8px 1fr 8px var(--right-width, 300px);
   height: 100%;
   overflow: hidden;
 }
@@ -12,14 +12,27 @@
   min-width: 0;
 }
 
+// 8px hit target with a 4px visible line centered inside — same wider-hit-zone
+// pattern as `.col-resize-handle`, easier to grab than the visible line alone.
 .divider-left {
-  width: 4px;
+  width: 8px;
   cursor: col-resize;
-  background: var(--border);
-  transition: background 0.15s;
+  background: transparent;
+  position: relative;
 
-  &:hover,
-  &.dragging {
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 4px;
+    background: var(--border);
+    transition: background 0.15s;
+  }
+
+  &:hover::after,
+  &.dragging::after {
     background: var(--accent);
   }
 }
@@ -37,13 +50,24 @@
 }
 
 .divider-right {
-  width: 4px;
+  width: 8px;
   cursor: col-resize;
-  background: var(--border);
-  transition: background 0.15s;
+  background: transparent;
+  position: relative;
 
-  &:hover,
-  &.dragging {
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 4px;
+    background: var(--border);
+    transition: background 0.15s;
+  }
+
+  &:hover::after,
+  &.dragging::after {
     background: var(--accent);
   }
 }

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -46,7 +46,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly LEFT_MIN = 180;
   private readonly RIGHT_MIN = 150;
   private readonly CENTER_MIN = 100;
-  private readonly DIVIDER_TOTAL = 8; // 2 × 4px dividers
+  private readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
   private dragging = false;
   private draggingRight = false;

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -1,6 +1,6 @@
 .layout {
   display: grid;
-  grid-template-columns: var(--left-width, 300px) 4px 1fr 4px var(--right-width, 300px);
+  grid-template-columns: var(--left-width, 300px) 8px 1fr 8px var(--right-width, 300px);
   height: 100%;
   overflow: hidden;
 }
@@ -12,14 +12,27 @@
   min-width: 0;
 }
 
+// 8px hit target with a 4px visible line centered inside — same wider-hit-zone
+// pattern as `.col-resize-handle`, easier to grab than the visible line alone.
 .divider-left {
-  width: 4px;
+  width: 8px;
   cursor: col-resize;
-  background: var(--border);
-  transition: background 0.15s;
+  background: transparent;
+  position: relative;
 
-  &:hover,
-  &.dragging {
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 4px;
+    background: var(--border);
+    transition: background 0.15s;
+  }
+
+  &:hover::after,
+  &.dragging::after {
     background: var(--accent);
   }
 }
@@ -36,13 +49,24 @@
 }
 
 .divider-right {
-  width: 4px;
+  width: 8px;
   cursor: col-resize;
-  background: var(--border);
-  transition: background 0.15s;
+  background: transparent;
+  position: relative;
 
-  &:hover,
-  &.dragging {
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 4px;
+    background: var(--border);
+    transition: background 0.15s;
+  }
+
+  &:hover::after,
+  &.dragging::after {
     background: var(--accent);
   }
 }

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -75,7 +75,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly LEFT_MIN = 180;
   private readonly RIGHT_MIN = 150;
   private readonly CENTER_MIN = 100;
-  private readonly DIVIDER_TOTAL = 8; // 2 × 4px dividers
+  private readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private scoringProgressPoll$: Subscription | null = null;


### PR DESCRIPTION
## Summary

Addresses task **7.4 Resize-cursor on small drag handles** — the left/right panel dividers in `find-view` and `label-view` were 4px-wide grab zones, narrow enough to be fiddly to land on. Bumps them to **8px hit targets** while keeping the visible 4px line, following the wider-hit-zone / narrower-visual pattern already used by `.col-resize-handle`.

## What changed

- `find-view.component.scss` / `label-view.component.scss`: grid columns for dividers `4px` → `8px`; `.divider-left` / `.divider-right` are now 8px transparent elements with a centered 4px `::after` carrying the border-colored line (and accent-colored hover/dragging state). `cursor: col-resize` is preserved.
- `find-view.component.ts` / `label-view.component.ts`: `DIVIDER_TOTAL` constant (used for center-panel min-width clamping during drag) bumped from `8` → `16` to reflect 2 × 8px dividers.

## What was *not* changed

- **Column-resize handles** (`.col-resize-handle` in `_data-table.scss` and `_picker-shared.scss`): already use the same pattern — 12px transparent hit zone with a 2px visible `::after` line and `cursor: col-resize`. The "~2px" in the task description refers to their visible line, not their hit target. No change needed.
- **Image-region and crop-modal handles** (10–12px squares with directional cursors): different UX (resize a region/crop, not a panel) and already adequately sized. Out of scope.

## Test plan

- [x] `npm run build:prod` succeeds with no warnings or budget violations
- [ ] Manual: hover over the gap between left/right panels and the center panel — cursor flips to `col-resize` within an 8px zone (≈4px of "padding" around the visible line)
- [ ] Manual: drag works as before; center panel still respects `CENTER_MIN = 100px` thanks to the updated `DIVIDER_TOTAL`
- [ ] Manual: visual appearance of the divider line is unchanged (still 4px, border-colored, accent on hover)

---
_Generated by [Claude Code](https://claude.ai/code/session_01752qnxTru6mqRGsus19YNB)_