### PR TITLE
feat(importer-modal): hide clipper picker behind Advanced toggle (Phase 3)

### DIFF
--- a/docs/plans/smart-clipper-defaults.md
+++ b/docs/plans/smart-clipper-defaults.md
@@ -86,8 +86,8 @@ would be a no-op.
 ### Files
 
 - `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts` — Added `clipperAdvancedOpen` field plus `isDefaultClipperSelected(context)`, `showClipperPicker(context)`, and `toggleClipperAdvanced()`.
-- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html` — Wrapped each of the four clipper-button blocks (form, lf, sf, demo) in `.advanced-section` with the toggle button gating the picker.
-- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss` — `.advanced-toggle` link-styled button (subtle muted text, hover underline) and `.advanced-section` flex wrapper.
+- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html` — Gated each of the four clipper-button blocks (form, lf, sf, demo) behind the toggle button.
+- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss` — `.advanced-toggle` link-styled button (subtle muted text, hover underline). The demo context (inline in the embedder row) uses `.advanced-toggle--inline` for a small left margin.
 
 ## Open follow-ups
 

--- a/docs/plans/smart-clipper-defaults.md
+++ b/docs/plans/smart-clipper-defaults.md
@@ -1,9 +1,10 @@
 # Smart clipper defaults
 
-*Status: Phase 1 and Phase 2 shipped — picker offers an "Auto
+*Status: Phase 1, Phase 2, and Phase 3 shipped — picker offers an "Auto
 (recommended)" clipper for audio and video that routes each media
-through pass-through or tiling based on its own duration. Phase 3
-deferred — see Open follow-ups.*
+through pass-through or tiling based on its own duration, and the
+clipper picker itself is hidden behind an "Advanced ▾" toggle in the
+importer modal so users who don't need the override don't see it.*
 
 This plan implements [ux-brainstorm.md §1.10](ux-brainstorm.md#110-clipper-default-from-media-type--duration-) ("Clipper default from media type + duration").
 
@@ -66,14 +67,29 @@ was wrong for whichever subset fell on the other side of the threshold.
 Phase 2 fixes that without changing the user-facing controls or the
 origin format.
 
+## Phase 3 — Hide the clipper picker behind Advanced (shipped)
+
+The picker no longer surfaces the clipper button on first sight. Each of
+the four importer-modal contexts (generic form, local-folder/files,
+server-folder, demo) wraps the clipper button in an **Advanced ▾**
+toggle. Clicking the toggle reveals the existing "Use MediaClipper: …"
+chooser button; clicking again collapses it. A single
+`clipperAdvancedOpen` boolean drives all four contexts (only one is
+visible at a time).
+
+If the user has already picked a non-default (non-first-in-list)
+clipper, the picker stays visible regardless of the toggle so they can
+see and re-edit their selection. The Advanced toggle hides itself in
+that case — collapsing wouldn't actually hide the picker, so the toggle
+would be a no-op.
+
+### Files
+
+- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts` — Added `clipperAdvancedOpen` field plus `isDefaultClipperSelected(context)`, `showClipperPicker(context)`, and `toggleClipperAdvanced()`.
+- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html` — Wrapped each of the four clipper-button blocks (form, lf, sf, demo) in `.advanced-section` with the toggle button gating the picker.
+- `frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss` — `.advanced-toggle` link-styled button (subtle muted text, hover underline) and `.advanced-section` flex wrapper.
+
 ## Open follow-ups
-
-### Phase 3 — Hide the clipper picker behind Advanced (deferred)
-
-The ux-brainstorm entry also proposed hiding the clipper button entirely
-until the user opens an "Advanced" section, on the theory that the
-default is almost always right. Deferred until we have evidence on how
-often users tweak the default after Phase 2 lands.
 
 ### Per-item routing for image and text (out of scope)
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -401,7 +401,7 @@
       }
 
       @if (availableClippers.length > 1) {
-        <div class="form-group advanced-section">
+        <div class="form-group">
           @if (isDefaultClipperSelected('form')) {
             <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
               Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
@@ -637,7 +637,7 @@
       }
 
       @if (lfClippers.length > 1) {
-        <div class="form-group form-group--section advanced-section">
+        <div class="form-group form-group--section">
           @if (isDefaultClipperSelected('lf')) {
             <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
               Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
@@ -873,7 +873,7 @@
       }
 
       @if (sfClippers.length > 1) {
-        <div class="form-group advanced-section">
+        <div class="form-group">
           @if (isDefaultClipperSelected('sf')) {
             <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
               Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -103,9 +103,16 @@
               <div class="license-warning" role="note">⚠ {{ notice }}</div>
             }
             @if (demoClippers.length > 1) {
-              <button class="btn btn--secondary btn--sm clipper-btn" (click)="openClipperChooser('demo')" title="Choose a MediaClipper to segment or trim media before embedding">
-                Clipper: {{ clipperDisplayName('demo') }}
-              </button>
+              @if (isDefaultClipperSelected('demo')) {
+                <button type="button" class="advanced-toggle advanced-toggle--inline" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
+                  Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+                </button>
+              }
+              @if (showClipperPicker('demo')) {
+                <button class="btn btn--secondary btn--sm clipper-btn" (click)="openClipperChooser('demo')" title="Choose a MediaClipper to segment or trim media before embedding">
+                  Clipper: {{ clipperDisplayName('demo') }}
+                </button>
+              }
             }
           </div>
         }
@@ -394,11 +401,18 @@
       }
 
       @if (availableClippers.length > 1) {
-        <div class="form-group">
-          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('form')" title="Choose a MediaClipper to segment or trim media before embedding">
-            Use MediaClipper: {{ clipperDisplayName('form') }}
-          </button>
+        <div class="form-group advanced-section">
+          @if (isDefaultClipperSelected('form')) {
+            <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
+              Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+            </button>
+          }
+          @if (showClipperPicker('form')) {
+            <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+            <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('form')" title="Choose a MediaClipper to segment or trim media before embedding">
+              Use MediaClipper: {{ clipperDisplayName('form') }}
+            </button>
+          }
         </div>
       }
 
@@ -623,11 +637,18 @@
       }
 
       @if (lfClippers.length > 1) {
-        <div class="form-group form-group--section">
-          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('lf')" title="Choose a MediaClipper to segment or trim media before embedding">
-            Use MediaClipper: {{ clipperDisplayName('lf') }}
-          </button>
+        <div class="form-group form-group--section advanced-section">
+          @if (isDefaultClipperSelected('lf')) {
+            <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
+              Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+            </button>
+          }
+          @if (showClipperPicker('lf')) {
+            <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+            <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('lf')" title="Choose a MediaClipper to segment or trim media before embedding">
+              Use MediaClipper: {{ clipperDisplayName('lf') }}
+            </button>
+          }
         </div>
       }
 
