### PR TITLE
Per-plugin marshmallow schemas for plugin-field routes

### DIFF
--- a/docs/plans/openapi-schema.md
+++ b/docs/plans/openapi-schema.md
@@ -1,6 +1,6 @@
 # OpenAPI schema + generated TS client
 
-Status: in progress (pilot landing alongside this doc). Tracking issue: feature-brainstorm.md §12.9.
+Status: every blueprint migrated; per-plugin runtime validation in place for the six plugin-field routes; one cosmetic follow-up (real spec types for plugin-field bodies) is deferred — see *Open follow-ups*. Tracking issue: feature-brainstorm.md §12.9.
 
 ## The problem
 
@@ -242,36 +242,56 @@ checks off this follow-up.
 - **Plugin field endpoints** (`/api/exporters/<name>`,
   `/api/importers/<name>/run`, `/api/label-importers/import/<name>`,
   `/api/dataset/stage-import/<name>`, `/api/dataset/import/<name>`,
-  `/api/detectors/registry/from-labelset/<name>`, etc.) — request
-  shapes depend on each plugin's declared `fields`. **Decision:
-  option (c) — generate a per-plugin marshmallow schema at startup
-  from each plugin's `fields` declaration**, and pass it to
-  `@blp.arguments(...)` per call site. The `FieldType` literal is
-  `{file, folder, url, text, password, email, select, server_path,
-  checkbox}`, which maps mechanically to marshmallow:
+  `/api/detectors/registry/from-labelset/<name>`,
+  `/api/settings-importers/import/<name>`, etc.) — request shapes
+  depend on each plugin's declared `fields`. **Decision: hybrid of
+  option (c) and option (b).**
+
+  Per-plugin marshmallow schemas are built lazily from each plugin's
+  `fields` declaration (`vtsearch/plugins/schema.py::make_plugin_arg_schema`)
+  and cached on the plugin instance — the runtime validation tier.
+  Each route handler looks up `plugin._arg_schema_instance` via
+  `validate_plugin_args(plugin, ...)` and feeds the request body
+  through it; schema-level rejects raise the standard `422 + errors`
+  envelope. The `FieldType` literal is `{file, folder, url, text,
+  password, email, number, select, server_path, checkbox}`, which
+  maps to marshmallow as:
   - `text` / `url` / `email` / `password` / `server_path` / `folder` →
-    `fields.String` (with `validate.Length(min=1)` when `required`).
+    `fields.String` (with the legacy "non-empty after strip" validator
+    when `required`).
   - `select` with static `options` → `fields.String` +
     `validate.OneOf(options)`. `dynamic_options=True` falls back to
     `fields.String` (frontend re-fetches via the existing
     `<name>/options` route).
-  - `checkbox` → `fields.Boolean`.
-  - `file` → not representable in JSON schema; routes that take a
-    `file` field stay on multipart with `@arguments` omitted, declare
-    error responses via `alt_response`, and declare the success body
-    via `response` — same pattern as `add-to-pile` and
-    `server-media-files/upload`. The handler still uses
-    `extract_plugin_fields` / `validate_required_fields` internally
-    for these.
+  - `number` → `fields.Integer` (when step/default/min/max are
+    integer-looking) or `fields.Float`.
+  - `checkbox` → `fields.Function(deserialize=_coerce_checkbox)` that
+    accepts both bool and `"true"` / `"false"` form-encoded strings.
+  - `file` → skipped at the schema layer; the helper reads
+    `request.files` after `schema.load()` and merges file uploads
+    into the validated dict (either as `FileStorage` or as
+    in-memory `BytesIO`, selected via `file_mode=`).
 
-  Schemas are built once at startup (after plugin discovery) and
-  cached on the plugin instance; the route helper looks up
-  `plugin._arg_schema` and `plugin._response_schema` (when defined).
-  Spec consumers see real per-field types instead of
-  `additionalProperties: true`, which is the whole point of this
-  plan. (a) leaves the largest chunk of the API permanently
-  un-typed; (b) gets the route into the spec but loses per-field
-  typing.
+  The schema uses `Meta.unknown = "exclude"` so it stays a faithful
+  description of the plugin's declared field set — pass-through keys
+  (`converters`, `source_specs`, `clipper`, `embedder`,
+  `dataset_name`, `name`) are declared explicitly per call site via
+  `extra_keys=(...)`.
+
+  Where the design *doesn't* go to option (c): each plugin-field
+  route still uses one parameterised URL (`<importer_name>`) rather
+  than one static URL per plugin variant, so its request body is
+  *not* described in the OpenAPI spec at all — the spec lists the
+  path but with an empty / loose body schema. That's the option (b)
+  half: runtime validation is per-plugin, but spec consumers don't
+  see per-plugin types. Lifting the spec to real per-field types
+  would require registering one Flask URL rule per plugin variant at
+  startup (e.g. `/api/dataset/import/server_folder`,
+  `/api/dataset/import/pickle`, …) — a bigger refactor than runtime
+  validation, and the dynamic frontend (which discovers field shapes
+  via `/api/importers` etc. and builds forms generically) doesn't
+  directly benefit from compile-time types here. Captured in *Open
+  follow-ups* if the calculus changes later.
 
 - **Pagination.** flask-smorest has a built-in helper, but no current
   list endpoint actually needs it: `/api/medias/ids` is already the
@@ -973,38 +993,63 @@ checks off this follow-up.
       ``MediaStateService.getMedia(id)`` helper that returns the cached
       batch first and falls back to the stub (same pattern as the
       ``selectedMedia`` getter).
+- [x] Per-plugin marshmallow schemas built from each plugin's ``fields``
+      declaration, cached on the plugin instance
+      (``vtsearch/plugins/schema.py``). The six plugin-field routes
+      (``stage-import``, ``import``, ``label-importers/import``,
+      ``detectors/<name>/import-labels``, ``from-labelset``,
+      ``settings-importers/import``) now run their request bodies
+      through the per-plugin schema via ``validate_plugin_args(...)``;
+      schema-level rejects raise 422 with the standard ``errors``
+      envelope. Pass-through keys (``converters``, ``source_specs``,
+      ``clipper``, ``embedder``, ``dataset_name``, ``name``) are
+      declared per call site via ``extra_keys=(...)``. Legacy helpers
+      ``extract_plugin_fields`` / ``validate_required_fields`` /
+      ``get_request_field`` / ``_extract_importer_fields`` deleted.
+      Spec-side per-plugin types are still loose — see *Open
+      follow-ups / OpenAPI spec types for plugin-field route bodies*.
+
+## What shipped
+
+- **Per-plugin runtime validation for plugin-field routes.** The six
+  plugin-field routes (``POST /api/label-importers/import/<imp>``,
+  ``POST /api/dataset/stage-import/<imp>``,
+  ``POST /api/dataset/import/<imp>``,
+  ``POST /api/detectors/<name>/import-labels/<imp>``,
+  ``POST /api/detectors/registry/from-labelset/<imp>``,
+  ``POST /api/settings-importers/import/<imp>``) now validate the
+  request body against a marshmallow schema built from the named
+  plugin's :attr:`fields` declaration (``vtsearch/plugins/schema.py``).
+  Schema-level rejects (missing required field, invalid select value,
+  unparseable number) surface as 422 with the standard ``errors``
+  envelope, matching the rest of the API. Pass-through keys
+  (``converters``, ``source_specs``, ``clipper``, ``embedder``,
+  ``dataset_name``, ``name``) are declared explicitly per call site via
+  ``validate_plugin_args(..., extra_keys=(...))`` — the schema itself
+  uses ``Meta.unknown = "exclude"`` so it stays a faithful description
+  of the plugin's declared field set. The legacy
+  ``extract_plugin_fields`` / ``validate_required_fields`` /
+  ``get_request_field`` helpers in ``vtsearch/routes/_shared.py`` and
+  ``_extract_importer_fields`` in ``vtsearch/routes/datasets/_helpers.py``
+  are deleted.
 
 ## Open follow-ups
 
