### PR TITLE
Smart clipper defaults: Phase 2 per-media auto routing

### DIFF
--- a/docs/plans/smart-clipper-defaults.md
+++ b/docs/plans/smart-clipper-defaults.md
@@ -1,9 +1,9 @@
 # Smart clipper defaults
 
-*Status: Phase 1 shipped — picker now offers an "Auto (recommended)"
-clipper for audio and video that resolves to pass-through or tiling
-based on the dataset's median duration. Phase 2 deferred — see Open
-follow-ups.*
+*Status: Phase 1 and Phase 2 shipped — picker offers an "Auto
+(recommended)" clipper for audio and video that routes each media
+through pass-through or tiling based on its own duration. Phase 3
+deferred — see Open follow-ups.*
 
 This plan implements [ux-brainstorm.md §1.10](ux-brainstorm.md#110-clipper-default-from-media-type--duration-) ("Clipper default from media type + duration").
 
@@ -17,13 +17,13 @@ manually means knowing the difference between `sound_default`,
 `sound_tiling`, and `sound_clip` — and what good values for `duration`
 and `min_overlap` are. The user doesn't have that context.
 
-## Phase 1 — Auto clippers (shipped)
+## Phase 1 — Auto clippers, per-dataset routing (shipped)
 
-Add an **Auto (recommended)** entry to the clipper picker for the two
-duration-bearing media types: audio and video. Register it FIRST in
-each media type's `CLIPPERS` list so the picker defaults to it, and
-have the load pipeline resolve it to a concrete clipper for the whole
-dataset based on the median media duration.
+Added an **Auto (recommended)** entry to the clipper picker for the two
+duration-bearing media types: audio and video. Registered FIRST in each
+media type's `CLIPPERS` list so the picker defaults to it. The load
+pipeline resolved it to a single concrete clipper for the whole dataset
+based on the median media duration.
 
 ### Files
 
@@ -32,68 +32,55 @@ dataset based on the median media duration.
 - `vtsearch/media/video/clipper.py` — Added `VideoAutoClipper(threshold=30, tile_duration=10)`.
 - `vtsearch/media/audio/__init__.py` — `SoundAutoClipper()` first in `CLIPPERS`.
 - `vtsearch/media/video/__init__.py` — `VideoAutoClipper()` first in `CLIPPERS`.
-- `vtsearch/datasets/load_pipeline.py` — `_apply_clipper` calls `clipper.resolve_for_durations(durations)` once per dataset and uses the resolved clipper's `name` and `to_dict()` for origin tagging.
+- `vtsearch/datasets/load_pipeline.py` — `_apply_clipper` called `clipper.resolve_for_durations(durations)` once per dataset.
+
+## Phase 2 — Per-media auto routing (shipped)
+
+Moved the auto routing decision from per-dataset (median duration) to
+per-media (each item's own duration). A short clip and a long clip in
+the same dataset now take different branches.
+
+### Files
+
+- `vtsearch/media/clipper.py` — Added `MediaClipper.resolve_for_media(media)` hook on the base class, default returns `self`. `resolve_for_durations` stays as a no-op base hook reserved for clippers that need a dataset-level decision.
+- `vtsearch/media/audio/clipper.py` — `SoundAutoClipper.resolve_for_media(media)` branches on `media["duration"]`, falling back to reading the WAV header if duration is absent. `clip()` is now just `resolve_for_media(media).clip(media)`.
+- `vtsearch/media/video/clipper.py` — `VideoAutoClipper.resolve_for_media(media)` mirrors the audio implementation.
+- `vtsearch/datasets/load_pipeline.py` — `_apply_clipper` calls `resolve_for_media(media)` per item and tags each clip's origin with the resolved concrete clipper's name and parameters.
 
 ### Behavior
 
-- Picker shows **Auto (recommended)** first (the importer modal default-selects the first clipper, and the chooser tab bar prefers the first non-`*_default` clipper).
-- When the user accepts Auto, the load pipeline collects `media["duration"]` across the staged medias, takes the median, and resolves:
-  - `median <= 30s` → `*_default` (pass-through).
-  - `median > 30s` → `*_tiling` with `duration=10s`.
-- The threshold and tile length are configurable via the chooser's parameter fields (`threshold`, `tile_duration`).
-- Each resulting clip records the **resolved** clipper in its origin (`clipper=sound_tiling` or `clipper=sound_default`), not `sound_auto`. Cross-dataset replay is deterministic and ignores the original auto policy.
-- Direct calls (`SoundAutoClipper().clip(media)` outside the load pipeline) fall back to per-media routing using the same threshold, so the clipper still works correctly if used without a dataset context.
+- Picker still shows **Auto (recommended)** first.
+- For each media in the dataset:
+  - `duration <= 30s` → routed through `*_default` (pass-through).
+  - `duration > 30s` → routed through `*_tiling` with `duration=10s`.
+- Threshold and tile length remain configurable via the chooser's parameter fields (`threshold`, `tile_duration`).
+- Each clip records the **resolved** concrete clipper in its origin (`clipper=sound_tiling` or `clipper=sound_default`), not `sound_auto`. Different clips in the same dataset can have different `clipper` values. Cross-dataset replay is deterministic and ignores the original auto policy.
+- Direct calls (`SoundAutoClipper().clip(media)` outside the load pipeline) use the same per-media routing.
 
-### Why per-dataset, not per-media
+### Why per-media wins over per-dataset
 
-Phase 1 makes the routing decision once per dataset because that matches the existing clipper UX: the picker takes one choice for the whole import. Per-media routing — "for this video, pass through; for that one, tile" — is a more powerful behavior but it changes the mental model and the origin format. It's deferred to Phase 2.
-
-## What shipped
-
-- `MediaClipper.resolve_for_durations()` hook on the base class.
-- `SoundAutoClipper` and `VideoAutoClipper` registered first per media type.
-- Load pipeline resolution before clipping begins.
-- Origin records the resolved concrete clipper, so replay is stable.
+A dataset with a mix of short voice memos and hour-long podcasts is the
+common case (a user dumps a folder of varied recordings). Phase 1 had
+to pick one strategy for the whole folder based on the median, which
+was wrong for whichever subset fell on the other side of the threshold.
+Phase 2 fixes that without changing the user-facing controls or the
+origin format.
 
 ## Open follow-ups
-
-### Phase 2 — Per-media auto routing via clipper options
-
-Today the auto clipper picks one concrete clipper for the whole dataset
-based on median duration. A more powerful approach is to expose the
-"sometimes clip depending on length" behavior **through the
-MediaClipper's options**, so a single clipper instance routes per
-media:
-
-- Each media item gets clipped via the strategy that matches its own
-  duration: short clips pass through, long clips get tiled.
-- The clipper's `parameters` would include the threshold and the tile
-  configuration, and `clip(media)` would branch on
-  `media["duration"]`.
-- This subsumes Phase 1: the picker still shows one "Auto" entry, but
-  resolution becomes a no-op (it returns self) and the per-media
-  branching lives inside `clip()`.
-
-Open questions for Phase 2:
-
-- **Origin recording**: each clip's origin needs to record which
-  branch was taken (`sound_tiling` vs `sound_default`) so cross-dataset
-  resolution still works. Either the auto clipper emits the resolved
-  branch name in its `clip()` output, or origins carry the auto clipper
-  plus a per-clip "branch" marker.
-- **UI**: the parameter fields ("threshold", "tile length") stay the
-  same — users don't need to know whether the decision is per-dataset
-  or per-media. But the description string should change from
-  "tile *the dataset* if median > 30s" to "tile *each item* if > 30s".
-- **Other media types**: image and text don't have a meaningful
-  duration. Should we extend the same pattern (e.g. tile tall images
-  automatically, sentence-split long paragraphs)? Out of scope for now
-  — but the design should not assume "duration" is the only routing
-  signal.
 
 ### Phase 3 — Hide the clipper picker behind Advanced (deferred)
 
 The ux-brainstorm entry also proposed hiding the clipper button entirely
 until the user opens an "Advanced" section, on the theory that the
 default is almost always right. Deferred until we have evidence on how
-often users tweak the default after Phase 1 lands.
+often users tweak the default after Phase 2 lands.
+
+### Per-item routing for image and text (out of scope)
+
+Phase 2's `resolve_for_media` hook only ships on the duration-bearing
+media types. Image and text don't have a meaningful "duration", but
+analogous signals exist (image aspect ratio for "tile tall images
+automatically", paragraph length for "sentence-split long paragraphs").
+Out of scope for now; if pursued, follow the same shape as the audio
+and video auto clippers — register an `*_auto` clipper first in
+`CLIPPERS` and have it override `resolve_for_media`.

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -1492,31 +1492,50 @@ class TestSoundAutoClipper:
         with pytest.raises(ValueError):
             SoundAutoClipper(tile_duration=-1)
 
-    def test_resolve_short_returns_default(self):
+    def test_resolve_for_media_short_returns_default(self):
         from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
 
-        resolved = SoundAutoClipper().resolve_for_durations([1.0, 5.0, 10.0, 20.0])
+        media = {"id": 1, "type": "audio", "duration": 5.0}
+        resolved = SoundAutoClipper().resolve_for_media(media)
         assert isinstance(resolved, SoundDefaultClipper)
 
-    def test_resolve_long_returns_tiling(self):
+    def test_resolve_for_media_long_returns_tiling(self):
         from vtsearch.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
 
-        resolved = SoundAutoClipper().resolve_for_durations([60.0, 120.0, 180.0])
+        media = {"id": 1, "type": "audio", "duration": 120.0}
+        resolved = SoundAutoClipper().resolve_for_media(media)
         assert isinstance(resolved, SoundTilingClipper)
         assert resolved.duration == 10.0
 
-    def test_resolve_empty_returns_default(self):
-        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
+    def test_resolve_for_media_uses_own_duration_not_dataset(self):
+        """Each media gets its own routing decision — no median trick."""
+        from vtsearch.media.audio.clipper import (
+            SoundAutoClipper,
+            SoundDefaultClipper,
+            SoundTilingClipper,
+        )
 
-        resolved = SoundAutoClipper().resolve_for_durations([])
-        assert isinstance(resolved, SoundDefaultClipper)
+        c = SoundAutoClipper()
+        short = {"id": 1, "type": "audio", "duration": 5.0}
+        long_media = {"id": 2, "type": "audio", "duration": 120.0}
+        assert isinstance(c.resolve_for_media(short), SoundDefaultClipper)
+        assert isinstance(c.resolve_for_media(long_media), SoundTilingClipper)
 
-    def test_resolve_uses_median_not_mean(self):
-        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper
+    def test_resolve_for_media_falls_back_to_wav_when_no_duration(self):
+        from vtsearch.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
 
-        # Mean is 100, median is 5 → should pass through
-        resolved = SoundAutoClipper().resolve_for_durations([5.0, 5.0, 5.0, 500.0])
-        assert isinstance(resolved, SoundDefaultClipper)
+        long_wav = generate_wav(440, 5.0)
+        media = {"id": 1, "type": "audio", "media_bytes": long_wav}
+        resolved = SoundAutoClipper(threshold=3.0, tile_duration=1.0).resolve_for_media(media)
+        assert isinstance(resolved, SoundTilingClipper)
+
+    def test_resolve_for_durations_is_noop(self):
+        """Phase 2 routing is per-media; the per-dataset hook is a no-op."""
+        from vtsearch.media.audio.clipper import SoundAutoClipper
+
+        c = SoundAutoClipper()
+        assert c.resolve_for_durations([1.0, 1000.0]) is c
+        assert c.resolve_for_durations([]) is c
 
     def test_with_params_overrides_threshold(self):
         from vtsearch.media.audio.clipper import SoundAutoClipper, SoundTilingClipper
@@ -1525,7 +1544,7 @@ class TestSoundAutoClipper:
         assert c.threshold == 5.0
         assert c.tile_duration == 3.0
         # 10s exceeds 5s threshold → tiling with 3s segments
-        resolved = c.resolve_for_durations([10.0])
+        resolved = c.resolve_for_media({"id": 1, "type": "audio", "duration": 10.0})
         assert isinstance(resolved, SoundTilingClipper)
         assert resolved.duration == 3.0
 
@@ -1542,16 +1561,15 @@ class TestSoundAutoClipper:
         assert "threshold" in param_keys
         assert "tile_duration" in param_keys
 
-    def test_clip_fallback_per_media(self):
+    def test_clip_routes_per_media(self):
         """Direct .clip() use (outside the load pipeline) routes per-media."""
-        from vtsearch.media.audio.audio_generator import generate_wav
         from vtsearch.media.audio.clipper import SoundAutoClipper
 
         c = SoundAutoClipper(threshold=3.0, tile_duration=1.0)
         # Short clip → pass-through
         short_wav = generate_wav(440, 2.0)
         short = {"id": 1, "type": "audio", "media_bytes": short_wav, "duration": 2.0}
-        assert SoundAutoClipper(threshold=3.0).clip(short) == [short]
+        assert c.clip(short) == [short]
         # Long clip → tiled
         long_wav = generate_wav(440, 5.0)
         long_media = {"id": 1, "type": "audio", "media_bytes": long_wav, "duration": 5.0}
@@ -1585,31 +1603,45 @@ class TestVideoAutoClipper:
         with pytest.raises(ValueError):
             VideoAutoClipper(tile_duration=0)
 
-    def test_resolve_short_returns_default(self):
+    def test_resolve_for_media_short_returns_default(self):
         from vtsearch.media.video.clipper import VideoAutoClipper, VideoDefaultClipper
 
-        resolved = VideoAutoClipper().resolve_for_durations([5.0, 10.0, 20.0])
+        resolved = VideoAutoClipper().resolve_for_media({"id": 1, "type": "video", "duration": 10.0})
         assert isinstance(resolved, VideoDefaultClipper)
 
-    def test_resolve_long_returns_tiling(self):
+    def test_resolve_for_media_long_returns_tiling(self):
         from vtsearch.media.video.clipper import VideoAutoClipper, VideoTilingClipper
 
-        resolved = VideoAutoClipper().resolve_for_durations([60.0, 120.0])
+        resolved = VideoAutoClipper().resolve_for_media({"id": 1, "type": "video", "duration": 90.0})
         assert isinstance(resolved, VideoTilingClipper)
         assert resolved.duration == 10.0
 
-    def test_resolve_empty_returns_default(self):
-        from vtsearch.media.video.clipper import VideoAutoClipper, VideoDefaultClipper
+    def test_resolve_for_media_uses_own_duration_not_dataset(self):
+        from vtsearch.media.video.clipper import (
+            VideoAutoClipper,
+            VideoDefaultClipper,
+            VideoTilingClipper,
+        )
 
-        resolved = VideoAutoClipper().resolve_for_durations([])
-        assert isinstance(resolved, VideoDefaultClipper)
+        c = VideoAutoClipper()
+        short = {"id": 1, "type": "video", "duration": 10.0}
+        long_media = {"id": 2, "type": "video", "duration": 90.0}
+        assert isinstance(c.resolve_for_media(short), VideoDefaultClipper)
+        assert isinstance(c.resolve_for_media(long_media), VideoTilingClipper)
+
+    def test_resolve_for_durations_is_noop(self):
+        from vtsearch.media.video.clipper import VideoAutoClipper
+
+        c = VideoAutoClipper()
+        assert c.resolve_for_durations([1.0, 1000.0]) is c
+        assert c.resolve_for_durations([]) is c
 
     def test_with_params_overrides(self):
         from vtsearch.media.video.clipper import VideoAutoClipper, VideoTilingClipper
 
         c = VideoAutoClipper().with_params({"threshold": 4.0, "tile_duration": 2.0})
         assert c.threshold == 4.0
-        resolved = c.resolve_for_durations([10.0])
+        resolved = c.resolve_for_media({"id": 1, "type": "video", "duration": 10.0})
         assert isinstance(resolved, VideoTilingClipper)
         assert resolved.duration == 2.0
 
@@ -1621,11 +1653,10 @@ class TestVideoAutoClipper:
 
 
 class TestApplyClipperResolvesAuto:
-    """_apply_clipper resolves auto clippers per-dataset and tags origin
-    with the resolved concrete clipper, not the auto one."""
+    """_apply_clipper resolves auto clippers per-media and tags each
+    clip's origin with the resolved concrete clipper, not the auto one."""
 
     def test_short_dataset_resolves_to_default(self):
-        from vtsearch.media.audio.audio_generator import generate_wav
         from vtsearch.datasets.load_pipeline import _apply_clipper
 
         wav = generate_wav(440, 5.0)
@@ -1645,7 +1676,6 @@ class TestApplyClipperResolvesAuto:
         assert clip["origin"]["params"]["clipper"] == "sound_default"
 
     def test_long_dataset_resolves_to_tiling(self):
-        from vtsearch.media.audio.audio_generator import generate_wav
         from vtsearch.datasets.load_pipeline import _apply_clipper
 
         wav = generate_wav(440, 60.0)
@@ -1665,8 +1695,38 @@ class TestApplyClipperResolvesAuto:
         # Origin records the resolved clipper's parameter values.
         assert first["origin"]["params"]["clipper_duration"] == "10.0"
 
+    def test_mixed_durations_resolve_per_media(self):
+        """A short and a long item in the same dataset take different
+        branches, and each clip records its own resolved concrete clipper."""
+        from vtsearch.datasets.load_pipeline import _apply_clipper
+
+        short_wav = generate_wav(440, 2.0)
+        long_wav = generate_wav(440, 8.0)
+        clips = {
+            1: {
+                "id": 1,
+                "type": "audio",
+                "media_bytes": short_wav,
+                "duration": 2.0,
+                "origin": {"importer": "test", "params": {}},
+            },
+            2: {
+                "id": 2,
+                "type": "audio",
+                "media_bytes": long_wav,
+                "duration": 8.0,
+                "origin": {"importer": "test", "params": {}},
+            },
+        }
+        # Threshold 4s: short (2s) passes through, long (8s) tiles into 2s segments.
+        _apply_clipper(clips, "sound_auto", {"threshold": 4.0, "tile_duration": 2.0})
+        # 1 (pass-through) + 4 (8s / 2s) = 5 clips.
+        assert len(clips) == 5
+        resolved_names = [c["origin"]["params"]["clipper"] for c in clips.values()]
+        assert resolved_names.count("sound_default") == 1
+        assert resolved_names.count("sound_tiling") == 4
+
     def test_user_threshold_override_propagates(self):
-        from vtsearch.media.audio.audio_generator import generate_wav
         from vtsearch.datasets.load_pipeline import _apply_clipper
 
         wav = generate_wav(440, 8.0)

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -265,20 +265,13 @@ def _apply_clipper(
     if clipper_params:
         clipper = clipper.with_params(clipper_params)
 
-    # Resolve auto-selecting clippers to a concrete clipper for the
-    # whole dataset based on its typical media duration.  Non-auto
-    # clippers return self, so this is a no-op for them.
+    # Per-dataset resolution hook.  Default base implementation returns
+    # self; reserved for clippers that need a dataset-level decision.
+    # Auto routing now happens per-item via resolve_for_media() below.
     durations = [float(m.get("duration", 0) or 0) for m in clips_dict.values()]
     clipper = clipper.resolve_for_durations(durations)
-    clipper_name = clipper.name
 
-    # Extract the effective clipper parameter values so they can be
-    # stored in each clip's origin.  This uses to_dict() which concrete
-    # clippers override to add their current values (duration, threshold,
-    # etc.), then strips the base keys that aren't parameter values.
-    _clipper_dict = clipper.to_dict()
     _base_keys = {"name", "display_name", "media_type", "parameters", "description", "creation_questions"}
-    effective_params = {k: v for k, v in _clipper_dict.items() if k not in _base_keys}
 
     all_clipped: list[dict] = []
     # Track which clips need MD5/embedding recomputation.  Any clip that
@@ -288,17 +281,27 @@ def _apply_clipper(
 
     media_list = list(clips_dict.values())
     total_medias = len(media_list)
+    media_type = clipper.media_type
     for media_idx, media in enumerate(media_list):
         if on_progress:
             on_progress(media_idx, total_medias, "clipping")
-        clipped = clipper.clip(media)
+        # Per-media resolution.  Non-auto clippers return self; auto
+        # clippers branch on the item's own duration so different items
+        # can take different routes.  Each clip records the resolved
+        # concrete clipper's name and parameters in its origin, so
+        # cross-dataset replay is deterministic regardless of the
+        # original auto policy.
+        resolved = clipper.resolve_for_media(media)
+        resolved_dict = resolved.to_dict()
+        effective_params = {k: v for k, v in resolved_dict.items() if k not in _base_keys}
+        clipped = resolved.clip(media)
         is_real_clip = len(clipped) > 1
         for idx, clip in enumerate(clipped):
             orig = clip.get("origin")
             if isinstance(orig, dict):
                 clip["origin"] = dict(orig)
                 clip["origin"]["params"] = dict(clip["origin"].get("params", {}))
-                clip["origin"]["params"]["clipper"] = clipper_name
+                clip["origin"]["params"]["clipper"] = resolved.name
                 # Store the clipper's effective parameter values so that
                 # cross-dataset resolution can reconstruct the exact same
                 # clipper configuration.
@@ -318,11 +321,11 @@ def _apply_clipper(
             needs_recompute.append(is_real_clip)
 
     # Recompute MD5 and re-embed every genuine sub-item.
-    _fixup_clip_md5_and_embeddings(all_clipped, needs_recompute, clipper.media_type, on_progress=on_progress)
+    _fixup_clip_md5_and_embeddings(all_clipped, needs_recompute, media_type, on_progress=on_progress)
 
     # Regenerate thumbnails so audio/video clips show their own range
     # rather than the parent's full waveform / mid-frame.
-    _regenerate_clip_thumbnails(all_clipped, needs_recompute, clipper.media_type)
+    _regenerate_clip_thumbnails(all_clipped, needs_recompute, media_type)
 
     clips_dict.clear()
     for new_id, clip in enumerate(all_clipped, 1):

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -181,10 +181,11 @@ class SoundAutoClipper(MediaClipper):
     """Pass-through for short audio, tile longer audio.
 
     Designed as the recommended default in the importer picker. The
-    decision is made once per dataset: if the median media duration
-    exceeds *threshold*, the clipper resolves to a
-    :class:`SoundTilingClipper` with the configured *tile_duration*;
-    otherwise it resolves to :class:`SoundDefaultClipper`.
+    decision is made per item: if a media's duration exceeds
+    *threshold*, that item is clipped by :class:`SoundTilingClipper`
+    with the configured *tile_duration*; otherwise it passes through
+    via :class:`SoundDefaultClipper`. Different items in the same
+    dataset can take different branches.
 
     The chosen concrete clipper is what gets recorded in each clip's
     origin, so cross-dataset replay is deterministic.
@@ -225,28 +226,25 @@ class SoundAutoClipper(MediaClipper):
     def tile_duration(self) -> float:
         return self._tile_duration
 
-    def resolve_for_durations(self, durations: list[float]) -> "MediaClipper":
-        if not durations:
-            return SoundDefaultClipper()
-        median = sorted(durations)[len(durations) // 2]
-        if median > self._threshold:
+    def resolve_for_media(self, media: dict[str, Any]) -> "MediaClipper":
+        duration = float(media.get("duration", 0) or 0)
+        if duration <= 0:
+            wav_bytes = media.get("media_bytes")
+            if wav_bytes is not None:
+                try:
+                    duration = _wav_duration(wav_bytes)
+                except Exception:
+                    duration = 0.0
+        if duration > self._threshold:
             return SoundTilingClipper(self._tile_duration)
         return SoundDefaultClipper()
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
-        # Fallback path for direct use (outside the load pipeline).
-        # The load pipeline resolves auto → concrete before calling clip(),
-        # so this code only runs if someone uses SoundAutoClipper directly.
-        wav_bytes = media.get("media_bytes")
-        if wav_bytes is None:
-            return [media]
-        try:
-            duration = _wav_duration(wav_bytes)
-        except Exception:
-            return [media]
-        if duration > self._threshold:
-            return SoundTilingClipper(self._tile_duration).clip(media)
-        return SoundDefaultClipper().clip(media)
+        # Direct-call path (outside the load pipeline).  The pipeline
+        # uses resolve_for_media() then calls clip() on the concrete
+        # result, so this method only runs when someone uses
+        # SoundAutoClipper().clip(media) directly.
+        return self.resolve_for_media(media).clip(media)
 
     @property
     def parameters(self) -> list[dict[str, Any]]:

--- a/vtsearch/media/clipper.py
+++ b/vtsearch/media/clipper.py
@@ -147,10 +147,21 @@ class MediaClipper(ABC):
 
         Called by the load pipeline once per dataset, before any
         :meth:`clip` calls.  Most clippers ignore *durations* and return
-        ``self``.  Auto-selecting clippers (e.g. ``SoundAutoClipper``)
-        override this to pick a different concrete clipper based on the
-        dataset's typical duration — for example, pass-through for short
-        clips, tiling for longer ones.
+        ``self``.  Reserved for clippers that need a dataset-level
+        decision; auto-routing now happens per-item via
+        :meth:`resolve_for_media`.
+        """
+        return self
+
+    def resolve_for_media(self, media: dict[str, Any]) -> "MediaClipper":
+        """Return a concrete clipper for a single media item.
+
+        Called by the load pipeline once per media, after
+        :meth:`resolve_for_durations` and before :meth:`clip`.  Most
+        clippers ignore *media* and return ``self``.  Auto-selecting
+        clippers (e.g. ``SoundAutoClipper``) override this to pick a
+        different concrete clipper based on the item's own duration —
+        e.g. pass-through for short clips, tiling for longer ones.
 
         The resolved clipper's :attr:`name` and parameter values are what
         get recorded in each clip's origin, so cross-dataset replay is

--- a/vtsearch/media/video/clipper.py
+++ b/vtsearch/media/video/clipper.py
@@ -144,10 +144,11 @@ class VideoAutoClipper(MediaClipper):
     """Pass-through for short video, tile longer video.
 
     Designed as the recommended default in the importer picker. The
-    decision is made once per dataset: if the median media duration
-    exceeds *threshold*, the clipper resolves to a
-    :class:`VideoTilingClipper` with the configured *tile_duration*;
-    otherwise it resolves to :class:`VideoDefaultClipper`.
+    decision is made per item: if a media's duration exceeds
+    *threshold*, that item is clipped by :class:`VideoTilingClipper`
+    with the configured *tile_duration*; otherwise it passes through
+    via :class:`VideoDefaultClipper`. Different items in the same
+    dataset can take different branches.
 
     The chosen concrete clipper is what gets recorded in each clip's
     origin, so cross-dataset replay is deterministic.
@@ -188,20 +189,18 @@ class VideoAutoClipper(MediaClipper):
     def tile_duration(self) -> float:
         return self._tile_duration
 
-    def resolve_for_durations(self, durations: list[float]) -> "MediaClipper":
-        if not durations:
-            return VideoDefaultClipper()
-        median = sorted(durations)[len(durations) // 2]
-        if median > self._threshold:
+    def resolve_for_media(self, media: dict[str, Any]) -> "MediaClipper":
+        duration = float(media.get("duration", 0) or 0)
+        if duration > self._threshold:
             return VideoTilingClipper(self._tile_duration)
         return VideoDefaultClipper()
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
-        # Fallback path for direct use (outside the load pipeline).
-        duration = float(media.get("duration", 0) or 0)
-        if duration > self._threshold:
-            return VideoTilingClipper(self._tile_duration).clip(media)
-        return VideoDefaultClipper().clip(media)
+        # Direct-call path (outside the load pipeline).  The pipeline
+        # uses resolve_for_media() then calls clip() on the concrete
+        # result, so this method only runs when someone uses
+        # VideoAutoClipper().clip(media) directly.
+        return self.resolve_for_media(media).clip(media)
 
     @property
     def parameters(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Adds `MediaClipper.resolve_for_media(media)` hook so auto clippers can branch per item instead of once per dataset.
- `SoundAutoClipper` and `VideoAutoClipper` now route each media on its own duration: short items pass through, long items get tiled. A folder mixing short voice memos with hour-long podcasts now clips each correctly.
- `_apply_clipper` calls `resolve_for_media` per item; each clip's origin still records the resolved concrete clipper (`sound_tiling` or `sound_default`, never `sound_auto`), so cross-dataset replay is unchanged.
- `resolve_for_durations` stays as a no-op base hook for any future per-dataset clipper.
- Plan in `docs/plans/smart-clipper-defaults.md` updated: Phase 2 marked shipped, Phase 3 (hide picker behind Advanced) still deferred.

## Test plan

- [x] `./run-tests.sh detectors` — 866 passed
- [x] `./run-tests.sh datasets integration io` — 1214 passed
- [x] `python -m pytest tests/ -m 'not gpu'` — 3656 passed, 1 skipped
- [x] `cd frontend && npm run build:prod` — clean, no warnings
- [x] New tests cover: per-media `resolve_for_media` short/long branching, mixed-duration dataset (`test_mixed_durations_resolve_per_media`), WAV-header duration fallback, `resolve_for_durations` no-op on auto clippers.

Note: `./run-tests.sh` (full suite) is blocked by a pre-existing `webpack-dev-server` advisory with no upstream fix; this is the same on `dev` and unrelated to these changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPfHT8XZ9YwDiCoibc19BH)_