### PR TITLE
Standardize SSE progress event schemas (ux-brainstorm §6.9)

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -228,8 +228,10 @@ The right panel shows "Good" and "Bad" as two stacked stacks. There's no drag-to
 ### 5.10 Crop modal optionality ★ S
 After picking an example media, a crop modal appears even if the user wants to use the full file. Add a clear "Use full file" button alongside "Crop and confirm", and skip the modal entirely for text and audio < 5s.
 
-### 5.11 Settings tab nesting ★ S
+### 5.11 Settings tab nesting ★ S ❌
 The Settings modal has tabs → sub-tabs (per media type) → twin columns (left/right panel). That's three levels of nesting in a modal. Flatten by adopting (§5.4)'s mirror toggle and grouping per-media settings under a single accordion per type.
+
+**Rejected:** Not pursuing. The current Settings layout stays as-is — tabs → media-type sub-tabs → twin Left/Right columns.
 
 ### 5.12 "Achievements" tab discoverability ★ XS
 Achievements live in Settings, where users go for *settings*, not gamification rewards. Either move to its own menu item or a small trophy icon in the header.

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -276,8 +276,14 @@ Settings auto-save but show no "saved" feedback. Some forms (export modal) requi
 ### 6.8 Embedder display names ★★ XS
 The dropdown shows raw IDs (`siglip`, `dinov3_patch`, `e5`). Map each to a human label (`SigLIP (general images)`, `DINOv3 patch (region-aware)`, `E5 (text)`). Keep the raw ID as a secondary `<small>` line for power users.
 
-### 6.9 SSE channel/progress schemas ★ S
-Each long-running operation emits a slightly different progress payload (`step`/`total_steps` for dataset, `current`/`total` for eval, plain status strings for sort). Standardize on a single `ProgressEvent` interface so the frontend can render any of them with the same component.
+### 6.9 SSE channel/progress schemas ★ S — SHIPPED
+Each long-running operation used to emit a slightly different progress payload (`step`/`total_steps` for dataset, `current`/`total` for eval, plain status strings for sort). ~~Standardize on a single `ProgressEvent` interface so the frontend can render any of them with the same component.~~ Shipped:
+
+- **Backend** (`vtsearch/concurrency/progress.py`): every singleton `ProgressTracker` (dataset, sort, eval, find) and every per-task tracker created by `LoadingTasksTracker` now exposes the same `_PROGRESS_COMMON_EXTRAS = {"step": None, "total_steps": None, "error": None}` on top of the four base fields. `dataset_progress` additionally carries `staging_result` (used only by combine-datasets staging). `update_sort_progress` and `update_eval_progress` accept the new extras as optional kwargs, with the merge semantics shared through a single `_common_extras_kwargs` helper.
+- **Frontend** (`frontend/src/app/models/api.models.ts`): replaced `DatasetProgress` and the untyped `SortProgressResponse` with a single `ProgressEvent` interface. `LoadingTask extends ProgressEvent` and re-narrows the base fields as required. `ProgressEventsService` now types every channel subject as `BehaviorSubject<ProgressEvent>` (or `LoadingTask[]`); the `find$` and `eval$` channels are no longer `Record<string, unknown>`.
+- **Frontend** (`frontend/src/app/utils/format-progress.ts`): added `formatProgressMessage(progress, defaultMessage)` and `isProgressIndeterminate(progress)` — the single source of truth for the `[Step S/T] (C/T) message` layout that previously lived inline in `dashboard.component.ts` (×2), `dataset-card.component.ts`, `detector-card.component.html`, `find-view.component.ts`, and `label-view.component.ts`. All six call sites were converted.
+
+Wire-format note: no breaking change for current callers — the new sort/eval `step`/`total_steps`/`error` keys default to `null` and just become available for future multi-step phases.
 
 ### 6.10 Date formatting ★ XS — SHIPPED
 "last_trained / created" columns format dates differently from the version string in the footer. ~~Use one formatter (relative for < 7d ago, absolute YYYY-MM-DD otherwise) everywhere.~~ Shipped: a single `frontend/src/app/utils/format-date.ts` is now called from all four sites (detector card, dataset card, dataset stats modal, settings-modal version footer). Always-absolute — no relative branch. Columns render `YYYY-MM-DD HH:MM` (local), version renders `YYYY-MM-DD` (UTC). Relative time was dropped deliberately: it drifts on every reload and the coarse buckets (`2w ago`) throw away precision that matters in a model-management dashboard.

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -15,8 +15,8 @@ import { AuthService } from '../../services/auth.service';
 import { TopBarStateService } from '../../services/top-bar-state.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { AchievementsService } from '../../services/achievements.service';
