### PR TITLE
Unify folder browsers behind &lt;vt-folder-browser&gt; (§7.5 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ When you have a question for the user — to disambiguate requirements, choose b
 
 **Always ask via the `AskUserQuestion` tool when the question fits its shape** (a discrete choice with a small number of options). Do not leave dangling questions like "Want me to go with approach A or approach B?" at the end of a prose response — those are easy to miss and force the user to type out an answer that could have been a single click. The tool also captures the choice cleanly in the transcript.
 
+This applies *especially* to end-of-investigation "what scope should I take next?" prompts: when a research/investigation turn ends by offering Phase 1 / Phase 2 / smaller scope, the scope choice goes through `AskUserQuestion`, **not** into the prose summary. The investigation findings stay in prose; the "what next?" question is a tool call.
+
 Use plain prose questions only when the answer is genuinely open-ended (e.g. "What should this field be named?") and a multiple-choice list would be artificial.
 
 ## Frontend Scope: Desktop Only

--- a/docs/plans/ux-brainstorm.md
+++ b/docs/plans/ux-brainstorm.md
@@ -326,8 +326,15 @@ Hover-only confirmation for destructive actions is unfamiliar and fragile. Repla
 ### 7.4 Resize-cursor on small drag handles ★ XS
 Panel dividers and column-resize handles are ~2px wide. Make them 8px hit targets with a `cursor: col-resize` on hover (standard).
 
-### 7.5 Folder-tree breadcrumb browser ★ M
+### 7.5 Folder-tree breadcrumb browser ★ M — Phase 1 SHIPPED
 The server-folder browser has a custom breadcrumb + table UI. It's functional but every modern OS has standardized on the same "left sidebar with starred/recent locations, breadcrumb on top, list in middle, double-click to enter, Enter key to confirm". Bring ours closer to that.
+
+**What shipped (Phase 1):** New `<vt-folder-browser>` component at `frontend/src/app/components/folder-browser/` replaces the four previous browser implementations: `FileBrowserComponent`'s inline panel (the `.npz` / `.json` file pickers used by export, settings-importer/exporter, label-importer modals), the `dataset-importer-modal`'s `sf-*` server-folder picker, the `new-detector-modal`'s server-folder + demo file pickers, and the `load-sort-modal`'s file-browser view. Each caller wires up a small browse function (returning `{directories, files, rootPath?, currentPath}`) so the same component sits on top of both `/api/browse` and `/api/browse-media-files` (folder + `demo:*` sources). OS-standard interaction landed: single-click highlights a row, double-click enters a directory or confirms a file, `↑/↓` move selection, `Home`/`End` jump, `Enter` activates, `Backspace` (or `Alt+↑`) goes to parent, and type-ahead jumps to the first row whose name starts with the typed prefix. Column-header sort (name / modified / size) was added with a sticky header so column meaning stays visible while scrolling; directories always group above files. The legacy `.sf-*` chrome rules in `_picker-shared.scss` and the breadcrumb / file-row rules in `load-sort-modal.scss` were deleted.
+
+**Open follow-ups (Phase 2 — deferred):**
+- **Left sidebar with Pinned / Bookmarks / Recent.** The component renders a single column today. The sidebar would add: *Pinned* anchors derived from `SERVER_ROOTS`, `saved_datasets_dir`, and `detectors_dir`; *Bookmarks* the user explicitly stars via a ⭐ button on the breadcrumb (new per-user setting key `bookmarked_browse_paths: list[str]`); *Recent* MRU of the last 8 visited folders (new per-user setting key `recent_browse_paths: list[str]`). Settings would slot into `vtsearch/settings.py`'s per-user tier using the existing `_SETTING_SPECS` factory.
+- **Address-bar mode.** Click the breadcrumb whitespace to turn it into an editable text input pre-filled with the current path; `Enter` navigates to whatever the user typed. Mirrors the macOS Finder Cmd+Shift+G / GNOME Files Ctrl+L pattern.
+- **New-folder button.** Not currently exposed by the backend (`/api/browse` is read-only). Would need a `POST /api/browse/mkdir` route guarded by the same path-validation chain.
 
 ### 7.6 Drag-and-drop affordances ★ S — SHIPPED
 Several places accept drag-drop (file import, example media into detector) but show no drop zone until the drag is over the page. Add visible dashed drop zones with `"Drop a folder here to import"` text.

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -744,43 +744,13 @@
 
       <div class="sf-browse-section">
         <label class="form-label">Select Folder</label>
-        <div class="sf-breadcrumbs">
-          <button class="sf-breadcrumb" [class.active]="!sfBrowsePath" (click)="sfLoadDirectory('')">Root</button>
-          @for (crumb of sfBreadcrumbs; track $index) {
-            <span class="sf-breadcrumb-sep">/</span>
-            <button class="sf-breadcrumb" [class.active]="$index === sfBreadcrumbs.length - 1" (click)="sfNavigateBreadcrumb($index)">{{ crumb }}</button>
-          }
-        </div>
-
-        <div class="sf-dir-list">
-          @if (sfBrowseLoading) {
-            <p class="empty-state">Loading...</p>
-          } @else if (sfBrowseError) {
-            <p class="error-text">{{ sfBrowseError }}</p>
-          } @else if (sfBrowseDirs.length === 0) {
-            <p class="sf-empty-dir">No subdirectories. This folder will be imported.</p>
-          }
-          @if (sfBrowsePath) {
-            <button class="sf-dir-item" (click)="sfGoUp()" title="Go to parent directory">
-              <span class="sf-dir-icon"><vt-icon type="arrow-up"></vt-icon></span>
-              <span class="sf-dir-name">..</span>
-            </button>
-          }
-          @for (dir of sfBrowseDirs; track dir.path) {
-            <button class="sf-dir-item" (click)="sfEnterDirectory(dir)" [title]="dir.path">
-              <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
-              <span class="sf-dir-name">{{ dir.name }}</span>
-              @if (dir.modified_at) {
-                <span class="sf-dir-date">{{ dir.modified_at }}</span>
-              }
-            </button>
-          }
-        </div>
-
-        <div class="sf-selected-path">
-          <span class="form-label">Path:</span>
-          <code class="sf-path-display">{{ sfAbsolutePath }}</code>
-        </div>
+        <vt-folder-browser
+          [browse]="sfBrowseFn"
+          [showFiles]="false"
+          [showPathFooter]="true"
+          emptyMessage="No subdirectories. This folder will be imported."
+          (pathChange)="sfOnPathChange($event)"
+        ></vt-folder-browser>
       </div>
 
       <div class="form-group">
@@ -860,7 +830,7 @@
         </div>
       }
 
