### PR TITLE
Add empty-state illustration to dashboard datasets welcome banner

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -16,6 +16,35 @@
 
     @if (datasets.length === 0 && orphanLoadingTasks.length === 0 && !loading) {
       <div class="welcome-banner">
+        <svg class="welcome-banner-illustration"
+             xmlns="http://www.w3.org/2000/svg"
+             width="180" height="150" viewBox="0 0 180 150"
+             fill="none" stroke="currentColor"
+             stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+             aria-hidden="true">
+          <!-- Open empty crate in isometric projection: top rim is a
+               diamond, three visible walls drop to a single front-bottom
+               vertex. Dashed inner diamond hints at the empty interior.
+               currentColor lets it follow the muted text color in both
+               themes; the magnifying glass and sparkles tie it back to
+               the "search" theme of the app. -->
+          <path d="M 90 40 L 140 65 L 90 90 L 40 65 Z"/>
+          <path d="M 40 65 L 40 100 L 90 125"/>
+          <path d="M 140 65 L 140 100 L 90 125"/>
+          <line x1="90" y1="90" x2="90" y2="125"/>
+          <path d="M 90 75 L 122 91 L 90 107 L 58 91 Z"
+                opacity="0.35" stroke-dasharray="3 4"/>
+          <g opacity="0.75" stroke-width="2">
+            <circle cx="135" cy="28" r="11"/>
+            <line x1="143" y1="36" x2="152" y2="45"/>
+          </g>
+          <g opacity="0.55" fill="currentColor" stroke="none">
+            <circle cx="22" cy="32" r="2"/>
+            <circle cx="55" cy="15" r="1.5"/>
+            <circle cx="162" cy="95" r="2"/>
+            <circle cx="20" cy="118" r="1.5"/>
+          </g>
+        </svg>
         <p class="welcome-banner-text">{{ welcomeBannerMessage }}</p>
         <button class="btn btn--primary btn--sm welcome-banner-cta"
           (click)="openImporterModalOnTab(welcomeBannerCtaTab)"

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -259,6 +259,12 @@
   padding: 24px;
   text-align: center;
 
+  .welcome-banner-illustration {
+    color: var(--text-muted);
+    flex-shrink: 0;
+    margin-bottom: 4px;
+  }
+
   .welcome-banner-text {
     color: var(--text-primary);
     margin: 0;

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -403,6 +403,7 @@ describe('DashboardComponent', () => {
     const banner = el.querySelector('.welcome-banner');
     expect(banner).toBeTruthy();
     expect(banner?.textContent || '').toContain('Welcome');
+    expect(banner?.querySelector('.welcome-banner-illustration')).toBeTruthy();
   });
 
   describe('welcome banner', () => {


### PR DESCRIPTION
## Summary
- Renders an inline SVG above the welcome text in the dashboard's "no datasets yet" empty state — an isometric open crate with a magnifying glass and sparkle dots, drawn in `currentColor` strokes so it follows `--text-muted` in both light and dark themes.
- Echoes the section's "cubes" icon and the app's search theme; muted styling keeps the welcome copy and CTA as the primary focal points.
- Adds a spec assertion that `.welcome-banner-illustration` renders alongside the existing welcome-banner check.

## Test plan
- [x] `npm run build:prod` builds clean with no warnings (no budget overruns; component SCSS now 6.7 kB, well under the 8 kB warning threshold).
- [ ] Manual visual check in the browser at desktop viewport (couldn't run in this environment — no Chrome/Chromium available per CLAUDE.md). Verify the illustration appears centered above the welcome text in both light and dark themes, scales nicely, and doesn't shift the CTA layout.

## Notes
- Pre-existing `tsc -p tsconfig.spec.json` errors in `progress-indicators.component.spec.ts` and `autopilot-panel.component.spec.ts` (missing `bad_count`/`good_count`/`total_count` on `LabelingStatusResponse` mocks) were confirmed to exist on the base branch and are unrelated to this change. They are not caught by `./run-tests.sh` (which runs `build:prod`, not the spec typecheck).

https://claude.ai/code/session_01RpQtjyvoDdn7bcfbG9oPtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpQtjyvoDdn7bcfbG9oPtM)_