-import { AutoDetectResultsData, DatasetRegistryEntry, DemoDataset, LoadingTask, DetectorRegistryEntry, ImporterInfo } from '../../models/api.models';
-import { formatProgressFraction } from '../../utils/format-progress';
+import { AutoDetectResultsData, DatasetRegistryEntry, DemoDataset, LoadingTask, DetectorRegistryEntry, ImporterInfo, ProgressEvent } from '../../models/api.models';
+import { formatProgressMessage, isProgressIndeterminate } from '../../utils/format-progress';
 import {
   DashboardColumnsService,
   DatasetColumn,
@@ -1294,31 +1294,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.progressEvents.find$
       .pipe(takeUntil(this.findPolling$), takeUntil(this.destroy$))
       .subscribe({
-        next: (progress: any) => {
+        next: (progress: ProgressEvent) => {
           if (!progress || progress.status === 'idle') return;
 
-          if (progress.current != null && progress.total != null && progress.total > 0) {
+          if (!isProgressIndeterminate(progress)) {
             this.progressIndeterminate = false;
-            this.progressValue = progress.current;
-            this.progressTotal = progress.total;
+            this.progressValue = progress.current ?? 0;
+            this.progressTotal = progress.total ?? 0;
           } else {
             this.progressIndeterminate = true;
           }
 
-          let msg = progress.message || 'Running Find...';
-          if (progress.step != null && progress.total_steps != null && progress.total_steps > 1) {
-            msg = `[Step ${progress.step}/${progress.total_steps}] ${msg}`;
-          }
-          if (progress.current != null && progress.total != null && progress.total > 0) {
-            const fraction = `(${formatProgressFraction(progress.current, progress.total)})`;
-            const stepEnd = msg.indexOf('] ');
-            if (stepEnd !== -1) {
-              msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
-            } else {
-              msg = fraction + ' ' + msg;
-            }
-          }
-          this.datasetState.setProgressMessage(msg);
+          this.datasetState.setProgressMessage(
+            formatProgressMessage(progress, 'Running Find...'),
+          );
         },
       });
   }
@@ -1408,23 +1397,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   // --- Loading task helpers ---
 
   taskProgressMessage(task: LoadingTask): string {
-    let msg = task.message || 'Loading...';
-    if (task.step != null && task.total_steps != null && task.total_steps > 1) {
-      msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
-    }
-    if (task.current != null && task.total != null && task.total > 0) {
-      const fraction = `(${formatProgressFraction(task.current, task.total)})`;
-      const stepEnd = msg.indexOf('] ');
-      if (stepEnd !== -1) {
-        msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
-      } else {
-        msg = fraction + ' ' + msg;
-      }
-    }
-    return msg;
+    return formatProgressMessage(task, 'Loading...');
   }
 
   taskIsIndeterminate(task: LoadingTask): boolean {
-    return !(task.current != null && task.total != null && task.total > 0);
+    return isProgressIndeterminate(task);
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
-import { formatProgressFraction } from '../../../utils/format-progress';
+import { formatProgressMessage, isProgressIndeterminate } from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
 
 @Component({
@@ -148,25 +148,13 @@ export class DatasetCardComponent implements OnChanges {
   get taskProgressMessage(): string {
     const task = this.loadingTask;
     if (!task) return '';
-    let msg = task.message || 'Loading...';
-    if (task.step != null && task.total_steps != null && task.total_steps > 1) {
-      msg = `[Step ${task.step}/${task.total_steps}] ${msg}`;
-    }
-    if (task.current != null && task.total != null && task.total > 0) {
-      const fraction = `(${formatProgressFraction(task.current, task.total)})`;
-      const stepEnd = msg.indexOf('] ');
-      if (stepEnd !== -1) {
-        msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
-      } else {
-        msg = fraction + ' ' + msg;
-      }
-    }
-    return msg;
+    return formatProgressMessage(task, 'Loading...');
   }
 
   get taskIsIndeterminate(): boolean {
     const task = this.loadingTask;
-    return !(task && task.current != null && task.total != null && task.total > 0);
+    if (!task) return true;
+    return isProgressIndeterminate(task);
   }
 
   onCancelTask(event: MouseEvent): void {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -33,15 +33,7 @@
 @if (loadingTask && !loadingTask.error) {
   <td [attr.colspan]="columnOrder.length + 1">
     <div class="loading-task-progress">
-      <span class="progress-msg">
-        @if (loadingTask.step && loadingTask.total_steps) {
-          [Step {{ loadingTask.step }}/{{ loadingTask.total_steps }}]
-        }
-        {{ loadingTask.message }}
-        @if (loadingTask.current && loadingTask.total) {
-          ({{ formatFraction(loadingTask.current, loadingTask.total) }})
-        }
-      </span>
+      <span class="progress-msg">{{ taskProgressMessage }}</span>
       <vt-progress-bar
         [value]="loadingTask.current"
         [max]="loadingTask.total"

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
-import { formatProgressFraction } from '../../../utils/format-progress';
+import { formatProgressMessage, isProgressIndeterminate } from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
 
 @Component({
@@ -168,10 +168,11 @@ export class DetectorCardComponent implements OnChanges {
 
   taskIsIndeterminate(): boolean {
     const t = this.loadingTask;
-    return !(t && t.current != null && t.total != null && t.total > 0);
+    if (!t) return true;
+    return isProgressIndeterminate(t);
   }
 
-  formatFraction(current: number, total: number): string {
-    return formatProgressFraction(current, total);
+  get taskProgressMessage(): string {
+    return this.loadingTask ? formatProgressMessage(this.loadingTask, 'Loading...') : '';
   }
 }

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -15,6 +15,8 @@ import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ProgressEventsService } from '../../services/progress-events.service';
+import { ProgressEvent } from '../../models/api.models';
+import { formatProgressMessage } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
@@ -151,13 +153,10 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.stopProgressPolling();
     this.progressPollSub = this.progressEvents.find$
       .pipe(takeUntil(this.destroy$))
-      .subscribe((prog: any) => {
+      .subscribe((prog: ProgressEvent) => {
         if (prog.status === 'running') {
-          const msg = prog.message || 'Scoring with detector…';
-          const current = prog.current || 0;
-          const total = prog.total || 0;
-          this.sortState.setSortStatus(msg);
-          this.sortState.setSortProgress(current, total);
+          this.sortState.setSortStatus(formatProgressMessage(prog, 'Scoring with detector…'));
+          this.sortState.setSortProgress(prog.current ?? 0, prog.total ?? 0);
         }
       });
   }

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -17,11 +17,12 @@ import { SettingsStateService } from '../../services/settings-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { ProgressEventsService } from '../../services/progress-events.service';
-import { DetectorRegistryEntry } from '../../models/api.models';
+import { DetectorRegistryEntry, ProgressEvent } from '../../models/api.models';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
 import { LabelingStatusResponse } from '../../models/api.models';
 import type { LearnedSortResponse } from '../../generated/api-client/models/learned-sort-response';
+import { formatProgressMessage } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 
 @Component({
@@ -528,13 +529,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.stopScoringProgressPoll();
     this.scoringProgressPoll$ = this.progressEvents.find$
       .pipe(takeUntil(this.destroy$))
-      .subscribe((prog: any) => {
+      .subscribe((prog: ProgressEvent) => {
         if (prog.status === 'running') {
-          const msg = prog.message || 'Scoring with detector…';
-          const current = prog.current || 0;
-          const total = prog.total || 0;
-          this.sortState.setSortStatus(msg);
-          this.sortState.setSortProgress(current, total);
+          this.sortState.setSortStatus(formatProgressMessage(prog, 'Scoring with detector…'));
+          this.sortState.setSortProgress(prog.current ?? 0, prog.total ?? 0);
         }
       });
   }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -55,33 +55,51 @@ export interface LabelingStatusResponse {
   [key: string]: unknown;
 }
 
-export interface SortProgressResponse {
+// --- Progress ---
+
+/**
+ * The unified shape every long-running operation emits over the SSE stream
+ * (`/api/events` — see `progress-events.service.ts`).
+ *
+ * Backend: every singleton `ProgressTracker` (dataset, sort, eval, find) and
+ * every per-task tracker created by `LoadingTasksTracker` carries the same
+ * base fields plus the shared optional extras `step`/`total_steps`/`error`.
+ * See `vtsearch/concurrency/progress.py:_PROGRESS_COMMON_EXTRAS`.
+ *
+ * Frontend: a single component/helper (`utils/format-progress.ts`) can render
+ * any payload regardless of which operation produced it.
+ */
+export interface ProgressEvent {
+  status?: string;
+  message?: string;
+  current?: number;
+  total?: number;
+  /** Sub-step counter for multi-phase operations (e.g. load→embed→stage). */
+  step?: number | null;
+  total_steps?: number | null;
+  /** Error message if the operation failed. */
+  error?: string | null;
+  /** Dataset-only: payload returned by combine-datasets staging. */
+  staging_result?: unknown;
   [key: string]: unknown;
 }
 
 // --- Datasets ---
 
-export interface DatasetProgress {
-  status?: string;
-  message?: string;
-  current?: number;
-  total?: number;
-  step?: number;
-  total_steps?: number;
-  error?: string;
-  [key: string]: unknown;
-}
-
-export interface LoadingTask {
-  task_id: string;
-  name: string;
+/**
+ * A per-task progress event from the `loading-tasks` /
+ * `detector-loading-tasks` SSE channels. Wraps `ProgressEvent` with the
+ * task identity/metadata fields the dashboard needs to render one row per
+ * concurrent load. The base fields are non-optional here because every task
+ * tracker writes them through `ProgressTracker.update`.
+ */
+export interface LoadingTask extends ProgressEvent {
   status: string;
   message: string;
   current: number;
   total: number;
-  step?: number;
-  total_steps?: number;
-  error?: string;
+  task_id: string;
+  name: string;
   created_at: number;
   dataset_id?: string;
   detector_id?: string;

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, OnDestroy, NgZone } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import {
-  DatasetProgress,
   LoadingTask,
-  SortProgressResponse,
+  ProgressEvent,
   VotingIterationsResponse,
 } from '../models/api.models';
 
@@ -13,25 +12,27 @@ import {
  * /api/dataset/progress, etc.) with a server-push stream — see
  * `docs/plans/feature-brainstorm.md` §12.5.
  *
+ * Every channel carries the same `ProgressEvent` shape (see
+ * `models/api.models.ts`) so any consumer can render any of them with the
+ * shared `formatProgressMessage` helper in `utils/format-progress.ts`.
+ *
  * Channels carried over `/api/events`:
  *
- *  - `dataset` -> DatasetProgress (singleton tracker; staging operations)
- *  - `loading-tasks` -> LoadingTask[]
+ *  - `dataset` -> ProgressEvent (singleton tracker; staging operations)
+ *  - `loading-tasks` -> LoadingTask[] (per-task progress for dataset loads)
  *  - `detector-loading-tasks` -> LoadingTask[]
- *  - `sort` -> SortProgressResponse
- *  - `find` -> generic progress dict (used by /api/find)
- *  - `eval` -> singleton tracker dict (raw fields, not the
- *    {progress,total,done} shape the old `/api/eval/voting-iterations`
- *    endpoint returned — consumers derive `done` themselves)
+ *  - `sort` -> ProgressEvent (text-sort)
+ *  - `find` -> ProgressEvent (multi-dataset×detector /api/find)
+ *  - `eval` -> ProgressEvent (train-and-score; consumers derive `done` themselves)
  */
 @Injectable({ providedIn: 'root' })
 export class ProgressEventsService implements OnDestroy {
-  private readonly datasetSubject = new BehaviorSubject<DatasetProgress>({});
+  private readonly datasetSubject = new BehaviorSubject<ProgressEvent>({});
   private readonly loadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
   private readonly detectorLoadingTasksSubject = new BehaviorSubject<LoadingTask[]>([]);
-  private readonly sortSubject = new BehaviorSubject<SortProgressResponse>({});
-  private readonly findSubject = new BehaviorSubject<Record<string, unknown>>({});
-  private readonly evalSubject = new BehaviorSubject<Record<string, unknown>>({});
+  private readonly sortSubject = new BehaviorSubject<ProgressEvent>({});
+  private readonly findSubject = new BehaviorSubject<ProgressEvent>({});
+  private readonly evalSubject = new BehaviorSubject<ProgressEvent>({});
 
   readonly dataset$ = this.datasetSubject.asObservable();
   readonly loadingTasks$ = this.loadingTasksSubject.asObservable();
@@ -65,16 +66,16 @@ export class ProgressEventsService implements OnDestroy {
     return this.detectorLoadingTasksSubject.value;
   }
 
-  get find(): Record<string, unknown> {
+  get find(): ProgressEvent {
     return this.findSubject.value;
   }
 
   /** Derive the {progress,total,done} shape the eval modal cares about. */
   get votingIterations(): VotingIterationsResponse {
     const prog = this.evalSubject.value;
-    const current = Number(prog['current'] ?? 0);
-    const total = Number(prog['total'] ?? 0);
-    const status = String(prog['status'] ?? 'idle');
+    const current = Number(prog.current ?? 0);
+    const total = Number(prog.total ?? 0);
+    const status = String(prog.status ?? 'idle');
     const done = status === 'idle' && total > 0 && current >= total;
     return { progress: current, total, done };
   }
@@ -97,7 +98,7 @@ export class ProgressEventsService implements OnDestroy {
     this.source = es;
 
     es.addEventListener('dataset', (e) =>
-      this.zone.run(() => this.datasetSubject.next(this.parse<DatasetProgress>(e, {}))),
+      this.zone.run(() => this.datasetSubject.next(this.parse<ProgressEvent>(e, {}))),
     );
     es.addEventListener('loading-tasks', (e) =>
       this.zone.run(() => this.loadingTasksSubject.next(this.parse<LoadingTask[]>(e, []))),
@@ -106,13 +107,13 @@ export class ProgressEventsService implements OnDestroy {
       this.zone.run(() => this.detectorLoadingTasksSubject.next(this.parse<LoadingTask[]>(e, []))),
     );
     es.addEventListener('sort', (e) =>
-      this.zone.run(() => this.sortSubject.next(this.parse<SortProgressResponse>(e, {}))),
+      this.zone.run(() => this.sortSubject.next(this.parse<ProgressEvent>(e, {}))),
     );
     es.addEventListener('find', (e) =>
-      this.zone.run(() => this.findSubject.next(this.parse<Record<string, unknown>>(e, {}))),
+      this.zone.run(() => this.findSubject.next(this.parse<ProgressEvent>(e, {}))),
     );
     es.addEventListener('eval', (e) =>
-      this.zone.run(() => this.evalSubject.next(this.parse<Record<string, unknown>>(e, {}))),
+      this.zone.run(() => this.evalSubject.next(this.parse<ProgressEvent>(e, {}))),
     );
 
     es.onerror = () => {

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -1,3 +1,5 @@
+import { ProgressEvent } from '../models/api.models';
+
 /**
  * Format a current/total progress fraction for display.
  *
@@ -16,4 +18,50 @@ export function formatProgressFraction(current: number, total: number): string {
     return `${Math.round(current / MB)}/${Math.round(total / MB)}MB`;
   }
   return `${current.toLocaleString()}/${total.toLocaleString()}`;
+}
+
+/**
+ * Format a `ProgressEvent` into the canonical
+ * ``[Step S/T] (C/T) message`` string used by every progress consumer.
+ *
+ * Each piece is optional:
+ *   - The ``[Step S/T]`` prefix appears only when ``total_steps > 1``.
+ *   - The ``(C/T)`` fraction appears only when ``total > 0``.
+ *   - When neither is present, returns the bare ``message`` (or
+ *     ``defaultMessage`` if ``message`` is empty).
+ */
+export function formatProgressMessage(
+  progress: ProgressEvent | null | undefined,
+  defaultMessage = '',
+): string {
+  const prog = progress ?? {};
+  let msg = prog.message || defaultMessage;
+  const step = prog.step;
+  const totalSteps = prog.total_steps;
+  if (step != null && totalSteps != null && totalSteps > 1) {
+    msg = `[Step ${step}/${totalSteps}] ${msg}`;
+  }
+  const current = prog.current;
+  const total = prog.total;
+  if (current != null && total != null && total > 0) {
+    const fraction = `(${formatProgressFraction(current, total)})`;
+    const stepEnd = msg.indexOf('] ');
+    if (stepEnd !== -1) {
+      msg = msg.slice(0, stepEnd + 2) + fraction + ' ' + msg.slice(stepEnd + 2);
+    } else {
+      msg = msg ? `${fraction} ${msg}` : fraction;
+    }
+  }
+  return msg;
+}
+
+/**
+ * Return ``true`` when a progress event has no known total — i.e. callers
+ * should show an indeterminate spinner rather than a percent bar.
+ */
+export function isProgressIndeterminate(
+  progress: ProgressEvent | null | undefined,
+): boolean {
+  const prog = progress ?? {};
+  return !(prog.current != null && prog.total != null && prog.total > 0);
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,8 +242,8 @@ def reset_state():
 
     _dataset_progress.reset_cancel()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
-    _sort_progress.update("idle", "", 0, 0)
-    _eval_progress.update("idle", "", 0, 0)
+    _sort_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
+    _eval_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _loading_tasks.reset_for_tests()
     _model_loading_tasks.reset_for_tests()
 

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -174,6 +174,18 @@ def clear_thread_progress() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shared progress extras
+# ---------------------------------------------------------------------------
+#: Extras shared by every long-running operation: an optional sub-step counter
+#: (``step``/``total_steps`` — used when a single operation has multiple phases
+#: like load→embed→stage) and an ``error`` string. Every singleton tracker —
+#: and every per-task tracker created by :class:`LoadingTasksTracker` — exposes
+#: these so the frontend can render any progress payload with the same
+#: ``ProgressEvent`` interface (see ``frontend/src/app/models/api.models.ts``).
+_PROGRESS_COMMON_EXTRAS: dict[str, Any] = {"step": None, "total_steps": None, "error": None}
+
+
+# ---------------------------------------------------------------------------
 # Loading tasks tracker — manages multiple concurrent loading operations
 # ---------------------------------------------------------------------------
 
@@ -232,7 +244,7 @@ class LoadingTasksTracker:
 
         Returns the per-task :class:`ProgressTracker` instance.
         """
-        tracker = ProgressTracker(extra_fields={"error": None, "step": None, "total_steps": None})
+        tracker = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
         tracker.subscribe(lambda _snapshot: self._notify())
         with self._lock:
             self._tasks[task_id] = {
@@ -376,23 +388,45 @@ detector_loading_tasks = LoadingTasksTracker()
 # ---------------------------------------------------------------------------
 
 #: Dataset / import progress (used by dataset loading, downloading, embedding).
+#: Adds ``staging_result`` on top of the common extras for the combine-datasets
+#: staging flow.
 dataset_progress = ProgressTracker(
-    extra_fields={"error": None, "staging_result": None, "step": None, "total_steps": None}
+    extra_fields={**_PROGRESS_COMMON_EXTRAS, "staging_result": None}
 )
 
 #: Sort-specific progress (used by text-sort operations).
-sort_progress = ProgressTracker()
+sort_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
 
 #: Eval progress (used by train-and-score / voting-iterations analysis).
-eval_progress = ProgressTracker()
+eval_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
 
 #: Find progress (used by the /api/find multi-dataset×model scoring operation).
-find_progress = ProgressTracker(extra_fields={"step": None, "total_steps": None, "error": None})
+find_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
 
 
 # ---------------------------------------------------------------------------
 # Backward-compatible free-function API
 # ---------------------------------------------------------------------------
+
+
+def _common_extras_kwargs(
+    step: Any = _UNSET,
+    total_steps: Any = _UNSET,
+    error: Any = _UNSET,
+) -> dict[str, Any]:
+    """Build the kwargs dict for the shared ``step``/``total_steps``/``error`` extras.
+
+    Only fields explicitly supplied by the caller are forwarded so omitted
+    fields are left unchanged (true update/merge semantics).
+    """
+    kwargs: dict[str, Any] = {}
+    if step is not _UNSET:
+        kwargs["step"] = step
+    if total_steps is not _UNSET:
+        kwargs["total_steps"] = total_steps
+    if error is not _UNSET:
+        kwargs["error"] = error
+    return kwargs
 
 
 def update_progress(
@@ -414,15 +448,9 @@ def update_progress(
     Only extra fields explicitly supplied by the caller are forwarded;
     omitted fields are left unchanged (true update/merge semantics).
     """
-    kwargs: dict[str, Any] = {}
-    if error is not _UNSET:
-        kwargs["error"] = error
+    kwargs = _common_extras_kwargs(step, total_steps, error)
     if staging_result is not _UNSET:
         kwargs["staging_result"] = staging_result
-    if step is not _UNSET:
-        kwargs["step"] = step
-    if total_steps is not _UNSET:
-        kwargs["total_steps"] = total_steps
     dataset_progress.update(status, message, current, total, **kwargs)
 
 
@@ -463,9 +491,14 @@ def update_sort_progress(
     message: str = "",
     current: int = 0,
     total: int = 0,
+    step: Any = _UNSET,
+    total_steps: Any = _UNSET,
+    error: Any = _UNSET,
 ) -> None:
     """Update the sort progress tracker in a thread-safe manner."""
-    sort_progress.update(status, message, current, total)
+    sort_progress.update(
+        status, message, current, total, **_common_extras_kwargs(step, total_steps, error)
+    )
 
 
 def get_sort_progress() -> dict[str, Any]:
@@ -478,9 +511,14 @@ def update_eval_progress(
     message: str = "",
     current: int = 0,
     total: int = 0,
+    step: Any = _UNSET,
+    total_steps: Any = _UNSET,
+    error: Any = _UNSET,
 ) -> None:
     """Update the eval progress tracker in a thread-safe manner."""
-    eval_progress.update(status, message, current, total)
+    eval_progress.update(
+        status, message, current, total, **_common_extras_kwargs(step, total_steps, error)
+    )
 
 
 def get_eval_progress() -> dict[str, Any]:
@@ -498,14 +536,9 @@ def update_find_progress(
     error: Any = _UNSET,
 ) -> None:
     """Update the find progress tracker in a thread-safe manner."""
-    kwargs: dict[str, Any] = {}
-    if step is not _UNSET:
-        kwargs["step"] = step
-    if total_steps is not _UNSET:
-        kwargs["total_steps"] = total_steps
-    if error is not _UNSET:
-        kwargs["error"] = error
-    find_progress.update(status, message, current, total, **kwargs)
+    find_progress.update(
+        status, message, current, total, **_common_extras_kwargs(step, total_steps, error)
+    )
 
 
 def get_find_progress() -> dict[str, Any]:

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -390,9 +390,7 @@ detector_loading_tasks = LoadingTasksTracker()
 #: Dataset / import progress (used by dataset loading, downloading, embedding).
 #: Adds ``staging_result`` on top of the common extras for the combine-datasets
 #: staging flow.
-dataset_progress = ProgressTracker(
-    extra_fields={**_PROGRESS_COMMON_EXTRAS, "staging_result": None}
-)
+dataset_progress = ProgressTracker(extra_fields={**_PROGRESS_COMMON_EXTRAS, "staging_result": None})
 
 #: Sort-specific progress (used by text-sort operations).
 sort_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
@@ -496,9 +494,7 @@ def update_sort_progress(
     error: Any = _UNSET,
 ) -> None:
     """Update the sort progress tracker in a thread-safe manner."""
-    sort_progress.update(
-        status, message, current, total, **_common_extras_kwargs(step, total_steps, error)
-    )
+    sort_progress.update(status, message, current, total, **_common_extras_kwargs(step, total_steps, error))
 
 
 def get_sort_progress() -> dict[str, Any]:
@@ -516,9 +512,7 @@ def update_eval_progress(
     error: Any = _UNSET,
 ) -> None:
     """Update the eval progress tracker in a thread-safe manner."""
-    eval_progress.update(
-        status, message, current, total, **_common_extras_kwargs(step, total_steps, error)
-    )
+    eval_progress.update(status, message, current, total, **_common_extras_kwargs(step, total_steps, error))
 
 
 def get_eval_progress() -> dict[str, Any]:
@@ -536,9 +530,7 @@ def update_find_progress(
     error: Any = _UNSET,
 ) -> None:
     """Update the find progress tracker in a thread-safe manner."""
-    find_progress.update(
-        status, message, current, total, **_common_extras_kwargs(step, total_steps, error)
-    )
+    find_progress.update(status, message, current, total, **_common_extras_kwargs(step, total_steps, error))
 
 
 def get_find_progress() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Closes `docs/plans/ux-brainstorm.md` §6.9. Every long-running operation now reports progress through the same `ProgressEvent` shape so a single TS interface — and a single formatter — can render dataset loads, sort, eval, and find with identical UI.

### Backend (`vtsearch/concurrency/progress.py`)

- Introduced `_PROGRESS_COMMON_EXTRAS = {"step": None, "total_steps": None, "error": None}` and applied it to every singleton tracker (`dataset_progress`, `sort_progress`, `eval_progress`, `find_progress`) plus every per-task tracker created by `LoadingTasksTracker`. `dataset_progress` additionally keeps `staging_result` (used only by combine-datasets staging).
- `update_sort_progress` and `update_eval_progress` now accept the same optional `step`/`total_steps`/`error` kwargs as `update_progress` / `update_find_progress`, with the merge semantics extracted into a shared `_common_extras_kwargs` helper. No current caller breaks — the new keys default to `null`.

### Frontend types & service

- Replaced `DatasetProgress` and the untyped `SortProgressResponse` with a single `ProgressEvent` interface (`frontend/src/app/models/api.models.ts`).
- `LoadingTask extends ProgressEvent` and re-narrows the base fields as required (per-task trackers always set them).
- `ProgressEventsService` retypes every channel: `dataset$`/`sort$`/`find$`/`eval$` are now `Observable<ProgressEvent>` instead of `Record<string, unknown>` catch-alls. The SSE-channel doc comment is updated to reflect the unified shape.

### Shared formatter

- Added `formatProgressMessage(progress, default)` and `isProgressIndeterminate(progress)` in `frontend/src/app/utils/format-progress.ts` — the single source of truth for the `[Step S/T] (C/T) message` layout.
- Converted **six** previously-inline copies of that logic:
  - `dashboard.component.ts` — `startFindProgressPolling` and `taskProgressMessage`
  - `dataset-card.component.ts` — `taskProgressMessage` getter
  - `detector-card.component.html` + `.ts` — was building the message in the template
  - `find-view.component.ts` — `startProgressPolling`
  - `label-view.component.ts` — `startScoringProgressPoll`

### Plan doc

`docs/plans/ux-brainstorm.md` §6.9 marked SHIPPED with a summary of what landed and the wire-format note (no breaking change).

## Backwards compatibility

No wire-format breaking change for current callers. The new `step`/`total_steps`/`error` keys default to `null` on the sort and eval channels and just become available for future multi-step phases there.

## Test plan
- [x] `./run-tests.sh` — full backend suite (3627 passed, 1 skipped, 2 xpassed)
- [x] `cd frontend && npm run build:prod` — Angular production build clean, no warnings/errors
- [x] `ruff check .`, `ruff format --check .`, `codespell`, `deptry` — all green (run as part of `./run-tests.sh`)
- [ ] Manual smoke: trigger a dataset load, a find, a text sort, and the eval modal — verify each progress bar still updates correctly

https://claude.ai/code/session_01MkmJTwe3sAfbG1gLH8Uj1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkmJTwe3sAfbG1gLH8Uj1R)_