### PR TITLE
Enable ruff C901 (McCabe) complexity gate at default max-complexity=10

### DIFF
--- a/docs/plans/python-quality-tools.md
+++ b/docs/plans/python-quality-tools.md
@@ -1,11 +1,12 @@
 # Python quality tools
 
 *Status: Phases 1 + 2 + 3 shipped, plus the pyproject-consolidation
-follow-up, CI coverage publication, and the vulture audit pass. deptry,
-codespell, ruff's `S` ruleset, opt-in coverage (now also published in
-CI), and a tuned vulture invocation + whitelist are all in place
-alongside the original pre-commit + pip-audit, and `pyproject.toml` is
-now the single source of truth for runtime + dev dependencies. See
+follow-up, CI coverage publication, the vulture audit pass, and the
+McCabe (C901) complexity gate. deptry, codespell, ruff's `S` ruleset,
+opt-in coverage (now also published in CI), a tuned vulture invocation
++ whitelist, and ruff's `C901` (default max-complexity 10) are all in
+place alongside the original pre-commit + pip-audit, and `pyproject.toml`
+is the single source of truth for runtime + dev dependencies. See
 "Open follow-ups" at the bottom for the remaining maintenance items.*
 
 The ruff + pyright + pytest stack already covers the modern core of
@@ -350,6 +351,26 @@ added to the whitelist with a comment explaining why.
 - **safety** (the package) — overlaps `pip-audit` and has a more
   restrictive license. `pip-audit` is the right choice here.
 
+## What shipped (C901 complexity gate)
+
+- **Ruff `C901` (McCabe complexity)** at default `max-complexity = 10`,
+  added to `[tool.ruff.lint].select`. Three of the worst dispatcher
+  functions were refactored down under the threshold for real
+  (`load_demo_source` in audio/image/text media types, complexity
+  52/22/31 → <10; `learned_sort` in routes/sorting, 29 → 9). The
+  remaining 72 legacy hot-spots carry a per-function
+  `# noqa: C901` so the rule applies cleanly to new code without
+  forcing a multi-day refactor pass. Each noqa is a future-refactor
+  marker: simplifying the function lets you drop the comment.
+- **Per-file exemption** for `tests/**` and `scripts/**` — test
+  fixtures and one-off analysis scripts are not production code and
+  don't benefit from the gate (3 functions exempted: `init_medias`,
+  `test_concurrent_get_set_volume`, `analyse_one`).
+- **Pyright "S-equivalent" follow-up** — investigated and dropped.
+  Pyright is a type checker only; it has no security rule set
+  analogous to ruff's `S` (flake8-bandit). Security pattern detection
+  stays in ruff. The previous open follow-up was a category error.
+
 ## Open follow-ups
 
 - **Coverage-delta gate.** `coverage.yml` now publishes the baseline on
@@ -362,9 +383,15 @@ added to the whitelist with a comment explaining why.
   above for the deletions, whitelist additions, and final tuned
   invocation. The audit is meant to be re-run before each release;
   introducing new dead code will surface there.
-- **Pyright `S`-equivalent and `C901` complexity.** ruff has McCabe
-  complexity via `C901`; consider enabling alongside future
-  security-rule tightening if we want a complexity gate.
+- **Burn down the C901 noqa list.** 72 legacy functions carry
+  `# noqa: C901` markers (see `git grep "# noqa: C901"`). Each one is
+  a candidate for incremental refactoring; the markers can be deleted
+  as functions are simplified under complexity 10. Worst offenders
+  remaining: `multi_find` (41), `load_dataset_from_folder_chunked`
+  (35), `load_dataset_from_folder` (34), `_run_origin_load_in_background`
+  (31), `task` (27, inside load_pipeline), `load_dataset_from_pickle`
+  (26), `import_local_folder` (24), `_make_per_side_setting` (24).
+  No deadline — refactor opportunistically when touching the code.
 - Periodic: `pre-commit autoupdate` on a cadence so pinned hook
   versions don't drift too far from CI's `pip install ruff` (which
   always pulls latest). Worth a quarterly reminder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,11 @@ line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
-# Default rules (E4, E7, E9, F) + flake8-bandit (S) security checks.
-# Stays conservative on style rules (E501 line-length etc. remain off)
-# while adding the security backstop.
-select = ["E4", "E7", "E9", "F", "S"]
+# Default rules (E4, E7, E9, F) + flake8-bandit (S) security checks +
+# McCabe (C901) cyclomatic complexity gate. Stays conservative on style
+# rules (E501 line-length etc. remain off) while keeping the security
+# and complexity backstops on.
+select = ["E4", "E7", "E9", "F", "S", "C901"]
 # E402: Module level import not at top of file.
 # S101 (assert): used for type narrowing where pyright needs help; the
 #   project never runs under `python -O`.
@@ -83,9 +84,19 @@ select = ["E4", "E7", "E9", "F", "S"]
 #   never for cryptographic purposes.
 ignore = ["E402", "S101", "S104", "S105", "S110", "S112", "S311", "S324"]
 
+# Default McCabe threshold (10). Existing legacy hot-spots carry a
+# per-function `# noqa: C901` so the rule applies cleanly to new code;
+# refactoring a flagged function removes its marker.
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
 [tool.ruff.lint.per-file-ignores]
 # Tests use /tmp paths, pickle round-trips, and xml fixtures freely.
-"tests/**" = ["S108", "S301", "S314"]
+# C901 is also exempt for tests + scripts: test fixtures and one-off
+# analysis scripts are not production code and don't benefit from
+# the complexity gate.
+"tests/**" = ["S108", "S301", "S314", "C901"]
+"scripts/**" = ["C901"]
 # safe_pickle_load is the centralized helper that calls pickle.load on
 # whitelisted bytes — flagging it would defeat the purpose of the wrapper.
 "vtsearch/security/pickle.py" = ["S301"]

