### PR TITLE
Add Marquee toggle button for image region voting (§7.8)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -306,18 +306,28 @@ the way of fast keyboard voting.
 
 ### Drawing a region
 
-1. **Hold `Shift`** while the focus pane is showing an image.  The
-   cursor flips to a crosshair and the normal pan-on-drag gesture
-   is suppressed.
-2. **Click-drag-release** to draw a rectangle over the region you
-   want to vote good on.  After release the rectangle shows 8
-   resize handles plus a draggable body, so you can adjust it.
-3. **Press `→`** (or click **Good**) to submit a good vote with
-   the region attached.
+There are two ways into region-draw mode:
+
+- **Marquee button** — click the dashed-rectangle toggle in the
+  image view controls (below the image, next to Rotate / Zoom).
+  While the toggle is on, the cursor stays a crosshair and a normal
+  left-drag draws a region.  The toggle persists across items, so
+  you can annotate many in a row.  Click the button again to leave
+  marquee mode and restore the default pan-on-drag behaviour.
+- **`Shift`+drag** — a power-user shortcut that works whether or
+  not marquee mode is on.  Hold `Shift` while the focus pane is
+  showing an image: the cursor flips to a crosshair and the normal
+  pan-on-drag gesture is suppressed.
+
+Either way, **click-drag-release** to draw a rectangle over the
+region you want to vote good on.  After release the rectangle shows
+8 resize handles plus a draggable body, so you can adjust it.
+Then **press `→`** (or click **Good**) to submit a good vote with
+the region attached.
 
 The rectangle is stored in *normalised image coordinates* — it
 stays anchored to the same pixels of the image even if you zoom in,
-pan, or rotate before voting.  A `Shift`-click without dragging (a
+pan, or rotate before voting.  A click without dragging (a
 zero-area "click") restores the previously drawn rectangle rather
 than discarding it.  `Esc` clears the rectangle without voting.
 

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -339,8 +339,10 @@ Several places accept drag-drop (file import, example media into detector) but s
 ### 7.7 Modal stacking ★★ XS
 Some flows can stack 3 modals deep (importer → demo picker → embedder picker). Stacking modals is a known anti-pattern. Either convert nested modals to in-place sub-views with a back button (§6.4), or use a single multi-step wizard.
 
-### 7.8 Shift-drag to draw region ★★ XS
+### 7.8 Shift-drag to draw region ★★ XS — shipped
 The image region-vote uses Shift+drag with no UI cue. Standard image-region tools use a dedicated mode toggle (a button that turns the cursor into a marquee). Keep Shift+drag as a power-user shortcut, but also expose a Marquee button.
+
+**What shipped:** A dashed-rectangle toggle button in the image-view-controls toolbar (next to Rotate / Zoom / Reset). Clicking it flips `ImageViewerComponent.marqueeMode` on; while on, the cursor stays a crosshair and a normal left-drag draws a region — no Shift required. The toggle is sticky (persists across media navigation, by analogy with Photoshop / CVAT tool selection) and uses the accent colour for its active state so it doesn't conflate with the green Good-vote button. Shift+drag remains a power-user shortcut and works whether the toggle is on or off. Keyboard help + USER_GUIDE updated.
 
 ### 7.9 Region rectangle interaction ★ S
 After drawing, the rectangle is editable via 8 handles — good. But the "click on the rectangle to restore" interaction is non-discoverable. A standard "✓ confirm region" / "✗ clear" button overlay on the rectangle would replace the current "press ← twice to discard" pattern.

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -32,6 +32,17 @@
 
     @if (mediaType === 'image' && imageViewer) {
       <div class="image-view-controls">
+        <button
+          class="ivc-btn ivc-btn-toggle"
+          [class.active]="imageViewer.marqueeMode"
+          (click)="imageViewer.toggleMarqueeMode()"
+          title="Marquee — drag to draw a region (Shift+drag also works)"
+          aria-label="Marquee — draw region"
+          [attr.aria-pressed]="imageViewer.marqueeMode"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3 2.5" aria-hidden="true"><rect x="3.5" y="5.5" width="17" height="13" rx="0.5"/></svg>
+        </button>
+        <span class="ivc-sep" aria-hidden="true"></span>
         <button class="ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left">&#x21BA;</button>
         <button class="ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right">&#x21BB;</button>
         <button class="ivc-btn" (click)="imageViewer.zoomOut()" title="Zoom out (-)" aria-label="Zoom out">&minus;</button>

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -95,6 +95,32 @@
   }
 }
 
