### PR TITLE
Right-click left-panel media to sort by similarity / seed a detector

### DIFF
--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -374,8 +374,16 @@ The "combine detectors" feature exists but requires multi-select + a non-obvious
 ### 8.8 Renaming + re-syncing a detector ★ XS
 Renaming a detector with a labelset source filepath template (`{detector_name}.labels.json`) leaves the old file on disk. After rename, prompt: "Move existing labelset file to new name?" with a one-click yes.
 
-### 8.9 Audio segment example → trained detector ★★ M
+### 8.9 Audio segment example → trained detector ★★ M — **SHIPPED**
 "I want a detector for this 3-second cough sound": today requires opening a centre-panel item, opening the crop modal, dragging selection, confirming, then navigating to new-detector with that example. Add a right-click "Use this as a detector seed" on any media in the left panel.
+
+**What shipped:** Right-click in the left panel (click focus-mode only) opens a context menu with four actions, working for every media type: *Sort by similarity to this*, *Crop, then sort by similarity…* (audio/image), *Use as detector seed*, *Crop, then use as detector seed…* (audio/image). Backed by two new endpoints — `POST /api/example-sort-by-id` (reuses the in-memory embedding when no crop is requested — zero re-embed cost) and `POST /api/server-media-files/from-media-id` (materialises a loaded media's bytes into `example_media/` so the new-detector form can consume it via the existing `media_example` field). The new-detector flow learned a `seedMediaId` / `seedCropParams` pre-fill via `NewThingFlowsService`, and the existing `vt-media-crop-modal` is reused for the crop variants by fetching the loaded media as a blob via `/api/medias/<id>/{audio,image}`.
+
+**Hover focus-mode is unchanged** — right-click still votes good there; users in speed-labeling mode can't seed a detector via right-click and use the Dashboard's New Detector button instead. This was the chosen tradeoff during planning.
+
+**Open follow-ups:**
+- Video / document / text crop overlays. The crop modal only supports audio + image today; the right-click menu hides the crop entries for everything else. If we want time-range cropping on video or page-range cropping on documents, the bounded clippers and `vt-media-crop-modal` overlay both need new variants.
+- Context-pulldown parity. The right-click menu only exists on left-panel items; right-panel labelset / label items still bind right-click to vote-good. Worth considering if we want detector-card-style actions there too.
 
 ### 8.10 Resuming a labelling session ★★ S
 There's no "recent sessions" surface. Add a "Recent sessions" list on the dashboard (dataset + detector pair + last activity timestamp) so the user gets back into work in one click.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2061,6 +2061,23 @@
         ],
         "type": "object"
       },
+      "ExampleSortByIdRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "crop_params": {
+            "additionalProperties": {},
+            "nullable": true,
+            "type": "object"
+          },
+          "media_id": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "media_id"
+        ],
+        "type": "object"
+      },
       "ExampleSortOriginRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3360,6 +3377,23 @@
         "required": [
           "seeded",
           "skipped"
+        ],
+        "type": "object"
+      },
+      "ServerMediaFromMediaIdRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "crop_params": {
+            "additionalProperties": {},
+            "nullable": true,
+            "type": "object"
+          },
+          "media_id": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "media_id"
         ],
         "type": "object"
       },
@@ -7657,6 +7691,52 @@
         ]
       }
     },
+    "/api/example-sort-by-id": {
+      "post": {
+        "description": "When ``crop_params`` is absent the existing ``media[\"embedding\"]``\nis reused \u2014 no fetch, no re-embed.  When set, the media's bytes are\nmaterialised, cropped, and re-embedded before sorting.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExampleSortByIdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExampleSortResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "No medias loaded, or media_id not in the loaded snapshot."
+          },
+          "404": {
+            "description": "Media not found, or its bytes are unavailable when cropping is requested."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
+          },
+          "500": {
+            "description": "Example sort failed."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Sort medias by similarity to an already-loaded media item.",
+        "tags": [
+          "media_server"
+        ]
+      }
+    },
     "/api/example-sort-origin": {
       "post": {
         "description": "Accepts a JSON body with ``origin`` (an origin dict as stored on medias)\nand ``key`` (the item key / relative path within the source).  The file\nis fetched via the :class:`~vtsearch.datasets.sources.base.MediaSource`\nabstraction, embedded, and used for cosine-similarity sorting.\n\nExample request::\n\n    {\n        \"origin\": {\"importer\": \"server_folder\", \"params\": {\"path\": \"/data/sounds\"}},\n        \"key\": \"subdir/audio123.wav\"\n    }",
@@ -9081,6 +9161,49 @@
           }
         },
         "summary": "List media files saved on the server in the user's example_media/ dir.",
