### PR TITLE
Add visible drop zones for file/example imports (§7.6)

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -323,8 +323,12 @@ Panel dividers and column-resize handles are ~2px wide. Make them 8px hit target
 ### 7.5 Folder-tree breadcrumb browser ★ M
 The server-folder browser has a custom breadcrumb + table UI. It's functional but every modern OS has standardized on the same "left sidebar with starred/recent locations, breadcrumb on top, list in middle, double-click to enter, Enter key to confirm". Bring ours closer to that.
 
-### 7.6 Drag-and-drop affordances ★ S
+### 7.6 Drag-and-drop affordances ★ S — SHIPPED
 Several places accept drag-drop (file import, example media into detector) but show no drop zone until the drag is over the page. Add visible dashed drop zones with `"Drop a folder here to import"` text.
+
+**What shipped:** New reusable `vt-drop-zone` component (`frontend/src/app/components/drop-zone/`) renders a dashed-bordered, clickable target that doubles as a drag-drop receiver. It handles folder drops by walking `webkitGetAsEntry()` recursively and synthesising `webkitRelativePath` on each File so the existing upload code sees the same shape as a `<input type=file webkitdirectory>` selection. Wired into three places: (1) the dataset importer modal's Local Folder / Local Files views (`"Drop a folder here to import"` / `"Drop files here to import"`); (2) the new-detector modal's media-picker Local Folder / Local Files views (`"Drop a folder here to use as example"` / `"Drop a media file here to use as example"`); (3) the new-detector main form (tab=blank), where it replaces the inline "Upload File…" button alongside the existing "Browse Media…" button. The previous bare `<input type=file>` widgets in those locations were removed.
+
+**Open follow-ups:** The examples-editor modal (Edit Examples → + Add Good / + Add Bad) still uses small button-driven file inputs. Adding compact drop zones there is straightforward — the same `vt-drop-zone` component can drop in next to or in place of the `+ Add Good` / `+ Add Bad` buttons — but was descoped from this pass at the user's request.
 
 ### 7.7 Modal stacking ★★ XS
 Some flows can stack 3 modals deep (importer → demo picker → embedder picker). Stacking modals is a known anti-pattern. Either convert nested modals to in-place sub-views with a back button (§6.4), or use a single multi-step wizard.

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -228,8 +228,10 @@ The right panel shows "Good" and "Bad" as two stacked stacks. There's no drag-to
 ### 5.10 Crop modal optionality ★ S
 After picking an example media, a crop modal appears even if the user wants to use the full file. Add a clear "Use full file" button alongside "Crop and confirm", and skip the modal entirely for text and audio < 5s.
 
-### 5.11 Settings tab nesting ★ S
+### 5.11 Settings tab nesting ★ S ❌
 The Settings modal has tabs → sub-tabs (per media type) → twin columns (left/right panel). That's three levels of nesting in a modal. Flatten by adopting (§5.4)'s mirror toggle and grouping per-media settings under a single accordion per type.
