### PR TITLE
Add SoundSilenceClipper for silence-aware audio splitting

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -83,7 +83,7 @@ Today the framework allows one converter per source; consider explicit chains: `
 ## 3. New MediaClippers
 
 ### 3.1 Audio
-- **`sound_silence`** ★★ S — split on silence (librosa `effects.split`). Drop intro/outro silence. Param: `top_db`.
+- **`sound_silence`** ★★ S ✅ shipped — split on silence (librosa `effects.split`). Drop intro/outro silence. Params: `top_db`, `min_clip_duration` (drops noise-spike micro-clips), `pad` (keeps attack/decay around each interval). See `vtsearch/media/audio/clipper.py` (`SoundSilenceClipper`).
 - **`sound_beat`** ★ S — split on detected beats / downbeats (madmom). For music datasets.
 - **`sound_speech_activity`** ★★ S — VAD-based segmentation (Silero VAD). Useful for podcasts.
 - **`sound_energy_envelope`** ★ S — segment around energy peaks (find drum hits, claps, gunshots).

--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -933,6 +933,46 @@ checks off this follow-up.
       stay because the generated equivalents are loose
       ``{[key: string]: any}`` and the local versions describe the
       actual fields consumers read.
+- [x] ``LabelingStatusResponse`` consumers tightened to the generated
+      shape. Backend ``LabelingStatusResponseSchema`` (``vtsearch/schemas/eval.py``)
+      declares ``smart`` / ``stable`` / ``span`` as nested
+      ``StatusIndicatorSchema`` instances with a required ``status`` and an
+      optional ``reason``; ``Meta.unknown = "include"`` plus a
+      ``@post_dump(pass_original=True)`` hook preserves the metric-specific
+      keys (``cost``, ``flips``, ``avg_flip_rate``, ``diversity_level``,
+      ``max_level``, …) — ``unknown = "include"`` only affects ``load``, so
+      the post-dump re-merge is required to keep them in the response.
+      The generated TS ``StatusIndicator`` is ``{status: string; reason?:
+      string; [key: string]: any}``; ``LabelingStatusResponse`` references
+      it directly. ``AutopilotStateService``,
+      ``AutopilotStateService.spec``, ``LabelViewComponent``,
+      ``LeftPanelComponent``, ``ProgressIndicatorsComponent``, and
+      ``AutopilotPanelComponent`` all now ``import type`` the generated
+      ``LabelingStatusResponse`` from
+      ``generated/api-client/models/labeling-status-response``; the
+      ``startStatusPolling`` cast in ``LabelViewComponent`` is gone. The
+      spec file added a tiny ``makeStatus`` helper to construct fixtures
+      with the now-required ``good_count`` / ``bad_count`` /
+      ``total_count`` defaults. Removed from ``api.models.ts``:
+      ``StatusIndicator`` and ``LabelingStatusResponse``.
+- [x] ``MediaItem`` deleted from ``api.models.ts`` and replaced with a
+      generated-types-derived ``Media`` alias. ``MediaStateService`` now
+      stores ``MediaIdsListResponse[]`` (the stub list from
+      ``GET /api/medias/ids``); ``MediaMetadataCacheService`` now stores
+      ``MediaBatchResponse`` (the hydrated payload from
+      ``POST /api/medias/batch``). The renderer surface (media-item, media-
+      list, center panel + audio/video/image/text/document viewers, right
+      panel, label-list, label-view, find-view) consumes
+      ``Media = MediaIdsListResponse & Partial<Omit<RemoveIndex<MediaBatchResponse>,
+      keyof MediaIdsListResponse>>`` — a derivation that admits both stubs
+      (initial listing, cache miss) and hydrated batch entries, with the
+      ``MediaBatchResponse`` index signature stripped so direct property
+      access works under ``noPropertyAccessFromIndexSignature``. Sites
+      that read ``filename`` / ``origin_name`` for display via
+      ``mediaState.medias.find(…)`` were rerouted through a new
+      ``MediaStateService.getMedia(id)`` helper that returns the cached
+      batch first and falls back to the stub (same pattern as the
+      ``selectedMedia`` getter).
 
 ## Open follow-ups
 
@@ -950,29 +990,6 @@ checks off this follow-up.
   function-module paths for runtime symbols, no barrel) are required
   to keep the initial bundle under the 525 kB budget — see
   *Bundle-size discipline* above.
-- **Tighten ``LabelingStatusResponse`` consumers to the generated
-  shape.** ``SortingApiService.getLabelingStatus`` returns the generated
-  ``LabelingStatusResponse`` (``smart``/``stable``/``span`` typed as
-  ``{[key: string]: any}``), but ``LabelViewComponent`` keeps the legacy
-  ``LabelingStatusResponse`` (with ``StatusIndicator``-bearing fields)
-  for its ``labelingStatus`` member because the downstream chain
-  (``AutopilotStateService``, ``AutopilotPanelComponent``,
-  ``LeftPanelComponent`` and their spec files) all read
-  ``status.smart?.status`` / ``status.stable?.status`` /
-  ``status.span?.status``. A single cast at the polling subscribe
-  bridges the type gap. A follow-up PR can either retype every consumer
-  to the generated shape (and update the spec literals to include the
-  newly-required ``good_count`` / ``bad_count`` / ``total_count`` /
-  ``smart.status`` / ``stable.status`` / ``span.status`` fields) or
-  introduce a narrow ``StatusIndicator`` typed-projection layer.
-- **Replace ``MediaItem`` with the generated ``MediaIdsListResponse`` /
-  ``MediaBatchResponse`` pair.** ``MediaItem`` is the loose union type
-  consumed by ~20 components and the metadata cache. The
-  ``MediasApiService`` migration kept it in place because rewiring every
-  consumer is a larger task than swapping the service itself.  A
-  follow-up should narrow each consumer's type (lightweight stub vs.
-  full batch-response) and delete ``MediaItem`` from
-  ``api.models.ts``.
 - **Per-plugin schemas for plugin-field routes.** The four routes
   whose request body is a plugin-field shape stay on the legacy
   plain-Flask path on their (now smorest-typed) blueprints:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,4 +1,3 @@
-⏳ Initializing VTSearch... (PID 11505)
 {
   "components": {
     "responses": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,3 +1,4 @@
+⏳ Initializing VTSearch... (PID 11505)
 {
   "components": {
     "responses": {
@@ -2819,16 +2820,13 @@
             "type": "integer"
           },
           "smart": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/StatusIndicator"
           },
           "span": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/StatusIndicator"
           },
           "stable": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/StatusIndicator"
           },
           "total_count": {
             "type": "integer"
@@ -3772,6 +3770,21 @@
         "required": [
           "results",
           "threshold"
+        ],
+        "type": "object"
+      },
+      "StatusIndicator": {
+        "additionalProperties": true,
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
         ],
         "type": "object"
       },

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayerComponent } from './audio-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('AudioPlayerComponent', () => {
   let component: AudioPlayerComponent;
   let fixture: ComponentFixture<AudioPlayerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 1,
     type: 'audio',
     filename: 'test.wav',

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -20,7 +20,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './audio-player.component.scss',
 })
 export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
   @Input() volume = 1;
   @Input() audioPlaying = true;
   @Input() swipeClass = '';

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { CenterPanelComponent } from './center-panel.component';
-import { MediaItem } from '../../models/api.models';
+import { Media } from '../../models/api.models';
 import { RegionBox } from './image-viewer/image-viewer.component';
 
 describe('CenterPanelComponent', () => {
@@ -10,7 +10,7 @@ describe('CenterPanelComponent', () => {
   let fixture: ComponentFixture<CenterPanelComponent>;
   let httpMock: HttpTestingController;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 1,
     type: 'audio',
     filename: 'test.wav',
@@ -154,7 +154,7 @@ describe('CenterPanelComponent', () => {
    * region-agnostic — see "Vote attribution → v2" in docs/plans/patch-embedder.md).
    */
   describe('vote-API contract for region_box', () => {
-    const imageMedia: MediaItem = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const imageMedia: Media = { ...mockMedia, type: 'image', filename: 'pic.png' };
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
@@ -218,7 +218,7 @@ describe('CenterPanelComponent', () => {
    * clears the armed state and keeps the box.
    */
   describe('sticky bad-vote-confirm armed state', () => {
-    const imageMedia: MediaItem = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const imageMedia: Media = { ...mockMedia, type: 'image', filename: 'pic.png' };
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
@@ -275,7 +275,7 @@ describe('CenterPanelComponent', () => {
       component.castVote('bad');
       expect(component.pendingBadConfirm).toBeTrue();
 
-      const next: MediaItem = { ...imageMedia, id: 2, filename: 'next.png' };
+      const next: Media = { ...imageMedia, id: 2, filename: 'next.png' };
       component.media = next;
       component.ngOnChanges({
         media: {

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
-import { MediaItem } from '../../models/api.models';
+import { Media } from '../../models/api.models';
 import { MediasApiService } from '../../services/medias-api.service';
 import { KeyboardService } from '../../services/keyboard.service';
 import { VoteStateService } from '../../services/vote-state.service';
@@ -30,7 +30,7 @@ import { prefersReducedMotion } from '../../utils/reduced-motion';
   styleUrl: './center-panel.component.scss',
 })
 export class CenterPanelComponent implements OnChanges, OnDestroy {
-  @Input() media: MediaItem | null = null;
+  @Input() media: Media | null = null;
   @Input() disabled = false;
   @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
@@ -179,7 +179,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   /** Human-readable label for an item used in undo toasts. */
-  private mediaDisplayName(media: MediaItem): string {
+  private mediaDisplayName(media: Media): string {
     return media.filename || media.origin_name || `#${media.id}`;
   }
 

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DocumentViewerComponent } from './document-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('DocumentViewerComponent', () => {
   let component: DocumentViewerComponent;
   let fixture: ComponentFixture<DocumentViewerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 5,
     type: 'document',
     filename: 'test.pdf',

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './document-viewer.component.scss',
 })
 export class DocumentViewerComponent implements OnChanges {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
 
   mediaSrc = '';
 

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -2,13 +2,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ElementRef } from '@angular/core';
 import { ImageViewerComponent, RegionBox } from './image-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('ImageViewerComponent', () => {
   let component: ImageViewerComponent;
   let fixture: ComponentFixture<ImageViewerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 2,
     type: 'image',
     filename: 'test.png',