+        "tags": [
+          "media_server"
+        ]
+      }
+    },
+    "/api/server-media-files/from-media-id": {
+      "post": {
+        "description": "Used by the right-click ``Use as detector seed`` flow: the loaded\nmedia is materialised to disk so the new-detector form can reference\nit as ``media_example`` (the same field the upload path returns).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServerMediaFromMediaIdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerMediaUploadResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "description": "media_id not loaded, or invalid crop_params."
+          },
+          "404": {
+            "description": "Media bytes unavailable."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Save a loaded media's bytes to the example_media/ directory.",
         "tags": [
           "media_server"
         ]

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -121,6 +121,8 @@
   @if (newDetectorFlow.open) {
     <vt-new-detector-modal
       [defaultMediaType]="newDetectorFlow.defaultMediaType"
+      [seedMediaId]="newDetectorFlow.seedMediaId ?? null"
+      [seedCropParams]="newDetectorFlow.seedCropParams ?? null"
       (closed)="onNewDetectorClosed()"
       (created)="onDetectorCreated($event)"
     />

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -45,6 +45,15 @@ export class NewDetectorModalComponent implements OnInit {
   /** Media type of the currently active dataset, if any. */
   @Input() defaultMediaType = '';
 
+  /** When set, the modal opens with this loaded-media id materialised into
+   *  example_media/ as the seed example. The picker is bypassed and the
+   *  user lands directly on the form. Cleared by callers via
+   *  ``NewThingFlowsService.closeNewDetector``. */
+  @Input() seedMediaId: number | null = null;
+
+  /** Optional crop bounds applied when materialising ``seedMediaId``. */
+  @Input() seedCropParams: Record<string, unknown> | null = null;
+
   @Output() closed = new EventEmitter<void>();
   @Output() created = new EventEmitter<string>();
 
@@ -211,6 +220,37 @@ export class NewDetectorModalComponent implements OnInit {
         },
       });
     }
+
+    if (this.seedMediaId != null) {
+      this.materializeSeedFromMediaId(this.seedMediaId, this.seedCropParams ?? undefined);
+    }
+  }
+
+  /** Materialise a loaded media into example_media/ and pre-fill the
+   *  example fields, so the user lands on the form with the seed already
+   *  selected. */
+  private materializeSeedFromMediaId(
+    mediaId: number,
+    cropParams?: Record<string, unknown>,
+  ): void {
+    this.submitting = true;
+    this.sortingApi
+      .saveServerMediaFromMediaId({ media_id: mediaId, crop_params: cropParams })
+      .subscribe({
+        next: (res) => {
+          this.exampleType = 'media';
+          this.exampleValue = res.filename;
+          this.exampleDisplay = res.original_name || res.filename;
+          this.exampleMediaType = this.mediaType;
+          this.exampleThumbFailed = false;
+          this.pendingText = '';
+          this.submitting = false;
+        },
+        error: (err) => {
+          this.submitting = false;
+          this.error = err.error?.message || 'Failed to load seed media';
+        },
+      });
   }
 
   unlockMediaType(): void {

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -33,6 +33,7 @@
       (exampleSortStarted)="onExampleSortStarted($event)"
       (mediaSelect)="onMediaSelect($event)"
       (mediaVote)="onHoverVote($event)"
+      (mediaContextRequest)="onMediaContextRequest($event)"
       (indicatorClick)="onIndicatorClick($event)"
       [datasetName]="datasetName"
       [autopilotCollapsed]="autopilotCollapsed"
@@ -74,6 +75,25 @@
     [metric]="progressModalMetric"
     [useCachedHistory]="true"
     (closed)="onProgressModalClosed()"
+  />
+}
+
+@if (contextMenuOpen) {
+  <vt-media-context-menu
+    [x]="contextMenuX"
+    [y]="contextMenuY"
+    [items]="contextMenuItems"
+    (actionSelected)="onContextMenuAction($event)"
+    (dismissed)="dismissContextMenu()"
+  />
+}
+
+@if (cropPending) {
+  <vt-media-crop-modal
+    [file]="cropPending.file"
+    [mediaType]="cropPending.mediaType"
+    (confirmed)="onCropConfirmed($event)"
+    (cancelled)="onCropCancelled()"
   />
 }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -5,6 +5,16 @@ import { takeUntil, switchMap, filter, take } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
+import {
+  MediaContextMenuComponent,
+  MediaContextMenuItem,
+} from '../left-panel/media-item/media-context-menu.component';
+import {
+  MediaCropModalComponent,
+  MediaCropResult,
+} from '../modals/media-crop-modal/media-crop-modal.component';
+import { NewThingFlowsService } from '../../services/new-thing-flows.service';
+import { ToastService } from '../../services/toast.service';
 import { SortingApiService } from '../../services/sorting-api.service';
 import { DetectorsApiService } from '../../services/detectors-api.service';
 import { MediasApiService } from '../../services/medias-api.service';
@@ -27,7 +37,16 @@ import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/gr
 @Component({
   selector: 'vt-label-view',
   standalone: true,
-  imports: [CommonModule, LeftPanelComponent, CenterPanelComponent, RightPanelComponent, ProgressModalComponent, ResortPromptModalComponent],
+  imports: [
+    CommonModule,
+    LeftPanelComponent,
+    CenterPanelComponent,
+    RightPanelComponent,
+    ProgressModalComponent,
+    ResortPromptModalComponent,
+    MediaContextMenuComponent,
+    MediaCropModalComponent,
+  ],
   templateUrl: './label-view.component.html',
   styleUrl: './label-view.component.scss',
 })
@@ -108,6 +127,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     private autopilotStateService: AutopilotStateService,
     private activeContext: ActiveContextService,
     private progressEvents: ProgressEventsService,