--- a/vtsearch/cli.py
+++ b/vtsearch/cli.py
@@ -418,7 +418,7 @@ def _load_importer_chunked(
     yield from importer.run_chunked_cli(field_values, chunk_size, thin=True)
 
 
-def _run_pipeline(
+def _run_pipeline(  # noqa: C901
     media_source: Iterator[dict[int, dict[str, Any]]],
     *,
     settings_path: str | None = None,

--- a/vtsearch/cli_pipeline.py
+++ b/vtsearch/cli_pipeline.py
@@ -28,7 +28,7 @@ _TOP_LEVEL_KEYS = {
 _IMPORT_LABELS_KEYS = {"detector", "importer", "file"}
 
 
-def load_pipeline_file(path: str | Path) -> dict[str, Any]:
+def load_pipeline_file(path: str | Path) -> dict[str, Any]:  # noqa: C901
     """Read *path*, parse it as YAML, and return a normalised config dict.
 
     Raises :class:`FileNotFoundError` if the file is missing, and

--- a/vtsearch/concurrency/events.py
+++ b/vtsearch/concurrency/events.py
@@ -63,7 +63,7 @@ def initial_snapshot() -> list[str]:
     return frames
 
 
-def stream_progress_events(
+def stream_progress_events(  # noqa: C901
     *, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024
 ) -> Generator[str, None, None]:
     """Yield SSE-formatted strings for every progress channel until disconnect.

--- a/vtsearch/concurrency/progress.py
+++ b/vtsearch/concurrency/progress.py
@@ -308,7 +308,7 @@ class LoadingTasksTracker:
             self._tasks.pop(task_id, None)
         self._notify()
 
-    def list_tasks(self) -> list[dict[str, Any]]:
+    def list_tasks(self) -> list[dict[str, Any]]:  # noqa: C901
         """Return a snapshot of all active loading tasks.
 
         Each entry includes: ``task_id``, ``name``, ``created_at``, and

--- a/vtsearch/converters/audio2image.py
+++ b/vtsearch/converters/audio2image.py
@@ -105,7 +105,7 @@ class Audio2ImageMediaConverter(MediaConverter):
     def target_type(self) -> str:
         return "image"
 
-    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:  # noqa: C901
         spec_type = str(self.get_param(params, "spectrogram_type") or "mel").lower()
         if spec_type not in ("mel", "cqt"):
             spec_type = "mel"

--- a/vtsearch/converters/image2text.py
+++ b/vtsearch/converters/image2text.py
@@ -80,7 +80,7 @@ class Image2TextMediaConverter(MediaConverter):
     def target_type(self) -> str:
         return "text"
 
-    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:  # noqa: C901
         language = str(self.get_param(params, "language") or "en")
         try:
             threshold = float(self.get_param(params, "threshold") or 0.5)

--- a/vtsearch/converters/runner.py
+++ b/vtsearch/converters/runner.py
@@ -75,7 +75,7 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
-def run_converters_on_folder(
+def run_converters_on_folder(  # noqa: C901
     folder_path: Path,
     converter_names: list[str] | None = None,
     target_media_type: str = "",
@@ -330,7 +330,7 @@ def _compute_md5(output: dict[str, Any]) -> str:
     return hashlib.md5(b"").hexdigest()
 
 
-def apply_converter_to_demo(
+def apply_converter_to_demo(  # noqa: C901
     converter_name: str,
     dataset_name: str,
     medias: dict[int, dict[str, Any]],

--- a/vtsearch/converters/video2image.py
+++ b/vtsearch/converters/video2image.py
@@ -48,7 +48,7 @@ class Video2ImageMediaConverter(MediaConverter):
     def target_type(self) -> str:
         return "image"
 
-    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:  # noqa: C901
         import tempfile  # noqa: PLC0415
 
         try:

--- a/vtsearch/datasets/downloader/core.py
+++ b/vtsearch/datasets/downloader/core.py
@@ -226,7 +226,7 @@ def _move_tree_contents(src: Path, dst: Path) -> None:
                     shutil.copy2(child, target)
 
 
-def _download_and_extract(
+def _download_and_extract(  # noqa: C901
     *,
     url: str,
     archive_name: str,

--- a/vtsearch/datasets/downloader/documents.py
+++ b/vtsearch/datasets/downloader/documents.py
@@ -9,7 +9,7 @@ from vtsearch.datasets.downloader import core as _core
 from vtsearch.datasets.downloader.core import ProgressCallback
 
 
-def download_ucsf_documents(
+def download_ucsf_documents(  # noqa: C901
     categories: list[str],
     docs_per_category: int = 25,
     on_progress: Optional[ProgressCallback] = None,

--- a/vtsearch/datasets/downloader/images.py
+++ b/vtsearch/datasets/downloader/images.py
@@ -44,7 +44,7 @@ def download_cifar10(on_progress: Optional[ProgressCallback] = None) -> Path:
     return extract_dir
 
 
-def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
+def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:  # noqa: C901
     """Download and extract the Caltech-101 image classification dataset.
 
     Downloads ``caltech-101.zip`` from the configured ``CALTECH101_URL``

--- a/vtsearch/datasets/downloader/text.py
+++ b/vtsearch/datasets/downloader/text.py
@@ -118,7 +118,7 @@ def download_20newsgroups(
     return texts, labels, target_names
 
 
-def download_bbc_news(
+def download_bbc_news(  # noqa: C901
     on_progress: Optional[ProgressCallback] = None,
 ) -> dict[str, list[str]]:
     """Download and prepare the BBC News full-text dataset.
@@ -492,7 +492,7 @@ def _parse_arxiv_feed(xml_bytes: bytes) -> list[str]:
     return abstracts
 
 
-def download_arxiv_abstracts(
+def download_arxiv_abstracts(  # noqa: C901
     categories: Optional[list[str]] = None,
     max_per_category: int = 2000,
     on_progress: Optional[ProgressCallback] = None,

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -579,7 +579,7 @@ class DatasetImporter(PluginBase):
     # Source specs (multi-media import)
     # ------------------------------------------------------------------
 
-    def effective_source_specs(self, field_values: dict[str, Any]) -> list[SourceSpec]:
+    def effective_source_specs(self, field_values: dict[str, Any]) -> list[SourceSpec]:  # noqa: C901
         """Resolve *field_values* into a flat list of :class:`SourceSpec`.
 
         For importers with :attr:`multi_media` ``= True``, the user submits

--- a/vtsearch/datasets/importers/combine_datasets/__init__.py
+++ b/vtsearch/datasets/importers/combine_datasets/__init__.py
@@ -65,7 +65,7 @@ class CombineDatasetsImporter(DatasetImporter):
         name = (field_values.get("name") or "").strip()
         return name or self.display_name
 
-    def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+    def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:  # noqa: C901
         """Combine datasets specified by *field_values['datasets']*.
 
         ``field_values["datasets"]`` may be either:
@@ -163,7 +163,7 @@ class CombineDatasetsImporter(DatasetImporter):
     def supports_chunked(self) -> bool:
         return True
 
-    def run_chunked(
+    def run_chunked(  # noqa: C901
         self,
         field_values: dict[str, Any],
         chunk_size: int,

--- a/vtsearch/datasets/importers/demo/__init__.py
+++ b/vtsearch/datasets/importers/demo/__init__.py
@@ -126,7 +126,7 @@ class DemoDatasetImporter(DatasetImporter):
             field_values["converter"] = converter
         return field_values
 
-    def resolve_file(self, origin: dict[str, Any], origin_name: str = "", filename: str = "") -> Path | None:
+    def resolve_file(self, origin: dict[str, Any], origin_name: str = "", filename: str = "") -> Path | None:  # noqa: C901
         """Resolve a media file from a demo dataset origin.
 
         Maps the demo dataset name to its source, then resolves the file

--- a/vtsearch/datasets/importers/http_archive/__init__.py
+++ b/vtsearch/datasets/importers/http_archive/__init__.py
@@ -42,7 +42,7 @@ def _default_progress() -> ProgressCallback:
     return update_progress
 
 
-def _extract_archive(
+def _extract_archive(  # noqa: C901
     archive_path: Path,
     extract_dir: Path,
     on_progress: Optional[ProgressCallback] = None,

--- a/vtsearch/datasets/importers/server_folder/__init__.py
+++ b/vtsearch/datasets/importers/server_folder/__init__.py
@@ -58,7 +58,7 @@ def _load_vectors_file(field_values: dict[str, Any]) -> dict[str, Any]:
     return dict(read_npz_filenames_and_vectors(Path(raw)))
 
 
-def _load_pdf_images(
+def _load_pdf_images(  # noqa: C901
     folder: Path,
     medias: dict[int, dict[str, Any]],
     thin: bool = False,
@@ -311,7 +311,7 @@ class ServerFolderDatasetImporter(DatasetImporter):
             return False
         return True
 
-    def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
+    def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:  # noqa: C901
         folder = Path(field_values["path"])
         recursive = _coerce_recursive(field_values)
 

--- a/vtsearch/datasets/ingest.py
+++ b/vtsearch/datasets/ingest.py
@@ -304,7 +304,7 @@ def _ingest_via_resolver(
     return ingested
 
 
-def ingest_missing_medias(
+def ingest_missing_medias(  # noqa: C901
     missing_entries: list[dict[str, Any]],
     medias: dict[int, dict[str, Any]],
     on_progress: Optional[ProgressCallback] = None,

--- a/vtsearch/datasets/load_pipeline.py
+++ b/vtsearch/datasets/load_pipeline.py
@@ -229,7 +229,7 @@ def _normalize_media_type(value: str) -> str:
         return value
 
 
-def _apply_clipper(
+def _apply_clipper(  # noqa: C901
     clips_dict: dict,
     clipper_name: str,
     clipper_params: dict | None = None,
@@ -330,7 +330,7 @@ def _apply_clipper(
         clips_dict[new_id] = clip
 
 
-def _regenerate_clip_thumbnails(
+def _regenerate_clip_thumbnails(  # noqa: C901
     clips: list[dict],
     needs_recompute: list[bool],
     media_type: str,
@@ -391,7 +391,7 @@ def _regenerate_clip_thumbnails(
                 clip["thumbnail_bytes"] = thumb
 
 
-def _fixup_clip_md5_and_embeddings(
+def _fixup_clip_md5_and_embeddings(  # noqa: C901
     clips: list[dict],
     needs_recompute: list[bool],
     media_type: str,
@@ -629,7 +629,7 @@ def _auto_register_dataset(
 # ---------------------------------------------------------------------------
 
 
-def _run_origin_load_in_background(
+def _run_origin_load_in_background(  # noqa: C901
     load_fn,
     origin: dict,
     *,
@@ -687,7 +687,7 @@ def _run_origin_load_in_background(
     # state (settings writes, settings_source sync) resolves correctly.
     _request_user = created_by or get_current_user()
 
-    def task():
+    def task():  # noqa: C901
         from vtsearch.auth import set_thread_user
 
         set_thread_user(_request_user)

--- a/vtsearch/datasets/loader_demo.py
+++ b/vtsearch/datasets/loader_demo.py
@@ -40,7 +40,7 @@ def _stamp_demo_origin(
         media["origin"] = {"importer": "demo", "params": dict(demo_origin_params)}
 
 
-def load_demo_dataset(
+def load_demo_dataset(  # noqa: C901
     dataset_name: str,
     medias: dict[int, dict[str, Any]],
     on_progress: Optional[ProgressCallback] = None,

--- a/vtsearch/datasets/loader_folder.py
+++ b/vtsearch/datasets/loader_folder.py
@@ -199,7 +199,7 @@ def _attach_patch_regions(media_data: dict[str, Any], patch_out: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def load_dataset_from_folder(
+def load_dataset_from_folder(  # noqa: C901
     folder_path: Path,
     media_type: str,
     medias: dict[int, dict[str, Any]],
@@ -541,7 +541,7 @@ def apply_custom_metadata_md5(media_dict: dict[int, dict[str, Any]]) -> int:
     return count
 
 
-def load_dataset_from_folder_chunked(
+def load_dataset_from_folder_chunked(  # noqa: C901
     folder_path: Path,
     media_type: str,
     chunk_size: int,

--- a/vtsearch/datasets/loader_pickle.py
+++ b/vtsearch/datasets/loader_pickle.py
@@ -21,7 +21,7 @@ from vtsearch.datasets.loader import (
 from vtsearch.security.pickle import safe_pickle_load
 
 
-def load_dataset_from_pickle(
+def load_dataset_from_pickle(  # noqa: C901
     file_path: Path,
     medias: dict[int, dict[str, Any]],
     thin: bool = False,
@@ -221,7 +221,7 @@ def load_dataset_from_pickle(
     return None
 
 
-def load_dataset_from_pickle_chunked(
+def load_dataset_from_pickle_chunked(  # noqa: C901
     file_path: Path,
     chunk_size: int,
     thin: bool = False,

--- a/vtsearch/datasets/media_type_detection.py
+++ b/vtsearch/datasets/media_type_detection.py
@@ -33,7 +33,7 @@ from typing import Optional
 from vtsearch.media import get_by_extension
 
 
-def detect_media_types_in_folder(
+def detect_media_types_in_folder(  # noqa: C901
     folder: Path,
     recursive: bool = True,
     limit: int = 50,

--- a/vtsearch/detectors/label_restoration.py
+++ b/vtsearch/detectors/label_restoration.py
@@ -8,7 +8,7 @@ resolving origin files for cross-dataset scenarios.
 from __future__ import annotations
 
 
-def restore_labels_from_detector(det_data: dict) -> int:
+def restore_labels_from_detector(det_data: dict) -> int:  # noqa: C901
     """Restore saved labels from a detector's labelset into votes.
 
     Matches labelset entries to loaded medias by origin+origin_name, MD5, and

--- a/vtsearch/detectors/label_sync.py
+++ b/vtsearch/detectors/label_sync.py
@@ -14,7 +14,7 @@ label, or removed when the user has untoggled the vote.
 from __future__ import annotations
 
 
-def sync_labels_to_loaded_detector() -> None:
+def sync_labels_to_loaded_detector() -> None:  # noqa: C901
     """Persist the current votes into the loaded detector's labelset (if any).
 
     Called automatically after each vote so the dashboard's "# Training" and

--- a/vtsearch/detectors/labeling_progress.py
+++ b/vtsearch/detectors/labeling_progress.py
@@ -294,7 +294,7 @@ def _train_step(
     return model, threshold, stability
 
 
-def _ensure_cache(
+def _ensure_cache(  # noqa: C901
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
     inclusion_value: int,
@@ -383,7 +383,7 @@ def _ensure_cache(
 # ---------------------------------------------------------------------------
 
 
-def _eval_cached_models(
+def _eval_cached_models(  # noqa: C901
     clips_dict: dict[int, dict[str, Any]],
     current_good_votes: dict[int, None],
     current_bad_votes: dict[int, None],

--- a/vtsearch/detectors/media_seeding.py
+++ b/vtsearch/detectors/media_seeding.py
@@ -7,7 +7,7 @@ files, matches them to loaded dataset medias by MD5, and votes them good.
 from __future__ import annotations
 
 
-def seed_good_votes_from_examples(examples: list[dict]) -> int:
+def seed_good_votes_from_examples(examples: list[dict]) -> int:  # noqa: C901
     """Seed good votes from a model's media examples.
 
     For each ``type: "media"`` example, reads the file from

--- a/vtsearch/detectors/resolver.py
+++ b/vtsearch/detectors/resolver.py
@@ -240,7 +240,7 @@ def resolve_file_from_origin(
         return p
 
 
-def _resolve_with_stack(
+def _resolve_with_stack(  # noqa: C901
     stack: ExitStack,
     origin: dict[str, Any] | None,
     origin_name: str = "",
@@ -433,7 +433,7 @@ def embed_file(file_path: Path, media_type: str, embedder_name: str = "") -> np.
     return result
 
 
-def _apply_clip_and_embed(
+def _apply_clip_and_embed(  # noqa: C901
     file_path: Path,
     media_type: str,
     origin: dict[str, Any],
@@ -540,7 +540,7 @@ def _apply_clip_and_embed(
     return embed_file(file_path, media_type, embedder_name)
 
 
-def resolve_label_embeddings(
+def resolve_label_embeddings(  # noqa: C901
     labels: list[dict[str, Any]],
     media_type: str,
     progress_callback: Any | None = None,

--- a/vtsearch/detectors/training.py
+++ b/vtsearch/detectors/training.py
@@ -139,7 +139,7 @@ def _training_vec_for_vote(
     return media["embedding"]
 
 
-def train_and_score(
+def train_and_score(  # noqa: C901
     clips_dict: dict[int, dict[str, Any]],
     good_votes: dict[int, None],
     bad_votes: dict[int, None],

--- a/vtsearch/detectors/workflow.py
+++ b/vtsearch/detectors/workflow.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from vtsearch.state.core import DetectorContext
 
 
-def apply_and_retrain(
+def apply_and_retrain(  # noqa: C901
     detector_id: str,
     det_ctx: "DetectorContext",
     new_entries: list[dict],

--- a/vtsearch/eval/label_curve.py
+++ b/vtsearch/eval/label_curve.py
@@ -461,7 +461,7 @@ def evaluate_one(
     }
 
 
-def run_label_curve_eval(
+def run_label_curve_eval(  # noqa: C901
     dataset_clips: dict[str, dict[int, dict[str, Any]]],
     trainers: Sequence[str] = ("mlp", "svm_linear"),
     label_counts: Sequence[int] = (5, 10, 20, 50, 100),

--- a/vtsearch/exporters/server_csv_file/__init__.py
+++ b/vtsearch/exporters/server_csv_file/__init__.py
@@ -145,7 +145,7 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
             "filepath": str(filepath.resolve()),
         }
 
-    def _export_autodetect(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
+    def _export_autodetect(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:  # noqa: C901
         """Export autodetect results (detector hits)."""
         # Scan all hits to determine which clip columns are present.
         all_hits: list[tuple[str, Any, dict]] = []

--- a/vtsearch/labels/importers/server_csv_file/__init__.py
+++ b/vtsearch/labels/importers/server_csv_file/__init__.py
@@ -73,7 +73,7 @@ class ServerCsvLabelImporter(LabelImporter):
         )
 
 
-def _parse_csv_bytes(raw: bytes) -> list[dict[str, Any]]:
+def _parse_csv_bytes(raw: bytes) -> list[dict[str, Any]]:  # noqa: C901
     """Decode *raw* bytes as CSV and extract ``md5``/``label`` pairs."""
     try:
         text = raw.decode("utf-8-sig")  # strip BOM if present

--- a/vtsearch/labels/sync.py
+++ b/vtsearch/labels/sync.py
@@ -81,7 +81,7 @@ def sync_to_labelset_source() -> None:
             logger.exception("Failed to sync labels to source: %s", exc)
 
 
-def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, str]] | None:
+def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, str]] | None:  # noqa: C901
     """Pull labels from the active detector's labelset source and apply them.
 
     Args:

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -70,7 +70,7 @@ _STD_RECORD_ATTRS = frozenset(
 )
 
 
-def _resolve_context() -> dict[str, Any]:
+def _resolve_context() -> dict[str, Any]:  # noqa: C901
     """Pull the active VTSearch context from Flask ``g`` or thread-locals.
 
     Returns a dict with whatever subset of (``request_id``, ``user``,

--- a/vtsearch/media/audio/media_type.py
+++ b/vtsearch/media/audio/media_type.py
@@ -450,6 +450,91 @@ class AudioMediaType(MediaType):
     # Demo dataset loading
     # ------------------------------------------------------------------
 
+    def _collect_audio_files(
+        self,
+        source: str,
+        categories: list,
+        slice_start: int,
+        slice_end: int | None,
+        slice_frac_start: float | None,
+        slice_frac_end: float | None,
+        on_progress,
+    ):
+        """Resolve a demo source name → (audio_files, audio_dir)."""
+
+        def _sliced_by_category(by_cat: dict[str, list]) -> list:
+            out: list = []
+            for cat in categories:
+                out.extend(
+                    demo_slice(
+                        by_cat.get(cat, []),
+                        slice_start,
+                        slice_end,
+                        slice_frac_start,
+                        slice_frac_end,
+                    )
+                )
+            return out
+
+        if source == "gtzan":
+            from vtsearch.datasets.downloader import download_gtzan  # noqa: PLC0415
+            from vtsearch.datasets.loader import load_audio_metadata_from_folders  # noqa: PLC0415
+
+            audio_dir = download_gtzan(on_progress=on_progress)
+            metadata = load_audio_metadata_from_folders(audio_dir, categories)
+            by_cat = self._group_metadata_by_category(metadata, categories, filter_to_categories=False)
+            return _sliced_by_category(by_cat), audio_dir
+
+        if source == "speech_commands_v2":
+            from vtsearch.datasets.downloader import download_speech_commands_v2  # noqa: PLC0415
+            from vtsearch.datasets.loader import load_audio_metadata_from_folders  # noqa: PLC0415
+
+            audio_dir = download_speech_commands_v2(on_progress=on_progress)
+            metadata = load_audio_metadata_from_folders(audio_dir, categories)
+            by_cat = self._group_metadata_by_category(metadata, categories, filter_to_categories=False)
+            return _sliced_by_category(by_cat), audio_dir
+
+        if source == "urbansound8k":
+            from vtsearch.datasets.downloader import download_urbansound8k  # noqa: PLC0415
+            from vtsearch.datasets.loader import load_urbansound8k_metadata  # noqa: PLC0415
+
+            us8k_dir = download_urbansound8k(on_progress=on_progress)
+            metadata = load_urbansound8k_metadata(us8k_dir)
+            by_cat = self._group_metadata_by_category(metadata, categories, filter_to_categories=True)
+            return _sliced_by_category(by_cat), us8k_dir / "audio"
+
+        if not source or source == "esc50":
+            from vtsearch.datasets.downloader import download_esc50  # noqa: PLC0415
+            from vtsearch.datasets.loader import load_esc50_metadata  # noqa: PLC0415
+
+            audio_dir = download_esc50(on_progress=on_progress)
+            esc_metadata = load_esc50_metadata(audio_dir.parent)
+
+            by_cat: dict[str, list] = {}
+            for audio_path in sorted(audio_dir.glob("*.wav")):
+                if audio_path.name in esc_metadata:
+                    cat = esc_metadata[audio_path.name]["category"]
+                    if cat in categories:
+                        by_cat.setdefault(cat, []).append((audio_path, esc_metadata[audio_path.name]))
+            return _sliced_by_category(by_cat), audio_dir
+
+        raise ValueError(f"Unsupported audio source: {source!r}")
+
+    @staticmethod
+    def _group_metadata_by_category(
+        metadata: dict,
+        categories: list,
+        *,
+        filter_to_categories: bool,
+    ) -> dict[str, list]:
+        by_cat: dict[str, list] = {}
+        for _key, meta in sorted(metadata.items()):
+            cat = meta["category"]
+            if filter_to_categories and cat not in categories:
+                continue
+            by_cat.setdefault(cat, []).append((meta["path"], meta))
+        return by_cat
+
     def load_demo_source(
         self,
         source,
@@ -478,113 +563,15 @@ class AudioMediaType(MediaType):
                 raise ValueError(f"No embedders registered for media type {self.type_id!r}")
             embedder = avail[0]
 
-        if source == "gtzan":
-            from vtsearch.datasets.downloader import download_gtzan  # noqa: PLC0415
-            from vtsearch.datasets.loader import load_audio_metadata_from_folders  # noqa: PLC0415
-
-            genres_dir = download_gtzan(on_progress=on_progress)
-            metadata = load_audio_metadata_from_folders(genres_dir, categories)
-
-            by_cat: dict[str, list] = {}
-            for _key, meta in sorted(metadata.items()):
-                cat = meta["category"]
-                by_cat.setdefault(cat, []).append((meta["path"], meta))
-
-            audio_files: list = []
-            for cat in categories:
-                audio_files.extend(
-                    demo_slice(
-                        by_cat.get(cat, []),
-                        slice_start,
-                        slice_end,
-                        slice_frac_start,
-                        slice_frac_end,
-                    )
-                )
-
-            audio_dir = genres_dir
-
-        elif source == "speech_commands_v2":
-            from vtsearch.datasets.downloader import download_speech_commands_v2  # noqa: PLC0415
-            from vtsearch.datasets.loader import load_audio_metadata_from_folders  # noqa: PLC0415
-
-            sc_dir = download_speech_commands_v2(on_progress=on_progress)
-            metadata = load_audio_metadata_from_folders(sc_dir, categories)
-
-            by_cat = {}
-            for _key, meta in sorted(metadata.items()):
-                cat = meta["category"]
-                by_cat.setdefault(cat, []).append((meta["path"], meta))
-
-            audio_files = []
-            for cat in categories:
-                audio_files.extend(
-                    demo_slice(
-                        by_cat.get(cat, []),
-                        slice_start,
-                        slice_end,
-                        slice_frac_start,
-                        slice_frac_end,
-                    )
-                )
-
-            audio_dir = sc_dir
-
-        elif source == "urbansound8k":
-            from vtsearch.datasets.downloader import download_urbansound8k  # noqa: PLC0415
-            from vtsearch.datasets.loader import load_urbansound8k_metadata  # noqa: PLC0415
-
-            us8k_dir = download_urbansound8k(on_progress=on_progress)
-            metadata = load_urbansound8k_metadata(us8k_dir)
-
-            by_cat = {}
-            for _fname, meta in sorted(metadata.items()):
-                cat = meta["category"]
-                if cat in categories:
-                    by_cat.setdefault(cat, []).append((meta["path"], meta))
-
-            audio_files = []
-            for cat in categories:
-                audio_files.extend(
-                    demo_slice(
-                        by_cat.get(cat, []),
-                        slice_start,
-                        slice_end,
-                        slice_frac_start,
-                        slice_frac_end,
-                    )
-                )
-
-            audio_dir = us8k_dir / "audio"
-
-        elif not source or source == "esc50":
-            from vtsearch.datasets.downloader import download_esc50  # noqa: PLC0415
-            from vtsearch.datasets.loader import load_esc50_metadata  # noqa: PLC0415
-
-            audio_dir = download_esc50(on_progress=on_progress)
-            esc_metadata = load_esc50_metadata(audio_dir.parent)
-
-            by_cat = {}
-            for audio_path in sorted(audio_dir.glob("*.wav")):
-                if audio_path.name in esc_metadata:
-                    cat = esc_metadata[audio_path.name]["category"]
-                    if cat in categories:
-                        by_cat.setdefault(cat, []).append((audio_path, esc_metadata[audio_path.name]))
-
-            audio_files = []
-            for cat in categories:
-                audio_files.extend(
-                    demo_slice(
-                        by_cat.get(cat, []),
-                        slice_start,
-                        slice_end,
-                        slice_frac_start,
-                        slice_frac_end,
-                    )
-                )
-
-        else:
-            raise ValueError(f"Unsupported audio source: {source!r}")
+        audio_files, audio_dir = self._collect_audio_files(
+            source,
+            categories,
+            slice_start,
+            slice_end,
+            slice_frac_start,
+            slice_frac_end,
+            on_progress,
+        )
 
         # Load models
         if getattr(embedder, "_model", None) is None:

--- a/vtsearch/media/embedder.py
+++ b/vtsearch/media/embedder.py
@@ -212,7 +212,7 @@ def load_pretrained_local_first(load_fn: Callable[..., Any], *args: Any, **kwarg
 
 
 @contextlib.contextmanager
-def intercept_tqdm_progress(callback: ProgressCallback) -> Any:
+def intercept_tqdm_progress(callback: ProgressCallback) -> Any:  # noqa: C901
     """Temporarily hook tqdm progress bars to forward updates to *callback*.
 
     HuggingFace ``transformers`` and ``huggingface_hub`` use :mod:`tqdm` for
@@ -282,7 +282,7 @@ def intercept_tqdm_progress(callback: ProgressCallback) -> Any:
 
 
 @contextlib.contextmanager
-def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "Loading model weights…") -> Any:
+def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "Loading model weights…") -> Any:  # noqa: C901
     """Track tensor-level progress during model weight loading.
 
     HuggingFace ``transformers`` with ``low_cpu_mem_usage=True`` dispatches

--- a/vtsearch/media/image/_demo_sources.py
+++ b/vtsearch/media/image/_demo_sources.py
@@ -337,6 +337,275 @@ def build_demo_datasets() -> list[DemoDataset]:
     ]
 
 
+_FILE_SOURCE_DOWNLOADERS: dict[str, str] = {
+    "caltech101": "download_caltech101",
+    "caltech256": "download_caltech256",
+    "food101": "download_food101",
+    "eurosat": "download_eurosat",
+}
+
+
+def _slice_by_category(by_cat: dict, categories, slice_start, slice_end, slice_frac_start, slice_frac_end) -> list:
+    out: list = []
+    for cat in categories:
+        out.extend(demo_slice(by_cat.get(cat, []), slice_start, slice_end, slice_frac_start, slice_frac_end))
+    return out
+
+
+def _collect_simple_folder_files(source, categories, slice_args, on_progress) -> list:
+    """Sources that just download → load_image_metadata_from_folders → group by category."""
+    from vtsearch.datasets import downloader  # noqa: PLC0415
+    from vtsearch.datasets.loader import load_image_metadata_from_folders  # noqa: PLC0415
+
+    download_fn = getattr(downloader, _FILE_SOURCE_DOWNLOADERS[source])
+    img_dir = download_fn(on_progress=on_progress)
+    metadata = load_image_metadata_from_folders(img_dir, categories)
+    by_cat: dict = {}
+    for _fname, meta in sorted(metadata.items()):
+        by_cat.setdefault(meta["category"], []).append((meta["path"], meta["category"]))
+    return _slice_by_category(by_cat, categories, *slice_args)
+
+
+def _collect_oxford_flowers_files(categories, slice_args, on_progress) -> list:
+    from vtsearch.datasets.downloader import download_oxford_flowers  # noqa: PLC0415
+    from vtsearch.datasets.loader import load_oxford_flowers_metadata  # noqa: PLC0415
+
+    flowers_dir = download_oxford_flowers(on_progress=on_progress)
+    metadata = load_oxford_flowers_metadata(flowers_dir, OXFORD_FLOWERS_CATEGORIES)
+
+    by_cat: dict = {}
+    for _fname, meta in sorted(metadata.items()):
+        if meta["category"] in categories:
+            by_cat.setdefault(meta["category"], []).append((meta["path"], meta["category"]))
+    return _slice_by_category(by_cat, categories, *slice_args)
+
+
+def _collect_stanford_dogs_files(categories, slice_args, on_progress) -> list:
+    from vtsearch.datasets.downloader import download_stanford_dogs  # noqa: PLC0415
+
+    images_dir = download_stanford_dogs(on_progress=on_progress)
+    breed_to_folder: dict[str, Path] = {}
+    if images_dir.exists():
+        for folder in images_dir.iterdir():
+            if folder.is_dir() and "-" in folder.name:
+                breed_to_folder[folder.name.split("-", 1)[1]] = folder
+
+    by_cat: dict = {}
+    for cat in categories:
+        folder = breed_to_folder.get(cat)
+        if folder is None:
+            continue
+        for ext in ["*.jpg", "*.jpeg", "*.png"]:
+            for img_path in sorted(folder.glob(ext)):
+                by_cat.setdefault(cat, []).append((img_path, cat))
+    return _slice_by_category(by_cat, categories, *slice_args)
+
+
+def _collect_places365_files(categories, slice_args, on_progress) -> list:
+    from vtsearch.datasets.downloader import download_places365  # noqa: PLC0415
+    from vtsearch.datasets.loader import load_places365_metadata  # noqa: PLC0415
+
+    places_dir = download_places365(on_progress=on_progress)
+    metadata = load_places365_metadata(places_dir, PLACES365_CATEGORIES)
+
+    by_cat: dict = {}
+    for _fname, meta in sorted(metadata.items()):
+        if meta["category"] in categories:
+            by_cat.setdefault(meta["category"], []).append((meta["path"], meta["category"]))
+    return _slice_by_category(by_cat, categories, *slice_args)
+
+
+def _collect_ucsf_doc_pages(categories, slice_args, on_progress) -> list:
+    """Returns a list of (page_name, PIL.Image, category) tuples."""
+    from vtsearch.datasets.downloader import download_ucsf_documents  # noqa: PLC0415
+    from vtsearch.datasets.pdf import render_pdf_pages  # noqa: PLC0415
+
+    docs_dir = download_ucsf_documents(categories, on_progress=on_progress)
+
+    by_cat_pages: dict = {}
+    for cat in categories:
+        cat_dir = docs_dir / cat
+        if not cat_dir.is_dir():
+            continue
+        for pdf_path in sorted(cat_dir.glob("*.pdf")):
+            try:
+                pages = render_pdf_pages(pdf_path, dpi=150)
+                if pages:
+                    by_cat_pages.setdefault(cat, []).append(pages[0])
+            except Exception:
+                continue
+
+    selected_pages: list = []
+    slice_start, slice_end, slice_frac_start, slice_frac_end = slice_args
+    for cat in categories:
+        for page_name, pil_image in demo_slice(
+            by_cat_pages.get(cat, []), slice_start, slice_end, slice_frac_start, slice_frac_end
+        ):
+            selected_pages.append((page_name, pil_image, cat))
+    return selected_pages
+
+
+def _collect_cifar10_images(categories, slice_args, on_progress) -> list:
+    """Returns a list of (image_array, category) tuples."""
+    from vtsearch.datasets.downloader import download_cifar10  # noqa: PLC0415
+    from vtsearch.datasets.loader import load_cifar10_batch  # noqa: PLC0415
+
+    cifar_dir = download_cifar10(on_progress=on_progress)
+    images, labels, label_names = load_cifar10_batch(cifar_dir / "data_batch_1")
+    category_indices = {label_names[i]: i for i in range(len(label_names))}
+
+    slice_start, slice_end, slice_frac_start, slice_frac_end = slice_args
+    selected: list = []
+    for cat in categories:
+        if cat not in category_indices:
+            continue
+        cat_idx = category_indices[cat]
+        cat_mask = [i for i, lbl in enumerate(labels) if lbl == cat_idx]
+        for idx in demo_slice(cat_mask, slice_start, slice_end or len(cat_mask), slice_frac_start, slice_frac_end):
+            selected.append((images[idx], cat))
+    return selected
+
+
+def _ensure_image_embedder_loaded(embedder, on_progress) -> None:
+    if getattr(embedder, "_model", None) is None:
+        on_progress("loading", "Loading image embedding model…", 0, 0)
+        original_cb = embedder._on_progress
+        embedder._on_progress = on_progress
+        try:
+            embedder.load_models()
+        finally:
+            embedder._on_progress = original_cb
+
+
+def _embed_file_images(selected, clips, embedder, on_progress, demo_origin) -> None:
+    """Embed a list of (img_path, category) tuples into ``clips``."""
+    import hashlib  # noqa: PLC0415
+
+    from PIL import Image  # noqa: PLC0415
+
+    _ensure_image_embedder_loaded(embedder, on_progress)
+
+    clip_id = max(clips.keys(), default=0) + 1
+    total = len(selected)
+    on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+
+    from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
+
+    for i, (img_path, category) in enumerate(selected):
+        on_progress("embedding", f"Embedding {category}/{img_path.name}", i + 1, total)
+        embedding = embedder.embed_media(media_from_path(img_path))
+        if embedding is None:
+            continue
+        with open(img_path, "rb") as f:
+            image_bytes = f.read()
+        try:
+            with Image.open(img_path) as img:
+                width, height = img.width, img.height
+        except Exception:
+            width, height = None, None
+        clips[clip_id] = {
+            "id": clip_id,
+            "type": _MEDIA_TYPE_ID,
+            "embedder": embedder.name,
+            "duration": 0,
+            "file_size": len(image_bytes),
+            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "embedding": embedding,
+            "media_bytes": image_bytes,
+            "media_string": None,
+            "filename": f"{category}/{img_path.name}",
+            "category": category,
+            "width": width,
+            "height": height,
+            "origin": demo_origin,
+            "origin_name": f"{category}/{img_path.name}",
+        }
+        clip_id += 1
+
+
+def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin) -> None:
+    """Embed a list of (page_name, PIL.Image, category) tuples into ``clips``."""
+    import hashlib  # noqa: PLC0415
+    import io as _io  # noqa: PLC0415
+
+    _ensure_image_embedder_loaded(embedder, on_progress)
+
+    clip_id = max(clips.keys(), default=0) + 1
+    total = len(selected_pages)
+    on_progress("embedding", f"Starting embedding for {total} document pages...", 0, total)
+
+    for i, (page_name, pil_image, category) in enumerate(selected_pages):
+        on_progress("embedding", f"Embedding {page_name}", i + 1, total)
+        embedding = cast(Any, embedder).embed_pil_image(pil_image)
+        if embedding is None:
+            continue
+        img_buffer = _io.BytesIO()
+        pil_image.save(img_buffer, format="PNG")
+        image_bytes = img_buffer.getvalue()
+        rel_name = f"{category}/{page_name}"
+        clips[clip_id] = {
+            "id": clip_id,
+            "type": _MEDIA_TYPE_ID,
+            "embedder": embedder.name,
+            "duration": 0,
+            "file_size": len(image_bytes),
+            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "embedding": embedding,
+            "media_bytes": image_bytes,
+            "media_string": None,
+            "filename": f"{rel_name}.png",
+            "category": category,
+            "width": pil_image.width,
+            "height": pil_image.height,
+            "origin": demo_origin,
+            "origin_name": rel_name,
+        }
+        clip_id += 1
+
+
+def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin) -> None:
+    """Embed a list of (image_array, category) tuples into ``clips``."""
+    import hashlib  # noqa: PLC0415
+    import io as _io  # noqa: PLC0415
+
+    from PIL import Image  # noqa: PLC0415
+
+    _ensure_image_embedder_loaded(embedder, on_progress)
+
+    clip_id = max(clips.keys(), default=0) + 1
+    total = len(selected)
+    on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
+
+    for i, (image_array, category) in enumerate(selected):
+        on_progress("embedding", f"Embedding {category}", i + 1, total)
+        img = Image.fromarray(image_array.astype("uint8"), "RGB")
+        img_buffer = _io.BytesIO()
+        img.save(img_buffer, format="PNG")
+        image_bytes = img_buffer.getvalue()
+        embedding = cast(Any, embedder).embed_pil_image(img)
+        if embedding is None:
+            continue
+        fname = f"{category}/{category}_{clip_id}.png"
+        clips[clip_id] = {
+            "id": clip_id,
+            "type": _MEDIA_TYPE_ID,
+            "embedder": embedder.name,
+            "duration": 0,
+            "file_size": len(image_bytes),
+            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "embedding": embedding,
+            "media_bytes": image_bytes,
+            "media_string": None,
+            "filename": fname,
+            "category": category,
+            "width": img.width,
+            "height": img.height,
+            "origin": demo_origin,
+            "origin_name": fname,
+        }
+        clip_id += 1
+
+
 def load_demo_source(
     source,
     categories,
@@ -349,11 +618,6 @@ def load_demo_source(
     slice_frac_end=None,
     **kwargs,
 ):
-    import hashlib  # noqa: PLC0415
-    import io as _io  # noqa: PLC0415
-
-    from PIL import Image  # noqa: PLC0415
-
     if on_progress is None:
         from vtsearch.concurrency.progress import update_progress
 
@@ -367,351 +631,67 @@ def load_demo_source(
             raise ValueError(f"No embedders registered for media type {_MEDIA_TYPE_ID!r}")
         embedder = avail[0]
 
-    from vtsearch.datasets.loader import load_image_metadata_from_folders  # noqa: PLC0415
-
     demo_origin: dict = {"importer": "demo", "params": {}}
+    slice_args = (slice_start, slice_end, slice_frac_start, slice_frac_end)
 
-    def _embed_file_images(selected):
-        """Embed a list of (img_path, category) tuples."""
-        if getattr(embedder, "_model", None) is None:
-            on_progress("loading", "Loading image embedding model…", 0, 0)
-            original_cb = embedder._on_progress
-            embedder._on_progress = on_progress
-            try:
-                embedder.load_models()
-            finally:
-                embedder._on_progress = original_cb
-
-        clip_id = max(clips.keys(), default=0) + 1
-        total = len(selected)
-        on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
-
-        from vtsearch.media.embedder import media_from_path  # noqa: PLC0415
-
-        for i, (img_path, category) in enumerate(selected):
-            on_progress("embedding", f"Embedding {category}/{img_path.name}", i + 1, total)
-            embedding = embedder.embed_media(media_from_path(img_path))
-            if embedding is None:
-                continue
-            with open(img_path, "rb") as f:
-                image_bytes = f.read()
-            try:
-                with Image.open(img_path) as img:
-                    width, height = img.width, img.height
-            except Exception:
-                width, height = None, None
-            clips[clip_id] = {
-                "id": clip_id,
-                "type": _MEDIA_TYPE_ID,
-                "embedder": embedder.name,
-                "duration": 0,
-                "file_size": len(image_bytes),
-                "md5": hashlib.md5(image_bytes).hexdigest(),
-                "embedding": embedding,
-                "media_bytes": image_bytes,
-                "media_string": None,
-                "filename": f"{category}/{img_path.name}",
-                "category": category,
-                "width": width,
-                "height": height,
-                "origin": demo_origin,
-                "origin_name": f"{category}/{img_path.name}",
-            }
-            clip_id += 1
-
-    if source in ("caltech101", "caltech256"):
-        if source == "caltech101":
-            from vtsearch.datasets.downloader import download_caltech101  # noqa: PLC0415
-
-            img_dir = download_caltech101(on_progress=on_progress)
-        else:
-            from vtsearch.datasets.downloader import download_caltech256  # noqa: PLC0415
-
-            img_dir = download_caltech256(on_progress=on_progress)
-
-        metadata = load_image_metadata_from_folders(img_dir, categories)
-        by_cat: dict[str, list[tuple[Path, str]]] = {}
-        for fname, meta in sorted(metadata.items()):
-            cat = meta["category"]
-            by_cat.setdefault(cat, []).append((meta["path"], cat))
-
-        selected: list[tuple[Path, str]] = []
-        for cat in categories:
-            selected.extend(
-                demo_slice(
-                    by_cat.get(cat, []),
-                    slice_start,
-                    slice_end,
-                    slice_frac_start,
-                    slice_frac_end,
-                )
-            )
-
-        _embed_file_images(selected)
+    if source in _FILE_SOURCE_DOWNLOADERS:
+        _embed_file_images(
+            _collect_simple_folder_files(source, categories, slice_args, on_progress),
+            clips,
+            embedder,
+            on_progress,
+            demo_origin,
+        )
         return None
 
-    elif source == "oxford_flowers_102":
-        from vtsearch.datasets.downloader import download_oxford_flowers  # noqa: PLC0415
-        from vtsearch.datasets.loader import load_oxford_flowers_metadata  # noqa: PLC0415
-
-        flowers_dir = download_oxford_flowers(on_progress=on_progress)
-        metadata = load_oxford_flowers_metadata(flowers_dir, OXFORD_FLOWERS_CATEGORIES)
-
-        by_cat: dict[str, list[tuple[Path, str]]] = {}
-        for _fname, meta in sorted(metadata.items()):
-            cat = meta["category"]
-            if cat in categories:
-                by_cat.setdefault(cat, []).append((meta["path"], cat))
-
-        selected: list[tuple[Path, str]] = []
-        for cat in categories:
-            selected.extend(
-                demo_slice(
-                    by_cat.get(cat, []),
-                    slice_start,
-                    slice_end,
-                    slice_frac_start,
-                    slice_frac_end,
-                )
-            )
-
-        _embed_file_images(selected)
+    if source == "oxford_flowers_102":
+        _embed_file_images(
+            _collect_oxford_flowers_files(categories, slice_args, on_progress),
+            clips,
+            embedder,
+            on_progress,
+            demo_origin,
+        )
         return None
 
-    elif source in ("food101", "eurosat"):
-        if source == "food101":
-            from vtsearch.datasets.downloader import download_food101  # noqa: PLC0415
-
-            img_dir = download_food101(on_progress=on_progress)
-        else:
-            from vtsearch.datasets.downloader import download_eurosat  # noqa: PLC0415
-
-            img_dir = download_eurosat(on_progress=on_progress)
-
-        metadata = load_image_metadata_from_folders(img_dir, categories)
-        by_cat = {}
-        for _fname, meta in sorted(metadata.items()):
-            cat = meta["category"]
-            by_cat.setdefault(cat, []).append((meta["path"], cat))
-
-        selected = []
-        for cat in categories:
-            selected.extend(
-                demo_slice(
-                    by_cat.get(cat, []),
-                    slice_start,
-                    slice_end,
-                    slice_frac_start,
-                    slice_frac_end,
-                )
-            )
-
-        _embed_file_images(selected)
+    if source == "stanford_dogs":
+        _embed_file_images(
+            _collect_stanford_dogs_files(categories, slice_args, on_progress),
+            clips,
+            embedder,
+            on_progress,
+            demo_origin,
+        )
         return None
 
-    elif source == "stanford_dogs":
-        from vtsearch.datasets.downloader import download_stanford_dogs  # noqa: PLC0415
-
-        images_dir = download_stanford_dogs(on_progress=on_progress)
-
-        breed_to_folder: dict[str, Path] = {}
-        if images_dir.exists():
-            for folder in images_dir.iterdir():
-                if folder.is_dir() and "-" in folder.name:
-                    breed_name = folder.name.split("-", 1)[1]
-                    breed_to_folder[breed_name] = folder
-
-        by_cat = {}
-        for cat in categories:
-            folder = breed_to_folder.get(cat)
-            if folder is None:
-                continue
-            for ext in ["*.jpg", "*.jpeg", "*.png"]:
-                for img_path in sorted(folder.glob(ext)):
-                    by_cat.setdefault(cat, []).append((img_path, cat))
-
-        selected = []
-        for cat in categories:
-            selected.extend(
-                demo_slice(
-                    by_cat.get(cat, []),
-                    slice_start,
-                    slice_end,
-                    slice_frac_start,
-                    slice_frac_end,
-                )
-            )
-
-        _embed_file_images(selected)
+    if source == "places365":
+        _embed_file_images(
+            _collect_places365_files(categories, slice_args, on_progress),
+            clips,
+            embedder,
+            on_progress,
+            demo_origin,
+        )
         return None
 
-    elif source == "places365":
-        from vtsearch.datasets.downloader import download_places365  # noqa: PLC0415
-        from vtsearch.datasets.loader import load_places365_metadata  # noqa: PLC0415
-
-        places_dir = download_places365(on_progress=on_progress)
-        metadata = load_places365_metadata(places_dir, PLACES365_CATEGORIES)
-
-        by_cat: dict[str, list[tuple[Path, str]]] = {}
-        for _fname, meta in sorted(metadata.items()):
-            cat = meta["category"]
-            if cat in categories:
-                by_cat.setdefault(cat, []).append((meta["path"], cat))
-
-        selected: list[tuple[Path, str]] = []
-        for cat in categories:
-            selected.extend(
-                demo_slice(
-                    by_cat.get(cat, []),
-                    slice_start,
-                    slice_end,
-                    slice_frac_start,
-                    slice_frac_end,
-                )
-            )
-
-        _embed_file_images(selected)
+    if source == "ucsf_documents":
+        _embed_pil_pages(
+            _collect_ucsf_doc_pages(categories, slice_args, on_progress),
+            clips,
+            embedder,
+            on_progress,
+            demo_origin,
+        )
         return None
 
-    elif source == "ucsf_documents":
-        from vtsearch.datasets.downloader import download_ucsf_documents  # noqa: PLC0415
-        from vtsearch.datasets.pdf import render_pdf_pages  # noqa: PLC0415
-
-        docs_dir = download_ucsf_documents(categories, on_progress=on_progress)
-
-        by_cat_pages: dict[str, list[tuple[str, "Image.Image"]]] = {}
-        for cat in categories:
-            cat_dir = docs_dir / cat
-            if not cat_dir.is_dir():
-                continue
-            for pdf_path in sorted(cat_dir.glob("*.pdf")):
-                try:
-                    pages = render_pdf_pages(pdf_path, dpi=150)
-                    if pages:
-                        by_cat_pages.setdefault(cat, []).append(pages[0])
-                except Exception:
-                    continue
-
-        selected_pages: list[tuple[str, "Image.Image", str]] = []
-        for cat in categories:
-            for page_name, pil_image in demo_slice(
-                by_cat_pages.get(cat, []),
-                slice_start,
-                slice_end,
-                slice_frac_start,
-                slice_frac_end,
-            ):
-                selected_pages.append((page_name, pil_image, cat))
-
-        if getattr(embedder, "_model", None) is None:
-            on_progress("loading", "Loading image embedding model…", 0, 0)
-            original_cb = embedder._on_progress
-            embedder._on_progress = on_progress
-            try:
-                embedder.load_models()
-            finally:
-                embedder._on_progress = original_cb
-
-        clip_id = max(clips.keys(), default=0) + 1
-        total = len(selected_pages)
-        on_progress("embedding", f"Starting embedding for {total} document pages...", 0, total)
-
-        for i, (page_name, pil_image, category) in enumerate(selected_pages):
-            on_progress("embedding", f"Embedding {page_name}", i + 1, total)
-            embedding = cast(Any, embedder).embed_pil_image(pil_image)
-            if embedding is None:
-                continue
-            img_buffer = _io.BytesIO()
-            pil_image.save(img_buffer, format="PNG")
-            image_bytes = img_buffer.getvalue()
-            rel_name = f"{category}/{page_name}"
-            clips[clip_id] = {
-                "id": clip_id,
-                "type": _MEDIA_TYPE_ID,
-                "embedder": embedder.name,
-                "duration": 0,
-                "file_size": len(image_bytes),
-                "md5": hashlib.md5(image_bytes).hexdigest(),
-                "embedding": embedding,
-                "media_bytes": image_bytes,
-                "media_string": None,
-                "filename": f"{rel_name}.png",
-                "category": category,
-                "width": pil_image.width,
-                "height": pil_image.height,
-                "origin": demo_origin,
-                "origin_name": rel_name,
-            }
-            clip_id += 1
+    if source == "cifar10_sample" or not source:
+        _embed_cifar_arrays(
+            _collect_cifar10_images(categories, slice_args, on_progress),
+            clips,
+            embedder,
+            on_progress,
+            demo_origin,
+        )
         return None
 
-    elif source == "cifar10_sample" or not source:
-        from vtsearch.datasets.downloader import download_cifar10  # noqa: PLC0415
-        from vtsearch.datasets.loader import load_cifar10_batch  # noqa: PLC0415
-
-        cifar_dir = download_cifar10(on_progress=on_progress)
-        batch_file = cifar_dir / "data_batch_1"
-        images, labels, label_names = load_cifar10_batch(batch_file)
-        category_indices = {label_names[i]: i for i in range(len(label_names))}
-
-        selected_images = []
-        selected_labels = []
-        for cat in categories:
-            if cat in category_indices:
-                cat_idx = category_indices[cat]
-                cat_mask = [i for i, lbl in enumerate(labels) if lbl == cat_idx]
-                for idx in demo_slice(
-                    cat_mask,
-                    slice_start,
-                    slice_end or len(cat_mask),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_images.append(images[idx])
-                    selected_labels.append(cat)
-
-        if getattr(embedder, "_model", None) is None:
-            on_progress("loading", "Loading image embedding model…", 0, 0)
-            original_cb = embedder._on_progress
-            embedder._on_progress = on_progress
-            try:
-                embedder.load_models()
-            finally:
-                embedder._on_progress = original_cb
-
-        clip_id = max(clips.keys(), default=0) + 1
-        total = len(selected_images)
-        on_progress("embedding", f"Starting embedding for {total} images...", 0, total)
-
-        for i, (image_array, category) in enumerate(zip(selected_images, selected_labels)):
-            on_progress("embedding", f"Embedding {category}", i + 1, total)
-            img = Image.fromarray(image_array.astype("uint8"), "RGB")
-            img_buffer = _io.BytesIO()
-            img.save(img_buffer, format="PNG")
-            image_bytes = img_buffer.getvalue()
-            embedding = cast(Any, embedder).embed_pil_image(img)
-            if embedding is None:
-                continue
-            fname = f"{category}/{category}_{clip_id}.png"
-            clips[clip_id] = {
-                "id": clip_id,
-                "type": _MEDIA_TYPE_ID,
-                "embedder": embedder.name,
-                "duration": 0,
-                "file_size": len(image_bytes),
-                "md5": hashlib.md5(image_bytes).hexdigest(),
-                "embedding": embedding,
-                "media_bytes": image_bytes,
-                "media_string": None,
-                "filename": fname,
-                "category": category,
-                "width": img.width,
-                "height": img.height,
-                "origin": demo_origin,
-                "origin_name": fname,
-            }
-            clip_id += 1
-        return None
-
-    else:
-        raise ValueError(f"Unsupported image source: {source!r}")
+    raise ValueError(f"Unsupported image source: {source!r}")

--- a/vtsearch/media/text/media_type.py
+++ b/vtsearch/media/text/media_type.py
@@ -455,6 +455,79 @@ class TextMediaType(MediaType):
     # Demo dataset loading
     # ------------------------------------------------------------------
 
+    def _collect_demo_texts(
+        self,
+        source: str,
+        categories: list,
+        slice_start: int,
+        slice_end: int | None,
+        slice_frac_start: float | None,
+        slice_frac_end: float | None,
+        on_progress,
+    ) -> tuple[list[str], list[str]]:
+        """Resolve a demo text source → (selected_texts, selected_categories)."""
+
+        def _slice_by_dict(
+            categories_articles: dict[str, list[str]],
+        ) -> tuple[list[str], list[str]]:
+            texts: list[str] = []
+            cats: list[str] = []
+            for cat_name in categories:
+                articles = categories_articles.get(cat_name, [])
+                for article in demo_slice(
+                    articles,
+                    slice_start,
+                    slice_end or len(articles),
+                    slice_frac_start,
+                    slice_frac_end,
+                ):
+                    texts.append(article)
+                    cats.append(cat_name)
+            return texts, cats
+
+        if source == "20newsgroups":
+            from vtsearch.datasets.downloader import download_20newsgroups  # noqa: PLC0415
+
+            texts_in, labels, category_names = download_20newsgroups(categories, on_progress=on_progress)
+            selected_texts: list[str] = []
+            selected_categories: list[str] = []
+            for cat_name in categories:
+                if cat_name in category_names:
+                    cat_idx = category_names.index(cat_name)
+                    cat_texts = [texts_in[i] for i, lbl in enumerate(labels) if lbl == cat_idx]
+                    for text in demo_slice(
+                        cat_texts,
+                        slice_start,
+                        slice_end or len(cat_texts),
+                        slice_frac_start,
+                        slice_frac_end,
+                    ):
+                        selected_texts.append(text)
+                        selected_categories.append(cat_name)
+            return selected_texts, selected_categories
+
+        from vtsearch.datasets import downloader  # noqa: PLC0415
+
+        dict_downloaders = {
+            "ag_news": downloader.download_ag_news,
+            "bbc_news": downloader.download_bbc_news,
+            "imdb": downloader.download_imdb,
+            "dbpedia": downloader.download_dbpedia,
+            "reuters21578": downloader.download_reuters21578,
+        }
+        if source in dict_downloaders:
+            return _slice_by_dict(dict_downloaders[source](on_progress=on_progress))
+
+        if source == "arxiv":
+            return _slice_by_dict(
+                downloader.download_arxiv_abstracts(
+                    categories=categories,
+                    on_progress=on_progress,
+                )
+            )
+
+        raise ValueError(f"Unsupported text source: {source!r}")
+
     def load_demo_source(
         self,
         source,
@@ -483,135 +556,15 @@ class TextMediaType(MediaType):
                 raise ValueError(f"No embedders registered for media type {self.type_id!r}")
             embedder = avail[0]
 
-        selected_texts = []
-        selected_categories = []
-
-        if source == "20newsgroups":
-            from vtsearch.datasets.downloader import download_20newsgroups  # noqa: PLC0415
-
-            texts, labels, category_names = download_20newsgroups(categories, on_progress=on_progress)
-
-            for cat_name in categories:
-                if cat_name in category_names:
-                    cat_idx = category_names.index(cat_name)
-                    cat_texts = [texts[i] for i, lbl in enumerate(labels) if lbl == cat_idx]
-                    for text in demo_slice(
-                        cat_texts,
-                        slice_start,
-                        slice_end or len(cat_texts),
-                        slice_frac_start,
-                        slice_frac_end,
-                    ):
-                        selected_texts.append(text)
-                        selected_categories.append(cat_name)
-
-        elif source == "ag_news":
-            from vtsearch.datasets.downloader import download_ag_news  # noqa: PLC0415
-
-            categories_articles = download_ag_news(on_progress=on_progress)
-
-            for cat_name in categories:
-                articles = categories_articles.get(cat_name, [])
-                for article in demo_slice(
-                    articles,
-                    slice_start,
-                    slice_end or len(articles),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_texts.append(article)
-                    selected_categories.append(cat_name)
-
-        elif source == "bbc_news":
-            from vtsearch.datasets.downloader import download_bbc_news  # noqa: PLC0415
-
-            categories_articles = download_bbc_news(on_progress=on_progress)
-
-            for cat_name in categories:
-                articles = categories_articles.get(cat_name, [])
-                for article in demo_slice(
-                    articles,
-                    slice_start,
-                    slice_end or len(articles),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_texts.append(article)
-                    selected_categories.append(cat_name)
-
-        elif source == "imdb":
-            from vtsearch.datasets.downloader import download_imdb  # noqa: PLC0415
-
-            categories_reviews = download_imdb(on_progress=on_progress)
-
-            for cat_name in categories:
-                reviews = categories_reviews.get(cat_name, [])
-                for review in demo_slice(
-                    reviews,
-                    slice_start,
-                    slice_end or len(reviews),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_texts.append(review)
-                    selected_categories.append(cat_name)
-
-        elif source == "dbpedia":
-            from vtsearch.datasets.downloader import download_dbpedia  # noqa: PLC0415
-
-            categories_articles = download_dbpedia(on_progress=on_progress)
-
-            for cat_name in categories:
-                articles = categories_articles.get(cat_name, [])
-                for article in demo_slice(
-                    articles,
-                    slice_start,
-                    slice_end or len(articles),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_texts.append(article)
-                    selected_categories.append(cat_name)
-
-        elif source == "arxiv":
-            from vtsearch.datasets.downloader import download_arxiv_abstracts  # noqa: PLC0415
-
-            categories_papers = download_arxiv_abstracts(
-                categories=categories,
-                on_progress=on_progress,
-            )
-
-            for cat_name in categories:
-                papers = categories_papers.get(cat_name, [])
-                for paper in demo_slice(
-                    papers,
-                    slice_start,
-                    slice_end or len(papers),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_texts.append(paper)
-                    selected_categories.append(cat_name)
-
-        elif source == "reuters21578":
-            from vtsearch.datasets.downloader import download_reuters21578  # noqa: PLC0415
-
-            categories_articles = download_reuters21578(on_progress=on_progress)
-
-            for cat_name in categories:
-                articles = categories_articles.get(cat_name, [])
-                for article in demo_slice(
-                    articles,
-                    slice_start,
-                    slice_end or len(articles),
-                    slice_frac_start,
-                    slice_frac_end,
-                ):
-                    selected_texts.append(article)
-                    selected_categories.append(cat_name)
-
-        else:
-            raise ValueError(f"Unsupported text source: {source!r}")
+        selected_texts, selected_categories = self._collect_demo_texts(
+            source,
+            categories,
+            slice_start,
+            slice_end,
+            slice_frac_start,
+            slice_frac_end,
+            on_progress,
+        )
 
         if getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading text embedding model…", 0, 0)

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -71,7 +71,7 @@ LOCAL_UPLOADS_DIR = DATA_DIR / "local_uploads"
     ),
 )
 @datasets_load_bp.alt_response(500, description="The server_folder importer is unavailable.")
-def import_local_folder():
+def import_local_folder():  # noqa: C901
     """Import a folder uploaded from the user's *browser* machine.
 
     The browser uses ``<input type="file" webkitdirectory>`` to let the

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -112,7 +112,7 @@ def list_registered_datasets():
 @datasets_registry_bp.response(200, DatasetRegistryLoadResponseSchema)
 @datasets_registry_bp.alt_response(403, description="Access denied for the current user.")
 @datasets_registry_bp.alt_response(404, description="Dataset not found, or saved pkl file is missing.")
-def load_registered_dataset(dataset_id: str):
+def load_registered_dataset(dataset_id: str):  # noqa: C901
     """Load a registered dataset from its saved pkl file.
 
     If the dataset is already loaded in memory, it is simply activated

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -61,7 +61,7 @@ def _folder_has_content(folder) -> bool:
 @datasets_ui_bp.route("/api/dataset/demo-list")
 @datasets_ui_bp.arguments(DemoDatasetListQuerySchema, location="query")
 @datasets_ui_bp.response(200, DemoDatasetListResponseSchema)
-def demo_dataset_list(query: dict):
+def demo_dataset_list(query: dict):  # noqa: C901
     """List available demo datasets.
 
     Each dataset has a ``status`` field with one of three values:

--- a/vtsearch/routes/detectors/crud.py
+++ b/vtsearch/routes/detectors/crud.py
@@ -311,7 +311,7 @@ def set_detector_examples(body: dict, name: str):
 @detectors_crud_bp.alt_response(404, description="A source detector was not found.")
 @detectors_crud_bp.alt_response(409, description="A detector with the new name already exists.")
 @detectors_crud_bp.alt_response(422, description="Combined labelset is empty after applying the conflict policy.")
-def combine_detectors(body: dict):
+def combine_detectors(body: dict):  # noqa: C901
     """Combine the labelsets of two or more detectors into a new detector.
 
     All source detectors must share the same ``media_type``.  The new

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -40,7 +40,7 @@ _FIND_STEPS = 3
 @detector_find_bp.route("/api/find/check-labels", methods=["POST"])
 @detector_find_bp.arguments(FindCheckLabelsRequestSchema)
 @detector_find_bp.response(200, FindCheckLabelsResponseSchema)
-def find_check_labels(body: dict):
+def find_check_labels(body: dict):  # noqa: C901
     """Pre-flight check: report how many detector labels can be resolved.
 
     Takes the same ``detector_ids`` / ``dataset_ids`` payload as ``/api/find``
@@ -139,7 +139,7 @@ def find_check_labels(body: dict):
 )
 @detector_find_bp.alt_response(404, description="A selected dataset or detector ID is unknown / missing.")
 @detector_find_bp.alt_response(500, description="A dataset pkl file could not be loaded.")
-def multi_find(body: dict):
+def multi_find(body: dict):  # noqa: C901
     """Run selected detectors on selected datasets and return merged results.
 
     For each dataset: loads it from its saved pkl, then for each detector runs

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -175,7 +175,7 @@ def save_detector_labels(name: str):
     "/api/detectors/<name>/import-labels/<importer_name>",
     methods=["POST"],
 )
-def import_labels_into_detector(name: str, importer_name: str):
+def import_labels_into_detector(name: str, importer_name: str):  # noqa: C901
     """Run a label importer and merge results into this detector's labelset.
 
     Unlike the regular ``/api/label-importers/import/`` route, this does

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -170,7 +170,7 @@ def register_detector_route(body: dict):
     "/api/detectors/registry/from-labelset/<importer_name>",
     methods=["POST"],
 )
-def register_detector_from_labelset(importer_name: str):
+def register_detector_from_labelset(importer_name: str):  # noqa: C901
     """Create a detector seeded with labels from a label importer.
 
     Plugin-dependent body shape: not described in the OpenAPI spec.
@@ -403,7 +403,7 @@ def _maybe_start_label_reembed(det_ctx, entry: dict) -> str | None:
 @detectors_registry_bp.arguments(DetectorRegistryLoadRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryLoadResponseSchema)
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
-def load_detector_route(body: dict):
+def load_detector_route(body: dict):  # noqa: C901
     """Load a detector into memory and make it active.
 
     Pass ``detector_id=null`` (or omit the field) to unload the active

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -44,7 +44,7 @@ def _media_info_for_response(media: dict) -> dict:
     return {k: v for k, v in media.items() if k not in _HEAVYWEIGHT_KEYS}
 
 
-def _resolve_or_train_detector(
+def _resolve_or_train_detector(  # noqa: C901
     detector_id: str,
     det_data: dict | None,
     media_type: str,
@@ -181,7 +181,7 @@ def _resolve_or_train_detector(
 @detector_scoring_bp.response(200, FindLabelResponseSchema)
 @detector_scoring_bp.alt_response(400, description="No medias loaded, or the detector has no labels for scoring.")
 @detector_scoring_bp.alt_response(404, description="Detector not found.")
-def find_label(body: dict):
+def find_label(body: dict):  # noqa: C901
     """Score all loaded medias with a detector and apply labels based on threshold.
 
     Resolves the detector from the registry, scores every loaded media, and
@@ -372,7 +372,7 @@ def find_label(body: dict):
     description="No medias loaded, or no autorun detectors match the active media type.",
 )
 @detector_scoring_bp.alt_response(404, description="Named detector is not flagged for autorun.")
-def auto_detect(body: dict):
+def auto_detect(body: dict):  # noqa: C901
     """Score the active dataset with every detector flagged for autorun.
 
     Iterates :func:`~vtsearch.settings.get_autorun_detectors` and trains each

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -59,7 +59,7 @@ def _get_browse_root() -> Path:
 @file_browser_bp.alt_response(400, description="Invalid path (traversal blocked).")
 @file_browser_bp.alt_response(403, description="Permission denied reading the requested directory.")
 @file_browser_bp.alt_response(404, description="Directory not found within the allowed root.")
-def browse(query: dict):
+def browse(query: dict):  # noqa: C901
     """List directories and files at a relative path.
 
     Returns a directories+files listing with names, relative paths,

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -111,7 +111,7 @@ def get_label_importers():
 
 
 @label_importers_bp.route("/api/label-importers/import/<importer_name>", methods=["POST"])
-def run_label_import(importer_name: str):
+def run_label_import(importer_name: str):  # noqa: C901
     """Run the named label importer and apply the resulting labels.
 
     Plugin-dependent body shape: not described in the OpenAPI spec.

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -39,7 +39,7 @@ labels_bp = Blueprint(
 @labels_bp.route("/api/labels/export")
 @labels_bp.arguments(LabelsExportQuerySchema, location="query")
 @labels_bp.response(200, LabelsExportResponseSchema)
-def export_labels(query: dict):
+def export_labels(query: dict):  # noqa: C901
     """Export labels as a :class:`~vtsearch.datasets.labelset.LabelSet`.
 
     Each label entry includes the element's ``origin`` and ``origin_name``
@@ -183,7 +183,7 @@ def import_labels(body: dict):
 @labels_bp.route("/api/labels/fill-from-sort", methods=["POST"])
 @labels_bp.arguments(FillFromSortRequestSchema)
 @labels_bp.response(200, FillFromSortResponseSchema)
-def fill_labels_from_sort(body: dict):
+def fill_labels_from_sort(body: dict):  # noqa: C901
     """Fill labels from the current sort results.
 
     Assigns Good/Bad labels to currently-unlabeled medias based on their

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -78,7 +78,7 @@ def _parse_region_box(raw: Any) -> tuple[float, float, float, float] | None:
     return (x0, y0, x1, y1)
 
 
-def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:
+def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:  # noqa: C901
     """Transcode video bytes to browser-playable MP4.
 
     Tries ffmpeg first (preserves audio, H.264 output).  Falls back to OpenCV
@@ -407,7 +407,7 @@ def media_video(media_id: int):
 @medias_bp.route("/api/medias/<int:media_id>/image")
 @medias_bp.alt_response(400, description="Media is not an image and has no image_response delegate.")
 @medias_bp.alt_response(404, description="Media not found, or media bytes unavailable.")
-def media_image(media_id: int):
+def media_image(media_id: int):  # noqa: C901
     """Stream the image bytes for a single image media item.
 
     Determines the MIME type from the media's filename extension, defaulting
@@ -577,7 +577,7 @@ def vote_media(body: dict, media_id: int):
         "invalid label), no dataset loaded, or no embedder available."
     ),
 )
-def add_media_to_pile():
+def add_media_to_pile():  # noqa: C901
     """Upload a media file and add it directly to the Good or Bad pile.
 
     If a media with the same MD5 already exists in the dataset, the existing

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -228,11 +228,6 @@ def _learned_sort_done_payload(job) -> dict:
     }
 
 
-@sorting_bp.route("/api/learned-sort", methods=["POST"])
-@sorting_bp.arguments(LearnedSortRequestSchema)
-@sorting_bp.response(200, LearnedSortResponseSchema)
-@sorting_bp.alt_response(400, description="No good/bad votes available for training.")
-@sorting_bp.alt_response(500, description="Background learned-sort job failed (only when ``wait=true``).")
 def _resolve_active_labelset(det_ctx):
     """Resolve the labelset for the active detector → (labelset, media_type)."""
     from vtsearch.datasets.labelset import LabelSet
@@ -358,6 +353,11 @@ def _build_learned_sort_signature(
     )
 
 
+@sorting_bp.route("/api/learned-sort", methods=["POST"])
+@sorting_bp.arguments(LearnedSortRequestSchema)
+@sorting_bp.response(200, LearnedSortResponseSchema)
+@sorting_bp.alt_response(400, description="No good/bad votes available for training.")
+@sorting_bp.alt_response(500, description="Background learned-sort job failed (only when ``wait=true``).")
 def learned_sort(body: dict):
     """Kick off (or short-circuit) a learned-sort training job.
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -233,6 +233,131 @@ def _learned_sort_done_payload(job) -> dict:
 @sorting_bp.response(200, LearnedSortResponseSchema)
 @sorting_bp.alt_response(400, description="No good/bad votes available for training.")
 @sorting_bp.alt_response(500, description="Background learned-sort job failed (only when ``wait=true``).")
+def _resolve_active_labelset(det_ctx):
+    """Resolve the labelset for the active detector → (labelset, media_type)."""
+    from vtsearch.datasets.labelset import LabelSet
+    from vtsearch.detectors.registry import get_detector
+    from vtsearch.detectors.store import _detector_path, _read_detector
+    from vtsearch.state.core import _empty_detector_context
+
+    if det_ctx is _empty_detector_context or not det_ctx.detector_id:
+        return None, ""
+    if det_ctx.cached_labelset is not None:
+        return det_ctx.cached_labelset, det_ctx.cached_labelset_media_type
+    entry = get_detector(det_ctx.detector_id)
+    if not entry or not entry.get("name"):
+        return None, ""
+    det_data = _read_detector(_detector_path(entry["name"]))
+    if not det_data:
+        return None, ""
+    return LabelSet.from_dict(det_data.get("labelset") or {}), det_data.get("media_type", "") or ""
+
+
+def _validate_learned_sort_inputs(labelset, good, bad) -> None:
+    if labelset is not None:
+        good_count = sum(1 for el in labelset.elements if el.label == "good")
+        bad_count = sum(1 for el in labelset.elements if el.label == "bad")
+        if good_count == 0 or bad_count == 0:
+            abort(400, message="need at least one good and one bad vote")
+        return
+    if not good or not bad:
+        abort(400, message="need at least one good and one bad vote")
+
+
+def _resolve_labelset_local_state(labelset, snap):
+    """Resolve labelset elements to local cids using the dataset snapshot.
+
+    Returns (local_good, local_bad, training_medias, has_cross_dataset).
+    All are None when ``labelset`` is None (the non-labelset path).
+    """
+    if labelset is None:
+        return None, None, None, False
+
+    from vtsearch.state import build_media_lookup, resolve_media_ids
+
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+    local_good: set[int] = set()
+    local_bad: set[int] = set()
+    training_medias: dict[int, dict] = {}
+    has_cross_dataset = False
+    for el in labelset.elements:
+        if el.label not in ("good", "bad"):
+            continue
+        cids = resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup)
+        if not cids:
+            has_cross_dataset = True
+            continue
+        target = local_good if el.label == "good" else local_bad
+        for cid in cids:
+            target.add(cid)
+            if cid in snap:
+                training_medias[cid] = snap[cid]
+    return local_good, local_bad, training_medias, has_cross_dataset
+
+
+def _model_matches_local_votes(labelset, has_cross_dataset, local_good, local_bad, good, bad) -> bool:
+    """Decide whether the trained model maps cleanly onto current-dataset votes.
+
+    The progress cache is keyed on local cids, so we only inject when the
+    training set is fully representable there — otherwise we'd return a
+    cross-dataset model on a local-only replay.
+    """
+    if labelset is None:
+        return True
+    return not has_cross_dataset and local_good == set(good) and local_bad == set(bad)
+
+
+def _update_det_ctx_with_trained_model(det_ctx, model, threshold, labelset, training_medias, snap, good, bad) -> None:
+    det_ctx.model = model
+    det_ctx.threshold = threshold
+    if labelset is not None:
+        det_ctx.training_medias = training_medias or {}
+    else:
+        training = {}
+        for cid in list(good) + list(bad):
+            if cid in snap:
+                training[cid] = snap[cid]
+        det_ctx.training_medias = training
+    if snap:
+        first = next(iter(snap.values()), {})
+        det_ctx.embedder = first.get("embedder", "")
+        det_ctx.media_type = first.get("type", "")
+
+
+def _build_learned_sort_signature(
+    *,
+    det_ctx,
+    ds_ctx,
+    snap,
+    labelset,
+    good,
+    bad,
+    region_boxes_snapshot,
+    inclusion_value,
+    safe_thresholds_value,
+    calibrate_count_value,
+    calibration_fraction_value,
+):
+    if labelset is not None:
+        labels_sig = tuple(sorted((el.label, _stable_element_id_for_sig(el)) for el in labelset.elements))
+    else:
+        labels_sig = (
+            ("good", tuple(sorted(good))),
+            ("bad", tuple(sorted(bad))),
+            ("regions", tuple(sorted(region_boxes_snapshot.items()))),
+        )
+    return (
+        det_ctx.detector_id,
+        ds_ctx.dataset_id,
+        tuple(sorted(snap.keys())),
+        labels_sig,
+        inclusion_value,
+        safe_thresholds_value,
+        calibrate_count_value,
+        calibration_fraction_value,
+    )
+
+
 def learned_sort(body: dict):
     """Kick off (or short-circuit) a learned-sort training job.
 
@@ -249,9 +374,6 @@ def learned_sort(body: dict):
     Tests can pass ``{"wait": true}`` in the body to block until the job
     completes and receive the result inline.  The frontend leaves it false.
     """
-    from vtsearch.datasets.labelset import LabelSet
-    from vtsearch.detectors.registry import get_detector
-    from vtsearch.detectors.store import _detector_path, _read_detector
     from vtsearch.detectors.labelset_training import labelset_train_and_score
     from vtsearch.concurrency.async_jobs import learned_sort_jobs
     from vtsearch.state.core import (
@@ -266,34 +388,11 @@ def learned_sort(body: dict):
 
     snap = snapshot_medias()
 
-    # Resolve the active detector's labelset (if any).  Prefer the parsed
-    # labelset cached on det_ctx by ``ensure_votes_match_active_dataset`` to
-    # avoid re-reading the JSON file on every click.
     det_ctx = get_active_detector_context()
     ds_ctx = get_active_context()
-    labelset: LabelSet | None = None
-    det_media_type = ""
-    if det_ctx is not _empty_detector_context and det_ctx.detector_id:
-        if det_ctx.cached_labelset is not None:
-            labelset = det_ctx.cached_labelset
-            det_media_type = det_ctx.cached_labelset_media_type
-        else:
-            entry = get_detector(det_ctx.detector_id)
-            if entry and entry.get("name"):
-                det_data = _read_detector(_detector_path(entry["name"]))
-                if det_data:
-                    labelset = LabelSet.from_dict(det_data.get("labelset") or {})
-                    det_media_type = det_data.get("media_type", "") or ""
+    labelset, det_media_type = _resolve_active_labelset(det_ctx)
 
-    # Early validation so 400s come back before we spin a thread.
-    if labelset is not None:
-        good_count = sum(1 for el in labelset.elements if el.label == "good")
-        bad_count = sum(1 for el in labelset.elements if el.label == "bad")
-        if good_count == 0 or bad_count == 0:
-            abort(400, message="need at least one good and one bad vote")
-    else:
-        if not good_votes or not bad_votes:
-            abort(400, message="need at least one good and one bad vote")
+    _validate_learned_sort_inputs(labelset, good_votes, bad_votes)
 
     inclusion_value = get_inclusion()
     safe_thresholds_value = get_safe_thresholds()
@@ -301,35 +400,30 @@ def learned_sort(body: dict):
     calibration_fraction_value = get_calibration_fraction()
     region_boxes_snapshot = dict(vote_region_boxes)
 
-    # Signature: covers everything that changes the training output.  Re-sorts
-    # with the same vote set + settings reuse the cached result.
-    if labelset is not None:
-        labels_sig = tuple(sorted((el.label, _stable_element_id_for_sig(el)) for el in labelset.elements))
-    else:
-        labels_sig = (
-            ("good", tuple(sorted(good_votes))),
-            ("bad", tuple(sorted(bad_votes))),
-            ("regions", tuple(sorted(region_boxes_snapshot.items()))),
-        )
-    signature = (
-        det_ctx.detector_id,
-        ds_ctx.dataset_id,
-        tuple(sorted(snap.keys())),
-        labels_sig,
-        inclusion_value,
-        safe_thresholds_value,
-        calibrate_count_value,
-        calibration_fraction_value,
+    signature = _build_learned_sort_signature(
+        det_ctx=det_ctx,
+        ds_ctx=ds_ctx,
+        snap=snap,
+        labelset=labelset,
+        good=good_votes,
+        bad=bad_votes,
+        region_boxes_snapshot=region_boxes_snapshot,
+        inclusion_value=inclusion_value,
+        safe_thresholds_value=safe_thresholds_value,
+        calibrate_count_value=calibrate_count_value,
+        calibration_fraction_value=calibration_fraction_value,
     )
 
     cached = learned_sort_jobs.cached_for(signature)
     if cached is not None:
         return _learned_sort_done_payload(cached)
 
-    def _run(job):
-        # Background thread needs the same dataset/detector context as the
-        # request thread so proxies (good_votes, bad_votes, etc.) resolve
-        # correctly when the training helpers reach for them.
+    # _run is a closure over the resolved inputs above so we can pass it
+    # straight to the job manager without threading a 10-arg dataclass
+    # through the abstraction.  Its complexity is dominated by sequential
+    # state updates rather than nested branching; splitting it further
+    # would just smear cohesive logic across helpers.
+    def _run(job):  # noqa: C901
         set_thread_dataset_context(ds_ctx)
         set_thread_detector_context(det_ctx)
         try:
@@ -357,73 +451,19 @@ def learned_sort(body: dict):
                     det_ctx=det_ctx,
                 )
 
-            # Store scores so the /api/votes endpoint can provide confidence info.
             update_learned_scores({r["id"]: r["score"] for r in results})
 
-            # In the labelset path, training used the on-disk labelset
-            # (potentially cross-dataset) — derive the live-cache key and the
-            # cached training snapshot from the labelset itself, not from
-            # local cid-keyed votes.
-            labelset_local_good: set[int] | None = None
-            labelset_local_bad: set[int] | None = None
-            labelset_training_medias: dict[int, dict] | None = None
-            labelset_has_cross_dataset = False
-            if labelset is not None:
-                from vtsearch.state import (
-                    build_media_lookup,
-                    resolve_media_ids,
-                )
+            local_good, local_bad, training_medias, has_cross_dataset = _resolve_labelset_local_state(labelset, snap)
 
-                origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
-                labelset_local_good = set()
-                labelset_local_bad = set()
-                labelset_training_medias = {}
-                for el in labelset.elements:
-                    if el.label not in ("good", "bad"):
-                        continue
-                    cids = resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup)
-                    if not cids:
-                        labelset_has_cross_dataset = True
-                        continue
-                    target = labelset_local_good if el.label == "good" else labelset_local_bad
-                    for cid in cids:
-                        target.add(cid)
-                        if cid in snap:
-                            labelset_training_medias[cid] = snap[cid]
-
-            # Inject the live model into the progress cache so indicators and
-            # the progress line-graph use the actual model that guided
-            # sorting, rather than retraining an independent model from
-            # scratch.  The cache is keyed by current-dataset cids, so only
-            # inject when the model's training set is fully representable in
-            # that key — otherwise the cache would return a cross-dataset
-            # model when local-cids replay asks for a local-only one.
-            if model is not None:
-                if labelset is None:
-                    inject_live_model(good_votes, bad_votes, model, threshold)
-                elif (
-                    not labelset_has_cross_dataset
-                    and labelset_local_good == set(good_votes)
-                    and labelset_local_bad == set(bad_votes)
-                ):
-                    inject_live_model(good_votes, bad_votes, model, threshold)
+            if model is not None and _model_matches_local_votes(
+                labelset, has_cross_dataset, local_good, local_bad, good_votes, bad_votes
+            ):
+                inject_live_model(good_votes, bad_votes, model, threshold)
 
             if det_ctx is not _empty_detector_context and model is not None:
-                det_ctx.model = model
-                det_ctx.threshold = threshold
-                # Cache the voted media items with embeddings for cross-embedder scenarios.
-                if labelset is not None:
-                    det_ctx.training_medias = labelset_training_medias or {}
-                else:
-                    training = {}
-                    for cid in list(good_votes) + list(bad_votes):
-                        if cid in snap:
-                            training[cid] = snap[cid]
-                    det_ctx.training_medias = training
-                if snap:
-                    first = next(iter(snap.values()), {})
-                    det_ctx.embedder = first.get("embedder", "")
-                    det_ctx.media_type = first.get("type", "")
+                _update_det_ctx_with_trained_model(
+                    det_ctx, model, threshold, labelset, training_medias, snap, good_votes, bad_votes
+                )
 
             job.result = {"results": results, "threshold": round(threshold, 4)}
         finally:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -786,7 +786,7 @@ def example_sort():
     ),
 )
 @sorting_bp.alt_response(500, description="Label file sort failed (unexpected exception).")
-def label_file_sort():
+def label_file_sort():  # noqa: C901
     """Train MLP on external media files from a label file, then sort all medias."""
     if "file" not in request.files:
         abort(400, message="No file provided")

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -548,7 +548,7 @@ def _valid_media_types() -> tuple[str, ...]:
     return tuple(all_type_ids())
 
 
-def _make_per_side_setting(
+def _make_per_side_setting(  # noqa: C901
     key_base: str,
     defaults: dict[str, Any],
     *,

--- a/vtsearch/state/diversity_tree.py
+++ b/vtsearch/state/diversity_tree.py
@@ -103,7 +103,7 @@ class DiversityTree:
                 on_progress(self._estimated_total_work, self._estimated_total_work)
             self._on_progress = None
 
-    def _build_node(
+    def _build_node(  # noqa: C901
         self,
         name: str,
         ids: list[int],


### PR DESCRIPTION
## Summary

Closes the open follow-up in `docs/plans/python-quality-tools.md` about enabling McCabe complexity checking. Two pieces:

**1. Pyright "S-equivalent" — investigated and dropped.** Pyright is a type checker only; it has no security rule set analogous to ruff's `S` (flake8-bandit). The follow-up was a category error. Security pattern detection stays in ruff.

**2. Ruff `C901` complexity gate enabled at default `max-complexity = 10`.** The codebase had 80 functions over the threshold at the start of this work; the worst was 52 (`load_demo_source` for images). Approach:

- **Real refactors** for the four worst dispatcher/route functions where decomposition is clearly natural:
  - `vtsearch/media/audio/media_type.py:load_demo_source` (22 → <10)
  - `vtsearch/media/text/media_type.py:load_demo_source` (31 → <10)
  - `vtsearch/media/image/_demo_sources.py:load_demo_source` (52 → <10)
  - `vtsearch/routes/sorting.py:learned_sort` (29 → <10)
- **Per-function `# noqa: C901` markers** on the remaining 72 legacy hot-spots so the rule applies cleanly to new code without forcing a multi-day refactor pass. Each marker is a future-refactor candidate that gets deleted when the function is simplified under 10.
- **Per-file exemptions** for `tests/**` and `scripts/**` — test fixtures and one-off analysis scripts (3 functions: `init_medias`, `test_concurrent_get_set_volume`, `analyse_one`).

`docs/plans/python-quality-tools.md` is updated with the shipped status and lists the largest remaining `# noqa`-marked hot-spots (multi_find 41, load_dataset_from_folder_chunked 35, load_dataset_from_folder 34, _run_origin_load_in_background 31, task 27, load_dataset_from_pickle 26, import_local_folder 24, _make_per_side_setting 24) for opportunistic cleanup.

### Why noqa + refactor rather than refactor everything

Refactoring all 80 functions in one PR would be a multi-day, high-risk, sprawling diff across 50+ files. Industry practice for adopting a complexity gate on an established codebase is to gate forward with documented grandfathered exceptions, then refactor incrementally. The four real refactors here are the highest-leverage cases (the worst-scored functions, all clean dispatch-style patterns); the rest are tracked via `git grep "# noqa: C901"`.

### One bug fixed along the way

When extracting helpers out of `learned_sort`, the `@sorting_bp.route("/api/learned-sort")` decorator block initially ended up attached to the first extracted helper, so flask-smorest's `@arguments` decorator was passing the parsed body to the helper. Caught by the test suite (20 failing learned-sort tests), fixed by moving the helpers above the decorator block.

## Test plan

- [x] `ruff check .` — passes
- [x] `ruff format --check .` — passes
- [x] `codespell --toml pyproject.toml` — passes
- [x] `python -m deptry .` — passes
- [x] `python -m pytest tests/ -m 'not gpu and not slow'` — 3653 passed, 1 skipped, 2 xpassed (full suite)
- [x] `./run-tests.sh` lint chain passes; the test runner blocks on a pre-existing `npm audit` issue (webpack-dev-server CVE, no fix available — also fails on `dev`)

https://claude.ai/code/session_01SAfZFMfziKPX5uaQYcCCMi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAfZFMfziKPX5uaQYcCCMi)_