### PR TITLE
feat(clipper): add ImageObjectClipper for YOLO/RT-DETR object crops

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -90,7 +90,7 @@ Today the framework allows one converter per source; consider explicit chains: `
 
 ### 3.2 Image
 - **`image_saliency`** ★★ M — crop to salient region (U²-Net or SAM auto-mask). Improves embedding signal on "find dogs" by focusing on subject.
-- **`image_object`** ★★ M — clip per detected object using a lightweight YOLO/RT-DETR. Each clip becomes its own scoreable element.
+- **`image_object`** ★★ M — clip per detected object using a lightweight YOLO/RT-DETR. Each clip becomes its own scoreable element. **✓ shipped** (`vtsearch/media/image/clipper.py` — `ImageObjectClipper`, reuses the ultralytics weight already used by `ImageClassExtractor`; params: `threshold`, `class_filter`, `max_detections`, `padding`, `model_id`). Open follow-ups: experiment with SAM2 boxes for the same UI; consider a per-class confidence threshold instead of one global value if users ask for it.
 - **`image_face`** ★ S — face-cropped clips (RetinaFace).
 - **`image_window`** ★ XS — sliding window with stride, complements existing tiling.
 - **`image_color_palette`** ★ exploratory — clip into colour-region masks.

--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -933,6 +933,46 @@ checks off this follow-up.
       stay because the generated equivalents are loose
       ``{[key: string]: any}`` and the local versions describe the
       actual fields consumers read.
+- [x] ``LabelingStatusResponse`` consumers tightened to the generated
+      shape. Backend ``LabelingStatusResponseSchema`` (``vtsearch/schemas/eval.py``)
+      declares ``smart`` / ``stable`` / ``span`` as nested
+      ``StatusIndicatorSchema`` instances with a required ``status`` and an
+      optional ``reason``; ``Meta.unknown = "include"`` plus a
+      ``@post_dump(pass_original=True)`` hook preserves the metric-specific
+      keys (``cost``, ``flips``, ``avg_flip_rate``, ``diversity_level``,
+      ``max_level``, …) — ``unknown = "include"`` only affects ``load``, so
+      the post-dump re-merge is required to keep them in the response.
+      The generated TS ``StatusIndicator`` is ``{status: string; reason?:
+      string; [key: string]: any}``; ``LabelingStatusResponse`` references
+      it directly. ``AutopilotStateService``,
+      ``AutopilotStateService.spec``, ``LabelViewComponent``,
+      ``LeftPanelComponent``, ``ProgressIndicatorsComponent``, and
+      ``AutopilotPanelComponent`` all now ``import type`` the generated
+      ``LabelingStatusResponse`` from
+      ``generated/api-client/models/labeling-status-response``; the
+      ``startStatusPolling`` cast in ``LabelViewComponent`` is gone. The
+      spec file added a tiny ``makeStatus`` helper to construct fixtures
+      with the now-required ``good_count`` / ``bad_count`` /
+      ``total_count`` defaults. Removed from ``api.models.ts``:
+      ``StatusIndicator`` and ``LabelingStatusResponse``.
+- [x] ``MediaItem`` deleted from ``api.models.ts`` and replaced with a
+      generated-types-derived ``Media`` alias. ``MediaStateService`` now
+      stores ``MediaIdsListResponse[]`` (the stub list from
+      ``GET /api/medias/ids``); ``MediaMetadataCacheService`` now stores
+      ``MediaBatchResponse`` (the hydrated payload from
+      ``POST /api/medias/batch``). The renderer surface (media-item, media-
+      list, center panel + audio/video/image/text/document viewers, right
+      panel, label-list, label-view, find-view) consumes
+      ``Media = MediaIdsListResponse & Partial<Omit<RemoveIndex<MediaBatchResponse>,
+      keyof MediaIdsListResponse>>`` — a derivation that admits both stubs
+      (initial listing, cache miss) and hydrated batch entries, with the
+      ``MediaBatchResponse`` index signature stripped so direct property
+      access works under ``noPropertyAccessFromIndexSignature``. Sites
+      that read ``filename`` / ``origin_name`` for display via
+      ``mediaState.medias.find(…)`` were rerouted through a new
+      ``MediaStateService.getMedia(id)`` helper that returns the cached
+      batch first and falls back to the stub (same pattern as the
+      ``selectedMedia`` getter).
 
 ## Open follow-ups
 
@@ -950,29 +990,6 @@ checks off this follow-up.
   function-module paths for runtime symbols, no barrel) are required
   to keep the initial bundle under the 525 kB budget — see
   *Bundle-size discipline* above.
-- **Tighten ``LabelingStatusResponse`` consumers to the generated
-  shape.** ``SortingApiService.getLabelingStatus`` returns the generated
-  ``LabelingStatusResponse`` (``smart``/``stable``/``span`` typed as
-  ``{[key: string]: any}``), but ``LabelViewComponent`` keeps the legacy
-  ``LabelingStatusResponse`` (with ``StatusIndicator``-bearing fields)
-  for its ``labelingStatus`` member because the downstream chain
-  (``AutopilotStateService``, ``AutopilotPanelComponent``,
-  ``LeftPanelComponent`` and their spec files) all read
-  ``status.smart?.status`` / ``status.stable?.status`` /
-  ``status.span?.status``. A single cast at the polling subscribe
-  bridges the type gap. A follow-up PR can either retype every consumer
-  to the generated shape (and update the spec literals to include the
-  newly-required ``good_count`` / ``bad_count`` / ``total_count`` /
-  ``smart.status`` / ``stable.status`` / ``span.status`` fields) or
-  introduce a narrow ``StatusIndicator`` typed-projection layer.
-- **Replace ``MediaItem`` with the generated ``MediaIdsListResponse`` /
-  ``MediaBatchResponse`` pair.** ``MediaItem`` is the loose union type
-  consumed by ~20 components and the metadata cache. The
-  ``MediasApiService`` migration kept it in place because rewiring every
-  consumer is a larger task than swapping the service itself.  A
-  follow-up should narrow each consumer's type (lightweight stub vs.
-  full batch-response) and delete ``MediaItem`` from
-  ``api.models.ts``.
 - **Per-plugin schemas for plugin-field routes.** The four routes
   whose request body is a plugin-field shape stay on the legacy
   plain-Flask path on their (now smorest-typed) blueprints:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,4 +1,3 @@
-⏳ Initializing VTSearch... (PID 11505)
 {
   "components": {
     "responses": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,3 +1,4 @@
+⏳ Initializing VTSearch... (PID 11505)
 {
   "components": {
     "responses": {
@@ -2819,16 +2820,13 @@
             "type": "integer"
           },
           "smart": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/StatusIndicator"
           },
           "span": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/StatusIndicator"
           },
           "stable": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/StatusIndicator"
           },
           "total_count": {
             "type": "integer"
@@ -3772,6 +3770,21 @@
         "required": [
           "results",
           "threshold"
+        ],
+        "type": "object"
+      },
+      "StatusIndicator": {
+        "additionalProperties": true,
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
         ],
         "type": "object"
       },

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayerComponent } from './audio-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('AudioPlayerComponent', () => {
   let component: AudioPlayerComponent;
   let fixture: ComponentFixture<AudioPlayerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 1,
     type: 'audio',
     filename: 'test.wav',

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -20,7 +20,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './audio-player.component.scss',
 })
 export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
   @Input() volume = 1;
   @Input() audioPlaying = true;
   @Input() swipeClass = '';

--- a/frontend/src/app/components/center-panel/center-panel.component.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { CenterPanelComponent } from './center-panel.component';
-import { MediaItem } from '../../models/api.models';
+import { Media } from '../../models/api.models';
 import { RegionBox } from './image-viewer/image-viewer.component';
 
 describe('CenterPanelComponent', () => {
@@ -10,7 +10,7 @@ describe('CenterPanelComponent', () => {
   let fixture: ComponentFixture<CenterPanelComponent>;
   let httpMock: HttpTestingController;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 1,
     type: 'audio',
     filename: 'test.wav',
@@ -154,7 +154,7 @@ describe('CenterPanelComponent', () => {
    * region-agnostic — see "Vote attribution → v2" in docs/plans/patch-embedder.md).
    */
   describe('vote-API contract for region_box', () => {
-    const imageMedia: MediaItem = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const imageMedia: Media = { ...mockMedia, type: 'image', filename: 'pic.png' };
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
@@ -218,7 +218,7 @@ describe('CenterPanelComponent', () => {
    * clears the armed state and keeps the box.
    */
   describe('sticky bad-vote-confirm armed state', () => {
-    const imageMedia: MediaItem = { ...mockMedia, type: 'image', filename: 'pic.png' };
+    const imageMedia: Media = { ...mockMedia, type: 'image', filename: 'pic.png' };
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
@@ -275,7 +275,7 @@ describe('CenterPanelComponent', () => {
       component.castVote('bad');
       expect(component.pendingBadConfirm).toBeTrue();
 
-      const next: MediaItem = { ...imageMedia, id: 2, filename: 'next.png' };
+      const next: Media = { ...imageMedia, id: 2, filename: 'next.png' };
       component.media = next;
       component.ngOnChanges({
         media: {

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
-import { MediaItem } from '../../models/api.models';
+import { Media } from '../../models/api.models';
 import { MediasApiService } from '../../services/medias-api.service';
 import { KeyboardService } from '../../services/keyboard.service';
 import { VoteStateService } from '../../services/vote-state.service';
@@ -30,7 +30,7 @@ import { prefersReducedMotion } from '../../utils/reduced-motion';
   styleUrl: './center-panel.component.scss',
 })
 export class CenterPanelComponent implements OnChanges, OnDestroy {
-  @Input() media: MediaItem | null = null;
+  @Input() media: Media | null = null;
   @Input() disabled = false;
   @Output() mediaVoted = new EventEmitter<{ id: number; vote: 'good' | 'bad' }>();
 
@@ -179,7 +179,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   /** Human-readable label for an item used in undo toasts. */
-  private mediaDisplayName(media: MediaItem): string {
+  private mediaDisplayName(media: Media): string {
     return media.filename || media.origin_name || `#${media.id}`;
   }
 

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DocumentViewerComponent } from './document-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('DocumentViewerComponent', () => {
   let component: DocumentViewerComponent;
   let fixture: ComponentFixture<DocumentViewerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 5,
     type: 'document',
     filename: 'test.pdf',

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './document-viewer.component.scss',
 })
 export class DocumentViewerComponent implements OnChanges {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
 
   mediaSrc = '';
 

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.spec.ts
@@ -2,13 +2,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ElementRef } from '@angular/core';
 import { ImageViewerComponent, RegionBox } from './image-viewer.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('ImageViewerComponent', () => {
   let component: ImageViewerComponent;
   let fixture: ComponentFixture<ImageViewerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 2,
     type: 'image',
     filename: 'test.png',