-      @if (sfBrowseError && !sfBrowseLoading) {
+      @if (sfBrowseError) {
         <p class="error-text">{{ sfBrowseError }}</p>
       }
     </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,8 +1,13 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { map } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
+import {
+  FolderBrowserBrowseFn,
+  FolderBrowserComponent,
+} from '../../folder-browser/folder-browser.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ClipperChooserComponent, ClipperSelection } from '../clipper-chooser/clipper-chooser.component';
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
@@ -14,7 +19,7 @@ import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 @Component({
   selector: 'vt-dataset-importer-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, IconComponent, ClipperChooserComponent, DropZoneComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, FileBrowserComponent, FolderBrowserComponent, IconComponent, ClipperChooserComponent, DropZoneComponent],
   templateUrl: './dataset-importer-modal.component.html',
   styleUrl: './dataset-importer-modal.component.scss',
 })
@@ -123,11 +128,12 @@ export class DatasetImporterModalComponent implements OnInit {
    *  instead of running the embedding model for matching uploaded files. */
   lfVectorsFile: File | null = null;
 
-  // Server folder browser state
-  sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
+  // Server folder browser state.  The directory listing itself lives
+  // inside the embedded <vt-folder-browser>; the parent only caches the
+  // resolved path so the Import button can submit the right folder and
+  // the dataset-name / detection helpers can use it.
   sfBrowsePath = '';
   sfBrowseRootPath = '';
-  sfBrowseLoading = false;
   sfBrowseError = '';
   sfMediaType = '';
   sfMediaTypeOptions: string[] = [];
@@ -153,6 +159,19 @@ export class DatasetImporterModalComponent implements OnInit {
    *  name matches a key in the archive reuse the supplied vector
    *  instead of running the embedding model. */
   sfVectorsFile = '';
+
+  /** Browse function for the embedded ``<vt-folder-browser>``.  Folder
+   *  importer mode — files are hidden because the user is picking a
+   *  folder to import, not a file inside it. */
+  readonly sfBrowseFn: FolderBrowserBrowseFn = (path: string) =>
+    this.datasetsApi.browseMediaFiles('folder', path).pipe(
+      map((res) => ({
+        directories: res.directories || [],
+        files: [],
+        rootPath: res.root_path,
+        currentPath: path,
+      })),
+    );
 
   /** Auto-detect result for the local-folder / local-files picker.  Set
    *  after the user picks files; ``null`` when no detection has been run
@@ -1133,7 +1152,6 @@ export class DatasetImporterModalComponent implements OnInit {
     this.selectedImporter = importer || this.importers.find((i) => i.name === 'server_folder') || null;
     this.sfBrowsePath = '';
     this.sfBrowseRootPath = '';
-    this.sfBrowseDirs = [];
     this.sfBrowseError = '';
     this.sfDetection = null;
     this.sfSubmitting = false;
@@ -1158,28 +1176,21 @@ export class DatasetImporterModalComponent implements OnInit {
     this.sfLoadEmbedders(this.sfMediaType);
     this.sfLoadClippers(this.sfMediaType);
     this.sfResetSourceSpecs();
-    this.sfLoadDirectory('');
+    // The embedded <vt-folder-browser> loads itself on init.
   }
 
-  sfLoadDirectory(path: string): void {
-    this.sfBrowseLoading = true;
+  /** Path-change handler wired to ``<vt-folder-browser>``.  The browser
+   *  itself owns directory navigation; the parent reacts to each
+   *  successful load by refreshing the auto-detected dataset name and
+   *  re-running media-type detection. */
+  sfOnPathChange(evt: { path: string; rootPath: string }): void {
+    this.sfBrowsePath = evt.path;
+    this.sfBrowseRootPath = evt.rootPath;
     this.sfBrowseError = '';
-    this.datasetsApi.browseMediaFiles('folder', path).subscribe({
-      next: (res) => {
-        this.sfBrowseDirs = res.directories;
-        this.sfBrowsePath = path;
-        this.sfBrowseRootPath = res.root_path;
-        this.sfBrowseLoading = false;
-        if (!this.sfDatasetNameDirty) {
-          this.sfDatasetName = this.sfDerivedDatasetName();
-        }
-        this.sfRunDetection();
-      },
-      error: (err) => {
-        this.sfBrowseError = err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
-        this.sfBrowseLoading = false;
-      },
-    });
+    if (!this.sfDatasetNameDirty) {
+      this.sfDatasetName = this.sfDerivedDatasetName();
+    }
+    this.sfRunDetection();
   }
 
   /** Token guarding overlapping detection responses for the sf-* picker.
@@ -1235,27 +1246,6 @@ export class DatasetImporterModalComponent implements OnInit {
   sfOnDatasetNameInput(value: string): void {
     this.sfDatasetName = value;
     this.sfDatasetNameDirty = true;
-  }
-
-  sfEnterDirectory(dir: { name: string; path: string }): void {
-    this.sfLoadDirectory(dir.path);
-  }
-
-  sfGoUp(): void {
-    if (!this.sfBrowsePath) return;
-    const parts = this.sfBrowsePath.split('/');
-    parts.pop();
-    this.sfLoadDirectory(parts.join('/'));
-  }
-
-  get sfBreadcrumbs(): string[] {
-    if (!this.sfBrowsePath) return [];
-    return this.sfBrowsePath.split('/');
-  }
-
-  sfNavigateBreadcrumb(index: number): void {
-    const parts = this.sfBrowsePath.split('/');
-    this.sfLoadDirectory(parts.slice(0, index + 1).join('/'));
   }
 
   get sfAbsolutePath(): string {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -408,106 +408,34 @@
         </div>
       }
 
-      <!-- Demo file browser: appears after picking a demo from the table.
-           Reuses the server-folder-browser chrome so both file pickers feel
-           the same. -->
+      <!-- Demo file browser: appears after picking a demo from the table. -->
       @if (activePickerView === 'demo' && selectedImporter && demoFileBrowsing) {
         <div class="server-folder-browser">
           <button class="btn btn--secondary btn--sm back-btn" (click)="backToDemoTable()" title="Return to the demo list">&larr; Back to demo list</button>
-          <div class="sf-browse-section">
-            <div class="sf-breadcrumbs">
-              @for (seg of demoFileBrowsePath; track $index) {
-                @if ($index > 0) { <span class="sf-breadcrumb-sep">/</span> }
-                <button class="sf-breadcrumb" [class.active]="$index === demoFileBrowsePath.length - 1" (click)="navigateDemoBreadcrumb($index)">{{ seg }}</button>
-              }
-            </div>
-
-            <div class="sf-dir-list">
-              @if (demoFileLoading) {
-                <p class="empty-state">Loading...</p>
-              } @else if (demoFileBrowseEntries.length === 0) {
-                <p class="sf-empty-dir">No media files found in this directory.</p>
-              }
-              @for (entry of demoFileBrowseEntries; track entry.path) {
-                @if (entry.isDir) {
-                  <button class="sf-dir-item" (click)="enterDemoDirectory(entry)" [title]="entry.path">
-                    <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
-                    <span class="sf-dir-name">{{ entry.name }}</span>
-                    @if (entry.modified_at) {
-                      <span class="sf-dir-date">{{ entry.modified_at }}</span>
-                    }
-                  </button>
-                } @else {
-                  <button class="sf-dir-item" (click)="selectDemoFile(entry)" [title]="'Use ' + entry.path + ' as the example'" [disabled]="demoFileLoading">
-                    <span class="sf-dir-icon"><vt-icon type="file-text"></vt-icon></span>
-                    <span class="sf-dir-name">{{ entry.name }}</span>
-                    @if (entry.size_bytes != null) {
-                      <span class="sf-dir-date">{{ formatSize(entry.size_bytes) }}</span>
-                    }
-                  </button>
-                }
-              }
-            </div>
-          </div>
+          <vt-folder-browser
+            [browse]="demoBrowseFn"
+            [rootLabel]="demoFileBrowseLabel"
+            [busy]="demoFileLoading"
+            emptyMessage="No media files found in this directory."
+            (confirm)="selectDemoFile($event)"
+          ></vt-folder-browser>
         </div>
       }
 
-      <!-- Server folder browser: same breadcrumb chrome as the Add Dataset
-           modal, but lists files alongside directories so the user can pick
-           one to use as an example. -->
+      <!-- Server folder browser: lists files alongside directories so the
+           user can pick one to use as an example. -->
       @if (activePickerView === 'server_folder' && selectedImporter) {
         <div class="server-folder-browser">
-          <div class="sf-browse-section">
-            <label class="form-label">Browse server folders</label>
-            <div class="sf-breadcrumbs">
-              <button class="sf-breadcrumb" [class.active]="!sfBrowsePath" (click)="sfLoadDirectory('')">Root</button>
-              @for (crumb of sfBreadcrumbs; track $index) {
-                <span class="sf-breadcrumb-sep">/</span>
-                <button class="sf-breadcrumb" [class.active]="$index === sfBreadcrumbs.length - 1" (click)="sfNavigateBreadcrumb($index)">{{ crumb }}</button>
-              }
-            </div>
+          <label class="form-label">Browse server folders</label>
+          <vt-folder-browser
+            [browse]="sfBrowseFn"
+            [showPathFooter]="true"
+            [busy]="sfFileSelecting"
+            emptyMessage="No subdirectories or media files in this folder."
+            (confirm)="sfSelectFile($event)"
+          ></vt-folder-browser>
 
-            <div class="sf-dir-list">
-              @if (sfBrowseLoading) {
-                <p class="empty-state">Loading...</p>
-              } @else if (sfBrowseError) {
-                <p class="error-text">{{ sfBrowseError }}</p>
-              } @else if (sfBrowseDirs.length === 0 && sfBrowseFiles.length === 0) {
-                <p class="sf-empty-dir">No subdirectories or media files in this folder.</p>
-              }
-              @if (sfBrowsePath) {
-                <button class="sf-dir-item" (click)="sfGoUp()" title="Go to parent directory">
-                  <span class="sf-dir-icon"><vt-icon type="arrow-up"></vt-icon></span>
-                  <span class="sf-dir-name">..</span>
-                </button>
-              }
-              @for (dir of sfBrowseDirs; track dir.path) {
-                <button class="sf-dir-item" (click)="sfEnterDirectory(dir)" [title]="dir.path">
-                  <span class="sf-dir-icon"><vt-icon type="folder"></vt-icon></span>
-                  <span class="sf-dir-name">{{ dir.name }}</span>
-                  @if (dir.modified_at) {
-                    <span class="sf-dir-date">{{ dir.modified_at }}</span>
-                  }
-                </button>
-              }
-              @for (file of sfBrowseFiles; track file.path) {
-                <button class="sf-dir-item" (click)="sfSelectFile(file)" [title]="'Use ' + file.path + ' as the example'" [disabled]="sfFileSelecting">
-                  <span class="sf-dir-icon"><vt-icon type="file-text"></vt-icon></span>
-                  <span class="sf-dir-name">{{ file.name }}</span>
-                  @if (file.size_bytes != null) {
-                    <span class="sf-dir-date">{{ formatSize(file.size_bytes) }}</span>
-                  }
-                </button>
-              }
-            </div>
-
-            <div class="sf-selected-path">
-              <span class="form-label">Path:</span>
-              <code class="sf-path-display">{{ sfAbsolutePath }}</code>
-            </div>
-          </div>
-
-          @if (sfBrowseError && !sfBrowseLoading) {
+          @if (sfBrowseError) {
             <p class="error-text">{{ sfBrowseError }}</p>
           }
         </div>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,9 +1,15 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { map } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { FileBrowserComponent } from '../../file-browser/file-browser.component';
+import {
+  FolderBrowserBrowseFn,
+  FolderBrowserComponent,
+  FolderBrowserFileEntry,
+} from '../../folder-browser/folder-browser.component';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -23,14 +29,6 @@ import {
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 
-interface BrowseEntry {
-  name: string;
-  path: string;
-  size_bytes?: number;
-  modified_at?: string;
-  isDir: boolean;
-}
-
 type ModalView = 'main' | 'media-picker';
 type ModalTab = 'blank' | 'trained';
 type TrainedSubView = 'picker' | 'form';
@@ -38,7 +36,7 @@ type TrainedSubView = 'picker' | 'form';
 @Component({
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FileBrowserComponent, MediaCropModalComponent, DropZoneComponent],
+  imports: [CommonModule, FormsModule, ModalComponent, IconComponent, FileBrowserComponent, FolderBrowserComponent, MediaCropModalComponent, DropZoneComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -143,19 +141,37 @@ export class NewDetectorModalComponent implements OnInit {
   demoFileBrowsing = false;
   demoFileBrowseSource = '';
   demoFileBrowseLabel = '';
-  demoFileBrowsePath: string[] = [];
-  demoFileBrowseEntries: BrowseEntry[] = [];
   demoFileLoading = false;
 
-  // --- Server folder browser (mirrors the Add Dataset breadcrumb browser
-  //     but lists files too so the user can pick one as an example). ---
-  sfBrowsePath = '';
-  sfBrowseRootPath = '';
-  sfBrowseDirs: { name: string; path: string; modified_at?: string }[] = [];
-  sfBrowseFiles: BrowseEntry[] = [];
-  sfBrowseLoading = false;
+  // --- Server folder browser (mirrors the Add Dataset browser but
+  //     lists files too so the user can pick one as an example). ---
   sfBrowseError = '';
   sfFileSelecting = false;
+
+  /** Browse fn for the embedded ``<vt-folder-browser>`` in the demo
+   *  file picker.  Uses the demo-scoped source (``demo:<name>``). */
+  readonly demoBrowseFn: FolderBrowserBrowseFn = (path: string) =>
+    this.datasetsApi.browseMediaFiles(this.demoFileBrowseSource, path).pipe(
+      map((res) => ({
+        directories: res.directories || [],
+        files: res.files || [],
+        rootPath: res.root_path,
+        currentPath: path,
+      })),
+    );
+
+  /** Browse fn for the embedded ``<vt-folder-browser>`` in the server
+   *  folder picker.  Lists both folders and files (filtered server-side
+   *  to known media extensions). */
+  readonly sfBrowseFn: FolderBrowserBrowseFn = (path: string) =>
+    this.datasetsApi.browseMediaFiles('folder', path).pipe(
+      map((res) => ({
+        directories: res.directories || [],
+        files: res.files || [],
+        rootPath: res.root_path,
+        currentPath: path,
+      })),
+    );
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -425,8 +441,6 @@ export class NewDetectorModalComponent implements OnInit {
     this.demoFileBrowsing = false;
     this.demoFileBrowseSource = '';
     this.demoFileBrowseLabel = '';
-    this.demoFileBrowsePath = [];
-    this.demoFileBrowseEntries = [];
     this.demoFileLoading = false;
   }
 
@@ -496,41 +510,10 @@ export class NewDetectorModalComponent implements OnInit {
     this.demoFileBrowsing = true;
     this.demoFileBrowseSource = `demo:${demo.name}`;
     this.demoFileBrowseLabel = demo.label;
-    this.demoFileBrowsePath = [demo.label];
-    this.loadDemoDirectory('');
   }
 
-  private loadDemoDirectory(relPath: string): void {
-    this.demoFileLoading = true;
-    this.demoFileBrowseEntries = [];
-    this.datasetsApi.browseMediaFiles(this.demoFileBrowseSource, relPath).subscribe({
-      next: (res) => {
-        this.demoFileBrowseEntries = this.toEntries(res.directories, res.files);
-        this.demoFileLoading = false;
-      },
-      error: () => {
-        this.demoFileLoading = false;
-      },
-    });
-  }
-
-  enterDemoDirectory(entry: BrowseEntry): void {
-    this.demoFileBrowsePath.push(entry.name);
-    this.loadDemoDirectory(entry.path);
-  }
-
-  navigateDemoBreadcrumb(index: number): void {
-    if (index === 0) {
-      this.demoFileBrowsePath = [this.demoFileBrowseLabel];
-      this.loadDemoDirectory('');
-      return;
-    }
-    this.demoFileBrowsePath = this.demoFileBrowsePath.slice(0, index + 1);
-    const relPath = this.demoFileBrowsePath.slice(1).join('/');
-    this.loadDemoDirectory(relPath);
-  }
-
-  selectDemoFile(entry: BrowseEntry): void {
+  /** Confirm handler for the demo file browser. */
+  selectDemoFile(entry: FolderBrowserFileEntry): void {
     this.demoFileLoading = true;
     this.datasetsApi.selectBrowsedFile(this.demoFileBrowseSource, entry.path).subscribe({
       next: (res) => {
@@ -555,80 +538,21 @@ export class NewDetectorModalComponent implements OnInit {
     this.demoFileBrowsing = false;
     this.demoFileBrowseSource = '';
     this.demoFileBrowseLabel = '';
-    this.demoFileBrowsePath = [];
-    this.demoFileBrowseEntries = [];
   }
 
   // --- Server folder browser (with file selection) ---
 
   private resetServerFolderState(): void {
-    this.sfBrowsePath = '';
-    this.sfBrowseRootPath = '';
-    this.sfBrowseDirs = [];
-    this.sfBrowseFiles = [];
-    this.sfBrowseLoading = false;
     this.sfBrowseError = '';
     this.sfFileSelecting = false;
   }
 
   private openServerFolderBrowser(): void {
     this.resetServerFolderState();
-    this.sfLoadDirectory('');
   }
 
-  sfLoadDirectory(path: string): void {
-    this.sfBrowseLoading = true;
-    this.sfBrowseError = '';
-    this.datasetsApi.browseMediaFiles('folder', path).subscribe({
-      next: (res) => {
-        this.sfBrowseDirs = res.directories || [];
-        this.sfBrowseFiles = (res.files || []).map((f) => ({
-          name: f.name,
-          path: f.path,
-          size_bytes: f.size_bytes,
-          modified_at: f.modified_at,
-          isDir: false,
-        }));
-        this.sfBrowsePath = path;
-        this.sfBrowseRootPath = res.root_path;
-        this.sfBrowseLoading = false;
-      },
-      error: (err) => {
-        this.sfBrowseError =
-          err.error?.error || 'Could not browse server folders. Is saved_datasets_dir configured?';
-        this.sfBrowseLoading = false;
-      },
-    });
-  }
-
-  sfEnterDirectory(dir: { name: string; path: string }): void {
-    this.sfLoadDirectory(dir.path);
-  }
-
-  sfGoUp(): void {
-    if (!this.sfBrowsePath) return;
-    const parts = this.sfBrowsePath.split('/');
-    parts.pop();
-    this.sfLoadDirectory(parts.join('/'));
-  }
-
-  get sfBreadcrumbs(): string[] {
-    if (!this.sfBrowsePath) return [];
-    return this.sfBrowsePath.split('/');
-  }
-
-  sfNavigateBreadcrumb(index: number): void {
-    const parts = this.sfBrowsePath.split('/');
-    this.sfLoadDirectory(parts.slice(0, index + 1).join('/'));
-  }
-
-  get sfAbsolutePath(): string {
-    if (!this.sfBrowseRootPath) return '';
-    if (!this.sfBrowsePath) return this.sfBrowseRootPath;
-    return this.sfBrowseRootPath + '/' + this.sfBrowsePath;
-  }
-
-  sfSelectFile(entry: BrowseEntry): void {
+  /** Confirm handler for the server folder browser. */
+  sfSelectFile(entry: FolderBrowserFileEntry): void {
     this.sfFileSelecting = true;
     this.datasetsApi.selectBrowsedFile('folder', entry.path).subscribe({
       next: (res) => {
@@ -649,29 +573,6 @@ export class NewDetectorModalComponent implements OnInit {
   }
 
   // --- Local file upload (single file for the example) ---
-
-  /** Build a unified entry list (directories first, then files). */
-  private toEntries(
-    directories: { name: string; path: string; modified_at?: string }[] | undefined,
-    files:
-      | { name: string; path: string; size_bytes: number; modified_at?: string }[]
-      | undefined,
-  ): BrowseEntry[] {
-    const entries: BrowseEntry[] = [];
-    for (const d of directories || []) {
-      entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
-    }
-    for (const f of files || []) {
-      entries.push({
-        name: f.name,
-        path: f.path,
-        size_bytes: f.size_bytes,
-        modified_at: f.modified_at,
-        isDir: false,
-      });
-    }
-    return entries;
-  }
 
   formatSize(bytes?: number): string {
     if (bytes == null) return '';

--- a/frontend/src/app/components/file-browser/file-browser.component.html
+++ b/frontend/src/app/components/file-browser/file-browser.component.html
@@ -18,57 +18,11 @@
 
   @if (browserOpen) {
     <div class="file-browser-panel">
-      <div class="file-browser-breadcrumbs">
-        <button
-          class="file-browser-crumb"
-          [class.active]="!currentPath"
-          (click)="loadDirectory('')"
-        >Root</button>
-        @for (crumb of breadcrumbs; track $index) {
-          <span class="file-browser-sep">/</span>
-          <button
-            class="file-browser-crumb"
-            [class.active]="$index === breadcrumbs.length - 1"
-            (click)="navigateBreadcrumb($index)"
-          >{{ crumb }}</button>
-        }
-      </div>
-
-      <div class="file-browser-list">
-        @if (loading) {
-          <div class="file-browser-empty">Loading...</div>
-        } @else if (error) {
-          <div class="file-browser-error">{{ error }}</div>
-        } @else {
-          @if (currentPath) {
-            <button class="file-browser-item file-browser-dir" (click)="goUp()" title="Go to parent directory">
-              <span class="file-browser-icon"><svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 2l5 6H9v6H7V8H3z"/></svg></span>
-              <span class="file-browser-name">..</span>
-            </button>
-          }
-          @for (dir of directories; track dir.path) {
-            <button class="file-browser-item file-browser-dir" (click)="enterDirectory(dir)" [title]="dir.path">
-              <span class="file-browser-icon"><svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M1 3h5l1.5 1.5H15v9.5H1V3zm1 1v8.5h12V5.5H7.1L5.6 4H2z"/></svg></span>
-              <span class="file-browser-name">{{ dir.name }}</span>
-              <span class="file-browser-date">{{ dir.modified_at }}</span>
-            </button>
-          }
-          @for (file of files; track file.path) {
-            <button class="file-browser-item file-browser-file" (click)="selectFile(file)" [title]="file.path">
-              <span class="file-browser-icon"><svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M3 1h7l4 4v10H3V1zm1 1v12h9V5.5L9.5 2H4zm6 0v3.5h3.5"/></svg></span>
-              <span class="file-browser-name">{{ file.name }}</span>
-              <span class="file-browser-date">{{ file.modified_at }}</span>
-              <span class="file-browser-size">{{ formatSize(file.size_bytes) }}</span>
-            </button>
-          }
-          @if (!loading && directories.length === 0 && files.length === 0 && !currentPath) {
-            <div class="file-browser-empty">No files or directories found.</div>
-          }
-          @if (!loading && directories.length === 0 && files.length === 0 && currentPath) {
-            <div class="file-browser-empty">Empty directory.</div>
-          }
-        }
-      </div>
+      <vt-folder-browser
+        [browse]="browseFn"
+        [showFiles]="true"
+        (confirm)="onFileConfirmed($event)"
+      ></vt-folder-browser>
     </div>
   }
 </div>

--- a/frontend/src/app/components/file-browser/file-browser.component.scss
+++ b/frontend/src/app/components/file-browser/file-browser.component.scss
@@ -20,122 +20,13 @@
   font-size: 0.85rem;
 }
 
+// Outer chrome around the embedded folder-browser panel. The list,
+// breadcrumb, and rows themselves are styled by vt-folder-browser.
 .file-browser-panel {
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg-subtle);
-  max-height: 280px;
+  padding: 6px 8px;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-}
-
-.file-browser-breadcrumbs {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 2px;
-  padding: 6px 10px;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.8rem;
-  background: var(--bg-hover);
-}
-
-.file-browser-crumb {
-  background: none;
-  border: none;
-  padding: 2px 4px;
-  border-radius: 3px;
-  cursor: pointer;
-  color: var(--accent);
-  font-size: 0.8rem;
-
-  &:hover {
-    background: var(--bg-subtle);
-    text-decoration: underline;
-  }
-
-  &.active {
-    color: var(--text-primary);
-    font-weight: 500;
-  }
-}
-
-.file-browser-sep {
-  color: var(--text-muted);
-  font-size: 0.75rem;
-}
-
-.file-browser-list {
-  overflow-y: auto;
-  flex: 1;
-}
-
-.file-browser-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 6px 10px;
-  border: none;
-  background: none;
-  cursor: pointer;
-  text-align: left;
-  font-size: 0.85rem;
-  color: var(--text-primary);
-  transition: background 0.1s;
-
-  &:hover {
-    background: var(--bg-hover);
-  }
-}
-
-.file-browser-dir .file-browser-name {
-  font-weight: 500;
-}
-
-.file-browser-icon {
-  flex-shrink: 0;
-  width: 20px;
-  text-align: center;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  svg {
-    vertical-align: middle;
-  }
-}
-
-.file-browser-name {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.file-browser-date {
-  flex-shrink: 0;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  white-space: nowrap;
-}
-
-.file-browser-size {
-  flex-shrink: 0;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-}
-
-.file-browser-empty,
-.file-browser-error {
-  padding: 16px;
-  text-align: center;
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.file-browser-error {
-  color: var(--color-bad);
 }

--- a/frontend/src/app/components/file-browser/file-browser.component.ts
+++ b/frontend/src/app/components/file-browser/file-browser.component.ts
@@ -1,14 +1,25 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { FileBrowserApiService } from '../../services/file-browser-api.service';
-import type { BrowseDirectoryEntry } from '../../generated/api-client/models/browse-directory-entry';
-import type { BrowseFileEntry } from '../../generated/api-client/models/browse-file-entry';
+import { map } from 'rxjs/operators';
 
+import { FileBrowserApiService } from '../../services/file-browser-api.service';
+import {
+  FolderBrowserBrowseFn,
+  FolderBrowserComponent,
+  FolderBrowserFileEntry,
+} from '../folder-browser/folder-browser.component';
+
+/** "Text input + Browse button" field that opens an inline OS-style
+ *  folder browser panel.
+ *
+ *  Thin wrapper around :cmp:`FolderBrowserComponent` — the field
+ *  controls open/close state and binds a ``/api/browse``-backed
+ *  ``browseFn`` to the unified browser. */
 @Component({
   selector: 'vt-file-browser',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, FolderBrowserComponent],
   templateUrl: './file-browser.component.html',
   styleUrl: './file-browser.component.scss',
 })
@@ -26,15 +37,20 @@ export class FileBrowserComponent implements OnInit, OnChanges {
   @Output() pathSelected = new EventEmitter<string>();
 
   browserOpen = false;
-  loading = false;
-  error = '';
-
-  directories: BrowseDirectoryEntry[] = [];
-  files: BrowseFileEntry[] = [];
-  currentPath = '';
 
   /** The text value in the manual input field. */
   inputValue = '';
+
+  /** Bound to the inner ``<vt-folder-browser>``.  Arrow function so
+   *  ``this`` resolves correctly when the child component invokes it. */
+  readonly browseFn: FolderBrowserBrowseFn = (path: string) =>
+    this.fileBrowserApi.browse(path, this.extensions).pipe(
+      map((res) => ({
+        directories: res.directories,
+        files: res.files,
+        currentPath: res.current_path,
+      })),
+    );
 
   constructor(private fileBrowserApi: FileBrowserApiService) {}
 
@@ -48,77 +64,21 @@ export class FileBrowserComponent implements OnInit, OnChanges {
     }
   }
 
-  /** Open the file browser panel and load the root directory. */
   openBrowser(): void {
     this.browserOpen = true;
-    this.error = '';
-    this.loadDirectory('');
   }
 
   closeBrowser(): void {
     this.browserOpen = false;
   }
 
-  /** Navigate into a directory. */
-  loadDirectory(path: string): void {
-    this.loading = true;
-    this.error = '';
-    this.fileBrowserApi.browse(path, this.extensions).subscribe({
-      next: (res) => {
-        this.directories = res.directories;
-        this.files = res.files;
-        this.currentPath = res.current_path;
-        this.loading = false;
-      },
-      error: (err) => {
-        this.error = err.error?.error || 'Failed to browse directory';
-        this.loading = false;
-      },
-    });
-  }
-
-  /** Navigate up one level. */
-  goUp(): void {
-    if (!this.currentPath) return;
-    const parts = this.currentPath.split('/');
-    parts.pop();
-    this.loadDirectory(parts.join('/'));
-  }
-
-  /** Enter a subdirectory. */
-  enterDirectory(dir: BrowseDirectoryEntry): void {
-    this.loadDirectory(dir.path);
-  }
-
-  /** Select a file and emit its relative path. */
-  selectFile(file: BrowseFileEntry): void {
-    this.inputValue = file.path;
-    this.pathSelected.emit(file.path);
+  onFileConfirmed(entry: FolderBrowserFileEntry): void {
+    this.inputValue = entry.path;
+    this.pathSelected.emit(entry.path);
     this.browserOpen = false;
   }
 
-  /** Emit the manually typed path when the user changes it. */
   onInputChange(): void {
     this.pathSelected.emit(this.inputValue);
-  }
-
-  /** Breadcrumb segments from the current path. */
-  get breadcrumbs(): string[] {
-    if (!this.currentPath) return [];
-    return this.currentPath.split('/');
-  }
-
-  /** Navigate to a breadcrumb index. */
-  navigateBreadcrumb(index: number): void {
-    const parts = this.currentPath.split('/');
-    this.loadDirectory(parts.slice(0, index + 1).join('/'));
-  }
-
-  /** Format bytes as a human-readable size. */
-  formatSize(bytes?: number): string {
-    if (bytes === undefined || bytes === null) return '';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 }

--- a/frontend/src/app/components/folder-browser/folder-browser.component.html
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.html
@@ -1,0 +1,108 @@
+<div class="vfb">
+  <div class="vfb-breadcrumbs" role="navigation" aria-label="Folder path">
+    <button
+      type="button"
+      class="vfb-crumb"
+      [class.active]="!currentPath"
+      (click)="navigateRoot()"
+    >{{ rootLabel }}</button>
+    @for (crumb of breadcrumbs; track $index) {
+      <span class="vfb-crumb-sep">/</span>
+      <button
+        type="button"
+        class="vfb-crumb"
+        [class.active]="$index === breadcrumbs.length - 1"
+        (click)="navigateBreadcrumb($index)"
+      >{{ crumb }}</button>
+    }
+  </div>
+
+  <div
+    #listEl
+    class="vfb-list"
+    tabindex="0"
+    role="listbox"
+    [class.vfb-list--loading]="loading"
+  >
+    <div class="vfb-header" role="row">
+      <button
+        type="button"
+        class="vfb-col vfb-col-name"
+        (click)="setSort('name')"
+        title="Sort by name"
+      >Name <span class="vfb-sort-ind">{{ sortIndicator('name') }}</span></button>
+      @if (showDate) {
+        <button
+          type="button"
+          class="vfb-col vfb-col-date"
+          (click)="setSort('modified')"
+          title="Sort by modified date"
+        >Modified <span class="vfb-sort-ind">{{ sortIndicator('modified') }}</span></button>
+      }
+      @if (showFiles && showSize) {
+        <button
+          type="button"
+          class="vfb-col vfb-col-size"
+          (click)="setSort('size')"
+          title="Sort by size"
+        >Size <span class="vfb-sort-ind">{{ sortIndicator('size') }}</span></button>
+      }
+    </div>
+
+    @if (loading) {
+      <p class="vfb-empty">Loading…</p>
+    } @else if (error) {
+      <p class="vfb-error">{{ error }}</p>
+    } @else {
+      @if (currentPath) {
+        <button
+          type="button"
+          class="vfb-row vfb-row--up"
+          (click)="goUp()"
+          title="Go to parent directory"
+        >
+          <span class="vfb-icon"><vt-icon type="arrow-up"></vt-icon></span>
+          <span class="vfb-name">..</span>
+        </button>
+      }
+      @if (rows.length === 0) {
+        <p class="vfb-empty">{{ emptyMessage || (showFiles ? 'Empty folder.' : 'No subdirectories.') }}</p>
+      }
+      @for (row of rows; track trackRow($index, row); let i = $index) {
+        <button
+          type="button"
+          class="vfb-row"
+          [class.vfb-row--dir]="row.kind === 'dir'"
+          [class.vfb-row--file]="row.kind === 'file'"
+          [class.vfb-row--selected]="i === selectedIndex"
+          [disabled]="busy && row.kind === 'file'"
+          (click)="selectRow(i)"
+          (dblclick)="onRowDblClick(row)"
+          [title]="row.path"
+        >
+          <span class="vfb-icon">
+            @if (row.kind === 'dir') {
+              <vt-icon type="folder"></vt-icon>
+            } @else {
+              <vt-icon type="file-text"></vt-icon>
+            }
+          </span>
+          <span class="vfb-name">{{ row.name }}</span>
+          @if (showDate) {
+            <span class="vfb-date">{{ row.modified_at }}</span>
+          }
+          @if (showFiles && showSize) {
+            <span class="vfb-size">{{ row.kind === 'file' ? formatSize(row.size_bytes) : '' }}</span>
+          }
+        </button>
+      }
+    }
+  </div>
+
+  @if (showPathFooter && rootPath) {
+    <div class="vfb-path-footer">
+      <span class="vfb-path-label">Path:</span>
+      <code class="vfb-path-value">{{ absolutePath }}</code>
+    </div>
+  }
+</div>

--- a/frontend/src/app/components/folder-browser/folder-browser.component.scss
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.scss
@@ -1,0 +1,220 @@
+// vt-folder-browser — single source of truth for the OS-style folder
+// browser used in the importer, new-detector, load-sort, and file-field
+// pickers. Replaces the previous .sf-* and .file-browser-* class
+// families that lived inline in those components.
+
+.vfb {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+// ---------------------------------------------------------------------
+// Breadcrumb
+// ---------------------------------------------------------------------
+
+.vfb-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: .8rem;
+  flex-wrap: wrap;
+}
+
+.vfb-crumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: .8rem;
+
+  &:hover { background: var(--bg-subtle); }
+
+  &.active {
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: default;
+    &:hover { background: none; }
+  }
+}
+
+.vfb-crumb-sep {
+  color: var(--text-muted);
+  font-size: .75rem;
+}
+
+// ---------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------
+
+.vfb-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  max-height: 320px;
+  overflow-y: auto;
+  outline: none;
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+  }
+}
+
+.vfb-list--loading {
+  cursor: progress;
+}
+
+// Sortable header row stays pinned while the list scrolls so the
+// column meaning is always visible.
+.vfb-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  font-size: .72rem;
+  text-transform: uppercase;
+  letter-spacing: .03em;
+  color: var(--text-secondary, var(--text-muted));
+  user-select: none;
+}
+
+.vfb-col {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover { color: var(--text-primary); }
+}
+
+.vfb-col-name { flex: 1; min-width: 0; text-align: left; }
+.vfb-col-date { width: 110px; flex-shrink: 0; text-align: left; }
+.vfb-col-size { width: 70px; flex-shrink: 0; text-align: right; }
+
+.vfb-sort-ind {
+  display: inline-block;
+  width: 1em;
+  font-size: .7rem;
+}
+
+// Rows are buttons so they're keyboard-and-screen-reader-friendly.
+.vfb-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-subtle, var(--border));
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: .85rem;
+  transition: background .12s;
+
+  &:last-child { border-bottom: none; }
+  &:hover:not(:disabled) { background: var(--bg-subtle); }
+  &:disabled { opacity: 0.55; cursor: wait; }
+}
+
+.vfb-row--selected {
+  background: var(--bg-hover);
+
+  &:hover { background: var(--bg-hover); }
+}
+
+.vfb-row--dir .vfb-name { font-weight: 500; }
+.vfb-row--up { color: var(--text-muted); }
+
+.vfb-icon {
+  flex-shrink: 0;
+  width: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vfb-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vfb-date {
+  width: 110px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: .75rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vfb-size {
+  width: 70px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: .75rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.vfb-empty {
+  margin: 0;
+  padding: 16px;
+  text-align: center;
+  font-size: .85rem;
+  color: var(--text-muted);
+}
+
+.vfb-error {
+  margin: 0;
+  padding: 12px;
+  color: var(--color-bad);
+  font-size: .85rem;
+}
+
+// ---------------------------------------------------------------------
+// Path footer
+// ---------------------------------------------------------------------
+
+.vfb-path-footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.vfb-path-label {
+  font-size: .8rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.vfb-path-value {
+  font-size: .8rem;
+  color: var(--text-secondary, var(--text-muted));
+  background: var(--bg-subtle);
+  padding: 3px 8px;
+  border-radius: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -1,0 +1,412 @@
+import { CommonModule } from '@angular/common';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+
+import { IconComponent } from '../icon/icon.component';
+
+export interface FolderBrowserDirEntry {
+  name: string;
+  path: string;
+  modified_at?: string;
+}
+
+export interface FolderBrowserFileEntry {
+  name: string;
+  path: string;
+  modified_at?: string;
+  size_bytes?: number;
+}
+
+/** Response shape from the caller-supplied browse function.
+ *
+ *  ``rootPath`` is optional because two endpoints back this UI:
+ *  ``/api/browse`` omits it (intentional path leak guard), while
+ *  ``/api/browse-media-files`` returns it. When present and
+ *  ``showPathFooter`` is true the resolved absolute path is shown
+ *  under the list. */
+export interface FolderBrowserListing {
+  directories: FolderBrowserDirEntry[];
+  files: FolderBrowserFileEntry[];
+  rootPath?: string;
+  currentPath?: string;
+}
+
+export type FolderBrowserBrowseFn = (path: string) => Observable<FolderBrowserListing>;
+
+interface Row {
+  kind: 'dir' | 'file';
+  name: string;
+  path: string;
+  modified_at?: string;
+  size_bytes?: number;
+}
+
+type SortKey = 'name' | 'modified' | 'size';
+type SortDir = 'asc' | 'desc';
+
+const TYPEAHEAD_RESET_MS = 800;
+
+/** OS-style folder/file picker panel.
+ *
+ *  Renders a breadcrumb on top and a list of directories + files in the
+ *  middle.  Single-click highlights a row, double-click or Enter enters
+ *  a directory or confirms a file.  ↑/↓ moves the selection, Backspace
+ *  (or Alt+↑) goes to the parent directory.  Typing letters jumps to
+ *  the first row whose name starts with the typed prefix.
+ *
+ *  Callers supply a ``browse`` function so the same component works on
+ *  top of multiple backend endpoints (``/api/browse``,
+ *  ``/api/browse-media-files``, ...).  The component never imports an
+ *  API service directly. */
+@Component({
+  selector: 'vt-folder-browser',
+  standalone: true,
+  imports: [CommonModule, IconComponent],
+  templateUrl: './folder-browser.component.html',
+  styleUrl: './folder-browser.component.scss',
+})
+export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
+  /** Required: returns the listing for a given relative path. */
+  @Input({ required: true }) browse!: FolderBrowserBrowseFn;
+
+  /** When false, only directories are rendered (the user is picking a
+   *  folder, not a file inside it). */
+  @Input() showFiles = true;
+
+  /** Initial relative path to load.  Changes to this re-load the list. */
+  @Input() initialPath = '';
+
+  /** Label for the root crumb.  Defaults to "Root". */
+  @Input() rootLabel = 'Root';
+
+  /** Show the absolute-path footer (only meaningful when the browse fn
+   *  returns ``rootPath``). */
+  @Input() showPathFooter = false;
+
+  /** Show the modified-at column.  Defaults to true. */
+  @Input() showDate = true;
+
+  /** Show the size column for files.  Defaults to true. */
+  @Input() showSize = true;
+
+  /** When true, file rows show a wait cursor and ignore clicks (e.g. the
+   *  caller is processing a previous confirm). */
+  @Input() busy = false;
+
+  /** Empty-state message shown when the listing is empty. */
+  @Input() emptyMessage = '';
+
+  /** Whether to auto-focus the list on init so keyboard navigation works
+   *  without an extra click.  Defaults to true. */
+  @Input() autoFocus = true;
+
+  /** Fired whenever the displayed directory changes.  ``path`` is
+   *  relative to the browse root; ``rootPath`` is the absolute server
+   *  path if the backend exposes one (empty string otherwise). */
+  @Output() pathChange = new EventEmitter<{ path: string; rootPath: string }>();
+
+  /** Fired when the user confirms a file (Enter on selected file, or
+   *  double-click on a file).  Folders are never emitted — they
+   *  navigate. */
+  @Output() confirm = new EventEmitter<FolderBrowserFileEntry>();
+
+  /** Fired on browse() errors so the parent can surface them in its own
+   *  way.  The component also shows an inline error message. */
+  @Output() loadError = new EventEmitter<unknown>();
+
+  rows: Row[] = [];
+  currentPath = '';
+  rootPath = '';
+  loading = false;
+  error = '';
+  selectedIndex = -1;
+  sortKey: SortKey = 'name';
+  sortDir: SortDir = 'asc';
+
+  private typeaheadBuf = '';
+  private typeaheadTimer: ReturnType<typeof setTimeout> | null = null;
+  private currentSub?: Subscription;
+
+  @ViewChild('listEl') listEl?: ElementRef<HTMLDivElement>;
+
+  ngOnInit(): void {
+    this.loadDirectory(this.initialPath || '');
+  }
+
+  ngAfterViewInit(): void {
+    if (this.autoFocus) {
+      // Defer one tick so the list element is in the DOM.
+      setTimeout(() => this.listEl?.nativeElement.focus(), 0);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('initialPath' in changes && !changes['initialPath'].firstChange) {
+      this.loadDirectory(this.initialPath || '');
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.currentSub?.unsubscribe();
+    if (this.typeaheadTimer) clearTimeout(this.typeaheadTimer);
+  }
+
+  // ------------------------------------------------------------------
+  // Loading
+  // ------------------------------------------------------------------
+
+  private loadDirectory(path: string): void {
+    this.loading = true;
+    this.error = '';
+    this.currentSub?.unsubscribe();
+    this.currentSub = this.browse(path).subscribe({
+      next: (res) => {
+        const dirs = res.directories || [];
+        const files = this.showFiles ? res.files || [] : [];
+        const rows: Row[] = [];
+        for (const d of dirs) {
+          rows.push({ kind: 'dir', name: d.name, path: d.path, modified_at: d.modified_at });
+        }
+        for (const f of files) {
+          rows.push({
+            kind: 'file',
+            name: f.name,
+            path: f.path,
+            modified_at: f.modified_at,
+            size_bytes: f.size_bytes,
+          });
+        }
+        this.rows = this.sortRows(rows, this.sortKey, this.sortDir);
+        this.currentPath = res.currentPath ?? path;
+        this.rootPath = res.rootPath ?? '';
+        this.selectedIndex = -1;
+        this.loading = false;
+        this.pathChange.emit({ path: this.currentPath, rootPath: this.rootPath });
+      },
+      error: (err) => {
+        const msg = (err && err.error && err.error.message) || (err && err.error && err.error.error) || 'Could not browse this folder.';
+        this.error = typeof msg === 'string' ? msg : 'Could not browse this folder.';
+        this.loading = false;
+        this.rows = [];
+        this.loadError.emit(err);
+      },
+    });
+  }
+
+  /** Re-load the current directory (e.g. after the caller changed a
+   *  filter that affects the listing). */
+  reload(): void {
+    this.loadDirectory(this.currentPath);
+  }
+
+  // ------------------------------------------------------------------
+  // Navigation
+  // ------------------------------------------------------------------
+
+  get breadcrumbs(): string[] {
+    return this.currentPath ? this.currentPath.split('/').filter(Boolean) : [];
+  }
+
+  navigateRoot(): void {
+    this.loadDirectory('');
+  }
+
+  navigateBreadcrumb(index: number): void {
+    const parts = this.currentPath.split('/').filter(Boolean);
+    this.loadDirectory(parts.slice(0, index + 1).join('/'));
+  }
+
+  enter(row: Row): void {
+    if (this.busy) return;
+    if (row.kind === 'dir') {
+      this.loadDirectory(row.path);
+    } else if (row.kind === 'file') {
+      this.confirm.emit({
+        name: row.name,
+        path: row.path,
+        modified_at: row.modified_at,
+        size_bytes: row.size_bytes,
+      });
+    }
+  }
+
+  goUp(): void {
+    if (!this.currentPath) return;
+    const parts = this.currentPath.split('/').filter(Boolean);
+    parts.pop();
+    this.loadDirectory(parts.join('/'));
+  }
+
+  get absolutePath(): string {
+    if (!this.rootPath) return '';
+    if (!this.currentPath) return this.rootPath;
+    return this.rootPath + '/' + this.currentPath;
+  }
+
+  // ------------------------------------------------------------------
+  // Selection
+  // ------------------------------------------------------------------
+
+  selectRow(index: number): void {
+    if (index < 0 || index >= this.rows.length) return;
+    this.selectedIndex = index;
+  }
+
+  onRowDblClick(row: Row): void {
+    this.enter(row);
+  }
+
+  // ------------------------------------------------------------------
+  // Sorting
+  // ------------------------------------------------------------------
+
+  setSort(key: SortKey): void {
+    if (this.sortKey === key) {
+      this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortKey = key;
+      this.sortDir = 'asc';
+    }
+    this.rows = this.sortRows(this.rows, this.sortKey, this.sortDir);
+    this.selectedIndex = -1;
+  }
+
+  private sortRows(rows: Row[], key: SortKey, dir: SortDir): Row[] {
+    const sign = dir === 'asc' ? 1 : -1;
+    // Always keep directories above files (matches OS file managers).
+    const dirs = rows.filter((r) => r.kind === 'dir');
+    const files = rows.filter((r) => r.kind === 'file');
+    const cmp = (a: Row, b: Row): number => {
+      if (key === 'name') {
+        return sign * a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+      }
+      if (key === 'modified') {
+        return sign * ((a.modified_at || '').localeCompare(b.modified_at || ''));
+      }
+      // size — directories have no size so sort by name within dirs.
+      const av = a.size_bytes ?? -1;
+      const bv = b.size_bytes ?? -1;
+      if (av === bv) return a.name.localeCompare(b.name);
+      return sign * (av - bv);
+    };
+    dirs.sort(cmp);
+    files.sort(cmp);
+    return [...dirs, ...files];
+  }
+
+  sortIndicator(key: SortKey): string {
+    if (this.sortKey !== key) return '';
+    return this.sortDir === 'asc' ? '▲' : '▼';
+  }
+
+  // ------------------------------------------------------------------
+  // Keyboard
+  // ------------------------------------------------------------------
+
+  @HostListener('keydown', ['$event'])
+  onKeyDown(e: KeyboardEvent): void {
+    if (this.loading) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      this.moveSelection(1);
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      this.moveSelection(-1);
+      return;
+    }
+    if (e.key === 'Home') {
+      e.preventDefault();
+      if (this.rows.length > 0) this.selectRow(0);
+      return;
+    }
+    if (e.key === 'End') {
+      e.preventDefault();
+      if (this.rows.length > 0) this.selectRow(this.rows.length - 1);
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (this.selectedIndex >= 0) this.enter(this.rows[this.selectedIndex]);
+      return;
+    }
+    if (e.key === 'Backspace' || (e.key === 'ArrowUp' && e.altKey)) {
+      e.preventDefault();
+      this.goUp();
+      return;
+    }
+    // Type-ahead: any single printable character extends the buffer and
+    // jumps the selection to the first matching row.
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      this.applyTypeahead(e.key);
+      e.preventDefault();
+    }
+  }
+
+  private moveSelection(delta: number): void {
+    if (this.rows.length === 0) return;
+    let i = this.selectedIndex + delta;
+    if (this.selectedIndex < 0) i = delta > 0 ? 0 : this.rows.length - 1;
+    if (i < 0) i = 0;
+    if (i >= this.rows.length) i = this.rows.length - 1;
+    this.selectRow(i);
+    this.scrollSelectionIntoView();
+  }
+
+  private scrollSelectionIntoView(): void {
+    const list = this.listEl?.nativeElement;
+    if (!list) return;
+    const row = list.querySelectorAll('.vfb-row')[this.selectedIndex] as HTMLElement | undefined;
+    row?.scrollIntoView({ block: 'nearest' });
+  }
+
+  private applyTypeahead(ch: string): void {
+    this.typeaheadBuf += ch.toLowerCase();
+    if (this.typeaheadTimer) clearTimeout(this.typeaheadTimer);
+    this.typeaheadTimer = setTimeout(() => {
+      this.typeaheadBuf = '';
+      this.typeaheadTimer = null;
+    }, TYPEAHEAD_RESET_MS);
+    const needle = this.typeaheadBuf;
+    // Search starting from the row after the current selection so
+    // repeated presses cycle through matches.
+    const start = this.selectedIndex >= 0 ? this.selectedIndex : 0;
+    for (let off = 0; off < this.rows.length; off++) {
+      const idx = (start + off + (needle.length === 1 ? 1 : 0)) % this.rows.length;
+      if (this.rows[idx].name.toLowerCase().startsWith(needle)) {
+        this.selectRow(idx);
+        this.scrollSelectionIntoView();
+        return;
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Helpers
+  // ------------------------------------------------------------------
+
+  formatSize(bytes?: number): string {
+    if (bytes === undefined || bytes === null) return '';
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  trackRow(_index: number, row: Row): string {
+    return row.kind + ':' + row.path;
+  }
+}

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -45,7 +45,9 @@
       <!-- File browser (recursive directory navigation) -->
       @if (mediaPickerView === 'file-browser') {
         <div class="file-browser-step">
-          <button class="btn btn--secondary btn--sm back-btn" (click)="backFromFileBrowser()" title="Return to the previous step">&larr; Back</button>
+          @if (selectedSource?.name === 'demo') {
+            <button class="btn btn--secondary btn--sm back-btn" (click)="backFromFileBrowser()" title="Return to the demo list">&larr; Back to demo list</button>
+          }
           <vt-folder-browser
             [browse]="browseFn"
             [rootLabel]="browseSourceLabel"

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -44,49 +44,16 @@
 
       <!-- File browser (recursive directory navigation) -->
       @if (mediaPickerView === 'file-browser') {
-        <div class="breadcrumbs">
-          @for (seg of browsePath; track $index) {
-            @if ($index > 0) { <span class="breadcrumb-sep">/</span> }
-            @if ($index < browsePath.length - 1) {
-              <button class="breadcrumb-link" (click)="navigateBreadcrumb($index)">{{ seg }}</button>
-            } @else {
-              <span class="breadcrumb-current">{{ seg }}</span>
-            }
-          }
+        <div class="file-browser-step">
+          <button class="btn btn--secondary btn--sm back-btn" (click)="backFromFileBrowser()" title="Return to the previous step">&larr; Back</button>
+          <vt-folder-browser
+            [browse]="browseFn"
+            [rootLabel]="browseSourceLabel"
+            [busy]="fileLoading"
+            emptyMessage="No media files found in this directory."
+            (confirm)="onFileConfirmed($event)"
+          ></vt-folder-browser>
         </div>
-
-        @if (fileLoading) {
-          <p class="empty-state">Loading...</p>
-        }
-
-        @if (!fileLoading && browseEntries.length > 0) {
-          <div class="browse-list">
-            @for (entry of browseEntries; track entry.path) {
-              @if (entry.isDir) {
-                <button class="browse-item browse-dir" (click)="enterDirectory(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="folder"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                </button>
-              } @else {
-                <button class="browse-item browse-file" (click)="selectFile(entry)" [title]="entry.path">
-                  <span class="entry-icon"><vt-icon type="file-text"></vt-icon></span> {{ entry.name }}
-                  @if (entry.modified_at) {
-                    <span class="entry-date">{{ entry.modified_at }}</span>
-                  }
-                  @if (entry.size_bytes != null) {
-                    <span class="entry-size">{{ formatSize(entry.size_bytes) }}</span>
-                  }
-                </button>
-              }
-            }
-          </div>
-        }
-
-        @if (!fileLoading && browseEntries.length === 0) {
-          <p class="empty-state">No media files found in this directory.</p>
-        }
       }
     </div>
   } @else {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -135,57 +135,14 @@
   }
 }
 
-.browse-file {
+// (Breadcrumbs, file rows, and entry metadata are now rendered by
+// vt-folder-browser. The file-browser-step wrapper just stacks the
+// Back button and the folder browser.)
+
+.file-browser-step {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.entry-icon {
-  margin-right: 0.35rem;
-}
-
-.entry-date {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  margin-left: auto;
-  padding-left: 0.5rem;
-  white-space: nowrap;
-}
-
-.entry-size {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  margin-left: 0;
-  padding-left: 0.5rem;
-}
-
-.breadcrumbs {
-  margin-bottom: 0.75rem;
-  font-size: 0.8rem;
-}
-
-.breadcrumb-link {
-  background: none;
-  border: none;
-  color: var(--text-link);
-  cursor: pointer;
-  padding: 0;
-  font-size: inherit;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
-.breadcrumb-current {
-  color: var(--text-primary);
-  font-weight: 500;
-}
-
-.breadcrumb-sep {
-  margin: 0 0.25rem;
-  color: var(--text-secondary);
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .empty-state {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -1,7 +1,13 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { map } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
+import {
+  FolderBrowserBrowseFn,
+  FolderBrowserComponent,
+  FolderBrowserFileEntry,
+} from '../../folder-browser/folder-browser.component';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { DatasetsApiService } from '../../../services/datasets-api.service';
 import { DetectorsApiService } from '../../../services/detectors-api.service';
@@ -17,20 +23,12 @@ interface BrowseItem {
   display: string;
 }
 
-interface BrowseEntry {
-  name: string;
-  path: string;
-  size_bytes?: number;
-  modified_at?: string;
-  isDir: boolean;
-}
-
 type MediaPickerView = 'sources' | 'browse-items' | 'file-browser';
 
 @Component({
   selector: 'vt-load-sort-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent, IconComponent, MediaCropModalComponent],
+  imports: [CommonModule, ModalComponent, IconComponent, FolderBrowserComponent, MediaCropModalComponent],
   templateUrl: './load-sort-modal.component.html',
   styleUrl: './load-sort-modal.component.scss',
 })
@@ -55,9 +53,21 @@ export class LoadSortModalComponent implements OnInit {
 
   // File browser state (for demo & folder drill-down)
   browseSource = '';
-  browsePath: string[] = [];
-  browseEntries: BrowseEntry[] = [];
+  browseSourceLabel = '';
   fileLoading = false;
+
+  /** Browse fn for the embedded ``<vt-folder-browser>``.  Routes through
+   *  ``/api/browse-media-files`` with whichever source the user picked
+   *  (``demo:<name>`` or ``folder``). */
+  readonly browseFn: FolderBrowserBrowseFn = (path: string) =>
+    this.datasetsApi.browseMediaFiles(this.browseSource, path).pipe(
+      map((res) => ({
+        directories: res.directories || [],
+        files: res.files || [],
+        rootPath: res.root_path,
+        currentPath: path,
+      })),
+    );
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -162,9 +172,8 @@ export class LoadSortModalComponent implements OnInit {
     this.selectedSource = null;
     this.mediaPickerView = 'sources';
     this.browseItems = [];
-    this.browseEntries = [];
-    this.browsePath = [];
     this.browseSource = '';
+    this.browseSourceLabel = '';
     this.loadMediaSources();
   }
 
@@ -242,50 +251,22 @@ export class LoadSortModalComponent implements OnInit {
   private startFileBrowsing(source: string, label: string): void {
     this.mediaPickerView = 'file-browser';
     this.browseSource = source;
-    this.browsePath = [label];
-    this.loadDirectory('');
+    this.browseSourceLabel = label;
   }
 
-  private loadDirectory(relPath: string): void {
-    this.fileLoading = true;
-    this.browseEntries = [];
-
-    this.datasetsApi.browseMediaFiles(this.browseSource, relPath).subscribe({
-      next: (res) => {
-        const entries: BrowseEntry[] = [];
-        for (const d of res.directories || []) {
-          entries.push({ name: d.name, path: d.path, modified_at: d.modified_at, isDir: true });
-        }
-        for (const f of res.files || []) {
-          entries.push({ name: f.name, path: f.path, size_bytes: f.size_bytes, modified_at: f.modified_at, isDir: false });
-        }
-        this.browseEntries = entries;
-        this.fileLoading = false;
-      },
-      error: () => {
-        this.fileLoading = false;
-      },
-    });
+  /** Back-arrow handler for the file-browser view — returns to the
+   *  source-listing step that opened it (demo list / saved-datasets
+   *  list). */
+  backFromFileBrowser(): void {
+    this.mediaPickerView = this.selectedSource?.name === 'demo' ? 'browse-items' : 'sources';
+    this.browseSource = '';
+    this.browseSourceLabel = '';
   }
 
-  enterDirectory(entry: BrowseEntry): void {
-    this.browsePath.push(entry.name);
-    this.loadDirectory(entry.path);
-  }
-
-  navigateBreadcrumb(index: number): void {
-    if (index === 0) {
-      this.mediaPickerView = 'browse-items';
-      this.browseEntries = [];
-      this.browsePath = [];
-      return;
-    }
-    this.browsePath = this.browsePath.slice(0, index + 1);
-    const relPath = this.browsePath.slice(1).join('/');
-    this.loadDirectory(relPath);
-  }
-
-  selectFile(entry: BrowseEntry): void {
+  /** Confirm handler for the file browser — materialises the picked
+   *  file via ``/api/browse-media-files/select`` and kicks off an
+   *  example sort. */
+  onFileConfirmed(entry: FolderBrowserFileEntry): void {
     this.fileLoading = true;
     this.datasetsApi.selectBrowsedFile(this.browseSource, entry.path).subscribe({
       next: (res) => {

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -182,7 +182,7 @@
 
 .col-num { text-align: right; padding-right: 12px; }
 
-.col-desc, .col-name, .sf-dir-name, .col-status {
+.col-desc, .col-name, .col-status {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -207,91 +207,6 @@
 .badge-embedding { background: var(--badge-embedding, var(--accent)); }
 .badge-download { background: var(--border); color: var(--text-muted); }
 
-// --- Server folder browser ---
-
-.sf-breadcrumbs {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  font-size: .8rem;
-  flex-wrap: wrap;
-}
-
-.sf-breadcrumb {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 3px;
-  font-size: .8rem;
-
-  &:hover { background: var(--bg-subtle); }
-
-  &.active {
-    color: var(--text-primary);
-    font-weight: 600;
-    cursor: default;
-    &:hover { background: none; }
-  }
-}
-
-.sf-breadcrumb-sep { color: var(--text-muted); font-size: .75rem; }
-
-.sf-dir-list {
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  max-height: 320px;
-  overflow-y: auto;
-}
-
-.sf-dir-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-  text-align: left;
-  color: var(--text-primary);
-  font-size: .85rem;
-  transition: background .15s;
-
-  &:last-child { border-bottom: none; }
-  &:hover:not(:disabled) { background: var(--bg-subtle); }
-  &:disabled { opacity: 0.55; cursor: wait; }
-}
-
-.sf-dir-icon { font-size: .9rem; flex-shrink: 0; }
-
-.sf-dir-date {
-  margin-left: auto;
-  color: var(--text-muted);
-  font-size: .75rem;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.sf-empty-dir {
-  color: var(--text-muted);
-  font-size: .8rem;
-  padding: 12px;
-  text-align: center;
-}
-
-.sf-selected-path { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
-
-.sf-path-display {
-  font-size: .8rem;
-  color: var(--text-secondary, var(--text-muted));
-  background: var(--bg-subtle);
-  padding: 3px 8px;
-  border-radius: 3px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-}
+// (The server folder browser chrome — breadcrumbs, list, items, path
+// footer — now lives in `vt-folder-browser`. See
+// frontend/src/app/components/folder-browser/.)


### PR DESCRIPTION
## Summary

§7.5 of `docs/plans/ux-brainstorm.md`, Phase 1. The folder browser pattern lived in four parallel implementations across the frontend, with overlapping but slightly different UI. This consolidates them into a single `<vt-folder-browser>` component and brings the interaction closer to the OS standard (single-click selects, double-click enters / confirms, full keyboard nav, sortable columns).

- New `frontend/src/app/components/folder-browser/` component consumes a caller-supplied browse function, so the same UI sits on top of both `/api/browse` and `/api/browse-media-files` (folder + `demo:*` sources). No new backend endpoints.
- Four call sites migrated: `FileBrowserComponent` (now a thin "text input + Browse toggle" wrapper that embeds `<vt-folder-browser>`), `dataset-importer-modal`'s `sf-*` server-folder picker, `new-detector-modal`'s server-folder + demo file pickers, `load-sort-modal`'s file-browser view.
- The legacy `.sf-*` chrome rules in `_picker-shared.scss` and the equivalent breadcrumb / file-row rules in `load-sort-modal.component.scss` are deleted.

### OS-standard interaction landed in Phase 1

- Single-click highlights a row (selection state); double-click enters a directory or confirms a file.
- Keyboard: `↑/↓` move selection, `Home`/`End` jump, `Enter` activates the selected row, `Backspace` (or `Alt+↑`) goes to the parent, type-ahead jumps to the first row whose name starts with the typed prefix (800ms reset).
- Column-header sort (Name / Modified / Size) with a sticky header; directories always group above files.
- Optional absolute-path footer via `[showPathFooter]="true"` for flows where the resolved server path is the affordance the user actually picks (the server-folder importer).

### Deferred to Phase 2 (recorded in `docs/plans/ux-brainstorm.md`)

- Left sidebar with **Pinned** (`SERVER_ROOTS`, `saved_datasets_dir`, `detectors_dir`), **Bookmarks** (user-starred), **Recent** (MRU). Needs new per-user settings keys `recent_browse_paths` / `bookmarked_browse_paths`.
- Address-bar mode (click breadcrumb whitespace → editable text input, Enter to navigate).
- New-folder action (needs a `POST /api/browse/mkdir` route guarded by the existing path-validation chain).

## Test plan

- [x] `npm run build:prod` — clean (no TypeScript or template-typecheck errors).
- [x] `python -m pytest tests/core tests/api tests/integration tests/datasets tests/io tests/detectors tests/sorting tests/converters tests/cli -m "not gpu and not slow"` — all 3,530 backend tests pass.
- [x] Hit `GET /api/browse` and `GET /api/browse-media-files?source=folder` against a running `python app.py` — both still return the expected `{directories, files, root_path}` / `{directories, files, current_path}` shape the new component consumes.
- [ ] Manual UI spot-check across the migrated modals (Add Dataset → Server Folder, New Detector → Server Folder, New Detector → Demo, Load Sort → Server Folder / Demo, file-picker fields in Export / Settings Importer / Settings Exporter / Label Importer).

## Notes for reviewer

- `./run-tests.sh` itself is currently blocked on a pre-existing `npm audit` advisory (`webpack-dev-server` ≤5.2.3, pulled in by `@angular-devkit/build-angular` 19.2.22, "No fix available" upstream). This advisory was published after the audit step was added on March 27 and would fire on `dev` today; I'm flagging rather than silencing it. The backend pytest groups were run directly to verify there's no regression from my changes.
- This intentionally changes click semantics for casual users: previously a single click on a directory entered it. The §7.5 brief calls out "double-click to enter, Enter key to confirm" as the standard target, so single-click is now select-only. Keyboard nav (`Enter`) gives the OS-equivalent shortcut.


---
_Generated by [Claude Code](https://claude.ai/code/session_015qbzDVKkVnKru1pEJNpirh)_