### PR TITLE
Move orphaned labelset file after detector rename

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -390,8 +390,10 @@ Currently: open export modal → pick webhook → fill URL → fill auth → sub
 ### 8.7 Combining detectors ★ M
 The "combine detectors" feature exists but requires multi-select + a non-obvious icon button. Surface as a clear "Merge detectors" CTA with a preview of what the merged detector would look like (count, intersection vs union choice, name).
 
-### 8.8 Renaming + re-syncing a detector ★ XS
+### 8.8 Renaming + re-syncing a detector ★ XS — shipped
 Renaming a detector with a labelset source filepath template (`{detector_name}.labels.json`) leaves the old file on disk. After rename, prompt: "Move existing labelset file to new name?" with a one-click yes.
+
+**What shipped**: the registry and CRUD rename endpoints now (a) update `DetectorContext.name` so future syncs immediately resolve `{detector_name}` to the new value (was a stale-in-memory bug — until process restart, the next vote would re-create the file at the OLD path), and (b) return `pending_labelset_move: {old_path, new_path}` in the rename response when a labelset source with a `server_json_file` template leaves an orphaned file on disk. New endpoint `POST /api/detectors/registry/<id>/labelset-source/move-file` atomically renames the file (validated against the file-access base dir). The dashboard and right-panel rename flows show a one-click `dialog.confirm` after a successful rename and call the move endpoint when accepted. Files: `vtsearch/detectors/labelset_rename.py` (new helpers), `vtsearch/labels/sources/server_json_file/__init__.py` (new `resolve_filepath_for(detector_id, detector_name)`), `vtsearch/routes/detectors/{registry,crud}.py`, `vtsearch/schemas/detectors.py`, `frontend/src/app/services/detectors-api.service.ts` (`moveLabelsetSourceFile`, `promptMoveOrphanedLabelsetFile`), `frontend/src/app/components/dashboard/dashboard.component.ts`, `frontend/src/app/components/right-panel/right-panel.component.ts`.
 
 ### 8.9 Audio segment example → trained detector ★★ M — **SHIPPED**
 "I want a detector for this 3-second cough sound": today requires opening a centre-panel item, opening the crop modal, dragging selection, confirming, then navigating to new-detector with that example. Add a right-click "Use this as a detector seed" on any media in the left panel.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,3 +1,4 @@
+⏳ Initializing VTSearch... (PID 22379)
 {
   "components": {
     "responses": {
@@ -1615,6 +1616,48 @@
         ],
         "type": "object"
       },
+      "DetectorLabelsetMoveRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "new_path": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "old_path": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "new_path",
+          "old_path"
+        ],
+        "type": "object"
+      },
+      "DetectorLabelsetMoveResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "moved": {
+            "type": "boolean"
+          },
+          "new_path": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "old_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "moved",
+          "new_path",
+          "ok",
+          "old_path"
+        ],
+        "type": "object"
+      },
       "DetectorRegistryAutorunRequest": {
         "additionalProperties": false,
         "properties": {
@@ -1832,6 +1875,18 @@
           },
           "ok": {
             "type": "boolean"
+          },
+          "pending_labelset_move": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PendingLabelsetMove"
+              },
+              {
+                "nullable": true,
+                "type": "object"
+              }
+            ],
+            "default": null
           }
         },
         "required": [
@@ -1876,6 +1931,18 @@
           },
           "old_name": {
             "type": "string"
+          },
+          "pending_labelset_move": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PendingLabelsetMove"
+              },
+              {
+                "nullable": true,
+                "type": "object"
+              }
+            ],
+            "default": null
           },
           "success": {
             "type": "boolean"
@@ -3170,6 +3237,22 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "PendingLabelsetMove": {
+        "additionalProperties": false,
+        "properties": {
+          "new_path": {
+            "type": "string"
+          },
+          "old_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "new_path",
+          "old_path"
+        ],
         "type": "object"
       },
       "PregenProcessorsAddResponse": {
@@ -6857,6 +6940,63 @@
           }
         },
         "summary": "Toggle the autorun flag for a registered detector.",
