### PR TITLE
docs: drop video_uniform_with_keyframes from the brainstorm

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -77,9 +77,7 @@ Camelot/Tabula extracts CSVs from PDF tables → tabular media type.
 For language-agnostic code search via natural language.
 
 ### 2.10 `video → keyframe-image` ★★ S
-Already partially covered by `video→image`, but with smarter frame selection. Two strategies worth implementing:
-- **Scene-boundary picking** — use **TransNet V2** to pick frames at detected shot boundaries. Far more content-aware than uniform sampling; heavier dependency.
-- **Uniform-with-keyframe-snap** — take *n* uniform timestamps (as `Video2ImageMediaConverter` does today) but snap each to the nearest decoded I-frame. Free quality bump: I-frames decode without GOP reference lookups (faster on long videos), have no motion-compensation artefacts (cleaner stills), and encoders often place them at natural cuts. Strict upgrade over the current uniform sampler, and far cheaper than TransNet V2.
+Already partially covered by `video→image`, but with **TransNet V2** scene boundary picking instead of uniform sampling. Far better for content-aware clipping.
 
 ### 2.11 `email → text` ★ XS
 Strip MIME, dedupe quoted replies, normalise headers.

--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -77,7 +77,9 @@ Camelot/Tabula extracts CSVs from PDF tables → tabular media type.
 For language-agnostic code search via natural language.
 
 ### 2.10 `video → keyframe-image` ★★ S
-Already partially covered by `video→image`, but with **TransNet V2** scene boundary picking instead of uniform sampling. Far better for content-aware clipping.
+Already partially covered by `video→image`, but with smarter frame selection. Two strategies worth implementing:
+- **Scene-boundary picking** — use **TransNet V2** to pick frames at detected shot boundaries. Far more content-aware than uniform sampling; heavier dependency.
+- **Uniform-with-keyframe-snap** — take *n* uniform timestamps (as `Video2ImageMediaConverter` does today) but snap each to the nearest decoded I-frame. Free quality bump: I-frames decode without GOP reference lookups (faster on long videos), have no motion-compensation artefacts (cleaner stills), and encoders often place them at natural cuts. Strict upgrade over the current uniform sampler, and far cheaper than TransNet V2.
 
 ### 2.11 `email → text` ★ XS
 Strip MIME, dedupe quoted replies, normalise headers.
@@ -111,7 +113,6 @@ Today the framework allows one converter per source; consider explicit chains: `
 ### 3.4 Video
 - **`video_action`** ★ M — clip around detected action peaks (motion histogram or VideoMAE attention).
 - **`video_audio_cue`** ★ M — clip around audio-event peaks (loud noise, vocal onset).
-- **`video_uniform_with_keyframes`** ★★ S — uniform sampling biased to nearest I-frame.
 - **`video_dialogue`** ★ M — clip per speech turn (VAD on demuxed audio).
 
 ### 3.5 Document


### PR DESCRIPTION
## Summary

`video_uniform_with_keyframes ★★ S — uniform sampling biased to nearest I-frame` was listed under §3.4 Video clippers. Investigation says: wrong category, weak idea, cut it.

**Wrong category.** It produces images, not video sub-clips, so it'd be a converter (parallel to `Video2ImageMediaConverter` in `vtsearch/converters/video2image.py`), not a clipper (which emits same-type sub-spans with `clip_start`/`clip_end` metadata per `vtsearch/media/video/clipper.py`).

**Weak idea, on three points:**

1. **"Cleaner stills" was wrong.** OpenCV's `cap.set(CAP_PROP_POS_FRAMES, idx)` on the FFmpeg backend already seeks to the nearest preceding I-frame and decodes forward to `idx`. A correctly-decoded P-frame is bit-exact what the encoder produced — no motion-compensation artefacts to avoid.
2. **Speed win is real but small** and needs a new tool. Saving the forward-decode is a few hundred ms per sample at 1080p with x264 defaults. `cv2.VideoCapture` doesn't expose per-frame keyframe flags, so cashing it in needs `ffprobe` (not bundled — `imageio-ffmpeg` only ships `ffmpeg`) or PyAV. New dependency for a marginal gain.
3. **Scene-alignment story is encoder-dependent** (only with x264 `scenecut` on; absent in fixed-GOP camera / screen-recorder output) and strictly inferior to §2.10 TransNet V2, which works on pixels regardless of how the video was encoded.

So: cut the bullet, revert §2.10 to the original TransNet-only wording. Net diff vs `dev` is the single removed line in §3.4.

## Test plan

- [x] `git diff origin/dev -- docs/plans/feature-brainstorm.md` shows only the §3.4 deletion; §2.10 is byte-identical to `dev`.

https://claude.ai/code/session_01Qtpwfr4BMrfaKDwSd6o2Yh