### PR TITLE
feat(toast): success-level toast replaces dialog.alert for autopilot-complete

### DIFF
--- a/docs/plans/feature-brainstorm.md
+++ b/docs/plans/feature-brainstorm.md
@@ -417,7 +417,7 @@ Skip the modal. Drop a folder → start importing.
 Persistent across sessions.
 
 ### 11.18 Light improvements
-- Toast notifications instead of alert dialogs ★ XS
+- Toast notifications instead of alert dialogs ★ XS — **DONE.** `ToastService.success()` (auto-dismisses after 5s) replaces the modal `dialog.alert()` for the autopilot-complete notification. The unused `VtDialogService.alert()` method is gone. Confirmation flows (`confirm` / `confirmDestructive` / `prompt`) stay as modals because they require a user decision.
 - Empty-state illustrations for "no datasets yet" ★ XS
 - Skeleton loaders (today: spinners) ★ S
 - Per-detector colour accent ★ XS

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -4,26 +4,17 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { AppComponent } from './app.component';
 import { provideRouter } from '@angular/router';
-import { VtDialogService } from './services/dialog.service';
 import { MediaStateService } from './services/media-state.service';
 import { DatasetStateService } from './services/dataset-state.service';
 
 describe('AppComponent', () => {
-  let dialogSpy: jasmine.SpyObj<VtDialogService>;
-
   beforeEach(async () => {
-    dialogSpy = jasmine.createSpyObj('VtDialogService', ['alert'], {
-      dialogOpen: false,
-    });
-    dialogSpy.alert.and.returnValue(Promise.resolve(true));
-
     await TestBed.configureTestingModule({
       imports: [AppComponent],
       providers: [
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
-        { provide: VtDialogService, useValue: dialogSpy },
       ],
     }).compileComponents();
   });
@@ -171,7 +162,7 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const mediaState = TestBed.inject(MediaStateService);
     spyOnProperty(mediaState, 'medias', 'get').and.returnValue([
-      { id: 1, type: 'image', filename: 'a.png', md5: 'abc', custom_metadata: {} },
+      { id: 1, type: 'image' },
     ]);
     fixture.componentInstance.isOnLabelView = true;
     fixture.componentInstance.onSettings();

--- a/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.spec.ts
@@ -54,14 +54,4 @@ describe('DialogHostComponent', () => {
     await promise;
   });
 
-  it('should render alert dialog', async () => {
-    const promise = dialogService.alert('Something happened');
-    fixture.detectChanges();
-
-    expect(dialogService.dialogOpen).toBeTrue();
-    expect(dialogService.dialogMessage).toBe('Something happened');
-
-    component.onButtonClick(true);
-    await promise;
-  });
 });