@@ -389,7 +389,7 @@ describe('ImageViewerComponent', () => {
 
     it('persists across media changes', () => {
       component.marqueeMode = true;
-      const next: MediaItem = { ...mockMedia, id: 99, filename: 'b.png' };
+      const next: Media = { ...mockMedia, id: 99, filename: 'b.png' };
       component.media = next;
       component.ngOnChanges({
         media: { currentValue: next, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { NgStyle } from '@angular/common';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 export type RegionBox = readonly [number, number, number, number];
@@ -32,7 +32,7 @@ const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a s
   styleUrl: './image-viewer.component.scss',
 })
 export class ImageViewerComponent implements OnChanges, OnDestroy {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
   /**
    * True while the parent is in the v2 "bad-vote-with-box discard confirm" armed state.
    * The viewer uses it to (a) render the box with a sticky red pulse, and (b) route Esc /

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -2,14 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TextViewerComponent } from './text-viewer.component';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('TextViewerComponent', () => {
   let component: TextViewerComponent;
   let fixture: ComponentFixture<TextViewerComponent>;
   let httpMock: HttpTestingController;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 4,
     type: 'text',
     filename: 'test.txt',

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MediasApiService } from '../../../services/medias-api.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 @Component({
   selector: 'vt-text-viewer',
@@ -10,7 +10,7 @@ import { MediaItem } from '../../../models/api.models';
   styleUrl: './text-viewer.component.scss',
 })
 export class TextViewerComponent implements OnChanges, OnDestroy {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
 
   text = 'Loading...';
   private sub: Subscription | null = null;

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VideoPlayerComponent } from './video-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('VideoPlayerComponent', () => {
   let component: VideoPlayerComponent;
   let fixture: ComponentFixture<VideoPlayerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 3,
     type: 'video',
     filename: 'test.mp4',

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -11,7 +11,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './video-player.component.scss',
 })
 export class VideoPlayerComponent implements OnChanges, OnDestroy {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
   @Input() volume = 1;
   @Input() audioPlaying = true;
   @Output() playingChanged = new EventEmitter<boolean>();

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -372,7 +372,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
     if (this.sortState.sortBusy) return;
-    const m = this.mediaState.medias.find((x) => x.id === event.id);
+    const m = this.mediaState.getMedia(event.id);
     const name = m?.filename || m?.origin_name || `#${event.id}`;
     this.voteState.recordVote(event.id, event.vote, name);
     this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -775,7 +775,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private openCropOverlay(mediaId: number, action: 'sort' | 'seed'): void {
-    const media = this.mediaState.medias.find((m) => m.id === mediaId);
+    const media = this.mediaState.getMedia(mediaId);
     if (!media) return;
     const mediaType = media.type;
     const url =
@@ -846,7 +846,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private mediaDisplayName(id: number): string {
-    const m = this.mediaState.medias.find((x) => x.id === id);
+    const m = this.mediaState.getMedia(id);
     return m?.filename || m?.origin_name || `#${id}`;
   }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -30,7 +30,7 @@ import { ProgressEventsService } from '../../services/progress-events.service';
 import { DetectorRegistryEntry, ProgressEvent } from '../../models/api.models';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
-import { LabelingStatusResponse } from '../../models/api.models';
+import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import type { LearnedSortResponse } from '../../generated/api-client/models/learned-sort-response';
 import { formatProgressMessage } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
@@ -438,14 +438,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       )
       .subscribe({
         next: (status) => {
-          // The generated `LabelingStatusResponse` types `smart` / `stable` /
-          // `span` as `{[key: string]: any}` while the legacy field type
-          // expects `StatusIndicator` with a required `status` string.  The
-          // backend always sends `{status, ...}` for these — the cast is safe
-          // and only crosses the type-system gap until a follow-up tightens
-          // the consumer (autopilot, left-panel, autopilot-panel) to the
-          // generated shape.
-          this.labelingStatus = status as unknown as LabelingStatusResponse;
+          this.labelingStatus = status;
         },
       });
   }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LabelingStatusResponse } from '../../../models/api.models';
+import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 import {
   AutopilotStateService,
   AutopilotPhase,

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -8,7 +8,8 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
-import { MediaItem, LabelingStatusResponse, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import { MediaItem, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -8,7 +8,7 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
-import { MediaItem, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import { Media, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
 import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
@@ -33,7 +33,7 @@ export type { SortMode, SelectMode, SortedItem };
   styleUrl: './left-panel.component.scss',
 })
 export class LeftPanelComponent implements OnInit, OnChanges {
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
   @Input() selectedId: number | null = null;

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MediaItemComponent } from './media-item.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('MediaItemComponent', () => {
   let component: MediaItemComponent;
   let fixture: ComponentFixture<MediaItemComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 1,
     type: 'audio',
     filename: 'test.wav',

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -11,7 +11,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './media-item.component.scss',
 })
 export class MediaItemComponent implements OnChanges {
-  @Input({ required: true }) media!: MediaItem;
+  @Input({ required: true }) media!: Media;
   @Input() active = false;
   @Input() voteLabel: 'good' | 'bad' | null = null;
   @Input() score: number | null = null;

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MediaListComponent } from './media-list.component';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('MediaListComponent', () => {
   let component: MediaListComponent;
   let fixture: ComponentFixture<MediaListComponent>;
 
-  const mockMedias: MediaItem[] = [
+  const mockMedias: Media[] = [
     { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
     { id: 2, type: 'audio', filename: 'b.wav', md5: 'b2', custom_metadata: {} },
     { id: 3, type: 'audio', filename: 'c.wav', md5: 'c3', custom_metadata: {} },

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -16,7 +16,7 @@ import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrollin
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MediaItemComponent } from '../media-item/media-item.component';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { SortedItem } from '../left-panel.component';
 import { prefersReducedMotion } from '../../../utils/reduced-motion';
@@ -36,7 +36,7 @@ const PREFETCH_BUFFER = 50;
   styleUrl: './media-list.component.scss',
 })
 export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
   @Input() selectedId: number | null = null;
@@ -54,7 +54,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
 
   /** Cached ordered items — rebuilt only when inputs change, not on every CD cycle. */
-  cachedOrderedItems: { media: MediaItem; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
+  cachedOrderedItems: { media: Media; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
 
   readonly listItemHeight = LIST_ITEM_HEIGHT;
 
@@ -113,10 +113,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     // rows; fall back to the stub so the row renders immediately and gets
     // upgraded once the batch fetch lands.
     const stubMap = new Map(this.medias.map((m) => [m.id, m]));
-    const enrich = (id: number): MediaItem | undefined =>
+    const enrich = (id: number): Media | undefined =>
       this.metadataCache.get(id) ?? stubMap.get(id);
 
-    const items: { media: MediaItem; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
+    const items: { media: Media; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
 
     if (this.sortOrder && this.sortOrder.length > 0) {
       let thresholdInserted = false;
@@ -229,7 +229,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     });
   }
 
-  trackByMediaId(_index: number, item: { media: MediaItem }): number {
+  trackByMediaId(_index: number, item: { media: Media }): number {
     return item.media.id;
   }
 

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
-import { LabelingStatusResponse } from '../../../models/api.models';
+import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 
 @Component({
   selector: 'vt-progress-indicators',
@@ -24,15 +24,15 @@ export class ProgressIndicatorsComponent {
   }
 
   get smartStatus(): string {
-    return (this.labelingStatus?.smart?.status as string) || '';
+    return this.labelingStatus?.smart.status || '';
   }
 
   get stableStatus(): string {
-    return (this.labelingStatus?.stable?.status as string) || '';
+    return this.labelingStatus?.stable.status || '';
   }
 
   get spanStatus(): string {
-    return (this.labelingStatus?.span?.status as string) || '';
+    return this.labelingStatus?.span.status || '';
   }
 
   get smartSubtext(): string {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LabelListComponent, LabelEntry } from './label-list.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('LabelListComponent', () => {
   let component: LabelListComponent;
   let fixture: ComponentFixture<LabelListComponent>;
 
-  const sampleMedias: MediaItem[] = [
+  const sampleMedias: Media[] = [
     { id: 1, type: 'audio', filename: 'song.wav', md5: 'aaa', custom_metadata: {} },
     { id: 2, type: 'image', filename: 'photo.jpg', md5: 'bbb', custom_metadata: {} },
     { id: 3, type: 'video', filename: 'clip.mp4', md5: 'ccc', custom_metadata: {} },

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChange
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
@@ -25,7 +25,7 @@ export interface LabelEntry {
 export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() clickTimes: Record<string, number> = {};
   @Input() learnedScores: Record<string, number> = {};
   @Input() sortMode: LabelSortMode = 'time-desc';
@@ -40,7 +40,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   sortedEntries: LabelEntry[] = [];
   private pendingScrollPct: number | null = null;
   /** Pre-built Map for O(1) media stub lookups by id (rebuilt when medias input changes). */
-  private mediaMap = new Map<number, MediaItem>();
+  private mediaMap = new Map<number, Media>();
   private readonly destroy$ = new Subject<void>();
 
   constructor(
@@ -80,7 +80,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     this.destroy$.complete();
   }
 
-  private lookup(id: number): MediaItem | undefined {
+  private lookup(id: number): Media | undefined {
     return this.metadataCache.get(id) ?? this.mediaMap.get(id);
   }
 

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DetectorsApiService } from '../../services/detectors-api.service';
 import type { DetectorLabelView } from '../../generated/api-client/models/detector-label-view';
-import { MediaItem } from '../../models/api.models';
+import { Media } from '../../models/api.models';
 import { VoteStateService } from '../../services/vote-state.service';
 import { LabelsetStateService } from '../../services/labelset-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
@@ -40,7 +40,7 @@ export interface TrainModeContext {
   styleUrl: './right-panel.component.scss',
 })
 export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() trainMode: TrainModeContext | null = null;
   @Input() focusMode: 'click' | 'hover' = 'click';
   /** 'label' = Labeling mode (detector export allowed), 'find' = Finding mode (no detector export). */

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -38,23 +38,6 @@ export interface VotesResponse {
   labelset_bad_count?: number;
 }
 
-// --- Labeling Status ---
-
-export interface StatusIndicator {
-  status: string;
-  [key: string]: unknown;
-}
-
-export interface LabelingStatusResponse {
-  good_count?: number;
-  bad_count?: number;
-  total_count?: number;
-  smart?: StatusIndicator;
-  stable?: StatusIndicator;
-  span?: StatusIndicator;
-  [key: string]: unknown;
-}
-
 // --- Progress ---
 
 /**

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -1,31 +1,33 @@
 /* TypeScript interfaces matching the Flask API response shapes. */
 
+import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+
 // --- Medias ---
 
 /**
- * One media item.
- *
- * Only ``id`` and ``type`` are guaranteed — the dataset listing
- * (``GET /api/medias/ids``) returns just those plus an optional
- * ``embedder``.  The remaining display-worthy fields are populated on
- * demand for items currently in the viewport via the metadata cache
- * (``POST /api/medias/batch``).
+ * Strip a type's catch-all index signature (``[key: string]: any``) so
+ * intersecting it with another type doesn't force every property access
+ * to go through the bracket form (TS4111 under
+ * ``noPropertyAccessFromIndexSignature``).
  */
-export interface MediaItem {
-  id: number;
-  type: string;
-  filename?: string;
-  md5?: string;
-  custom_metadata?: Record<string, unknown>;
-  origin_name?: string;
-  description?: string;
-  clip_start?: number;
-  clip_end?: number;
-  clip_index?: number;
-  clip_box?: number[];
-  /** Name of the embedder that produced this media's vector. */
-  embedder?: string;
-}
+type RemoveIndex<T> = {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
+};
+
+/**
+ * The renderable media shape — a stub from ``GET /api/medias/ids``
+ * (``id``, ``type``, optional ``embedder``) optionally augmented with the
+ * full per-item metadata returned by ``POST /api/medias/batch``
+ * (``filename``, ``md5``, ``custom_metadata``, clip extents, …).
+ *
+ * Derived directly from the two generated DTOs so backend schema changes
+ * propagate without a hand-maintained mirror.  Components consume this
+ * type wherever the data flow can deliver either a stub (initial listing,
+ * cache miss) or a hydrated batch entry.
+ */
+export type Media = MediaIdsListResponse &
+  Partial<Omit<RemoveIndex<MediaBatchResponse>, keyof MediaIdsListResponse>>;
 
 // --- Sorting ---
 

--- a/frontend/src/app/services/autopilot-state.service.spec.ts
+++ b/frontend/src/app/services/autopilot-state.service.spec.ts
@@ -1,6 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 import { AutopilotStateService } from './autopilot-state.service';
-import { LabelingStatusResponse } from '../models/api.models';
+import type { LabelingStatusResponse } from '../generated/api-client/models/labeling-status-response';
+import type { StatusIndicator } from '../generated/api-client/models/status-indicator';
+
+function makeStatus(
+  smart: StatusIndicator,
+  stable: StatusIndicator,
+  span: StatusIndicator,
+): LabelingStatusResponse {
+  return { good_count: 0, bad_count: 0, total_count: 0, smart, stable, span };
+}
 
 describe('AutopilotStateService', () => {
   let service: AutopilotStateService;
@@ -56,11 +65,11 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    const status: LabelingStatusResponse = {
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    };
+    const status: LabelingStatusResponse = makeStatus(
+      { status: 'green' },
+      { status: 'green' },
+      { status: 'yellow' },
+    );
     service.updateFromLabelingStatus(status);
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
@@ -71,18 +80,14 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'green' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'green' }),
+    );
     service.checkPhaseTransition(15, 15);
     expect(service.state.phase).toBe('done');
   });
@@ -92,20 +97,16 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Smart drops to yellow (surprise destabilized the model)
-    service.updateFromLabelingStatus({
-      smart: { status: 'yellow' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'yellow' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('hard');
   });
@@ -115,20 +116,16 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Stable drops to yellow (surprise caused prediction flips)
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'yellow' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'yellow' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('hard');
   });
@@ -138,29 +135,23 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Bounce back to hard
-    service.updateFromLabelingStatus({
-      smart: { status: 'yellow' },
-      stable: { status: 'yellow' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'yellow' }, { status: 'yellow' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('hard');
 
     // Indicators recover — should go back to new
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(15, 15);
     expect(service.state.phase).toBe('new');
   });
@@ -170,20 +161,16 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Both still green — should stay in new
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('new');
   });
@@ -203,11 +190,11 @@ describe('AutopilotStateService', () => {
 
   it('updateFromLabelingStatus should update status fields', () => {
     service.activate();
-    const status: LabelingStatusResponse = {
-      smart: { status: 'yellow' },
-      stable: { status: 'green' },
-      span: { status: 'red', diversity_level: 0.75 },
-    };
+    const status: LabelingStatusResponse = makeStatus(
+      { status: 'yellow' },
+      { status: 'green' },
+      { status: 'red', diversity_level: 0.75 },
+    );
     service.updateFromLabelingStatus(status);
 
     expect(service.state.smartStatus).toBe('yellow');

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LabelingStatusResponse } from '../models/api.models';
+import type { LabelingStatusResponse } from '../generated/api-client/models/labeling-status-response';
 
 export type AutopilotPhase = 'idle' | 'good' | 'bad' | 'hard' | 'new' | 'done';
 
@@ -68,11 +68,11 @@ export class AutopilotStateService {
     const current = this.stateSubject.value;
     this.stateSubject.next({
       ...current,
-      smartStatus: (status.smart?.status as string) || '',
-      stableStatus: (status.stable?.status as string) || '',
-      spanStatus: (status.span?.status as string) || '',
+      smartStatus: status.smart.status || '',
+      stableStatus: status.stable.status || '',
+      spanStatus: status.span.status || '',
       fracDiversity:
-        status.span?.['diversity_level'] != null
+        status.span['diversity_level'] != null
           ? (status.span['diversity_level'] as number)
           : current.fracDiversity,
     });

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MediaItem } from '../models/api.models';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
 import { MediasApiService } from './medias-api.service';
 
 /**
@@ -23,12 +23,12 @@ const BATCH_SIZE = 200;
  *   1. Call `ensureLoaded(ids)` with the IDs the viewport needs.
  *   2. Subscribe to `version$` to re-render when new items arrive, or call
  *      `get(id)` to read a single cached item.
- *   3. `toMediaItems(ids)` returns MediaItem[] for already-cached IDs (skips
- *      unknown ones so the template can render immediately).
+ *   3. `toMediaItems(ids)` returns MediaBatchResponse[] for already-cached
+ *      IDs (skips unknown ones so the template can render immediately).
  */
 @Injectable({ providedIn: 'root' })
 export class MediaMetadataCacheService implements OnDestroy {
-  private readonly cache = new Map<number, MediaItem>();
+  private readonly cache = new Map<number, MediaBatchResponse>();
   private readonly pendingIds = new Set<number>();
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly destroy$ = new Subject<void>();
@@ -45,8 +45,8 @@ export class MediaMetadataCacheService implements OnDestroy {
     if (this.batchTimer) clearTimeout(this.batchTimer);
   }
 
-  /** Return a cached MediaItem or undefined if not yet fetched. */
-  get(id: number): MediaItem | undefined {
+  /** Return a cached metadata entry or undefined if not yet fetched. */
+  get(id: number): MediaBatchResponse | undefined {
     return this.cache.get(id);
   }
 
@@ -85,11 +85,11 @@ export class MediaMetadataCacheService implements OnDestroy {
   }
 
   /**
-   * Build a MediaItem[] for the given IDs using cached data.
+   * Build a MediaBatchResponse[] for the given IDs using cached data.
    * IDs that are not yet cached are omitted.
    */
-  toMediaItems(ids: number[]): MediaItem[] {
-    const result: MediaItem[] = [];
+  toMediaItems(ids: number[]): MediaBatchResponse[] {
+    const result: MediaBatchResponse[] = [];
     for (const id of ids) {
       const item = this.cache.get(id);
       if (item) result.push(item);

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -2,13 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { MediaStateService } from './media-state.service';
-import { MediaItem } from '../models/api.models';
+import { Media } from '../models/api.models';
 
 describe('MediaStateService', () => {
   let service: MediaStateService;
   let httpMock: HttpTestingController;
 
-  const mockMedias: MediaItem[] = [
+  const mockMedias: Media[] = [
     { id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} },
     { id: 2, type: 'image', filename: 'b.png', md5: 'def', custom_metadata: {} },
   ];
@@ -68,7 +68,7 @@ describe('MediaStateService', () => {
   });
 
   it('medias$ should emit on load', (done) => {
-    const emissions: MediaItem[][] = [];
+    const emissions: Media[][] = [];
     service.medias$.subscribe((m) => emissions.push(m));
 
     service.loadMedias();

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MediaItem } from '../models/api.models';
+import type { Media } from '../models/api.models';
+import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import { MediasApiService } from './medias-api.service';
 import { MediaMetadataCacheService } from './media-metadata-cache.service';
 
@@ -17,7 +18,7 @@ import { MediaMetadataCacheService } from './media-metadata-cache.service';
  */
 @Injectable({ providedIn: 'root' })
 export class MediaStateService implements OnDestroy {
-  private readonly mediasSubject = new BehaviorSubject<MediaItem[]>([]);
+  private readonly mediasSubject = new BehaviorSubject<MediaIdsListResponse[]>([]);
   private readonly selectedIdSubject = new BehaviorSubject<number | null>(null);
   private readonly destroy$ = new Subject<void>();
 
@@ -34,7 +35,7 @@ export class MediaStateService implements OnDestroy {
     this.destroy$.complete();
   }
 
-  get medias(): MediaItem[] {
+  get medias(): MediaIdsListResponse[] {
     return this.mediasSubject.value;
   }
 
@@ -42,9 +43,18 @@ export class MediaStateService implements OnDestroy {
     return this.selectedIdSubject.value;
   }
 
-  get selectedMedia(): MediaItem | null {
+  get selectedMedia(): Media | null {
     const id = this.selectedIdSubject.value;
     if (id === null) return null;
+    return this.getMedia(id);
+  }
+
+  /**
+   * Return the best-available representation of a media item: the cached
+   * batch entry (with ``filename`` / ``md5`` / metadata) if loaded, else
+   * the stub from the dataset listing, else ``null``.
+   */
+  getMedia(id: number): Media | null {
     const cached = this.metadataCache.get(id);
     if (cached) return cached;
     return this.mediasSubject.value.find((m) => m.id === id) ?? null;

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -308,6 +308,226 @@ class TestSoundClipClipper:
 
 
 # ---------------------------------------------------------------------------
+# SoundSilenceClipper
+# ---------------------------------------------------------------------------
+
+
+def _concat_wavs(*wavs: bytes) -> bytes:
+    """Concatenate multiple WAV byte strings into a single WAV file.
+
+    All inputs must share the same sample rate, channel count, and sample
+    width.  Used to build tone/silence/tone test fixtures.
+    """
+    all_frames: list[bytes] = []
+    params = None
+    for wb in wavs:
+        with wave.open(io.BytesIO(wb), "rb") as wf:
+            if params is None:
+                params = wf.getparams()
+            all_frames.append(wf.readframes(wf.getnframes()))
+    assert params is not None
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as out:
+        out.setparams(params)
+        out.writeframes(b"".join(all_frames))
+    return buf.getvalue()
+
+
+class TestSoundSilenceClipper:
+    def test_identity(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        c = SoundSilenceClipper()
+        assert c.name == "sound_silence"
+        assert c.media_type == "audio"
+        assert c.top_db == 40.0
+        assert c.min_clip_duration == 0.3
+        assert c.pad == 0.05
+        assert isinstance(c, MediaClipper)
+
+    def test_custom_params(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        c = SoundSilenceClipper(top_db=20.0, min_clip_duration=0.5, pad=0.1)
+        assert c.top_db == 20.0
+        assert c.min_clip_duration == 0.5
+        assert c.pad == 0.1
+
+    def test_rejects_non_positive_top_db(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        with pytest.raises(ValueError):
+            SoundSilenceClipper(top_db=0)
+        with pytest.raises(ValueError):
+            SoundSilenceClipper(top_db=-1)
+
+    def test_rejects_negative_min_clip_duration(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        with pytest.raises(ValueError):
+            SoundSilenceClipper(min_clip_duration=-0.1)
+
+    def test_rejects_negative_pad(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        with pytest.raises(ValueError):
+            SoundSilenceClipper(pad=-0.1)
+
+    def test_no_media_bytes_returns_unchanged(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        media = {"id": 1, "type": "audio", "duration": 3.0}
+        result = SoundSilenceClipper().clip(media)
+        assert result == [media]
+
+    def test_invalid_bytes_returns_unchanged(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        media = {"id": 1, "type": "audio", "media_bytes": b"not a wav", "duration": 1.0}
+        result = SoundSilenceClipper().clip(media)
+        assert result == [media]
+
+    def test_splits_tone_silence_tone(self):
+        """Tone | silence | tone | silence | tone → three non-silent clips."""
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        # Build a 5 s clip: 1 s tone, 1 s silence, 1 s tone, 1 s silence, 1 s tone.
+        wav = _concat_wavs(
+            generate_wav(440, 1.0),
+            generate_wav(0, 1.0),
+            generate_wav(440, 1.0),
+            generate_wav(0, 1.0),
+            generate_wav(440, 1.0),
+        )
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 5.0}
+
+        result = SoundSilenceClipper(top_db=40, min_clip_duration=0.1, pad=0.0).clip(media)
+        assert len(result) == 3
+        for idx, clip in enumerate(result):
+            assert clip["clip_index"] == idx
+            assert clip["clip_end"] > clip["clip_start"]
+            # Each non-silent block is ~1 s
+            assert clip["duration"] == pytest.approx(1.0, abs=0.15)
+            # Output should be valid WAV
+            with wave.open(io.BytesIO(clip["media_bytes"]), "rb") as wf:
+                assert wf.getframerate() == 48000
+
+    def test_drops_intro_outro_silence(self):
+        """Leading and trailing silence should be discarded."""
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        # 0.5 s silence | 1 s tone | 0.5 s silence
+        wav = _concat_wavs(
+            generate_wav(0, 0.5),
+            generate_wav(440, 1.0),
+            generate_wav(0, 0.5),
+        )
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+
+        result = SoundSilenceClipper(top_db=40, min_clip_duration=0.1, pad=0.0).clip(media)
+        assert len(result) == 1
+        clip = result[0]
+        # Clip should start at ~0.5 s and end at ~1.5 s, NOT at 0 and 2.0
+        assert clip["clip_start"] == pytest.approx(0.5, abs=0.15)
+        assert clip["clip_end"] == pytest.approx(1.5, abs=0.15)
+        assert clip["duration"] < 2.0  # intro/outro silence was dropped
+
+    def test_padding_extends_clip_bounds(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        wav = _concat_wavs(
+            generate_wav(0, 0.5),
+            generate_wav(440, 1.0),
+            generate_wav(0, 0.5),
+        )
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+
+        # With 0.2 s pad, the single clip should extend ~0.2 s into the surrounding silence.
+        result = SoundSilenceClipper(top_db=40, min_clip_duration=0.1, pad=0.2).clip(media)
+        assert len(result) == 1
+        clip = result[0]
+        assert clip["clip_start"] < 0.5
+        assert clip["clip_end"] > 1.5
+        # But never beyond the actual audio bounds.
+        assert clip["clip_start"] >= 0.0
+        assert clip["clip_end"] <= 2.0
+
+    def test_min_clip_duration_drops_short_intervals(self):
+        """Non-silent intervals shorter than min_clip_duration are dropped."""
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        # 50 ms blip | 1 s silence | 1 s tone
+        wav = _concat_wavs(
+            generate_wav(440, 0.05),
+            generate_wav(0, 1.0),
+            generate_wav(440, 1.0),
+        )
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.05}
+
+        # min_clip_duration=0.3 should drop the blip but keep the 1 s tone.
+        result = SoundSilenceClipper(top_db=40, min_clip_duration=0.3, pad=0.0).clip(media)
+        assert len(result) == 1
+        assert result[0]["duration"] == pytest.approx(1.0, abs=0.15)
+
+    def test_all_silence_returns_unchanged(self):
+        """Audio that's silent throughout is returned unchanged (not dropped)."""
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        wav = generate_wav(0, 2.0)
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 2.0}
+        result = SoundSilenceClipper().clip(media)
+        assert result == [media]
+
+    def test_with_params(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        c = SoundSilenceClipper()
+        c2 = c.with_params({"top_db": 25, "min_clip_duration": 0.5, "pad": 0.2})
+        assert isinstance(c2, SoundSilenceClipper)
+        assert c2.top_db == 25.0
+        assert c2.min_clip_duration == 0.5
+        assert c2.pad == 0.2
+        # Original unchanged.
+        assert c.top_db == 40.0
+        assert c.min_clip_duration == 0.3
+        assert c.pad == 0.05
+
+    def test_to_dict(self):
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        c = SoundSilenceClipper(top_db=30, min_clip_duration=0.4, pad=0.1)
+        d = c.to_dict()
+        assert d["name"] == "sound_silence"
+        assert d["display_name"] == "Silence"
+        assert d["media_type"] == "audio"
+        assert d["top_db"] == 30
+        assert d["min_clip_duration"] == 0.4
+        assert d["pad"] == 0.1
+        # Parameters surface as creation questions automatically.
+        assert "creation_questions" in d
+        assert {q["key"] for q in d["creation_questions"]} == {"top_db", "min_clip_duration", "pad"}
+
+    def test_librosa_unavailable_returns_unchanged(self, monkeypatch):
+        """If librosa import fails, clipper returns the media unchanged."""
+        import builtins
+
+        from vtsearch.media.audio.clipper import SoundSilenceClipper
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "librosa":
+                raise ImportError("no librosa")
+            return real_import(name, *args, **kwargs)
+
+        wav = generate_wav(440, 1.0)
+        media = {"id": 1, "type": "audio", "media_bytes": wav, "duration": 1.0}
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        result = SoundSilenceClipper().clip(media)
+        assert result == [media]
+
+
+# ---------------------------------------------------------------------------
 # VideoDefaultClipper
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/media/audio/__init__.py
+++ b/vtsearch/media/audio/__init__.py
@@ -1,5 +1,10 @@
-from vtsearch.media.audio.clipper import SoundAutoClipper, SoundDefaultClipper, SoundTilingClipper
+from vtsearch.media.audio.clipper import (
+    SoundAutoClipper,
+    SoundDefaultClipper,
+    SoundSilenceClipper,
+    SoundTilingClipper,
+)
 from vtsearch.media.audio.media_type import AudioMediaType
 
 MEDIA_TYPE = AudioMediaType()
-CLIPPERS = [SoundAutoClipper(), SoundDefaultClipper(), SoundTilingClipper(2.0)]
+CLIPPERS = [SoundAutoClipper(), SoundDefaultClipper(), SoundTilingClipper(2.0), SoundSilenceClipper()]

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -283,6 +283,180 @@ class SoundAutoClipper(MediaClipper):
         return d
 
 
+class SoundSilenceClipper(MediaClipper):
+    """Split audio into non-silent segments via :func:`librosa.effects.split`.
+
+    Detects silence using an amplitude threshold (*top_db* dB below the
+    reference) and returns one clip per non-silent interval — intro/outro
+    silence is dropped automatically.  Suitable for podcasts, voice
+    recordings, and sound-event datasets where each "thing" is separated
+    by quiet.
+
+    Parameters
+    ----------
+    top_db : float
+        Threshold in dB below the reference to consider as silence.
+        Lower values are more aggressive (more, shorter clips).
+        Defaults to 40.
+    min_clip_duration : float
+        Non-silent intervals shorter than this (in seconds) are discarded,
+        suppressing noise-spike micro-clips.  Defaults to 0.3.
+    pad : float
+        Padding (seconds) added on each side of every non-silent interval
+        so the attack/decay of the audible content isn't trimmed.
+        Defaults to 0.05.
+
+    If ``librosa`` is unavailable, the audio cannot be decoded, or no
+    non-silent intervals survive the *min_clip_duration* filter, the media
+    is returned unchanged (single-element list).
+    """
+
+    def __init__(
+        self,
+        top_db: float = 40.0,
+        min_clip_duration: float = 0.3,
+        pad: float = 0.05,
+    ) -> None:
+        if top_db <= 0:
+            raise ValueError("top_db must be positive")
+        if min_clip_duration < 0:
+            raise ValueError("min_clip_duration must be non-negative")
+        if pad < 0:
+            raise ValueError("pad must be non-negative")
+        self._top_db = top_db
+        self._min_clip_duration = min_clip_duration
+        self._pad = pad
+
+    @property
+    def name(self) -> str:
+        return "sound_silence"
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    @property
+    def description(self) -> str:
+        return "Split each audio file into non-silent segments. Drops intro/outro silence."
+
+    @property
+    def top_db(self) -> float:
+        return self._top_db
+
+    @property
+    def min_clip_duration(self) -> float:
+        return self._min_clip_duration
+
+    @property
+    def pad(self) -> float:
+        return self._pad
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        media_bytes = media.get("media_bytes")
+        if media_bytes is None:
+            return [media]
+
+        try:
+            import librosa  # noqa: PLC0415
+        except ImportError:
+            return [media]
+
+        try:
+            audio_data, sr = librosa.load(io.BytesIO(media_bytes), sr=None, mono=True)
+        except Exception:
+            return [media]
+
+        if audio_data.size == 0 or sr <= 0:
+            return [media]
+
+        total = len(audio_data) / sr
+
+        try:
+            intervals = librosa.effects.split(audio_data, top_db=self._top_db)
+        except Exception:
+            return [media]
+
+        if len(intervals) == 0:
+            return [media]
+
+        segments: list[tuple[float, float]] = []
+        for s0, s1 in intervals:
+            t0 = max(0.0, float(s0) / sr - self._pad)
+            t1 = min(total, float(s1) / sr + self._pad)
+            if t1 - t0 >= self._min_clip_duration:
+                segments.append((t0, t1))
+
+        if not segments:
+            return [media]
+
+        try:
+            results: list[dict[str, Any]] = []
+            for idx, (t0, t1) in enumerate(segments):
+                sliced = _wav_slice(media_bytes, t0, t1)
+                clip = dict(media)
+                clip["media_bytes"] = sliced
+                clip["duration"] = round(t1 - t0, 6)
+                clip["file_size"] = len(sliced)
+                clip["clip_index"] = idx
+                clip["clip_start"] = round(t0, 6)
+                clip["clip_end"] = round(t1, 6)
+                results.append(clip)
+            return results
+        except Exception:
+            return [media]
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "top_db",
+                "label": "Silence threshold (dB)",
+                "description": (
+                    "Audio quieter than this many dB below the reference is treated as silence. "
+                    "Lower values are more aggressive — more, shorter clips."
+                ),
+                "type": "number",
+                "default": self._top_db,
+                "min": 5,
+                "max": 80,
+                "step": 1,
+            },
+            {
+                "key": "min_clip_duration",
+                "label": "Minimum clip length (seconds)",
+                "description": "Non-silent intervals shorter than this are discarded.",
+                "type": "number",
+                "default": self._min_clip_duration,
+                "min": 0,
+                "max": 60,
+                "step": 0.1,
+            },
+            {
+                "key": "pad",
+                "label": "Padding (seconds)",
+                "description": "Extra audio kept on each side of every non-silent interval so attack/decay isn't trimmed.",
+                "type": "number",
+                "default": self._pad,
+                "min": 0,
+                "max": 5,
+                "step": 0.05,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "SoundSilenceClipper":
+        top_db = float(params.get("top_db", self._top_db))
+        min_clip_duration = float(params.get("min_clip_duration", self._min_clip_duration))
+        pad = float(params.get("pad", self._pad))
+        return SoundSilenceClipper(top_db=top_db, min_clip_duration=min_clip_duration, pad=pad)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["top_db"] = self._top_db
+        d["min_clip_duration"] = self._min_clip_duration
+        d["pad"] = self._pad
+        return d
+
+
 class SoundClipClipper(MediaClipper):
     """Extract a single user-specified ``[start, end)`` slice from an audio media.
 

--- a/vtsearch/media/audio/clipper.py
+++ b/vtsearch/media/audio/clipper.py
@@ -351,41 +351,56 @@ class SoundSilenceClipper(MediaClipper):
     def pad(self) -> float:
         return self._pad
 
-    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
-        media_bytes = media.get("media_bytes")
-        if media_bytes is None:
-            return [media]
+    def _detect_segments(self, media_bytes: bytes) -> list[tuple[float, float]] | None:
+        """Detect non-silent ``(start, end)`` ranges (seconds) in *media_bytes*.
 
+        Returns ``None`` if the audio cannot be decoded or librosa is
+        unavailable.  Returns an empty list if no intervals survive the
+        ``min_clip_duration`` filter.
+        """
         try:
             import librosa  # noqa: PLC0415
         except ImportError:
-            return [media]
+            return None
 
         try:
             audio_data, sr = librosa.load(io.BytesIO(media_bytes), sr=None, mono=True)
         except Exception:
-            return [media]
+            return None
 
         if audio_data.size == 0 or sr <= 0:
-            return [media]
-
-        total = len(audio_data) / sr
+            return None
 
         try:
             intervals = librosa.effects.split(audio_data, top_db=self._top_db)
         except Exception:
-            return [media]
+            return None
 
         if len(intervals) == 0:
-            return [media]
+            return []
 
+        total_samples = len(audio_data)
+        # librosa's effects.split returns a single full-coverage interval on
+        # degenerate input (e.g. pure silence — ref amplitude is zero, so the
+        # dB threshold is meaningless).  Treat that as "no segmentation".
+        if len(intervals) == 1 and int(intervals[0][0]) <= 0 and int(intervals[0][1]) >= total_samples:
+            return []
+
+        total = total_samples / sr
         segments: list[tuple[float, float]] = []
         for s0, s1 in intervals:
             t0 = max(0.0, float(s0) / sr - self._pad)
             t1 = min(total, float(s1) / sr + self._pad)
             if t1 - t0 >= self._min_clip_duration:
                 segments.append((t0, t1))
+        return segments
 
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        media_bytes = media.get("media_bytes")
+        if media_bytes is None:
+            return [media]
+
+        segments = self._detect_segments(media_bytes)
         if not segments:
             return [media]
 

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -25,7 +25,7 @@ and flows through without per-key declarations.
 
 from __future__ import annotations
 
-from marshmallow import Schema, fields, validate
+from marshmallow import Schema, fields, post_dump, validate
 
 
 _METRIC_VALIDATOR = validate.OneOf(["smart", "stable", "diverse"])
@@ -51,20 +51,42 @@ class LabelingProgressResponseSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
-class LabelingStatusResponseSchema(Schema):
-    """Response for ``GET /api/labeling-status``.
+class StatusIndicatorSchema(Schema):
+    """One ``smart`` / ``stable`` / ``span`` indicator in the labeling-status
+    response.  ``status`` is the red/yellow/green flag every indicator emits;
+    ``reason`` is the human-readable explanation.  Metric-specific keys
+    (``cost``, ``flips``, ``diversity_level``, ``avg_flip_rate``, …) flow
+    through unchanged via ``unknown = "include"`` plus :meth:`_include_extras`
+    — the :mod:`vtsearch.detectors.labeling_progress` analyzer remains the
+    source of truth for that shape."""
 
-    The three sub-objects (``smart``, ``stable``, ``span``) each carry
-    ``status`` plus metric-specific keys; declared as plain dicts so
-    the analyzer remains the source of truth for their shape.
-    """
+    status = fields.String(required=True)
+    reason = fields.String()
+
+    class Meta:
+        unknown = "include"
+
+    @post_dump(pass_original=True)
+    def _include_extras(self, data: dict, original: dict, **_: object) -> dict:
+        # ``unknown = "include"`` only affects ``load``; declared schemas drop
+        # unknown keys on ``dump``.  Re-merge the original dict's metric-
+        # specific keys so callers receive the full indicator payload.
+        if isinstance(original, dict):
+            for k, v in original.items():
+                if k not in data:
+                    data[k] = v
+        return data
+
+
+class LabelingStatusResponseSchema(Schema):
+    """Response for ``GET /api/labeling-status``."""
 
     good_count = fields.Integer(required=True)
     bad_count = fields.Integer(required=True)
     total_count = fields.Integer(required=True)
-    smart = fields.Dict(required=True)
-    stable = fields.Dict(required=True)
-    span = fields.Dict(required=True)
+    smart = fields.Nested(StatusIndicatorSchema, required=True)
+    stable = fields.Nested(StatusIndicatorSchema, required=True)
+    span = fields.Nested(StatusIndicatorSchema, required=True)
 
 
 # ---------------------------------------------------------------------------
@@ -159,4 +181,5 @@ __all__ = [
     "IndicatorScoreHistoryResponseSchema",
     "LabelingProgressResponseSchema",
     "LabelingStatusResponseSchema",
+    "StatusIndicatorSchema",
 ]


### PR DESCRIPTION
## Summary

Adds `SoundSilenceClipper` — a new audio clipper that splits each audio file at silence boundaries using `librosa.effects.split`, automatically dropping intro/outro silence. Useful for podcasts, voice recordings, and sound-event datasets where each item is separated by quiet stretches.

- New class `SoundSilenceClipper` in `vtsearch/media/audio/clipper.py`, registered in `CLIPPERS` so it appears in the clipper-chooser UI (the frontend renders parameter forms automatically from the API metadata — no frontend changes needed).
- Marks the item as shipped in `docs/plans/feature-brainstorm.md` §3.1.

## Parameters

| key | default | purpose |
|---|---|---|
| `top_db` | 40 | dB threshold below the reference to consider as silence (lower → more aggressive, more/shorter clips). |
| `min_clip_duration` | 0.3 | non-silent intervals shorter than this are discarded (suppresses noise-spike micro-clips). |
| `pad` | 0.05 | extra audio kept on each side of every interval so attack/decay isn't trimmed. |

The brainstorm spec only listed `top_db`; `min_clip_duration` and `pad` were added because in practice `librosa.effects.split` produces unusable micro-clips and chops attack/decay without them.

## Graceful fallbacks

Returns `[media]` unchanged when:
- `librosa` is unavailable
- the bytes cannot be decoded
- no non-silent intervals survive the `min_clip_duration` filter
- `librosa.effects.split` returns a single full-coverage interval on degenerate input (e.g. pure-zero audio — the dB threshold is meaningless when the reference amplitude is 0)

This matches the same fail-safe-to-passthrough pattern as `SoundTilingClipper` and `VideoSceneClipper`.

## Test plan

- [x] `./run-tests.sh detectors` — 881 passed (includes 15 new `TestSoundSilenceClipper` cases covering identity, param validation, splitting tone/silence/tone, intro/outro trimming, padding, `min_clip_duration` filter, all-silence input, `with_params`, `to_dict`, and graceful fallback when librosa is unavailable)
- [x] `./run-tests.sh core io` — 1144 passed
- [x] full `./run-tests.sh` — 3677 passed (1 unrelated skip)
- [x] `ruff check` / `ruff format --check` / `codespell` / `deptry` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDLH2Nqc1h5uCgRyW1c7sE)_