@@ -389,7 +389,7 @@ describe('ImageViewerComponent', () => {
 
     it('persists across media changes', () => {
       component.marqueeMode = true;
-      const next: MediaItem = { ...mockMedia, id: 99, filename: 'b.png' };
+      const next: Media = { ...mockMedia, id: 99, filename: 'b.png' };
       component.media = next;
       component.ngOnChanges({
         media: { currentValue: next, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { NgStyle } from '@angular/common';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 export type RegionBox = readonly [number, number, number, number];
@@ -32,7 +32,7 @@ const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a s
   styleUrl: './image-viewer.component.scss',
 })
 export class ImageViewerComponent implements OnChanges, OnDestroy {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
   /**
    * True while the parent is in the v2 "bad-vote-with-box discard confirm" armed state.
    * The viewer uses it to (a) render the box with a sticky red pulse, and (b) route Esc /

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -2,14 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TextViewerComponent } from './text-viewer.component';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('TextViewerComponent', () => {
   let component: TextViewerComponent;
   let fixture: ComponentFixture<TextViewerComponent>;
   let httpMock: HttpTestingController;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 4,
     type: 'text',
     filename: 'test.txt',

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MediasApiService } from '../../../services/medias-api.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 @Component({
   selector: 'vt-text-viewer',
@@ -10,7 +10,7 @@ import { MediaItem } from '../../../models/api.models';
   styleUrl: './text-viewer.component.scss',
 })
 export class TextViewerComponent implements OnChanges, OnDestroy {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
 
   text = 'Loading...';
   private sub: Subscription | null = null;

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VideoPlayerComponent } from './video-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('VideoPlayerComponent', () => {
   let component: VideoPlayerComponent;
   let fixture: ComponentFixture<VideoPlayerComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 3,
     type: 'video',
     filename: 'test.mp4',

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -11,7 +11,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './video-player.component.scss',
 })
 export class VideoPlayerComponent implements OnChanges, OnDestroy {
-  @Input() media!: MediaItem;
+  @Input() media!: Media;
   @Input() volume = 1;
   @Input() audioPlaying = true;
   @Output() playingChanged = new EventEmitter<boolean>();

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -372,7 +372,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
     if (this.sortState.sortBusy) return;
-    const m = this.mediaState.medias.find((x) => x.id === event.id);
+    const m = this.mediaState.getMedia(event.id);
     const name = m?.filename || m?.origin_name || `#${event.id}`;
     this.voteState.recordVote(event.id, event.vote, name);
     this.mediasApi.vote(event.id, event.vote).pipe(takeUntil(this.destroy$)).subscribe({

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -775,7 +775,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private openCropOverlay(mediaId: number, action: 'sort' | 'seed'): void {
-    const media = this.mediaState.medias.find((m) => m.id === mediaId);
+    const media = this.mediaState.getMedia(mediaId);
     if (!media) return;
     const mediaType = media.type;
     const url =
@@ -846,7 +846,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private mediaDisplayName(id: number): string {
-    const m = this.mediaState.medias.find((x) => x.id === id);
+    const m = this.mediaState.getMedia(id);
     return m?.filename || m?.origin_name || `#${id}`;
   }
 

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -30,7 +30,7 @@ import { ProgressEventsService } from '../../services/progress-events.service';
 import { DetectorRegistryEntry, ProgressEvent } from '../../models/api.models';
 import { ProgressModalComponent, ProgressMetric } from '../modals/progress-modal/progress-modal.component';
 import { ResortPromptModalComponent, ResortResult } from '../modals/resort-prompt-modal/resort-prompt-modal.component';
-import { LabelingStatusResponse } from '../../models/api.models';
+import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import type { LearnedSortResponse } from '../../generated/api-client/models/learned-sort-response';
 import { formatProgressMessage } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
@@ -438,14 +438,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       )
       .subscribe({
         next: (status) => {
-          // The generated `LabelingStatusResponse` types `smart` / `stable` /
-          // `span` as `{[key: string]: any}` while the legacy field type
-          // expects `StatusIndicator` with a required `status` string.  The
-          // backend always sends `{status, ...}` for these — the cast is safe
-          // and only crosses the type-system gap until a follow-up tightens
-          // the consumer (autopilot, left-panel, autopilot-panel) to the
-          // generated shape.
-          this.labelingStatus = status as unknown as LabelingStatusResponse;
+          this.labelingStatus = status;
         },
       });
   }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LabelingStatusResponse } from '../../../models/api.models';
+import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 import {
   AutopilotStateService,
   AutopilotPhase,

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -8,7 +8,8 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
-import { MediaItem, LabelingStatusResponse, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import { MediaItem, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -8,7 +8,7 @@ import { MediaListComponent } from './media-list/media-list.component';
 import { StripeOverviewComponent } from './stripe-overview/stripe-overview.component';
 import { AutopilotPanelComponent } from './autopilot-panel/autopilot-panel.component';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
-import { MediaItem, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
+import { Media, MediaTypeInfo, EmbedderInfo } from '../../models/api.models';
 import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsApiService } from '../../services/datasets-api.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
@@ -33,7 +33,7 @@ export type { SortMode, SelectMode, SortedItem };
   styleUrl: './left-panel.component.scss',
 })
 export class LeftPanelComponent implements OnInit, OnChanges {
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
   @Input() selectedId: number | null = null;

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MediaItemComponent } from './media-item.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('MediaItemComponent', () => {
   let component: MediaItemComponent;
   let fixture: ComponentFixture<MediaItemComponent>;
 
-  const mockMedia: MediaItem = {
+  const mockMedia: Media = {
     id: 1,
     type: 'audio',
     filename: 'test.wav',

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 
 @Component({
@@ -11,7 +11,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
   styleUrl: './media-item.component.scss',
 })
 export class MediaItemComponent implements OnChanges {
-  @Input({ required: true }) media!: MediaItem;
+  @Input({ required: true }) media!: Media;
   @Input() active = false;
   @Input() voteLabel: 'good' | 'bad' | null = null;
   @Input() score: number | null = null;

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MediaListComponent } from './media-list.component';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('MediaListComponent', () => {
   let component: MediaListComponent;
   let fixture: ComponentFixture<MediaListComponent>;
 
-  const mockMedias: MediaItem[] = [
+  const mockMedias: Media[] = [
     { id: 1, type: 'audio', filename: 'a.wav', md5: 'a1', custom_metadata: {} },
     { id: 2, type: 'audio', filename: 'b.wav', md5: 'b2', custom_metadata: {} },
     { id: 3, type: 'audio', filename: 'c.wav', md5: 'c3', custom_metadata: {} },

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -16,7 +16,7 @@ import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrollin
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MediaItemComponent } from '../media-item/media-item.component';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { SortedItem } from '../left-panel.component';
 import { prefersReducedMotion } from '../../../utils/reduced-motion';
@@ -36,7 +36,7 @@ const PREFETCH_BUFFER = 50;
   styleUrl: './media-list.component.scss',
 })
 export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() sortOrder: SortedItem[] | null = null;
   @Input() threshold: number | null = null;
   @Input() selectedId: number | null = null;
@@ -54,7 +54,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
 
   /** Cached ordered items — rebuilt only when inputs change, not on every CD cycle. */
-  cachedOrderedItems: { media: MediaItem; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
+  cachedOrderedItems: { media: Media; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
 
   readonly listItemHeight = LIST_ITEM_HEIGHT;
 
@@ -113,10 +113,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     // rows; fall back to the stub so the row renders immediately and gets
     // upgraded once the batch fetch lands.
     const stubMap = new Map(this.medias.map((m) => [m.id, m]));
-    const enrich = (id: number): MediaItem | undefined =>
+    const enrich = (id: number): Media | undefined =>
       this.metadataCache.get(id) ?? stubMap.get(id);
 
-    const items: { media: MediaItem; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
+    const items: { media: Media; score: number | null; showThreshold: boolean; bestRegion: number[] | null }[] = [];
 
     if (this.sortOrder && this.sortOrder.length > 0) {
       let thresholdInserted = false;
@@ -229,7 +229,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     });
   }
 
-  trackByMediaId(_index: number, item: { media: MediaItem }): number {
+  trackByMediaId(_index: number, item: { media: Media }): number {
     return item.media.id;
   }
 

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
-import { LabelingStatusResponse } from '../../../models/api.models';
+import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 
 @Component({
   selector: 'vt-progress-indicators',
@@ -24,15 +24,15 @@ export class ProgressIndicatorsComponent {
   }
 
   get smartStatus(): string {
-    return (this.labelingStatus?.smart?.status as string) || '';
+    return this.labelingStatus?.smart.status || '';
   }
 
   get stableStatus(): string {
-    return (this.labelingStatus?.stable?.status as string) || '';
+    return this.labelingStatus?.stable.status || '';
   }
 
   get spanStatus(): string {
-    return (this.labelingStatus?.span?.status as string) || '';
+    return this.labelingStatus?.span.status || '';
   }
 
   get smartSubtext(): string {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LabelListComponent, LabelEntry } from './label-list.component';
 import { ActiveContextService } from '../../../services/active-context.service';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 
 describe('LabelListComponent', () => {
   let component: LabelListComponent;
   let fixture: ComponentFixture<LabelListComponent>;
 
-  const sampleMedias: MediaItem[] = [
+  const sampleMedias: Media[] = [
     { id: 1, type: 'audio', filename: 'song.wav', md5: 'aaa', custom_metadata: {} },
     { id: 2, type: 'image', filename: 'photo.jpg', md5: 'bbb', custom_metadata: {} },
     { id: 3, type: 'video', filename: 'clip.mp4', md5: 'ccc', custom_metadata: {} },

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChange
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MediaItem } from '../../../models/api.models';
+import { Media } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
@@ -25,7 +25,7 @@ export interface LabelEntry {
 export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterViewChecked {
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() clickTimes: Record<string, number> = {};
   @Input() learnedScores: Record<string, number> = {};
   @Input() sortMode: LabelSortMode = 'time-desc';
@@ -40,7 +40,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
   sortedEntries: LabelEntry[] = [];
   private pendingScrollPct: number | null = null;
   /** Pre-built Map for O(1) media stub lookups by id (rebuilt when medias input changes). */
-  private mediaMap = new Map<number, MediaItem>();
+  private mediaMap = new Map<number, Media>();
   private readonly destroy$ = new Subject<void>();
 
   constructor(
@@ -80,7 +80,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy, AfterVi
     this.destroy$.complete();
   }
 
-  private lookup(id: number): MediaItem | undefined {
+  private lookup(id: number): Media | undefined {
     return this.metadataCache.get(id) ?? this.mediaMap.get(id);
   }
 

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DetectorsApiService } from '../../services/detectors-api.service';
 import type { DetectorLabelView } from '../../generated/api-client/models/detector-label-view';
-import { MediaItem } from '../../models/api.models';
+import { Media } from '../../models/api.models';
 import { VoteStateService } from '../../services/vote-state.service';
 import { LabelsetStateService } from '../../services/labelset-state.service';
 import { SettingsStateService } from '../../services/settings-state.service';
@@ -40,7 +40,7 @@ export interface TrainModeContext {
   styleUrl: './right-panel.component.scss',
 })
 export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() medias: MediaItem[] = [];
+  @Input() medias: Media[] = [];
   @Input() trainMode: TrainModeContext | null = null;
   @Input() focusMode: 'click' | 'hover' = 'click';
   /** 'label' = Labeling mode (detector export allowed), 'find' = Finding mode (no detector export). */

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -38,23 +38,6 @@ export interface VotesResponse {
   labelset_bad_count?: number;
 }
 
-// --- Labeling Status ---
-
-export interface StatusIndicator {
-  status: string;
-  [key: string]: unknown;
-}
-
-export interface LabelingStatusResponse {
-  good_count?: number;
-  bad_count?: number;
-  total_count?: number;
-  smart?: StatusIndicator;
-  stable?: StatusIndicator;
-  span?: StatusIndicator;
-  [key: string]: unknown;
-}
-
 // --- Progress ---
 
 /**

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -1,31 +1,33 @@
 /* TypeScript interfaces matching the Flask API response shapes. */
 
+import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+
 // --- Medias ---
 
 /**
- * One media item.
- *
- * Only ``id`` and ``type`` are guaranteed — the dataset listing
- * (``GET /api/medias/ids``) returns just those plus an optional
- * ``embedder``.  The remaining display-worthy fields are populated on
- * demand for items currently in the viewport via the metadata cache
- * (``POST /api/medias/batch``).
+ * Strip a type's catch-all index signature (``[key: string]: any``) so
+ * intersecting it with another type doesn't force every property access
+ * to go through the bracket form (TS4111 under
+ * ``noPropertyAccessFromIndexSignature``).
  */
-export interface MediaItem {
-  id: number;
-  type: string;
-  filename?: string;
-  md5?: string;
-  custom_metadata?: Record<string, unknown>;
-  origin_name?: string;
-  description?: string;
-  clip_start?: number;
-  clip_end?: number;
-  clip_index?: number;
-  clip_box?: number[];
-  /** Name of the embedder that produced this media's vector. */
-  embedder?: string;
-}
+type RemoveIndex<T> = {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
+};
+
+/**
+ * The renderable media shape — a stub from ``GET /api/medias/ids``
+ * (``id``, ``type``, optional ``embedder``) optionally augmented with the
+ * full per-item metadata returned by ``POST /api/medias/batch``
+ * (``filename``, ``md5``, ``custom_metadata``, clip extents, …).
+ *
+ * Derived directly from the two generated DTOs so backend schema changes
+ * propagate without a hand-maintained mirror.  Components consume this
+ * type wherever the data flow can deliver either a stub (initial listing,
+ * cache miss) or a hydrated batch entry.
+ */
+export type Media = MediaIdsListResponse &
+  Partial<Omit<RemoveIndex<MediaBatchResponse>, keyof MediaIdsListResponse>>;
 
 // --- Sorting ---
 

--- a/frontend/src/app/services/autopilot-state.service.spec.ts
+++ b/frontend/src/app/services/autopilot-state.service.spec.ts
@@ -1,6 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 import { AutopilotStateService } from './autopilot-state.service';
-import { LabelingStatusResponse } from '../models/api.models';
+import type { LabelingStatusResponse } from '../generated/api-client/models/labeling-status-response';
+import type { StatusIndicator } from '../generated/api-client/models/status-indicator';
+
+function makeStatus(
+  smart: StatusIndicator,
+  stable: StatusIndicator,
+  span: StatusIndicator,
+): LabelingStatusResponse {
+  return { good_count: 0, bad_count: 0, total_count: 0, smart, stable, span };
+}
 
 describe('AutopilotStateService', () => {
   let service: AutopilotStateService;
@@ -56,11 +65,11 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    const status: LabelingStatusResponse = {
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    };
+    const status: LabelingStatusResponse = makeStatus(
+      { status: 'green' },
+      { status: 'green' },
+      { status: 'yellow' },
+    );
     service.updateFromLabelingStatus(status);
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
@@ -71,18 +80,14 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'green' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'green' }),
+    );
     service.checkPhaseTransition(15, 15);
     expect(service.state.phase).toBe('done');
   });
@@ -92,20 +97,16 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Smart drops to yellow (surprise destabilized the model)
-    service.updateFromLabelingStatus({
-      smart: { status: 'yellow' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'yellow' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('hard');
   });
@@ -115,20 +116,16 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Stable drops to yellow (surprise caused prediction flips)
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'yellow' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'yellow' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('hard');
   });
@@ -138,29 +135,23 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Bounce back to hard
-    service.updateFromLabelingStatus({
-      smart: { status: 'yellow' },
-      stable: { status: 'yellow' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'yellow' }, { status: 'yellow' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('hard');
 
     // Indicators recover — should go back to new
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(15, 15);
     expect(service.state.phase).toBe('new');
   });
@@ -170,20 +161,16 @@ describe('AutopilotStateService', () => {
     service.checkPhaseTransition(3, 0);
     service.checkPhaseTransition(3, 4);
 
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(10, 10);
     expect(service.state.phase).toBe('new');
 
     // Both still green — should stay in new
-    service.updateFromLabelingStatus({
-      smart: { status: 'green' },
-      stable: { status: 'green' },
-      span: { status: 'yellow' },
-    });
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'yellow' }),
+    );
     service.checkPhaseTransition(12, 12);
     expect(service.state.phase).toBe('new');
   });
@@ -203,11 +190,11 @@ describe('AutopilotStateService', () => {
 
   it('updateFromLabelingStatus should update status fields', () => {
     service.activate();
-    const status: LabelingStatusResponse = {
-      smart: { status: 'yellow' },
-      stable: { status: 'green' },
-      span: { status: 'red', diversity_level: 0.75 },
-    };
+    const status: LabelingStatusResponse = makeStatus(
+      { status: 'yellow' },
+      { status: 'green' },
+      { status: 'red', diversity_level: 0.75 },
+    );
     service.updateFromLabelingStatus(status);
 
     expect(service.state.smartStatus).toBe('yellow');

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LabelingStatusResponse } from '../models/api.models';
+import type { LabelingStatusResponse } from '../generated/api-client/models/labeling-status-response';
 
 export type AutopilotPhase = 'idle' | 'good' | 'bad' | 'hard' | 'new' | 'done';
 
@@ -68,11 +68,11 @@ export class AutopilotStateService {
     const current = this.stateSubject.value;
     this.stateSubject.next({
       ...current,
-      smartStatus: (status.smart?.status as string) || '',
-      stableStatus: (status.stable?.status as string) || '',
-      spanStatus: (status.span?.status as string) || '',
+      smartStatus: status.smart.status || '',
+      stableStatus: status.stable.status || '',
+      spanStatus: status.span.status || '',
       fracDiversity:
-        status.span?.['diversity_level'] != null
+        status.span['diversity_level'] != null
           ? (status.span['diversity_level'] as number)
           : current.fracDiversity,
     });

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MediaItem } from '../models/api.models';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
 import { MediasApiService } from './medias-api.service';
 
 /**
@@ -23,12 +23,12 @@ const BATCH_SIZE = 200;
  *   1. Call `ensureLoaded(ids)` with the IDs the viewport needs.
  *   2. Subscribe to `version$` to re-render when new items arrive, or call
  *      `get(id)` to read a single cached item.
- *   3. `toMediaItems(ids)` returns MediaItem[] for already-cached IDs (skips
- *      unknown ones so the template can render immediately).
+ *   3. `toMediaItems(ids)` returns MediaBatchResponse[] for already-cached
+ *      IDs (skips unknown ones so the template can render immediately).
  */
 @Injectable({ providedIn: 'root' })
 export class MediaMetadataCacheService implements OnDestroy {
-  private readonly cache = new Map<number, MediaItem>();
+  private readonly cache = new Map<number, MediaBatchResponse>();
   private readonly pendingIds = new Set<number>();
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly destroy$ = new Subject<void>();
@@ -45,8 +45,8 @@ export class MediaMetadataCacheService implements OnDestroy {
     if (this.batchTimer) clearTimeout(this.batchTimer);
   }
 
-  /** Return a cached MediaItem or undefined if not yet fetched. */
-  get(id: number): MediaItem | undefined {
+  /** Return a cached metadata entry or undefined if not yet fetched. */
+  get(id: number): MediaBatchResponse | undefined {
     return this.cache.get(id);
   }
 
@@ -85,11 +85,11 @@ export class MediaMetadataCacheService implements OnDestroy {
   }
 
   /**
-   * Build a MediaItem[] for the given IDs using cached data.
+   * Build a MediaBatchResponse[] for the given IDs using cached data.
    * IDs that are not yet cached are omitted.
    */
-  toMediaItems(ids: number[]): MediaItem[] {
-    const result: MediaItem[] = [];
+  toMediaItems(ids: number[]): MediaBatchResponse[] {
+    const result: MediaBatchResponse[] = [];
     for (const id of ids) {
       const item = this.cache.get(id);
       if (item) result.push(item);

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -2,13 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { MediaStateService } from './media-state.service';
-import { MediaItem } from '../models/api.models';
+import { Media } from '../models/api.models';
 
 describe('MediaStateService', () => {
   let service: MediaStateService;
   let httpMock: HttpTestingController;
 
-  const mockMedias: MediaItem[] = [
+  const mockMedias: Media[] = [
     { id: 1, type: 'audio', filename: 'a.wav', md5: 'abc', custom_metadata: {} },
     { id: 2, type: 'image', filename: 'b.png', md5: 'def', custom_metadata: {} },
   ];
@@ -68,7 +68,7 @@ describe('MediaStateService', () => {
   });
 
   it('medias$ should emit on load', (done) => {
-    const emissions: MediaItem[][] = [];
+    const emissions: Media[][] = [];
     service.medias$.subscribe((m) => emissions.push(m));
 
     service.loadMedias();

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { MediaItem } from '../models/api.models';
+import type { Media } from '../models/api.models';
+import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import { MediasApiService } from './medias-api.service';
 import { MediaMetadataCacheService } from './media-metadata-cache.service';
 
@@ -17,7 +18,7 @@ import { MediaMetadataCacheService } from './media-metadata-cache.service';
  */
 @Injectable({ providedIn: 'root' })
 export class MediaStateService implements OnDestroy {
-  private readonly mediasSubject = new BehaviorSubject<MediaItem[]>([]);
+  private readonly mediasSubject = new BehaviorSubject<MediaIdsListResponse[]>([]);
   private readonly selectedIdSubject = new BehaviorSubject<number | null>(null);
   private readonly destroy$ = new Subject<void>();
 
@@ -34,7 +35,7 @@ export class MediaStateService implements OnDestroy {
     this.destroy$.complete();
   }
 
-  get medias(): MediaItem[] {
+  get medias(): MediaIdsListResponse[] {
     return this.mediasSubject.value;
   }
 
@@ -42,9 +43,18 @@ export class MediaStateService implements OnDestroy {
     return this.selectedIdSubject.value;
   }
 
-  get selectedMedia(): MediaItem | null {
+  get selectedMedia(): Media | null {
     const id = this.selectedIdSubject.value;
     if (id === null) return null;
+    return this.getMedia(id);
+  }
+
+  /**
+   * Return the best-available representation of a media item: the cached
+   * batch entry (with ``filename`` / ``md5`` / metadata) if loaded, else
+   * the stub from the dataset listing, else ``null``.
+   */
+  getMedia(id: number): Media | null {
     const cached = this.metadataCache.get(id);
     if (cached) return cached;
     return this.mediasSubject.value.find((m) => m.id === id) ?? null;

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -644,6 +644,285 @@ class TestImageBboxClipper:
 
 
 # ---------------------------------------------------------------------------
+# ImageObjectClipper
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_yolo(detections, class_names):
+    """Build a mock ultralytics YOLO callable.
+
+    *detections* is a list of ``(class_id, confidence, [x1, y1, x2, y2])``.
+    *class_names* maps class_id -> label string.
+    """
+    from unittest.mock import MagicMock
+
+    import torch
+
+    mock_boxes = MagicMock()
+    mock_boxes.conf = torch.tensor([d[1] for d in detections]) if detections else torch.empty(0)
+    mock_boxes.cls = torch.tensor([d[0] for d in detections]) if detections else torch.empty(0, dtype=torch.long)
+    mock_boxes.xyxy = (
+        torch.tensor([d[2] for d in detections], dtype=torch.float32) if detections else torch.empty((0, 4))
+    )
+    mock_boxes.__len__ = lambda self: len(detections)
+
+    mock_result = MagicMock()
+    mock_result.boxes = mock_boxes
+    mock_result.names = class_names
+
+    mock_model = MagicMock()
+    mock_model.return_value = [mock_result]
+    return mock_model
+
+
+class TestImageObjectClipper:
+    def test_identity(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        c = ImageObjectClipper()
+        assert c.name == "image_object"
+        assert c.media_type == "image"
+        assert c.display_name == "Object"
+        assert isinstance(c, MediaClipper)
+
+    def test_default_params(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        c = ImageObjectClipper()
+        assert c.threshold == 0.25
+        assert c.class_filter == ""
+        assert c.max_detections == 20
+        assert c.padding == 0.0
+        assert c.model_id == "yolo11n.pt"
+
+    def test_parameters_schema(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        params = ImageObjectClipper().parameters
+        keys = {p["key"] for p in params}
+        assert keys == {"threshold", "class_filter", "max_detections", "padding", "model_id"}
+
+    def test_creation_questions_match_parameters(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        c = ImageObjectClipper()
+        assert c.creation_questions == c.parameters
+
+    def test_to_dict(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        c = ImageObjectClipper(threshold=0.4, class_filter="person,car", max_detections=5, padding=0.1)
+        d = c.to_dict()
+        assert d["name"] == "image_object"
+        assert d["media_type"] == "image"
+        assert d["threshold"] == 0.4
+        assert d["class_filter"] == "person,car"
+        assert d["max_detections"] == 5
+        assert d["padding"] == 0.1
+        assert d["model_id"] == "yolo11n.pt"
+        assert "creation_questions" in d
+
+    def test_with_params_returns_new_instance(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        c = ImageObjectClipper()
+        c2 = c.with_params({"threshold": 0.7, "class_filter": "dog", "max_detections": 3, "padding": 0.2})
+        assert isinstance(c2, ImageObjectClipper)
+        assert c2.threshold == 0.7
+        assert c2.class_filter == "dog"
+        assert c2.max_detections == 3
+        assert c2.padding == 0.2
+        # original unchanged
+        assert c.threshold == 0.25
+        assert c.class_filter == ""
+
+    def test_no_media_bytes_returns_unchanged(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        c = ImageObjectClipper()
+        media = {"id": 1, "type": "image", "width": 100, "height": 100}
+        result = c.clip(media)
+        assert result == [media]
+
+    def test_no_detections_returns_original(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        c = ImageObjectClipper()
+        c._model = _make_mock_yolo([], {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 1
+        assert result[0] is media
+
+    def test_emits_one_clip_per_detection(self):
+        from PIL import Image
+
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        detections = [
+            (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
+            (0, 0.8, [100.0, 100.0, 180.0, 180.0]),
+        ]
+        c = ImageObjectClipper(threshold=0.5)
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 2
+        # Sorted by confidence desc
+        assert result[0]["clip_box"] == [10, 10, 60, 60]
+        assert result[1]["clip_box"] == [100, 100, 180, 180]
+        for clip in result:
+            assert "media_bytes" in clip and clip["media_bytes"] != img_bytes
+            img = Image.open(io.BytesIO(clip["media_bytes"]))
+            assert img.size == (clip["width"], clip["height"])
+            assert "clip_index" in clip
+            assert clip["file_size"] == len(clip["media_bytes"])
+
+    def test_sorts_by_confidence_desc(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        detections = [
+            (0, 0.3, [10.0, 10.0, 40.0, 40.0]),
+            (0, 0.95, [50.0, 50.0, 120.0, 120.0]),
+            (0, 0.6, [130.0, 130.0, 190.0, 190.0]),
+        ]
+        c = ImageObjectClipper(threshold=0.25)
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 3
+        assert result[0]["clip_box"] == [50, 50, 120, 120]
+        assert result[1]["clip_box"] == [130, 130, 190, 190]
+        assert result[2]["clip_box"] == [10, 10, 40, 40]
+
+    def test_threshold_filters_low_confidence(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        detections = [
+            (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
+            (0, 0.2, [100.0, 100.0, 180.0, 180.0]),
+        ]
+        c = ImageObjectClipper(threshold=0.5)
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 1
+        assert result[0]["clip_box"] == [10, 10, 60, 60]
+
+    def test_class_filter_keeps_only_whitelisted(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        detections = [
+            (0, 0.9, [10.0, 10.0, 60.0, 60.0]),  # person
+            (1, 0.85, [80.0, 80.0, 150.0, 150.0]),  # car
+            (2, 0.8, [120.0, 120.0, 190.0, 190.0]),  # dog
+        ]
+        c = ImageObjectClipper(threshold=0.5, class_filter="person,dog")
+        c._model = _make_mock_yolo(detections, {0: "person", 1: "car", 2: "dog"})
+        result = c.clip(media)
+        assert len(result) == 2
+        # 'car' (cls=1) excluded; remaining sorted by confidence
+        boxes = {tuple(r["clip_box"]) for r in result}
+        assert boxes == {(10, 10, 60, 60), (120, 120, 190, 190)}
+
+    def test_empty_class_filter_keeps_all(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        detections = [
+            (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
+            (1, 0.8, [80.0, 80.0, 150.0, 150.0]),
+        ]
+        c = ImageObjectClipper(threshold=0.5, class_filter="")
+        c._model = _make_mock_yolo(detections, {0: "person", 1: "car"})
+        result = c.clip(media)
+        assert len(result) == 2
+
+    def test_max_detections_caps_output(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(400, 400)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 400, "height": 400}
+        # 6 detections with varying confidence; cap at 3 should keep top 3
+        detections = [
+            (0, 0.5, [0.0, 0.0, 20.0, 20.0]),
+            (0, 0.95, [30.0, 30.0, 60.0, 60.0]),
+            (0, 0.4, [70.0, 70.0, 100.0, 100.0]),
+            (0, 0.85, [120.0, 120.0, 160.0, 160.0]),
+            (0, 0.6, [180.0, 180.0, 220.0, 220.0]),
+            (0, 0.7, [240.0, 240.0, 280.0, 280.0]),
+        ]
+        c = ImageObjectClipper(threshold=0.0, max_detections=3)
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 3
+        confs_kept = {(r["clip_box"][0], r["clip_box"][1]) for r in result}
+        # Top 3 confidences are 0.95, 0.85, 0.7 → boxes starting at (30,30), (120,120), (240,240)
+        assert confs_kept == {(30, 30), (120, 120), (240, 240)}
+
+    def test_padding_expands_box(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(400, 400)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 400, "height": 400}
+        # 100x100 box at (150,150)-(250,250) with 10% padding → expand by 10px each side
+        detections = [(0, 0.9, [150.0, 150.0, 250.0, 250.0])]
+        c = ImageObjectClipper(threshold=0.0, padding=0.1)
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 1
+        box = result[0]["clip_box"]
+        assert box == [140, 140, 260, 260]
+        assert result[0]["width"] == 120
+        assert result[0]["height"] == 120
+
+    def test_padding_clamps_to_image_bounds(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        # Box near the corner; aggressive padding would go negative / past edge.
+        detections = [(0, 0.9, [10.0, 10.0, 50.0, 50.0])]
+        c = ImageObjectClipper(threshold=0.0, padding=1.0)  # +40px each side
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert len(result) == 1
+        box = result[0]["clip_box"]
+        # x1, y1 clamped to 0; x2, y2 within bounds
+        assert box[0] == 0
+        assert box[1] == 0
+        assert box[2] <= 200
+        assert box[3] <= 200
+
+    def test_clip_index_is_set(self):
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        img_bytes = _make_image_bytes(200, 200)
+        media = {"id": 1, "type": "image", "media_bytes": img_bytes, "width": 200, "height": 200}
+        detections = [
+            (0, 0.9, [10.0, 10.0, 60.0, 60.0]),
+            (0, 0.8, [70.0, 70.0, 120.0, 120.0]),
+        ]
+        c = ImageObjectClipper(threshold=0.0)
+        c._model = _make_mock_yolo(detections, {0: "person"})
+        result = c.clip(media)
+        assert [r["clip_index"] for r in result] == [0, 1]
+
+    def test_registered_in_clippers_list(self):
+        from vtsearch.media.image import CLIPPERS
+        from vtsearch.media.image.clipper import ImageObjectClipper
+
+        assert any(isinstance(c, ImageObjectClipper) for c in CLIPPERS)
+
+
+# ---------------------------------------------------------------------------
 # TextDefaultClipper
 # ---------------------------------------------------------------------------
 

--- a/vtsearch/media/image/__init__.py
+++ b/vtsearch/media/image/__init__.py
@@ -1,5 +1,5 @@
-from vtsearch.media.image.clipper import ImageDefaultClipper, ImageTilingClipper
+from vtsearch.media.image.clipper import ImageDefaultClipper, ImageObjectClipper, ImageTilingClipper
 from vtsearch.media.image.media_type import ImageMediaType
 
 MEDIA_TYPE = ImageMediaType()
-CLIPPERS = [ImageDefaultClipper(), ImageTilingClipper()]
+CLIPPERS = [ImageDefaultClipper(), ImageTilingClipper(), ImageObjectClipper()]

--- a/vtsearch/media/image/clipper.py
+++ b/vtsearch/media/image/clipper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import math
-from typing import Any
+from typing import Any, Optional
 
 from vtsearch.media.clipper import MediaClipper
 
@@ -199,4 +199,231 @@ class ImageBboxClipper(MediaClipper):
     def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         d["box"] = list(self._box)
+        return d
+
+
+class ImageObjectClipper(MediaClipper):
+    """Crop one clip per detected object using a lightweight YOLO/RT-DETR.
+
+    Each output clip is a crop around one detection's bounding box, with an
+    optional padding margin to give downstream embedders a bit of context.
+    Detections can be filtered by class and confidence, and capped at
+    ``max_detections`` (sorted by confidence, highest first) to prevent a
+    single image from exploding into hundreds of clips.
+
+    Images with no surviving detections fall through unchanged so the load
+    pipeline keeps them as the original (single-element) media; the
+    ``MediaClipper.clip`` contract requires at least one element.
+
+    The default ``model_id`` of ``"yolo11n.pt"`` matches
+    :class:`~vtsearch.media.image.extractor.ImageClassExtractor` so a single
+    YOLO weight serves both detection-as-metadata and detection-as-clips.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.25,
+        class_filter: str = "",
+        max_detections: int = 20,
+        padding: float = 0.0,
+        model_id: str = "yolo11n.pt",
+    ) -> None:
+        self._threshold = float(threshold)
+        self._class_filter = str(class_filter or "").strip()
+        self._max_detections = max(1, int(max_detections))
+        self._padding = max(0.0, float(padding))
+        self._model_id = str(model_id)
+        self._model: Optional[Any] = None
+
+    @property
+    def name(self) -> str:
+        return "image_object"
+
+    @property
+    def media_type(self) -> str:
+        return "image"
+
+    @property
+    def description(self) -> str:
+        return "Detect objects with YOLO/RT-DETR and crop one clip per detection."
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    @property
+    def class_filter(self) -> str:
+        return self._class_filter
+
+    @property
+    def max_detections(self) -> int:
+        return self._max_detections
+
+    @property
+    def padding(self) -> float:
+        return self._padding
+
+    @property
+    def model_id(self) -> str:
+        return self._model_id
+
+    def _class_whitelist(self) -> set[str] | None:
+        if not self._class_filter:
+            return None
+        return {c.strip() for c in self._class_filter.split(",") if c.strip()} or None
+
+    def _load_model(self) -> None:
+        if self._model is not None:
+            return
+        from ultralytics import YOLO  # pyright: ignore[reportPrivateImportUsage] # noqa: PLC0415
+
+        self._model = YOLO(self._model_id)
+
+    def _collect_hits(
+        self,
+        results: Any,
+        img_w: int,
+        img_h: int,
+    ) -> list[tuple[float, tuple[int, int, int, int]]]:
+        whitelist = self._class_whitelist()
+        hits: list[tuple[float, tuple[int, int, int, int]]] = []
+        for result in results:
+            boxes = getattr(result, "boxes", None)
+            if boxes is None:
+                continue
+            names = getattr(result, "names", {}) or {}
+            for i in range(len(boxes)):
+                conf = float(boxes.conf[i])
+                if conf < self._threshold:
+                    continue
+                cls_id = int(boxes.cls[i])
+                label = names.get(cls_id, str(cls_id))
+                if whitelist is not None and label not in whitelist:
+                    continue
+                box = self._pad_and_clamp(boxes.xyxy[i].tolist(), img_w, img_h)
+                if box is None:
+                    continue
+                hits.append((conf, box))
+        return hits
+
+    def _pad_and_clamp(self, raw: list[float], img_w: int, img_h: int) -> tuple[int, int, int, int] | None:
+        x1, y1, x2, y2 = (float(v) for v in raw)
+        if self._padding > 0:
+            bw = x2 - x1
+            bh = y2 - y1
+            x1 -= bw * self._padding
+            x2 += bw * self._padding
+            y1 -= bh * self._padding
+            y2 += bh * self._padding
+        ix1 = max(0, int(math.floor(x1)))
+        iy1 = max(0, int(math.floor(y1)))
+        ix2 = min(img_w, int(math.ceil(x2)))
+        iy2 = min(img_h, int(math.ceil(y2)))
+        if ix2 <= ix1 or iy2 <= iy1:
+            return None
+        return (ix1, iy1, ix2, iy2)
+
+    def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
+        from PIL import Image  # noqa: PLC0415
+
+        media_bytes = media.get("media_bytes")
+        if media_bytes is None:
+            return [media]
+
+        img = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        fmt = Image.open(io.BytesIO(media_bytes)).format or "PNG"
+        img_w, img_h = img.size
+
+        self._load_model()
+        assert self._model is not None
+        results = self._model(img, verbose=False)
+
+        hits = self._collect_hits(results, img_w, img_h)
+        hits.sort(key=lambda h: h[0], reverse=True)
+        hits = hits[: self._max_detections]
+
+        if not hits:
+            return [media]
+
+        clips: list[dict[str, Any]] = []
+        for idx, (_conf, (cx1, cy1, cx2, cy2)) in enumerate(hits):
+            cropped = img.crop((cx1, cy1, cx2, cy2))
+            buf = io.BytesIO()
+            cropped.save(buf, format=fmt)
+            crop_bytes = buf.getvalue()
+            clip = dict(media)
+            clip["media_bytes"] = crop_bytes
+            clip["width"] = cx2 - cx1
+            clip["height"] = cy2 - cy1
+            clip["file_size"] = len(crop_bytes)
+            clip["clip_index"] = idx
+            clip["clip_box"] = [cx1, cy1, cx2, cy2]
+            clips.append(clip)
+        return clips
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "threshold",
+                "label": "Confidence threshold",
+                "description": "Minimum YOLO confidence (0–1) for a detection to become a clip.",
+                "type": "number",
+                "default": self._threshold,
+                "min": 0.0,
+                "max": 1.0,
+                "step": 0.05,
+            },
+            {
+                "key": "class_filter",
+                "label": "Class filter",
+                "description": "Comma-separated YOLO class names to keep (e.g. 'person,car'). Empty = all classes.",
+                "type": "string",
+                "default": self._class_filter,
+            },
+            {
+                "key": "max_detections",
+                "label": "Max clips per image",
+                "description": "Cap on clips per image; highest-confidence detections win.",
+                "type": "number",
+                "default": self._max_detections,
+                "min": 1,
+                "max": 200,
+                "step": 1,
+            },
+            {
+                "key": "padding",
+                "label": "Box padding",
+                "description": "Fractional margin added around each box (0.0 = tight, 0.1 = 10% wider).",
+                "type": "number",
+                "default": self._padding,
+                "min": 0.0,
+                "max": 1.0,
+                "step": 0.05,
+            },
+            {
+                "key": "model_id",
+                "label": "YOLO model",
+                "description": "ultralytics weight file (e.g. yolo11n.pt, yolo11s.pt, yolo11l.pt).",
+                "type": "string",
+                "default": self._model_id,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "ImageObjectClipper":
+        return ImageObjectClipper(
+            threshold=float(params.get("threshold", self._threshold)),
+            class_filter=str(params.get("class_filter", self._class_filter)),
+            max_detections=int(params.get("max_detections", self._max_detections)),
+            padding=float(params.get("padding", self._padding)),
+            model_id=str(params.get("model_id", self._model_id)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["threshold"] = self._threshold
+        d["class_filter"] = self._class_filter
+        d["max_detections"] = self._max_detections
+        d["padding"] = self._padding
+        d["model_id"] = self._model_id
         return d

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -25,7 +25,7 @@ and flows through without per-key declarations.
 
 from __future__ import annotations
 
-from marshmallow import Schema, fields, validate
+from marshmallow import Schema, fields, post_dump, validate
 
 
 _METRIC_VALIDATOR = validate.OneOf(["smart", "stable", "diverse"])
@@ -51,20 +51,42 @@ class LabelingProgressResponseSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
-class LabelingStatusResponseSchema(Schema):
-    """Response for ``GET /api/labeling-status``.
+class StatusIndicatorSchema(Schema):
+    """One ``smart`` / ``stable`` / ``span`` indicator in the labeling-status
+    response.  ``status`` is the red/yellow/green flag every indicator emits;
+    ``reason`` is the human-readable explanation.  Metric-specific keys
+    (``cost``, ``flips``, ``diversity_level``, ``avg_flip_rate``, …) flow
+    through unchanged via ``unknown = "include"`` plus :meth:`_include_extras`
+    — the :mod:`vtsearch.detectors.labeling_progress` analyzer remains the
+    source of truth for that shape."""
 
-    The three sub-objects (``smart``, ``stable``, ``span``) each carry
-    ``status`` plus metric-specific keys; declared as plain dicts so
-    the analyzer remains the source of truth for their shape.
-    """
+    status = fields.String(required=True)
+    reason = fields.String()
+
+    class Meta:
+        unknown = "include"
+
+    @post_dump(pass_original=True)
+    def _include_extras(self, data: dict, original: dict, **_: object) -> dict:
+        # ``unknown = "include"`` only affects ``load``; declared schemas drop
+        # unknown keys on ``dump``.  Re-merge the original dict's metric-
+        # specific keys so callers receive the full indicator payload.
+        if isinstance(original, dict):
+            for k, v in original.items():
+                if k not in data:
+                    data[k] = v
+        return data
+
+
+class LabelingStatusResponseSchema(Schema):
+    """Response for ``GET /api/labeling-status``."""
 
     good_count = fields.Integer(required=True)
     bad_count = fields.Integer(required=True)
     total_count = fields.Integer(required=True)
-    smart = fields.Dict(required=True)
-    stable = fields.Dict(required=True)
-    span = fields.Dict(required=True)
+    smart = fields.Nested(StatusIndicatorSchema, required=True)
+    stable = fields.Nested(StatusIndicatorSchema, required=True)
+    span = fields.Nested(StatusIndicatorSchema, required=True)
 
 
 # ---------------------------------------------------------------------------
@@ -159,4 +181,5 @@ __all__ = [
     "IndicatorScoreHistoryResponseSchema",
     "LabelingProgressResponseSchema",
     "LabelingStatusResponseSchema",
+    "StatusIndicatorSchema",
 ]


### PR DESCRIPTION
## Summary

- New `ImageObjectClipper` (`vtsearch/media/image/clipper.py`) turns each YOLO/RT-DETR detection into its own scoreable clip. Reuses the ultralytics weight (`yolo11n.pt`) already loaded by `ImageClassExtractor` so there's no new heavy dep.
- Registered in `vtsearch/media/image/__init__.py`'s `CLIPPERS` list so it auto-appears in the clipper-chooser UI alongside `image_default` and `image_tiling`.
- Params (`threshold`, `class_filter`, `max_detections`, `padding`, `model_id`) round-trip through `parameters` / `creation_questions` so the frontend renders them automatically and they get stamped into each clip's `origin["params"]` for cross-dataset replay.
- Images with zero surviving detections fall through unchanged — required by the `MediaClipper.clip` >=1-element contract.

## Design choices

- **`max_detections` default 20** — caps clips per image (sorted by confidence desc) to prevent a single crowded photo from spawning hundreds of crops. Tunable up to 200.
- **`padding` default 0.0** — tight YOLO boxes. Users who find embeddings need more context can dial up to ~0.1 or so.
- **`class_filter` empty = all classes** — comma-separated whitelist like `"person,car"` mirrors `ImageClassExtractor`'s single-class field but multi-valued.
- **0 detections returns `[media]`** — the safer fallthrough; treating it as "drop this image" would require pipeline changes.

## Follow-ups

Recorded in `docs/plans/feature-brainstorm.md` under §3.2:
- Try SAM2 boxes through the same UI once the SAM2 embedder lands (§4.1).
- Consider per-class confidence threshold if users ask for it.

## Test plan

- [x] `./run-tests.sh detectors` — 884 passed (includes 17 new `ImageObjectClipper` tests with a mocked ultralytics model)
- [x] `./run-tests.sh` — 3680 passed, 1 skipped, ruff clean, codespell clean, deptry clean
- [x] Frontend build check (`npm run build:prod`) — clean
- [x] Frontend audit — 0 vulnerabilities

## Note on commits

This branch was forked from `main` and rebased onto `dev` by the session-start hook per `CLAUDE.md`. Three openapi commits already merged to `main` via #1463 appear ahead of `dev` in this branch and will show in the diff; they're equivalents of what's already on `main` and will collapse cleanly the next time `dev` pulls `main`.

https://claude.ai/code/session_014FhwkusGCwNyoY7fKkFBXS

---
_Generated by [Claude Code](https://claude.ai/code/session_014FhwkusGCwNyoY7fKkFBXS)_