--- a/frontend/src/app/components/label-view/label-view.component.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.component.spec.ts
@@ -357,6 +357,9 @@ describe('LabelViewComponent', () => {
     });
 
     autopilot.updateFromLabelingStatus({
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: 'yellow' },
@@ -368,6 +371,9 @@ describe('LabelViewComponent', () => {
 
     // Surprise vote causes smart to drop → bounce back to hard
     autopilot.updateFromLabelingStatus({
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'yellow' },
       stable: { status: 'green' },
       span: { status: 'yellow' },

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -75,6 +75,9 @@ describe('AutopilotPanelComponent', () => {
     expect(component.state.phase).toBe('hard');
 
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: '' },
@@ -92,6 +95,9 @@ describe('AutopilotPanelComponent', () => {
     autopilotState.checkPhaseTransition(3, 0);
     autopilotState.checkPhaseTransition(3, 4);
     autopilotState.updateFromLabelingStatus({
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: '' },
@@ -100,6 +106,9 @@ describe('AutopilotPanelComponent', () => {
     expect(component.state.phase).toBe('new');
 
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: 'green' },
@@ -117,6 +126,9 @@ describe('AutopilotPanelComponent', () => {
     autopilotState.checkPhaseTransition(3, 0);
     autopilotState.checkPhaseTransition(3, 4);
     autopilotState.updateFromLabelingStatus({
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: '' },
@@ -126,6 +138,9 @@ describe('AutopilotPanelComponent', () => {
 
     // A surprise vote causes smart to drop
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'yellow' },
       stable: { status: 'green' },
       span: { status: 'yellow' },
@@ -141,6 +156,9 @@ describe('AutopilotPanelComponent', () => {
     autopilotState.checkPhaseTransition(3, 0);
     autopilotState.checkPhaseTransition(3, 4);
     autopilotState.updateFromLabelingStatus({
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: 'yellow' },

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -6,7 +6,7 @@ import {
   AutopilotPhase,
   AutopilotState,
 } from '../../../services/autopilot-state.service';
-import { VtDialogService } from '../../../services/dialog.service';
+import { ToastService } from '../../../services/toast.service';
 
 export type { AutopilotPhase, AutopilotState };
 
@@ -56,7 +56,7 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
 
   constructor(
     public autopilotState: AutopilotStateService,
-    private dialogService: VtDialogService,
+    private toastService: ToastService,
   ) {}
 
   get state(): AutopilotState {
@@ -106,10 +106,10 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       this.autopilotState.checkPhaseTransition(this.goodVotes.size, this.badVotes.size);
       if (prevPhase !== 'done' && this.autopilotState.state.phase === 'done' && !this.completionAlerted) {
         this.completionAlerted = true;
-        this.dialogService.alert(
-          'Autopilot is complete! All quality indicators are green. You can continue labeling or export your results.',
-          'success',
-        );
+        this.toastService.success({
+          message: 'Autopilot complete',
+          detail: 'All quality indicators are green. You can continue labeling or export your results.',
+        });
       }
     }
   }

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
@@ -32,6 +32,9 @@ describe('ProgressIndicatorsComponent', () => {
 
   it('should reflect labeling status', () => {
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'yellow' },
       span: { status: '' },
@@ -55,20 +58,35 @@ describe('ProgressIndicatorsComponent', () => {
 
   it('should show smart subtext with cost', () => {
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'yellow', cost: 0.123 },
+      stable: { status: '' },
+      span: { status: '' },
     };
     expect(component.smartSubtext).toBe('Cost: 0.123');
   });
 
   it('should show stable subtext with flips', () => {
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
+      smart: { status: '' },
       stable: { status: 'yellow', flips: 5 },
+      span: { status: '' },
     };
     expect(component.stableSubtext).toBe('Flips: 5');
   });
 
   it('should show span subtext with diversity level', () => {
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
+      smart: { status: '' },
+      stable: { status: '' },
       span: { status: 'green', diversity_level: 2.5, max_level: 4 },
     };
     expect(component.spanSubtext).toBe('3/4');
@@ -99,6 +117,9 @@ describe('ProgressIndicatorsComponent', () => {
 
   it('should set data-status attribute on indicators', () => {
     component.labelingStatus = {
+      good_count: 0,
+      bad_count: 0,
+      total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'yellow' },
       span: { status: 'red' },

--- a/frontend/src/app/components/toast-container/toast-container.component.html
+++ b/frontend/src/app/components/toast-container/toast-container.component.html
@@ -1,11 +1,18 @@
 <div class="toast-stack" aria-live="assertive" aria-atomic="false">
   @for (t of toasts; track trackById($index, t)) {
-    <div class="toast" role="alert">
+    <div class="toast" [class.toast--success]="t.level === 'success'" role="alert">
       <div class="toast__main">
-        <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
-          <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
-        </svg>
+        @if (t.level === 'success') {
+          <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
+            <path d="M5 8.2l2.2 2.2L11 6.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        } @else {
+          <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
+            <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+          </svg>
+        }
         <div class="toast__text">
           <div class="toast__title">{{ t.message }}</div>
           @if (t.detail) {
@@ -17,10 +24,10 @@
             <button type="button" class="toast__btn" (click)="toggleDetails(t)" [attr.aria-expanded]="expandedId === t.id" title="Show full error details">
               {{ expandedId === t.id ? 'Hide details' : 'Details' }}
             </button>
+            <button type="button" class="toast__btn" (click)="copyDebugInfo(t)" title="Copy a debug bundle to your clipboard">
+              {{ copiedId === t.id ? 'Copied!' : 'Copy debug info' }}
+            </button>
           }
-          <button type="button" class="toast__btn" (click)="copyDebugInfo(t)" title="Copy a debug bundle to your clipboard">
-            {{ copiedId === t.id ? 'Copied!' : 'Copy debug info' }}
-          </button>
           <button type="button" class="toast__close" (click)="dismiss(t)" aria-label="Dismiss" title="Dismiss">
             <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -25,6 +25,18 @@
   font-size: 13px;
   line-height: 1.4;
   animation: toast-slide-in 180ms ease-out;
+
+  &.toast--success {
+    border-color: var(--color-good);
+    border-left-color: var(--color-good);
+
+    .toast__icon { color: var(--color-good); }
+    .toast__title { color: var(--color-good); }
+    .toast__btn:hover {
+      background: var(--good-bg);
+      border-color: var(--color-good);
+    }
+  }
 }
 
 @keyframes toast-slide-in {

--- a/frontend/src/app/services/dialog.service.spec.ts
+++ b/frontend/src/app/services/dialog.service.spec.ts
@@ -17,19 +17,6 @@ describe('VtDialogService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('alert should open dialog and resolve on OK', async () => {
-    const promise = service.alert('Hello');
-    expect(service.dialogOpen).toBeTrue();
-    expect(service.dialogMessage).toBe('Hello');
-    expect(service.dialogType).toBe('info');
-    expect(service.dialogButtons.length).toBe(1);
-
-    service.resolve(true);
-    const result = await promise;
-    expect(result).toBeTrue();
-    expect(service.dialogOpen).toBeFalse();
-  });
-
   it('confirm should have Cancel and OK buttons', async () => {
     const promise = service.confirm('Are you sure?');
     expect(service.dialogButtons.length).toBe(2);

--- a/frontend/src/app/services/dialog.service.ts
+++ b/frontend/src/app/services/dialog.service.ts
@@ -11,11 +11,9 @@ interface DialogButton {
 
 /**
  * VtDialogService — Angular replacement for dialogs.js.
- * Provides alert(), confirm(), and prompt() returning Promises.
- *
- * Uses a lightweight approach: creates temporary ModalComponent instances.
- * For Phase 2 this keeps things simple; a more elaborate approach using
- * dynamic components can be added later if needed.
+ * Provides confirm() and prompt() returning Promises. Pure
+ * informational notifications go through ToastService instead of a
+ * modal alert.
  */
 @Injectable({ providedIn: 'root' })
 export class VtDialogService {
@@ -40,15 +38,6 @@ export class VtDialogService {
 
   getIconType(): string {
     return VtDialogService.ICON_TYPES[this.dialogType] || VtDialogService.ICON_TYPES.info;
-  }
-
-  alert(message: string, type: DialogType = 'info'): Promise<boolean> {
-    return this.show({
-      message,
-      type,
-      showInput: false,
-      buttons: [{ label: 'OK', primary: true, value: true }],
-    }) as Promise<boolean>;
   }
 
   confirm(message: string, type: DialogType = 'warning'): Promise<boolean> {

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -23,8 +23,11 @@ export interface ErrorContext {
   timestamp: string;
 }
 
+export type ToastLevel = 'error' | 'success';
+
 export interface Toast {
   id: number;
+  level: ToastLevel;
   message: string;
   detail?: string;
   /** Optional rich HTTP error context — enables the Details / Copy debug info actions. */
@@ -46,6 +49,7 @@ interface ShowOptions {
 }
 
 const MAX_TOASTS = 5;
+const SUCCESS_AUTO_DISMISS_MS = 5000;
 
 /**
  * Central toast sink for the frontend. Every error surface routes
@@ -67,6 +71,7 @@ export class ToastService {
   private readonly toastsSubject = new BehaviorSubject<Toast[]>([]);
   readonly toasts$ = this.toastsSubject.asObservable();
   private readonly seenTaskKeys = new Set<string>();
+  private readonly autoDismissTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
   constructor(progressEvents: ProgressEventsService) {
     progressEvents.loadingTasks$.subscribe((tasks) => this.routeTaskErrors(tasks, 'dataset'));
@@ -92,8 +97,22 @@ export class ToastService {
   }
 
   error(opts: ShowOptions): number {
+    return this.push('error', opts);
+  }
+
+  /**
+   * Non-blocking success notification. Auto-dismisses after
+   * ``SUCCESS_AUTO_DISMISS_MS`` so the user is not forced to click
+   * through a modal for "X is done" style messages.
+   */
+  success(opts: ShowOptions): number {
+    return this.push('success', opts, SUCCESS_AUTO_DISMISS_MS);
+  }
+
+  private push(level: ToastLevel, opts: ShowOptions, autoDismissMs = 0): number {
     const toast: Toast = {
       id: this.nextId++,
+      level,
       message: opts.message,
       detail: opts.detail,
       errorContext: opts.errorContext,
@@ -104,15 +123,30 @@ export class ToastService {
     let next = this.toastsSubject.value.slice();
     if (opts.dedupKey) {
       const existing = next.findIndex((t) => t.dedupKey === opts.dedupKey);
-      if (existing >= 0) next.splice(existing, 1);
+      if (existing >= 0) {
+        const evicted = next[existing];
+        this.clearTimer(evicted.id);
+        next.splice(existing, 1);
+      }
     }
     next.push(toast);
-    while (next.length > MAX_TOASTS) next.shift();
+    while (next.length > MAX_TOASTS) {
+      const dropped = next.shift();
+      if (dropped) this.clearTimer(dropped.id);
+    }
     this.toastsSubject.next(next);
+
+    if (autoDismissMs > 0) {
+      this.autoDismissTimers.set(
+        toast.id,
+        setTimeout(() => this.dismiss(toast.id), autoDismissMs),
+      );
+    }
     return toast.id;
   }
 
   dismiss(id: number): void {
+    this.clearTimer(id);
     const next = this.toastsSubject.value.filter((t) => t.id !== id);
     if (next.length !== this.toastsSubject.value.length) {
       this.toastsSubject.next(next);
@@ -120,7 +154,16 @@ export class ToastService {
   }
 
   dismissAll(): void {
+    for (const id of this.autoDismissTimers.keys()) this.clearTimer(id);
     this.toastsSubject.next([]);
+  }
+
+  private clearTimer(id: number): void {
+    const t = this.autoDismissTimers.get(id);
+    if (t !== undefined) {
+      clearTimeout(t);
+      this.autoDismissTimers.delete(id);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Finishes item 1 of `docs/plans/feature-brainstorm.md` §11.18 ("Toast notifications instead of alert dialogs"). The autopilot-complete notification — previously a modal the user had to dismiss before continuing to label — is now a non-blocking, auto-dismissing success toast.

- `ToastService` gains a `success()` method with 5-second auto-dismiss and a `level` field on `Toast`. The container styles `toast--success` with the green `--color-good` accent and a checkmark icon.
- `AutopilotPanelComponent` now injects `ToastService` instead of `VtDialogService` and emits the completion toast via `toastService.success(...)`.
- The unused `VtDialogService.alert()` method is removed. Confirmation flows (`confirm` / `confirmDestructive` / `prompt`) stay as modals because they require a user decision and a toast cannot capture one.
- "Copy debug info" no longer renders on toasts that have no error context — it was only meaningful for HTTP-failure toasts.

Pre-existing `tsc -p tsconfig.spec.json` errors (LabelingStatusResponse fixtures missing `good_count`/`bad_count`/`total_count`, an obsolete `MediaIdsListResponse` literal in `app.component.spec.ts`) are fixed in the same change so spec files typecheck cleanly per CLAUDE.md.

## Test plan

- [x] `./run-tests.sh` — 3769 passed, 1 skipped (includes ruff/codespell/deptry/pyright/frontend build)
- [x] `npx tsc -p tsconfig.spec.json --noEmit` — clean
- [ ] Trigger autopilot completion in the UI: success toast slides in at the top, fades out after 5s without blocking labeling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdmZrFadM3REsLnP6oYEQF)_