-- **Migrate the remaining Angular services to the generated client.**
-  Settings, auth, achievements, file-browser, exporters, settings-io,
-  label-importers, medias, sorting, detectors, and datasets have all
-  moved over. The remaining service is ``ProcessorImportersApiService``
-  (~17 LOC) which still references ``/api/processor-importers`` — a
-  legacy route with no live backend handler; the consuming
-  ``processor-importer-modal`` is wired up but the endpoint isn't in
-  the OpenAPI spec, so this service is left untouched until the
-  backend route is rebuilt under ``vtsearch/routes/processors/``
-  (probably as a flask-smorest blueprint with a per-plugin field
-  schema). The hybrid imports (``import type`` for DTOs, direct
-  function-module paths for runtime symbols, no barrel) are required
-  to keep the initial bundle under the 525 kB budget — see
-  *Bundle-size discipline* above.
-- **Per-plugin schemas for plugin-field routes.** The four routes
-  whose request body is a plugin-field shape stay on the legacy
-  plain-Flask path on their (now smorest-typed) blueprints:
-  ``POST /api/label-importers/import/<importer_name>``,
-  ``POST /api/dataset/stage-import/<importer_name>``,
-  ``POST /api/dataset/import/<importer_name>``, and
-  ``POST /api/detectors/<name>/import-labels/<importer_name>``
-  (plus ``POST /api/detectors/registry/from-labelset/<importer_name>``).
-  The *Resolved questions / Plugin field endpoints* section above
-  describes the eventual design — generate a per-plugin marshmallow
-  schema at startup from each plugin's ``fields`` declaration and
-  attach it to the route call site. That requires either registering
-  one Flask URL rule per plugin variant at startup or invoking
-  ``plugin._arg_schema.load(...)`` manually inside the handler.
-  Neither is wired yet; the routes are documented in their module
-  docstrings as "Plugin-dependent body shape: not described in the
-  OpenAPI spec" so spec consumers see them in the URL map but without
-  a request body schema.
+- **OpenAPI spec types for plugin-field route bodies.** The six routes
+  above are validated at runtime against the per-plugin schema, but
+  their request bodies are still un-typed in ``/api/openapi.json``
+  (each handler is a plain ``@blueprint.route`` with no ``@arguments``
+  decorator). To surface real per-field types in the spec we'd need to
+  register one Flask URL rule per plugin variant at startup —
+  ``/api/dataset/import/server_folder``, ``/api/dataset/import/pickle``,
+  etc. — each decorated with its own ``@blp.arguments(plugin._arg_schema)``.
+  That's a bigger refactor than runtime validation and the dynamic
+  frontend (which discovers field shapes via ``/api/importers`` etc.
+  and builds forms generically) doesn't directly benefit from compile-
+  time types here, so the spec stays loose for now. The runtime
+  validation captures the per-plugin field types where it matters
+  (bad input → 422 → frontend's error pipeline).
+- **``ProcessorImportersApiService`` follow-up — RESOLVED.** The
+  service, modal, and DTO were deleted in commit ``6b4c0b4d`` once it
+  became clear the backend route had been removed. Initial bundle
+  dropped from 512 kB to 496 kB.

--- a/tests/core/test_plugin_schema.py
+++ b/tests/core/test_plugin_schema.py
@@ -1,0 +1,141 @@
+"""Unit tests for :mod:`vtsearch.plugins.schema`.
+
+Covers the per-field-type mapping (``PluginField`` →
+:class:`marshmallow.fields.Field`) plus the high-level ``load()``
+behaviour that the route helpers depend on:
+
+* required text-like fields raise ``ValidationError`` on missing /
+  empty / whitespace-only values;
+* ``select`` fields enforce ``OneOf`` when ``options`` is static;
+* ``number`` fields coerce strings to int/float per
+  ``is_integer_number``;
+* ``checkbox`` fields accept both ``bool`` and ``"true"`` / ``"false"``;
+* unknown keys are dropped (``Meta.unknown = "exclude"``);
+* the cache returns the same instance across calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+from marshmallow import ValidationError
+
+from vtsearch.plugins import PluginField
+from vtsearch.plugins.schema import get_plugin_arg_schema, make_plugin_arg_schema
+
+
+class _FakePlugin:
+    """Bare-minimum stand-in for a real plugin instance."""
+
+    def __init__(self, fields: list[PluginField]) -> None:
+        self.fields = fields
+
+
+class TestSchemaBuilder:
+    def test_required_text_rejects_missing(self):
+        plugin = _FakePlugin([PluginField(key="name", label="Name", field_type="text", required=True)])
+        schema = make_plugin_arg_schema(plugin)()
+        with pytest.raises(ValidationError) as exc:
+            schema.load({})
+        assert "name" in exc.value.messages
+
+    def test_required_text_rejects_whitespace_only(self):
+        plugin = _FakePlugin([PluginField(key="name", label="Name", field_type="text", required=True)])
+        schema = make_plugin_arg_schema(plugin)()
+        with pytest.raises(ValidationError) as exc:
+            schema.load({"name": "   "})
+        assert "name" in exc.value.messages
+
+    def test_required_text_accepts_value(self):
+        plugin = _FakePlugin([PluginField(key="name", label="Name", field_type="text", required=True)])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"name": "hello"}) == {"name": "hello"}
+
+    def test_default_used_when_missing(self):
+        plugin = _FakePlugin(
+            [PluginField(key="name", label="Name", field_type="text", required=False, default="fallback")]
+        )
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({}) == {"name": "fallback"}
+
+    def test_select_rejects_unknown_option(self):
+        plugin = _FakePlugin(
+            [
+                PluginField(
+                    key="mode",
+                    label="Mode",
+                    field_type="select",
+                    options=["a", "b", "c"],
+                    required=True,
+                )
+            ]
+        )
+        schema = make_plugin_arg_schema(plugin)()
+        with pytest.raises(ValidationError) as exc:
+            schema.load({"mode": "z"})
+        assert "mode" in exc.value.messages
+
+    def test_select_dynamic_options_skips_oneof(self):
+        plugin = _FakePlugin(
+            [
+                PluginField(
+                    key="mode",
+                    label="Mode",
+                    field_type="select",
+                    options=["a"],
+                    dynamic_options=True,
+                    required=False,
+                )
+            ]
+        )
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"mode": "anything-goes"}) == {"mode": "anything-goes"}
+
+    def test_number_integer(self):
+        plugin = _FakePlugin([PluginField(key="n", label="N", field_type="number", default="3", step="1")])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"n": 7}) == {"n": 7}
+        # Marshmallow accepts numeric strings for Integer fields.
+        assert schema.load({"n": "9"}) == {"n": 9}
+
+    def test_number_float(self):
+        plugin = _FakePlugin([PluginField(key="x", label="X", field_type="number", default="1.5", step="0.1")])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"x": 2.5}) == {"x": 2.5}
+
+    def test_checkbox_accepts_string_true_false(self):
+        plugin = _FakePlugin([PluginField(key="flag", label="Flag", field_type="checkbox", default="false")])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({"flag": "true"}) == {"flag": True}
+        assert schema.load({"flag": "false"}) == {"flag": False}
+        assert schema.load({"flag": True}) == {"flag": True}
+
+    def test_checkbox_uses_default_when_missing(self):
+        plugin = _FakePlugin([PluginField(key="flag", label="Flag", field_type="checkbox", default="true")])
+        schema = make_plugin_arg_schema(plugin)()
+        assert schema.load({}) == {"flag": True}
+
+    def test_file_field_skipped(self):
+        plugin = _FakePlugin(
+            [
+                PluginField(key="upload", label="Upload", field_type="file", required=True),
+                PluginField(key="name", label="Name", field_type="text", required=False),
+            ]
+        )
+        schema = make_plugin_arg_schema(plugin)()
+        # File fields are populated outside the schema; the validator
+        # mustn't complain about them being missing.
+        assert schema.load({"name": "ok"}) == {"name": "ok"}
+
+    def test_unknown_keys_excluded(self):
+        plugin = _FakePlugin([PluginField(key="name", label="Name", field_type="text", required=False)])
+        schema = make_plugin_arg_schema(plugin)()
+        loaded = schema.load({"name": "ok", "bogus": "junk", "chunk_size": 99})
+        assert "bogus" not in loaded
+        assert "chunk_size" not in loaded
+        assert loaded["name"] == "ok"
+
+    def test_cache_returns_same_instance(self):
+        plugin = _FakePlugin([PluginField(key="x", label="X", field_type="text", required=False)])
+        first = get_plugin_arg_schema(plugin)
+        second = get_plugin_arg_schema(plugin)
+        assert first is second

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1690,15 +1690,15 @@ class TestRegisterModelFromLabelset:
         assert tm_data["media_example"] == ""
         assert tm_data["examples"] == []
 
-    def test_missing_name_returns_400(self, client, tmp_path):
+    def test_missing_name_returns_422(self, client, tmp_path):
         labels_path = tmp_path / "labels.json"
         labels_path.write_text('{"labels": []}')
         res = client.post(
             "/api/detectors/registry/from-labelset/server_json_file",
             json={"filepath": str(labels_path)},
         )
-        assert res.status_code == 400
-        assert "name" in res.get_json()["error"]
+        assert res.status_code == 422
+        assert "name" in res.get_json().get("errors", {}).get("json", {})
 
     def test_md5_only_labelset_returns_400(self, client, tmp_path):
         """Legacy md5-only labels have no origin — media type cannot be inferred."""

--- a/tests/io/test_settings_io.py
+++ b/tests/io/test_settings_io.py
@@ -396,12 +396,17 @@ class TestSettingsImportEndpoint:
         res = client.post("/api/settings-importers/import/nonexistent", json={})
         assert res.status_code == 404
 
-    def test_missing_filepath_400(self, client):
+    def test_missing_filepath_422(self, client):
+        # Schema-level validation: the per-plugin marshmallow schema
+        # rejects the empty ``filepath`` with the standard 422 envelope
+        # (the field is declared ``required=True`` on the
+        # server_json_file importer).
         res = client.post(
             "/api/settings-importers/import/server_json_file",
             json={"filepath": ""},
         )
-        assert res.status_code == 400
+        assert res.status_code == 422
+        assert "filepath" in res.get_json().get("errors", {}).get("json", {})
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/datasets/importers/base.py
+++ b/vtsearch/datasets/importers/base.py
@@ -107,9 +107,10 @@ PickerView = str  # one of: "form", "demo", "server_folder", "local_folder"
 # Synthetic per-importer field that lets the user pick a name for the new
 # dataset.  Injected at the front of every importer's serialised field list
 # in :meth:`DatasetImporter.to_dict`, so the frontend renders it generically
-# without each subclass having to duplicate the declaration.  The field is
-# extracted out of band by the import route handler — see
-# :func:`vtsearch.routes.datasets._helpers._extract_importer_fields`.
+# without each subclass having to duplicate the declaration.  Routed through
+# the per-plugin marshmallow schema as a regular field (see
+# :func:`vtsearch.routes._shared.validate_plugin_args`) and read downstream
+# by :meth:`DatasetImporter.resolve_display_name`.
 DATASET_NAME_FIELD_KEY = "dataset_name"
 
 

--- a/vtsearch/plugins/schema.py
+++ b/vtsearch/plugins/schema.py
@@ -90,6 +90,10 @@ def _presence_kwargs(pf: PluginField) -> dict:
 
 
 def _build_checkbox(pf: PluginField, kwargs: dict) -> fields.Field:
+    # Checkboxes always have a sensible default (``False`` if the plugin
+    # doesn't set one) — drop ``required`` to avoid the
+    # ``required + load_default`` conflict marshmallow would raise.
+    kwargs.pop("required", None)
     kwargs["load_default"] = str(pf.default).lower() == "true"
     return fields.Function(deserialize=_coerce_checkbox, **kwargs)
 
@@ -148,10 +152,13 @@ def _build_marshmallow_field(pf: PluginField) -> fields.Field | None:
 def make_plugin_arg_schema(plugin: PluginBase) -> type[Schema]:
     """Build a marshmallow ``Schema`` class for *plugin*'s declared fields.
 
-    Unknown keys are kept (``Meta.unknown = "include"``) so callers can
-    read pass-through params (``converters``, ``source_specs``,
-    ``clipper``, ``embedder``, ``dataset_name``, ``name``) alongside the
-    plugin-declared fields without listing them as plugin fields.
+    Unknown keys are dropped (``Meta.unknown = "exclude"``) — the schema
+    is a faithful description of the plugin's declared field set, not a
+    free-form bag.  Route handlers that need to pass extra keys
+    alongside the plugin-declared fields (e.g. ``converters``,
+    ``source_specs``, ``clipper``, ``embedder``, ``dataset_name``,
+    ``name``) declare them explicitly via the ``extra_keys`` argument to
+    :func:`vtsearch.routes._shared.validate_plugin_args`.
     """
     attrs: dict = {}
     for pf in plugin.fields:
@@ -159,7 +166,7 @@ def make_plugin_arg_schema(plugin: PluginBase) -> type[Schema]:
         if mf is not None:
             attrs[pf.key] = mf
 
-    attrs["Meta"] = type("Meta", (), {"unknown": "include"})
+    attrs["Meta"] = type("Meta", (), {"unknown": "exclude"})
     cls_name = f"{type(plugin).__name__}ArgSchema"
     return type(cls_name, (Schema,), attrs)
 

--- a/vtsearch/plugins/schema.py
+++ b/vtsearch/plugins/schema.py
@@ -72,54 +72,77 @@ def _coerce_checkbox(value: object) -> bool:
     raise ValidationError("Not a valid boolean.")
 
 
+def _presence_kwargs(pf: PluginField) -> dict:
+    """Return marshmallow ``required`` / ``load_default`` kwargs for *pf*.
+
+    The three states are mutually exclusive:
+    - required AND no default → ``required=True`` (marshmallow raises
+      on missing input).
+    - has default → ``load_default=<default>``.
+    - neither → ``load_default=""`` (preserves the legacy ``.get(key, "")``
+      fallback).
+    """
+    if pf.required and not pf.default:
+        return {"required": True}
+    if pf.default:
+        return {"load_default": pf.default}
+    return {"load_default": ""}
+
+
+def _build_checkbox(pf: PluginField, kwargs: dict) -> fields.Field:
+    kwargs["load_default"] = str(pf.default).lower() == "true"
+    return fields.Function(deserialize=_coerce_checkbox, **kwargs)
+
+
+def _build_number(pf: PluginField, kwargs: dict) -> fields.Field:
+    kwargs.pop("load_default", None)
+    if pf.default:
+        try:
+            kwargs["load_default"] = int(pf.default) if pf.is_integer_number() else float(pf.default)
+        except (TypeError, ValueError):
+            # Bad default — let marshmallow raise on missing input.
+            kwargs.pop("load_default", None)
+    if pf.is_integer_number():
+        return fields.Integer(**kwargs)
+    return fields.Float(**kwargs)
+
+
+def _build_select(pf: PluginField, kwargs: dict) -> fields.Field:
+    validators: list = []
+    if pf.required:
+        validators.append(_non_empty_after_strip)
+    if pf.options and not pf.dynamic_options:
+        validators.append(validate.OneOf([*pf.options, ""] if not pf.required else pf.options))
+    if validators:
+        kwargs["validate"] = validators
+    return fields.String(**kwargs)
+
+
+def _build_text(pf: PluginField, kwargs: dict) -> fields.Field:
+    # text / url / email / password / folder / server_path
+    # Use ``fields.String`` for emails (not ``fields.Email``) — empty
+    # strings are acceptable for non-required fields, and the frontend /
+    # plugin can tighten validation if it needs RFC compliance.
+    if pf.required:
+        kwargs["validate"] = _non_empty_after_strip
+    return fields.String(**kwargs)
+
+
 def _build_marshmallow_field(pf: PluginField) -> fields.Field | None:
     """Return the marshmallow field for *pf*, or ``None`` to skip it."""
     if pf.field_type == "file":
         # File fields are populated from ``request.files`` after schema load.
         return None
 
-    kwargs: dict = {}
-    if pf.required and not pf.default:
-        kwargs["required"] = True
-    elif pf.default:
-        kwargs["load_default"] = pf.default
-    else:
-        kwargs["load_default"] = ""
+    kwargs = _presence_kwargs(pf)
 
     if pf.field_type == "checkbox":
-        # ``load_default`` overrides any text-default we set above.
-        kwargs["load_default"] = str(pf.default).lower() == "true"
-        return fields.Function(deserialize=_coerce_checkbox, **kwargs)
-
+        return _build_checkbox(pf, kwargs)
     if pf.field_type == "number":
-        kwargs.pop("load_default", None)
-        if pf.default:
-            try:
-                kwargs["load_default"] = int(pf.default) if pf.is_integer_number() else float(pf.default)
-            except (TypeError, ValueError):
-                # Bad default — let marshmallow raise on missing input.
-                kwargs.pop("load_default", None)
-        if pf.is_integer_number():
-            return fields.Integer(**kwargs)
-        return fields.Float(**kwargs)
-
+        return _build_number(pf, kwargs)
     if pf.field_type == "select":
-        validators: list = []
-        if pf.required:
-            validators.append(_non_empty_after_strip)
-        if pf.options and not pf.dynamic_options:
-            validators.append(validate.OneOf([*pf.options, ""] if not pf.required else pf.options))
-        if validators:
-            kwargs["validate"] = validators
-        return fields.String(**kwargs)
-
-    # text / url / email / password / folder / server_path
-    # Use fields.String (not fields.Email) for emails — empty strings are
-    # acceptable for non-required fields and the frontend / plugin can
-    # tighten the validation if it cares about RFC compliance.
-    if pf.required:
-        kwargs["validate"] = _non_empty_after_strip
-    return fields.String(**kwargs)
+        return _build_select(pf, kwargs)
+    return _build_text(pf, kwargs)
 
 
 def make_plugin_arg_schema(plugin: PluginBase) -> type[Schema]:

--- a/vtsearch/plugins/schema.py
+++ b/vtsearch/plugins/schema.py
@@ -1,0 +1,157 @@
+"""Build marshmallow schemas from :class:`PluginField` declarations.
+
+The five plugin-field HTTP routes
+(``/api/dataset/import/<importer>``, ``/api/dataset/stage-import/<importer>``,
+``/api/label-importers/import/<importer>``,
+``/api/detectors/<name>/import-labels/<importer>``,
+``/api/detectors/registry/from-labelset/<importer>``) accept a request
+body whose shape depends on the named plugin's :attr:`PluginBase.fields`
+declaration. Static marshmallow schemas can't express that shape because
+each plugin has its own field list — so we build a schema *per plugin*
+at request time, cache it on the plugin instance, and validate the
+incoming body against it.
+
+The mapping is:
+
+============ =====================================================
+field_type   marshmallow field
+============ =====================================================
+text         :class:`fields.String`
+url          :class:`fields.String`
+email        :class:`fields.Email`
+password     :class:`fields.String`
+folder       :class:`fields.String`
+server_path  :class:`fields.String`
+number       :class:`fields.Integer` (integer-looking)
+             / :class:`fields.Float`
+select       :class:`fields.String` + :class:`validate.OneOf`
+             (static options); plain :class:`fields.String` for
+             dynamic-options fields
+checkbox     :class:`fields.Boolean` (with string-coercion loader)
+file         skipped — file fields are populated from
+             ``request.files`` outside the schema
+============ =====================================================
+
+Required text-like fields are marshmallow-required *and* validated as
+non-empty after stripping whitespace (matching the pre-migration
+hand-rolled validator that rejected ``"   "`` as well as ``""``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from marshmallow import Schema, ValidationError, fields, validate
+
+if TYPE_CHECKING:
+    from vtsearch.plugins import PluginBase, PluginField
+
+
+_NON_EMPTY = validate.Length(min=1)
+
+
+def _non_empty_after_strip(value: object) -> None:
+    """Reject empty / whitespace-only strings.
+
+    Marshmallow's :class:`validate.Length` checks the raw value length,
+    but the pre-migration behaviour was to reject ``"   "`` as well as
+    ``""``. We mirror that by stripping before measuring.
+    """
+    if isinstance(value, str) and not value.strip():
+        raise ValidationError("Field may not be empty.")
+
+
+def _coerce_checkbox(value: object) -> bool:
+    """Accept ``true`` / ``false`` strings (legacy form-encoded source) and bools."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    if isinstance(value, (int, float)):
+        return bool(value)
+    raise ValidationError("Not a valid boolean.")
+
+
+def _build_marshmallow_field(pf: PluginField) -> fields.Field | None:
+    """Return the marshmallow field for *pf*, or ``None`` to skip it."""
+    if pf.field_type == "file":
+        # File fields are populated from ``request.files`` after schema load.
+        return None
+
+    kwargs: dict = {}
+    if pf.required and not pf.default:
+        kwargs["required"] = True
+    elif pf.default:
+        kwargs["load_default"] = pf.default
+    else:
+        kwargs["load_default"] = ""
+
+    if pf.field_type == "checkbox":
+        # ``load_default`` overrides any text-default we set above.
+        kwargs["load_default"] = str(pf.default).lower() == "true"
+        return fields.Function(deserialize=_coerce_checkbox, **kwargs)
+
+    if pf.field_type == "number":
+        kwargs.pop("load_default", None)
+        if pf.default:
+            try:
+                kwargs["load_default"] = int(pf.default) if pf.is_integer_number() else float(pf.default)
+            except (TypeError, ValueError):
+                # Bad default — let marshmallow raise on missing input.
+                kwargs.pop("load_default", None)
+        if pf.is_integer_number():
+            return fields.Integer(**kwargs)
+        return fields.Float(**kwargs)
+
+    if pf.field_type == "select":
+        validators: list = []
+        if pf.required:
+            validators.append(_non_empty_after_strip)
+        if pf.options and not pf.dynamic_options:
+            validators.append(validate.OneOf([*pf.options, ""] if not pf.required else pf.options))
+        if validators:
+            kwargs["validate"] = validators
+        return fields.String(**kwargs)
+
+    # text / url / email / password / folder / server_path
+    # Use fields.String (not fields.Email) for emails — empty strings are
+    # acceptable for non-required fields and the frontend / plugin can
+    # tighten the validation if it cares about RFC compliance.
+    if pf.required:
+        kwargs["validate"] = _non_empty_after_strip
+    return fields.String(**kwargs)
+
+
+def make_plugin_arg_schema(plugin: PluginBase) -> type[Schema]:
+    """Build a marshmallow ``Schema`` class for *plugin*'s declared fields.
+
+    Unknown keys are kept (``Meta.unknown = "include"``) so callers can
+    read pass-through params (``converters``, ``source_specs``,
+    ``clipper``, ``embedder``, ``dataset_name``, ``name``) alongside the
+    plugin-declared fields without listing them as plugin fields.
+    """
+    attrs: dict = {}
+    for pf in plugin.fields:
+        mf = _build_marshmallow_field(pf)
+        if mf is not None:
+            attrs[pf.key] = mf
+
+    attrs["Meta"] = type("Meta", (), {"unknown": "include"})
+    cls_name = f"{type(plugin).__name__}ArgSchema"
+    return type(cls_name, (Schema,), attrs)
+
+
+def get_plugin_arg_schema(plugin: PluginBase) -> Schema:
+    """Return a cached :class:`Schema` instance for *plugin*.
+
+    Caches on the plugin instance so we pay the schema-build cost once
+    per process. Plugin instances are long-lived (one per registered
+    plugin per process), so this is safe.
+    """
+    cached = getattr(plugin, "_arg_schema_instance", None)
+    if cached is not None:
+        return cached
+    schema_cls = make_plugin_arg_schema(plugin)
+    instance = schema_cls()
+    plugin._arg_schema_instance = instance  # type: ignore[attr-defined]
+    return instance

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -6,6 +6,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from flask import g, jsonify, request
+from flask_smorest import abort
+from marshmallow import ValidationError
 
 if TYPE_CHECKING:
     from vtsearch.plugins import PluginBase
@@ -100,49 +102,89 @@ def get_json_or_400():
 # ---------------------------------------------------------------------------
 
 
-def extract_plugin_fields(plugin: PluginBase) -> dict:
-    """Build a ``field_values`` dict from the current Flask request.
+def validate_plugin_args(plugin: PluginBase, *, file_mode: str = "filestorage") -> dict:
+    """Validate the request body against the plugin's per-field schema.
 
-    Handles both ``multipart/form-data`` (when the plugin has ``"file"``
-    fields) and JSON request bodies.  File fields are populated from
-    ``request.files``; non-file fields come from ``request.form`` or the
-    JSON body, falling back to the field's default value.
+    Builds a marshmallow schema from the plugin's :attr:`fields`
+    declaration (cached on the plugin instance) and runs the incoming
+    request body through it.  Returns the validated ``field_values``
+    dict on success, including file uploads keyed by their declared
+    field name.
+
+    Schema-level rejects (missing required field, invalid select value,
+    unparseable number) surface as ``422`` with the standard
+    ``errors`` envelope — matching the validation behaviour of routes
+    using ``@blp.arguments(...)``.  Pass-through keys that aren't
+    declared as plugin fields (``converters``, ``source_specs``,
+    ``clipper``, ``embedder``, ``dataset_name``, ``name``, etc.) are
+    preserved on the returned dict so callers can read them alongside
+    the plugin-declared values.
+
+    Parameters
+    ----------
+    plugin:
+        Any plugin instance with a :attr:`fields` declaration.
+    file_mode:
+        How to surface file uploads.  ``"filestorage"`` (default) keeps
+        :class:`werkzeug.datastructures.FileStorage` objects — used by
+        label-importer routes where the file is consumed synchronously.
+        ``"bytesio"`` reads each upload into an in-memory
+        :class:`io.BytesIO` carrying the original filename on its
+        ``.name`` attribute — used by dataset-importer routes that hand
+        the file off to a background thread (the request context, and
+        the underlying ``FileStorage``, are torn down before the thread
+        reads).
     """
+    import io  # noqa: PLC0415 — defer to avoid import cost when unused
+
+    from vtsearch.plugins.schema import get_plugin_arg_schema  # noqa: PLC0415
+
     has_file_fields = any(f.field_type == "file" for f in plugin.fields)
-    field_values: dict = {}
+    file_keys = {f.key for f in plugin.fields if f.field_type == "file"}
 
     if has_file_fields:
-        for f in plugin.fields:
-            if f.field_type == "file":
-                field_values[f.key] = request.files.get(f.key)
-            else:
-                field_values[f.key] = request.form.get(f.key, f.default if f.default is not None else "")
+        # ``request.form`` is a MultiDict; marshmallow handles plain dicts.
+        body: dict = {k: v for k, v in request.form.items()}
     else:
-        body = get_json_safe()
-        for f in plugin.fields:
-            field_values[f.key] = body.get(f.key, f.default if f.default is not None else "")
+        body = request.get_json(force=True, silent=True) or {}
+        if not isinstance(body, dict):
+            abort(400, message="Invalid request body")
 
-    return field_values
+    schema = get_plugin_arg_schema(plugin)
+    try:
+        validated: dict = schema.load(body)
+    except ValidationError as exc:
+        abort(422, message="Validation error", errors={"json": exc.messages})
 
+    # Add file uploads in the chosen mode.  Required file fields are
+    # checked here (the schema skips them) so callers get a consistent
+    # 422 envelope across all field types.
+    missing_files: list[str] = []
+    for f in plugin.fields:
+        if f.field_type != "file":
+            continue
+        storage = request.files.get(f.key) if has_file_fields else None
+        if storage is None or not getattr(storage, "filename", None):
+            if f.required:
+                missing_files.append(f.key)
+            else:
+                validated[f.key] = None
+            continue
+        if file_mode == "bytesio":
+            buf = io.BytesIO(storage.read())
+            buf.name = storage.filename  # type: ignore[attr-defined]
+            validated[f.key] = buf
+        else:
+            validated[f.key] = storage
 
-def validate_required_fields(plugin: PluginBase, field_values: dict) -> tuple | None:
-    """Check that all required non-file fields have non-empty values.
-
-    Returns a ``(response, 400)`` tuple on failure, or ``None`` if all
-    required fields are present.
-    """
-    missing = [
-        f.key
-        for f in plugin.fields
-        if f.required and f.field_type != "file" and not str(field_values.get(f.key, "")).strip()
-    ]
-    if missing:
-        return error_response(
-            f"Missing required field(s): {missing}",
-            400,
-            missing_fields=missing,
+    if missing_files:
+        abort(
+            422,
+            message="Validation error",
+            errors={"json": {k: ["Missing data for required field."] for k in missing_files}},
         )
-    return None
+
+    return validated
 
 
 def validate_filepath_field(field_values: dict) -> tuple | None:
@@ -198,13 +240,6 @@ def get_embedder_for_medias(media_dict: dict):
 
     avail = embedders_for_type(media_type)
     return avail[0] if avail else None
-
-
-def get_request_field(key: str, has_file_fields: bool) -> str:
-    """Read a single pass-through parameter from form data or JSON body."""
-    if has_file_fields:
-        return request.form.get(key, "")
-    return get_json_safe().get(key, "")
 
 
 def format_exception_detail(exc: BaseException) -> str:

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -140,7 +140,6 @@ def validate_plugin_args(plugin: PluginBase, *, file_mode: str = "filestorage") 
     from vtsearch.plugins.schema import get_plugin_arg_schema  # noqa: PLC0415
 
     has_file_fields = any(f.field_type == "file" for f in plugin.fields)
-    file_keys = {f.key for f in plugin.fields if f.field_type == "file"}
 
     if has_file_fields:
         # ``request.form`` is a MultiDict; marshmallow handles plain dicts.

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -102,7 +102,12 @@ def get_json_or_400():
 # ---------------------------------------------------------------------------
 
 
-def validate_plugin_args(plugin: PluginBase, *, file_mode: str = "filestorage") -> dict:
+def validate_plugin_args(
+    plugin: PluginBase,
+    *,
+    file_mode: str = "filestorage",
+    extra_keys: tuple[str, ...] = (),
+) -> dict:
     """Validate the request body against the plugin's per-field schema.
 
     Builds a marshmallow schema from the plugin's :attr:`fields`
@@ -114,11 +119,10 @@ def validate_plugin_args(plugin: PluginBase, *, file_mode: str = "filestorage") 
     Schema-level rejects (missing required field, invalid select value,
     unparseable number) surface as ``422`` with the standard
     ``errors`` envelope — matching the validation behaviour of routes
-    using ``@blp.arguments(...)``.  Pass-through keys that aren't
-    declared as plugin fields (``converters``, ``source_specs``,
-    ``clipper``, ``embedder``, ``dataset_name``, ``name``, etc.) are
-    preserved on the returned dict so callers can read them alongside
-    the plugin-declared values.
+    using ``@blp.arguments(...)``.  Keys the schema doesn't recognise
+    are dropped (the schema uses ``Meta.unknown = "exclude"``) — pass
+    *extra_keys* to allow specific extra body fields through to the
+    returned dict (e.g. ``"converters"``, ``"clipper"``, ``"name"``).
 
     Parameters
     ----------
@@ -134,6 +138,11 @@ def validate_plugin_args(plugin: PluginBase, *, file_mode: str = "filestorage") 
         the file off to a background thread (the request context, and
         the underlying ``FileStorage``, are torn down before the thread
         reads).
+    extra_keys:
+        Pass-through keys whose values should ride along on the
+        returned dict if present in the request body.  Each is copied
+        verbatim — type / shape validation is the route handler's
+        responsibility.
     """
     import io  # noqa: PLC0415 — defer to avoid import cost when unused
 
@@ -182,6 +191,10 @@ def validate_plugin_args(plugin: PluginBase, *, file_mode: str = "filestorage") 
             message="Validation error",
             errors={"json": {k: ["Missing data for required field."] for k in missing_files}},
         )
+
+    for key in extra_keys:
+        if key in body:
+            validated[key] = body[key]
 
     return validated
 

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -144,8 +144,6 @@ def validate_plugin_args(
         verbatim — type / shape validation is the route handler's
         responsibility.
     """
-    import io  # noqa: PLC0415 — defer to avoid import cost when unused
-
     from vtsearch.plugins.schema import get_plugin_arg_schema  # noqa: PLC0415
 
     has_file_fields = any(f.field_type == "file" for f in plugin.fields)
@@ -164,9 +162,30 @@ def validate_plugin_args(
     except ValidationError as exc:
         abort(422, message="Validation error", errors={"json": exc.messages})
 
-    # Add file uploads in the chosen mode.  Required file fields are
-    # checked here (the schema skips them) so callers get a consistent
-    # 422 envelope across all field types.
+    _populate_file_fields(plugin, validated, has_file_fields=has_file_fields, file_mode=file_mode)
+
+    for key in extra_keys:
+        if key in body:
+            validated[key] = body[key]
+
+    return validated
+
+
+def _populate_file_fields(
+    plugin: PluginBase,
+    validated: dict,
+    *,
+    has_file_fields: bool,
+    file_mode: str,
+) -> None:
+    """Read file uploads off the request and merge them into *validated*.
+
+    Required file fields surface as a 422 with the standard ``errors``
+    envelope (matching schema-level rejects); optional missing fields
+    land in *validated* as ``None``.
+    """
+    import io  # noqa: PLC0415 — defer to avoid import cost when unused
+
     missing_files: list[str] = []
     for f in plugin.fields:
         if f.field_type != "file":
@@ -191,12 +210,6 @@ def validate_plugin_args(
             message="Validation error",
             errors={"json": {k: ["Missing data for required field."] for k in missing_files}},
         )
-
-    for key in extra_keys:
-        if key in body:
-            validated[key] = body[key]
-
-    return validated
 
 
 def validate_filepath_field(field_values: dict) -> tuple | None:

--- a/vtsearch/routes/datasets/_helpers.py
+++ b/vtsearch/routes/datasets/_helpers.py
@@ -5,7 +5,6 @@ These were inlined into ``crud.py`` before the split; they now live here so
 the modules importing from each other.
 """
 
-import io
 import json
 from pathlib import PurePosixPath
 from typing import Any
@@ -26,44 +25,6 @@ def _normalize_media_type_param(value: str) -> str:
         return get_by_folder_name(value).type_id
     except KeyError:
         return normalize_type_id(value)
-
-
-def _extract_importer_fields(importer):
-    """Build field_values for a dataset importer from the current request.
-
-    Unlike :func:`extract_plugin_fields`, this reads file contents into
-    :class:`io.BytesIO` so they remain valid after the Flask request context
-    ends (required for background-thread execution).
-
-    Returns ``(field_values, None)`` on success, or ``(None, error_tuple)``
-    when a required field is missing.
-    """
-    file_keys = {f.key for f in importer.fields if f.field_type == "file"}
-
-    field_values: dict = {}
-    if file_keys:
-        for key in file_keys:
-            if key not in request.files:
-                return None, (jsonify({"error": f"Missing file field: {key!r}"}), 400)
-            file_bytes = io.BytesIO(request.files[key].read())
-            file_bytes.name = request.files[key].filename
-            field_values[key] = file_bytes
-        for f in importer.fields:
-            if f.field_type != "file":
-                field_values[f.key] = request.form.get(f.key, f.default)
-        dataset_name = (request.form.get("dataset_name") or "").strip()
-    else:
-        body = request.get_json(force=True) or {}
-        for f in importer.fields:
-            if f.key not in body and f.required:
-                return None, (jsonify({"error": f"Missing required field: {f.key!r}"}), 400)
-            field_values[f.key] = body.get(f.key, f.default)
-        dataset_name = str(body.get("dataset_name") or "").strip()
-
-    if dataset_name:
-        field_values["dataset_name"] = dataset_name
-
-    return field_values, None
 
 
 def _extract_clipper_params(has_file_fields: bool) -> tuple[dict | None, Any]:

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -164,7 +164,11 @@ def stage_import(importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values = validate_plugin_args(importer, file_mode="bytesio")
+    field_values = validate_plugin_args(
+        importer,
+        file_mode="bytesio",
+        extra_keys=("converters", "source_specs", "dataset_name"),
+    )
 
     _stage_importer_in_background(importer, field_values)
     return jsonify({"ok": True, "message": "Staging started"})
@@ -275,7 +279,11 @@ def import_dataset(importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values = validate_plugin_args(importer, file_mode="bytesio")
+    field_values = validate_plugin_args(
+        importer,
+        file_mode="bytesio",
+        extra_keys=("converters", "source_specs", "clipper", "embedder", "dataset_name"),
+    )
 
     # ``clipper_params`` is multipart-encoded as a JSON string when the
     # importer has file fields; the per-plugin schema treats it as an

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -8,10 +8,12 @@ importer-field-options) use the standard ``@arguments`` + ``@response``
 decorators; schema-level validation failures surface as 422.
 Multipart-upload routes (``stage-file``) and plugin-field routes
 (``stage-import/<importer>``, ``import/<importer>``) keep ``@arguments``
-omitted — the latter pair stays on the legacy plain-Flask path because
-the request body is a plugin-field shape that doesn't fit a static
-marshmallow schema (see *Resolved questions / Plugin field endpoints*
-in the plan doc).
+omitted — the latter pair's body shape depends on the importer plugin
+and isn't described in the OpenAPI spec.  Runtime validation goes
+through :func:`validate_plugin_args` (per-plugin schema built from the
+importer's :attr:`fields`), so missing required fields / invalid select
+values raise 422.  See *Resolved questions / Plugin field endpoints*
+in the plan doc.
 """
 
 from pathlib import Path
@@ -28,11 +30,8 @@ from vtsearch.datasets.load_pipeline import (
     _run_importer_in_background,
     _stage_importer_in_background,
 )
-from vtsearch.routes._shared import get_plugin_or_404, get_request_field
-from vtsearch.routes.datasets._helpers import (
-    _extract_clipper_params,
-    _extract_importer_fields,
-)
+from vtsearch.routes._shared import get_plugin_or_404, validate_plugin_args
+from vtsearch.routes.datasets._helpers import _extract_clipper_params
 from vtsearch.schemas.datasets import (
     ClearStagingResponseSchema,
     DatasetAvailableFilesResponseSchema,
@@ -142,9 +141,15 @@ def stage_file():
 # ---------------------------------------------------------------------------
 # POST /api/dataset/stage-import/<importer_name>
 #
-# Plugin-field route — multipart-or-JSON depending on the importer's
-# declared ``fields``. Stays on the legacy plain-Flask path; not in spec.
-# See *Resolved questions / Plugin field endpoints* in the plan doc.
+# Plugin-field route — body shape depends on the importer plugin.  Not
+# described in the OpenAPI spec; runtime validation goes through
+# :func:`validate_plugin_args` (per-plugin schema built from the
+# importer's :attr:`fields`), so missing required fields / invalid
+# select values raise 422.  File fields are read into ``BytesIO`` so the
+# background staging thread can consume them after the request context
+# tears down.  Pass-through keys (``converters``, ``source_specs``,
+# ``dataset_name``) ride along on the request body and are preserved via
+# ``Meta.unknown = "include"`` in the per-plugin schema.
 # ---------------------------------------------------------------------------
 
 
@@ -159,17 +164,7 @@ def stage_import(importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values, field_err = _extract_importer_fields(importer)
-    if field_err:
-        return field_err
-    assert field_values is not None  # narrowed by field_err check
-
-    # Pass through optional keys not declared as plugin fields.
-    file_keys = {f.key for f in importer.fields if f.field_type == "file"}
-    for key in ("converters", "source_specs"):
-        val = get_request_field(key, bool(file_keys))
-        if val:
-            field_values[key] = val
+    field_values = validate_plugin_args(importer, file_mode="bytesio")
 
     _stage_importer_in_background(importer, field_values)
     return jsonify({"ok": True, "message": "Staging started"})
@@ -260,7 +255,12 @@ def importer_field_options(body: dict, importer_name: str):
 # ---------------------------------------------------------------------------
 # POST /api/dataset/import/<importer_name>
 #
-# Plugin-field route — same legacy treatment as ``stage-import``.
+# Plugin-field route — same per-plugin validation pattern as
+# ``stage-import``.  Body shape isn't in the OpenAPI spec, but
+# :func:`validate_plugin_args` enforces the per-plugin field types at
+# request time; pass-through keys (``converters``, ``source_specs``,
+# ``clipper``, ``embedder``, ``clipper_params``, ``dataset_name``) ride
+# along on the body and are preserved via ``Meta.unknown = "include"``.
 # ---------------------------------------------------------------------------
 
 
@@ -275,18 +275,12 @@ def import_dataset(importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values, field_err = _extract_importer_fields(importer)
-    if field_err:
-        return field_err
-    assert field_values is not None  # narrowed by field_err check
+    field_values = validate_plugin_args(importer, file_mode="bytesio")
 
-    # Pass through optional keys not declared as plugin fields.
+    # ``clipper_params`` is multipart-encoded as a JSON string when the
+    # importer has file fields; the per-plugin schema treats it as an
+    # opaque pass-through (string) — decode it here before handing off.
     file_keys = {f.key for f in importer.fields if f.field_type == "file"}
-    for key in ("converters", "source_specs", "clipper", "embedder"):
-        val = get_request_field(key, bool(file_keys))
-        if val:
-            field_values[key] = val
-
     clipper_params, params_err = _extract_clipper_params(bool(file_keys))
     if params_err:
         return params_err

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -26,13 +26,16 @@ POST /api/detectors/<name>/labels/<element_id>/vote
     Toggle the label on a saved labelset element.
 
 Migrated to ``flask_smorest`` for the JSON-shaped routes (save, labels-detail,
-vote). ``import-labels`` stays on the legacy plain-Flask path — its body is
-the chosen importer's plugin fields (see *Open questions / Plugin field
-endpoints* in ``docs/plans/openapi-schema.md``). The ``preview`` and
-``thumbnail`` routes serve binary bodies (or a tiny content-only JSON for
-text media); they declare their non-default JSON error responses via
-``alt_response`` but no success schema, so OpenAPI describes the error
-shape without lying about the success body.
+vote). ``import-labels`` keeps its plain-Flask route on the same smorest
+blueprint — its body shape depends on the importer plugin and isn't
+described in the OpenAPI spec, but runtime validation goes through
+:func:`validate_plugin_args` so the per-plugin field types are enforced
+and schema-level failures surface as 422.  See *Resolved questions /
+Plugin field endpoints* in ``docs/plans/openapi-schema.md``.  The
+``preview`` and ``thumbnail`` routes serve binary bodies (or a tiny
+content-only JSON for text media); they declare their non-default JSON
+error responses via ``alt_response`` but no success schema, so OpenAPI
+describes the error shape without lying about the success body.
 """
 
 from __future__ import annotations
@@ -164,10 +167,12 @@ def save_detector_labels(name: str):
 # ---------------------------------------------------------------------------
 # POST /api/detectors/<name>/import-labels/<importer_name>
 #
-# Plugin-field route — stays on the legacy ``request.get_json`` path. The
-# request body is the importer's declared ``fields`` (file uploads,
-# free-form params) and doesn't fit a static marshmallow schema. See
-# ``docs/plans/openapi-schema.md`` (Open questions / Plugin field endpoints).
+# Plugin-field route — body shape depends on the importer plugin and isn't
+# described in the OpenAPI spec.  Runtime validation goes through
+# :func:`validate_plugin_args` (per-plugin schema built from the importer's
+# :attr:`fields`), so missing required fields / invalid select values
+# raise 422.  See ``docs/plans/openapi-schema.md`` (Resolved questions /
+# Plugin field endpoints).
 # ---------------------------------------------------------------------------
 
 
@@ -198,11 +203,10 @@ def import_labels_into_detector(name: str, importer_name: str):  # noqa: C901
 
     from vtsearch.labels.importers import get_label_importer, list_label_importers
     from vtsearch.routes._shared import (
-        extract_plugin_fields,
         get_plugin_or_404,
         run_plugin_or_error,
         validate_filepath_field,
-        validate_required_fields,
+        validate_plugin_args,
     )
 
     importer, err = get_plugin_or_404(get_label_importer, list_label_importers, importer_name, "label importer")
@@ -210,10 +214,7 @@ def import_labels_into_detector(name: str, importer_name: str):  # noqa: C901
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values = extract_plugin_fields(importer)
-    err = validate_required_fields(importer, field_values)
-    if err:
-        return err
+    field_values = validate_plugin_args(importer)
     err = validate_filepath_field(field_values)
     if err:
         return err

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -159,10 +159,12 @@ def register_detector_route(body: dict):
 # ---------------------------------------------------------------------------
 # POST /api/detectors/registry/from-labelset/<importer_name>
 #
-# Plugin-field route — stays on the legacy ``request.get_json`` path. The
-# request body is the importer's declared ``fields`` (file uploads,
-# free-form params) and doesn't fit a static marshmallow schema. See
-# ``docs/plans/openapi-schema.md`` (Open questions / Plugin field endpoints).
+# Plugin-field route — body shape depends on the importer plugin and isn't
+# described in the OpenAPI spec.  Runtime validation goes through
+# :func:`validate_plugin_args` (per-plugin schema built from the importer's
+# :attr:`fields`), so missing required fields / invalid select values
+# raise 422.  See ``docs/plans/openapi-schema.md`` (Resolved questions /
+# Plugin field endpoints).
 # ---------------------------------------------------------------------------
 
 
@@ -180,12 +182,10 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
     from vtsearch.labels.importers import get_label_importer, list_label_importers
     from vtsearch.detectors.registry import register_detector, update_detector
     from vtsearch.routes._shared import (
-        extract_plugin_fields,
         get_plugin_or_404,
-        get_request_field,
         run_plugin_or_error,
         validate_filepath_field,
-        validate_required_fields,
+        validate_plugin_args,
     )
 
     importer, err = get_plugin_or_404(get_label_importer, list_label_importers, importer_name, "label importer")
@@ -193,20 +193,20 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
         return err
     assert importer is not None  # narrowed by err check
 
-    has_file_fields = any(f.field_type == "file" for f in importer.fields)
-    name = get_request_field("name", has_file_fields).strip()
+    field_values = validate_plugin_args(importer)
 
+    # ``name`` is a pass-through key (not a declared plugin field) but is
+    # required by this route.  ``validate_plugin_args`` keeps unknown keys
+    # via ``Meta.unknown = "include"``, so it's already on field_values
+    # if the caller supplied it.
+    name = str(field_values.pop("name", "") or "").strip()
     if not name:
-        return jsonify({"error": "name is required"}), 400
+        abort(422, message="Validation error", errors={"json": {"name": ["Missing data for required field."]}})
 
     det_path = _detector_path(name)
     if det_path.exists():
-        return jsonify({"error": f"A detector named '{name}' already exists"}), 409
+        abort(409, message=f"A detector named '{name}' already exists")
 
-    field_values = extract_plugin_fields(importer)
-    err = validate_required_fields(importer, field_values)
-    if err:
-        return err
     err = validate_filepath_field(field_values)
     if err:
         return err

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -193,12 +193,12 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values = validate_plugin_args(importer)
+    field_values = validate_plugin_args(importer, extra_keys=("name",))
 
     # ``name`` is a pass-through key (not a declared plugin field) but is
-    # required by this route.  ``validate_plugin_args`` keeps unknown keys
-    # via ``Meta.unknown = "include"``, so it's already on field_values
-    # if the caller supplied it.
+    # required by this route.  ``validate_plugin_args`` only keeps the
+    # keys we list in ``extra_keys``, so the route is in charge of
+    # enforcing presence.
     name = str(field_values.pop("name", "") or "").strip()
     if not name:
         abort(422, message="Validation error", errors={"json": {"name": ["Missing data for required field."]}})

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -12,11 +12,16 @@ GET  /api/label-importers
 POST /api/label-importers/import/<importer_name>
     Run the named label importer. Accepts ``multipart/form-data`` (when
     the importer has a ``"file"`` field) or JSON (for text-only
-    importers). The request body is a plugin-field shape and doesn't fit
-    a static marshmallow schema — this route stays on the legacy
-    plain-Flask path (no ``@arguments`` / ``@response`` decorators) and
-    is omitted from the OpenAPI spec. See *Resolved questions / Plugin
-    field endpoints* in ``docs/plans/openapi-schema.md``.
+    importers). The request body shape is plugin-dependent and not
+    described in the OpenAPI spec — instead, the body is validated at
+    request time via :func:`validate_plugin_args`, which builds a
+    marshmallow schema from the named importer's :attr:`fields`
+    declaration. Schema-level rejects (missing required field, invalid
+    select value) surface as ``422`` with the standard ``errors``
+    envelope; handler-level rejects (path traversal, plugin error) keep
+    their original HTTP codes (400 / 500) with the standard ``message``
+    envelope. See *Resolved questions / Plugin field endpoints* in
+    ``docs/plans/openapi-schema.md``.
 
 POST /api/label-importers/ingest-missing
     Accept a list of missing label entries, re-ingest them from their
@@ -30,11 +35,10 @@ from flask_smorest import Blueprint
 
 from vtsearch.labels.importers import get_label_importer, list_label_importers
 from vtsearch.routes._shared import (
-    extract_plugin_fields,
     get_plugin_or_404,
     run_plugin_or_error,
     validate_filepath_field,
-    validate_required_fields,
+    validate_plugin_args,
 )
 from vtsearch.schemas.labels import (
     IngestMissingRequestSchema,
@@ -102,11 +106,13 @@ def get_label_importers():
 # ---------------------------------------------------------------------------
 # POST /api/label-importers/import/<importer_name>
 #
-# Plugin-field route — stays on the legacy ``request.get_json`` / multipart
-# path. The request body is the importer's declared ``fields`` (file
-# uploads, free-form params) and doesn't fit a static marshmallow schema.
-# See ``docs/plans/openapi-schema.md`` (Resolved questions / Plugin field
-# endpoints). Not described in the OpenAPI spec.
+# Plugin-field route — the request body is the importer's declared ``fields``
+# (file uploads, free-form params).  Static marshmallow schemas can't
+# describe the shape because each importer has its own field list, so the
+# OpenAPI spec doesn't list a request body for this route.  Runtime
+# validation goes through :func:`validate_plugin_args`, which builds a
+# per-plugin schema from the importer's :attr:`fields` declaration and
+# raises 422 on schema-level failures (matching the rest of the API).
 # ---------------------------------------------------------------------------
 
 
@@ -121,11 +127,7 @@ def run_label_import(importer_name: str):  # noqa: C901
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values = extract_plugin_fields(importer)
-
-    err = validate_required_fields(importer, field_values)
-    if err:
-        return err
+    field_values = validate_plugin_args(importer)
 
     err = validate_filepath_field(field_values)
     if err:

--- a/vtsearch/routes/settings/io.py
+++ b/vtsearch/routes/settings/io.py
@@ -10,11 +10,12 @@ GET  /api/settings-importers
 
 POST /api/settings-importers/import/<importer_name>
     Run the named settings importer and apply the imported settings.
-    The request body is a plugin-field shape and doesn't fit a static
-    marshmallow schema — this route stays on the legacy plain-Flask path
-    (no ``@arguments`` / ``@response`` decorators) and is omitted from
-    the OpenAPI spec.  See *Resolved questions / Plugin field endpoints*
-    in ``docs/plans/openapi-schema.md``.
+    The request body shape depends on the importer plugin and isn't
+    described in the OpenAPI spec; runtime validation goes through
+    :func:`validate_plugin_args` (per-plugin schema built from the
+    importer's :attr:`fields`), so missing required fields / invalid
+    select values raise 422.  See *Resolved questions / Plugin field
+    endpoints* in ``docs/plans/openapi-schema.md``.
 
 GET  /api/settings-exporters
     List all registered settings exporters with their metadata and fields.
@@ -36,11 +37,10 @@ from flask_smorest import Blueprint, abort
 
 from vtsearch import settings
 from vtsearch.routes._shared import (
-    extract_plugin_fields,
     get_plugin_or_404,
     run_plugin_or_error,
     validate_filepath_field,
-    validate_required_fields,
+    validate_plugin_args,
 )
 from vtsearch.schemas.settings_io import (
     RunSettingsExportRequestSchema,
@@ -76,11 +76,12 @@ def get_settings_importers():
 # ---------------------------------------------------------------------------
 # POST /api/settings-importers/import/<importer_name>
 #
-# Plugin-field route — stays on the legacy ``request.get_json`` / multipart
-# path. The request body is the importer's declared ``fields`` (file
-# uploads, free-form params) and doesn't fit a static marshmallow schema.
-# See ``docs/plans/openapi-schema.md`` (Resolved questions / Plugin field
-# endpoints).  Not described in the OpenAPI spec.
+# Plugin-field route — body shape depends on the importer plugin and isn't
+# described in the OpenAPI spec.  Runtime validation goes through
+# :func:`validate_plugin_args` (per-plugin schema built from the importer's
+# :attr:`fields`), so missing required fields / invalid select values
+# raise 422.  See ``docs/plans/openapi-schema.md`` (Resolved questions /
+# Plugin field endpoints).
 # ---------------------------------------------------------------------------
 
 
@@ -97,11 +98,7 @@ def run_settings_import(importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_values = extract_plugin_fields(importer)
-
-    err = validate_required_fields(importer, field_values)
-    if err:
-        return err
+    field_values = validate_plugin_args(importer)
 
     err = validate_filepath_field(field_values)
     if err:


### PR DESCRIPTION
## Summary

- Six plugin-field routes (`/api/dataset/stage-import/<imp>`, `/api/dataset/import/<imp>`, `/api/label-importers/import/<imp>`, `/api/detectors/<name>/import-labels/<imp>`, `/api/detectors/registry/from-labelset/<imp>`, `/api/settings-importers/import/<imp>`) now run their request bodies through a marshmallow schema built from each plugin's `fields` declaration. Schema-level rejects (missing required field, invalid select value, unparseable number) surface as 422 with the standard `errors` envelope.
- Per-plugin schema builder lives at `vtsearch/plugins/schema.py` and is cached on the plugin instance. Routes call it via the new `validate_plugin_args(plugin, *, file_mode=, extra_keys=)` helper in `vtsearch/routes/_shared.py`. File uploads stay multipart and are merged in after `schema.load()`; `file_mode="bytesio"` (for dataset importers) reads each upload into an in-memory `BytesIO` so the background thread can consume after the request context tears down.
- Legacy hand-rolled validators (`extract_plugin_fields`, `validate_required_fields`, `get_request_field`, `_extract_importer_fields`) are deleted — every plugin-field route now flows through `validate_plugin_args`.
- Plan doc updated: per-plugin schemas marked shipped on the status checklist; *Resolved questions / Plugin field endpoints* rewritten to describe what actually got built (hybrid of options b + c — runtime validation per-plugin, spec stays loose); the stale `ProcessorImportersApiService` follow-up is closed (commit 6b4c0b4d deleted the dead service).
- New `tests/core/test_plugin_schema.py` (13 cases) covers the per-field-type mapping plus the high-level `load()` behaviour the route helpers depend on.

## Test plan

- [x] `./run-tests.sh` — 3675 passed, 1 skipped, 2 xpassed
- [x] Schema-builder unit tests pass in isolation (`python -m pytest tests/core/test_plugin_schema.py`)
- [x] `ruff check`, `ruff format --check`, `codespell`, `deptry` all green via `./run-tests.sh`
- [x] Existing route tests updated to expect the new envelope shape (`test_missing_name_returns_422`, `test_missing_filepath_422`); other plugin-field route tests pass unchanged

https://claude.ai/code/session_013gy3q3S1FHLGgXcLNmMQuV

---
_Generated by [Claude Code](https://claude.ai/code/session_013gy3q3S1FHLGgXcLNmMQuV)_