+    private newThingFlows: NewThingFlowsService,
+    private toast: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -649,6 +670,163 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onMediaSelect(id: number): void {
     this.mediaState.selectMedia(id);
+  }
+
+  // --- Right-click media context menu ---
+
+  contextMenuOpen = false;
+  contextMenuX = 0;
+  contextMenuY = 0;
+  contextMenuMediaId: number | null = null;
+  contextMenuItems: MediaContextMenuItem[] = [];
+
+  /** Pending crop modal state. When set, the user has chosen a "Crop and …"
+   *  action and we have fetched the media bytes; the crop modal renders. */
+  cropPending: {
+    file: File;
+    mediaId: number;
+    mediaType: string;
+    /** What to do after the crop is confirmed. */
+    action: 'sort' | 'seed';
+  } | null = null;
+
+  onMediaContextRequest(event: { id: number; x: number; y: number }): void {
+    const media = this.mediaState.medias.find((m) => m.id === event.id);
+    const mediaType = media?.type ?? '';
+    const cropAble = mediaType === 'audio' || mediaType === 'image';
+
+    const items: MediaContextMenuItem[] = [
+      {
+        id: 'sort',
+        label: 'Sort by similarity to this',
+        title: 'Sort all loaded items by similarity to this item, using its existing embedding.',
+      },
+    ];
+    if (cropAble) {
+      items.push({
+        id: 'crop-sort',
+        label: 'Crop, then sort by similarity…',
+        title: 'Open the crop tool to pick a sub-region, then sort by similarity.',
+      });
+    }
+    items.push({
+      id: 'seed',
+      label: 'Use as detector seed',
+      title: 'Open the New Detector form with this item pre-selected as the example.',
+    });
+    if (cropAble) {
+      items.push({
+        id: 'crop-seed',
+        label: 'Crop, then use as detector seed…',
+        title: 'Open the crop tool to pick a sub-region, then seed a new detector.',
+      });
+    }
+
+    this.contextMenuItems = items;
+    this.contextMenuMediaId = event.id;
+    this.contextMenuX = event.x;
+    this.contextMenuY = event.y;
+    this.contextMenuOpen = true;
+  }
+
+  onContextMenuAction(action: string): void {
+    const mediaId = this.contextMenuMediaId;
+    this.dismissContextMenu();
+    if (mediaId == null) return;
+
+    if (action === 'sort') {
+      this.runExampleSortById(mediaId);
+    } else if (action === 'seed') {
+      this.openSeedNewDetector(mediaId);
+    } else if (action === 'crop-sort' || action === 'crop-seed') {
+      this.openCropOverlay(mediaId, action === 'crop-sort' ? 'sort' : 'seed');
+    }
+  }
+
+  dismissContextMenu(): void {
+    this.contextMenuOpen = false;
+    this.contextMenuMediaId = null;
+  }
+
+  private runExampleSortById(mediaId: number, cropParams?: Record<string, unknown>): void {
+    this.sortState.setSortBusy(true);
+    this.sortState.setSortStatus('Sorting by example…');
+    this.sortingApi
+      .exampleSortById({ media_id: mediaId, crop_params: cropParams })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          this.sortState.setSortMode('load');
+          this.sortState.setSortResults(
+            response.results.map((r) => ({ id: r.id, score: r.similarity, bestRegion: r.best_region })),
+            response.threshold,
+          );
+          this.sortState.setLoadSortLabel(this.mediaDisplayName(mediaId));
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus('');
+          this.autoSelectNext();
+        },
+        error: (err) => {
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus('Example sort failed');
+          this.toast.error({ message: err?.error?.message || 'Example sort failed' });
+        },
+      });
+  }
+
+  private openSeedNewDetector(mediaId: number, cropParams?: Record<string, unknown>): void {
+    const media = this.mediaState.medias.find((m) => m.id === mediaId);
+    this.newThingFlows.openNewDetector({
+      defaultMediaType: media?.type ?? '',
+      seedMediaId: mediaId,
+      seedCropParams: cropParams,
+    });
+  }
+
+  private openCropOverlay(mediaId: number, action: 'sort' | 'seed'): void {
+    const media = this.mediaState.medias.find((m) => m.id === mediaId);
+    if (!media) return;
+    const mediaType = media.type;
+    const url =
+      mediaType === 'audio'
+        ? this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`)
+        : this.activeContext.mediaUrl(`/api/medias/${mediaId}/image`);
+
+    this.sortState.setSortBusy(true);
+    this.sortState.setSortStatus('Loading media for crop…');
+    fetch(url, { credentials: 'same-origin' })
+      .then((r) => {
+        if (!r.ok) throw new Error(`Failed to fetch media (${r.status})`);
+        return r.blob();
+      })
+      .then((blob) => {
+        const name = media.filename || `media_${mediaId}`;
+        const file = new File([blob], name, { type: blob.type });
+        this.cropPending = { file, mediaId, mediaType, action };
+        this.sortState.setSortBusy(false);
+        this.sortState.setSortStatus('');
+      })
+      .catch((err) => {
+        this.sortState.setSortBusy(false);
+        this.sortState.setSortStatus('');
+        this.toast.error({ message: err?.message || 'Failed to load media for crop' });
+      });
+  }
+
+  onCropConfirmed(result: MediaCropResult): void {
+    const pending = this.cropPending;
+    this.cropPending = null;
+    if (!pending) return;
+    const cropParams = result.cropParams as Record<string, unknown> | undefined;
+    if (pending.action === 'sort') {
+      this.runExampleSortById(pending.mediaId, cropParams);
+    } else {
+      this.openSeedNewDetector(pending.mediaId, cropParams);
+    }
+  }
+
+  onCropCancelled(): void {
+    this.cropPending = null;
   }
 
   private refreshTrainableModelName(modelId: string): void {

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -136,6 +136,7 @@
             [showScores]="false"
             (mediaSelect)="mediaSelect.emit($event)"
             (mediaVote)="mediaVote.emit($event)"
+            (mediaContextRequest)="mediaContextRequest.emit($event)"
           />
           <vt-stripe-overview
             [sortOrder]="sortOrder"

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -80,6 +80,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   @Output() exampleSortStarted = new EventEmitter<unknown>();
   @Output() mediaSelect = new EventEmitter<number>();
   @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  @Output() mediaContextRequest = new EventEmitter<{ id: number; x: number; y: number }>();
   @Output() indicatorClick = new EventEmitter<string>();
   @Output() autopilotStart = new EventEmitter<void>();
   @Output() autopilotStop = new EventEmitter<void>();

--- a/frontend/src/app/components/left-panel/media-item/media-context-menu.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-context-menu.component.html
@@ -1,0 +1,20 @@
+<div
+  class="media-context-menu"
+  role="menu"
+  [style.left.px]="x"
+  [style.top.px]="y"
+>
+  @for (item of items; track item.id) {
+    <button
+      type="button"
+      class="menu-item"
+      role="menuitem"
+      [class.disabled]="item.disabled"
+      [disabled]="item.disabled"
+      [title]="item.title || ''"
+      (click)="onItemClick($event, item)"
+    >
+      {{ item.label }}
+    </button>
+  }
+</div>

--- a/frontend/src/app/components/left-panel/media-item/media-context-menu.component.scss
+++ b/frontend/src/app/components/left-panel/media-item/media-context-menu.component.scss
@@ -1,0 +1,32 @@
+.media-context-menu {
+  position: fixed;
+  z-index: var(--z-burger-menu);
+  min-width: 220px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-xs) 0;
+  box-shadow: 0 8px 24px var(--shadow-dropdown);
+  display: flex;
+  flex-direction: column;
+}
+
+.menu-item {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: var(--font-md);
+  text-align: left;
+  padding: var(--space-md) var(--space-lg);
+  cursor: pointer;
+
+  &:hover:not(.disabled) {
+    background: var(--bg-hover);
+  }
+
+  &.disabled,
+  &:disabled {
+    color: var(--text-muted);
+    cursor: not-allowed;
+  }
+}

--- a/frontend/src/app/components/left-panel/media-item/media-context-menu.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-context-menu.component.ts
@@ -1,0 +1,59 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+
+export interface MediaContextMenuItem {
+  id: string;
+  label: string;
+  title?: string;
+  disabled?: boolean;
+}
+
+@Component({
+  selector: 'vt-media-context-menu',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './media-context-menu.component.html',
+  styleUrl: './media-context-menu.component.scss',
+})
+export class MediaContextMenuComponent {
+  @Input({ required: true }) x = 0;
+  @Input({ required: true }) y = 0;
+  @Input() items: MediaContextMenuItem[] = [];
+
+  @Output() actionSelected = new EventEmitter<string>();
+  @Output() dismissed = new EventEmitter<void>();
+
+  constructor(private host: ElementRef<HTMLElement>) {}
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.dismissed.emit();
+    }
+  }
+
+  @HostListener('document:contextmenu', ['$event'])
+  onDocumentContextMenu(event: MouseEvent): void {
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.dismissed.emit();
+    }
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.dismissed.emit();
+  }
+
+  onItemClick(event: MouseEvent, item: MediaContextMenuItem): void {
+    event.stopPropagation();
+    if (item.disabled) return;
+    this.actionSelected.emit(item.id);
+  }
+}

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -23,6 +23,7 @@ export class MediaItemComponent implements OnChanges {
 
   @Output() select = new EventEmitter<number>();
   @Output() vote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  @Output() contextRequest = new EventEmitter<{ id: number; x: number; y: number }>();
 
   thumbnailFailed = false;
   private lastMediaId: number | null = null;
@@ -95,9 +96,15 @@ export class MediaItemComponent implements OnChanges {
 
   onContextMenu(event: MouseEvent): void {
     if (this.focusMode === 'hover') {
+      // Hover mode keeps the existing right-click = vote-good shortcut; the
+      // context menu is intentionally not available so speed-labeling stays
+      // fast. Users can still seed a detector via the dashboard.
       event.preventDefault();
       this.vote.emit({ id: this.media.id, vote: 'good' });
+      return;
     }
+    event.preventDefault();
+    this.contextRequest.emit({ id: this.media.id, x: event.clientX, y: event.clientY });
   }
 
   onMouseEnter(): void {

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -17,6 +17,7 @@
         [focusMode]="focusMode"
         (select)="onMediaSelect($event)"
         (vote)="onMediaVote($event)"
+        (contextRequest)="onMediaContextRequest($event)"
       />
     </ng-container>
   </cdk-virtual-scroll-viewport>
@@ -39,6 +40,7 @@
         [focusMode]="focusMode"
         (select)="onMediaSelect($event)"
         (vote)="onMediaVote($event)"
+        (contextRequest)="onMediaContextRequest($event)"
       />
     }
 

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -49,6 +49,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
   @Output() mediaSelect = new EventEmitter<number>();
   @Output() mediaVote = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
+  @Output() mediaContextRequest = new EventEmitter<{ id: number; x: number; y: number }>();
   @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
   @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
 
@@ -161,6 +162,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
   onMediaVote(event: { id: number; vote: 'good' | 'bad' }): void {
     this.mediaVote.emit(event);
+  }
+
+  onMediaContextRequest(event: { id: number; x: number; y: number }): void {
+    this.mediaContextRequest.emit(event);
   }
 
   ngAfterViewChecked(): void {

--- a/frontend/src/app/services/new-thing-flows.service.ts
+++ b/frontend/src/app/services/new-thing-flows.service.ts
@@ -12,6 +12,14 @@ export interface ImporterFlowState {
 export interface NewDetectorFlowState {
   open: boolean;
   defaultMediaType: string;
+  /** ID of a loaded media to use as the new detector's seed example.
+   *  When set, the modal materialises this media to ``example_media/``
+   *  on open and pre-fills the example field, skipping the picker. */
+  seedMediaId?: number;
+  /** Optional crop bounds applied when materialising the seed media.
+   *  Shape matches the bounded clippers (audio: ``{start, end}``;
+   *  image: ``{box: [x1, y1, x2, y2]}``). */
+  seedCropParams?: Record<string, unknown>;
 }
 
 export interface ThingCreatedEvent {
@@ -48,6 +56,8 @@ export class NewThingFlowsService {
   private readonly newDetectorSubject = new BehaviorSubject<NewDetectorFlowState>({
     open: false,
     defaultMediaType: '',
+    seedMediaId: undefined,
+    seedCropParams: undefined,
   });
   private readonly createdSubject = new Subject<ThingCreatedEvent>();
   private readonly demoSelectedSubject = new Subject<DemoSelectedEvent>();
@@ -96,6 +106,8 @@ export class NewThingFlowsService {
     this.newDetectorSubject.next({
       open: true,
       defaultMediaType: opts.defaultMediaType ?? '',
+      seedMediaId: opts.seedMediaId,
+      seedCropParams: opts.seedCropParams,
     });
   }
 
@@ -103,6 +115,8 @@ export class NewThingFlowsService {
     this.newDetectorSubject.next({
       open: false,
       defaultMediaType: '',
+      seedMediaId: undefined,
+      seedCropParams: undefined,
     });
   }
 

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -43,8 +43,10 @@ import { apiEvalTrainAndScorePost } from '../generated/api-client/fn/eval/api-ev
 import { apiEvalTrainAndScoreResultGet } from '../generated/api-client/fn/eval/api-eval-train-and-score-result-get';
 import { apiIndicatorScoreHistoryGet } from '../generated/api-client/fn/eval/api-indicator-score-history-get';
 import { apiLabelingStatusGet } from '../generated/api-client/fn/eval/api-labeling-status-get';
+import { apiExampleSortByIdPost } from '../generated/api-client/fn/media-server/api-example-sort-by-id-post';
 import { apiExampleSortOriginPost } from '../generated/api-client/fn/media-server/api-example-sort-origin-post';
 import { apiExampleSortServerPost } from '../generated/api-client/fn/media-server/api-example-sort-server-post';
+import { apiServerMediaFilesFromMediaIdPost } from '../generated/api-client/fn/media-server/api-server-media-files-from-media-id-post';
 import { apiServerMediaFilesGet } from '../generated/api-client/fn/media-server/api-server-media-files-get';
 
 @Injectable({ providedIn: 'root' })
@@ -148,6 +150,29 @@ export class SortingApiService {
     return apiExampleSortOriginPost(this.http, this.config.rootUrl, { body: params }).pipe(
       map((r) => r.body),
     );
+  }
+
+  /** Sort the loaded snapshot by similarity to an already-loaded media.
+   *  Skips re-embedding when ``crop_params`` is absent — the in-memory
+   *  embedding is reused directly. */
+  exampleSortById(params: {
+    media_id: number;
+    crop_params?: Record<string, unknown>;
+  }): Observable<ExampleSortResponse> {
+    return apiExampleSortByIdPost(this.http, this.config.rootUrl, { body: params }).pipe(
+      map((r) => r.body),
+    );
+  }
+
+  /** Save a loaded media's bytes to example_media/ so the new-detector
+   *  flow can reference it via ``media_example``. */
+  saveServerMediaFromMediaId(params: {
+    media_id: number;
+    crop_params?: Record<string, unknown>;
+  }): Observable<ServerMediaUploadResponse> {
+    return apiServerMediaFilesFromMediaIdPost(this.http, this.config.rootUrl, {
+      body: params,
+    }).pipe(map((r) => r.body));
   }
 
   /** Multipart upload — see {@link exampleSort}. */

--- a/tests/api/test_example_sort_by_id.py
+++ b/tests/api/test_example_sort_by_id.py
@@ -81,9 +81,7 @@ class TestServerMediaFileFromMediaIdEndpoint:
         assert "media_id" in resp.get_json()["errors"]["json"]
 
     def test_unknown_media_id(self, client):
-        resp = client.post(
-            "/api/server-media-files/from-media-id", json={"media_id": 999_999}
-        )
+        resp = client.post("/api/server-media-files/from-media-id", json={"media_id": 999_999})
         assert resp.status_code == 400
         assert "not loaded" in resp.get_json()["message"].lower()
 

--- a/tests/api/test_example_sort_by_id.py
+++ b/tests/api/test_example_sort_by_id.py
@@ -1,0 +1,129 @@
+"""Tests for the right-click ``Use this as detector seed`` endpoints.
+
+Covers:
+
+* ``POST /api/example-sort-by-id`` — sort by similarity to an
+  already-loaded media (in-memory embedding path, no re-embed).
+* ``POST /api/server-media-files/from-media-id`` — materialise a loaded
+  media's bytes to ``example_media/`` for the new-detector seed flow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch.state import medias
+
+
+@pytest.fixture
+def loaded_media_id(reset_state):
+    """Return the id of a loaded media. The autouse ``reset_state`` fixture
+    seeds the snapshot from ``_test_medias_snapshot`` — pick the first id."""
+    if not medias:
+        pytest.skip("No medias loaded in test environment")
+    return next(iter(medias.keys()))
+
+
+class TestExampleSortByIdEndpoint:
+    def test_missing_media_id(self, client):
+        resp = client.post("/api/example-sort-by-id", json={})
+        assert resp.status_code == 422
+        assert "media_id" in resp.get_json()["errors"]["json"]
+
+    def test_unknown_media_id(self, client, loaded_media_id):
+        resp = client.post("/api/example-sort-by-id", json={"media_id": 999_999})
+        assert resp.status_code == 400
+        assert "not loaded" in resp.get_json()["message"].lower()
+
+    def test_no_medias_loaded(self, client):
+        saved = dict(medias)
+        medias.clear()
+        try:
+            resp = client.post("/api/example-sort-by-id", json={"media_id": 1})
+            assert resp.status_code == 400
+            assert "no medias loaded" in resp.get_json()["message"].lower()
+        finally:
+            medias.update(saved)
+
+    def test_success_uses_in_memory_embedding(self, client, loaded_media_id):
+        """Happy path: the existing embedding is reused, no fetch / re-embed."""
+        resp = client.post(
+            "/api/example-sort-by-id",
+            json={"media_id": loaded_media_id},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert "results" in body
+        assert "threshold" in body
+        # Cosine similarity to self is 1.0 — the query item should rank #1.
+        assert body["results"][0]["id"] == loaded_media_id
+
+    def test_media_without_embedding_returns_400(self, client, loaded_media_id):
+        """Cropping is the only path that can re-derive; without crop, an
+        embedding-less media is unsortable."""
+        saved = medias[loaded_media_id].copy()
+        medias[loaded_media_id].pop("embedding", None)
+        try:
+            resp = client.post(
+                "/api/example-sort-by-id",
+                json={"media_id": loaded_media_id},
+            )
+            assert resp.status_code == 400
+            assert "no embedding" in resp.get_json()["message"].lower()
+        finally:
+            medias[loaded_media_id] = saved
+
+
+class TestServerMediaFileFromMediaIdEndpoint:
+    def test_missing_media_id(self, client):
+        resp = client.post("/api/server-media-files/from-media-id", json={})
+        assert resp.status_code == 422
+        assert "media_id" in resp.get_json()["errors"]["json"]
+
+    def test_unknown_media_id(self, client):
+        resp = client.post(
+            "/api/server-media-files/from-media-id", json={"media_id": 999_999}
+        )
+        assert resp.status_code == 400
+        assert "not loaded" in resp.get_json()["message"].lower()
+
+    def test_media_without_bytes_returns_404(self, client, loaded_media_id):
+        """A loaded media that has no resolvable bytes (no media_bytes,
+        no media_path, no media_string) is a 404 — we can't materialise it."""
+        saved = medias[loaded_media_id].copy()
+        for key in ("media_bytes", "media_path", "media_string"):
+            medias[loaded_media_id].pop(key, None)
+        try:
+            resp = client.post(
+                "/api/server-media-files/from-media-id",
+                json={"media_id": loaded_media_id},
+            )
+            assert resp.status_code == 404
+        finally:
+            medias[loaded_media_id] = saved
+
+    def test_success_materialises_bytes(self, client, loaded_media_id, tmp_path, monkeypatch):
+        """Happy path: media bytes are written under example_media/ and the
+        saved filename + original name come back in the response."""
+        # Redirect the per-user example_media/ dir so we don't pollute disk.
+        import vtsearch.routes.media.server as server_module
+
+        monkeypatch.setattr(server_module, "SERVER_MEDIA_DIR", tmp_path / "example_media")
+
+        # Make sure the media has resolvable bytes.
+        media = medias[loaded_media_id]
+        if not media.get("media_bytes") and not media.get("media_path"):
+            media["media_bytes"] = b"fake content for materialisation test"
+
+        resp = client.post(
+            "/api/server-media-files/from-media-id",
+            json={"media_id": loaded_media_id},
+        )
+        assert resp.status_code == 201, resp.get_json()
+        body = resp.get_json()
+        assert body["filename"]
+        assert body["original_name"]
+
+        saved_path = tmp_path / "example_media" / body["filename"]
+        assert saved_path.exists()
+        assert saved_path.stat().st_size > 0

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -20,13 +20,15 @@ from werkzeug.exceptions import HTTPException
 from vtsearch.config import DATA_DIR
 from vtsearch.routes._shared import format_exception_detail
 from vtsearch.schemas.media import (
+    ExampleSortByIdRequestSchema,
     ExampleSortOriginRequestSchema,
     ExampleSortResponseSchema,
     ExampleSortServerRequestSchema,
+    ServerMediaFromMediaIdRequestSchema,
     ServerMediaListResponseSchema,
     ServerMediaUploadResponseSchema,
 )
-from vtsearch.state import snapshot_medias
+from vtsearch.state import get_media, snapshot_medias
 
 media_server_bp = Blueprint(
     "media_server",
@@ -347,3 +349,156 @@ def example_sort_origin(body: dict):
         abort(500, message=f"Example sort failed: {format_exception_detail(exc)}")
     finally:
         source.cleanup()
+
+
+def _media_extension(media: dict) -> str:
+    """Return the file extension (with leading dot) for a loaded media.
+
+    Falls back to ``.wav`` for audio (the on-the-fly serving format),
+    ``.bin`` for unknown types.
+    """
+    filename = media.get("filename", "")
+    suffix = Path(filename).suffix
+    if suffix:
+        return suffix
+    media_type = media.get("type", "")
+    if media_type == "audio":
+        return ".wav"
+    if media_type == "image":
+        return ".jpg"
+    if media_type == "video":
+        return ".mp4"
+    if media_type == "text":
+        return ".txt"
+    return ".bin"
+
+
+def _resolve_media_bytes(media: dict) -> bytes | None:
+    """Return the raw bytes for a loaded media item.
+
+    Mirrors :func:`vtsearch.routes.media.list._resolve_bytes` but is also
+    aware of text media (which stores its content as ``media_string``).
+    """
+    media_bytes = media.get("media_bytes")
+    if media_bytes is not None:
+        return media_bytes
+    media_path = media.get("media_path")
+    if media_path:
+        p = Path(media_path)
+        if p.exists():
+            return p.read_bytes()
+    media_string = media.get("media_string")
+    if media_string is not None:
+        return media_string.encode("utf-8")
+    return None
+
+
+@media_server_bp.route("/api/example-sort-by-id", methods=["POST"])
+@media_server_bp.arguments(ExampleSortByIdRequestSchema)
+@media_server_bp.response(200, ExampleSortResponseSchema)
+@media_server_bp.alt_response(400, description="No medias loaded, or media_id not in the loaded snapshot.")
+@media_server_bp.alt_response(404, description="Media not found, or its bytes are unavailable when cropping is requested.")
+@media_server_bp.alt_response(500, description="Example sort failed.")
+def example_sort_by_id(body: dict):
+    """Sort medias by similarity to an already-loaded media item.
+
+    When ``crop_params`` is absent the existing ``media["embedding"]``
+    is reused — no fetch, no re-embed.  When set, the media's bytes are
+    materialised, cropped, and re-embedded before sorting.
+    """
+    media_id = body["media_id"]
+
+    if not snapshot_medias():
+        abort(400, message="No medias loaded")
+
+    media = get_media(media_id)
+    if media is None:
+        abort(400, message=f"Media id {media_id} is not loaded")
+
+    crop_params = body.get("crop_params") if isinstance(body.get("crop_params"), dict) else None
+
+    try:
+        from vtsearch.routes.sorting import (
+            _apply_crop_or_keep,
+            _cosine_sort,
+            _example_sort_from_path,
+        )
+
+        if crop_params:
+            media_bytes = _resolve_media_bytes(media)
+            if media_bytes is None:
+                abort(404, message="Media bytes unavailable for cropping")
+
+            import uuid
+
+            DATA_DIR.mkdir(exist_ok=True)
+            tmp = DATA_DIR / f"temp_example_{uuid.uuid4().hex}{_media_extension(media)}"
+            tmp.write_bytes(media_bytes)
+            try:
+                _apply_crop_or_keep(tmp, crop_params)
+                results, thresh = _example_sort_from_path(tmp)
+            finally:
+                tmp.unlink(missing_ok=True)
+        else:
+            embedding = media.get("embedding")
+            if embedding is None:
+                abort(400, message="Media has no embedding (cannot sort)")
+            results, thresh = _cosine_sort(embedding)
+        return {"results": results, "threshold": thresh}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).exception("example-sort-by-id failed")
+        abort(500, message=f"Example sort failed: {format_exception_detail(exc)}")
+
+
+@media_server_bp.route("/api/server-media-files/from-media-id", methods=["POST"])
+@media_server_bp.arguments(ServerMediaFromMediaIdRequestSchema)
+@media_server_bp.response(201, ServerMediaUploadResponseSchema)
+@media_server_bp.alt_response(400, description="media_id not loaded, or invalid crop_params.")
+@media_server_bp.alt_response(404, description="Media bytes unavailable.")
+def server_media_file_from_media_id(body: dict):
+    """Save a loaded media's bytes to the example_media/ directory.
+
+    Used by the right-click ``Use as detector seed`` flow: the loaded
+    media is materialised to disk so the new-detector form can reference
+    it as ``media_example`` (the same field the upload path returns).
+    """
+    import uuid
+
+    media_id = body["media_id"]
+    media = get_media(media_id)
+    if media is None:
+        abort(400, message=f"Media id {media_id} is not loaded")
+
+    media_bytes = _resolve_media_bytes(media)
+    if media_bytes is None:
+        abort(404, message="Media bytes unavailable")
+
+    crop_params = body.get("crop_params") if isinstance(body.get("crop_params"), dict) else None
+    if crop_params:
+        media_type = media.get("type", "")
+        try:
+            from vtsearch.media.cropping import crop_file_bytes
+
+            DATA_DIR.mkdir(exist_ok=True)
+            tmp = DATA_DIR / f"temp_seed_{uuid.uuid4().hex}{_media_extension(media)}"
+            tmp.write_bytes(media_bytes)
+            try:
+                media_bytes = crop_file_bytes(tmp, media_type, crop_params)
+            finally:
+                tmp.unlink(missing_ok=True)
+        except (ValueError, FileNotFoundError):
+            abort(400, message="Invalid crop_params for this media type")
+
+    suffix = _media_extension(media)
+    safe_name = f"{uuid.uuid4().hex}{suffix}"
+    media_dir = _get_server_media_dir()
+    media_dir.mkdir(parents=True, exist_ok=True)
+    dest = media_dir / safe_name
+    dest.write_bytes(media_bytes)
+
+    original = media.get("filename") or media.get("origin_name") or f"media_{media_id}{suffix}"
+    return {"filename": safe_name, "original_name": original}

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -397,7 +397,9 @@ def _resolve_media_bytes(media: dict) -> bytes | None:
 @media_server_bp.arguments(ExampleSortByIdRequestSchema)
 @media_server_bp.response(200, ExampleSortResponseSchema)
 @media_server_bp.alt_response(400, description="No medias loaded, or media_id not in the loaded snapshot.")
-@media_server_bp.alt_response(404, description="Media not found, or its bytes are unavailable when cropping is requested.")
+@media_server_bp.alt_response(
+    404, description="Media not found, or its bytes are unavailable when cropping is requested."
+)
 @media_server_bp.alt_response(500, description="Example sort failed.")
 def example_sort_by_id(body: dict):
     """Sort medias by similarity to an already-loaded media item.

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -31,6 +31,11 @@ Server media files + example-sort routes (``vtsearch/routes/media/server.py``):
                                        :class:`ExampleSortResponseSchema`
 * ``POST /api/example-sort-origin`` — :class:`ExampleSortOriginRequestSchema` →
                                        :class:`ExampleSortResponseSchema`
+* ``POST /api/example-sort-by-id`` — :class:`ExampleSortByIdRequestSchema` →
+                                      :class:`ExampleSortResponseSchema`
+* ``POST /api/server-media-files/from-media-id`` —
+        :class:`ServerMediaFromMediaIdRequestSchema` →
+        :class:`ServerMediaUploadResponseSchema`
 
 The ``POST /api/embed`` route (``vtsearch/routes/media/embed.py``) is a
 dual-mode dispatcher (multipart upload OR JSON body) and is left
@@ -248,6 +253,32 @@ class ExampleSortOriginRequestSchema(Schema):
     crop_params = fields.Dict(allow_none=True)
 
 
+class ExampleSortByIdRequestSchema(Schema):
+    """Body for ``POST /api/example-sort-by-id``.
+
+    Sorts the loaded snapshot by similarity to an already-loaded media,
+    identified by its in-memory ``media_id``.  When ``crop_params`` is
+    absent the existing ``media["embedding"]`` is reused — no fetch or
+    re-embed.  When set, the media's bytes are materialised, cropped,
+    and re-embedded before sorting.
+    """
+
+    media_id = fields.Integer(required=True)
+    crop_params = fields.Dict(allow_none=True)
+
+
+class ServerMediaFromMediaIdRequestSchema(Schema):
+    """Body for ``POST /api/server-media-files/from-media-id``.
+
+    Materialises the bytes of a loaded media to the per-user
+    ``example_media/`` directory and returns the saved filename so the
+    new-detector flow can reference it as ``media_example``.
+    """
+
+    media_id = fields.Integer(required=True)
+    crop_params = fields.Dict(allow_none=True)
+
+
 class _SortResultEntrySchema(Schema):
     """One scored media in an example-sort ``results`` list.
 
@@ -271,6 +302,7 @@ class ExampleSortResponseSchema(Schema):
 
 
 __all__ = [
+    "ExampleSortByIdRequestSchema",
     "ExampleSortOriginRequestSchema",
     "ExampleSortResponseSchema",
     "ExampleSortServerRequestSchema",
@@ -281,6 +313,7 @@ __all__ = [
     "MediaParagraphResponseSchema",
     "MediaVoteRequestSchema",
     "MediaVoteResponseSchema",
+    "ServerMediaFromMediaIdRequestSchema",
     "ServerMediaListResponseSchema",
     "ServerMediaUploadResponseSchema",
 ]


### PR DESCRIPTION
Implements **§8.9 Audio segment example → trained detector** from `docs/plans/ux-brainstorm.md`, generalised to every media type per the brainstorm's footnote.

## What's new

Right-click on any media in the left panel (in click focus-mode) now opens a context menu with up to four actions:

1. **Sort by similarity to this** — reuses the loaded media's in-memory embedding via the new `POST /api/example-sort-by-id`. Zero re-embed cost.
2. **Crop, then sort by similarity…** *(audio + image only)* — opens `vt-media-crop-modal`, then calls the same endpoint with `crop_params`.
3. **Use as detector seed** — materialises the media to `example_media/` via the new `POST /api/server-media-files/from-media-id` and opens the new-detector modal with the seed pre-filled (skipping the file picker).
4. **Crop, then use as detector seed…** *(audio + image only)* — same with `crop_params`.

Both new endpoints follow the existing `/api/example-sort-server` / `/api/example-sort-origin` and `/api/server-media-files/upload` patterns, share response schemas, and live in `vtsearch/routes/media/server.py`.

`NewThingFlowsService` learned `seedMediaId` / `seedCropParams`; the new-detector modal materialises the seed on open before showing the form.

## Hover focus-mode

The user explicitly opted to **not** change hover focus-mode's existing right-click = vote-good shortcut. The context menu therefore only opens in click focus-mode — hover-mode speed-labeling is unaffected.

## Open follow-ups

Recorded in `docs/plans/ux-brainstorm.md` §8.9:

- Video / document / text crop overlays (today the bounded clippers + crop modal cover only audio + image).
- Right-panel labelset / label list context-menu parity (currently only the left panel has the menu).

## Test plan

- [x] `./run-tests.sh` — 3636 passed, 1 skipped
- [x] `cd frontend && npm run build:prod` — clean
- [x] New tests for both endpoints in `tests/api/test_example_sort_by_id.py` (missing field, unknown id, no medias loaded, in-memory embedding path, embedding-less media, bytes materialisation)
- [ ] Manual: right-click a media item in click focus-mode → confirm menu appears, each action behaves; switch to hover mode → confirm right-click still votes good


---
_Generated by [Claude Code](https://claude.ai/code/session_013ZqovfrdEAfCDPJdcUrmXw)_