+        "tags": [
+          "detectors_registry"
+        ]
+      }
+    },
+    "/api/detectors/registry/{detector_id}/labelset-source/move-file": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "detector_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Called by the frontend when the user confirms the *Move existing\nlabelset file?* prompt that surfaces after a rename leaves the file\nat the OLD template-resolved path on disk.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetectorLabelsetMoveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectorLabelsetMoveResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Invalid path (e.g. traversal outside allowed base)."
+          },
+          "404": {
+            "description": "Detector not found."
+          },
+          "409": {
+            "description": "Destination already exists."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Move an orphaned labelset file after a detector rename.",
         "tags": [
           "detectors_registry"
         ]

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,4 +1,3 @@
-⏳ Initializing VTSearch... (PID 22379)
 {
   "components": {
     "responses": {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -747,8 +747,25 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   renameDetector(model: DetectorRegistryEntry, newName: string): void {
     this.detectorsApi.renameInRegistry(model.id, newName).subscribe({
-      next: () => this.datasetState.refresh(),
+      next: response => {
+        this.datasetState.refresh();
+        this.promptMoveOrphanedLabelsetFile(model.id, response.pending_labelset_move);
+      },
     });
+  }
+
+  private async promptMoveOrphanedLabelsetFile(
+    detectorId: string,
+    pending: { old_path: string; new_path: string } | null | undefined,
+  ): Promise<void> {
+    if (!pending) return;
+    const ok = await this.dialog.confirm(
+      `Move existing labelset file "${pending.old_path}" to "${pending.new_path}"?`,
+    );
+    if (!ok) return;
+    this.detectorsApi
+      .moveLabelsetSourceFile(detectorId, pending.old_path, pending.new_path)
+      .subscribe();
   }
 
   async deleteDetector(model: DetectorRegistryEntry): Promise<void> {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -749,23 +749,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.detectorsApi.renameInRegistry(model.id, newName).subscribe({
       next: response => {
         this.datasetState.refresh();
-        this.promptMoveOrphanedLabelsetFile(model.id, response.pending_labelset_move);
+        this.detectorsApi.promptMoveOrphanedLabelsetFile(
+          this.dialog,
+          model.id,
+          response.pending_labelset_move,
+        );
       },
     });
-  }
-
-  private async promptMoveOrphanedLabelsetFile(
-    detectorId: string,
-    pending: { old_path: string; new_path: string } | null | undefined,
-  ): Promise<void> {
-    if (!pending) return;
-    const ok = await this.dialog.confirm(
-      `Move existing labelset file "${pending.old_path}" to "${pending.new_path}"?`,
-    );
-    if (!ok) return;
-    this.detectorsApi
-      .moveLabelsetSourceFile(detectorId, pending.old_path, pending.new_path)
-      .subscribe();
   }
 
   async deleteDetector(model: DetectorRegistryEntry): Promise<void> {

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -8,6 +8,7 @@ import { MediaItem } from '../../models/api.models';
 import { VoteStateService } from '../../services/vote-state.service';
 import { LabelsetStateService } from '../../services/labelset-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import { VtDialogService } from '../../services/dialog.service';
 
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 import { LabelSortComponent, LabelSortMode } from './label-sort/label-sort.component';
@@ -78,6 +79,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
     public voteState: VoteStateService,
     public labelsetState: LabelsetStateService,
     private settingsState: SettingsStateService,
+    private dialog: VtDialogService,
   ) {}
 
   /** True when the right pane should be sourced from the labelset (not /api/votes). */
@@ -160,13 +162,29 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   onDetectorRenamed(newName: string): void {
     if (!this.trainMode?.model?.registry_id) return;
-    this.detectorsApi.renameInRegistry(this.trainMode.model.registry_id, newName).subscribe({
-      next: () => {
+    const registryId = this.trainMode.model.registry_id;
+    this.detectorsApi.renameInRegistry(registryId, newName).subscribe({
+      next: response => {
         if (this.trainMode?.model) {
           this.trainMode.model.name = newName;
         }
+        this.promptMoveOrphanedLabelsetFile(registryId, response.pending_labelset_move);
       },
     });
+  }
+
+  private async promptMoveOrphanedLabelsetFile(
+    detectorId: string,
+    pending: { old_path: string; new_path: string } | null | undefined,
+  ): Promise<void> {
+    if (!pending) return;
+    const ok = await this.dialog.confirm(
+      `Move existing labelset file "${pending.old_path}" to "${pending.new_path}"?`,
+    );
+    if (!ok) return;
+    this.detectorsApi
+      .moveLabelsetSourceFile(detectorId, pending.old_path, pending.new_path)
+      .subscribe();
   }
 
   private loadSettings(): void {

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -168,23 +168,13 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
         if (this.trainMode?.model) {
           this.trainMode.model.name = newName;
         }
-        this.promptMoveOrphanedLabelsetFile(registryId, response.pending_labelset_move);
+        this.detectorsApi.promptMoveOrphanedLabelsetFile(
+          this.dialog,
+          registryId,
+          response.pending_labelset_move,
+        );
       },
     });
-  }
-
-  private async promptMoveOrphanedLabelsetFile(
-    detectorId: string,
-    pending: { old_path: string; new_path: string } | null | undefined,
-  ): Promise<void> {
-    if (!pending) return;
-    const ok = await this.dialog.confirm(
-      `Move existing labelset file "${pending.old_path}" to "${pending.new_path}"?`,
-    );
-    if (!ok) return;
-    this.detectorsApi
-      .moveLabelsetSourceFile(detectorId, pending.old_path, pending.new_path)
-      .subscribe();
   }
 
   private loadSettings(): void {

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -26,6 +26,7 @@ import type { DetectorExamplesRequest } from '../generated/api-client/models/det
 import type { DetectorExamplesResponse } from '../generated/api-client/models/detector-examples-response';
 import type { DetectorLabelVoteResponse } from '../generated/api-client/models/detector-label-vote-response';
 import type { DetectorLabelsDetailResponse } from '../generated/api-client/models/detector-labels-detail-response';
+import type { DetectorLabelsetMoveResponse } from '../generated/api-client/models/detector-labelset-move-response';
 import type { DetectorRegistryAutorunResponse } from '../generated/api-client/models/detector-registry-autorun-response';
 import type { DetectorRegistryCreateRequest } from '../generated/api-client/models/detector-registry-create-request';
 import type { DetectorRegistryCreateResponse } from '../generated/api-client/models/detector-registry-create-response';
@@ -74,6 +75,7 @@ import { apiDetectorsNameRenamePut } from '../generated/api-client/fn/detectors-
 import { apiDetectorsPost } from '../generated/api-client/fn/detectors-crud/api-detectors-post';
 import { apiDetectorsRegistryDetectorIdAutorunPut } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-autorun-put';
 import { apiDetectorsRegistryDetectorIdDelete } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-delete';
+import { apiDetectorsRegistryDetectorIdLabelsetSourceMoveFilePost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-labelset-source-move-file-post';
 import { apiDetectorsRegistryDetectorIdRenamePut } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-rename-put';
 import { apiDetectorsRegistryDetectorIdUnloadPost } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-detector-id-unload-post';
 import { apiDetectorsRegistryGet } from '../generated/api-client/fn/detectors-registry/api-detectors-registry-get';
@@ -244,6 +246,21 @@ export class DetectorsApiService {
       detector_id: detectorId,
       body: { name: newName },
     }).pipe(map((r) => r.body));
+  }
+
+  moveLabelsetSourceFile(
+    detectorId: string,
+    oldPath: string,
+    newPath: string,
+  ): Observable<DetectorLabelsetMoveResponse> {
+    return apiDetectorsRegistryDetectorIdLabelsetSourceMoveFilePost(
+      this.http,
+      this.config.rootUrl,
+      {
+        detector_id: detectorId,
+        body: { old_path: oldPath, new_path: newPath },
+      },
+    ).pipe(map((r) => r.body));
   }
 
   loadDetector(detectorId: string | null): Observable<DetectorRegistryLoadResponse> {

--- a/frontend/src/app/services/detectors-api.service.ts
+++ b/frontend/src/app/services/detectors-api.service.ts
@@ -89,6 +89,7 @@ import { apiLocalizePost } from '../generated/api-client/fn/processors-scoring/a
 import { apiPregenProcessorsAddPost } from '../generated/api-client/fn/processors-crud/api-pregen-processors-add-post';
 import { apiPregenProcessorsGet } from '../generated/api-client/fn/processors-crud/api-pregen-processors-get';
 import { ActiveContextService } from './active-context.service';
+import { VtDialogService } from './dialog.service';
 
 /** Backwards-compatible alias for the generated ``FindCheckLabelsWarning`` —
  *  consumers of this service still import this name. */
@@ -261,6 +262,33 @@ export class DetectorsApiService {
         body: { old_path: oldPath, new_path: newPath },
       },
     ).pipe(map((r) => r.body));
+  }
+
+  /** Prompt the user to move an orphaned labelset file after a rename.
+   *  Generated ``PendingLabelsetMove`` arrives as ``{old_path,new_path} | {} | null``
+   *  (a marshmallow ``allow_none`` artifact); narrow it here so callers
+   *  pass the rename response through unchanged. */
+  async promptMoveOrphanedLabelsetFile(
+    dialog: VtDialogService,
+    detectorId: string,
+    pending: unknown,
+  ): Promise<void> {
+    if (
+      !pending ||
+      typeof pending !== 'object' ||
+      !('old_path' in pending) ||
+      !('new_path' in pending) ||
+      typeof (pending as { old_path: unknown }).old_path !== 'string' ||
+      typeof (pending as { new_path: unknown }).new_path !== 'string'
+    ) {
+      return;
+    }
+    const { old_path: oldPath, new_path: newPath } = pending as { old_path: string; new_path: string };
+    const ok = await dialog.confirm(
+      `Move existing labelset file "${oldPath}" to "${newPath}"?`,
+    );
+    if (!ok) return;
+    this.moveLabelsetSourceFile(detectorId, oldPath, newPath).subscribe();
   }
 
   loadDetector(detectorId: string | null): Observable<DetectorRegistryLoadResponse> {

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -251,6 +251,199 @@ class TestRenameDetector:
         assert res.status_code == 409
 
 
+class TestRenameLabelsetSourceCleanup:
+    """Renaming a detector with a {detector_name} labelset source should
+    surface the orphaned file path so the user can move it."""
+
+    def _create_registered_detector(self, client):
+        client.post(
+            "/api/detectors",
+            json={"name": "Old Name", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "Old Name", "media_type": "audio", "text_query": "test"},
+        )
+        assert res.status_code == 201
+        return res.get_json()["detector"]["id"]
+
+    def _attach_labelset_source(self, detector_id, template):
+        from vtsearch.state.core import DetectorContext, register_detector_context
+
+        ctx = DetectorContext(detector_id, name="Old Name", media_type="audio")
+        ctx.labelset_source = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": template},
+        }
+        register_detector_context(ctx)
+        return ctx
+
+    def test_rename_returns_pending_move_when_old_file_exists(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        template = str(tmp_path / "{detector_name}.labels.json")
+        self._attach_labelset_source(detector_id, template)
+
+        # Pretend a previous sync wrote the old labelset file.
+        old_file = tmp_path / "Old Name.labels.json"
+        old_file.write_text('{"labels": []}')
+
+        res = client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body["ok"] is True
+        assert body["name"] == "New Name"
+        pending = body["pending_labelset_move"]
+        assert pending is not None
+        assert pending["old_path"].endswith("Old Name.labels.json")
+        assert pending["new_path"].endswith("New Name.labels.json")
+
+    def test_rename_updates_ctx_name_for_future_syncs(self, client, tmp_path):
+        from vtsearch.state.core import get_detector_context
+
+        detector_id = self._create_registered_detector(client)
+        template = str(tmp_path / "{detector_name}.labels.json")
+        self._attach_labelset_source(detector_id, template)
+
+        client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+
+        ctx = get_detector_context(detector_id)
+        assert ctx is not None
+        assert ctx.name == "New Name"
+
+    def test_rename_no_pending_when_old_file_missing(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        template = str(tmp_path / "{detector_name}.labels.json")
+        self._attach_labelset_source(detector_id, template)
+
+        # No old file on disk.
+        res = client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["pending_labelset_move"] is None
+
+    def test_rename_no_pending_when_template_has_no_name_var(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        # Template without {detector_name} — old and new resolve to same path.
+        template = str(tmp_path / "shared.labels.json")
+        self._attach_labelset_source(detector_id, template)
+
+        (tmp_path / "shared.labels.json").write_text('{"labels": []}')
+
+        res = client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["pending_labelset_move"] is None
+
+    def test_rename_no_pending_when_destination_exists(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        template = str(tmp_path / "{detector_name}.labels.json")
+        self._attach_labelset_source(detector_id, template)
+
+        (tmp_path / "Old Name.labels.json").write_text('{"labels": []}')
+        (tmp_path / "New Name.labels.json").write_text('{"labels": []}')
+
+        res = client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+        assert res.status_code == 200
+        # We refuse to propose a move that would clobber an existing file.
+        assert res.get_json()["pending_labelset_move"] is None
+
+    def test_rename_no_pending_without_labelset_source(self, client):
+        detector_id = self._create_registered_detector(client)
+        # No source attached (no _attach_labelset_source call).
+        res = client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["pending_labelset_move"] is None
+
+    def test_move_endpoint_moves_file(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        template = str(tmp_path / "{detector_name}.labels.json")
+        self._attach_labelset_source(detector_id, template)
+
+        old_file = tmp_path / "Old Name.labels.json"
+        old_file.write_text('{"labels": [{"md5": "abc", "label": "good"}]}')
+        new_file = tmp_path / "New Name.labels.json"
+
+        res = client.put(
+            f"/api/detectors/registry/{detector_id}/rename",
+            json={"name": "New Name"},
+        )
+        pending = res.get_json()["pending_labelset_move"]
+
+        res = client.post(
+            f"/api/detectors/registry/{detector_id}/labelset-source/move-file",
+            json={"old_path": pending["old_path"], "new_path": pending["new_path"]},
+        )
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body["ok"] is True
+        assert body["moved"] is True
+
+        assert not old_file.exists()
+        assert new_file.exists()
+        # Content preserved.
+        assert "abc" in new_file.read_text()
+
+    def test_move_endpoint_idempotent_when_old_missing(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        self._attach_labelset_source(detector_id, str(tmp_path / "{detector_name}.labels.json"))
+
+        res = client.post(
+            f"/api/detectors/registry/{detector_id}/labelset-source/move-file",
+            json={
+                "old_path": str(tmp_path / "nope.json"),
+                "new_path": str(tmp_path / "dest.json"),
+            },
+        )
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body["ok"] is True
+        assert body["moved"] is False
+
+    def test_move_endpoint_rejects_existing_destination(self, client, tmp_path):
+        detector_id = self._create_registered_detector(client)
+        self._attach_labelset_source(detector_id, str(tmp_path / "{detector_name}.labels.json"))
+
+        old_file = tmp_path / "src.json"
+        old_file.write_text("{}")
+        new_file = tmp_path / "dst.json"
+        new_file.write_text("{}")
+
+        res = client.post(
+            f"/api/detectors/registry/{detector_id}/labelset-source/move-file",
+            json={"old_path": str(old_file), "new_path": str(new_file)},
+        )
+        assert res.status_code == 409
+        # Neither file touched.
+        assert old_file.exists()
+        assert new_file.exists()
+
+    def test_move_endpoint_404_for_unknown_detector(self, client, tmp_path):
+        res = client.post(
+            "/api/detectors/registry/nonexistent/labelset-source/move-file",
+            json={
+                "old_path": str(tmp_path / "x"),
+                "new_path": str(tmp_path / "y"),
+            },
+        )
+        assert res.status_code == 404
+
+
 class TestSaveLabels:
     def test_save_labels_empty(self, client):
         """Save labels when there are no votes — should produce empty labelset."""

--- a/vtsearch/detectors/labelset_rename.py
+++ b/vtsearch/detectors/labelset_rename.py
@@ -1,0 +1,97 @@
+"""Helpers for handling labelset source files when a detector is renamed.
+
+When a detector with a labelset source whose ``filepath`` template uses
+``{detector_name}`` is renamed, the old on-disk file becomes orphaned —
+the next sync writes to the NEW resolved path, leaving the OLD file
+behind as garbage.  These helpers detect the orphaned-file situation
+and perform an atomic move when the user confirms.
+
+Only the ``server_json_file`` labelset source has an on-disk
+representation that benefits from a rename move; other source types
+(remote APIs, etc.) are skipped silently.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def detect_pending_labelset_move(
+    labelset_source: dict[str, Any] | None,
+    *,
+    detector_id: str,
+    old_name: str,
+    new_name: str,
+) -> dict[str, str] | None:
+    """Return ``{"old_path", "new_path"}`` if the rename orphans a labelset file.
+
+    Returns ``None`` when:
+      * no labelset source is configured,
+      * the source is not the on-disk ``server_json_file`` plugin,
+      * the resolved old and new paths are identical (template doesn't
+        reference ``{detector_name}``),
+      * the old file does not exist on disk, or
+      * the new file already exists (so a move would clobber it).
+    """
+    if not labelset_source:
+        return None
+    if labelset_source.get("source_name") != "server_json_file":
+        return None
+
+    field_values = labelset_source.get("field_values") or {}
+    from vtsearch.labels.sources.server_json_file import resolve_filepath_for
+
+    try:
+        old_resolved = resolve_filepath_for(field_values, detector_id=detector_id, detector_name=old_name)
+        new_resolved = resolve_filepath_for(field_values, detector_id=detector_id, detector_name=new_name)
+    except ValueError:
+        # Empty / malformed template — nothing to move.
+        return None
+
+    if old_resolved == new_resolved:
+        return None
+
+    old_path = Path(old_resolved)
+    new_path = Path(new_resolved)
+    if not old_path.is_file():
+        return None
+    if new_path.exists():
+        # Don't propose a move that would overwrite an existing file.
+        return None
+
+    return {"old_path": str(old_path), "new_path": str(new_path)}
+
+
+def move_labelset_file(old_path: str, new_path: str) -> bool:
+    """Atomically rename *old_path* to *new_path*.
+
+    Both paths are validated against the file-access base directory to
+    prevent path traversal.  Returns ``True`` if the move happened,
+    ``False`` if *old_path* doesn't exist (idempotent — a repeated click
+    after a successful move is a no-op, not an error).
+
+    Raises ``ValueError`` for invalid paths and ``FileExistsError`` if
+    *new_path* already exists.
+    """
+    from vtsearch.security.path_validation import (
+        get_file_access_base_dir,
+        validate_server_filepath,
+    )
+
+    base = get_file_access_base_dir()
+    old_resolved = validate_server_filepath(old_path, base)
+    new_resolved = validate_server_filepath(new_path, base)
+
+    if not old_resolved.is_file():
+        return False
+    if new_resolved.exists():
+        raise FileExistsError(f"Destination already exists: {new_resolved}")
+
+    new_resolved.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(old_resolved, new_resolved)
+    return True

--- a/vtsearch/labels/sources/server_json_file/__init__.py
+++ b/vtsearch/labels/sources/server_json_file/__init__.py
@@ -90,6 +90,29 @@ class ServerFileLabelsetSource(LabelsetSource):
         os.replace(tmp, filepath)
 
 
+def resolve_filepath_for(
+    field_values: dict[str, Any],
+    *,
+    detector_id: str,
+    detector_name: str,
+) -> str:
+    """Resolve the filepath using explicit detector identity values.
+
+    Used by flows that need to resolve a path for a detector other than the
+    currently-active one — notably the rename endpoint, which needs to
+    resolve both the OLD and NEW paths to detect an orphaned labelset file.
+    """
+    from vtsearch.security.path_validation import sanitize_template_value
+
+    filepath = (field_values.get("filepath") or "").strip()
+    if not filepath:
+        raise ValueError("A file path is required.")
+
+    filepath = filepath.replace("{detector_id}", sanitize_template_value(detector_id))
+    filepath = filepath.replace("{detector_name}", sanitize_template_value(detector_name))
+    return filepath
+
+
 def _resolve_filepath(field_values: dict[str, Any]) -> str:
     """Resolve the filepath, expanding template variables.
 
@@ -102,13 +125,15 @@ def _resolve_filepath(field_values: dict[str, Any]) -> str:
         raise ValueError("A file path is required.")
 
     if "{detector_id}" in filepath or "{detector_name}" in filepath:
-        from vtsearch.security.path_validation import sanitize_template_value
         from vtsearch.state.core import get_active_detector_context
 
         ctx = get_active_detector_context()
         if ctx is not None:
-            filepath = filepath.replace("{detector_id}", sanitize_template_value(ctx.detector_id))
-            filepath = filepath.replace("{detector_name}", sanitize_template_value(ctx.name))
+            return resolve_filepath_for(
+                field_values,
+                detector_id=ctx.detector_id,
+                detector_name=ctx.name,
+            )
 
     return filepath
 

--- a/vtsearch/routes/detectors/crud.py
+++ b/vtsearch/routes/detectors/crud.py
@@ -233,11 +233,24 @@ def rename_detector(body: dict, name: str):
         old_path.unlink(missing_ok=True)
 
     # Update the detector registry entry that references this detector
+    from vtsearch.detectors.labelset_rename import detect_pending_labelset_move
     from vtsearch.detectors.registry import find_by_name, rename_detector as _rename_in_registry
+    from vtsearch.state.core import get_detector_context
 
     reg_entry = find_by_name(name)
+    pending_move: dict[str, str] | None = None
     if reg_entry:
-        _rename_in_registry(reg_entry["id"], new_name)
+        registry_id = reg_entry["id"]
+        ctx = get_detector_context(registry_id)
+        if ctx is not None:
+            pending_move = detect_pending_labelset_move(
+                ctx.labelset_source,
+                detector_id=registry_id,
+                old_name=name,
+                new_name=new_name,
+            )
+            ctx.name = new_name
+        _rename_in_registry(registry_id, new_name)
 
     # Rename autorun flag if present.
     try:
@@ -250,7 +263,12 @@ def rename_detector(body: dict, name: str):
     except Exception:
         logger.exception("Failed to rename autorun entry for %s", name)
 
-    return {"success": True, "old_name": name, "new_name": new_name}
+    return {
+        "success": True,
+        "old_name": name,
+        "new_name": new_name,
+        "pending_labelset_move": pending_move,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -13,6 +13,8 @@ POST   /api/detectors/registry/load                   Load a detector into memor
 POST   /api/detectors/registry/<id>/unload            Unload a detector from memory.
 DELETE /api/detectors/registry/<id>                   Remove a detector from the registry.
 PUT    /api/detectors/registry/<id>/rename            Rename a registered detector.
+POST   /api/detectors/registry/<id>/labelset-source/move-file
+                                                      Move an orphaned labelset file after a rename.
 PUT    /api/detectors/registry/<id>/autorun           Toggle the detector's autorun flag.
 POST   /api/detectors/cancel/<task_id>                Cancel a load task.
 
@@ -44,6 +46,8 @@ from vtsearch.detectors.label_sync import sync_labels_to_loaded_detector
 from vtsearch.detectors.media_seeding import seed_good_votes_from_examples as _seed_good_votes_from_examples
 from vtsearch.schemas.detectors import (
     DetectorCancelResponseSchema,
+    DetectorLabelsetMoveRequestSchema,
+    DetectorLabelsetMoveResponseSchema,
     DetectorRegistryAutorunRequestSchema,
     DetectorRegistryAutorunResponseSchema,
     DetectorRegistryCreateRequestSchema,
@@ -714,7 +718,9 @@ def cancel_detector_loading_task(task_id: str):
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
 def rename_registered_detector(body: dict, detector_id: str):
     """Rename a registered detector and its on-disk labelset file."""
+    from vtsearch.detectors.labelset_rename import detect_pending_labelset_move
     from vtsearch.detectors.registry import get_detector, rename_detector
+    from vtsearch.state.core import get_detector_context
 
     new_name = body["name"].strip()
     if not new_name:
@@ -724,6 +730,7 @@ def rename_registered_detector(body: dict, detector_id: str):
     if entry is None:
         abort(404, message="Detector not found")
 
+    pending_move: dict[str, str] | None = None
     old_name = entry.get("name", "")
     if old_name and old_name != new_name:
         old_path = _detector_path(old_name)
@@ -746,8 +753,65 @@ def rename_registered_detector(body: dict, detector_id: str):
         except Exception:
             logger.exception("Failed to rename autorun entry for %s", detector_id)
 
+        # Update the loaded in-memory context so future syncs use the new
+        # name in {detector_name} template substitution, and detect any
+        # orphaned labelset file the rename leaves behind.
+        ctx = get_detector_context(detector_id)
+        if ctx is not None:
+            pending_move = detect_pending_labelset_move(
+                ctx.labelset_source,
+                detector_id=detector_id,
+                old_name=old_name,
+                new_name=new_name,
+            )
+            ctx.name = new_name
+
     rename_detector(detector_id, new_name)
-    return {"ok": True, "name": new_name}
+    return {"ok": True, "name": new_name, "pending_labelset_move": pending_move}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/detectors/registry/<detector_id>/labelset-source/move-file
+# ---------------------------------------------------------------------------
+
+
+@detectors_registry_bp.route(
+    "/api/detectors/registry/<detector_id>/labelset-source/move-file",
+    methods=["POST"],
+)
+@detectors_registry_bp.arguments(DetectorLabelsetMoveRequestSchema)
+@detectors_registry_bp.response(200, DetectorLabelsetMoveResponseSchema)
+@detectors_registry_bp.alt_response(400, description="Invalid path (e.g. traversal outside allowed base).")
+@detectors_registry_bp.alt_response(404, description="Detector not found.")
+@detectors_registry_bp.alt_response(409, description="Destination already exists.")
+def move_labelset_source_file(body: dict, detector_id: str):
+    """Move an orphaned labelset file after a detector rename.
+
+    Called by the frontend when the user confirms the *Move existing
+    labelset file?* prompt that surfaces after a rename leaves the file
+    at the OLD template-resolved path on disk.
+    """
+    from vtsearch.detectors.labelset_rename import move_labelset_file
+    from vtsearch.detectors.registry import get_detector
+
+    if get_detector(detector_id) is None:
+        abort(404, message="Detector not found")
+
+    old_path = body["old_path"]
+    new_path = body["new_path"]
+    try:
+        moved = move_labelset_file(old_path, new_path)
+    except FileExistsError as exc:
+        abort(409, message=str(exc))
+    except ValueError as exc:
+        abort(400, message=str(exc))
+
+    return {
+        "ok": True,
+        "moved": moved,
+        "old_path": old_path,
+        "new_path": new_path,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -177,12 +177,28 @@ class DetectorRenameRequestSchema(Schema):
     new_name = fields.String(required=True, validate=validate.Length(min=1))
 
 
+class PendingLabelsetMoveSchema(Schema):
+    """Labelset file paths that were orphaned by a detector rename.
+
+    Populated on a rename response when the detector has a configured
+    labelset source whose filepath template (``{detector_name}`` /
+    ``{detector_id}``) resolves to a different on-disk location after
+    the rename, and the OLD file still exists.  The frontend uses
+    these paths to prompt the user to move the file and to invoke
+    :class:`DetectorLabelsetMoveRequestSchema` on confirmation.
+    """
+
+    old_path = fields.String(required=True)
+    new_path = fields.String(required=True)
+
+
 class DetectorRenameResponseSchema(Schema):
     """Response for ``PUT /api/detectors/<name>/rename``."""
 
     success = fields.Boolean(required=True)
     old_name = fields.String(required=True)
     new_name = fields.String(required=True)
+    pending_labelset_move = fields.Nested(PendingLabelsetMoveSchema, allow_none=True, load_default=None)
 
 
 class DetectorExamplesRequestSchema(Schema):
@@ -350,6 +366,23 @@ class DetectorRegistryRenameResponseSchema(Schema):
 
     ok = fields.Boolean(required=True)
     name = fields.String(required=True)
+    pending_labelset_move = fields.Nested(PendingLabelsetMoveSchema, allow_none=True, load_default=None)
+
+
+class DetectorLabelsetMoveRequestSchema(Schema):
+    """Body for ``POST /api/detectors/registry/<id>/labelset-source/move-file``."""
+
+    old_path = fields.String(required=True, validate=validate.Length(min=1))
+    new_path = fields.String(required=True, validate=validate.Length(min=1))
+
+
+class DetectorLabelsetMoveResponseSchema(Schema):
+    """Response for ``POST /api/detectors/registry/<id>/labelset-source/move-file``."""
+
+    ok = fields.Boolean(required=True)
+    moved = fields.Boolean(required=True)
+    old_path = fields.String(required=True)
+    new_path = fields.String(required=True)
 
 
 class DetectorRegistryAutorunRequestSchema(Schema):
@@ -612,6 +645,8 @@ __all__ = [
     "DetectorExamplesRequestSchema",
     "DetectorExamplesResponseSchema",
     "DetectorLabelsDetailResponseSchema",
+    "DetectorLabelsetMoveRequestSchema",
+    "DetectorLabelsetMoveResponseSchema",
     "DetectorLabelVoteRequestSchema",
     "DetectorLabelVoteResponseSchema",
     "DetectorRegistryAutorunRequestSchema",
@@ -636,4 +671,5 @@ __all__ = [
     "FindLabelResponseSchema",
     "FindRequestSchema",
     "FindResponseSchema",
+    "PendingLabelsetMoveSchema",
 ]


### PR DESCRIPTION
## Summary

Closes **ux-brainstorm.md §8.8** — *"Renaming + re-syncing a detector"*.

When a detector has a labelset source whose filepath template references `{detector_name}` (e.g. `data/labels/{detector_name}.labels.json`), renaming the detector previously had two problems:

1. **Orphaned file** — the next sync wrote to the NEW resolved path, leaving the OLD file behind on disk as garbage.
2. **Stale in-memory `DetectorContext.name`** (related bug, fixed in the same change) — nothing updated `ctx.name` after a rename, so `_resolve_filepath()` continued substituting the OLD name in `{detector_name}`. Until the process restarted, the very next vote would re-create the file at the OLD path, even if the user manually deleted it.

## Changes

- **Backend**
  - `vtsearch/detectors/labelset_rename.py` (new): `detect_pending_labelset_move()` and `move_labelset_file()` helpers. The move helper validates both paths against the file-access base directory (so it can't escape `data/<user>/` in multi-user mode) and refuses to clobber an existing destination.
  - `vtsearch/labels/sources/server_json_file/__init__.py`: extracted `resolve_filepath_for(detector_id, detector_name)` so callers can resolve a template for a specific detector identity, not just the currently-active context. `_resolve_filepath()` now delegates to it.
  - `vtsearch/routes/detectors/registry.py` + `crud.py`: both rename endpoints now update `ctx.name` for the loaded context, run the orphan-detection helper, and return `pending_labelset_move: {old_path, new_path} | null` in the rename response.
  - New endpoint `POST /api/detectors/registry/<id>/labelset-source/move-file` performs the atomic `os.replace()` after path validation.
  - `vtsearch/schemas/detectors.py`: added `PendingLabelsetMoveSchema`, `DetectorLabelsetMoveRequestSchema`, `DetectorLabelsetMoveResponseSchema`, and extended both rename response schemas.

- **Frontend**
  - `DetectorsApiService.moveLabelsetSourceFile()` calls the new endpoint.
  - `DetectorsApiService.promptMoveOrphanedLabelsetFile()` shows a single `dialog.confirm("Move existing labelset file X to Y?")` and only fires the move on accept. Narrows the generated `PendingLabelsetMove | {} | null` union (a marshmallow `allow_none` quirk that ng-openapi-gen translates as a permissive `{}`) once for both callers.
  - `dashboard.component.ts` (rename from the dashboard) and `right-panel.component.ts` (rename from the detector context bar) both call the shared prompt helper after a successful rename.
  - `frontend/openapi.json` and generated client regenerated.

## Test plan
- [x] `./run-tests.sh` — 3637 passed, 1 skipped
- [x] `./run-tests.sh detectors` — 863 passed
- [x] `./run-tests.sh io` — 643 passed
- [x] `cd frontend && npm run build:prod` — clean, no warnings
- [x] New tests in `tests/detectors/test_detectors.py::TestRenameLabelsetSourceCleanup` cover: orphaned-file detection (template with/without `{detector_name}`, destination exists, no labelset source, old file missing), `ctx.name` updated post-rename, move endpoint happy path, move endpoint idempotent when source missing, move endpoint rejects clobber, 404 on unknown detector.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VqvczRaH9SYGsn2GswWPHG)_