+.ivc-btn-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  line-height: 1;
+
+  &.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--btn-filled-text);
+  }
+
+  &.active:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+}
+
+.ivc-sep {
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  display: inline-block;
+}
+
 .ivc-zoom-slider {
   width: 100px;
 }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -1,7 +1,7 @@
 <div
   #imageWrap
   class="image-wrap"
-  [class.region-mode]="shiftHeld"
+  [class.region-mode]="regionDrawActive"
   [style.cursor]="wrapCursor"
   (wheel)="onWheel($event)"
   (mousedown)="onMouseDown($event)"

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -325,6 +325,79 @@ describe('ImageViewerComponent', () => {
     });
   });
 
+  describe('marquee mode toggle', () => {
+    function setupWrap(component: ImageViewerComponent) {
+      component.renderedW = 100;
+      component.renderedH = 100;
+      component.wrapRef = {
+        nativeElement: {
+          getBoundingClientRect: () => ({
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+            right: 100,
+            bottom: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>;
+    }
+
+    it('starts off and flips on toggle', () => {
+      expect(component.marqueeMode).toBeFalse();
+      component.toggleMarqueeMode();
+      expect(component.marqueeMode).toBeTrue();
+      component.toggleMarqueeMode();
+      expect(component.marqueeMode).toBeFalse();
+    });
+
+    it('reports regionDrawActive when either Shift is held or marquee is on', () => {
+      expect(component.regionDrawActive).toBeFalse();
+      component.shiftHeld = true;
+      expect(component.regionDrawActive).toBeTrue();
+      component.shiftHeld = false;
+      component.marqueeMode = true;
+      expect(component.regionDrawActive).toBeTrue();
+    });
+
+    it('shows a crosshair cursor when marquee mode is on', () => {
+      expect(component.wrapCursor).not.toBe('crosshair');
+      component.marqueeMode = true;
+      expect(component.wrapCursor).toBe('crosshair');
+    });
+
+    it('starts a draw-drag on mousedown when marquee mode is on (no Shift required)', () => {
+      setupWrap(component);
+      component.marqueeMode = true;
+
+      const ev: MouseEvent = {
+        button: 0,
+        clientX: 30,
+        clientY: 30,
+        preventDefault: () => {},
+      } as unknown as MouseEvent;
+      component.onMouseDown(ev);
+
+      // Mid-drag the box should already exist as the zero-area anchor.
+      expect(component.regionBox).not.toBeNull();
+      expect(component.regionBox![0]).toBeCloseTo(0.3, 5);
+      expect(component.regionBox![1]).toBeCloseTo(0.3, 5);
+    });
+
+    it('persists across media changes', () => {
+      component.marqueeMode = true;
+      const next: MediaItem = { ...mockMedia, id: 99, filename: 'b.png' };
+      component.media = next;
+      component.ngOnChanges({
+        media: { currentValue: next, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
+      });
+      expect(component.marqueeMode).toBeTrue();
+    });
+  });
+
   describe('armed-confirm cancel routing', () => {
     it('emits armedConfirmCanceled instead of clearing the box when Esc is pressed while armed', () => {
       component.regionBox = [0.1, 0.2, 0.5, 0.6];

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -60,6 +60,11 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   regionBox: RegionBox | null = null;
   regionBoxShake = false;
   shiftHeld = false;
+  // Sticky toggle exposed by the Marquee button in .image-view-controls. While true the
+  // viewer behaves as if Shift were held: cursor is a crosshair and a left-drag draws a
+  // new region instead of panning. Shift+drag remains a power-user shortcut even when
+  // the toggle is off; toggling the button just turns the gesture on without a modifier.
+  marqueeMode = false;
   renderedW = 0;
   renderedH = 0;
 
@@ -165,12 +170,21 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     this.applyTransform();
   }
 
+  /** True when a drag should draw a region (either Shift-held or Marquee toggle on). */
+  get regionDrawActive(): boolean {
+    return this.shiftHeld || this.marqueeMode;
+  }
+
+  toggleMarqueeMode(): void {
+    this.marqueeMode = !this.marqueeMode;
+  }
+
   onMouseDown(event: MouseEvent): void {
     if (event.button !== 0) return;
 
-    if (this.shiftHeld && this.renderedW > 0 && this.renderedH > 0) {
-      // Shift-drag from anywhere on the canvas starts a fresh box. If an
-      // older box existed, discard it before recording the new anchor.
+    if (this.regionDrawActive && this.renderedW > 0 && this.renderedH > 0) {
+      // Drag from anywhere on the canvas (Shift-held or marquee mode) starts a fresh
+      // box. If an older box existed, discard it before recording the new anchor.
       const local = this.screenToImageNormalized(event);
       if (!local) return;
       const x = clamp01(local.x);
@@ -239,7 +253,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   get wrapCursor(): string {
-    if (this.shiftHeld) return 'crosshair';
+    if (this.regionDrawActive) return 'crosshair';
     const max = this.getMaxPan();
     return max.x > 0 || max.y > 0 ? 'grab' : '';
   }

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -45,7 +45,7 @@ export class KeyboardHelpModalComponent {
         { keys: ['-'], description: 'Zoom out' },
         { keys: ['['], description: 'Rotate left' },
         { keys: [']'], description: 'Rotate right' },
-        { keys: ['Shift', 'drag'], description: 'Draw region box (patch embedder)' },
+        { keys: ['Shift', 'drag'], description: 'Draw region box (or use the Marquee button)' },
         { keys: ['Esc'], description: 'Cancel armed vote / clear region box' },
       ],
     },


### PR DESCRIPTION
## Summary

Implements §7.8 of `docs/plans/ux-brainstorm.md`. Shift+drag for image region voting had no UI cue, so users had to discover it from the docs. This adds a dashed-rectangle **Marquee** toggle to the image-view-controls toolbar (next to Rotate / Zoom / Reset). While the toggle is on the cursor stays a crosshair and a normal left-drag draws a region — no Shift required. Shift+drag remains as a power-user shortcut that works regardless of the toggle.

## What changed

- `ImageViewerComponent` (`frontend/.../image-viewer.component.ts`)
  - New `marqueeMode` sticky toggle + `toggleMarqueeMode()` method.
  - New `regionDrawActive` getter (`shiftHeld || marqueeMode`); `onMouseDown` and `wrapCursor` now key off it so the marquee gesture works without Shift.
- `image-viewer.component.html` — `[class.region-mode]` now reflects either entry path.
- `center-panel.component.html` — adds the toggle button (inline dashed-rect SVG icon) plus a thin separator in the existing `.image-view-controls` toolbar. `aria-pressed` reflects state.
- `center-panel.component.scss` — `.ivc-btn-toggle.active` uses `--accent` (deliberately not `--color-good`, to avoid conflation with the Good-vote button). Thin `.ivc-sep` divider.
- Tests in `image-viewer.component.spec.ts` cover the toggle lifecycle, `regionDrawActive` parity for both entry paths, the crosshair cursor, mousedown-starts-a-draw without Shift, and that the toggle persists across media changes.
- `keyboard-help-modal.component.ts` — Shift+drag entry now mentions the Marquee button as the alternative.
- `docs/USER_GUIDE.md` — "Drawing a region" section rewritten to document both entry points.
- `docs/plans/ux-brainstorm.md` — §7.8 marked **shipped** with a "What shipped" note.

## Design choices

- **Persistent toggle**: matches Photoshop / LabelImg / CVAT — once a tool is selected it stays selected so the user can annotate many items in a row. The toggle also persists across media navigation. Voting does not flip the toggle off.
- **Placement in the image-view-controls toolbar**: the toolbar only renders for images, sits below the image so it never overlaps the region box, and inherits the existing opacity-on-hover styling.
- **`--accent` for the active state**, not `--color-good`: the green Good-vote color would visually conflate a tool toggle with a primary vote action.
- **Inline dashed-rect SVG** rather than a Unicode glyph — unambiguously reads as a marquee tool to anyone who has used an image editor.

## Test plan

- [x] `npm run build:prod` clean (no warnings, no budget overruns; initial total 514 kB vs 525 kB warn-budget)
- [x] `tsc --noEmit -p tsconfig.spec.json` clean (specs typecheck)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `codespell --toml pyproject.toml` clean
- [ ] Manual: load an image, click Marquee, verify cursor turns into crosshair, drag draws a region without holding Shift, toggle off restores pan-on-drag
- [ ] Manual: with toggle on, navigate to next image — toggle stays on, region box clears (existing behavior)
- [ ] Manual: Shift+drag still works whether the toggle is on or off

https://claude.ai/code/session_01VvzDdAY8RKwp5uR2mcZo9x

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvzDdAY8RKwp5uR2mcZo9x)_