+
+**Rejected:** Not pursuing. The current Settings layout stays as-is — tabs → media-type sub-tabs → twin Left/Right columns.
 
 ### 5.12 "Achievements" tab discoverability ★ XS
 Achievements live in Settings, where users go for *settings*, not gamification rewards. Either move to its own menu item or a small trophy icon in the header.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -521,25 +521,22 @@
 
       <div class="form-group form-group--section">
         @if (lfPickerKind === 'folder') {
-          <label class="form-label" for="lf-folder-input" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
-          <input
-            id="lf-folder-input"
-            type="file"
-            class="form-input"
-            webkitdirectory
-            directory
-            multiple
-            (change)="lfOnFolderSelected($event)"
-          />
+          <label class="form-label" title="Choose a folder on your local machine. All files inside (including subdirectories) will be uploaded.">Folder<span class="required">*</span></label>
+          <vt-drop-zone
+            label="Drop a folder here to import"
+            sublabel="or click to browse"
+            [directory]="true"
+            [multiple]="true"
+            (filesSelected)="lfOnFilesDropped($event)"
+          ></vt-drop-zone>
         } @else {
-          <label class="form-label" for="lf-files-input" title="Choose one or more files on your local machine. Each selected file will be uploaded.">Files<span class="required">*</span></label>
-          <input
-            id="lf-files-input"
-            type="file"
-            class="form-input"
-            multiple
-            (change)="lfOnFolderSelected($event)"
-          />
+          <label class="form-label" title="Choose one or more files on your local machine. Each selected file will be uploaded.">Files<span class="required">*</span></label>
+          <vt-drop-zone
+            label="Drop files here to import"
+            sublabel="or click to browse"
+            [multiple]="true"
+            (filesSelected)="lfOnFilesDropped($event)"
+          ></vt-drop-zone>
         }
         @if (lfFiles.length > 0) {
           <p class="info-text">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -5,6 +5,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
+import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { ImporterInfo, ImporterField, ImporterPickerTab, DemoDataset, MediaTypeInfo, MediaTypeDetectionResponse, ClipperInfo, ClipperParameter, EmbedderInfo, ConverterInfo, SourceSpec } from '../../../models/api.models';
@@ -13,7 +14,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent, ClipperChooserComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent, ClipperChooserComponent, DropZoneComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -911,14 +912,17 @@ export class DatasetImporterModalComponent implements OnInit {
     this.lfResetSourceSpecs();
   }
 
-  lfOnFolderSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    if (!input.files) {
+  lfOnFilesDropped(files: File[]): void {
+    this.lfAcceptFiles(files);
+  }
+
+  private lfAcceptFiles(files: File[]): void {
+    if (files.length === 0) {
       this.lfFiles = [];
       this.lfDetection = null;
       return;
     }
-    this.lfFiles = Array.from(input.files);
+    this.lfFiles = files;
     this.lfError = '';
     if (!this.lfDatasetNameDirty) {
       this.lfDatasetName = this.lfDerivedDatasetName();

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -111,13 +111,12 @@
             <div class="example-col">
               <label class="col-label">Media Example</label>
               <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" [disabled]="hasPendingText" title="Browse demos, server folders, or upload a file to pick an example">Browse Media...</button>
-              <input
-                #fileInput
-                type="file"
-                class="hidden-file-input"
-                (change)="onLocalFileSelected($event)"
-              />
-              <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()" [disabled]="hasPendingText" title="Upload a media file from your computer">Upload File...</button>
+              <vt-drop-zone
+                label="Drop a media file here"
+                sublabel="or click to upload from this computer"
+                [disabled]="hasPendingText"
+                (filesSelected)="onLocalFileDropped($event)"
+              ></vt-drop-zone>
             </div>
           </div>
         }
@@ -524,26 +523,23 @@
             and used as the example for this detector.
           </p>
           @if (activePickerView === 'local_folder') {
-            <input
-              id="nmm-local-folder-input"
-              type="file"
-              class="form-input"
-              webkitdirectory
-              directory
-              multiple
-              (change)="onLocalFileSelected($event)"
-            />
+            <vt-drop-zone
+              label="Drop a folder here to use as example"
+              sublabel="or click to browse — the first file is used"
+              [directory]="true"
+              [multiple]="true"
+              (filesSelected)="onLocalFileDropped($event)"
+            ></vt-drop-zone>
             <p class="info-text">
               The first file in the picked folder will be used. To pick a single file directly,
               switch to the <strong>Local Files</strong> tab.
             </p>
           } @else {
-            <input
-              id="nmm-local-files-input"
-              type="file"
-              class="form-input"
-              (change)="onLocalFileSelected($event)"
-            />
+            <vt-drop-zone
+              label="Drop a media file here to use as example"
+              sublabel="or click to browse"
+              (filesSelected)="onLocalFileDropped($event)"
+            ></vt-drop-zone>
           }
         </div>
       }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -119,7 +119,16 @@
   text-align: center;
 }
 
-.hidden-file-input { display: none; }
+// In the example column the drop zone sits below the "Browse Media…" button,
+// so use a more compact padding than the standalone version inside the media
+// picker — the column is short and we don't want it to dwarf the text input.
+.example-col vt-drop-zone ::ng-deep .drop-zone {
+  padding: 14px 12px;
+}
+.example-col vt-drop-zone ::ng-deep .drop-zone-icon {
+  width: 22px;
+  height: 22px;
+}
 
 // Single example display
 .example-display { margin-top: 4px; }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -20,6 +20,7 @@ import {
   MediaCropModalComponent,
   MediaCropResult,
 } from '../../modals/media-crop-modal/media-crop-modal.component';
+import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
 interface BrowseEntry {
@@ -37,7 +38,7 @@ type TrainedSubView = 'picker' | 'form';
 @Component({
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FileBrowserComponent, MediaCropModalComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FileBrowserComponent, MediaCropModalComponent, DropZoneComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -639,15 +640,13 @@ export class NewDetectorModalComponent implements OnInit {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
-  /** Local file picker handler.  Used by both the inline "Upload File…"
-   *  button on the main form and the Local Folder / Local Files cards in
-   *  the picker.  Multi-file selections (e.g. webkitdirectory) are
-   *  collapsed to the first file since only one example is needed. */
-  onLocalFileSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    if (!input.files || input.files.length === 0) return;
-    const file = input.files[0];
-    input.value = '';
+  /** Local file picker handler.  Used by the drop-zone affordance in both
+   *  the main form (next to "Browse Media…") and the Local Folder / Local
+   *  Files cards in the media picker.  Multi-file drops (e.g. a folder)
+   *  collapse to the first file since only one example is needed. */
+  onLocalFileDropped(files: File[]): void {
+    if (files.length === 0) return;
+    const file = files[0];
     this.pendingFile = file;
     this.pendingFileMediaType = this.mediaType || this.mediaTypeFromFile(file);
   }

--- a/frontend/src/app/components/drop-zone/drop-zone.component.html
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.html
@@ -1,0 +1,36 @@
+<div
+  class="drop-zone"
+  [class.drop-zone--active]="isDragging"
+  [class.drop-zone--disabled]="disabled"
+  role="button"
+  tabindex="0"
+  [attr.aria-disabled]="disabled ? 'true' : null"
+  [attr.aria-label]="label"
+  (click)="openPicker()"
+  (keydown.enter)="openPicker()"
+  (keydown.space)="$event.preventDefault(); openPicker()"
+  (dragenter)="onDragEnter($event)"
+  (dragover)="onDragOver($event)"
+  (dragleave)="onDragLeave($event)"
+  (drop)="onDrop($event)"
+>
+  <svg class="drop-zone-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="17 8 12 3 7 8" />
+    <line x1="12" y1="3" x2="12" y2="15" />
+  </svg>
+  <p class="drop-zone-label">{{ label }}</p>
+  @if (sublabel) {
+    <p class="drop-zone-sublabel">{{ sublabel }}</p>
+  }
+  <input
+    #fileInput
+    type="file"
+    class="drop-zone-input"
+    [attr.accept]="accept || null"
+    [attr.multiple]="multiple ? '' : null"
+    [attr.webkitdirectory]="directory ? '' : null"
+    [attr.directory]="directory ? '' : null"
+    (change)="onInputChange($event)"
+  />
+</div>

--- a/frontend/src/app/components/drop-zone/drop-zone.component.scss
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.scss
@@ -1,0 +1,66 @@
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 22px 16px;
+  border: 2px dashed var(--border-secondary);
+  border-radius: 8px;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  text-align: center;
+  user-select: none;
+
+  &:hover:not(.drop-zone--disabled) {
+    border-color: var(--accent);
+    color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  // Active = a file drag is currently hovering this zone.
+  &--active {
+    border-color: var(--accent);
+    background: var(--accent-highlight-bg);
+    color: var(--text-primary);
+    // Drop the dashed look while a file hovers so the highlight reads as
+    // "release here" rather than the idle dashed placeholder.
+    border-style: solid;
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.drop-zone-icon {
+  width: 28px;
+  height: 28px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.drop-zone-label {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+.drop-zone-sublabel {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.drop-zone-input {
+  display: none;
+}

--- a/frontend/src/app/components/drop-zone/drop-zone.component.ts
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.ts
@@ -1,0 +1,146 @@
+import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'vt-drop-zone',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './drop-zone.component.html',
+  styleUrl: './drop-zone.component.scss',
+})
+export class DropZoneComponent {
+  @Input() label = 'Drop files here, or click to browse';
+  @Input() sublabel = '';
+  @Input() accept = '';
+  @Input() multiple = false;
+  @Input() directory = false;
+  @Input() disabled = false;
+  @Output() filesSelected = new EventEmitter<File[]>();
+
+  @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
+
+  isDragging = false;
+  private dragDepth = 0;
+
+  openPicker(): void {
+    if (this.disabled) return;
+    this.fileInput?.nativeElement.click();
+  }
+
+  onInputChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    this.filesSelected.emit(Array.from(input.files));
+    input.value = '';
+  }
+
+  onDragEnter(event: DragEvent): void {
+    if (!this.hasFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.disabled) return;
+    this.dragDepth++;
+    this.isDragging = true;
+  }
+
+  onDragOver(event: DragEvent): void {
+    if (!this.hasFiles(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.disabled) return;
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragDepth = Math.max(0, this.dragDepth - 1);
+    if (this.dragDepth === 0) this.isDragging = false;
+  }
+
+  async onDrop(event: DragEvent): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragDepth = 0;
+    this.isDragging = false;
+    if (this.disabled) return;
+    const dt = event.dataTransfer;
+    if (!dt) return;
+
+    const files: File[] = [];
+    const items = dt.items;
+    const canUseEntries = items && items.length > 0
+      && typeof (items[0] as DataTransferItem & { webkitGetAsEntry?: () => FileSystemEntry | null }).webkitGetAsEntry === 'function';
+    if (canUseEntries) {
+      const entries: FileSystemEntry[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const entry = (items[i] as DataTransferItem & { webkitGetAsEntry?: () => FileSystemEntry | null }).webkitGetAsEntry?.();
+        if (entry) entries.push(entry);
+      }
+      for (const entry of entries) {
+        await this.walkEntry(entry, '', files);
+      }
+    } else if (dt.files) {
+      for (let i = 0; i < dt.files.length; i++) {
+        files.push(dt.files[i]);
+      }
+    }
+
+    if (files.length === 0) return;
+    // For single-file pickers, only emit the first dropped file.
+    if (!this.directory && !this.multiple) {
+      this.filesSelected.emit([files[0]]);
+    } else {
+      this.filesSelected.emit(files);
+    }
+  }
+
+  // Some drag events on a page also carry text/other payloads — only react to
+  // drags that actually include files so users can still e.g. drag-select text
+  // over the zone without triggering the highlight.
+  private hasFiles(event: DragEvent): boolean {
+    const types = event.dataTransfer?.types;
+    if (!types) return false;
+    for (let i = 0; i < types.length; i++) {
+      if (types[i] === 'Files') return true;
+    }
+    return false;
+  }
+
+  private async walkEntry(entry: FileSystemEntry, prefix: string, out: File[]): Promise<void> {
+    if (entry.isFile) {
+      const fileEntry = entry as FileSystemFileEntry;
+      const file = await new Promise<File>((resolve, reject) => {
+        fileEntry.file(resolve, reject);
+      });
+      const rel = prefix ? `${prefix}/${file.name}` : file.name;
+      // webkitRelativePath is normally a getter on File.prototype — define an
+      // own property to shadow it so consumers (e.g. the dataset importer's
+      // recursive-folder filter and folder-name derivation) see the path from
+      // the drop root.
+      try {
+        Object.defineProperty(file, 'webkitRelativePath', { value: rel, configurable: true });
+      } catch {
+        /* some browsers may refuse to override the getter; the file still uploads */
+      }
+      out.push(file);
+    } else if (entry.isDirectory) {
+      const dirEntry = entry as FileSystemDirectoryEntry;
+      const reader = dirEntry.createReader();
+      const subPrefix = prefix ? `${prefix}/${entry.name}` : entry.name;
+      // readEntries() returns entries in batches; call until it returns an
+      // empty array to drain a large directory.
+      while (true) {
+        const batch: FileSystemEntry[] = await new Promise((resolve, reject) => {
+          reader.readEntries(resolve, reject);
+        });
+        if (batch.length === 0) break;
+        for (const e of batch) {
+          await this.walkEntry(e, subPrefix, out);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New reusable `vt-drop-zone` component (`frontend/src/app/components/drop-zone/`) renders a dashed-bordered, clickable target that also accepts drag-drop, with hover/active states and an `Upload` icon. Folder drops walk `webkitGetAsEntry()` recursively and synthesise `webkitRelativePath` on each File so the existing upload code sees the same shape as a `<input type=file webkitdirectory>` selection.
- Wired into three places: dataset importer modal Local Folder / Local Files views, new-detector modal media-picker Local Folder / Local Files views, and the new-detector main form (where it replaces the inline "Upload File…" button next to "Browse Media…").
- Dead `.hidden-file-input` SCSS rule and the now-unused event-handler methods (`lfOnFolderSelected`, `onLocalFileSelected`) deleted per the no-compat-shims rule. The ux-brainstorm plan §7.6 marked SHIPPED with open follow-ups (examples-editor modal still uses button-driven file inputs, descoped from this pass).

## Test plan
- [x] `cd frontend && npm run build:prod` — clean (no errors, no warnings)
- [x] `ruff check .` / `ruff format --check .` — pass
- [ ] Manual: open dataset importer → Local Folder, drop a folder, verify it imports with correct `webkitRelativePath`-based folder name and recursive filter behaviour.
- [ ] Manual: open dataset importer → Local Files, drop several files, verify the file count + dataset name autofill.
- [ ] Manual: open new-detector modal, drop a media file onto the zone next to "Browse Media…", verify the crop modal opens with the right media type.
- [ ] Manual: open new-detector modal → Browse Media → Local Folder, drop a folder, verify the first file gets used.
- [ ] Manual: drag a file over the page but NOT over a drop zone — verify the zone does not highlight (only file drags over the zone activate the highlight; text-selection drags are ignored via the `Files` dataTransfer type check).

https://claude.ai/code/session_019wz3bkFVV3dPhEkvm1zkZa

---
_Generated by [Claude Code](https://claude.ai/code/session_019wz3bkFVV3dPhEkvm1zkZa)_