### PR TITLE
fix(tests): drain dataset-load gates between TestLoadingGates tests

### DIFF
--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -587,6 +587,41 @@ class TestConcurrentModelLoading:
 class TestLoadingGates:
     """Verify the download/embed gates serialise (or pipeline) concurrent loads."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_loading_gates(self):
+        """Drain the dataset-load gates around each test in this class.
+
+        ``conftest.reset_state`` clears the loading-tasks dict between
+        tests but cannot stop worker threads from a prior test that are
+        still holding ``_download_gate`` / ``_embed_gate``. When the
+        suite is under load and a leaked thread is still draining when
+        this test starts, the assertions on ``gate.active`` see stale
+        counts and the test fails with a cryptic ``assert 1 == 0``.
+
+        This fixture cancels any in-flight loading tasks and waits for
+        both gates to settle at zero before yielding, then does the
+        same again on teardown so the next test starts clean.
+        """
+        from vtsearch.datasets.load_pipeline import _download_gate, _embed_gate
+
+        def drain(timeout_s: float = 10.0) -> None:
+            loading_tasks.cancel_all()
+            deadline = time.time() + timeout_s
+            while time.time() < deadline:
+                if _download_gate.active == 0 and _embed_gate.active == 0 and not loading_tasks.has_active_tasks():
+                    return
+                time.sleep(0.05)
+
+        drain()
+        assert _download_gate.active == 0, (
+            "Download gate not clean at test start — a prior test leaked a thread that is still holding the gate."
+        )
+        assert _embed_gate.active == 0, (
+            "Embed gate not clean at test start — a prior test leaked a thread that is still holding the gate."
+        )
+        yield
+        drain()
+
     def test_second_load_waits_for_first(self):
         """With the download limit at 1, a second load should show 'Waiting…'
         for the download gate and only proceed after the first releases it."""


### PR DESCRIPTION
## Summary

Fixes a long-suite flake in `TestLoadingGates::test_download_and_embed_can_overlap` (and its sibling tests) where assertions on `_download_gate.active` / `_embed_gate.active` would intermittently fail with a cryptic `assert 1 == 0` after ~4 minutes of full-suite churn.

**Root cause**: the `_download_gate` and `_embed_gate` in `vtsearch/datasets/load_pipeline.py` are module-level singletons. `conftest.reset_state` calls `_loading_tasks.reset_for_tests()` between tests, which clears the tasks dict but does NOT cancel or join the worker threads — those threads continue to hold their gate until they finish their post-load cleanup. When the suite is under load and a leaked worker is still draining at the moment one of these tests runs, the gate-count assertions see a stale `1` instead of `0`.

**Fix**: add a class-level autouse fixture to `TestLoadingGates` that, before each test, calls `loading_tasks.cancel_all()` and waits up to 10 seconds for both gates to settle at zero. If they don't, the test fails fast with a clear message about a state leak instead of the cryptic `1 == 0`. Same drain runs on teardown so the next test in the class starts clean.

This is a test-only change — no runtime code is modified.

## Test plan

- [x] `python -m pytest tests/datasets/test_parallel_loading.py::TestLoadingGates` — passes 5 consecutive runs.
- [x] `python -m pytest tests/datasets/` (494 tests) — passes 2 consecutive runs.
- [x] Full fast suite `python -m pytest tests/ -m 'not gpu and not slow'` — 3662 passed.
- [x] `ruff check` / `ruff format --check` clean.

https://claude.ai/code/session_01XMdfrKW5DEqEH8YA45ViU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMdfrKW5DEqEH8YA45ViU5)_