@@ -852,11 +873,18 @@
       }
 
       @if (sfClippers.length > 1) {
-        <div class="form-group">
-          <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
-          <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('sf')" title="Choose a MediaClipper to segment or trim media before embedding">
-            Use MediaClipper: {{ clipperDisplayName('sf') }}
-          </button>
+        <div class="form-group advanced-section">
+          @if (isDefaultClipperSelected('sf')) {
+            <button type="button" class="advanced-toggle" (click)="toggleClipperAdvanced()" [attr.aria-expanded]="clipperAdvancedOpen" title="Pre-processing clipper that segments or trims media before embedding">
+              Advanced {{ clipperAdvancedOpen ? '▴' : '▾' }}
+            </button>
+          }
+          @if (showClipperPicker('sf')) {
+            <label class="form-label" title="Pre-processing clipper that segments or trims media before embedding">Clipper</label>
+            <button class="btn btn--secondary clipper-btn" (click)="openClipperChooser('sf')" title="Choose a MediaClipper to segment or trim media before embedding">
+              Use MediaClipper: {{ clipperDisplayName('sf') }}
+            </button>
+          }
         </div>
       }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -65,6 +65,36 @@
   white-space: nowrap;
 }
 
+// Phase 3 of smart-clipper-defaults: the clipper picker hides behind a
+// subtle "Advanced ▾" link. Designed to disappear into the surrounding
+// form so users who don't need the override aren't distracted by it.
+// Sits between `.form-group` siblings, so margin is set on the wrapper
+// (`.advanced-section`) rather than the button.
+.advanced-toggle {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  font-size: .82rem;
+  color: var(--text-muted, #666);
+  cursor: pointer;
+
+  &:hover { color: var(--text, #222); text-decoration: underline; }
+  &:focus-visible { outline: 2px solid var(--focus, #4a90e2); outline-offset: 2px; }
+}
+
+.advanced-toggle--inline {
+  margin-left: 4px;
+}
+
+// When the section is expanded, the picker shows up directly after the
+// toggle inside the same form-group, so tighten the gap between them.
+.advanced-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .server-folder-browser { gap: 12px; }
 .sf-browse-section { gap: 6px; }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -68,8 +68,6 @@
 // Phase 3 of smart-clipper-defaults: the clipper picker hides behind a
 // subtle "Advanced ▾" link. Designed to disappear into the surrounding
 // form so users who don't need the override aren't distracted by it.
-// Sits between `.form-group` siblings, so margin is set on the wrapper
-// (`.advanced-section`) rather than the button.
 .advanced-toggle {
   align-self: flex-start;
   background: transparent;
@@ -85,14 +83,6 @@
 
 .advanced-toggle--inline {
   margin-left: 4px;
-}
-
-// When the section is expanded, the picker shows up directly after the
-// toggle inside the same form-group, so tighten the gap between them.
-.advanced-section {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
 }
 
 .server-folder-browser { gap: 12px; }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -176,6 +176,12 @@ export class DatasetImporterModalComponent implements OnInit {
   clipperChooserContext: 'form' | 'demo' | 'sf' | 'lf' = 'form';
   clipperChooserClippers: ClipperInfo[] = [];
 
+  // Phase 3 of smart-clipper-defaults: the clipper picker is hidden
+  // behind an "Advanced" toggle by default. When the user has picked a
+  // non-default clipper, the picker is always visible regardless of
+  // this flag (so they can see and re-edit their selection).
+  clipperAdvancedOpen = false;
+
   constructor(
     private datasetsApi: DatasetsApiService,
     private settingsState: SettingsStateService,
@@ -1734,6 +1740,40 @@ export class DatasetImporterModalComponent implements OnInit {
     if (!clipper) return 'None';
     if (clipper.name.endsWith('_default')) return 'None';
     return clipper.display_name || clipper.name;
+  }
+
+  /** Whether the recommended (first-in-list) clipper is currently selected for
+   *  the given context. Used to decide whether the Advanced section can stay
+   *  collapsed — if the user has overridden the default, we keep the picker
+   *  visible so they can see and re-edit their choice. */
+  isDefaultClipperSelected(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    let clippers: ClipperInfo[];
+    let selected: string;
+    if (context === 'form') {
+      clippers = this.availableClippers;
+      selected = this.selectedClipper;
+    } else if (context === 'demo') {
+      clippers = this.demoClippers;
+      selected = this.selectedDemoClipper;
+    } else if (context === 'sf') {
+      clippers = this.sfClippers;
+      selected = this.sfSelectedClipper;
+    } else {
+      clippers = this.lfClippers;
+      selected = this.lfSelectedClipper;
+    }
+    return clippers.length > 0 && clippers[0].name === selected;
+  }
+
+  /** Whether the clipper picker should be visible in the given context.
+   *  True when the Advanced section is expanded or when a non-default
+   *  clipper is selected. */
+  showClipperPicker(context: 'form' | 'demo' | 'sf' | 'lf'): boolean {
+    return this.clipperAdvancedOpen || !this.isDefaultClipperSelected(context);
+  }
+
+  toggleClipperAdvanced(): void {
+    this.clipperAdvancedOpen = !this.clipperAdvancedOpen;
   }
 
   sfSubmit(): void {


### PR DESCRIPTION
## Summary

Phase 3 of [`docs/plans/smart-clipper-defaults.md`](docs/plans/smart-clipper-defaults.md). The clipper button is now hidden by default in the importer modal and only appears when the user expands a subtle **Advanced ▾** toggle. The "default is almost always right" assumption was the original rationale in `ux-brainstorm.md §1.10`, and Phase 2's per-media auto-routing made the auto clipper the right default for nearly every audio/video folder.

- Applied in all four importer contexts (generic form, local-folder/files, server-folder, demo).
- A single `clipperAdvancedOpen` boolean drives all four (only one importer view is visible at a time).
- If the user has picked a non-default clipper (i.e. anything other than the first-in-list "recommended" choice), the picker stays visible and the toggle hides itself, so a non-default selection can't be accidentally collapsed out of view.

## Test plan
- [x] `npm run build:prod` — clean, no warnings.
- [x] `npx tsc --noEmit -p frontend/tsconfig.spec.json` — spec files typecheck.
- [x] `pytest tests/ -m 'not gpu and not slow'` — all 3662 tests pass.
- [ ] Manual: open Add Dataset modal on each tab (Server, Local, Demo, generic Services importer), confirm the clipper button is hidden initially and an "Advanced ▾" toggle is shown. Click toggle, confirm picker appears. Pick a non-default clipper, return — picker stays visible, toggle disappears. Pick default back — toggle reappears.

**Note (pre-existing, not blocking this PR):** `./run-tests.sh` fails on the `npm audit` step due to a moderate `webpack-dev-server` advisory pulled in transitively by `@angular-devkit/build-angular` ("No fix available"). Same failure reproduces on `dev`; unrelated to this change.

https://claude.ai/code/session_01UDuCK43HfA4JCuheUSxTez

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDuCK43HfA4JCuheUSxTez)_